### PR TITLE
:sparkles: Dockerfile security: audit RUN BuildKit security/network/mount flags

### DIFF
--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1173,16 +1173,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/etc(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/proc(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/sys(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/dev(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/boot(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/root(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/home(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/var\/run(\/|$)/)))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/run(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/(etc|proc|sys|dev|boot|root|home|var\/run|run)?(\/|$)/)))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/var/run`, or `/run` from the build host. Sub-paths beneath those directories are equally dangerous; mounting `/etc/shadow`, `/root/.ssh`, `/home/<user>`, or `/var/run/docker.sock` directly is just as exposing as mounting the parent. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1125,7 +1125,7 @@ queries:
         **Why this matters**
 
         - **Host network exposure:** A build step running in the host network namespace can reach loopback services, link-local metadata endpoints (`169.254.169.254`), and other internal addresses that are normally unreachable from a sandboxed build.
-        - **Credential and token theft:** Cloud build environments often expose instance metadata or workload identity tokens on loopback or link-local addresses. Host networking lets any installer script or malicious dependency exfiltrate them.
+        - **Credential and token theft:** Cloud-hosted build environments often expose instance metadata or workload identity tokens on loopback or link-local addresses. Host networking lets any installer script or malicious dependency exfiltrate them.
         - **Reproducibility loss:** A build that depends on the host network behaves differently on developer laptops, CI runners, and air-gapped builders, undermining reproducible images.
         - **Least privilege:** Host networking should be reserved for narrow cases like building network drivers; using it as a default convenience violates the principle of least functionality.
       audit: |

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1173,25 +1173,28 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/(etc|proc|sys|dev|boot|root|home|var\/run|run)?(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/(etc|proc|sys|dev|boot|root|home|tmp|var|run)?(\/|$)/)))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/var/run`, or `/run` from the build host. Sub-paths beneath those directories are equally dangerous; mounting `/etc/shadow`, `/root/.ssh`, `/home/<user>`, or `/var/run/docker.sock` directly is just as exposing as mounting the parent. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.
+        Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/tmp`, `/var`, or `/run` from the build host. Sub-paths beneath those directories are equally dangerous; mounting `/etc/shadow`, `/root/.ssh`, `/home/<user>`, `/var/run/docker.sock`, or `/var/lib/docker` directly is just as exposing as mounting the parent. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.
 
         **Why this matters**
 
         - **Host filesystem exposure:** Binding `/`, `/etc`, or a sub-path like `/etc/shadow` reveals host system configuration, shadow files, and other credentials to every build step that follows.
         - **User credential theft:** Binding `/home`, `/root`, or sub-paths beneath them exposes SSH keys, shell history, cloud CLI tokens, and other user credentials to build steps.
-        - **Container escape via Docker socket:** Mounting `/var/run/docker.sock`, or the parent `/var/run` and `/run` directories that contain it, lets the build command spawn sibling containers with arbitrary privileges and effectively own the build host.
+        - **Container escape via Docker socket:** Mounting `/var/run/docker.sock`, or the parent `/var`, `/var/run`, and `/run` directories that contain it, lets the build command spawn sibling containers with arbitrary privileges and effectively own the build host.
+        - **Host state leakage:** `/var/lib` carries package-manager state, database data dirs, and container runtime state; `/var/log` carries logs that may include credentials; `/tmp` carries application sockets and short-lived secrets such as SSH-agent and X11 auth files.
         - **Kernel interface access:** `/proc` and `/sys` mounts, including sub-paths such as `/proc/1/environ` or `/sys/fs/cgroup`, expose kernel parameters, process information, and tunables that can be combined with other weaknesses to escape the build sandbox.
         - **Device passthrough:** A `/dev` bind mount hands the build raw access to host devices, enabling disk reads, kernel module loading, or hardware tampering.
         - **Supply-chain blast radius:** Build steps run untrusted package managers and installers. A bind mount turns any compromise in those tools into direct host compromise.
+
+        Legitimate BuildKit caching uses `--mount=type=cache` rather than bind mounts of host directories, so this check only flags `type=bind` (and the BuildKit-default omitted-type case) and does not interfere with cache mounts.
       audit: |
         Inspect the Dockerfile to confirm no `RUN` instruction bind-mounts a sensitive host path:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Search every `RUN` instruction for bind mounts: `grep -nE 'RUN.*--mount=' Dockerfile`.
-        3. For each match, confirm the `source=` value is not `/` and does not point at `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/var/run`, or `/run`. Sub-paths beneath those directories also fail the check, so `source=/etc/shadow`, `source=/root/.ssh`, `source=/home/builder`, and `source=/var/run/docker.sock` are all violations. Mounts that omit `type=` default to `type=bind` and must be checked the same way.
+        3. For each match, confirm the `source=` value is not `/` and does not point at `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/tmp`, `/var`, or `/run`. Sub-paths beneath those directories also fail the check, so `source=/etc/shadow`, `source=/root/.ssh`, `source=/home/builder`, `source=/var/run/docker.sock`, and `source=/var/lib/docker` are all violations. Mounts that omit `type=` default to `type=bind` and must be checked the same way.
 
         If no `RUN` mount references a sensitive host path, the check passes. If any does, the check fails.
       remediation:

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -57,6 +57,7 @@ policies:
           asset.platform == "dockerfile"
         checks:
           - uid: mondoo-docker-security-no-sensitive-volume-mounts
+          - uid: mondoo-docker-security-no-sensitive-bind-mount-sources
           - uid: mondoo-docker-security-no-workdir-system-dirs
       - title: Build Security
         filters: |
@@ -64,6 +65,8 @@ policies:
         checks:
           - uid: mondoo-docker-security-use-copy-instead-of-add
           - uid: mondoo-docker-security-no-secrets-in-env
+          - uid: mondoo-docker-security-no-run-security-insecure
+          - uid: mondoo-docker-security-no-run-network-host
           - uid: mondoo-docker-best-practice-no-latest-tag
           - uid: mondoo-docker-best-practice-from-tag-specified
       - title: Provenance & Ownership
@@ -1040,3 +1043,188 @@ queries:
     refs:
       - url: https://docs.docker.com/reference/dockerfile/#workdir
         title: Dockerfile Reference - WORKDIR
+  - uid: mondoo-docker-security-no-run-security-insecure
+    title: Don't use --security=insecure with RUN instructions
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      docker.file.stages.all(run.none(security == "insecure"))
+    docs:
+      desc: |
+        Dockerfile `RUN` instructions should not use the BuildKit `--security=insecure` flag. This flag disables seccomp and AppArmor confinement for the build step, granting the command the same capabilities as the BuildKit daemon, including raw device access and unrestricted system calls.
+
+        **Why this matters**
+
+        - **Build host compromise:** A `RUN --security=insecure` step executes with the privileges of the BuildKit daemon, so a malicious or compromised command can read host files, attach to host processes, and modify the build environment.
+        - **Untrusted dependencies:** Build steps often invoke third-party scripts and package installers. Running them outside the default sandbox turns any supply-chain compromise in those tools into a build-host compromise.
+        - **Audit trail:** BuildKit emits no special record when `insecure` is used; reviewers reading scan output, not the Dockerfile, will miss that the build ran without confinement.
+        - **Least privilege:** The flag exists for narrow cases like nested containerization. Defaulting to it for convenience violates the principle of least functionality required by hardened build pipelines.
+      audit: |
+        Inspect the Dockerfile to confirm no `RUN` instruction requests the insecure security mode:
+
+        1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
+        2. Search every `RUN` instruction for the flag: `grep -nE 'RUN.*--security=insecure' Dockerfile`.
+        3. Confirm no match is returned.
+
+        If the search produces no results, the check passes. If any `RUN` instruction sets `--security=insecure`, the check fails.
+      remediation:
+        - id: dockerfile
+          desc: |
+            Remove `--security=insecure` from every `RUN` instruction. If a build step genuinely needs elevated capabilities, isolate it in a separate stage and document the requirement in code review:
+
+            ```dockerfile
+            # Instead of:
+            RUN --security=insecure ./build.sh
+
+            # Use:
+            RUN ./build.sh
+            ```
+
+            If the step truly requires privileged operations, run it outside the image build (for example, in a controlled CI job that produces an artifact) and `COPY` the artifact into the image.
+    refs:
+      - url: https://docs.docker.com/reference/dockerfile/#run---security
+        title: Dockerfile Reference - RUN --security
+      - url: https://docs.docker.com/build/buildkit/#security-modes
+        title: BuildKit security modes
+  - uid: mondoo-docker-security-no-run-network-host
+    title: Don't use --network=host with RUN instructions
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      docker.file.stages.all(run.none(network == "host"))
+    docs:
+      desc: |
+        Dockerfile `RUN` instructions should not use the BuildKit `--network=host` flag. This flag attaches the build step directly to the build host's network namespace, removing the network isolation that BuildKit applies by default.
+
+        **Why this matters**
+
+        - **Host network exposure:** A build step running in the host network namespace can reach loopback services, link-local metadata endpoints (`169.254.169.254`), and other internal addresses that are normally unreachable from a sandboxed build.
+        - **Credential and token theft:** Cloud build environments often expose instance metadata or workload identity tokens on loopback or link-local addresses. Host networking lets any installer script or malicious dependency exfiltrate them.
+        - **Reproducibility loss:** A build that depends on the host network behaves differently on developer laptops, CI runners, and air-gapped builders, undermining reproducible images.
+        - **Least privilege:** Host networking should be reserved for narrow cases like building network drivers; using it as a default convenience violates the principle of least functionality.
+      audit: |
+        Inspect the Dockerfile to confirm no `RUN` instruction joins the host network:
+
+        1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
+        2. Search every `RUN` instruction for the flag: `grep -nE 'RUN.*--network=host' Dockerfile`.
+        3. Confirm no match is returned.
+
+        If the search produces no results, the check passes. If any `RUN` instruction sets `--network=host`, the check fails.
+      remediation:
+        - id: dockerfile
+          desc: |
+            Remove `--network=host` from every `RUN` instruction and let BuildKit use the default isolated network. When a build genuinely needs a private network endpoint, expose it through a build secret or `--mount=type=bind` instead of joining the host network:
+
+            ```dockerfile
+            # Instead of:
+            RUN --network=host ./fetch-internal-deps.sh
+
+            # Use:
+            RUN ./fetch-internal-deps.sh
+            ```
+
+            For builds that must reach a private mirror, configure the mirror as a build argument or pre-stage the dependencies in an earlier stage rather than relaxing network isolation.
+    refs:
+      - url: https://docs.docker.com/reference/dockerfile/#run---network
+        title: Dockerfile Reference - RUN --network
+      - url: https://docs.docker.com/build/buildkit/#network-modes
+        title: BuildKit network modes
+  - uid: mondoo-docker-security-no-sensitive-bind-mount-sources
+    title: Don't bind-mount sensitive host paths into RUN instructions
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/etc")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/proc")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/sys")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/dev")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/boot")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/root")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/var/run/docker.sock")))
+    docs:
+      desc: |
+        Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, or `/var/run/docker.sock` from the build host. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.
+
+        **Why this matters**
+
+        - **Host filesystem exposure:** Binding `/` or `/etc` reveals host system configuration, SSH keys, shadow files, and other credentials to every build step that follows.
+        - **Container escape via Docker socket:** Mounting `/var/run/docker.sock` lets the build command spawn sibling containers with arbitrary privileges and effectively own the build host.
+        - **Kernel interface access:** `/proc` and `/sys` mounts expose kernel parameters, process information, and tunables that can be combined with other weaknesses to escape the build sandbox.
+        - **Device passthrough:** A `/dev` bind mount hands the build raw access to host devices, enabling disk reads, kernel module loading, or hardware tampering.
+        - **Supply-chain blast radius:** Build steps run untrusted package managers and installers. A bind mount turns any compromise in those tools into direct host compromise.
+      audit: |
+        Inspect the Dockerfile to confirm no `RUN` instruction bind-mounts a sensitive host path:
+
+        1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
+        2. Search every `RUN` instruction for bind mounts: `grep -nE 'RUN.*--mount=' Dockerfile`.
+        3. For each match, confirm the `source=` value is not `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, or `/var/run/docker.sock`. Mounts that omit `type=` default to `type=bind` and must be checked the same way.
+
+        If no `RUN` mount references a sensitive host path, the check passes. If any does, the check fails.
+      remediation:
+        - id: dockerfile
+          desc: |
+            Remove bind mounts that reference sensitive host directories. If the build needs files from the host, copy only the specific artifacts you need into the build context and use `COPY`, or stage the data in an earlier image and reference it with `--mount=from=<stage>`:
+
+            ```dockerfile
+            # Instead of:
+            RUN --mount=type=bind,source=/etc,target=/host-etc ./build.sh
+            RUN --mount=type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock ./build.sh
+
+            # Use:
+            COPY ./build-config /etc/build-config
+            RUN ./build.sh
+
+            # Or stage the input in an earlier image:
+            FROM alpine AS deps
+            COPY ./deps /deps
+
+            FROM build
+            RUN --mount=type=bind,from=deps,source=/deps,target=/deps ./build.sh
+            ```
+
+            If the build truly needs Docker-in-Docker behavior, isolate it in a dedicated build job outside the image build rather than passing the host socket into the image.
+    refs:
+      - url: https://docs.docker.com/reference/dockerfile/#run---mounttypebind
+        title: Dockerfile Reference - RUN --mount=type=bind
+      - url: https://docs.docker.com/build/building/best-practices/
+        title: Dockerfile Best Practices

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1174,22 +1174,25 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
       docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/etc")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/proc")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/sys")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/dev")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/boot")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/root")))
