### PR TITLE
Add AIBOM generation: AI supply chain inventory with CycloneDX ML-BOM output

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -8,7 +8,6 @@ acr
 acs
 ACTIVEMQ
 ADBs
-Adddays
 adddays
 adduser
 ADH
@@ -19,6 +18,7 @@ admpwd
 admx
 adversarially
 aescbc
+aibom
 aiplatform
 AKIAIOSFODNN
 allkeys
@@ -191,6 +191,7 @@ ctl
 ctx
 CUSTOMERID
 CYAAAAAAAKEY
+cyclonedx
 cyserver
 databricks
 datafactory
@@ -296,6 +297,7 @@ filebase
 fileless
 fileshare
 filestore
+finetune
 fips
 firefox
 firestore
@@ -341,6 +343,7 @@ Graphviz
 grouplist
 groupname
 grouppolicy
+groq
 grundschutz
 GTK
 guestlib
@@ -361,6 +364,7 @@ hostpath
 hotlinking
 hpa
 hsts
+huggingface
 hvm
 hwaddr
 Iaa
@@ -380,6 +384,7 @@ inodes
 insertafter
 installable
 intransit
+interoperates
 iommu
 iosxe
 iosxr
@@ -398,6 +403,7 @@ junos
 jwks
 kaniko
 kek
+Keras
 kexalgorithms
 kexalgorithms
 kexalgos
@@ -472,6 +478,7 @@ misconfigures
 misrouted
 mknod
 MLE
+mlflow
 mmap
 MMK
 mongodb
@@ -520,6 +527,7 @@ ntalk
 NTE
 ntpserver
 ntpsync
+nvidia
 nullglob
 nxos
 Nxxxx
@@ -533,6 +541,7 @@ offsite
 oidc
 ollama
 omsagent
+onnx
 oncall
 ondigitalocean
 onestop
@@ -583,6 +592,7 @@ Petya
 pfs
 pii
 pipefail
+pipx
 pkgng
 pki
 pkill
@@ -659,6 +669,7 @@ saoudrizwan
 SAs
 Sasl
 savecore
+sbom
 scc
 SCENo
 SCHANNEL
@@ -754,6 +765,7 @@ tbl
 tde
 TDS
 tensorboard
+textlist
 tfa
 timeadd
 timeframes
@@ -766,6 +778,7 @@ tmpfiles
 tmsh
 TNS
 toset
+togetherai
 totp
 Tpng
 trae
@@ -791,7 +804,6 @@ uninventoried
 unlinkat
 uploaders
 upnp
-Usb
 usb
 usepam
 userdel
@@ -802,6 +814,7 @@ USERPROFILE
 userspace
 USLACKBOT
 utm
+uvx
 valkey
 VALUEX
 VAULTNAME

--- a/apps/cnspec/cmd/aibom.go
+++ b/apps/cnspec/cmd/aibom.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.mondoo.com/cnspec/v13/cli/reporter"
+	"go.mondoo.com/cnspec/v13/internal/aibom"
+	"go.mondoo.com/cnspec/v13/internal/aibom/generator"
+	"go.mondoo.com/cnspec/v13/internal/aibom/pack"
+	"go.mondoo.com/cnspec/v13/policy/scan"
+	"go.mondoo.com/mql/v13/logger"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func init() {
+	rootCmd.AddCommand(aibomCmd)
+	aibomCmd.Flags().String("asset-name", "", "User-override for the asset name")
+	aibomCmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset in the form KEY=VALUE")
+	aibomCmd.Flags().StringP("output", "o", "markdown", "Set output format: "+aibom.AllFormats())
+	aibomCmd.Flags().String("output-target", "", "Set output target to which the AIBOM report will be written")
+}
+
+var aibomCmd = &cobra.Command{
+	Use:   "aibom",
+	Short: "Generate an AI bill of materials (AIBOM) for AI models across providers",
+	Long: `Generate an AI bill of materials (AIBOM) that inventories AI/ML models
+across cloud providers, model registries, inference APIs, and local runtimes.
+
+Supported providers:
+- local          Local system (agents, cached models)
+- ollama         Ollama models
+- huggingface    HuggingFace Hub models
+- openai         OpenAI API (models, vector stores, fine-tuning)
+- claude         Anthropic Claude API (models, agents, skills)
+- vllm           vLLM inference server
+- aws            AWS Bedrock + SageMaker
+- gcp            GCP Vertex AI + Model Armor
+- azure          Azure AI Services (OpenAI, Cognitive Services)
+
+Output formats:
+- markdown (default)
+- json
+- cyclonedx-json
+- cyclonedx-xml
+
+Examples:
+  cnspec aibom local
+  cnspec aibom local -o json
+  cnspec aibom ollama -o cyclonedx-json
+  cnspec aibom aws -o cyclonedx-json
+`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlag("output", cmd.Flags().Lookup("output")); err != nil {
+			log.Fatal().Err(err).Msg("failed to bind output flag")
+		}
+		if err := viper.BindPFlag("output-target", cmd.Flags().Lookup("output-target")); err != nil {
+			log.Fatal().Err(err).Msg("failed to bind output-target flag")
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var aibomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
+	pb, err := pack.QueryPack()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to load AIBOM query pack")
+	}
+
+	conf, err := getCobraScanConfig(cmd, runtime, cliRes)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to get scan config")
+	}
+
+	conf.PolicyNames = nil
+	conf.PolicyPaths = nil
+	conf.Bundle = pb
+	conf.IsIncognito = true
+
+	report, err := RunScan(conf, scan.DisableProgressBar())
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to run scan")
+	}
+
+	cnspecReport, err := reporter.ConvertToProto(report)
+	if err == nil {
+		log.Debug().Msg("converted report to proto")
+		data, _ := cnspecReport.ToJSON()
+		logger.DebugDumpJSON("mondoo-aibom-report", data)
+	}
+
+	boms := generator.GenerateAiBom(cnspecReport.ToCnqueryReport())
+
+	output := viper.GetString("output")
+	formatter := aibom.NewFormatter(output)
+	if formatter == nil {
+		log.Fatal().Msg("unsupported output format: " + output)
+	}
+
+	outputTarget := viper.GetString("output-target")
+	for i := range boms {
+		bom := boms[i]
+		buf := bytes.Buffer{}
+		err := formatter.Render(&buf, bom)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to render AIBOM")
+		}
+
+		if outputTarget != "" {
+			filename := outputTarget
+			if len(boms) > 1 {
+				filename = fmt.Sprintf("%s-%d.%s", path.Base(outputTarget), i, path.Ext(outputTarget))
+			}
+			if err := os.WriteFile(filename, buf.Bytes(), 0o600); err != nil {
+				log.Fatal().Err(err).Msg("failed to write AIBOM to file")
+			}
+		} else {
+			fmt.Println(buf.String())
+		}
+	}
+}

--- a/apps/cnspec/cmd/root.go
+++ b/apps/cnspec/cmd/root.go
@@ -102,6 +102,12 @@ func BuildRootCmd() (*cobra.Command, error) {
 			Action:              "Collect a software bill of materials (SBOM) for ",
 			SupportedConnectors: []string{"docker", "container", "filesystem", "local", "ssh", "vagrant", "winrm", "sbom"},
 		},
+		&providers.Command{
+			Command:             aibomCmd,
+			Run:                 aibomCmdRun,
+			Action:              "Generate an AI bill of materials (AIBOM) for ",
+			SupportedConnectors: []string{"local", "docker", "container", "filesystem", "ssh", "vagrant", "winrm", "ollama", "huggingface", "aws", "gcp", "azure"},
+		},
 	)
 	return rootCmd, err
 }