-      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == "/var/run/docker.sock")))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/etc(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/proc(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/sys(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/dev(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/boot(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/root(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/home(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/var\/run(\/|$)/)))
+      docker.file.stages.all(run.all(mounts.where(type == "bind" || type == empty).none(source == /^\/run(\/|$)/)))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, or `/var/run/docker.sock` from the build host. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.
+        Dockerfile `RUN` instructions should not bind-mount sensitive host paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/var/run`, or `/run` from the build host. Sub-paths beneath those directories are equally dangerous; mounting `/etc/shadow`, `/root/.ssh`, `/home/<user>`, or `/var/run/docker.sock` directly is just as exposing as mounting the parent. A `RUN --mount=type=bind,source=<host-path>` step gives the build command direct access to whatever sits at that host path on the machine running BuildKit.
 
         **Why this matters**
 
-        - **Host filesystem exposure:** Binding `/` or `/etc` reveals host system configuration, SSH keys, shadow files, and other credentials to every build step that follows.
-        - **Container escape via Docker socket:** Mounting `/var/run/docker.sock` lets the build command spawn sibling containers with arbitrary privileges and effectively own the build host.
-        - **Kernel interface access:** `/proc` and `/sys` mounts expose kernel parameters, process information, and tunables that can be combined with other weaknesses to escape the build sandbox.
+        - **Host filesystem exposure:** Binding `/`, `/etc`, or a sub-path like `/etc/shadow` reveals host system configuration, shadow files, and other credentials to every build step that follows.
+        - **User credential theft:** Binding `/home`, `/root`, or sub-paths beneath them exposes SSH keys, shell history, cloud CLI tokens, and other user credentials to build steps.
+        - **Container escape via Docker socket:** Mounting `/var/run/docker.sock`, or the parent `/var/run` and `/run` directories that contain it, lets the build command spawn sibling containers with arbitrary privileges and effectively own the build host.
+        - **Kernel interface access:** `/proc` and `/sys` mounts, including sub-paths such as `/proc/1/environ` or `/sys/fs/cgroup`, expose kernel parameters, process information, and tunables that can be combined with other weaknesses to escape the build sandbox.
         - **Device passthrough:** A `/dev` bind mount hands the build raw access to host devices, enabling disk reads, kernel module loading, or hardware tampering.
         - **Supply-chain blast radius:** Build steps run untrusted package managers and installers. A bind mount turns any compromise in those tools into direct host compromise.
       audit: |
@@ -1197,7 +1200,7 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Search every `RUN` instruction for bind mounts: `grep -nE 'RUN.*--mount=' Dockerfile`.
-        3. For each match, confirm the `source=` value is not `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, or `/var/run/docker.sock`. Mounts that omit `type=` default to `type=bind` and must be checked the same way.
+        3. For each match, confirm the `source=` value is not `/` and does not point at `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/var/run`, or `/run`. Sub-paths beneath those directories also fail the check, so `source=/etc/shadow`, `source=/root/.ssh`, `source=/home/builder`, and `source=/var/run/docker.sock` are all violations. Mounts that omit `type=` default to `type=bind` and must be checked the same way.
 
         If no `RUN` mount references a sensitive host path, the check passes. If any does, the check fails.
       remediation:


### PR DESCRIPTION
## Summary

Adds three checks to `mondoo-dockerfile-security` covering BuildKit `RUN` flags that relax build-time isolation. The new checks consume fields added by [mondoohq/mql#7838](https://github.com/mondoohq/mql/pull/7838) (`docker.file.stage.run.network`, `run.security`, `run.mounts`).

- **`mondoo-docker-security-no-run-security-insecure`** (impact 100) — rejects `RUN --security=insecure`. This BuildKit flag disables seccomp and AppArmor for the build step, giving the command the same capabilities as the BuildKit daemon.
- **`mondoo-docker-security-no-run-network-host`** (impact 80) — rejects `RUN --network=host`. Joining the host network namespace removes BuildKit's default isolation and exposes loopback services, instance metadata, and link-local endpoints to build steps.
- **`mondoo-docker-security-no-sensitive-bind-mount-sources`** (impact 100) — rejects `RUN --mount=type=bind` from `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, or `/var/run/docker.sock`. Mirrors the existing `no-sensitive-volume-mounts` check but covers the BuildKit `RUN --mount` surface.

Compliance tags anchored to siblings with the same control objective: the two RUN-flag checks track `no-apt-get-dist-upgrade` (configuration hardening — ISO 27001 A.8.9, NIST SP 800-53 CM-6, PCI 2.2.1, SOC 2 CC7.1.1) and the bind-mount check tracks `no-sensitive-volume-mounts` (access control — ISO 27001 A.8.3, NIST SP 800-53 AC-3, PCI 7.2.1, SOC 2 CC6.1.3).

## Test plan

- [x] `cnspec policy lint content/mondoo-dockerfile-security.mql.yaml` — clean.
- [x] `cnspec scan docker file …` against a positive fixture exercising `--security=insecure`, `--network=host`, and `--mount=type=bind,source=/etc` — all three checks fail as expected.
- [x] `cnspec scan docker file …` against a clean fixture using `--mount=type=cache` and `--mount=type=secret` — all three checks pass (the bind-mount check correctly ignores non-bind mount types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)