--- a/docs/adr/0003-aibom-generation.md
+++ b/docs/adr/0003-aibom-generation.md
@@ -1,0 +1,255 @@
+# ADR-0003: AI Bill of Materials (AIBOM) Generation
+
+**Date:** 2026-05-22
+**Status:** Accepted
+
+## Context
+
+Organizations deploying AI models across multiple clouds lack a unified inventory of what models they run, where they came from, what data they were trained on, and what licenses or ethical constraints apply. Beyond models, the proliferation of AI coding agents, MCP servers, guardrails, knowledge bases, and AI-capable compute creates a shadow AI problem — teams adopt AI tools without centralized visibility.
+
+The [CycloneDX](https://cyclonedx.org/) standard (ECMA-424) defines a full-stack Bill of Materials format with distinct BOM types: [SBOM](https://cyclonedx.org/capabilities/sbom/), [ML-BOM](https://cyclonedx.org/capabilities/mlbom/), [CBOM](https://cyclonedx.org/capabilities/cbom/), [HBOM](https://cyclonedx.org/capabilities/hbom/), and others. The [ML-BOM capability](https://cyclonedx.org/capabilities/mlbom/) (introduced in CycloneDX 1.5) provides machine-readable representation of AI/ML model transparency information including model parameters, datasets, performance metrics, fairness assessments, and ethical considerations — aligned with the [CycloneDX Machine Learning Model Card](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard) schema.
+
+cnspec already generates software SBOMs via `cnspec sbom` in CycloneDX, SPDX, and custom JSON formats. The CycloneDX Go library we depend on (`github.com/CycloneDX/cyclonedx-go` v0.11.0) already includes full ML-BOM support:
+
+- [`ComponentTypeMachineLearningModel`](https://cyclonedx.org/docs/1.6/json/#components_items_type) and [`ComponentTypeData`](https://cyclonedx.org/docs/1.6/json/#components_items_type) component types
+- [`MLModelCard`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard) with `MLModelParameters`, `MLQuantitativeAnalysis`, `MLModelCardConsiderations`
+- [`MLModelCardEthicalConsideration`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard_considerations_ethicalConsiderations), `MLModelCardFairnessAssessment`
+- [`ComponentData`](https://cyclonedx.org/docs/1.6/json/#components_items_data) for dataset representation
+
+No library upgrade is needed.
+
+## Decision
+
+### 1. New `cnspec aibom` command
+
+Add a new top-level `cnspec aibom` command, parallel to the existing `cnspec sbom`:
+
+```bash
+cnspec sbom local -o cyclonedx-json               # software BOM (unchanged)
+
+# Local systems
+cnspec aibom local -o cyclonedx-json               # AI BOM from local machine (agents, cached models)
+cnspec aibom local -o table                         # human-readable summary
+
+# Cloud platforms
+cnspec aibom aws -o cyclonedx-json                 # AI BOM from AWS (Bedrock + SageMaker + Lambda)
+cnspec aibom gcp -o cyclonedx-json                 # AI BOM from GCP (Vertex AI + Model Armor + Cloud Functions/Run)
+cnspec aibom azure -o cyclonedx-json               # AI BOM from Azure (OpenAI + Cognitive Services + Functions)
+
+# Model registries and inference APIs
+cnspec aibom ollama -o cyclonedx-json              # AI BOM from local Ollama
+cnspec aibom huggingface -o cyclonedx-json         # AI BOM from HuggingFace
+cnspec aibom openai -o cyclonedx-json              # AI BOM from OpenAI API (models, vector stores, fine-tuning)
+cnspec aibom claude -o cyclonedx-json              # AI BOM from Anthropic Claude API (models, agents, skills)
+cnspec aibom vllm -o cyclonedx-json                # AI BOM from vLLM server
+
+# Filesystem / remote
+cnspec aibom filesystem --path /path -o table      # scan filesystem for cached models
+cnspec aibom ssh user@host -o cyclonedx-json       # remote host agent & model discovery
+cnspec aibom docker image:tag -o cyclonedx-json    # container AI BOM
+```
+
+**Rationale:** CycloneDX defines [BOM as an umbrella standard](https://cyclonedx.org/capabilities/) with SBOM, ML-BOM, CBOM, HBOM, etc. as peer types. A dedicated `cnspec aibom` command keeps the naming clear and avoids overloading `cnspec sbom` with `--type` flags that change its fundamental behavior. The two commands share format rendering infrastructure (`cyclonedx.go`) but have separate query packs and generators.
+
+### 2. Data model
+
+The AIBOM data model extends beyond models to capture the full AI supply chain. Hand-written Go types in `internal/aibom/types.go` mirror proto definitions in `internal/aibom/cnspec_aibom.proto`:
+
+```protobuf
+message AiBom {
+  Generator generator = 1;
+  string timestamp = 2;
+  Status status = 3;
+  Asset asset = 4;
+  repeated ModelComponent models = 5;
+  repeated AgentComponent agents = 6;
+  repeated Guardrail guardrails = 7;
+  repeated KnowledgeBase knowledge_bases = 8;
+  repeated ComputeAIAccess compute_access = 9;
+  repeated AIDependency ai_dependencies = 10;
+  CompletenessScore completeness = 11;
+  repeated string errors = 12;
+}
+```
+
+**ModelComponent** — AI/ML models from cloud providers, registries, local caches, and inference APIs:
+
+```protobuf
+message ModelComponent {
+  string name = 1;
+  string version = 2;
+  string provider = 3;              // "ollama", "huggingface", "aws-bedrock", "aws-sagemaker",
+                                     // "gcp-vertexai", "azure-openai", "openai", "anthropic", "vllm"
+  string model_id = 4;
+  string description = 5;
+  string author = 6;
+  string license = 7;
+  string task = 8;
+  string architecture_family = 9;
+  string model_architecture = 10;
+  string approach_type = 11;
+  repeated string input_modalities = 12;
+  repeated string output_modalities = 13;
+  repeated string intended_uses = 14;
+  repeated string limitations = 15;
+  repeated string training_datasets = 16;
+  repeated EthicalConsideration ethical_considerations = 17;
+  map<string, string> performance_metrics = 18;
+  map<string, string> labels = 19;
+  string purl = 20;
+  string source_url = 21;
+  string created_at = 22;
+  string updated_at = 23;
+  map<string, string> provenance = 24;
+  string format = 25;               // "gguf", "safetensors", "onnx", etc.
+  string quantization = 26;
+  string parameter_size = 27;
+  repeated string tags = 28;
+  repeated string capabilities = 29;
+}
+```
+
+**AgentComponent** — AI coding agents (25 types) with MCP servers, plugins, extensions, and skills:
+
+```protobuf
+message AgentComponent {
+  string name = 1;
+  string provider = 2;              // "local", "anthropic", "aws-bedrock", "gcp-cloud-functions"
+  string config_path = 3;
+  string version = 4;
+  string model = 5;
+  repeated McpServer mcp_servers = 6;
+  repeated AgentPlugin plugins = 7;
+  repeated AgentExtension extensions = 8;
+  repeated AgentSkill skills = 9;
+  repeated AgentDependency dependencies = 10;
+  map<string, string> labels = 11;
+}
+```
+
+**Guardrail** — Safety guardrails from AWS Bedrock, GCP Model Armor, and Azure RAI policies.
+
+**KnowledgeBase** — Vector stores and knowledge bases from AWS Bedrock, OpenAI, and Claude memory stores.
+
+**ComputeAIAccess** — Compute services (Lambda, Cloud Functions, Cloud Run, Azure Functions) with IAM roles or environment variables that indicate AI service access. Environment variable values are redacted to `"(configured)"` to prevent API key leakage.
+
+**AIDependency** — AI/ML libraries detected in npm and Python packages, classified by category (model-framework, api-client, agent-framework, vector-db, ml-tool).
+
+### 3. CycloneDX ML-BOM rendering
+
+Each `ModelComponent` maps to a [`cyclonedx.Component`](https://cyclonedx.org/docs/1.6/json/#components_items) with:
+
+- `Type`: [`machine-learning-model`](https://cyclonedx.org/docs/1.6/json/#components_items_type)
+- [`ModelCard`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard):
+  - [`ModelParameters`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard_modelParameters) — task, architectureFamily, modelArchitecture, approach, datasets, inputs/outputs
+  - [`Considerations`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard_considerations) — useCases, technicalLimitations, ethicalConsiderations, fairnessAssessments
+  - [`QuantitativeAnalysis`](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard_quantitativeAnalysis) — performance metrics
+- [`Licenses`](https://cyclonedx.org/docs/1.6/json/#components_items_licenses) from model license (SPDX-normalized)
+- [`PackageURL`](https://cyclonedx.org/docs/1.6/json/#components_items_purl) with provider-specific PURL
+- [`ExternalReferences`](https://cyclonedx.org/docs/1.6/json/#components_items_externalReferences) for source URL, model card URL
+
+Training datasets render as nested components with `Type`: [`data`](https://cyclonedx.org/docs/1.6/json/#components_items_type) and populated [`ComponentData`](https://cyclonedx.org/docs/1.6/json/#components_items_data) fields. Local file paths (`file://`) are excluded from distribution references.
+
+### 4. Completeness scoring
+
+Weighted scoring per model, averaged across the BOM:
+
+| Section | Weight | Fields |
+|---------|--------|--------|
+| Identity | 0.25 | name, version, provider, model_id, author |
+| License & Legal | 0.20 | license |
+| Technical | 0.20 | task, architecture, approach, input/output modalities |
+| Training & Data | 0.20 | training_datasets, provenance |
+| Ethics & Risk | 0.15 | ethical_considerations, limitations, intended_uses |
+
+Output as CycloneDX BOM-level [`properties`](https://cyclonedx.org/docs/1.6/json/#metadata_properties) and in cnspec-json as the `completeness` field.
+
+### 5. Embedded AIBOM query pack
+
+The AIBOM query pack is embedded in `internal/aibom/pack/aibom.mql.yaml` and loaded at runtime via `internal/aibom/pack/pack.go`. Queries are platform-filtered so only relevant queries execute per scan target:
+
+- `asset.family.contains("unix") || asset.family.contains("windows")` — local agents, cached models, npm/python packages
+- `asset.platform == "aws"` — Bedrock, SageMaker, Lambda
+- `asset.platform == "gcp"` — Vertex AI, Model Armor, Cloud Functions, Cloud Run, IAM
+- `asset.platform == "azure"` — Cognitive Services, Function Apps, RAI policies
+- `asset.platform == "ollama"` — Ollama models with license detection
+- `asset.family.contains("huggingface")` — HuggingFace models with card data
+- `asset.platform == "openai"` — OpenAI models, vector stores, fine-tuning jobs
+- `asset.platform == "claude"` — Claude models, agents, skills, memory stores, vaults
+- `asset.platform == "vllm"` — vLLM server and models
+
+### 6. Local AI agent and model discovery
+
+**Coding agents** (25 types): Claude Code, OpenAI Codex, Cursor, GitHub Copilot, Windsurf, Gemini, Goose, Zed, Roo, Cline, Kiro, Trae, Junie, Augment, Kilocode, Continue, Mistral Vibe, Antigravity, IBM Bob, OpenClaw, Snowflake Cortex, Warp, OpenHands, OpenCode, Pi, Qwen Code. Each agent's query pack extracts config path, skills, MCP servers, and (where available) plugins and extensions.
+
+**Local model cache detection** (`ai.models` resource): 8 filesystem detectors scan for cached AI models from Ollama, HuggingFace, LM Studio, GPT4All, PyTorch Hub, Keras, TFHub, and Jan. Extracts name, source, vendor, family, format, version, quantization, parameter size, architecture, license, and tags.
+
+**AI dependency classification**: npm and Python packages are classified against a registry of ~80 known AI/ML libraries into categories: model-framework, api-client, agent-framework, vector-db, and ml-tool.
+
+**MCP server package correlation**: Agent MCP server commands (npx, uvx, pipx, etc.) are correlated with discovered npm/Python packages to enrich servers with version, PURL, and CPE data.
+
+### 7. Compute AI access detection
+
+Lambda functions, GCP Cloud Functions, GCP Cloud Run services, and Azure Function Apps are analyzed for AI service access through:
+
+- **IAM policy analysis**: AWS Lambda roles scanned for `bedrock:*`, `sagemaker:*`, `comprehend:*`, etc. action prefixes; GCP service accounts checked for `roles/aiplatform.*` and `roles/ml.*` roles
+- **Environment variable hints**: Keys containing `BEDROCK`, `SAGEMAKER`, `OPENAI`, `ANTHROPIC`, `VERTEX`, `AI_MODEL`, `MODEL_ID`, `LLM`, `GEMINI`, `CLAUDE`, `HUGGINGFACE`, `INFERENCE`, `EMBEDDING` — values redacted to `"(configured)"`
+- **Bedrock agent enrichment**: Agent action-group Lambda ARNs are resolved to enrich with runtime, code hash, image URI, and layers
+
+## cnspec Changes
+
+| File | Change |
+|------|--------|
+| `apps/cnspec/cmd/aibom.go` | `cnspec aibom` command with format flags (table, json, cyclonedx-json) |
+| `apps/cnspec/cmd/root.go` | Register `aibomCmd` with supported connectors |
+| `internal/aibom/types.go` | Hand-written Go types: `AiBom`, `ModelComponent`, `AgentComponent`, `Guardrail`, `KnowledgeBase`, `ComputeAIAccess`, `AIDependency`, etc. |
+| `internal/aibom/cnspec_aibom.proto` | Proto definitions (not yet compiled — types.go used directly) |
+| `internal/aibom/pack/aibom.mql.yaml` | Embedded AIBOM query pack with per-platform queries |
+| `internal/aibom/pack/pack.go` | Query pack embedding and loading |
+| `internal/aibom/generator/generator.go` | Parse MQL report into AIBOM components per provider; AI dependency classification; compute AI access detection |
+| `internal/aibom/generator/report_collection.go` | `AiBomFields` struct for deserializing MQL report data points |
+| `internal/aibom/generator/scoring.go` | Completeness scoring algorithm |
+| `internal/aibom/cyclonedx.go` | CycloneDX ML-BOM rendering with model cards, SPDX license normalization |
+| `internal/aibom/json.go` | cnspec-json format rendering |
+| `internal/aibom/textlist.go` | Human-readable table format with glamour markdown rendering |
+| `internal/aibom/aibom.go` | Format registry and output dispatch |
+
+## MQL Provider Dependencies
+
+The `cnspec aibom` command uses MQL resources from the OS provider and cloud providers. All listed providers have the required resources implemented:
+
+| Provider | MQL Resources |
+|----------|--------------|
+| OS (local/ssh/container) | `ai.models`, 25 coding agent resources (`claude.code`, `cursor`, `github.copilot`, etc.), `npm.packages`, `python.packages` |
+| AWS | `aws.bedrock.foundationModels`, `aws.bedrock.customModels`, `aws.bedrock.agents`, `aws.bedrock.knowledgeBases`, `aws.bedrock.guardrails`, `aws.bedrock.flows`, `aws.sagemaker.models`, `aws.lambda.functions` |
+| GCP | `gcp.project.vertexaiService.models`, `gcp.project.modelArmorService.templates`, `gcp.project.cloudFunctions`, `gcp.project.cloudRunService.services`, `gcp.project.iamPolicy` |
+| Azure | `azure.subscription.cognitiveServices().accounts` (incl. `raiPolicies`), `azure.subscription.functionsService.functions` |
+| Ollama | `ollama.models` (with `info` block and license detection) |
+| HuggingFace | `huggingface.models` (with `config`, `cardData`) |
+| OpenAI | `openai.models`, `openai.fineTuningJobs`, `openai.vectorStores`, `openai.projects` |
+| Claude (Anthropic) | `claude.models`, `claude.agents`, `claude.skills`, `claude.environments`, `claude.vaults`, `claude.memoryStores` |
+| vLLM | `vllm.server`, `vllm.models` |
+
+## Consequences
+
+**Advantages:**
+- Dedicated `cnspec aibom` command — clear separation from `cnspec sbom`, aligned with [CycloneDX BOM taxonomy](https://cyclonedx.org/capabilities/)
+- Full AI supply chain visibility — models, agents, guardrails, knowledge bases, compute access, and AI dependencies in a single BOM
+- Continuous & policy-driven — unlike one-shot generators, cnspec can enforce completeness thresholds and security baselines across fleets of models
+- Multi-cloud + local — single tool covers cloud platforms (AWS, GCP, Azure), inference APIs (OpenAI, Anthropic), model registries (HuggingFace, Ollama), local runtimes (vLLM), and local coding agents (25 types)
+- Standards-based — [CycloneDX ML-BOM](https://cyclonedx.org/capabilities/mlbom/) output interoperates with existing BOM tooling
+- Shadow AI detection — local agent discovery (25 coding agents with MCP/plugins/skills), cached model detection (8 filesystem detectors), and AI dependency classification provide visibility into unauthorized AI adoption
+
+**Risks:**
+- **Metadata asymmetry:** HuggingFace and Ollama completeness scores will be higher than cloud providers that expose less metadata. Scores reflect provider transparency, not security posture.
+- **Agent detection lag:** New AI coding agents appear frequently. The detection list must be maintained.
+- **AI library registry maintenance:** The `aiPackageRegistry` (~80 packages) needs periodic updates as the AI/ML ecosystem evolves.
+
+## References
+
+- [CycloneDX ML-BOM Capability](https://cyclonedx.org/capabilities/mlbom/)
+- [CycloneDX 1.6 JSON Schema — modelCard](https://cyclonedx.org/docs/1.6/json/#components_items_modelCard)
+- [CycloneDX 1.6 JSON Schema — component types](https://cyclonedx.org/docs/1.6/json/#components_items_type)
+- [CycloneDX 1.6 JSON Schema — data](https://cyclonedx.org/docs/1.6/json/#components_items_data)
+- [CycloneDX Specification (ECMA-424)](https://ecma-international.org/publications-and-standards/standards/ecma-424/)
+- [cyclonedx-go library](https://github.com/CycloneDX/cyclonedx-go)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
-	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/cockroachdb/errors v1.13.0
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -95,6 +95,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/participle v0.3.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
+	github.com/alecthomas/repr v0.5.1 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/alecthomas/participle v0.3.0 h1:e8vhrYR1nDjzDxyDwpLO27TWOYWilaT+glkwb
 github.com/alecthomas/participle v0.3.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
-github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
-github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
+github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -273,8 +273,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
-github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
+github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
+github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=

--- a/internal/aibom/aibom.go
+++ b/internal/aibom/aibom.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aibom
+
+//go:generate protoc --plugin=protoc-gen-go=../../scripts/protoc/protoc-gen-go --plugin=protoc-gen-rangerrpc=../../scripts/protoc/protoc-gen-rangerrpc --plugin=protoc-gen-go-vtproto=../../scripts/protoc/protoc-gen-go-vtproto --proto_path=. --go_out=. --go_opt=paths=source_relative --go-vtproto_out=. --go-vtproto_opt=paths=source_relative --go-vtproto_opt=features=marshal+unmarshal+size cnspec_aibom.proto
+
+import (
+	"io"
+	"strings"
+
+	cyclonedx "github.com/CycloneDX/cyclonedx-go"
+)
+
+const (
+	FormatCycloneDxJSON string = "cyclonedx-json"
+	FormatCycloneDxXML  string = "cyclonedx-xml"
+	FormatJSON          string = "json"
+	FormatMarkdown      string = "markdown"
+)
+
+// FormatHandler renders an AiBom to a specific output format.
+type FormatHandler interface {
+	Render(w io.Writer, bom *AiBom) error
+}
+
+func AllFormats() string {
+	return strings.Join([]string{
+		FormatMarkdown, FormatJSON, FormatCycloneDxJSON, FormatCycloneDxXML,
+	}, ", ")
+}
+
+func NewFormatter(format string) FormatHandler {
+	switch format {
+	case FormatCycloneDxJSON:
+		return &CycloneDXFormatter{Format: cyclonedx.BOMFileFormatJSON}
+	case FormatCycloneDxXML:
+		return &CycloneDXFormatter{Format: cyclonedx.BOMFileFormatXML}
+	case FormatJSON:
+		return &JSONFormatter{}
+	case FormatMarkdown:
+		fallthrough
+	default:
+		return &TextListFormatter{}
+	}
+}

--- a/internal/aibom/cnspec_aibom.proto
+++ b/internal/aibom/cnspec_aibom.proto
@@ -1,0 +1,237 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+syntax = "proto3";
+
+package mondoo.cnspec.aibom.v1;
+
+option go_package = "go.mondoo.com/cnspec/v13/internal/aibom";
+
+// Status represents the possible states of AIBOM generation.
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STATUS_SUCCEEDED = 1;
+  STATUS_PARTIALLY_SUCCEEDED = 2;
+  STATUS_FAILED = 3;
+  STATUS_STARTED = 4;
+}
+
+// AiBom (AI Bill of Materials) represents a comprehensive inventory of
+// AI/ML models, agents, guardrails, knowledge bases, and compute services
+// discovered across cloud providers, registries, inference APIs, and local
+// runtimes.
+message AiBom {
+  Generator generator = 1;
+  string timestamp = 2;
+  Status status = 3;
+  Asset asset = 4;
+  repeated ModelComponent models = 5;
+  repeated AgentComponent agents = 6;
+  repeated Guardrail guardrails = 7;
+  repeated KnowledgeBase knowledge_bases = 8;
+  repeated ComputeAIAccess compute_access = 9;
+  repeated AIDependency ai_dependencies = 10;
+  CompletenessScore completeness = 11;
+  repeated string errors = 12;
+}
+
+// Generator describes the tool that created the AIBOM.
+message Generator {
+  string vendor = 1;
+  string name = 2;
+  string version = 3;
+  string url = 4;
+}
+
+// Asset represents the target that was scanned for AI models.
+message Asset {
+  string name = 1;
+  repeated string platform_ids = 2;
+  Platform platform = 3;
+  map<string, string> labels = 4;
+}
+
+// Platform describes the target platform.
+message Platform {
+  string name = 1;
+  string version = 2;
+  string arch = 3;
+  string title = 4;
+  repeated string family = 5;
+}
+
+// ModelComponent represents a single AI/ML model discovered during the scan.
+message ModelComponent {
+  string name = 1;
+  string version = 2;
+  string provider = 3;
+  string model_id = 4;
+  string description = 5;
+  string author = 6;
+  string license = 7;
+  string task = 8;
+  string architecture_family = 9;
+  string model_architecture = 10;
+  string approach_type = 11;
+  repeated string input_modalities = 12;
+  repeated string output_modalities = 13;
+  repeated string intended_uses = 14;
+  repeated string limitations = 15;
+  repeated string training_datasets = 16;
+  repeated EthicalConsideration ethical_considerations = 17;
+  map<string, string> performance_metrics = 18;
+  map<string, string> labels = 19;
+  string purl = 20;
+  string source_url = 21;
+  string created_at = 22;
+  string updated_at = 23;
+  map<string, string> provenance = 24;
+  string format = 25;
+  string quantization = 26;
+  string parameter_size = 27;
+  repeated string tags = 28;
+  repeated string capabilities = 29;
+}
+
+// AgentComponent represents an AI agent (coding agent, cloud agent, or
+// orchestration flow).
+message AgentComponent {
+  string name = 1;
+  string provider = 2;
+  string config_path = 3;
+  string version = 4;
+  string model = 5;
+  repeated McpServer mcp_servers = 6;
+  repeated AgentPlugin plugins = 7;
+  repeated AgentExtension extensions = 8;
+  repeated AgentSkill skills = 9;
+  repeated AgentDependency dependencies = 10;
+  map<string, string> labels = 11;
+}
+
+// McpServer represents a Model Context Protocol server attached to an agent.
+message McpServer {
+  string name = 1;
+  string type = 2;
+  string command = 3;
+  repeated string args = 4;
+  string url = 5;
+  bool has_env = 6;
+  string purl = 7;
+  repeated PackageRef packages = 8;
+}
+
+// PackageRef is a reference to a software package correlated with an MCP server.
+message PackageRef {
+  string name = 1;
+  string version = 2;
+  string purl = 3;
+  repeated string cpes = 4;
+}
+
+// AgentPlugin represents a plugin installed in an AI agent.
+message AgentPlugin {
+  string name = 1;
+  string version = 2;
+  string author = 3;
+  string description = 4;
+  string install_path = 5;
+  string git_commit_sha = 6;
+  bool enabled = 7;
+  string purl = 8;
+}
+
+// AgentExtension represents an extension or integration in an AI agent.
+message AgentExtension {
+  string name = 1;
+  string type = 2;
+  string description = 3;
+  bool enabled = 4;
+  bool bundled = 5;
+}
+
+// AgentSkill represents a skill or capability registered with an AI agent.
+message AgentSkill {
+  string name = 1;
+  string description = 2;
+  string source = 3;
+  string sha256 = 4;
+}
+
+// AgentDependency represents a dependency of a cloud agent (e.g., Lambda
+// functions backing Bedrock agent action groups).
+message AgentDependency {
+  string type = 1;
+  string name = 2;
+  string arn = 3;
+  string runtime = 4;
+  string image_uri = 5;
+  string code_hash = 6;
+  repeated string layers = 7;
+  map<string, string> labels = 8;
+}
+
+// Guardrail represents an AI safety guardrail (Bedrock, Model Armor, Azure RAI).
+message Guardrail {
+  string name = 1;
+  string provider = 2;
+  string id = 3;
+  string arn = 4;
+  string status = 5;
+  string version = 6;
+  repeated string policies = 7;
+  map<string, string> labels = 8;
+}
+
+// KnowledgeBase represents a knowledge base or vector store.
+message KnowledgeBase {
+  string name = 1;
+  string provider = 2;
+  string id = 3;
+  string arn = 4;
+  string status = 5;
+  string description = 6;
+  string embedding_model = 7;
+  string storage_type = 8;
+  repeated string data_sources = 9;
+  map<string, string> labels = 10;
+}
+
+// ComputeAIAccess represents a compute service with detected AI service access.
+message ComputeAIAccess {
+  string name = 1;
+  string type = 2;
+  string provider = 3;
+  string arn = 4;
+  string runtime = 5;
+  string image_uri = 6;
+  string code_hash = 7;
+  string service_account = 8;
+  repeated string ai_services = 9;
+  repeated string ai_actions = 10;
+  map<string, string> env_hints = 11;
+  map<string, string> labels = 12;
+}
+
+// AIDependency represents an AI/ML library detected in package manifests.
+message AIDependency {
+  string name = 1;
+  string version = 2;
+  string category = 3;
+  string purl = 4;
+  string language = 5;
+}
+
+// EthicalConsideration describes an ethical concern and its mitigation.
+message EthicalConsideration {
+  string name = 1;
+  string mitigation_strategy = 2;
+}
+
+// CompletenessScore measures how complete the AIBOM metadata is.
+message CompletenessScore {
+  float total_score = 1;
+  map<string, float> section_scores = 2;
+  repeated string missing_fields = 3;
+  repeated string recommendations = 4;
+}

--- a/internal/aibom/cyclonedx.go
+++ b/internal/aibom/cyclonedx.go
@@ -1,0 +1,625 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aibom
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	cyclonedx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/google/uuid"
+)
+
+type CycloneDXFormatter struct {
+	Format cyclonedx.BOMFileFormat
+}
+
+func (f *CycloneDXFormatter) Render(w io.Writer, bom *AiBom) error {
+	cdxBom, err := f.convert(bom)
+	if err != nil {
+		return err
+	}
+	encoder := cyclonedx.NewBOMEncoder(w, f.Format)
+	encoder.SetPretty(true)
+	return encoder.Encode(cdxBom)
+}
+
+func (f *CycloneDXFormatter) convert(bom *AiBom) (*cyclonedx.BOM, error) {
+	cdx := cyclonedx.NewBOM()
+	cdx.SerialNumber = uuid.New().URN()
+	cdx.Metadata = &cyclonedx.Metadata{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Tools: &cyclonedx.ToolsChoice{
+			Components: &[]cyclonedx.Component{
+				{
+					Type:    cyclonedx.ComponentTypeApplication,
+					Author:  bom.Generator.Vendor,
+					Name:    bom.Generator.Name,
+					Version: bom.Generator.Version,
+				},
+			},
+		},
+		Properties: &[]cyclonedx.Property{
+			{Name: "mondoo:aibom:completeness:total", Value: fmt.Sprintf("%.2f", bom.Completeness.GetTotalScore())},
+			{Name: "mondoo:aibom:model_count", Value: fmt.Sprintf("%d", len(bom.Models))},
+			{Name: "mondoo:aibom:agent_count", Value: fmt.Sprintf("%d", len(bom.Agents))},
+			{Name: "mondoo:aibom:guardrail_count", Value: fmt.Sprintf("%d", len(bom.Guardrails))},
+			{Name: "mondoo:aibom:knowledge_base_count", Value: fmt.Sprintf("%d", len(bom.KnowledgeBases))},
+			{Name: "mondoo:aibom:ai_dependency_count", Value: fmt.Sprintf("%d", len(bom.AIDependencies))},
+		},
+	}
+
+	if bom.Asset != nil {
+		cdx.Metadata.Component = &cyclonedx.Component{
+			BOMRef: uuid.New().String(),
+			Type:   cyclonedx.ComponentTypePlatform,
+			Name:   bom.Asset.Name,
+		}
+	}
+
+	components := make([]cyclonedx.Component, 0, len(bom.Models)+len(bom.Agents)+len(bom.Guardrails)+len(bom.KnowledgeBases)+len(bom.ComputeAccess)+len(bom.AIDependencies))
+	for _, model := range bom.Models {
+		components = append(components, modelToComponent(model))
+	}
+	for _, agent := range bom.Agents {
+		components = append(components, agentToComponent(agent))
+	}
+	for _, g := range bom.Guardrails {
+		components = append(components, guardrailToComponent(g))
+	}
+	for _, kb := range bom.KnowledgeBases {
+		components = append(components, knowledgeBaseToComponent(kb))
+	}
+	for _, ca := range bom.ComputeAccess {
+		components = append(components, computeAccessToComponent(ca))
+	}
+	for _, dep := range bom.AIDependencies {
+		components = append(components, aiDependencyToComponent(dep))
+	}
+	cdx.Components = &components
+
+	return cdx, nil
+}
+
+func modelToComponent(m *ModelComponent) cyclonedx.Component {
+	c := cyclonedx.Component{
+		Type:    cyclonedx.ComponentTypeMachineLearningModel,
+		Name:    m.Name,
+		Version: m.Version,
+	}
+
+	if m.Purl != "" {
+		c.BOMRef = m.Purl
+		c.PackageURL = m.Purl
+	} else {
+		c.BOMRef = uuid.New().String()
+	}
+
+	if m.Description != "" {
+		c.Description = m.Description
+	}
+
+	// Set group, supplier, manufacturer, and authors from Author field
+	if m.Author != "" {
+		c.Group = m.Author
+		c.Supplier = &cyclonedx.OrganizationalEntity{Name: m.Author}
+		c.Manufacturer = &cyclonedx.OrganizationalEntity{Name: m.Author}
+		authors := []cyclonedx.OrganizationalContact{{Name: m.Author}}
+		c.Authors = &authors
+
+		if m.SourceUrl != "" {
+			c.Manufacturer.URL = &[]string{m.SourceUrl}
+		}
+	}
+
+	// Licenses — use SPDX ID for well-known licenses
+	if m.License != "" {
+		license := cyclonedx.LicenseChoice{}
+		if isSPDXLicense(m.License) {
+			license.License = &cyclonedx.License{ID: spdxNormalize(m.License)}
+		} else {
+			license.License = &cyclonedx.License{Name: m.License}
+		}
+		c.Licenses = &cyclonedx.Licenses{license}
+	}
+
+	// External references
+	refs := []cyclonedx.ExternalReference{}
+	if m.SourceUrl != "" {
+		refs = append(refs, cyclonedx.ExternalReference{
+			Type:    cyclonedx.ERTypeWebsite,
+			URL:     m.SourceUrl,
+			Comment: "Model repository",
+		})
+	}
+	// Distribution and VCS links only for HuggingFace-style repo URLs
+	if m.SourceUrl != "" && strings.Contains(m.SourceUrl, "huggingface.co/") {
+		refs = append(refs, cyclonedx.ExternalReference{
+			Type:    cyclonedx.ERTypeDistribution,
+			URL:     m.SourceUrl + "/tree/main",
+			Comment: "Model files",
+		})
+		if sha, ok := m.Provenance["sha"]; ok {
+			refs = append(refs, cyclonedx.ExternalReference{
+				Type:    cyclonedx.ERTypeVCS,
+				URL:     m.SourceUrl + "/commit/" + sha,
+				Comment: "Specific commit",
+			})
+		}
+	} else if m.SourceUrl != "" && !strings.HasPrefix(m.SourceUrl, "file://") {
+		refs = append(refs, cyclonedx.ExternalReference{
+			Type:    cyclonedx.ERTypeDistribution,
+			URL:     m.SourceUrl,
+			Comment: "Model endpoint",
+		})
+	}
+	// ArXiv paper reference
+	if arxiv, ok := m.Provenance["arxiv"]; ok {
+		refs = append(refs, cyclonedx.ExternalReference{
+			Type:    cyclonedx.ERTypeDocumentation,
+			URL:     "https://arxiv.org/abs/" + arxiv,
+			Comment: "ArXiv Paper",
+		})
+	}
+	// Training dataset references
+	for _, ds := range m.TrainingDatasets {
+		refs = append(refs, cyclonedx.ExternalReference{
+			Type:    cyclonedx.ERTypeDistribution,
+			URL:     "https://huggingface.co/datasets/" + ds,
+			Comment: "Training dataset: " + ds,
+		})
+	}
+	if len(refs) > 0 {
+		c.ExternalReferences = &refs
+	}
+
+	// ModelCard
+	mc := &cyclonedx.MLModelCard{}
+	hasModelCard := false
+
+	// ModelParameters
+	params := &cyclonedx.MLModelParameters{}
+	hasParams := false
+
+	if m.Task != "" {
+		params.Task = m.Task
+		hasParams = true
+	}
+	if m.ArchitectureFamily != "" {
+		params.ArchitectureFamily = m.ArchitectureFamily
+		hasParams = true
+	}
+	if m.ModelArchitecture != "" {
+		params.ModelArchitecture = m.ModelArchitecture
+		hasParams = true
+	}
+	if m.ApproachType != "" {
+		params.Approach = &cyclonedx.MLModelParametersApproach{
+			Type: cyclonedx.MLModelParametersApproachType(m.ApproachType),
+		}
+		hasParams = true
+	}
+
+	// Input/output modalities
+	if len(m.InputModalities) > 0 {
+		inputs := &[]cyclonedx.MLInputOutputParameters{}
+		for _, mod := range m.InputModalities {
+			*inputs = append(*inputs, cyclonedx.MLInputOutputParameters{
+				Format: mod,
+			})
+		}
+		params.Inputs = inputs
+		hasParams = true
+	}
+	if len(m.OutputModalities) > 0 {
+		outputs := &[]cyclonedx.MLInputOutputParameters{}
+		for _, mod := range m.OutputModalities {
+			*outputs = append(*outputs, cyclonedx.MLInputOutputParameters{
+				Format: mod,
+			})
+		}
+		params.Outputs = outputs
+		hasParams = true
+	}
+
+	// Training datasets
+	if len(m.TrainingDatasets) > 0 {
+		datasets := &[]cyclonedx.MLDatasetChoice{}
+		for _, ds := range m.TrainingDatasets {
+			*datasets = append(*datasets, cyclonedx.MLDatasetChoice{
+				ComponentData: &cyclonedx.ComponentData{
+					Type: cyclonedx.ComponentDataTypeDataset,
+					Name: ds,
+					Contents: &cyclonedx.ComponentDataContents{
+						URL: "https://huggingface.co/datasets/" + ds,
+					},
+				},
+			})
+		}
+		params.Datasets = datasets
+		hasParams = true
+	}
+
+	if hasParams {
+		mc.ModelParameters = params
+		hasModelCard = true
+	}
+
+	// Considerations
+	considerations := &cyclonedx.MLModelCardConsiderations{}
+	hasConsiderations := false
+
+	if len(m.IntendedUses) > 0 {
+		uses := make([]string, len(m.IntendedUses))
+		copy(uses, m.IntendedUses)
+		considerations.UseCases = &uses
+		hasConsiderations = true
+	}
+	if len(m.Limitations) > 0 {
+		lims := make([]string, len(m.Limitations))
+		copy(lims, m.Limitations)
+		considerations.TechnicalLimitations = &lims
+		hasConsiderations = true
+	}
+	if len(m.EthicalConsiderations) > 0 {
+		ethics := &[]cyclonedx.MLModelCardEthicalConsideration{}
+		for _, ec := range m.EthicalConsiderations {
+			*ethics = append(*ethics, cyclonedx.MLModelCardEthicalConsideration{
+				Name:               ec.Name,
+				MitigationStrategy: ec.MitigationStrategy,
+			})
+		}
+		considerations.EthicalConsiderations = ethics
+		hasConsiderations = true
+	}
+
+	if hasConsiderations {
+		mc.Considerations = considerations
+		hasModelCard = true
+	}
+
+	// Quantitative analysis (performance metrics)
+	if len(m.PerformanceMetrics) > 0 {
+		metrics := &[]cyclonedx.MLPerformanceMetric{}
+		for name, value := range m.PerformanceMetrics {
+			*metrics = append(*metrics, cyclonedx.MLPerformanceMetric{
+				Type:  name,
+				Value: value,
+			})
+		}
+		mc.QuantitativeAnalysis = &cyclonedx.MLQuantitativeAnalysis{
+			PerformanceMetrics: metrics,
+		}
+		hasModelCard = true
+	}
+
+	if hasModelCard {
+		c.ModelCard = mc
+	}
+
+	// Properties for fields not covered by CycloneDX ML-BOM schema
+	props := []cyclonedx.Property{
+		{Name: "mondoo:model:provider", Value: m.Provider},
+	}
+	if m.Format != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:model:format", Value: m.Format})
+	}
+	if m.Quantization != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:model:quantization", Value: m.Quantization})
+	}
+	if m.ParameterSize != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:model:parameterSize", Value: m.ParameterSize})
+	}
+	if len(m.Capabilities) > 0 {
+		for _, cap := range m.Capabilities {
+			props = append(props, cyclonedx.Property{Name: "mondoo:model:capability", Value: cap})
+		}
+	}
+	for k, v := range m.Labels {
+		props = append(props, cyclonedx.Property{Name: "genai:aibom:modelcard:" + k, Value: v})
+	}
+	for k, v := range m.Provenance {
+		props = append(props, cyclonedx.Property{Name: "mondoo:model:provenance:" + k, Value: v})
+	}
+	c.Properties = &props
+
+	return c
+}
+
+var spdxLicenses = map[string]string{
+	"apache-2.0":   "Apache-2.0",
+	"mit":          "MIT",
+	"gpl-3.0":      "GPL-3.0-only",
+	"gpl-2.0":      "GPL-2.0-only",
+	"bsd-2-clause": "BSD-2-Clause",
+	"bsd-3-clause": "BSD-3-Clause",
+	"lgpl-3.0":     "LGPL-3.0-only",
+	"lgpl-2.1":     "LGPL-2.1-only",
+	"mpl-2.0":      "MPL-2.0",
+	"isc":          "ISC",
+	"unlicense":    "Unlicense",
+	"cc-by-4.0":    "CC-BY-4.0",
+	"cc-by-sa-4.0": "CC-BY-SA-4.0",
+	"cc-by-nc-4.0": "CC-BY-NC-4.0",
+	"cc0-1.0":      "CC0-1.0",
+}
+
+func isSPDXLicense(license string) bool {
+	_, ok := spdxLicenses[strings.ToLower(license)]
+	return ok
+}
+
+func spdxNormalize(license string) string {
+	if id, ok := spdxLicenses[strings.ToLower(license)]; ok {
+		return id
+	}
+	return license
+}
+
+func aiDependencyToComponent(dep *AIDependency) cyclonedx.Component {
+	compType := cyclonedx.ComponentTypeLibrary
+	if dep.Category == "agent-framework" {
+		compType = cyclonedx.ComponentTypeFramework
+	}
+
+	c := cyclonedx.Component{
+		Type:    compType,
+		Name:    dep.Name,
+		Version: dep.Version,
+	}
+
+	if dep.Purl != "" {
+		c.BOMRef = dep.Purl
+		c.PackageURL = dep.Purl
+	} else {
+		c.BOMRef = uuid.New().String()
+	}
+
+	props := []cyclonedx.Property{
+		{Name: "mondoo:ai:category", Value: dep.Category},
+	}
+	if dep.Language != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:ai:language", Value: dep.Language})
+	}
+	c.Properties = &props
+
+	return c
+}
+
+func computeAccessToComponent(ca *ComputeAIAccess) cyclonedx.Component {
+	c := cyclonedx.Component{
+		BOMRef: uuid.New().String(),
+		Type:   cyclonedx.ComponentTypeApplication,
+		Name:   ca.Name,
+	}
+	props := []cyclonedx.Property{
+		{Name: "mondoo:compute:type", Value: ca.Type},
+		{Name: "mondoo:compute:provider", Value: ca.Provider},
+	}
+	if ca.Runtime != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:runtime", Value: ca.Runtime})
+	}
+	if ca.Arn != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:arn", Value: ca.Arn})
+	}
+	if ca.ImageUri != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:imageUri", Value: ca.ImageUri})
+	}
+	if ca.CodeHash != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:codeSha256", Value: ca.CodeHash})
+	}
+	if ca.ServiceAccount != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:serviceAccount", Value: ca.ServiceAccount})
+	}
+	for _, svc := range ca.AIServices {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:aiService", Value: svc})
+	}
+	for _, action := range ca.AIActions {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:aiAction", Value: action})
+	}
+	for k, v := range ca.EnvHints {
+		props = append(props, cyclonedx.Property{Name: "mondoo:compute:envHint:" + k, Value: v})
+	}
+	c.Properties = &props
+	return c
+}
+
+func agentToComponent(a *AgentComponent) cyclonedx.Component {
+	agentRef := uuid.New().String()
+	c := cyclonedx.Component{
+		BOMRef:  agentRef,
+		Type:    cyclonedx.ComponentTypeApplication,
+		Name:    a.Name,
+		Version: a.Version,
+	}
+
+	props := []cyclonedx.Property{
+		{Name: "mondoo:agent:provider", Value: a.Provider},
+		{Name: "mondoo:agent:type", Value: "coding-agent"},
+	}
+	if a.ConfigPath != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:agent:configPath", Value: a.ConfigPath})
+	}
+	if a.Model != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:agent:model", Value: a.Model})
+	}
+	for _, s := range a.Skills {
+		p := cyclonedx.Property{Name: "mondoo:agent:skill", Value: s.Name}
+		props = append(props, p)
+		if s.Sha256 != "" {
+			props = append(props, cyclonedx.Property{Name: "mondoo:agent:skill:sha256:" + s.Name, Value: s.Sha256})
+		}
+	}
+	for k, v := range a.Labels {
+		props = append(props, cyclonedx.Property{Name: "mondoo:agent:label:" + k, Value: v})
+	}
+
+	// Nested components: plugins + MCP servers form the agent's SBOM
+	var nested []cyclonedx.Component
+
+	for _, p := range a.Plugins {
+		pc := cyclonedx.Component{
+			BOMRef:  uuid.New().String(),
+			Type:    cyclonedx.ComponentTypeLibrary,
+			Name:    p.Name,
+			Version: p.Version,
+			Author:  p.Author,
+		}
+		if p.Purl != "" {
+			pc.PackageURL = p.Purl
+		}
+		if p.Description != "" {
+			pc.Description = p.Description
+		}
+		pprops := []cyclonedx.Property{
+			{Name: "mondoo:plugin:agent", Value: a.Name},
+		}
+		if p.GitCommitSha != "" {
+			pprops = append(pprops, cyclonedx.Property{Name: "mondoo:plugin:gitCommitSha", Value: p.GitCommitSha})
+		}
+		if p.InstallPath != "" {
+			pprops = append(pprops, cyclonedx.Property{Name: "mondoo:plugin:installPath", Value: p.InstallPath})
+		}
+		pc.Properties = &pprops
+		nested = append(nested, pc)
+	}
+
+	for _, m := range a.McpServers {
+		mc := cyclonedx.Component{
+			BOMRef: uuid.New().String(),
+			Type:   cyclonedx.ComponentTypeApplication,
+			Name:   "mcp:" + m.Name,
+		}
+		if m.Purl != "" {
+			mc.PackageURL = m.Purl
+		}
+		mprops := []cyclonedx.Property{
+			{Name: "mondoo:mcp:agent", Value: a.Name},
+		}
+		if m.Command != "" {
+			mprops = append(mprops, cyclonedx.Property{Name: "mondoo:mcp:command", Value: m.Command})
+		}
+		if m.Url != "" {
+			mprops = append(mprops, cyclonedx.Property{Name: "mondoo:mcp:url", Value: m.Url})
+		}
+		if m.HasEnv {
+			mprops = append(mprops, cyclonedx.Property{Name: "mondoo:mcp:hasEnv", Value: "true"})
+		}
+		mc.Properties = &mprops
+		nested = append(nested, mc)
+	}
+
+	for _, e := range a.Extensions {
+		ec := cyclonedx.Component{
+			BOMRef: uuid.New().String(),
+			Type:   cyclonedx.ComponentTypeLibrary,
+			Name:   e.Name,
+		}
+		if e.Description != "" {
+			ec.Description = e.Description
+		}
+		eprops := []cyclonedx.Property{
+			{Name: "mondoo:extension:agent", Value: a.Name},
+			{Name: "mondoo:extension:type", Value: e.Type},
+		}
+		ec.Properties = &eprops
+		nested = append(nested, ec)
+	}
+
+	for _, d := range a.Dependencies {
+		dc := cyclonedx.Component{
+			BOMRef: uuid.New().String(),
+			Name:   d.Name,
+		}
+		switch d.Type {
+		case "action-group", "cloud-function":
+			dc.Type = cyclonedx.ComponentTypeApplication
+		case "knowledge-base":
+			dc.Type = cyclonedx.ComponentTypeData
+		default:
+			dc.Type = cyclonedx.ComponentTypeApplication
+		}
+		dprops := []cyclonedx.Property{
+			{Name: "mondoo:dependency:agent", Value: a.Name},
+			{Name: "mondoo:dependency:type", Value: d.Type},
+		}
+		if d.Arn != "" {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:arn", Value: d.Arn})
+		}
+		if d.Runtime != "" {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:runtime", Value: d.Runtime})
+		}
+		if d.ImageUri != "" {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:imageUri", Value: d.ImageUri})
+		}
+		if d.CodeHash != "" {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:codeSha256", Value: d.CodeHash})
+		}
+		for _, layer := range d.Layers {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:layer", Value: layer})
+		}
+		for k, v := range d.Labels {
+			dprops = append(dprops, cyclonedx.Property{Name: "mondoo:dependency:" + k, Value: v})
+		}
+		dc.Properties = &dprops
+		nested = append(nested, dc)
+	}
+
+	if len(nested) > 0 {
+		c.Components = &nested
+	}
+
+	c.Properties = &props
+	return c
+}
+
+func guardrailToComponent(g *Guardrail) cyclonedx.Component {
+	c := cyclonedx.Component{
+		BOMRef:  uuid.New().String(),
+		Type:    cyclonedx.ComponentTypeApplication,
+		Name:    g.Name,
+		Version: g.Version,
+	}
+	props := []cyclonedx.Property{
+		{Name: "mondoo:guardrail:provider", Value: g.Provider},
+		{Name: "mondoo:guardrail:status", Value: g.Status},
+	}
+	if g.Arn != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:guardrail:arn", Value: g.Arn})
+	}
+	for _, p := range g.Policies {
+		props = append(props, cyclonedx.Property{Name: "mondoo:guardrail:policy", Value: p})
+	}
+	c.Properties = &props
+	return c
+}
+
+func knowledgeBaseToComponent(kb *KnowledgeBase) cyclonedx.Component {
+	c := cyclonedx.Component{
+		BOMRef:      uuid.New().String(),
+		Type:        cyclonedx.ComponentTypeData,
+		Name:        kb.Name,
+		Description: kb.Description,
+	}
+	props := []cyclonedx.Property{
+		{Name: "mondoo:knowledgeBase:provider", Value: kb.Provider},
+		{Name: "mondoo:knowledgeBase:status", Value: kb.Status},
+	}
+	if kb.Arn != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:knowledgeBase:arn", Value: kb.Arn})
+	}
+	if kb.EmbeddingModel != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:knowledgeBase:embeddingModel", Value: kb.EmbeddingModel})
+	}
+	if kb.StorageType != "" {
+		props = append(props, cyclonedx.Property{Name: "mondoo:knowledgeBase:storageType", Value: kb.StorageType})
+	}
+	for _, ds := range kb.DataSources {
+		props = append(props, cyclonedx.Property{Name: "mondoo:knowledgeBase:dataSource", Value: ds})
+	}
+	c.Properties = &props
+	return c
+}

--- a/internal/aibom/generator/generator.go
+++ b/internal/aibom/generator/generator.go
@@ -1,0 +1,1687 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/v13"
+	"go.mondoo.com/cnspec/v13/internal/aibom"
+	cr "go.mondoo.com/mql/v13/cli/reporter"
+	"go.mondoo.com/mql/v13/utils/sortx"
+)
+
+// GenerateAiBom generates an AI Bill of Materials from a cnspec report.
+func GenerateAiBom(r *cr.Report) []*aibom.AiBom {
+	if r == nil {
+		return nil
+	}
+
+	gen := &aibom.Generator{
+		Vendor:  "Mondoo, Inc.",
+		Name:    "cnspec",
+		Version: cnspec.Version,
+		Url:     "https://mondoo.com",
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	boms := []*aibom.AiBom{}
+	for assetMrn, asset := range r.Assets {
+		bom := &aibom.AiBom{
+			Generator: gen,
+			Timestamp: now,
+			Status:    aibom.Status_STATUS_SUCCEEDED,
+			Asset: &aibom.Asset{
+				Name: asset.GetName(),
+			},
+		}
+
+		dataPoints := r.Data[assetMrn]
+		if dataPoints == nil {
+			bom.Status = aibom.Status_STATUS_FAILED
+			bom.Errors = append(bom.Errors, "no data points found")
+			boms = append(boms, bom)
+			continue
+		}
+
+		// Collected sub-collections for downstream helpers (parsed once)
+		var allNpm, allPython []SoftwarePackage
+		var allLambdas []AWSLambdaFunction
+		var allGCPFunctions []GCPCloudFunction
+		var allGCPRunServices []GCPCloudRunService
+		var allAzureFuncApps []AzureFunctionApp
+		var allGCPIAMBindings []GCPIAMBinding
+
+		keys := sortx.Keys(dataPoints.Values)
+		for _, k := range keys {
+			dataValue := dataPoints.Values[k]
+			jsondata, err := cr.JsonValue(dataValue.Content)
+			if err != nil {
+				bom.Status = aibom.Status_STATUS_PARTIALLY_SUCCEEDED
+				bom.Errors = append(bom.Errors, errors.Wrap(err, "failed to parse json data").Error())
+				continue
+			}
+
+			fields := AiBomFields{}
+			err = json.Unmarshal(jsondata, &fields)
+			if err != nil {
+				bom.Status = aibom.Status_STATUS_PARTIALLY_SUCCEEDED
+				bom.Errors = append(bom.Errors, errors.Wrap(err, "failed to parse aibom fields").Error())
+				continue
+			}
+
+			// Collect sub-collections for downstream processing
+			allNpm = append(allNpm, fields.NpmPackages...)
+			allPython = append(allPython, fields.PythonPackages...)
+			allLambdas = append(allLambdas, fields.LambdaFunctions...)
+			allGCPFunctions = append(allGCPFunctions, fields.GCPCloudFunctions...)
+			allGCPRunServices = append(allGCPRunServices, fields.GCPCloudRunServices...)
+			allAzureFuncApps = append(allAzureFuncApps, fields.AzureFunctionApps...)
+			allGCPIAMBindings = append(allGCPIAMBindings, fields.GCPIAMBindings...)
+
+			if fields.Asset != nil {
+				bom.Asset.Name = fields.Asset.Name
+				bom.Asset.PlatformIds = fields.Asset.IDs
+				bom.Asset.Platform = &aibom.Platform{
+					Name:    fields.Asset.Platform,
+					Version: fields.Asset.Version,
+					Arch:    fields.Asset.Arch,
+					Family:  fields.Asset.Family,
+				}
+			}
+
+			// Process locally cached AI models (filesystem detection)
+			for _, m := range fields.LocalModels {
+				bom.Models = append(bom.Models, localModelToComponent(m))
+			}
+
+			// Process Ollama models
+			for _, m := range fields.OllamaModels {
+				bom.Models = append(bom.Models, ollamaToModelComponent(m))
+			}
+
+			// Process HuggingFace models
+			for _, m := range fields.HuggingFaceModels {
+				bom.Models = append(bom.Models, huggingfaceToModelComponent(m))
+			}
+
+			// Process AWS Bedrock foundation models
+			for _, m := range fields.BedrockFoundationModels {
+				bom.Models = append(bom.Models, bedrockFoundationToModelComponent(m))
+			}
+
+			// Process AWS Bedrock custom models
+			for _, m := range fields.BedrockCustomModels {
+				bom.Models = append(bom.Models, bedrockCustomToModelComponent(m))
+			}
+
+			// Process AWS SageMaker models
+			for _, m := range fields.SageMakerModels {
+				bom.Models = append(bom.Models, sagemakerToModelComponent(m))
+			}
+
+			// Process GCP Vertex AI models
+			for _, m := range fields.VertexAIModels {
+				bom.Models = append(bom.Models, vertexaiToModelComponent(m))
+			}
+
+			// Process Azure Cognitive Services accounts
+			for _, m := range fields.AzureCognitiveAccounts {
+				if m.Kind == "OpenAI" {
+					bom.Models = append(bom.Models, azureOpenAIToModelComponent(m))
+				}
+			}
+
+			// Process vLLM models and server
+			if fields.VLLM != nil {
+				if len(fields.VLLM.Models) > 0 {
+					for _, m := range fields.VLLM.Models {
+						bom.Models = append(bom.Models, vllmModelToComponent(m, fields.VLLM.Server))
+					}
+				} else {
+					bom.Models = append(bom.Models, vllmToModelComponent(fields.VLLM))
+				}
+			}
+
+			// Process Claude API models
+			for _, m := range fields.ClaudeModels {
+				bom.Models = append(bom.Models, claudeModelToComponent(m))
+			}
+
+			// Process Claude managed agents (skills are org-level, attach to first agent only)
+			for i, a := range fields.ClaudeAgents {
+				var skills []ClaudeSkill
+				if i == 0 {
+					skills = fields.ClaudeSkills
+				}
+				bom.Agents = append(bom.Agents, claudeAgentToComponent(a, skills))
+			}
+
+			// Process Claude memory stores as knowledge bases
+			for _, ms := range fields.ClaudeMemoryStores {
+				bom.KnowledgeBases = append(bom.KnowledgeBases, claudeMemoryStoreToKB(ms))
+			}
+
+			// Process OpenAI API models
+			for _, m := range fields.OpenAIModels {
+				bom.Models = append(bom.Models, openaiModelToComponent(m, fields.OpenAIFineTuningJobs))
+			}
+
+			// Process OpenAI vector stores as knowledge bases
+			for _, vs := range fields.OpenAIVectorStores {
+				bom.KnowledgeBases = append(bom.KnowledgeBases, openaiVectorStoreToKB(vs))
+			}
+
+			// Process AWS Bedrock guardrails
+			for _, g := range fields.BedrockGuardrails {
+				bom.Guardrails = append(bom.Guardrails, bedrockGuardrailToComponent(g))
+			}
+
+			// Process AWS Bedrock agents
+			for _, a := range fields.BedrockAgents {
+				bom.Agents = append(bom.Agents, bedrockAgentToComponent(a))
+			}
+
+			// Process AWS Bedrock knowledge bases
+			for _, kb := range fields.BedrockKnowledgeBases {
+				bom.KnowledgeBases = append(bom.KnowledgeBases, bedrockKBToComponent(kb))
+			}
+
+			// Process AWS Bedrock flows as agents (workflow orchestration)
+			for _, f := range fields.BedrockFlows {
+				bom.Agents = append(bom.Agents, bedrockFlowToComponent(f))
+			}
+
+			// Process GCP Model Armor as guardrails
+			for _, t := range fields.ModelArmorTemplates {
+				bom.Guardrails = append(bom.Guardrails, modelArmorToGuardrail(t))
+			}
+			if fields.ModelArmorFloorSetting != nil && fields.ModelArmorFloorSetting.Name != "" {
+				bom.Guardrails = append(bom.Guardrails, modelArmorFloorToGuardrail(fields.ModelArmorFloorSetting))
+			}
+
+			// Process GCP Cloud Functions as scannable dependencies
+			for _, fn := range fields.GCPCloudFunctions {
+				bom.Agents = append(bom.Agents, gcpCloudFuncToComponent(fn))
+			}
+
+			// Process local coding agents
+			agentMap := map[string]*CodingAgent{
+				"claude.code":      fields.ClaudeCode,
+				"openai.codex":     fields.OpenAICodex,
+				"cursor":           fields.Cursor,
+				"github.copilot":   fields.GithubCopilot,
+				"windsurf":         fields.Windsurf,
+				"gemini":           fields.Gemini,
+				"goose":            fields.Goose,
+				"zed":              fields.Zed,
+				"roo":              fields.Roo,
+				"cline":            fields.Cline,
+				"kiro":             fields.Kiro,
+				"trae":             fields.Trae,
+				"junie":            fields.Junie,
+				"augment":          fields.Augment,
+				"kilocode":         fields.Kilocode,
+				"continuedev":      fields.Continuedev,
+				"mistral.vibe":     fields.MistralVibe,
+				"antigravity":      fields.Antigravity,
+				"ibm.bob":          fields.IbmBob,
+				"openclaw":         fields.OpenClaw,
+				"snowflake.cortex": fields.SnowflakeCortex,
+				"warp":             fields.Warp,
+				"openhands":        fields.OpenHands,
+				"opencode":         fields.OpenCode,
+				"pi":               fields.Pi,
+				"qwen.code":        fields.QwenCode,
+			}
+			for _, name := range sortx.Keys(agentMap) {
+				agent := agentMap[name]
+				if agent != nil && agent.ConfigPath != "" {
+					bom.Agents = append(bom.Agents, codingAgentToComponent(name, agent))
+				}
+			}
+		}
+
+		// Classify AI dependencies from discovered software packages
+		bom.AIDependencies = classifyAIDependencies(allNpm, allPython)
+
+		// Detect compute services with AI access
+		detectComputeAIAccess(bom, allLambdas, allGCPFunctions, allGCPRunServices, allAzureFuncApps, allGCPIAMBindings)
+
+		// Correlate MCP server packages with discovered npm/python packages
+		correlateAgentPackages(bom.Agents, allNpm, allPython)
+
+		// Enrich Bedrock agent dependencies with Lambda function metadata
+		enrichAgentLambdas(bom.Agents, allLambdas)
+
+		bom.Completeness = ComputeCompleteness(bom.Models)
+		boms = append(boms, bom)
+	}
+	return boms
+}
+
+func correlateAgentPackages(agents []*aibom.AgentComponent, npmPkgs, pythonPkgs []SoftwarePackage) {
+	npmIdx := map[string]*SoftwarePackage{}
+	pyIdx := map[string]*SoftwarePackage{}
+	for i := range npmPkgs {
+		npmIdx[npmPkgs[i].Name] = &npmPkgs[i]
+	}
+	for i := range pythonPkgs {
+		pyIdx[pythonPkgs[i].Name] = &pythonPkgs[i]
+	}
+
+	if len(npmIdx) == 0 && len(pyIdx) == 0 {
+		return
+	}
+
+	for _, agent := range agents {
+		for _, mcp := range agent.McpServers {
+			pkgName := mcpPackageName(mcp)
+			if pkgName == "" {
+				continue
+			}
+
+			if p, ok := npmIdx[pkgName]; ok {
+				mcp.Packages = append(mcp.Packages, &aibom.PackageRef{
+					Name:    p.Name,
+					Version: p.Version,
+					Purl:    p.Purl,
+					Cpes:    p.Cpes,
+				})
+			}
+			if p, ok := pyIdx[pkgName]; ok {
+				mcp.Packages = append(mcp.Packages, &aibom.PackageRef{
+					Name:    p.Name,
+					Version: p.Version,
+					Purl:    p.Purl,
+					Cpes:    p.Cpes,
+				})
+			}
+		}
+	}
+}
+
+// aiPackageRegistry maps known AI/ML package names to their category.
+var aiPackageRegistry = map[string]string{
+	// Python - Model frameworks
+	"transformers":          "model-framework",
+	"torch":                 "model-framework",
+	"torchvision":           "model-framework",
+	"torchaudio":            "model-framework",
+	"tensorflow":            "model-framework",
+	"tensorflow-gpu":        "model-framework",
+	"keras":                 "model-framework",
+	"onnxruntime":           "model-framework",
+	"onnxruntime-gpu":       "model-framework",
+	"diffusers":             "model-framework",
+	"sentence-transformers": "model-framework",
+	"accelerate":            "model-framework",
+	"safetensors":           "model-framework",
+	"optimum":               "model-framework",
+	"peft":                  "model-framework",
+	"trl":                   "model-framework",
+	"jax":                   "model-framework",
+	"flax":                  "model-framework",
+	// Python - API clients
+	"openai":              "api-client",
+	"anthropic":           "api-client",
+	"google-generativeai": "api-client",
+	"cohere":              "api-client",
+	"mistralai":           "api-client",
+	"replicate":           "api-client",
+	"together":            "api-client",
+	"groq":                "api-client",
+	"fireworks-ai":        "api-client",
+	"voyageai":            "api-client",
+	// Python - Agent frameworks
+	"langchain":           "agent-framework",
+	"langchain-core":      "agent-framework",
+	"langchain-community": "agent-framework",
+	"langchain-openai":    "agent-framework",
+	"langchain-anthropic": "agent-framework",
+	"langgraph":           "agent-framework",
+	"crewai":              "agent-framework",
+	"autogen":             "agent-framework",
+	"pyautogen":           "agent-framework",
+	"phidata":             "agent-framework",
+	"smolagents":          "agent-framework",
+	"llama-index":         "agent-framework",
+	"llama-index-core":    "agent-framework",
+	"dspy-ai":             "agent-framework",
+	"semantic-kernel":     "agent-framework",
+	"haystack-ai":         "agent-framework",
+	// Python - Vector databases
+	"chromadb":        "vector-db",
+	"pinecone-client": "vector-db",
+	"weaviate-client": "vector-db",
+	"qdrant-client":   "vector-db",
+	"pymilvus":        "vector-db",
+	"pgvector":        "vector-db",
+	"lancedb":         "vector-db",
+	// Python - ML tools
+	"mlflow":          "ml-tool",
+	"wandb":           "ml-tool",
+	"huggingface-hub": "ml-tool",
+	"datasets":        "ml-tool",
+	"vllm":            "ml-tool",
+	"bentoml":         "ml-tool",
+	"ray":             "ml-tool",
+	"unsloth":         "ml-tool",
+	// npm - AI SDKs (langchain, openai, chromadb shared with Python above)
+	"@anthropic-ai/sdk":           "api-client",
+	"@google/generative-ai":       "api-client",
+	"@mistralai/mistralai":        "api-client",
+	"@langchain/core":             "agent-framework",
+	"@langchain/openai":           "agent-framework",
+	"@langchain/anthropic":        "agent-framework",
+	"@langchain/community":        "agent-framework",
+	"ai":                          "api-client",
+	"@ai-sdk/openai":              "api-client",
+	"@ai-sdk/anthropic":           "api-client",
+	"@ai-sdk/google":              "api-client",
+	"llamaindex":                  "agent-framework",
+	"@pinecone-database/pinecone": "vector-db",
+	"@qdrant/js-client-rest":      "vector-db",
+}
+
+func classifyAIDependencies(npmPkgs, pythonPkgs []SoftwarePackage) []*aibom.AIDependency {
+	var deps []*aibom.AIDependency
+	seen := map[string]bool{}
+
+	for _, pkg := range pythonPkgs {
+		cat, ok := aiPackageRegistry[strings.ToLower(pkg.Name)]
+		if !ok {
+			continue
+		}
+		key := "python:" + strings.ToLower(pkg.Name)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deps = append(deps, &aibom.AIDependency{
+			Name:     pkg.Name,
+			Version:  pkg.Version,
+			Category: cat,
+			Purl:     pkg.Purl,
+			Language: "python",
+		})
+	}
+
+	for _, pkg := range npmPkgs {
+		cat, ok := aiPackageRegistry[strings.ToLower(pkg.Name)]
+		if !ok {
+			continue
+		}
+		key := "npm:" + strings.ToLower(pkg.Name)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deps = append(deps, &aibom.AIDependency{
+			Name:     pkg.Name,
+			Version:  pkg.Version,
+			Category: cat,
+			Purl:     pkg.Purl,
+			Language: "javascript",
+		})
+	}
+
+	return deps
+}
+
+// AI service action prefixes to detect in IAM policies.
+var aiActionPrefixes = []string{
+	"bedrock:", "sagemaker:", "comprehend:", "rekognition:",
+	"textract:", "translate:", "polly:", "transcribe:", "lex:",
+}
+
+// Environment variable keys that hint at AI service usage.
+var aiEnvKeywords = []string{
+	"BEDROCK", "SAGEMAKER", "OPENAI", "ANTHROPIC", "VERTEX",
+	"AI_MODEL", "MODEL_ID", "LLM", "GEMINI", "CLAUDE",
+	"HUGGINGFACE", "INFERENCE", "EMBEDDING",
+}
+
+func detectComputeAIAccess(bom *aibom.AiBom, lambdas []AWSLambdaFunction, gcpFuncs []GCPCloudFunction, gcpRun []GCPCloudRunService, azureFuncs []AzureFunctionApp, gcpBindings []GCPIAMBinding) {
+	// Build GCP IAM AI-role index: service account email → roles
+	gcpAIRoles := map[string][]string{}
+	for _, binding := range gcpBindings {
+		for _, member := range binding.Members {
+			gcpAIRoles[member] = append(gcpAIRoles[member], binding.Role)
+		}
+	}
+
+	for _, fn := range lambdas {
+		ca := detectLambdaAIAccess(fn)
+		if ca != nil {
+			bom.ComputeAccess = append(bom.ComputeAccess, ca)
+		}
+	}
+	for _, fn := range gcpFuncs {
+		ca := detectCloudFuncAIAccess(fn, gcpAIRoles)
+		if ca != nil {
+			bom.ComputeAccess = append(bom.ComputeAccess, ca)
+		}
+	}
+	for _, svc := range gcpRun {
+		ca := detectCloudRunAIAccess(svc, gcpAIRoles)
+		if ca != nil {
+			bom.ComputeAccess = append(bom.ComputeAccess, ca)
+		}
+	}
+	for _, app := range azureFuncs {
+		ca := detectAzureFuncAIAccess(app)
+		if ca != nil {
+			bom.ComputeAccess = append(bom.ComputeAccess, ca)
+		}
+	}
+}
+
+func detectLambdaAIAccess(fn AWSLambdaFunction) *aibom.ComputeAIAccess {
+	aiActions := extractAIActionsFromRole(fn.Role)
+	envHints := extractAIEnvHints(fn.Environment)
+
+	if len(aiActions) == 0 && len(envHints) == 0 {
+		return nil
+	}
+
+	services := map[string]bool{}
+	for _, action := range aiActions {
+		svc := strings.SplitN(action, ":", 2)[0]
+		services[svc] = true
+	}
+
+	ca := &aibom.ComputeAIAccess{
+		Name:      fn.Name,
+		Type:      "lambda",
+		Provider:  "aws",
+		Arn:       fn.Arn,
+		Runtime:   fn.Runtime,
+		CodeHash:  fn.CodeSha256,
+		AIActions: aiActions,
+		EnvHints:  envHints,
+		Labels: map[string]string{
+			"handler":      fn.Handler,
+			"package_type": fn.PackageType,
+		},
+	}
+	if fn.ImageUri != "" {
+		ca.ImageUri = fn.ImageUri
+	} else if fn.ResolvedImageUri != "" {
+		ca.ImageUri = fn.ResolvedImageUri
+	}
+	if fn.Role != nil {
+		ca.ServiceAccount = fn.Role.Arn
+	}
+	for svc := range services {
+		ca.AIServices = append(ca.AIServices, svc)
+	}
+	sort.Strings(ca.AIServices)
+	return ca
+}
+
+func detectCloudFuncAIAccess(fn GCPCloudFunction, aiRoles map[string][]string) *aibom.ComputeAIAccess {
+	sa := ""
+	if fn.ServiceConfig != nil {
+		sa = fn.ServiceConfig.ServiceAccountEmail
+	}
+
+	// Check if the service account has AI-related IAM roles
+	saKey := "serviceAccount:" + sa
+	roles := aiRoles[saKey]
+
+	// Check environment variables for AI hints
+	envHints := map[string]string{}
+	if fn.ServiceConfig != nil {
+		envHints = extractAIEnvHints(fn.ServiceConfig.EnvironmentVariables)
+	}
+
+	if len(roles) == 0 && len(envHints) == 0 {
+		return nil
+	}
+
+	ca := &aibom.ComputeAIAccess{
+		Name:           fn.Name,
+		Type:           "cloud-function",
+		Provider:       "gcp",
+		ServiceAccount: sa,
+		AIServices:     roles,
+		EnvHints:       envHints,
+		Labels: map[string]string{
+			"state":       fn.State,
+			"environment": fn.Environment,
+		},
+	}
+	if fn.BuildConfig != nil {
+		ca.Runtime = fn.BuildConfig.Runtime
+		if fn.BuildConfig.DockerRepository != "" {
+			ca.ImageUri = fn.BuildConfig.DockerRepository
+		}
+	}
+	if fn.URL != "" {
+		ca.Labels["url"] = fn.URL
+	}
+	return ca
+}
+
+func detectCloudRunAIAccess(svc GCPCloudRunService, aiRoles map[string][]string) *aibom.ComputeAIAccess {
+	sa := ""
+	if svc.Template != nil {
+		sa = svc.Template.ServiceAccountEmail
+	}
+
+	saKey := "serviceAccount:" + sa
+	roles := aiRoles[saKey]
+
+	// Check container env vars for AI hints
+	envHints := map[string]string{}
+	if svc.Template != nil {
+		for _, c := range svc.Template.Containers {
+			maps.Copy(envHints, extractAIEnvHints(c.Env))
+		}
+	}
+
+	if len(roles) == 0 && len(envHints) == 0 {
+		return nil
+	}
+
+	ca := &aibom.ComputeAIAccess{
+		Name:           svc.Name,
+		Type:           "cloud-run",
+		Provider:       "gcp",
+		ServiceAccount: sa,
+		AIServices:     roles,
+		EnvHints:       envHints,
+		Labels:         map[string]string{},
+	}
+	if svc.URI != "" {
+		ca.Labels["url"] = svc.URI
+	}
+	if svc.Template != nil {
+		for _, c := range svc.Template.Containers {
+			if c.Image != "" {
+				ca.ImageUri = c.Image
+				break
+			}
+		}
+	}
+	return ca
+}
+
+func detectAzureFuncAIAccess(app AzureFunctionApp) *aibom.ComputeAIAccess {
+	envHints := map[string]string{}
+	for _, s := range app.AppSettings {
+		for _, kw := range aiEnvKeywords {
+			if strings.Contains(strings.ToUpper(s.Name), kw) {
+				envHints[s.Name] = "(configured)"
+				break
+			}
+		}
+	}
+
+	if len(envHints) == 0 && app.ManagedServiceIdentityID == "" {
+		return nil
+	}
+
+	ca := &aibom.ComputeAIAccess{
+		Name:     app.Name,
+		Type:     "function-app",
+		Provider: "azure",
+		Arn:      app.ID,
+		EnvHints: envHints,
+		Labels: map[string]string{
+			"location": app.Location,
+		},
+	}
+	if app.ManagedServiceIdentityID != "" {
+		ca.ServiceAccount = app.ManagedServiceIdentityID
+	}
+	return ca
+}
+
+func extractAIActionsFromRole(role *AWSIAMRole) []string {
+	if role == nil {
+		return nil
+	}
+	var aiActions []string
+	for _, policy := range role.AttachedPolicies {
+		if policy.DefaultVersion == nil || policy.DefaultVersion.Document == nil {
+			continue
+		}
+		actions := extractActionsFromPolicyDoc(policy.DefaultVersion.Document)
+		for _, action := range actions {
+			for _, prefix := range aiActionPrefixes {
+				if strings.HasPrefix(strings.ToLower(action), prefix) {
+					aiActions = append(aiActions, action)
+					break
+				}
+			}
+		}
+	}
+	return deduplicate(aiActions)
+}
+
+func extractActionsFromPolicyDoc(doc map[string]any) []string {
+	var actions []string
+	stmts, ok := doc["Statement"]
+	if !ok {
+		return nil
+	}
+	stmtList, ok := stmts.([]any)
+	if !ok {
+		return nil
+	}
+	for _, s := range stmtList {
+		stmt, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		effect, _ := stmt["Effect"].(string)
+		if strings.ToLower(effect) != "allow" {
+			continue
+		}
+		switch a := stmt["Action"].(type) {
+		case string:
+			actions = append(actions, a)
+		case []any:
+			for _, v := range a {
+				if s, ok := v.(string); ok {
+					actions = append(actions, s)
+				}
+			}
+		}
+	}
+	return actions
+}
+
+func extractAIEnvHints(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	hints := map[string]string{}
+	for k := range env {
+		for _, kw := range aiEnvKeywords {
+			if strings.Contains(strings.ToUpper(k), kw) {
+				hints[k] = "(configured)"
+				break
+			}
+		}
+	}
+	if len(hints) == 0 {
+		return nil
+	}
+	return hints
+}
+
+func enrichAgentLambdas(agents []*aibom.AgentComponent, lambdas []AWSLambdaFunction) {
+	lambdaIdx := map[string]*AWSLambdaFunction{}
+	for i := range lambdas {
+		lambdaIdx[lambdas[i].Arn] = &lambdas[i]
+	}
+
+	if len(lambdaIdx) == 0 {
+		return
+	}
+
+	for _, agent := range agents {
+		if agent.Provider != "aws-bedrock" {
+			continue
+		}
+		for _, dep := range agent.Dependencies {
+			if dep.Type != "action-group" || dep.Arn == "" {
+				continue
+			}
+			fn, ok := lambdaIdx[dep.Arn]
+			if !ok {
+				continue
+			}
+			dep.Runtime = fn.Runtime
+			dep.CodeHash = fn.CodeSha256
+			if fn.ImageUri != "" {
+				dep.ImageUri = fn.ImageUri
+			} else if fn.ResolvedImageUri != "" {
+				dep.ImageUri = fn.ResolvedImageUri
+			}
+			for _, layer := range fn.Layers {
+				dep.Layers = append(dep.Layers, layer.Arn)
+			}
+			dep.Labels = map[string]string{
+				"handler":      fn.Handler,
+				"package_type": fn.PackageType,
+				"code_size":    fmt.Sprintf("%d", fn.CodeSize),
+			}
+		}
+	}
+}
+
+func mcpPackageName(mcp *aibom.McpServer) string {
+	if mcp.Command == "" {
+		return ""
+	}
+	args := mcp.Args
+	switch mcp.Command {
+	case "npx", "bunx":
+		if len(args) > 0 {
+			pkg := args[0]
+			if pkg == "-y" && len(args) > 1 {
+				pkg = args[1]
+			}
+			return pkg
+		}
+	case "uvx", "pipx":
+		if len(args) > 0 {
+			return args[0]
+		}
+	case "node":
+		if len(args) > 0 {
+			return args[0]
+		}
+	case "python", "python3":
+		for i, a := range args {
+			if a == "-m" && i+1 < len(args) {
+				return args[i+1]
+			}
+		}
+	}
+	return ""
+}
+
+func localModelToComponent(m LocalAIModel) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:               m.Name,
+		Provider:           m.Source,
+		Author:             m.Vendor,
+		ArchitectureFamily: m.Family,
+		ModelArchitecture:  m.Architecture,
+		Format:             m.Format,
+		Version:            m.Version,
+		Quantization:       m.Quantization,
+		ParameterSize:      m.ParameterSize,
+		License:            m.License,
+		Description:        m.Description,
+		Tags:               m.Tags,
+		Labels:             map[string]string{},
+		Provenance: map[string]string{
+			"detection_source": "ai.models",
+		},
+	}
+
+	if m.Path != "" {
+		mc.SourceUrl = "file://" + m.Path
+		mc.Provenance["local_path"] = m.Path
+	}
+	if m.Size > 0 {
+		mc.Labels["size_bytes"] = fmt.Sprintf("%d", m.Size)
+	}
+	if m.ModifiedAt != "" {
+		mc.UpdatedAt = m.ModifiedAt
+	}
+
+	mc.Purl = localModelPurl(m)
+
+	return mc
+}
+
+func localModelPurl(m LocalAIModel) string {
+	name := m.Name
+	vendor := m.Vendor
+	version := m.Version
+
+	switch m.Source {
+	case "ollama":
+		if vendor != "" {
+			return fmt.Sprintf("pkg:ollama/%s/%s@%s", vendor, name, version)
+		}
+		return fmt.Sprintf("pkg:ollama/%s@%s", name, version)
+	case "huggingface":
+		return fmt.Sprintf("pkg:huggingface/%s/%s@%s", vendor, name, version)
+	default:
+		source := m.Source
+		if source == "" {
+			source = "generic"
+		}
+		if vendor != "" {
+			return fmt.Sprintf("pkg:generic/%s/%s/%s@%s", source, vendor, name, version)
+		}
+		return fmt.Sprintf("pkg:generic/%s/%s@%s", source, name, version)
+	}
+}
+
+func ollamaToModelComponent(m OllamaModel) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:               m.Name,
+		Provider:           "ollama",
+		ModelId:            m.Model,
+		ArchitectureFamily: m.Family,
+		Format:             m.Format,
+		ParameterSize:      m.ParameterSize,
+		Quantization:       m.QuantizationLevel,
+		Capabilities:       m.Capabilities,
+		UpdatedAt:          m.ModifiedAt,
+		Labels:             map[string]string{},
+		Provenance:         map[string]string{},
+	}
+
+	// Extract version from name (after colon)
+	if parts := strings.SplitN(m.Name, ":", 2); len(parts) == 2 {
+		mc.Version = parts[1]
+	}
+
+	// Use digest as version fallback
+	if mc.Version == "" && m.Digest != "" {
+		mc.Version = m.Digest[:12]
+	}
+
+	// Enrich from info block
+	if m.Info.Architecture != "" {
+		mc.ModelArchitecture = m.Info.Architecture
+	}
+	if m.Info.Author != "" {
+		mc.Author = m.Info.Author
+	}
+	if m.Info.Description != "" {
+		mc.Description = m.Info.Description
+	}
+	if m.Info.License != "" {
+		mc.License = m.Info.License
+	} else if m.License != "" {
+		mc.License = m.License
+	}
+	if len(m.Info.Datasets) > 0 {
+		mc.TrainingDatasets = m.Info.Datasets
+	}
+	if len(m.Info.Tags) > 0 {
+		mc.Tags = m.Info.Tags
+	}
+	if len(m.Info.Languages) > 0 {
+		mc.Labels["languages"] = strings.Join(m.Info.Languages, ",")
+	}
+	if m.Info.ParameterCount > 0 {
+		mc.Provenance["parameter_count"] = fmt.Sprintf("%d", m.Info.ParameterCount)
+	}
+	if m.Info.ContextLength > 0 {
+		mc.Provenance["context_length"] = fmt.Sprintf("%d", m.Info.ContextLength)
+	}
+
+	// Generate PURL
+	vendor := m.Info.Author
+	name := m.Name
+	if parts := strings.SplitN(m.Name, ":", 2); len(parts) == 2 {
+		name = parts[0]
+	}
+	if vendor != "" {
+		mc.Purl = fmt.Sprintf("pkg:ollama/%s/%s@%s", vendor, name, mc.Version)
+	} else {
+		mc.Purl = fmt.Sprintf("pkg:ollama/%s@%s", name, mc.Version)
+	}
+
+	return mc
+}
+
+func huggingfaceToModelComponent(m HuggingFaceModel) *aibom.ModelComponent {
+	// Split ID into group (author) and short name
+	shortName := m.ID
+	author := m.Author
+	if parts := strings.SplitN(m.ID, "/", 2); len(parts) == 2 {
+		if author == "" {
+			author = parts[0]
+		}
+		shortName = parts[1]
+	}
+
+	mc := &aibom.ModelComponent{
+		Name:     shortName,
+		Provider: "huggingface",
+		ModelId:  m.ModelID,
+		Author:   author,
+		License:  m.License,
+		Task:     m.PipelineTag,
+		Tags:     m.Tags,
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"library":   m.LibraryName,
+			"full_name": m.ID,
+		},
+	}
+
+	if m.SHA != "" && len(m.SHA) >= 8 {
+		mc.Version = m.SHA[:8]
+		mc.Provenance["sha"] = m.SHA
+	}
+	if m.CreatedAt != "" {
+		mc.CreatedAt = m.CreatedAt
+	}
+	if m.LastModified != "" {
+		mc.UpdatedAt = m.LastModified
+	}
+
+	// Extract architecture from config
+	if m.Config != nil {
+		if archs, ok := m.Config["architectures"]; ok {
+			if archList, ok := archs.([]any); ok && len(archList) > 0 {
+				mc.ModelArchitecture = fmt.Sprintf("%v", archList[0])
+			}
+		}
+		if modelType, ok := m.Config["model_type"]; ok {
+			mc.ArchitectureFamily = fmt.Sprintf("%v", modelType)
+		}
+		if vocabSize, ok := m.Config["vocab_size"]; ok {
+			mc.Labels["vocab_size"] = fmt.Sprintf("%v", vocabSize)
+		}
+		if tokenizerClass, ok := m.Config["tokenizer_class"]; ok {
+			mc.Labels["tokenizer_class"] = fmt.Sprintf("%v", tokenizerClass)
+		}
+	}
+
+	// Derive input/output modalities from pipeline tag
+	mc.InputModalities, mc.OutputModalities = pipelineTagToModalities(m.PipelineTag)
+
+	// Extract metadata from cardData
+	if m.CardData != nil {
+		if datasets, ok := m.CardData["datasets"]; ok {
+			if dsList, ok := datasets.([]any); ok {
+				for _, ds := range dsList {
+					mc.TrainingDatasets = append(mc.TrainingDatasets, fmt.Sprintf("%v", ds))
+				}
+			}
+		}
+		// Extract datasets from model-index (used by many HuggingFace models)
+		if len(mc.TrainingDatasets) == 0 {
+			if modelIndex, ok := m.CardData["model-index"]; ok {
+				if miList, ok := modelIndex.([]any); ok {
+					seen := map[string]bool{}
+					for _, mi := range miList {
+						miMap, ok := mi.(map[string]any)
+						if !ok {
+							continue
+						}
+						results, ok := miMap["results"].([]any)
+						if !ok {
+							continue
+						}
+						for _, result := range results {
+							rMap, ok := result.(map[string]any)
+							if !ok {
+								continue
+							}
+							ds, ok := rMap["dataset"].(map[string]any)
+							if !ok {
+								continue
+							}
+							dsType := fmt.Sprintf("%v", ds["type"])
+							if dsType != "" && !seen[dsType] {
+								mc.TrainingDatasets = append(mc.TrainingDatasets, dsType)
+								seen[dsType] = true
+							}
+						}
+					}
+				}
+			}
+		}
+		if baseModel, ok := m.CardData["base_model"]; ok {
+			mc.Provenance["base_model"] = fmt.Sprintf("%v", baseModel)
+		}
+	}
+
+	// Extract arxiv paper references from tags
+	for _, tag := range m.Tags {
+		if arxivID, ok := strings.CutPrefix(tag, "arxiv:"); ok {
+			mc.Provenance["arxiv"] = arxivID
+		}
+	}
+
+	// Generate PURL with namespace
+	if mc.Author != "" {
+		mc.Purl = fmt.Sprintf("pkg:huggingface/%s/%s@%s", mc.Author, shortName, mc.Version)
+	} else {
+		mc.Purl = fmt.Sprintf("pkg:huggingface/%s@%s", m.ID, mc.Version)
+	}
+	mc.SourceUrl = fmt.Sprintf("https://huggingface.co/%s", m.ID)
+
+	return mc
+}
+
+func pipelineTagToModalities(tag string) (inputs []string, outputs []string) {
+	switch tag {
+	case "automatic-speech-recognition":
+		return []string{"audio"}, []string{"text"}
+	case "text-to-speech":
+		return []string{"text"}, []string{"audio"}
+	case "text-generation", "text2text-generation", "translation",
+		"summarization", "fill-mask", "question-answering", "text-classification",
+		"token-classification", "table-question-answering", "conversational":
+		return []string{"text"}, []string{"text"}
+	case "image-classification", "image-to-text", "visual-question-answering":
+		return []string{"image"}, []string{"text"}
+	case "text-to-image":
+		return []string{"text"}, []string{"image"}
+	case "image-to-image":
+		return []string{"image"}, []string{"image"}
+	case "text-to-video", "image-to-video":
+		return []string{"text"}, []string{"video"}
+	case "feature-extraction", "sentence-similarity":
+		return []string{"text"}, []string{"tensor"}
+	case "object-detection", "image-segmentation":
+		return []string{"image"}, []string{"tensor"}
+	case "audio-classification":
+		return []string{"audio"}, []string{"text"}
+	case "video-classification":
+		return []string{"video"}, []string{"text"}
+	default:
+		return nil, nil
+	}
+}
+
+func bedrockFoundationToModelComponent(m AWSBedrockFoundationModel) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:             m.ModelName,
+		Provider:         "aws-bedrock",
+		ModelId:          m.ModelID,
+		Author:           m.ProviderName,
+		InputModalities:  m.InputModalities,
+		OutputModalities: m.OutputModalities,
+		Purl:             fmt.Sprintf("pkg:aws-bedrock/%s/%s", m.ProviderName, m.ModelID),
+		Labels:           map[string]string{},
+		Provenance: map[string]string{
+			"provider_name": m.ProviderName,
+		},
+	}
+	if m.ModelLifecycleStatus != "" {
+		mc.Labels["lifecycle_status"] = m.ModelLifecycleStatus
+	}
+	if len(m.InferenceTypesSupported) > 0 {
+		mc.Labels["inference_types"] = strings.Join(m.InferenceTypesSupported, ",")
+	}
+	return mc
+}
+
+func bedrockCustomToModelComponent(m AWSBedrockCustomModel) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:     m.ModelName,
+		Provider: "aws-bedrock",
+		ModelId:  m.ModelArn,
+		Purl:     fmt.Sprintf("pkg:aws-bedrock/custom/%s", m.ModelName),
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"model_arn": m.ModelArn,
+		},
+	}
+	if m.BaseModel != nil {
+		mc.Provenance["base_model"] = m.BaseModel.ModelID
+		mc.Author = m.BaseModel.ProviderName
+	}
+	return mc
+}
+
+func sagemakerToModelComponent(m AWSSageMakerModel) *aibom.ModelComponent {
+	return &aibom.ModelComponent{
+		Name:     m.Name,
+		Provider: "aws-sagemaker",
+		ModelId:  m.Arn,
+		Purl:     fmt.Sprintf("pkg:aws-sagemaker/%s", m.Name),
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"arn": m.Arn,
+		},
+	}
+}
+
+func vertexaiToModelComponent(m GCPVertexAIModel) *aibom.ModelComponent {
+	return &aibom.ModelComponent{
+		Name:     m.DisplayName,
+		Provider: "gcp-vertexai",
+		ModelId:  m.Name,
+		Purl:     fmt.Sprintf("pkg:gcp-vertexai/%s", m.DisplayName),
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"resource_name": m.Name,
+		},
+	}
+}
+
+func azureOpenAIToModelComponent(m AzureCognitiveServicesAccount) *aibom.ModelComponent {
+	return &aibom.ModelComponent{
+		Name:     m.Name,
+		Provider: "azure-openai",
+		ModelId:  m.ID,
+		Labels: map[string]string{
+			"location":           m.Location,
+			"public_network":     m.PublicNetworkAccess,
+			"disable_local_auth": fmt.Sprintf("%t", m.DisableLocalAuth),
+		},
+		Provenance: map[string]string{
+			"endpoint":    m.Endpoint,
+			"resource_id": m.ID,
+		},
+		SourceUrl: m.Endpoint,
+	}
+}
+
+func vllmToModelComponent(v *VLLMData) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:     "vLLM Server",
+		Provider: "vllm",
+		Version:  v.Version,
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"runtime": "vllm",
+		},
+	}
+	if v.Server != nil {
+		mc.Purl = fmt.Sprintf("pkg:vllm/server@%s", v.Server.Version)
+		if v.Server.BaseUrl != "" {
+			mc.SourceUrl = v.Server.BaseUrl
+			mc.Labels["base_url"] = v.Server.BaseUrl
+		}
+		mc.Labels["tls"] = fmt.Sprintf("%t", v.Server.UsesTls)
+		mc.Labels["reachable"] = fmt.Sprintf("%t", v.Server.Reachable)
+		if v.Server.Version != "" {
+			mc.Version = v.Server.Version
+		}
+	}
+	return mc
+}
+
+func vllmModelToComponent(m VLLMModel, server *VLLMServer) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:     m.ID,
+		Provider: "vllm",
+		ModelId:  m.ID,
+		Author:   m.OwnedBy,
+		Labels:   map[string]string{},
+		Provenance: map[string]string{
+			"runtime": "vllm",
+		},
+	}
+
+	if m.Root != "" && m.Root != m.ID {
+		mc.SourceUrl = fmt.Sprintf("https://huggingface.co/%s", m.Root)
+		mc.Provenance["root"] = m.Root
+		mc.Purl = fmt.Sprintf("pkg:huggingface/%s", m.Root)
+	} else {
+		mc.Purl = fmt.Sprintf("pkg:vllm/%s", m.ID)
+	}
+
+	if m.Parent != "" {
+		mc.Provenance["parent"] = m.Parent
+		mc.ApproachType = "fine-tuned"
+	}
+
+	if m.MaxModelLen > 0 {
+		mc.Provenance["context_length"] = fmt.Sprintf("%d", m.MaxModelLen)
+	}
+
+	if m.Created != "" {
+		mc.CreatedAt = m.Created
+	}
+
+	if server != nil {
+		if server.BaseUrl != "" {
+			mc.Labels["base_url"] = server.BaseUrl
+		}
+		mc.Labels["tls"] = fmt.Sprintf("%t", server.UsesTls)
+	}
+
+	return mc
+}
+
+func claudeModelToComponent(m ClaudeModel) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:               m.DisplayName,
+		Provider:           "anthropic",
+		ModelId:            m.ID,
+		Author:             m.Vendor,
+		ArchitectureFamily: m.Family,
+		CreatedAt:          m.CreatedAt,
+		Labels:             map[string]string{},
+		Provenance:         map[string]string{},
+		Purl:               fmt.Sprintf("pkg:anthropic/%s", m.ID),
+	}
+
+	// Derive capabilities from supported features
+	if m.ImageInputSupported {
+		mc.InputModalities = append(mc.InputModalities, "image")
+	}
+	if m.PdfInputSupported {
+		mc.InputModalities = append(mc.InputModalities, "pdf")
+	}
+	mc.InputModalities = append(mc.InputModalities, "text")
+	mc.OutputModalities = append(mc.OutputModalities, "text")
+
+	var caps []string
+	if m.ThinkingSupported {
+		caps = append(caps, "extended-thinking")
+	}
+	if m.CodeExecutionSupported {
+		caps = append(caps, "code-execution")
+	}
+	if m.CitationsSupported {
+		caps = append(caps, "citations")
+	}
+	if m.StructuredOutputsSupported {
+		caps = append(caps, "structured-outputs")
+	}
+	if m.BatchSupported {
+		caps = append(caps, "batch")
+	}
+	mc.Capabilities = caps
+
+	if m.MaxInputTokens > 0 {
+		mc.Provenance["max_input_tokens"] = fmt.Sprintf("%d", m.MaxInputTokens)
+	}
+	if m.MaxTokens > 0 {
+		mc.Provenance["max_output_tokens"] = fmt.Sprintf("%d", m.MaxTokens)
+	}
+
+	return mc
+}
+
+func claudeAgentToComponent(a ClaudeAgent, skills []ClaudeSkill) *aibom.AgentComponent {
+	ac := &aibom.AgentComponent{
+		Name:     a.Name,
+		Provider: "anthropic",
+		Model:    a.Model,
+		Version:  fmt.Sprintf("%d", a.Version),
+		Labels: map[string]string{
+			"agent_id": a.ID,
+		},
+	}
+
+	if a.CreatedAt != "" {
+		ac.Labels["created_at"] = a.CreatedAt
+	}
+
+	// Attach skills discovered in the same scan
+	for _, s := range skills {
+		ac.Skills = append(ac.Skills, &aibom.AgentSkill{
+			Name:   s.DisplayTitle,
+			Source: s.Source,
+		})
+	}
+
+	return ac
+}
+
+func claudeMemoryStoreToKB(ms ClaudeMemoryStore) *aibom.KnowledgeBase {
+	return &aibom.KnowledgeBase{
+		Name:        ms.Name,
+		Provider:    "anthropic",
+		ID:          ms.ID,
+		Description: ms.Description,
+		StorageType: "memory-store",
+		Labels: map[string]string{
+			"created_at": ms.CreatedAt,
+		},
+	}
+}
+
+func openaiModelToComponent(m OpenAIModel, ftJobs []OpenAIFineTuningJob) *aibom.ModelComponent {
+	mc := &aibom.ModelComponent{
+		Name:       m.ID,
+		Provider:   "openai",
+		ModelId:    m.ID,
+		Author:     m.OwnedBy,
+		Labels:     map[string]string{},
+		Provenance: map[string]string{},
+		Purl:       fmt.Sprintf("pkg:openai/%s", m.ID),
+	}
+
+	if m.CreatedAt != "" {
+		mc.CreatedAt = m.CreatedAt
+	}
+
+	if m.IsFineTuned {
+		mc.ApproachType = "fine-tuned"
+		if m.BaseModel != "" {
+			mc.Provenance["base_model"] = m.BaseModel
+		}
+
+		// Enrich with fine-tuning job data if available
+		for _, job := range ftJobs {
+			if job.FineTunedModel == m.ID && job.Status == "succeeded" {
+				mc.Provenance["fine_tune_job"] = job.ID
+				mc.Provenance["fine_tune_base"] = job.Model
+				if job.TrainedTokens > 0 {
+					mc.Provenance["trained_tokens"] = fmt.Sprintf("%d", job.TrainedTokens)
+				}
+				break
+			}
+		}
+	}
+
+	return mc
+}
+
+func openaiVectorStoreToKB(vs OpenAIVectorStore) *aibom.KnowledgeBase {
+	kb := &aibom.KnowledgeBase{
+		Name:        vs.Name,
+		Provider:    "openai",
+		ID:          vs.ID,
+		Status:      vs.Status,
+		StorageType: "vector-store",
+		Labels:      map[string]string{},
+	}
+
+	if vs.UsageBytes > 0 {
+		kb.Labels["usage_bytes"] = fmt.Sprintf("%d", vs.UsageBytes)
+	}
+
+	// Extract file count summary
+	if vs.FileCounts != nil {
+		total := 0
+		for _, v := range vs.FileCounts {
+			if n, ok := v.(float64); ok {
+				total += int(n)
+			}
+		}
+		if total > 0 {
+			kb.DataSources = append(kb.DataSources, fmt.Sprintf("%d files", total))
+		}
+	}
+
+	return kb
+}
+
+func bedrockGuardrailToComponent(g AWSBedrockGuardrail) *aibom.Guardrail {
+	gr := &aibom.Guardrail{
+		Name:     g.Name,
+		Provider: "aws-bedrock",
+		ID:       g.ID,
+		Arn:      g.Arn,
+		Status:   g.Status,
+		Version:  g.Version,
+		Labels:   map[string]string{},
+	}
+
+	if g.ContentPolicy != nil {
+		gr.Policies = append(gr.Policies, "content-filter")
+	}
+	if g.SensitiveInformationPolicy != nil {
+		gr.Policies = append(gr.Policies, "pii-detection")
+	}
+	if g.TopicPolicy != nil {
+		gr.Policies = append(gr.Policies, "topic-filter")
+	}
+	if g.WordPolicy != nil {
+		gr.Policies = append(gr.Policies, "word-filter")
+	}
+
+	return gr
+}
+
+func bedrockAgentToComponent(a AWSBedrockAgent) *aibom.AgentComponent {
+	ac := &aibom.AgentComponent{
+		Name:     a.Name,
+		Provider: "aws-bedrock",
+		Model:    a.FoundationModel,
+		Labels: map[string]string{
+			"status": a.Status,
+		},
+	}
+	if a.Arn != "" {
+		ac.Labels["arn"] = a.Arn
+	}
+	if a.ID != "" {
+		ac.Labels["agent_id"] = a.ID
+	}
+
+	// Extract action group dependencies (Lambda functions, APIs)
+	for _, ag := range a.ActionGroups {
+		agMap, ok := ag.(map[string]any)
+		if !ok {
+			continue
+		}
+		dep := &aibom.AgentDependency{Type: "action-group"}
+		if name, ok := agMap["actionGroupName"].(string); ok {
+			dep.Name = name
+		}
+		if executor, ok := agMap["actionGroupExecutor"].(map[string]any); ok {
+			if lambdaArn, ok := executor["lambda"].(string); ok {
+				dep.Arn = lambdaArn
+			}
+		}
+		ac.Dependencies = append(ac.Dependencies, dep)
+	}
+
+	// Extract knowledge base dependencies
+	for _, kb := range a.KnowledgeBases {
+		kbMap, ok := kb.(map[string]any)
+		if !ok {
+			continue
+		}
+		dep := &aibom.AgentDependency{Type: "knowledge-base"}
+		if id, ok := kbMap["knowledgeBaseId"].(string); ok {
+			dep.Name = id
+		}
+		if desc, ok := kbMap["description"].(string); ok && dep.Name == "" {
+			dep.Name = desc
+		}
+		ac.Dependencies = append(ac.Dependencies, dep)
+	}
+
+	return ac
+}
+
+func bedrockFlowToComponent(f AWSBedrockFlow) *aibom.AgentComponent {
+	return &aibom.AgentComponent{
+		Name:     f.Name,
+		Provider: "aws-bedrock",
+		Version:  f.Version,
+		Labels: map[string]string{
+			"type":   "flow",
+			"status": f.Status,
+			"arn":    f.Arn,
+		},
+	}
+}
+
+func bedrockKBToComponent(kb AWSBedrockKnowledgeBase) *aibom.KnowledgeBase {
+	kbc := &aibom.KnowledgeBase{
+		Name:        kb.Name,
+		Provider:    "aws-bedrock",
+		ID:          kb.ID,
+		Arn:         kb.Arn,
+		Status:      kb.Status,
+		Description: kb.Description,
+		Labels:      map[string]string{},
+	}
+
+	// Extract storage type from configuration
+	if kb.StorageConfiguration != nil {
+		if stype, ok := kb.StorageConfiguration["type"].(string); ok {
+			kbc.StorageType = stype
+		}
+	}
+
+	// Extract embedding model from KB configuration
+	if kb.KnowledgeBaseConfiguration != nil {
+		if vecConfig, ok := kb.KnowledgeBaseConfiguration["vectorKnowledgeBaseConfiguration"].(map[string]any); ok {
+			if modelArn, ok := vecConfig["embeddingModelArn"].(string); ok {
+				kbc.EmbeddingModel = modelArn
+			}
+		}
+	}
+
+	// Extract data source names/types
+	for _, ds := range kb.DataSources {
+		dsMap, ok := ds.(map[string]any)
+		if !ok {
+			continue
+		}
+		label := ""
+		if name, ok := dsMap["name"].(string); ok {
+			label = name
+		} else if dsType, ok := dsMap["type"].(string); ok {
+			label = dsType
+		} else if dsID, ok := dsMap["dataSourceId"].(string); ok {
+			label = dsID
+		}
+		if label != "" {
+			kbc.DataSources = append(kbc.DataSources, label)
+		}
+	}
+
+	return kbc
+}
+
+func modelArmorToGuardrail(t GCPModelArmorTemplate) *aibom.Guardrail {
+	return &aibom.Guardrail{
+		Name:     t.Name,
+		Provider: "gcp-model-armor",
+		Labels:   t.Labels,
+	}
+}
+
+func modelArmorFloorToGuardrail(f *GCPModelArmorFloorSetting) *aibom.Guardrail {
+	g := &aibom.Guardrail{
+		Name:     f.Name,
+		Provider: "gcp-model-armor",
+		Labels: map[string]string{
+			"type": "floor-setting",
+		},
+	}
+	if f.EnableFloorSettingEnforcement {
+		g.Status = "enforced"
+	}
+	return g
+}
+
+func gcpCloudFuncToComponent(fn GCPCloudFunction) *aibom.AgentComponent {
+	ac := &aibom.AgentComponent{
+		Name:     fn.Name,
+		Provider: "gcp-cloud-functions",
+		Labels: map[string]string{
+			"state":       fn.State,
+			"environment": fn.Environment,
+		},
+	}
+	if fn.URL != "" {
+		ac.Labels["url"] = fn.URL
+	}
+	if fn.BuildConfig != nil {
+		dep := &aibom.AgentDependency{
+			Type:    "cloud-function",
+			Name:    fn.Name,
+			Runtime: fn.BuildConfig.Runtime,
+			Labels: map[string]string{
+				"entry_point": fn.BuildConfig.EntryPoint,
+			},
+		}
+		if fn.BuildConfig.DockerRepository != "" {
+			dep.ImageUri = fn.BuildConfig.DockerRepository
+		}
+		ac.Dependencies = append(ac.Dependencies, dep)
+	}
+	return ac
+}
+
+func codingAgentToComponent(name string, a *CodingAgent) *aibom.AgentComponent {
+	ac := &aibom.AgentComponent{
+		Name:       name,
+		Provider:   "local",
+		ConfigPath: a.ConfigPath,
+		Version:    a.Version,
+		Model:      a.Model,
+		Labels:     map[string]string{},
+	}
+
+	for _, s := range a.Skills {
+		ac.Skills = append(ac.Skills, &aibom.AgentSkill{
+			Name:        s.Name,
+			Description: s.Description,
+			Source:      s.Source,
+			Sha256:      s.Sha256,
+		})
+	}
+
+	for _, m := range a.McpServers {
+		ms := &aibom.McpServer{
+			Name:    m.Name,
+			Type:    m.Type,
+			Command: m.Command,
+			Args:    m.Args,
+			Url:     m.Url,
+			HasEnv:  m.HasEnv,
+			Purl:    mcpServerToPurl(m),
+		}
+		ac.McpServers = append(ac.McpServers, ms)
+	}
+
+	for _, p := range a.Plugins {
+		ap := &aibom.AgentPlugin{
+			Name:         p.Name,
+			Version:      p.Version,
+			Author:       p.Author,
+			Description:  p.Description,
+			InstallPath:  p.InstallPath,
+			GitCommitSha: p.GitCommitSha,
+			Enabled:      p.Enabled,
+		}
+		if p.GitCommitSha != "" {
+			ap.Purl = fmt.Sprintf("pkg:generic/%s/%s@%s?vcs_url=git+%s", name, p.Name, p.Version, p.GitCommitSha)
+		} else if p.Version != "" {
+			ap.Purl = fmt.Sprintf("pkg:generic/%s/%s@%s", name, p.Name, p.Version)
+		}
+		ac.Plugins = append(ac.Plugins, ap)
+	}
+
+	for _, e := range a.Extensions {
+		ac.Extensions = append(ac.Extensions, &aibom.AgentExtension{
+			Name:        e.Name,
+			Type:        e.Type,
+			Description: e.Description,
+			Enabled:     e.Enabled,
+			Bundled:     e.Bundled,
+		})
+	}
+
+	if a.Email != "" {
+		ac.Labels["email"] = a.Email
+	}
+	if a.Organization != "" {
+		ac.Labels["organization"] = a.Organization
+	}
+	if a.Subscription != "" {
+		ac.Labels["subscription"] = a.Subscription
+	}
+	if a.Provider != "" {
+		ac.Labels["ai_provider"] = a.Provider
+	}
+
+	return ac
+}
+
+func mcpServerToPurl(m CodingAgentMcp) string {
+	if m.Command == "" && m.Url == "" {
+		return ""
+	}
+	cmd := m.Command
+	args := m.Args
+
+	switch cmd {
+	case "npx", "bunx":
+		if len(args) > 0 {
+			pkg := args[0]
+			if pkg == "-y" && len(args) > 1 {
+				pkg = args[1]
+			}
+			return fmt.Sprintf("pkg:npm/%s", pkg)
+		}
+	case "uvx", "pipx":
+		if len(args) > 0 {
+			return fmt.Sprintf("pkg:pypi/%s", args[0])
+		}
+	case "docker":
+		if len(args) >= 2 && args[0] == "run" {
+			return fmt.Sprintf("pkg:docker/%s", args[len(args)-1])
+		}
+	}
+	return ""
+}

--- a/internal/aibom/generator/generator_test.go
+++ b/internal/aibom/generator/generator_test.go
@@ -1,0 +1,691 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generator
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/internal/aibom"
+)
+
+// whisperTinyHuggingFace returns a HuggingFaceModel that simulates the MQL
+// report data for openai/whisper-tiny, matching the real HuggingFace API response.
+func whisperTinyHuggingFace() HuggingFaceModel {
+	return HuggingFaceModel{
+		ID:          "openai/whisper-tiny",
+		ModelID:     "openai/whisper-tiny",
+		Author:      "openai",
+		PipelineTag: "automatic-speech-recognition",
+		LibraryName: "transformers",
+		Tags: []string{
+			"transformers", "pytorch", "tf", "jax", "safetensors",
+			"whisper", "automatic-speech-recognition",
+			"audio", "hf-agentic-benchmark",
+			"en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr",
+			"arxiv:2212.04356",
+			"license:apache-2.0",
+		},
+		Downloads:    12345678,
+		Likes:        5678,
+		SHA:          "169d4a4341b33bc18d8881c4b69c2e104e1cc0af",
+		CreatedAt:    "2022-09-26T07:54:22.000Z",
+		LastModified: "2024-12-17T16:45:32.000Z",
+		License:      "apache-2.0",
+		CardData: map[string]any{
+			"language":     []any{"en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr"},
+			"tags":         []any{"audio", "automatic-speech-recognition"},
+			"pipeline_tag": "automatic-speech-recognition",
+			"license":      "apache-2.0",
+			"datasets":     []any{"680k", "name"},
+		},
+		Config: map[string]any{
+			"architectures":   []any{"WhisperForConditionalGeneration"},
+			"model_type":      "whisper",
+			"vocab_size":      float64(51865),
+			"tokenizer_class": "WhisperTokenizer",
+		},
+	}
+}
+
+func TestHuggingFaceWhisperTiny_ModelComponent(t *testing.T) {
+	hf := whisperTinyHuggingFace()
+	mc := huggingfaceToModelComponent(hf)
+
+	// Name should be the short name, not the full ID
+	assert.Equal(t, "whisper-tiny", mc.Name)
+	assert.Equal(t, "openai", mc.Author)
+	assert.Equal(t, "huggingface", mc.Provider)
+
+	// Version should be first 8 chars of SHA (OWASP AIBOM standard)
+	assert.Equal(t, "169d4a43", mc.Version)
+
+	// PURL should include namespace (author)
+	assert.Equal(t, "pkg:huggingface/openai/whisper-tiny@169d4a43", mc.Purl)
+
+	// Task from pipelineTag
+	assert.Equal(t, "automatic-speech-recognition", mc.Task)
+
+	// Architecture from config
+	assert.Equal(t, "whisper", mc.ArchitectureFamily)
+	assert.Equal(t, "WhisperForConditionalGeneration", mc.ModelArchitecture)
+
+	// License
+	assert.Equal(t, "apache-2.0", mc.License)
+
+	// Datasets from cardData
+	assert.Equal(t, []string{"680k", "name"}, mc.TrainingDatasets)
+
+	// Input/output modalities derived from pipelineTag
+	assert.Equal(t, []string{"audio"}, mc.InputModalities)
+	assert.Equal(t, []string{"text"}, mc.OutputModalities)
+
+	// Config-derived labels
+	assert.Equal(t, "51865", mc.Labels["vocab_size"])
+	assert.Equal(t, "WhisperTokenizer", mc.Labels["tokenizer_class"])
+
+	// Source URL
+	assert.Equal(t, "https://huggingface.co/openai/whisper-tiny", mc.SourceUrl)
+
+	// Provenance should contain full SHA
+	assert.Equal(t, "169d4a4341b33bc18d8881c4b69c2e104e1cc0af", mc.Provenance["sha"])
+	assert.Equal(t, "transformers", mc.Provenance["library"])
+	assert.Equal(t, "openai/whisper-tiny", mc.Provenance["full_name"])
+
+	// ArXiv should be extracted from tags
+	assert.Equal(t, "2212.04356", mc.Provenance["arxiv"])
+}
+
+func TestHuggingFaceWhisperTiny_EmptyAuthor(t *testing.T) {
+	hf := whisperTinyHuggingFace()
+	hf.Author = "" // Simulates list API behavior (no author field)
+	hf.SHA = ""    // List API also omits SHA
+
+	mc := huggingfaceToModelComponent(hf)
+
+	// Author should be extracted from the model ID
+	assert.Equal(t, "openai", mc.Author)
+	assert.Equal(t, "whisper-tiny", mc.Name)
+
+	// Without SHA, version should be empty and PURL should have trailing @
+	assert.Equal(t, "", mc.Version)
+	assert.Equal(t, "pkg:huggingface/openai/whisper-tiny@", mc.Purl)
+}
+
+func TestHuggingFaceWhisperTiny_CycloneDX(t *testing.T) {
+	hf := whisperTinyHuggingFace()
+	mc := huggingfaceToModelComponent(hf)
+
+	bom := &aibom.AiBom{
+		Generator: &aibom.Generator{
+			Vendor:  "Mondoo, Inc.",
+			Name:    "cnspec",
+			Version: "11.0.0",
+		},
+		Asset: &aibom.Asset{
+			Name: "openai/whisper-tiny",
+		},
+		Models:       []*aibom.ModelComponent{mc},
+		Completeness: &aibom.CompletenessScore{TotalScore: 0.646},
+	}
+
+	// Render to CycloneDX JSON
+	formatter := &aibom.CycloneDXFormatter{Format: 1} // JSON format
+	var buf bytes.Buffer
+	err := formatter.Render(&buf, bom)
+	require.NoError(t, err)
+
+	// Parse the output
+	var cdx map[string]any
+	err = json.Unmarshal(buf.Bytes(), &cdx)
+	require.NoError(t, err)
+
+	// Verify top-level structure
+	assert.Equal(t, "CycloneDX", cdx["bomFormat"])
+	assert.NotEmpty(t, cdx["serialNumber"])
+	assert.NotNil(t, cdx["metadata"])
+	assert.NotNil(t, cdx["components"])
+
+	// Get the first component
+	components := cdx["components"].([]any)
+	require.Len(t, components, 1)
+	comp := components[0].(map[string]any)
+
+	// Verify component fields match OWASP reference structure
+	assert.Equal(t, "machine-learning-model", comp["type"])
+	assert.Equal(t, "openai", comp["group"])
+	assert.Equal(t, "whisper-tiny", comp["name"])
+	assert.Equal(t, "169d4a43", comp["version"])
+	assert.Equal(t, "pkg:huggingface/openai/whisper-tiny@169d4a43", comp["purl"])
+
+	// Verify bom-ref uses PURL
+	assert.Equal(t, "pkg:huggingface/openai/whisper-tiny@169d4a43", comp["bom-ref"])
+
+	// Verify license uses SPDX ID
+	licenses := comp["licenses"].([]any)
+	require.Len(t, licenses, 1)
+	licenseEntry := licenses[0].(map[string]any)
+	licenseObj := licenseEntry["license"].(map[string]any)
+	assert.Equal(t, "Apache-2.0", licenseObj["id"])
+
+	// Verify supplier and manufacturer
+	supplier := comp["supplier"].(map[string]any)
+	assert.Equal(t, "openai", supplier["name"])
+
+	manufacturer := comp["manufacturer"].(map[string]any)
+	assert.Equal(t, "openai", manufacturer["name"])
+
+	// Verify authors
+	authors := comp["authors"].([]any)
+	require.Len(t, authors, 1)
+	assert.Equal(t, "openai", authors[0].(map[string]any)["name"])
+
+	// Verify modelCard
+	modelCard := comp["modelCard"].(map[string]any)
+	require.NotNil(t, modelCard)
+
+	modelParams := modelCard["modelParameters"].(map[string]any)
+	assert.Equal(t, "automatic-speech-recognition", modelParams["task"])
+	assert.Equal(t, "whisper", modelParams["architectureFamily"])
+
+	// Verify datasets
+	datasets := modelParams["datasets"].([]any)
+	require.Len(t, datasets, 2)
+	ds0 := datasets[0].(map[string]any)
+	assert.Equal(t, "dataset", ds0["type"])
+	assert.Equal(t, "680k", ds0["name"])
+
+	// Verify inputs/outputs
+	inputs := modelParams["inputs"].([]any)
+	require.Len(t, inputs, 1)
+	assert.Equal(t, "audio", inputs[0].(map[string]any)["format"])
+
+	outputs := modelParams["outputs"].([]any)
+	require.Len(t, outputs, 1)
+	assert.Equal(t, "text", outputs[0].(map[string]any)["format"])
+
+	// Verify external references
+	extRefs := comp["externalReferences"].([]any)
+	require.GreaterOrEqual(t, len(extRefs), 4)
+
+	// Should have website, distribution, VCS, and documentation references
+	refTypes := map[string]bool{}
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		refTypes[r["type"].(string)] = true
+	}
+	assert.True(t, refTypes["website"], "should have website reference")
+	assert.True(t, refTypes["distribution"], "should have distribution reference")
+	assert.True(t, refTypes["vcs"], "should have VCS reference")
+	assert.True(t, refTypes["documentation"], "should have documentation reference")
+}
+
+func TestHuggingFaceWhisperTiny_CycloneDX_MatchesOWASPStructure(t *testing.T) {
+	hf := whisperTinyHuggingFace()
+	mc := huggingfaceToModelComponent(hf)
+
+	bom := &aibom.AiBom{
+		Generator: &aibom.Generator{
+			Vendor:  "Mondoo, Inc.",
+			Name:    "cnspec",
+			Version: "11.0.0",
+		},
+		Asset: &aibom.Asset{
+			Name: "openai/whisper-tiny",
+		},
+		Models:       []*aibom.ModelComponent{mc},
+		Completeness: &aibom.CompletenessScore{TotalScore: 0.646},
+	}
+
+	formatter := &aibom.CycloneDXFormatter{Format: 1} // JSON
+	var buf bytes.Buffer
+	err := formatter.Render(&buf, bom)
+	require.NoError(t, err)
+
+	var cdx map[string]any
+	err = json.Unmarshal(buf.Bytes(), &cdx)
+	require.NoError(t, err)
+
+	comp := cdx["components"].([]any)[0].(map[string]any)
+
+	// Verify VCS reference includes full commit SHA
+	extRefs := comp["externalReferences"].([]any)
+	var vcsRef map[string]any
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		if r["type"] == "vcs" {
+			vcsRef = r
+			break
+		}
+	}
+	require.NotNil(t, vcsRef, "should have a VCS external reference")
+	assert.Equal(t,
+		"https://huggingface.co/openai/whisper-tiny/commit/169d4a4341b33bc18d8881c4b69c2e104e1cc0af",
+		vcsRef["url"],
+	)
+	assert.Equal(t, "Specific commit", vcsRef["comment"])
+
+	// Verify ArXiv documentation reference
+	var docRef map[string]any
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		if r["type"] == "documentation" {
+			docRef = r
+			break
+		}
+	}
+	require.NotNil(t, docRef, "should have a documentation reference for ArXiv paper")
+	assert.Equal(t, "https://arxiv.org/abs/2212.04356", docRef["url"])
+	assert.Equal(t, "ArXiv Paper", docRef["comment"])
+
+	// Verify training dataset external references
+	var datasetRefs []map[string]any
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		comment, _ := r["comment"].(string)
+		if r["type"] == "distribution" && len(comment) > 0 && comment != "Model files" {
+			datasetRefs = append(datasetRefs, r)
+		}
+	}
+	require.Len(t, datasetRefs, 2)
+	assert.Equal(t, "https://huggingface.co/datasets/680k", datasetRefs[0]["url"])
+	assert.Equal(t, "Training dataset: 680k", datasetRefs[0]["comment"])
+
+	// Verify properties include vocab_size and tokenizer_class
+	props := comp["properties"].([]any)
+	propMap := map[string]string{}
+	for _, p := range props {
+		prop := p.(map[string]any)
+		propMap[prop["name"].(string)] = prop["value"].(string)
+	}
+	assert.Equal(t, "51865", propMap["genai:aibom:modelcard:vocab_size"])
+	assert.Equal(t, "WhisperTokenizer", propMap["genai:aibom:modelcard:tokenizer_class"])
+	assert.Equal(t, "huggingface", propMap["mondoo:model:provider"])
+}
+
+func TestLocalModelToComponent_HuggingFaceCache(t *testing.T) {
+	m := LocalAIModel{
+		Name:          "Meta-Llama-3-8B-Instruct",
+		Source:        "huggingface",
+		Vendor:        "meta-llama",
+		Family:        "llama",
+		Path:          "/home/user/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B-Instruct",
+		Size:          16065438720,
+		Format:        "safetensors",
+		Version:       "abc123de",
+		Architecture:  "LlamaForCausalLM",
+		License:       "llama3",
+		ParameterSize: "8B",
+	}
+
+	mc := localModelToComponent(m)
+
+	assert.Equal(t, "Meta-Llama-3-8B-Instruct", mc.Name)
+	assert.Equal(t, "huggingface", mc.Provider)
+	assert.Equal(t, "meta-llama", mc.Author)
+	assert.Equal(t, "llama", mc.ArchitectureFamily)
+	assert.Equal(t, "LlamaForCausalLM", mc.ModelArchitecture)
+	assert.Equal(t, "safetensors", mc.Format)
+	assert.Equal(t, "abc123de", mc.Version)
+	assert.Equal(t, "8B", mc.ParameterSize)
+	assert.Equal(t, "llama3", mc.License)
+
+	assert.Equal(t, "file:///home/user/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B-Instruct", mc.SourceUrl)
+	assert.Equal(t, "16065438720", mc.Labels["size_bytes"])
+	assert.Equal(t, "ai.models", mc.Provenance["detection_source"])
+	assert.Equal(t, m.Path, mc.Provenance["local_path"])
+
+	assert.Equal(t, "pkg:huggingface/meta-llama/Meta-Llama-3-8B-Instruct@abc123de", mc.Purl)
+}
+
+func TestLocalModelToComponent_LMStudio(t *testing.T) {
+	m := LocalAIModel{
+		Name:         "mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		Source:       "lmstudio",
+		Vendor:       "TheBloke",
+		Family:       "mistral",
+		Path:         "/home/user/.cache/lm-studio/models/TheBloke/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		Format:       "gguf",
+		Quantization: "Q4_K_M",
+	}
+
+	mc := localModelToComponent(m)
+
+	assert.Equal(t, "mistral-7b-instruct-v0.2.Q4_K_M.gguf", mc.Name)
+	assert.Equal(t, "lmstudio", mc.Provider)
+	assert.Equal(t, "TheBloke", mc.Author)
+	assert.Equal(t, "gguf", mc.Format)
+	assert.Equal(t, "Q4_K_M", mc.Quantization)
+
+	assert.Equal(t, "pkg:generic/lmstudio/TheBloke/mistral-7b-instruct-v0.2.Q4_K_M.gguf@", mc.Purl)
+}
+
+func TestLocalModelToComponent_MinimalFields(t *testing.T) {
+	m := LocalAIModel{
+		Name:   "resnet50",
+		Source: "pytorch",
+		Path:   "/home/user/.cache/torch/hub/checkpoints/resnet50.pth",
+	}
+
+	mc := localModelToComponent(m)
+
+	assert.Equal(t, "resnet50", mc.Name)
+	assert.Equal(t, "pytorch", mc.Provider)
+	assert.Equal(t, "", mc.Author)
+	assert.Equal(t, "", mc.Version)
+	assert.Equal(t, "file:///home/user/.cache/torch/hub/checkpoints/resnet50.pth", mc.SourceUrl)
+	assert.Equal(t, "ai.models", mc.Provenance["detection_source"])
+
+	assert.Equal(t, "pkg:generic/pytorch/resnet50@", mc.Purl)
+}
+
+func TestLocalModelPurl(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    LocalAIModel
+		expected string
+	}{
+		{
+			name:     "ollama with vendor",
+			model:    LocalAIModel{Name: "llama3", Source: "ollama", Vendor: "meta", Version: "latest"},
+			expected: "pkg:ollama/meta/llama3@latest",
+		},
+		{
+			name:     "ollama without vendor",
+			model:    LocalAIModel{Name: "llama3", Source: "ollama", Version: "latest"},
+			expected: "pkg:ollama/llama3@latest",
+		},
+		{
+			name:     "huggingface",
+			model:    LocalAIModel{Name: "bert-base", Source: "huggingface", Vendor: "google", Version: "abc123"},
+			expected: "pkg:huggingface/google/bert-base@abc123",
+		},
+		{
+			name:     "lmstudio",
+			model:    LocalAIModel{Name: "model.gguf", Source: "lmstudio", Vendor: "TheBloke", Version: "v1"},
+			expected: "pkg:generic/lmstudio/TheBloke/model.gguf@v1",
+		},
+		{
+			name:     "gpt4all",
+			model:    LocalAIModel{Name: "falcon", Source: "gpt4all", Vendor: "nomic"},
+			expected: "pkg:generic/gpt4all/nomic/falcon@",
+		},
+		{
+			name:     "pytorch no vendor",
+			model:    LocalAIModel{Name: "resnet50", Source: "pytorch"},
+			expected: "pkg:generic/pytorch/resnet50@",
+		},
+		{
+			name:     "keras",
+			model:    LocalAIModel{Name: "efficientnet", Source: "keras", Vendor: "google", Version: "b0"},
+			expected: "pkg:generic/keras/google/efficientnet@b0",
+		},
+		{
+			name:     "tfhub",
+			model:    LocalAIModel{Name: "universal-sentence-encoder", Source: "tfhub", Vendor: "google"},
+			expected: "pkg:generic/tfhub/google/universal-sentence-encoder@",
+		},
+		{
+			name:     "jan",
+			model:    LocalAIModel{Name: "tinyllama", Source: "jan", Vendor: "", Version: "1.1"},
+			expected: "pkg:generic/jan/tinyllama@1.1",
+		},
+		{
+			name:     "empty source",
+			model:    LocalAIModel{Name: "model", Version: "1.0"},
+			expected: "pkg:generic/generic/model@1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, localModelPurl(tt.model))
+		})
+	}
+}
+
+func TestLocalModel_CycloneDX(t *testing.T) {
+	m := LocalAIModel{
+		Name:          "phi-3-mini",
+		Source:        "lmstudio",
+		Vendor:        "microsoft",
+		Family:        "phi",
+		Path:          "/home/user/.cache/lm-studio/models/microsoft/phi-3-mini.gguf",
+		Size:          4000000000,
+		Format:        "gguf",
+		Version:       "v3.8",
+		Quantization:  "Q4_K_M",
+		ParameterSize: "3.8B",
+		License:       "MIT",
+	}
+
+	mc := localModelToComponent(m)
+
+	bom := &aibom.AiBom{
+		Generator: &aibom.Generator{
+			Vendor:  "Mondoo, Inc.",
+			Name:    "cnspec",
+			Version: "11.0.0",
+		},
+		Asset: &aibom.Asset{
+			Name: "local-workstation",
+		},
+		Models:       []*aibom.ModelComponent{mc},
+		Completeness: &aibom.CompletenessScore{TotalScore: 0.5},
+	}
+
+	formatter := &aibom.CycloneDXFormatter{Format: 1}
+	var buf bytes.Buffer
+	err := formatter.Render(&buf, bom)
+	require.NoError(t, err)
+
+	var cdx map[string]any
+	err = json.Unmarshal(buf.Bytes(), &cdx)
+	require.NoError(t, err)
+
+	components := cdx["components"].([]any)
+	require.Len(t, components, 1)
+	comp := components[0].(map[string]any)
+
+	assert.Equal(t, "machine-learning-model", comp["type"])
+	assert.Equal(t, "microsoft", comp["group"])
+	assert.Equal(t, "phi-3-mini", comp["name"])
+	assert.Equal(t, "v3.8", comp["version"])
+
+	purl := "pkg:generic/lmstudio/microsoft/phi-3-mini@v3.8"
+	assert.Equal(t, purl, comp["purl"])
+	assert.Equal(t, purl, comp["bom-ref"])
+
+	// Verify file:// URL does NOT generate a broken distribution reference
+	extRefs := comp["externalReferences"].([]any)
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		if r["type"] == "distribution" {
+			t.Error("file:// URL should not generate a distribution reference with /tree/main")
+		}
+	}
+
+	// Should have a website reference with the file:// URL
+	var hasWebsite bool
+	for _, ref := range extRefs {
+		r := ref.(map[string]any)
+		if r["type"] == "website" {
+			assert.Equal(t, "file:///home/user/.cache/lm-studio/models/microsoft/phi-3-mini.gguf", r["url"])
+			hasWebsite = true
+		}
+	}
+	assert.True(t, hasWebsite, "should have website reference with file:// URL")
+
+	// Verify properties include format, quantization, provider
+	props := comp["properties"].([]any)
+	propMap := map[string]string{}
+	for _, p := range props {
+		prop := p.(map[string]any)
+		propMap[prop["name"].(string)] = prop["value"].(string)
+	}
+	assert.Equal(t, "lmstudio", propMap["mondoo:model:provider"])
+	assert.Equal(t, "Q4_K_M", propMap["mondoo:model:quantization"])
+	assert.Equal(t, "3.8B", propMap["mondoo:model:parameterSize"])
+	assert.Equal(t, "gguf", propMap["mondoo:model:format"])
+}
+
+func TestClassifyAIDependencies(t *testing.T) {
+	pythonPkgs := []SoftwarePackage{
+		{Name: "transformers", Version: "4.40.0", Purl: "pkg:pypi/transformers@4.40.0"},
+		{Name: "openai", Version: "1.30.0", Purl: "pkg:pypi/openai@1.30.0"},
+		{Name: "langchain", Version: "0.2.0", Purl: "pkg:pypi/langchain@0.2.0"},
+		{Name: "chromadb", Version: "0.5.0", Purl: "pkg:pypi/chromadb@0.5.0"},
+		{Name: "wandb", Version: "0.17.0", Purl: "pkg:pypi/wandb@0.17.0"},
+		{Name: "requests", Version: "2.32.0", Purl: "pkg:pypi/requests@2.32.0"},
+		{Name: "flask", Version: "3.0.0", Purl: "pkg:pypi/flask@3.0.0"},
+	}
+	npmPkgs := []SoftwarePackage{
+		{Name: "@anthropic-ai/sdk", Version: "0.24.0", Purl: "pkg:npm/%40anthropic-ai/sdk@0.24.0"},
+		{Name: "ai", Version: "3.1.0", Purl: "pkg:npm/ai@3.1.0"},
+		{Name: "express", Version: "4.19.0", Purl: "pkg:npm/express@4.19.0"},
+	}
+
+	deps := classifyAIDependencies(npmPkgs, pythonPkgs)
+
+	// Should find: transformers, openai, langchain, chromadb, wandb (Python)
+	// + @anthropic-ai/sdk, ai (npm) = 7 total
+	// requests, flask, express are not AI packages
+	assert.Len(t, deps, 7)
+
+	byName := map[string]*aibom.AIDependency{}
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+
+	assert.Equal(t, "model-framework", byName["transformers"].Category)
+	assert.Equal(t, "python", byName["transformers"].Language)
+	assert.Equal(t, "4.40.0", byName["transformers"].Version)
+
+	assert.Equal(t, "api-client", byName["openai"].Category)
+	assert.Equal(t, "python", byName["openai"].Language)
+
+	assert.Equal(t, "agent-framework", byName["langchain"].Category)
+	assert.Equal(t, "vector-db", byName["chromadb"].Category)
+	assert.Equal(t, "ml-tool", byName["wandb"].Category)
+
+	assert.Equal(t, "api-client", byName["@anthropic-ai/sdk"].Category)
+	assert.Equal(t, "javascript", byName["@anthropic-ai/sdk"].Language)
+
+	assert.Equal(t, "api-client", byName["ai"].Category)
+	assert.Equal(t, "javascript", byName["ai"].Language)
+
+	// Non-AI packages should not appear
+	_, hasRequests := byName["requests"]
+	assert.False(t, hasRequests)
+	_, hasExpress := byName["express"]
+	assert.False(t, hasExpress)
+}
+
+func TestClassifyAIDependencies_Deduplication(t *testing.T) {
+	pkgs := []SoftwarePackage{
+		{Name: "openai", Version: "1.30.0"},
+		{Name: "openai", Version: "1.30.0"},
+	}
+
+	deps := classifyAIDependencies(nil, pkgs)
+	assert.Len(t, deps, 1)
+}
+
+func TestClassifyAIDependencies_Empty(t *testing.T) {
+	deps := classifyAIDependencies(nil, nil)
+	assert.Nil(t, deps)
+}
+
+func TestAIDependency_CycloneDX(t *testing.T) {
+	pythonPkgs := []SoftwarePackage{
+		{Name: "transformers", Version: "4.40.0", Purl: "pkg:pypi/transformers@4.40.0"},
+		{Name: "langchain", Version: "0.2.0", Purl: "pkg:pypi/langchain@0.2.0"},
+	}
+
+	aiDeps := classifyAIDependencies(nil, pythonPkgs)
+
+	bom := &aibom.AiBom{
+		Generator: &aibom.Generator{
+			Vendor:  "Mondoo, Inc.",
+			Name:    "cnspec",
+			Version: "11.0.0",
+		},
+		Asset: &aibom.Asset{
+			Name: "python-project",
+		},
+		AIDependencies: aiDeps,
+		Completeness:   &aibom.CompletenessScore{TotalScore: 0.3},
+	}
+
+	formatter := &aibom.CycloneDXFormatter{Format: 1}
+	var buf bytes.Buffer
+	err := formatter.Render(&buf, bom)
+	require.NoError(t, err)
+
+	var cdx map[string]any
+	err = json.Unmarshal(buf.Bytes(), &cdx)
+	require.NoError(t, err)
+
+	components := cdx["components"].([]any)
+	require.Len(t, components, 2)
+
+	// transformers should be a library
+	comp0 := components[0].(map[string]any)
+	assert.Equal(t, "library", comp0["type"])
+	assert.Equal(t, "transformers", comp0["name"])
+	assert.Equal(t, "4.40.0", comp0["version"])
+	assert.Equal(t, "pkg:pypi/transformers@4.40.0", comp0["purl"])
+
+	// langchain should be a framework
+	comp1 := components[1].(map[string]any)
+	assert.Equal(t, "framework", comp1["type"])
+	assert.Equal(t, "langchain", comp1["name"])
+
+	// Verify properties
+	props0 := comp0["properties"].([]any)
+	propMap := map[string]string{}
+	for _, p := range props0 {
+		prop := p.(map[string]any)
+		propMap[prop["name"].(string)] = prop["value"].(string)
+	}
+	assert.Equal(t, "model-framework", propMap["mondoo:ai:category"])
+	assert.Equal(t, "python", propMap["mondoo:ai:language"])
+
+	// Verify metadata includes ai_dependency_count
+	metadata := cdx["metadata"].(map[string]any)
+	metaProps := metadata["properties"].([]any)
+	metaPropMap := map[string]string{}
+	for _, p := range metaProps {
+		prop := p.(map[string]any)
+		metaPropMap[prop["name"].(string)] = prop["value"].(string)
+	}
+	assert.Equal(t, "2", metaPropMap["mondoo:aibom:ai_dependency_count"])
+}
+
+func TestPipelineTagToModalities(t *testing.T) {
+	tests := []struct {
+		tag           string
+		expectInputs  []string
+		expectOutputs []string
+	}{
+		{"automatic-speech-recognition", []string{"audio"}, []string{"text"}},
+		{"text-generation", []string{"text"}, []string{"text"}},
+		{"image-classification", []string{"image"}, []string{"text"}},
+		{"text-to-image", []string{"text"}, []string{"image"}},
+		{"text-to-speech", []string{"text"}, []string{"audio"}},
+		{"feature-extraction", []string{"text"}, []string{"tensor"}},
+		{"unknown-task", nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			inputs, outputs := pipelineTagToModalities(tt.tag)
+			assert.Equal(t, tt.expectInputs, inputs)
+			assert.Equal(t, tt.expectOutputs, outputs)
+		})
+	}
+}

--- a/internal/aibom/generator/report_collection.go
+++ b/internal/aibom/generator/report_collection.go
@@ -1,0 +1,630 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generator
+
+// Structures to parse the data from cnspec report for AIBOM generation.
+// Each provider returns differently shaped JSON; these structs capture
+// the union of all fields across Ollama, HuggingFace, AWS, GCP, and Azure.
+
+type AiBomAsset struct {
+	Name     string   `json:"name,omitempty"`
+	Platform string   `json:"platform,omitempty"`
+	Version  string   `json:"version,omitempty"`
+	Build    string   `json:"build,omitempty"`
+	Family   []string `json:"family,omitempty"`
+	Arch     string   `json:"arch,omitempty"`
+	IDs      []string `json:"ids,omitempty"`
+}
+
+// OllamaModel represents an Ollama model from the MQL report.
+type OllamaModel struct {
+	Name              string     `json:"name,omitempty"`
+	Model             string     `json:"model,omitempty"`
+	Family            string     `json:"family,omitempty"`
+	Families          []string   `json:"families,omitempty"`
+	ParameterSize     string     `json:"parameterSize,omitempty"`
+	QuantizationLevel string     `json:"quantizationLevel,omitempty"`
+	Format            string     `json:"format,omitempty"`
+	Size              int64      `json:"size,omitempty"`
+	Digest            string     `json:"digest,omitempty"`
+	ModifiedAt        string     `json:"modifiedAt,omitempty"`
+	License           string     `json:"license,omitempty"`
+	Capabilities      []string   `json:"capabilities,omitempty"`
+	Info              OllamaInfo `json:"info"`
+}
+
+type OllamaInfo struct {
+	Architecture    string   `json:"architecture,omitempty"`
+	ParameterCount  int64    `json:"parameterCount,omitempty"`
+	ContextLength   int      `json:"contextLength,omitempty"`
+	EmbeddingLength int      `json:"embeddingLength,omitempty"`
+	BlockCount      int      `json:"blockCount,omitempty"`
+	VocabSize       int      `json:"vocabSize,omitempty"`
+	ExpertCount     int      `json:"expertCount,omitempty"`
+	SizeLabel       string   `json:"sizeLabel,omitempty"`
+	Basename        string   `json:"basename,omitempty"`
+	Finetune        string   `json:"finetune,omitempty"`
+	Author          string   `json:"author,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	Datasets        []string `json:"datasets,omitempty"`
+	Languages       []string `json:"languages,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	License         string   `json:"license,omitempty"`
+}
+
+// HuggingFaceModel represents a HuggingFace model from the MQL report.
+type HuggingFaceModel struct {
+	ID           string         `json:"id,omitempty"`
+	ModelID      string         `json:"modelId,omitempty"`
+	Author       string         `json:"author,omitempty"`
+	PipelineTag  string         `json:"pipelineTag,omitempty"`
+	LibraryName  string         `json:"libraryName,omitempty"`
+	Tags         []string       `json:"tags,omitempty"`
+	Downloads    int            `json:"downloads,omitempty"`
+	Likes        int            `json:"likes,omitempty"`
+	SHA          string         `json:"sha,omitempty"`
+	CreatedAt    string         `json:"createdAt,omitempty"`
+	LastModified string         `json:"lastModified,omitempty"`
+	Gated        bool           `json:"gated,omitempty"`
+	Disabled     bool           `json:"disabled,omitempty"`
+	Private      bool           `json:"private,omitempty"`
+	License      string         `json:"license,omitempty"`
+	CardData     map[string]any `json:"cardData,omitempty"`
+	Config       map[string]any `json:"config,omitempty"`
+}
+
+// AWSBedrockFoundationModel represents an AWS Bedrock foundation model.
+type AWSBedrockFoundationModel struct {
+	ModelID                 string   `json:"modelId,omitempty"`
+	ModelName               string   `json:"modelName,omitempty"`
+	ProviderName            string   `json:"providerName,omitempty"`
+	InputModalities         []string `json:"inputModalities,omitempty"`
+	OutputModalities        []string `json:"outputModalities,omitempty"`
+	InferenceTypesSupported []string `json:"inferenceTypesSupported,omitempty"`
+	ModelLifecycleStatus    string   `json:"modelLifecycleStatus,omitempty"`
+}
+
+// AWSBedrockCustomModel represents an AWS Bedrock custom/fine-tuned model.
+type AWSBedrockCustomModel struct {
+	ModelArn  string                     `json:"modelArn,omitempty"`
+	ModelName string                     `json:"modelName,omitempty"`
+	BaseModel *AWSBedrockFoundationModel `json:"baseModel,omitempty"`
+}
+
+// AWSSageMakerModel represents an AWS SageMaker model.
+type AWSSageMakerModel struct {
+	Name string `json:"name,omitempty"`
+	Arn  string `json:"arn,omitempty"`
+}
+
+// GCPVertexAIModel represents a GCP Vertex AI model.
+type GCPVertexAIModel struct {
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// AzureCognitiveServicesAccount represents an Azure AI Services account.
+type AzureCognitiveServicesAccount struct {
+	ID                  string `json:"id,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Location            string `json:"location,omitempty"`
+	Kind                string `json:"kind,omitempty"`
+	Endpoint            string `json:"endpoint,omitempty"`
+	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+	DisableLocalAuth    bool   `json:"disableLocalAuth,omitempty"`
+}
+
+// VLLMData represents the vLLM server data from the MQL report.
+type VLLMData struct {
+	Version string      `json:"version,omitempty"`
+	Server  *VLLMServer `json:"server,omitempty"`
+	Models  []VLLMModel `json:"models,omitempty"`
+}
+
+type VLLMServer struct {
+	BaseUrl                  string `json:"baseUrl,omitempty"`
+	Reachable                bool   `json:"reachable,omitempty"`
+	Version                  string `json:"version,omitempty"`
+	UsesTls                  bool   `json:"usesTls,omitempty"`
+	CorsConfigured           bool   `json:"corsConfigured,omitempty"`
+	CorsAllowsAny            bool   `json:"corsAllowsAnyOrigin,omitempty"`
+	MetricsExposed           bool   `json:"metricsExposed,omitempty"`
+	DocsExposed              bool   `json:"docsExposed,omitempty"`
+	OpenapiExposed           bool   `json:"openapiExposed,omitempty"`
+	LoadEndpointExposed      bool   `json:"loadEndpointExposed,omitempty"`
+	TokenizerInfoExposed     bool   `json:"tokenizerInfoExposed,omitempty"`
+	DevEndpointsExposed      bool   `json:"devEndpointsExposed,omitempty"`
+	ProfilerEndpointsExposed bool   `json:"profilerEndpointsExposed,omitempty"`
+}
+
+type VLLMModel struct {
+	ID          string `json:"id,omitempty"`
+	Root        string `json:"root,omitempty"`
+	Parent      string `json:"parent,omitempty"`
+	MaxModelLen int    `json:"maxModelLen,omitempty"`
+	Created     string `json:"created,omitempty"`
+	OwnedBy     string `json:"ownedBy,omitempty"`
+}
+
+// ClaudeModel represents a Claude API model.
+type ClaudeModel struct {
+	ID                         string `json:"id,omitempty"`
+	DisplayName                string `json:"displayName,omitempty"`
+	Vendor                     string `json:"vendor,omitempty"`
+	Family                     string `json:"family,omitempty"`
+	CreatedAt                  string `json:"createdAt,omitempty"`
+	MaxInputTokens             int    `json:"maxInputTokens,omitempty"`
+	MaxTokens                  int    `json:"maxTokens,omitempty"`
+	BatchSupported             bool   `json:"batchSupported,omitempty"`
+	CitationsSupported         bool   `json:"citationsSupported,omitempty"`
+	CodeExecutionSupported     bool   `json:"codeExecutionSupported,omitempty"`
+	ImageInputSupported        bool   `json:"imageInputSupported,omitempty"`
+	PdfInputSupported          bool   `json:"pdfInputSupported,omitempty"`
+	StructuredOutputsSupported bool   `json:"structuredOutputsSupported,omitempty"`
+	ThinkingSupported          bool   `json:"thinkingSupported,omitempty"`
+}
+
+// ClaudeAgent represents a Claude managed agent.
+type ClaudeAgent struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	System      string `json:"system,omitempty"`
+	Model       string `json:"model,omitempty"`
+	Version     int    `json:"version,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+// ClaudeSkill represents a Claude registered skill.
+type ClaudeSkill struct {
+	ID            string `json:"id,omitempty"`
+	DisplayTitle  string `json:"displayTitle,omitempty"`
+	Source        string `json:"source,omitempty"`
+	LatestVersion string `json:"latestVersion,omitempty"`
+	CreatedAt     string `json:"createdAt,omitempty"`
+	UpdatedAt     string `json:"updatedAt,omitempty"`
+}
+
+// ClaudeEnvironment represents a Claude execution environment.
+type ClaudeEnvironment struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+}
+
+// ClaudeVault represents a Claude secret vault.
+type ClaudeVault struct {
+	ID          string             `json:"id,omitempty"`
+	DisplayName string             `json:"displayName,omitempty"`
+	CreatedAt   string             `json:"createdAt,omitempty"`
+	Credentials []ClaudeCredential `json:"credentials,omitempty"`
+}
+
+type ClaudeCredential struct {
+	ID          string `json:"id,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	VaultId     string `json:"vaultId,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+}
+
+// ClaudeMemoryStore represents a Claude memory store.
+type ClaudeMemoryStore struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+}
+
+// OpenAIModel represents an OpenAI API model.
+type OpenAIModel struct {
+	ID          string `json:"id,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	OwnedBy     string `json:"ownedBy,omitempty"`
+	IsFineTuned bool   `json:"isFineTuned,omitempty"`
+	BaseModel   string `json:"baseModel,omitempty"`
+}
+
+// OpenAIFineTuningJob represents an OpenAI fine-tuning job.
+type OpenAIFineTuningJob struct {
+	ID              string         `json:"id,omitempty"`
+	Model           string         `json:"model,omitempty"`
+	Status          string         `json:"status,omitempty"`
+	CreatedAt       string         `json:"createdAt,omitempty"`
+	FinishedAt      string         `json:"finishedAt,omitempty"`
+	FineTunedModel  string         `json:"fineTunedModel,omitempty"`
+	TrainedTokens   int            `json:"trainedTokens,omitempty"`
+	OrganizationId  string         `json:"organizationId,omitempty"`
+	Hyperparameters map[string]any `json:"hyperparameters,omitempty"`
+}
+
+// OpenAIVectorStore represents an OpenAI vector store.
+type OpenAIVectorStore struct {
+	ID           string         `json:"id,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	Status       string         `json:"status,omitempty"`
+	UsageBytes   int64          `json:"usageBytes,omitempty"`
+	CreatedAt    string         `json:"createdAt,omitempty"`
+	LastActiveAt string         `json:"lastActiveAt,omitempty"`
+	FileCounts   map[string]any `json:"fileCounts,omitempty"`
+}
+
+// OpenAIProject represents an OpenAI project.
+type OpenAIProject struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+// AWSBedrockGuardrail represents an AWS Bedrock guardrail with policies.
+type AWSBedrockGuardrail struct {
+	ID                         string         `json:"id,omitempty"`
+	Name                       string         `json:"name,omitempty"`
+	Arn                        string         `json:"arn,omitempty"`
+	Status                     string         `json:"status,omitempty"`
+	Version                    string         `json:"version,omitempty"`
+	ContentPolicy              map[string]any `json:"contentPolicy,omitempty"`
+	SensitiveInformationPolicy map[string]any `json:"sensitiveInformationPolicy,omitempty"`
+	TopicPolicy                map[string]any `json:"topicPolicy,omitempty"`
+	WordPolicy                 map[string]any `json:"wordPolicy,omitempty"`
+}
+
+// AWSBedrockAgent represents an AWS Bedrock agent with dependencies.
+type AWSBedrockAgent struct {
+	ID              string `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Arn             string `json:"arn,omitempty"`
+	Status          string `json:"status,omitempty"`
+	Description     string `json:"description,omitempty"`
+	FoundationModel string `json:"foundationModel,omitempty"`
+	Instruction     string `json:"instruction,omitempty"`
+	ActionGroups    []any  `json:"actionGroups,omitempty"`
+	KnowledgeBases  []any  `json:"knowledgeBases,omitempty"`
+}
+
+// AWSBedrockKnowledgeBase represents an AWS Bedrock knowledge base with data sources.
+type AWSBedrockKnowledgeBase struct {
+	ID                         string         `json:"id,omitempty"`
+	Name                       string         `json:"name,omitempty"`
+	Arn                        string         `json:"arn,omitempty"`
+	Status                     string         `json:"status,omitempty"`
+	Description                string         `json:"description,omitempty"`
+	StorageConfiguration       map[string]any `json:"storageConfiguration,omitempty"`
+	KnowledgeBaseConfiguration map[string]any `json:"knowledgeBaseConfiguration,omitempty"`
+	DataSources                []any          `json:"dataSources,omitempty"`
+}
+
+// AWSBedrockFlow represents an AWS Bedrock flow (agent workflow).
+type AWSBedrockFlow struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Arn         string `json:"arn,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// GCPVertexAIPipelineJob represents a GCP Vertex AI pipeline job.
+type GCPVertexAIPipelineJob struct {
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	State       string `json:"state,omitempty"`
+}
+
+// GCPVertexAIDataset represents a GCP Vertex AI dataset.
+type GCPVertexAIDataset struct {
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// GCPModelArmorTemplate represents a GCP Model Armor safety template.
+type GCPModelArmorTemplate struct {
+	Name         string            `json:"name,omitempty"`
+	ProjectID    string            `json:"projectId,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	FilterConfig map[string]any    `json:"filterConfig,omitempty"`
+}
+
+// GCPModelArmorFloorSetting represents the GCP Model Armor floor setting.
+type GCPModelArmorFloorSetting struct {
+	Name                          string         `json:"name,omitempty"`
+	EnableFloorSettingEnforcement bool           `json:"enableFloorSettingEnforcement,omitempty"`
+	FilterConfig                  map[string]any `json:"filterConfig,omitempty"`
+}
+
+// AzureRAIAccount represents an Azure Cognitive Services account with RAI policies.
+type AzureRAIAccount struct {
+	Name        string           `json:"name,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	RAIPolicies []AzureRAIPolicy `json:"raiPolicies,omitempty"`
+}
+
+type AzureRAIPolicy struct {
+	Name           string                  `json:"name,omitempty"`
+	Mode           string                  `json:"mode,omitempty"`
+	PolicyType     string                  `json:"policyType,omitempty"`
+	ContentFilters []AzureRAIContentFilter `json:"contentFilters,omitempty"`
+}
+
+type AzureRAIContentFilter struct {
+	Name              string `json:"name,omitempty"`
+	Source            string `json:"source,omitempty"`
+	Enabled           bool   `json:"enabled,omitempty"`
+	Blocking          bool   `json:"blocking,omitempty"`
+	SeverityThreshold string `json:"severityThreshold,omitempty"`
+}
+
+// CodingAgent represents a local coding agent from the OS provider.
+type CodingAgent struct {
+	ConfigPath       string               `json:"configPath,omitempty"`
+	Version          string               `json:"version,omitempty"`
+	Email            string               `json:"email,omitempty"`
+	Organization     string               `json:"organization,omitempty"`
+	Subscription     string               `json:"subscription,omitempty"`
+	AuthMode         string               `json:"authMode,omitempty"`
+	AuthType         string               `json:"authType,omitempty"`
+	Provider         string               `json:"provider,omitempty"`
+	Model            string               `json:"model,omitempty"`
+	TelemetryEnabled bool                 `json:"telemetryEnabled,omitempty"`
+	Skills           []CodingAgentSkill   `json:"skills,omitempty"`
+	McpServers       []CodingAgentMcp     `json:"mcpServers,omitempty"`
+	Plugins          []CodingAgentPlugin  `json:"plugins,omitempty"`
+	Extensions       []CodingAgentExt     `json:"extensions,omitempty"`
+	Connectors       []CodingAgentConn    `json:"connectors,omitempty"`
+	Accounts         []CodingAgentAccount `json:"accounts,omitempty"`
+	ExtensionNames   []string             `json:"extensions_str,omitempty"`
+}
+
+type CodingAgentSkill struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Sha256      string `json:"sha256,omitempty"`
+}
+
+type CodingAgentMcp struct {
+	Name        string   `json:"name,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Command     string   `json:"command,omitempty"`
+	Args        []string `json:"args,omitempty"`
+	Url         string   `json:"url,omitempty"`
+	HasEnv      bool     `json:"hasEnv,omitempty"`
+	NeedsAuth   bool     `json:"needsAuth,omitempty"`
+	LastChecked string   `json:"lastChecked,omitempty"`
+	Plugin      string   `json:"plugin,omitempty"`
+}
+
+type CodingAgentPlugin struct {
+	Name         string   `json:"name,omitempty"`
+	Version      string   `json:"version,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Author       string   `json:"author,omitempty"`
+	Category     string   `json:"category,omitempty"`
+	Scope        string   `json:"scope,omitempty"`
+	InstallPath  string   `json:"installPath,omitempty"`
+	InstalledAt  string   `json:"installedAt,omitempty"`
+	LastUpdated  string   `json:"lastUpdated,omitempty"`
+	GitCommitSha string   `json:"gitCommitSha,omitempty"`
+	Enabled      bool     `json:"enabled,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+	HasMcp       bool     `json:"hasMcp,omitempty"`
+	HasHooks     bool     `json:"hasHooks,omitempty"`
+}
+
+type CodingAgentExt struct {
+	Name        string `json:"name,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Bundled     bool   `json:"bundled,omitempty"`
+	Timeout     int    `json:"timeout,omitempty"`
+}
+
+type CodingAgentConn struct {
+	Name   string `json:"name,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Plugin string `json:"plugin,omitempty"`
+}
+
+type CodingAgentAccount struct {
+	User        string `json:"user,omitempty"`
+	GithubAppID string `json:"githubAppId,omitempty"`
+}
+
+// AWSLambdaFunction represents an AWS Lambda function with IAM chain.
+type AWSLambdaFunction struct {
+	Arn              string            `json:"arn,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Runtime          string            `json:"runtime,omitempty"`
+	Handler          string            `json:"handler,omitempty"`
+	CodeSha256       string            `json:"codeSha256,omitempty"`
+	CodeSize         int64             `json:"codeSize,omitempty"`
+	PackageType      string            `json:"packageType,omitempty"`
+	ImageUri         string            `json:"imageUri,omitempty"`
+	ResolvedImageUri string            `json:"resolvedImageUri,omitempty"`
+	Environment      map[string]string `json:"environment,omitempty"`
+	Layers           []AWSLambdaLayer  `json:"layers,omitempty"`
+	Role             *AWSIAMRole       `json:"role,omitempty"`
+}
+
+type AWSLambdaLayer struct {
+	Arn      string `json:"arn,omitempty"`
+	CodeSize int64  `json:"codeSize,omitempty"`
+}
+
+type AWSIAMRole struct {
+	Arn              string         `json:"arn,omitempty"`
+	AttachedPolicies []AWSIAMPolicy `json:"attachedPolicies,omitempty"`
+}
+
+type AWSIAMPolicy struct {
+	Name           string               `json:"name,omitempty"`
+	DefaultVersion *AWSIAMPolicyVersion `json:"defaultVersion,omitempty"`
+}
+
+type AWSIAMPolicyVersion struct {
+	Document map[string]any `json:"document,omitempty"`
+}
+
+// GCPCloudFunction represents a GCP Cloud Function with service account.
+type GCPCloudFunction struct {
+	ProjectID     string                   `json:"projectId,omitempty"`
+	Name          string                   `json:"name,omitempty"`
+	Description   string                   `json:"description,omitempty"`
+	State         string                   `json:"state,omitempty"`
+	Environment   string                   `json:"environment,omitempty"`
+	URL           string                   `json:"url,omitempty"`
+	BuildConfig   *GCPCloudFuncBuildConfig `json:"buildConfig,omitempty"`
+	ServiceConfig *GCPCloudFuncSvcConfig   `json:"serviceConfig,omitempty"`
+}
+
+type GCPCloudFuncBuildConfig struct {
+	Runtime          string `json:"runtime,omitempty"`
+	EntryPoint       string `json:"entryPoint,omitempty"`
+	DockerRepository string `json:"dockerRepository,omitempty"`
+	ServiceAccount   string `json:"serviceAccount,omitempty"`
+}
+
+type GCPCloudFuncSvcConfig struct {
+	ServiceAccountEmail  string            `json:"serviceAccountEmail,omitempty"`
+	AvailableMemory      string            `json:"availableMemory,omitempty"`
+	EnvironmentVariables map[string]string `json:"environmentVariables,omitempty"`
+}
+
+// GCPCloudRunService represents a GCP Cloud Run service.
+type GCPCloudRunService struct {
+	Name        string               `json:"name,omitempty"`
+	Description string               `json:"description,omitempty"`
+	URI         string               `json:"uri,omitempty"`
+	Template    *GCPCloudRunTemplate `json:"template,omitempty"`
+}
+
+type GCPCloudRunTemplate struct {
+	ServiceAccountEmail string                 `json:"serviceAccountEmail,omitempty"`
+	Containers          []GCPCloudRunContainer `json:"containers,omitempty"`
+}
+
+type GCPCloudRunContainer struct {
+	Name  string            `json:"name,omitempty"`
+	Image string            `json:"image,omitempty"`
+	Env   map[string]string `json:"env,omitempty"`
+}
+
+// GCPIAMBinding represents a GCP IAM binding for an AI-related role.
+type GCPIAMBinding struct {
+	Role    string   `json:"role,omitempty"`
+	Members []string `json:"members,omitempty"`
+}
+
+// AzureFunctionApp represents an Azure Function App.
+type AzureFunctionApp struct {
+	Name                     string                    `json:"name,omitempty"`
+	ID                       string                    `json:"id,omitempty"`
+	Location                 string                    `json:"location,omitempty"`
+	ManagedServiceIdentityID string                    `json:"managedServiceIdentityId,omitempty"`
+	AppSettings              []AzureFunctionAppSetting `json:"appSettings,omitempty"`
+}
+
+type AzureFunctionAppSetting struct {
+	Name           string `json:"name,omitempty"`
+	HasKeyVaultRef bool   `json:"hasKeyVaultReference,omitempty"`
+	IsLikelySecret bool   `json:"isLikelySecret,omitempty"`
+}
+
+// LocalAIModel represents a locally cached AI model discovered by the ai.models resource.
+type LocalAIModel struct {
+	Name          string   `json:"name,omitempty"`
+	Source        string   `json:"source,omitempty"`
+	Vendor        string   `json:"vendor,omitempty"`
+	Family        string   `json:"family,omitempty"`
+	Path          string   `json:"path,omitempty"`
+	Size          int64    `json:"size,omitempty"`
+	ModifiedAt    string   `json:"modifiedAt,omitempty"`
+	Format        string   `json:"format,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	Quantization  string   `json:"quantization,omitempty"`
+	ParameterSize string   `json:"parameterSize,omitempty"`
+	Architecture  string   `json:"architecture,omitempty"`
+	License       string   `json:"license,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	Description   string   `json:"description,omitempty"`
+}
+
+// SoftwarePackage represents an npm or Python package discovered on the system.
+type SoftwarePackage struct {
+	Name    string   `json:"name,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Purl    string   `json:"purl,omitempty"`
+	Cpes    []string `json:"cpes,omitempty"`
+}
+
+// AiBomFields is the top-level structure for parsing MQL report data.
+type AiBomFields struct {
+	Asset                   *AiBomAsset                     `json:"asset,omitempty"`
+	OllamaModels            []OllamaModel                   `json:"ollama.models,omitempty"`
+	HuggingFaceModels       []HuggingFaceModel              `json:"huggingface.models,omitempty"`
+	BedrockFoundationModels []AWSBedrockFoundationModel     `json:"aws.bedrock.foundationModels,omitempty"`
+	BedrockCustomModels     []AWSBedrockCustomModel         `json:"aws.bedrock.customModels,omitempty"`
+	SageMakerModels         []AWSSageMakerModel             `json:"aws.sagemaker.models,omitempty"`
+	VertexAIModels          []GCPVertexAIModel              `json:"gcp.project.vertexaiService.models,omitempty"`
+	AzureCognitiveAccounts  []AzureCognitiveServicesAccount `json:"azure.subscription.cognitiveServices.accounts,omitempty"`
+	VLLM                    *VLLMData                       `json:"vllm,omitempty"`
+	ClaudeModels            []ClaudeModel                   `json:"claude.models,omitempty"`
+	ClaudeAgents            []ClaudeAgent                   `json:"claude.agents,omitempty"`
+	ClaudeSkills            []ClaudeSkill                   `json:"claude.skills,omitempty"`
+	ClaudeEnvironments      []ClaudeEnvironment             `json:"claude.environments,omitempty"`
+	ClaudeVaults            []ClaudeVault                   `json:"claude.vaults,omitempty"`
+	ClaudeMemoryStores      []ClaudeMemoryStore             `json:"claude.memoryStores,omitempty"`
+	OpenAIModels            []OpenAIModel                   `json:"openai.models,omitempty"`
+	OpenAIFineTuningJobs    []OpenAIFineTuningJob           `json:"openai.fineTuningJobs,omitempty"`
+	OpenAIVectorStores      []OpenAIVectorStore             `json:"openai.vectorStores,omitempty"`
+	OpenAIProjects          []OpenAIProject                 `json:"openai.projects,omitempty"`
+	BedrockGuardrails       []AWSBedrockGuardrail           `json:"aws.bedrock.guardrails,omitempty"`
+	BedrockAgents           []AWSBedrockAgent               `json:"aws.bedrock.agents,omitempty"`
+	BedrockKnowledgeBases   []AWSBedrockKnowledgeBase       `json:"aws.bedrock.knowledgeBases,omitempty"`
+	BedrockFlows            []AWSBedrockFlow                `json:"aws.bedrock.flows,omitempty"`
+	VertexAIPipelineJobs    []GCPVertexAIPipelineJob        `json:"gcp.project.vertexaiService.pipelineJobs,omitempty"`
+	VertexAIDatasets        []GCPVertexAIDataset            `json:"gcp.project.vertexaiService.datasets,omitempty"`
+	ModelArmorTemplates     []GCPModelArmorTemplate         `json:"gcp.project.modelArmorService.templates,omitempty"`
+	ModelArmorFloorSetting  *GCPModelArmorFloorSetting      `json:"gcp.project.modelArmorService.floorSetting,omitempty"`
+	AzureRAIAccounts        []AzureRAIAccount               `json:"azure.subscription.cognitiveServices.accounts.rai,omitempty"`
+	ClaudeCode              *CodingAgent                    `json:"claude.code,omitempty"`
+	OpenAICodex             *CodingAgent                    `json:"openai.codex,omitempty"`
+	Cursor                  *CodingAgent                    `json:"cursor,omitempty"`
+	GithubCopilot           *CodingAgent                    `json:"github.copilot,omitempty"`
+	Windsurf                *CodingAgent                    `json:"windsurf,omitempty"`
+	Gemini                  *CodingAgent                    `json:"gemini,omitempty"`
+	Goose                   *CodingAgent                    `json:"goose,omitempty"`
+	Zed                     *CodingAgent                    `json:"zed,omitempty"`
+	Roo                     *CodingAgent                    `json:"roo,omitempty"`
+	Cline                   *CodingAgent                    `json:"cline,omitempty"`
+	Kiro                    *CodingAgent                    `json:"kiro,omitempty"`
+	Trae                    *CodingAgent                    `json:"trae,omitempty"`
+	Junie                   *CodingAgent                    `json:"junie,omitempty"`
+	Augment                 *CodingAgent                    `json:"augment,omitempty"`
+	Kilocode                *CodingAgent                    `json:"kilocode,omitempty"`
+	Continuedev             *CodingAgent                    `json:"continuedev,omitempty"`
+	MistralVibe             *CodingAgent                    `json:"mistral.vibe,omitempty"`
+	Antigravity             *CodingAgent                    `json:"antigravity,omitempty"`
+	IbmBob                  *CodingAgent                    `json:"ibm.bob,omitempty"`
+	OpenClaw                *CodingAgent                    `json:"openclaw,omitempty"`
+	SnowflakeCortex         *CodingAgent                    `json:"snowflake.cortex,omitempty"`
+	Warp                    *CodingAgent                    `json:"warp,omitempty"`
+	OpenHands               *CodingAgent                    `json:"openhands,omitempty"`
+	OpenCode                *CodingAgent                    `json:"opencode,omitempty"`
+	Pi                      *CodingAgent                    `json:"pi,omitempty"`
+	QwenCode                *CodingAgent                    `json:"qwen.code,omitempty"`
+	LambdaFunctions         []AWSLambdaFunction             `json:"aws.lambda.functions,omitempty"`
+	GCPCloudFunctions       []GCPCloudFunction              `json:"gcp.project.cloudFunctions,omitempty"`
+	GCPCloudRunServices     []GCPCloudRunService            `json:"gcp.project.cloudRunService.services,omitempty"`
+	GCPIAMBindings          []GCPIAMBinding                 `json:"gcp.project.iamPolicy,omitempty"`
+	AzureFunctionApps       []AzureFunctionApp              `json:"azure.subscription.functionsService.functions,omitempty"`
+	NpmPackages             []SoftwarePackage               `json:"npm.packages,omitempty"`
+	PythonPackages          []SoftwarePackage               `json:"python.packages,omitempty"`
+	LocalModels             []LocalAIModel                  `json:"ai.models,omitempty"`
+}

--- a/internal/aibom/generator/scoring.go
+++ b/internal/aibom/generator/scoring.go
@@ -1,0 +1,219 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generator
+
+import (
+	"go.mondoo.com/cnspec/v13/internal/aibom"
+)
+
+// Section weights for completeness scoring (ADR-0003).
+var sectionWeights = map[string]float32{
+	"identity":      0.25,
+	"license_legal": 0.20,
+	"technical":     0.20,
+	"training_data": 0.20,
+	"ethics_risk":   0.15,
+}
+
+// ComputeCompleteness calculates the completeness score for an AIBOM.
+func ComputeCompleteness(models []*aibom.ModelComponent) *aibom.CompletenessScore {
+	if len(models) == 0 {
+		return &aibom.CompletenessScore{
+			TotalScore:      0,
+			SectionScores:   map[string]float32{},
+			MissingFields:   []string{},
+			Recommendations: []string{"No models discovered. Verify provider credentials and connectivity."},
+		}
+	}
+
+	totalIdentity := float32(0)
+	totalLicense := float32(0)
+	totalTechnical := float32(0)
+	totalTraining := float32(0)
+	totalEthics := float32(0)
+
+	var allMissing []string
+
+	for _, m := range models {
+		identity, missing := scoreIdentity(m)
+		totalIdentity += identity
+		allMissing = append(allMissing, missing...)
+
+		license, missing := scoreLicense(m)
+		totalLicense += license
+		allMissing = append(allMissing, missing...)
+
+		technical, missing := scoreTechnical(m)
+		totalTechnical += technical
+		allMissing = append(allMissing, missing...)
+
+		training, missing := scoreTraining(m)
+		totalTraining += training
+		allMissing = append(allMissing, missing...)
+
+		ethics, missing := scoreEthics(m)
+		totalEthics += ethics
+		allMissing = append(allMissing, missing...)
+	}
+
+	n := float32(len(models))
+	sections := map[string]float32{
+		"identity":      totalIdentity / n,
+		"license_legal": totalLicense / n,
+		"technical":     totalTechnical / n,
+		"training_data": totalTraining / n,
+		"ethics_risk":   totalEthics / n,
+	}
+
+	total := float32(0)
+	for section, score := range sections {
+		total += score * sectionWeights[section]
+	}
+
+	missing := deduplicate(allMissing)
+	recs := generateRecommendations(sections)
+
+	return &aibom.CompletenessScore{
+		TotalScore:      total,
+		SectionScores:   sections,
+		MissingFields:   missing,
+		Recommendations: recs,
+	}
+}
+
+func scoreIdentity(m *aibom.ModelComponent) (float32, []string) {
+	score := float32(0)
+	total := float32(5)
+	var missing []string
+
+	if m.Name != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":name")
+	}
+	if m.Version != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":version")
+	}
+	if m.Provider != "" {
+		score++
+	}
+	if m.ModelId != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":model_id")
+	}
+	if m.Author != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":author")
+	}
+	return score / total, missing
+}
+
+func scoreLicense(m *aibom.ModelComponent) (float32, []string) {
+	if m.License != "" {
+		return 1.0, nil
+	}
+	return 0, []string{m.Provider + ":license"}
+}
+
+func scoreTechnical(m *aibom.ModelComponent) (float32, []string) {
+	score := float32(0)
+	total := float32(4)
+	var missing []string
+
+	if m.Task != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":task")
+	}
+	if m.ArchitectureFamily != "" || m.ModelArchitecture != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":architecture")
+	}
+	if m.ApproachType != "" {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":approach_type")
+	}
+	if len(m.InputModalities) > 0 || len(m.OutputModalities) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":modalities")
+	}
+	return score / total, missing
+}
+
+func scoreTraining(m *aibom.ModelComponent) (float32, []string) {
+	score := float32(0)
+	total := float32(2)
+	var missing []string
+
+	if len(m.TrainingDatasets) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":training_datasets")
+	}
+	if len(m.Provenance) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":provenance")
+	}
+	return score / total, missing
+}
+
+func scoreEthics(m *aibom.ModelComponent) (float32, []string) {
+	score := float32(0)
+	total := float32(3)
+	var missing []string
+
+	if len(m.EthicalConsiderations) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":ethical_considerations")
+	}
+	if len(m.Limitations) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":limitations")
+	}
+	if len(m.IntendedUses) > 0 {
+		score++
+	} else {
+		missing = append(missing, m.Provider+":intended_uses")
+	}
+	return score / total, missing
+}
+
+func deduplicate(items []string) []string {
+	seen := map[string]bool{}
+	result := []string{}
+	for _, item := range items {
+		if !seen[item] {
+			seen[item] = true
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func generateRecommendations(sections map[string]float32) []string {
+	var recs []string
+	if sections["license_legal"] < 0.5 {
+		recs = append(recs, "Most models are missing license information. Add license metadata to improve compliance readiness.")
+	}
+	if sections["training_data"] < 0.3 {
+		recs = append(recs, "Training dataset provenance is largely unknown. Consider using providers with richer metadata (e.g., HuggingFace).")
+	}
+	if sections["ethics_risk"] < 0.2 {
+		recs = append(recs, "Ethical considerations and intended use documentation is sparse. This is common for cloud-hosted models.")
+	}
+	if sections["technical"] < 0.3 {
+		recs = append(recs, "Technical metadata (task, architecture, modalities) is incomplete for many models.")
+	}
+	return recs
+}

--- a/internal/aibom/json.go
+++ b/internal/aibom/json.go
@@ -1,0 +1,17 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aibom
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type JSONFormatter struct{}
+
+func (f *JSONFormatter) Render(w io.Writer, bom *AiBom) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(bom)
+}

--- a/internal/aibom/pack/aibom.mql.yaml
+++ b/internal/aibom/pack/aibom.mql.yaml
@@ -1,0 +1,895 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-aibom
+    name: Mondoo AI Bill of Materials
+    queries:
+      # Asset identity
+      - uid: mondoo-aibom-asset
+        title: Retrieve information about the AI platform
+        mql: asset { name platform version build family arch ids labels }
+
+      # Software packages (for agent SBOM correlation)
+      - uid: mondoo-aibom-npm-packages
+        title: Retrieve npm packages for agent SBOM
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          npm.packages { name version purl cpes }
+
+      - uid: mondoo-aibom-python-packages
+        title: Retrieve Python packages for agent SBOM
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          python.packages { name version purl cpes }
+
+      # Locally cached AI models (filesystem detection)
+      - uid: mondoo-aibom-local-models
+        title: Retrieve locally cached AI models
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          ai.models {
+            name source vendor family path size modifiedAt
+            format version quantization parameterSize
+            architecture license tags description
+          }
+
+      # Ollama models (local runtime)
+      - uid: mondoo-aibom-ollama-models
+        title: Retrieve Ollama models
+        filters:
+          - mql: asset.platform == "ollama"
+        mql: |
+          ollama.models {
+            name
+            model
+            family
+            families
+            parameterSize
+            quantizationLevel
+            format
+            size
+            digest
+            modifiedAt
+            license
+            capabilities
+            info {
+              architecture
+              parameterCount
+              contextLength
+              embeddingLength
+              blockCount
+              feedForwardLength
+              headCount
+              headCountKv
+              vocabSize
+              expertCount
+              expertUsedCount
+              sizeLabel
+              basename
+              finetune
+              author
+              description
+              datasets
+              languages
+              tags
+              license
+              tokenizerModel
+            }
+          }
+
+      # HuggingFace models (model registry)
+      - uid: mondoo-aibom-huggingface-models
+        title: Retrieve HuggingFace models
+        filters:
+          - mql: asset.family.contains("huggingface")
+        mql: |
+          huggingface.models {
+            id
+            modelId
+            author
+            pipelineTag
+            libraryName
+            tags
+            downloads
+            likes
+            sha
+            createdAt
+            lastModified
+            gated
+            disabled
+            private
+            license
+            cardData
+            config
+          }
+
+      # AWS Bedrock foundation models
+      - uid: mondoo-aibom-aws-bedrock-models
+        title: Retrieve AWS Bedrock foundation models
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.foundationModels {
+            modelId
+            modelName
+            providerName
+            inputModalities
+            outputModalities
+            inferenceTypesSupported
+            modelLifecycleStatus
+          }
+
+      # AWS Bedrock custom models
+      - uid: mondoo-aibom-aws-bedrock-custom-models
+        title: Retrieve AWS Bedrock custom models
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.customModels {
+            modelArn
+            modelName
+            baseModel { modelId modelName providerName }
+          }
+
+      # AWS SageMaker models
+      - uid: mondoo-aibom-aws-sagemaker-models
+        title: Retrieve AWS SageMaker models
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.sagemaker.models {
+            name
+            arn
+          }
+
+      # AWS SageMaker model cards
+      - uid: mondoo-aibom-aws-sagemaker-model-cards
+        title: Retrieve AWS SageMaker model cards
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.sagemaker.modelCards {
+            name
+            arn
+          }
+
+      # GCP Vertex AI models
+      - uid: mondoo-aibom-gcp-vertexai-models
+        title: Retrieve GCP Vertex AI models
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.vertexaiService.models {
+            name
+            displayName
+          }
+
+      # GCP Vertex AI endpoints
+      - uid: mondoo-aibom-gcp-vertexai-endpoints
+        title: Retrieve GCP Vertex AI endpoints
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.vertexaiService.endpoints {
+            name
+            displayName
+          }
+
+      # AWS Lambda functions (with IAM role chain for AI access detection)
+      - uid: mondoo-aibom-aws-lambda-functions
+        title: Retrieve AWS Lambda functions with IAM policies
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.lambda.functions {
+            arn
+            name
+            runtime
+            handler
+            codeSha256
+            codeSize
+            packageType
+            imageUri
+            resolvedImageUri
+            environment
+            layers { arn codeSize }
+            role {
+              arn
+              attachedPolicies {
+                name
+                defaultVersion { document }
+              }
+            }
+          }
+
+      # GCP Cloud Functions v2 (with service account for AI access detection)
+      - uid: mondoo-aibom-gcp-cloud-functions
+        title: Retrieve GCP Cloud Functions with service accounts
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.cloudFunctionsV2 {
+            projectId
+            name
+            description
+            state
+            environment
+            url
+            buildConfig { runtime entryPoint dockerRepository serviceAccount }
+            serviceConfig { serviceAccountEmail availableMemory environmentVariables }
+          }
+
+      # GCP Cloud Run services (AI agent hosting)
+      - uid: mondoo-aibom-gcp-cloud-run-services
+        title: Retrieve GCP Cloud Run services
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.cloudRunService.services {
+            name
+            description
+            uri
+            template {
+              serviceAccountEmail
+              containers {
+                name
+                image
+                env
+              }
+            }
+          }
+
+      # GCP IAM bindings (for AI service access detection)
+      - uid: mondoo-aibom-gcp-iam-bindings
+        title: Retrieve GCP IAM bindings for AI roles
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.iamPolicy.where(
+            role == "roles/aiplatform.user" ||
+            role == "roles/aiplatform.admin" ||
+            role == "roles/aiplatform.serviceAgent" ||
+            role == "roles/ml.admin" ||
+            role == "roles/ml.developer"
+          ) {
+            role
+            members
+          }
+
+      # Azure Function Apps (with identity for AI access detection)
+      - uid: mondoo-aibom-azure-function-apps
+        title: Retrieve Azure Function Apps with managed identity
+        filters:
+          - mql: asset.platform == "azure"
+        mql: |
+          azure.subscription.functionsService.functionApps {
+            name
+            id
+            location
+            managedServiceIdentityId
+            appSettings { name hasKeyVaultReference isLikelySecret }
+          }
+
+      # Azure Cognitive Services accounts (includes OpenAI)
+      - uid: mondoo-aibom-azure-cognitive-services
+        title: Retrieve Azure AI Services accounts
+        filters:
+          - mql: asset.platform == "azure"
+        mql: |
+          azure.subscription.cognitiveServices().accounts {
+            id
+            name
+            location
+            kind
+            endpoint
+            publicNetworkAccess
+            disableLocalAuth
+          }
+
+      # vLLM inference server
+      - uid: mondoo-aibom-vllm-server
+        title: Retrieve vLLM server information
+        filters:
+          - mql: asset.platform == "vllm"
+        mql: |
+          vllm {
+            version
+            server {
+              baseUrl
+              reachable
+              version
+              usesTls
+              corsConfigured
+              corsAllowsAnyOrigin
+              metricsExposed
+              docsExposed
+              openapiExposed
+              loadEndpointExposed
+              tokenizerInfoExposed
+              devEndpointsExposed
+              profilerEndpointsExposed
+            }
+            models {
+              id
+              root
+              parent
+              maxModelLen
+              created
+              ownedBy
+            }
+          }
+
+      # Claude API models
+      - uid: mondoo-aibom-claude-models
+        title: Retrieve Claude API models
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.models {
+            id
+            displayName
+            vendor
+            family
+            createdAt
+            maxInputTokens
+            maxTokens
+            batchSupported
+            citationsSupported
+            codeExecutionSupported
+            imageInputSupported
+            pdfInputSupported
+            structuredOutputsSupported
+            thinkingSupported
+          }
+
+      # Claude managed agents
+      - uid: mondoo-aibom-claude-agents
+        title: Retrieve Claude managed agents
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.agents {
+            id
+            name
+            description
+            system
+            model
+            version
+            createdAt
+            updatedAt
+          }
+
+      # Claude skills
+      - uid: mondoo-aibom-claude-skills
+        title: Retrieve Claude registered skills
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.skills {
+            id
+            displayTitle
+            source
+            latestVersion
+            createdAt
+            updatedAt
+          }
+
+      # Claude environments
+      - uid: mondoo-aibom-claude-environments
+        title: Retrieve Claude execution environments
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.environments {
+            id
+            name
+            description
+            scope
+            createdAt
+          }
+
+      # Claude vaults (secrets management for agents)
+      - uid: mondoo-aibom-claude-vaults
+        title: Retrieve Claude secret vaults
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.vaults {
+            id
+            displayName
+            createdAt
+            credentials { id displayName vaultId createdAt }
+          }
+
+      # Claude memory stores (persistent agent memory)
+      - uid: mondoo-aibom-claude-memory-stores
+        title: Retrieve Claude memory stores
+        filters:
+          - mql: asset.platform == "claude"
+        mql: |
+          claude.memoryStores {
+            id
+            name
+            description
+            createdAt
+          }
+
+      # OpenAI API models
+      - uid: mondoo-aibom-openai-models
+        title: Retrieve OpenAI API models
+        filters:
+          - mql: asset.platform == "openai"
+        mql: |
+          openai.models {
+            id
+            createdAt
+            ownedBy
+            isFineTuned
+            baseModel
+          }
+
+      # OpenAI fine-tuning jobs (model lineage)
+      - uid: mondoo-aibom-openai-fine-tuning-jobs
+        title: Retrieve OpenAI fine-tuning jobs
+        filters:
+          - mql: asset.platform == "openai"
+        mql: |
+          openai.fineTuningJobs {
+            id
+            model
+            status
+            createdAt
+            finishedAt
+            fineTunedModel
+            trainedTokens
+            organizationId
+            hyperparameters
+          }
+
+      # OpenAI vector stores (knowledge retrieval)
+      - uid: mondoo-aibom-openai-vector-stores
+        title: Retrieve OpenAI vector stores
+        filters:
+          - mql: asset.platform == "openai"
+        mql: |
+          openai.vectorStores {
+            id
+            name
+            status
+            usageBytes
+            createdAt
+            lastActiveAt
+            fileCounts
+          }
+
+      # OpenAI projects
+      - uid: mondoo-aibom-openai-projects
+        title: Retrieve OpenAI projects
+        filters:
+          - mql: asset.platform == "openai"
+        mql: |
+          openai.projects {
+            id
+            name
+            status
+            createdAt
+          }
+
+      # AWS Bedrock agents (with dependencies)
+      - uid: mondoo-aibom-aws-bedrock-agents
+        title: Retrieve AWS Bedrock agents with action groups and knowledge bases
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.agents {
+            id
+            name
+            arn
+            status
+            description
+            foundationModel
+            instruction
+            actionGroups
+            knowledgeBases
+          }
+
+      # AWS Bedrock knowledge bases (with data sources and config)
+      - uid: mondoo-aibom-aws-bedrock-knowledge-bases
+        title: Retrieve AWS Bedrock knowledge bases with data sources
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.knowledgeBases {
+            id
+            name
+            arn
+            status
+            description
+            storageConfiguration
+            knowledgeBaseConfiguration
+            dataSources
+          }
+
+      # AWS Bedrock guardrails (with policies)
+      - uid: mondoo-aibom-aws-bedrock-guardrails
+        title: Retrieve AWS Bedrock guardrails with policies
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.guardrails {
+            id
+            name
+            arn
+            status
+            version
+            contentPolicy
+            sensitiveInformationPolicy
+            topicPolicy
+            wordPolicy
+          }
+
+      # AWS Bedrock flows (agent workflows)
+      - uid: mondoo-aibom-aws-bedrock-flows
+        title: Retrieve AWS Bedrock flows
+        filters:
+          - mql: asset.platform == "aws"
+        mql: |
+          aws.bedrock.flows {
+            id
+            name
+            arn
+            status
+            version
+            description
+          }
+
+      # GCP Vertex AI pipeline jobs
+      - uid: mondoo-aibom-gcp-vertexai-pipeline-jobs
+        title: Retrieve GCP Vertex AI pipeline jobs
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.vertexaiService.pipelineJobs {
+            name
+            displayName
+            state
+          }
+
+      # GCP Vertex AI datasets
+      - uid: mondoo-aibom-gcp-vertexai-datasets
+        title: Retrieve GCP Vertex AI datasets
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.vertexaiService.datasets {
+            name
+            displayName
+            description
+          }
+
+      # GCP Model Armor templates (AI safety guardrails)
+      - uid: mondoo-aibom-gcp-model-armor-templates
+        title: Retrieve GCP Model Armor safety templates
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.modelArmorService.templates {
+            name
+            projectId
+            labels
+            filterConfig
+          }
+
+      # GCP Model Armor floor setting
+      - uid: mondoo-aibom-gcp-model-armor-floor
+        title: Retrieve GCP Model Armor floor setting
+        filters:
+          - mql: asset.platform == "gcp"
+        mql: |
+          gcp.project.modelArmorService.floorSetting {
+            name
+            enableFloorSettingEnforcement
+            filterConfig
+          }
+
+      # Azure RAI policies (content filtering)
+      - uid: mondoo-aibom-azure-rai-policies
+        title: Retrieve Azure RAI content filtering policies
+        filters:
+          - mql: asset.platform == "azure"
+        mql: |
+          azure.subscription.cognitiveServices().accounts {
+            name
+            kind
+            raiPolicies {
+              name
+              mode
+              policyType
+              contentFilters { name source enabled blocking severityThreshold }
+            }
+          }
+
+      # Local AI coding agents
+      - uid: mondoo-aibom-agent-claude-code
+        title: Retrieve Claude Code agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          claude.code {
+            configPath
+            email
+            organization
+            subscription
+            skills { name description source sha256 }
+            mcpServers { name needsAuth lastChecked }
+            plugins { name version scope installPath installedAt lastUpdated gitCommitSha enabled }
+          }
+
+      - uid: mondoo-aibom-agent-openai-codex
+        title: Retrieve OpenAI Codex agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          openai.codex {
+            configPath
+            version
+            authMode
+            skills { name description source sha256 }
+            mcpServers { name type url plugin }
+            plugins { name version description author category capabilities }
+            connectors { name id plugin }
+          }
+
+      - uid: mondoo-aibom-agent-cursor
+        title: Retrieve Cursor agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          cursor {
+            configPath
+            skills { name description source sha256 }
+            mcpServers { name command url args hasEnv }
+          }
+
+      - uid: mondoo-aibom-agent-github-copilot
+        title: Retrieve GitHub Copilot agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          github.copilot {
+            configPath
+            accounts { user githubAppId }
+            skills { name description source sha256 }
+            mcpServers { name type command args }
+          }
+
+      - uid: mondoo-aibom-agent-windsurf
+        title: Retrieve Windsurf agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          windsurf {
+            configPath
+            skills { name description source sha256 }
+            mcpServers { name command args hasEnv }
+          }
+
+      - uid: mondoo-aibom-agent-gemini
+        title: Retrieve Gemini Code agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          gemini {
+            configPath
+            authType
+            skills { name description source sha256 }
+            mcpServers { name command args hasEnv }
+          }
+
+      - uid: mondoo-aibom-agent-goose
+        title: Retrieve Goose agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          goose {
+            configPath
+            provider
+            model
+            telemetryEnabled
+            skills { name description source sha256 }
+            extensions { name enabled type description bundled timeout }
+          }
+
+      - uid: mondoo-aibom-agent-zed
+        title: Retrieve Zed agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          zed {
+            configPath
+            extensions
+          }
+
+      - uid: mondoo-aibom-agent-roo
+        title: Retrieve Roo agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          roo {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-cline
+        title: Retrieve Cline agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          cline {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-kiro
+        title: Retrieve Kiro agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          kiro {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-trae
+        title: Retrieve Trae agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          trae {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-junie
+        title: Retrieve Junie agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          junie {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-augment
+        title: Retrieve Augment agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          augment {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-kilocode
+        title: Retrieve Kilocode agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          kilocode {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-continuedev
+        title: Retrieve Continue agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          continuedev {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-mistral-vibe
+        title: Retrieve Mistral Vibe agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          mistral.vibe {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-antigravity
+        title: Retrieve Antigravity agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          antigravity {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-ibm-bob
+        title: Retrieve IBM Bob agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          ibm.bob {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-openclaw
+        title: Retrieve OpenClaw agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          openclaw {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-snowflake-cortex
+        title: Retrieve Snowflake Cortex agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          snowflake.cortex {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-warp
+        title: Retrieve Warp agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          warp {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-openhands
+        title: Retrieve OpenHands agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          openhands {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-opencode
+        title: Retrieve OpenCode agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          opencode {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-pi
+        title: Retrieve Pi agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          pi {
+            configPath
+            skills { name description source sha256 }
+          }
+
+      - uid: mondoo-aibom-agent-qwen-code
+        title: Retrieve Qwen Code agent
+        filters:
+          - mql: asset.family.contains("unix") || asset.family.contains("windows")
+        mql: |
+          qwen.code {
+            configPath
+            skills { name description source sha256 }
+          }

--- a/internal/aibom/pack/pack.go
+++ b/internal/aibom/pack/pack.go
@@ -1,0 +1,26 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pack
+
+import (
+	_ "embed"
+
+	"go.mondoo.com/cnspec/v13/policy"
+)
+
+//go:embed aibom.mql.yaml
+var aibomQueryPack []byte
+
+// QueryPack returns the AIBOM query pack as a policy bundle.
+// The bundle contains queries for collecting AI model inventory
+// information from providers including Ollama, HuggingFace,
+// AWS Bedrock/SageMaker, GCP Vertex AI, and Azure AI Services.
+func QueryPack() (*policy.Bundle, error) {
+	bundle, err := policy.BundleFromYAML(aibomQueryPack)
+	if err != nil {
+		return nil, err
+	}
+	bundle.ConvertQuerypacks()
+	return bundle, nil
+}

--- a/internal/aibom/textlist.go
+++ b/internal/aibom/textlist.go
@@ -1,0 +1,262 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aibom
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	statStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("14"))
+)
+
+type TextListFormatter struct{}
+
+func (f *TextListFormatter) Render(w io.Writer, bom *AiBom) error {
+	fmt.Fprintf(w, "\n%s\n", titleStyle.Render("AIBOM for "+bom.Asset.GetName()))
+
+	// Collect totals across all agents
+	type skillEntry struct {
+		Agent string
+		Skill *AgentSkill
+	}
+	type mcpEntry struct {
+		Agent string
+		Mcp   *McpServer
+	}
+	type pluginEntry struct {
+		Agent  string
+		Plugin *AgentPlugin
+	}
+	type extEntry struct {
+		Agent string
+		Ext   *AgentExtension
+	}
+
+	var allSkills []skillEntry
+	var allMcp []mcpEntry
+	var allPlugins []pluginEntry
+	var allExtensions []extEntry
+
+	for _, a := range bom.Agents {
+		for _, s := range a.Skills {
+			allSkills = append(allSkills, skillEntry{Agent: a.Name, Skill: s})
+		}
+		for _, m := range a.McpServers {
+			allMcp = append(allMcp, mcpEntry{Agent: a.Name, Mcp: m})
+		}
+		for _, p := range a.Plugins {
+			allPlugins = append(allPlugins, pluginEntry{Agent: a.Name, Plugin: p})
+		}
+		for _, e := range a.Extensions {
+			allExtensions = append(allExtensions, extEntry{Agent: a.Name, Ext: e})
+		}
+	}
+
+	// Summary stats
+	var stats []string
+	if len(bom.Models) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d models", len(bom.Models))))
+	}
+	if len(bom.Agents) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d agents", len(bom.Agents))))
+	}
+	if len(allSkills) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d skills", len(allSkills))))
+	}
+	if len(allMcp) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d MCP servers", len(allMcp))))
+	}
+	if len(allPlugins) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d plugins", len(allPlugins))))
+	}
+	if len(allExtensions) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d extensions", len(allExtensions))))
+	}
+	if len(bom.Guardrails) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d guardrails", len(bom.Guardrails))))
+	}
+	if len(bom.KnowledgeBases) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d knowledge bases", len(bom.KnowledgeBases))))
+	}
+	if len(bom.ComputeAccess) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d compute services", len(bom.ComputeAccess))))
+	}
+	if len(bom.AIDependencies) > 0 {
+		stats = append(stats, statStyle.Render(fmt.Sprintf("%d AI dependencies", len(bom.AIDependencies))))
+	}
+	if len(stats) > 0 {
+		fmt.Fprintf(w, "%s\n", strings.Join(stats, dimStyle.Render("  ·  ")))
+	}
+
+	// Models
+	if len(bom.Models) > 0 {
+		renderSection(w, "Models", "AI/ML models from local caches, registries, and cloud providers")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  NAME\tPROVIDER\tVERSION\tLICENSE\tFAMILY\tPARAMS")
+		fmt.Fprintln(tw, "  ----\t--------\t-------\t-------\t------\t------")
+		for _, m := range bom.Models {
+			license := m.License
+			if len(license) > 25 {
+				license = license[:25] + "..."
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+				m.Name, m.Provider, m.Version, license, m.ArchitectureFamily, m.ParameterSize)
+		}
+		tw.Flush()
+	}
+
+	// Agents
+	if len(bom.Agents) > 0 {
+		renderSection(w, "Agents", "AI coding agents and cloud orchestration services")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  AGENT\tPROVIDER\tVERSION\tMODEL")
+		fmt.Fprintln(tw, "  -----\t--------\t-------\t-----")
+		for _, a := range bom.Agents {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				a.Name, a.Provider, a.Version, a.Model)
+		}
+		tw.Flush()
+	}
+
+	// Skills
+	if len(allSkills) > 0 {
+		renderSection(w, "Skills", "Registered capabilities that extend agent behavior")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  SKILL\tAGENT")
+		fmt.Fprintln(tw, "  -----\t-----")
+		for _, s := range allSkills {
+			fmt.Fprintf(tw, "  %s\t%s\n", s.Skill.Name, s.Agent)
+		}
+		tw.Flush()
+	}
+
+	// MCP Servers
+	if len(allMcp) > 0 {
+		renderSection(w, "MCP Servers", "Model Context Protocol servers providing tools to agents")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  NAME\tAGENT\tTYPE\tENDPOINT")
+		fmt.Fprintln(tw, "  ----\t-----\t----\t--------")
+		for _, m := range allMcp {
+			endpoint := m.Mcp.Url
+			if endpoint == "" && m.Mcp.Command != "" {
+				endpoint = m.Mcp.Command
+				if len(m.Mcp.Args) > 0 {
+					endpoint += " " + strings.Join(m.Mcp.Args, " ")
+				}
+				if len(endpoint) > 60 {
+					endpoint = endpoint[:60] + "..."
+				}
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				m.Mcp.Name, m.Agent, m.Mcp.Type, endpoint)
+		}
+		tw.Flush()
+	}
+
+	// Plugins
+	if len(allPlugins) > 0 {
+		renderSection(w, "Plugins", "Agent plugins and integrations")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  PLUGIN\tAGENT\tVERSION\tENABLED")
+		fmt.Fprintln(tw, "  ------\t-----\t-------\t-------")
+		for _, p := range allPlugins {
+			enabled := "yes"
+			if !p.Plugin.Enabled {
+				enabled = "no"
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				p.Plugin.Name, p.Agent, p.Plugin.Version, enabled)
+		}
+		tw.Flush()
+	}
+
+	// Extensions
+	if len(allExtensions) > 0 {
+		renderSection(w, "Extensions", "Agent extensions and add-ons")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  EXTENSION\tAGENT\tTYPE\tENABLED")
+		fmt.Fprintln(tw, "  ---------\t-----\t----\t-------")
+		for _, e := range allExtensions {
+			enabled := "yes"
+			if !e.Ext.Enabled {
+				enabled = "no"
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				e.Ext.Name, e.Agent, e.Ext.Type, enabled)
+		}
+		tw.Flush()
+	}
+
+	// Guardrails
+	if len(bom.Guardrails) > 0 {
+		renderSection(w, "Guardrails", "AI safety and content filtering policies")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  GUARDRAIL\tPROVIDER\tSTATUS\tVERSION\tPOLICIES")
+		fmt.Fprintln(tw, "  ---------\t--------\t------\t-------\t--------")
+		for _, g := range bom.Guardrails {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%d\n",
+				g.Name, g.Provider, g.Status, g.Version, len(g.Policies))
+		}
+		tw.Flush()
+	}
+
+	// Knowledge Bases
+	if len(bom.KnowledgeBases) > 0 {
+		renderSection(w, "Knowledge Bases", "Vector stores and retrieval-augmented generation data")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  NAME\tPROVIDER\tSTATUS\tSTORAGE\tDATA SOURCES")
+		fmt.Fprintln(tw, "  ----\t--------\t------\t-------\t------------")
+		for _, kb := range bom.KnowledgeBases {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%d\n",
+				kb.Name, kb.Provider, kb.Status, kb.StorageType, len(kb.DataSources))
+		}
+		tw.Flush()
+	}
+
+	// Compute with AI Access
+	if len(bom.ComputeAccess) > 0 {
+		renderSection(w, "Compute with AI Access", "Serverless functions and services with AI service permissions")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  SERVICE\tTYPE\tPROVIDER\tRUNTIME\tAI SERVICES\tENV HINTS")
+		fmt.Fprintln(tw, "  -------\t----\t--------\t-------\t-----------\t---------")
+		for _, ca := range bom.ComputeAccess {
+			services := strings.Join(ca.AIServices, ",")
+			if len(services) > 30 {
+				services = services[:30] + "..."
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%d\n",
+				ca.Name, ca.Type, ca.Provider, ca.Runtime, services, len(ca.EnvHints))
+		}
+		tw.Flush()
+	}
+
+	// AI Dependencies
+	if len(bom.AIDependencies) > 0 {
+		renderSection(w, "AI Dependencies", "AI/ML libraries detected in package manifests")
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  PACKAGE\tVERSION\tCATEGORY\tLANGUAGE")
+		fmt.Fprintln(tw, "  -------\t-------\t--------\t--------")
+		for _, d := range bom.AIDependencies {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				d.Name, d.Version, d.Category, d.Language)
+		}
+		tw.Flush()
+	}
+
+	fmt.Fprintln(w)
+	return nil
+}
+
+func renderSection(w io.Writer, title, description string) {
+	fmt.Fprintf(w, "\n%s %s\n", headerStyle.Render("▌ "+title), dimStyle.Render("— "+description))
+}

--- a/internal/aibom/types.go
+++ b/internal/aibom/types.go
@@ -1,0 +1,230 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package aibom provides AI Bill of Materials generation.
+//
+// This file contains hand-written Go types that mirror the proto definitions
+// in cnspec_aibom.proto. Once the proto is compiled via `make cnspec/generate`,
+// this file should be replaced by the generated .pb.go code.
+package aibom
+
+type Status int32
+
+const (
+	Status_STATUS_UNSPECIFIED         Status = 0
+	Status_STATUS_SUCCEEDED           Status = 1
+	Status_STATUS_PARTIALLY_SUCCEEDED Status = 2
+	Status_STATUS_FAILED              Status = 3
+	Status_STATUS_STARTED             Status = 4
+)
+
+type AiBom struct {
+	Generator      *Generator         `json:"generator,omitempty"`
+	Timestamp      string             `json:"timestamp,omitempty"`
+	Status         Status             `json:"status,omitempty"`
+	Asset          *Asset             `json:"asset,omitempty"`
+	Models         []*ModelComponent  `json:"models,omitempty"`
+	Agents         []*AgentComponent  `json:"agents,omitempty"`
+	Guardrails     []*Guardrail       `json:"guardrails,omitempty"`
+	KnowledgeBases []*KnowledgeBase   `json:"knowledge_bases,omitempty"`
+	ComputeAccess  []*ComputeAIAccess `json:"compute_access,omitempty"`
+	AIDependencies []*AIDependency    `json:"ai_dependencies,omitempty"`
+	Completeness   *CompletenessScore `json:"completeness,omitempty"`
+	Errors         []string           `json:"errors,omitempty"`
+}
+
+type ComputeAIAccess struct {
+	Name           string            `json:"name,omitempty"`
+	Type           string            `json:"type,omitempty"`
+	Provider       string            `json:"provider,omitempty"`
+	Arn            string            `json:"arn,omitempty"`
+	Runtime        string            `json:"runtime,omitempty"`
+	ImageUri       string            `json:"image_uri,omitempty"`
+	CodeHash       string            `json:"code_hash,omitempty"`
+	ServiceAccount string            `json:"service_account,omitempty"`
+	AIServices     []string          `json:"ai_services,omitempty"`
+	AIActions      []string          `json:"ai_actions,omitempty"`
+	EnvHints       map[string]string `json:"env_hints,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+}
+
+type Generator struct {
+	Vendor  string `json:"vendor,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+	Url     string `json:"url,omitempty"`
+}
+
+type Asset struct {
+	Name        string            `json:"name,omitempty"`
+	PlatformIds []string          `json:"platform_ids,omitempty"`
+	Platform    *Platform         `json:"platform,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+func (a *Asset) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
+}
+
+type Platform struct {
+	Name    string   `json:"name,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Arch    string   `json:"arch,omitempty"`
+	Title   string   `json:"title,omitempty"`
+	Family  []string `json:"family,omitempty"`
+}
+
+type ModelComponent struct {
+	Name                  string                  `json:"name,omitempty"`
+	Version               string                  `json:"version,omitempty"`
+	Provider              string                  `json:"provider,omitempty"`
+	ModelId               string                  `json:"model_id,omitempty"`
+	Description           string                  `json:"description,omitempty"`
+	Author                string                  `json:"author,omitempty"`
+	License               string                  `json:"license,omitempty"`
+	Task                  string                  `json:"task,omitempty"`
+	ArchitectureFamily    string                  `json:"architecture_family,omitempty"`
+	ModelArchitecture     string                  `json:"model_architecture,omitempty"`
+	ApproachType          string                  `json:"approach_type,omitempty"`
+	InputModalities       []string                `json:"input_modalities,omitempty"`
+	OutputModalities      []string                `json:"output_modalities,omitempty"`
+	IntendedUses          []string                `json:"intended_uses,omitempty"`
+	Limitations           []string                `json:"limitations,omitempty"`
+	TrainingDatasets      []string                `json:"training_datasets,omitempty"`
+	EthicalConsiderations []*EthicalConsideration `json:"ethical_considerations,omitempty"`
+	PerformanceMetrics    map[string]string       `json:"performance_metrics,omitempty"`
+	Labels                map[string]string       `json:"labels,omitempty"`
+	Purl                  string                  `json:"purl,omitempty"`
+	SourceUrl             string                  `json:"source_url,omitempty"`
+	CreatedAt             string                  `json:"created_at,omitempty"`
+	UpdatedAt             string                  `json:"updated_at,omitempty"`
+	Provenance            map[string]string       `json:"provenance,omitempty"`
+	Format                string                  `json:"format,omitempty"`
+	Quantization          string                  `json:"quantization,omitempty"`
+	ParameterSize         string                  `json:"parameter_size,omitempty"`
+	Tags                  []string                `json:"tags,omitempty"`
+	Capabilities          []string                `json:"capabilities,omitempty"`
+}
+
+type AgentComponent struct {
+	Name         string             `json:"name,omitempty"`
+	Provider     string             `json:"provider,omitempty"`
+	ConfigPath   string             `json:"config_path,omitempty"`
+	Version      string             `json:"version,omitempty"`
+	Model        string             `json:"model,omitempty"`
+	McpServers   []*McpServer       `json:"mcp_servers,omitempty"`
+	Plugins      []*AgentPlugin     `json:"plugins,omitempty"`
+	Extensions   []*AgentExtension  `json:"extensions,omitempty"`
+	Skills       []*AgentSkill      `json:"skills,omitempty"`
+	Dependencies []*AgentDependency `json:"dependencies,omitempty"`
+	Labels       map[string]string  `json:"labels,omitempty"`
+}
+
+type McpServer struct {
+	Name     string        `json:"name,omitempty"`
+	Type     string        `json:"type,omitempty"`
+	Command  string        `json:"command,omitempty"`
+	Args     []string      `json:"args,omitempty"`
+	Url      string        `json:"url,omitempty"`
+	HasEnv   bool          `json:"has_env,omitempty"`
+	Purl     string        `json:"purl,omitempty"`
+	Packages []*PackageRef `json:"packages,omitempty"`
+}
+
+type PackageRef struct {
+	Name    string   `json:"name,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Purl    string   `json:"purl,omitempty"`
+	Cpes    []string `json:"cpes,omitempty"`
+}
+
+type AgentPlugin struct {
+	Name         string `json:"name,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Author       string `json:"author,omitempty"`
+	Description  string `json:"description,omitempty"`
+	InstallPath  string `json:"install_path,omitempty"`
+	GitCommitSha string `json:"git_commit_sha,omitempty"`
+	Enabled      bool   `json:"enabled,omitempty"`
+	Purl         string `json:"purl,omitempty"`
+}
+
+type AgentExtension struct {
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
+	Bundled     bool   `json:"bundled,omitempty"`
+}
+
+type AgentSkill struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Sha256      string `json:"sha256,omitempty"`
+}
+
+type Guardrail struct {
+	Name     string            `json:"name,omitempty"`
+	Provider string            `json:"provider,omitempty"`
+	ID       string            `json:"id,omitempty"`
+	Arn      string            `json:"arn,omitempty"`
+	Status   string            `json:"status,omitempty"`
+	Version  string            `json:"version,omitempty"`
+	Policies []string          `json:"policies,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+type KnowledgeBase struct {
+	Name           string            `json:"name,omitempty"`
+	Provider       string            `json:"provider,omitempty"`
+	ID             string            `json:"id,omitempty"`
+	Arn            string            `json:"arn,omitempty"`
+	Status         string            `json:"status,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	EmbeddingModel string            `json:"embedding_model,omitempty"`
+	StorageType    string            `json:"storage_type,omitempty"`
+	DataSources    []string          `json:"data_sources,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+}
+
+type AgentDependency struct {
+	Type     string            `json:"type,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	Arn      string            `json:"arn,omitempty"`
+	Runtime  string            `json:"runtime,omitempty"`
+	ImageUri string            `json:"image_uri,omitempty"`
+	CodeHash string            `json:"code_hash,omitempty"`
+	Layers   []string          `json:"layers,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+type AIDependency struct {
+	Name     string `json:"name,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Category string `json:"category,omitempty"`
+	Purl     string `json:"purl,omitempty"`
+	Language string `json:"language,omitempty"`
+}
+
+type EthicalConsideration struct {
+	Name               string `json:"name,omitempty"`
+	MitigationStrategy string `json:"mitigation_strategy,omitempty"`
+}
+
+type CompletenessScore struct {
+	TotalScore      float32            `json:"total_score,omitempty"`
+	SectionScores   map[string]float32 `json:"section_scores,omitempty"`
+	MissingFields   []string           `json:"missing_fields,omitempty"`
+	Recommendations []string           `json:"recommendations,omitempty"`
+}
+
+func (c *CompletenessScore) GetTotalScore() float32 {
+	if c == nil {
+		return 0
+	}
+	return c.TotalScore
+}

--- a/test/cli/testdata/cnspec.ct
+++ b/test/cli/testdata/cnspec.ct
@@ -11,6 +11,7 @@ Usage:
   cnspec [command]
 
 Available Commands:
+  aibom       Generate an AI bill of materials (AIBOM) for AI models across providers
   completion  Generate the autocompletion script for the specified shell
   discover    Discover assets
   framework   Manage local and Mondoo Platform hosted compliance frameworks


### PR DESCRIPTION
## Summary

<img width="938" height="299" alt="Screenshot 2026-05-27 at 14 59 39" src="https://github.com/user-attachments/assets/8570c98a-f823-4bbd-b054-2bab27040b22" />

- Adds `cnspec aibom` command that generates an AI Bill of Materials across cloud providers, model registries, and local runtimes
- Discovers **AI models** from Ollama, HuggingFace, OpenAI, AWS Bedrock/SageMaker, GCP Vertex AI, Azure OpenAI/ML, vLLM
- Discovers **25 AI coding agents** (Claude Code, Cursor, GitHub Copilot, Windsurf, etc.) with their MCP servers, plugins, extensions, and skills
- Detects **guardrails** (AWS Bedrock, GCP Model Armor), **knowledge bases** (AWS Bedrock, Azure AI Search), and **compute services with AI access** (Lambda, Cloud Functions, Cloud Run, Azure Functions)
- Classifies **AI dependencies** from npm and Python package manifests (model frameworks, API clients, agent frameworks, vector DBs)
- Output formats: markdown (default), JSON, CycloneDX JSON, CycloneDX XML
- Includes ADR-0003 documenting the design decisions

## Architecture

- **`internal/aibom/pack/aibom.mql.yaml`** — MQL query pack with per-platform filters for each provider
- **`internal/aibom/generator/`** — Converts MQL scan results into typed AiBom structs
- **`internal/aibom/cyclonedx.go`** — CycloneDX ML-BOM renderer (models as machine-learning-model components)
- **`internal/aibom/textlist.go`** — Styled CLI output with lipgloss (summary stats, tabular sections)
- **`apps/cnspec/cmd/aibom.go`** — CLI command wiring

## Test plan

- [x] `go test ./internal/aibom/...` — generator and scoring tests pass
- [x] `golangci-lint run ./internal/aibom/...` — zero issues
- [ ] `cnspec aibom local` — discovers agents and models on local system
- [ ] `cnspec aibom local -o cyclonedx-json` — valid CycloneDX ML-BOM output
- [ ] `cnspec aibom ollama` — discovers Ollama models
- [ ] `cnspec aibom aws -o json` — discovers Bedrock models, guardrails, knowledge bases, Lambda AI access

🤖 Generated with [Claude Code](https://claude.com/claude-code)