### PR TITLE
:sparkles: cloudflare: verify every member has two-factor authentication enabled

### DIFF
--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -54,6 +54,7 @@ policies:
         filters: asset.platform == "cloudflare-account"
         checks:
           - uid: mondoo-cloudflare-security-enforce-two-factor
+          - uid: mondoo-cloudflare-security-members-have-two-factor
           - uid: mondoo-cloudflare-security-r2-buckets-not-public
           - uid: mondoo-cloudflare-security-api-tokens-have-expiration
           - uid: mondoo-cloudflare-security-api-tokens-have-ip-allowlist
@@ -2264,6 +2265,96 @@ queries:
     refs:
       - url: https://developers.cloudflare.com/fundamentals/api/how-to/secure-api-tokens-with-restrictive-permissions/
         title: Cloudflare API token IP filtering
+  # No Terraform variants: the check inspects each accepted member's twoFactorAuthenticationEnabled flag, which is per-user account state managed by the underlying Cloudflare user — not configuration declared by cloudflare_account_member HCL.
+  - uid: mondoo-cloudflare-security-members-have-two-factor
+    title: Ensure every account member has two-factor authentication enabled
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      cloudflare.account.members.where(status == "accepted").all(twoFactorAuthenticationEnabled)
+    docs:
+      desc: |
+        This check ensures that every accepted member of the Cloudflare account has two-factor authentication enabled on their underlying Cloudflare user. The account-level **Enforce two-factor authentication** toggle prevents new sign-ins without 2FA, but it does not retroactively confirm that every existing member has actually configured a second factor on their personal account; sessions established before enforcement and accounts that bypass the toggle can remain single-factor.
+
+        **Why this matters**
+
+        - **Per-user gap behind the account toggle:** The account-level enforcement setting prevents future password-only sign-ins, but members who joined before enforcement or who held active sessions at the time of the change may still authenticate without a second factor. Verifying the per-user flag closes that gap.
+        - **Credential compromise scope:** Each member with broad account permissions can modify DNS, SSL/TLS, WAF, and access policies for every zone. A single compromised password without a second factor allows an attacker the same blast radius as the member's role.
+        - **Phishing and credential stuffing:** Reused or phished passwords are the most common entry point into cloud accounts. A second factor stops these attacks even after a password leak.
+        - **Compliance evidence:** Frameworks that require MFA on privileged access expect proof that each individual identity carries the factor, not only that the account-level toggle is on.
+
+        **Risk mitigation**
+
+        - **Account takeover prevention:** Confirming that every accepted member has 2FA configured ensures that knowing a password is insufficient to gain account access, regardless of when the member joined.
+        - **Drift detection:** Catches members who joined while enforcement was off, who disabled 2FA on their personal account, or who were invited under an account configuration that did not require it.
+      audit: |
+        ### Audit via Dashboard
+
+        1. Log in to the Cloudflare dashboard and select the account.
+        2. Navigate to **Manage Account** > **Members**.
+        3. For each member with **Status: Active**, confirm the **Two-Factor Authentication** column shows **Enabled**.
+
+        A passing account shows 2FA enabled for every active member. A failing account shows at least one active member with 2FA disabled.
+
+        ### Audit via API
+
+        1. List members for the account:
+
+        ```bash
+        curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/<account-id>/members" \
+          -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+        ```
+
+        2. For each entry where `status` is `accepted`, confirm `user.two_factor_authentication_enabled` is `true`.
+
+        A passing account returns `true` for every accepted member. A failing account returns `false` for at least one accepted member.
+      remediation:
+        - id: console
+          desc: |
+            To bring every member into compliance from the Cloudflare dashboard:
+
+            1. Log in and select the account.
+            2. Navigate to **Manage Account** > **Members**.
+            3. Identify each active member whose **Two-Factor Authentication** column is **Disabled**.
+            4. Contact each member and have them enable 2FA on their personal Cloudflare account under **My Profile** > **Authentication** by configuring a TOTP authenticator app or security key.
+            5. With 2FA in place for every member, enable the account-level **Enforce two-factor authentication** toggle under **Members** > **Authentication** so new members must configure 2FA before joining.
+        - id: cli
+          desc: |
+            The per-user 2FA enrollment cannot be performed by an account administrator through the API; each affected member must enroll on their own Cloudflare user account. After contacting affected members, verify their state with the members list endpoint:
+
+            ```bash
+            curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/<account-id>/members" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              | jq '.result[] | select(.status == "accepted" and .user.two_factor_authentication_enabled == false) | .user.email'
+            ```
+
+            Repeat until the query returns no email addresses. With every member compliant, set the account-level enforcement so future joiners cannot bypass the requirement:
+
+            ```bash
+            curl -X PUT "https://api.cloudflare.com/client/v4/accounts/<account-id>" \
+              -H "Authorization: Bearer <api-token>" \
+              -H "Content-Type: application/json" \
+              --data '{"name":"<account-name>","settings":{"enforce_twofactor":true}}'
+            ```
+        # No Terraform remediation: per-user two-factor enrollment is owned by each Cloudflare user account, not by account-membership configuration. The cloudflare_account_member resource grants role membership but does not declare or enforce the underlying user's 2FA state, so there is no HCL change that can remediate this finding.
+    refs:
+      - url: https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/
+        title: Cloudflare two-factor authentication
+      - url: https://developers.cloudflare.com/api/operations/account-members-list-members
+        title: Cloudflare API - List account members
   # No Terraform variants: the check inspects each token's modifiedOn timestamp (when its secret was last rotated), which is runtime telemetry with no analog in cloudflare_api_token HCL — Terraform expresses desired token configuration, not the age of the current secret.
   - uid: mondoo-cloudflare-security-api-tokens-not-older-than-365-days
     title: Ensure active API tokens have been rotated within the last 365 days


### PR DESCRIPTION
## Summary

Adds **`mondoo-cloudflare-security-members-have-two-factor`** (impact 90) to `mondoo-cloudflare-security`. The existing `enforce-two-factor` check inspects only the account-level **Enforce two-factor authentication** toggle. This new check inspects the per-user state surfaced by `cloudflare.account.members` (added in [mondoohq/mql#7812](https://github.com/mondoohq/mql/pull/7812)) and asserts:

```mql
cloudflare.account.members.where(status == "accepted").all(twoFactorAuthenticationEnabled)
```

That closes the realistic gap where the account toggle is on but specific members joined before enforcement, held an active session at the time, or disabled 2FA on their personal Cloudflare user. Both checks are intentionally kept — the toggle protects future joiners, this one detects existing drift.

Impact and compliance tags anchored to the sibling `enforce-two-factor` (MFA-strength family: ISO 27001 A.8.5, NIST SP 800-53 IA-2, NIST CSF 2 PR.AA-03, SOC 2 CC6.1.4, PCI DSS 8.4.2).

## On the stale-pending-invites check (originally requested)

The original ask was a second check flagging pending invites older than 30 days. The `cloudflare.account.member` resource added in [mql#7812](https://github.com/mondoohq/mql/pull/7812) exposes `id`, `status`, `userId`, `email`, `firstName`, `lastName`, `twoFactorAuthenticationEnabled`, and `roles` — but **no creation or invitation timestamp**. There is no field on the resource that the check could compare against `time.now - 30 * time.day`.

Two viable follow-up paths:

1. File an upstream PR against `mondoohq/mql` to add `invitedOn` (and likely `acceptedOn`) to `cloudflare.account.member`, then add the stale-invites check here.
2. Correlate against `cloudflare.account.auditLogs` (`when` + `actionType` for member-create events). Constrained by the audit-log accessor returning only the first ~100 entries, so this is unreliable for accounts with high admin throughput.

Path (1) is the right answer; happy to follow up with the mql PR.

## Test plan

- [x] `cnspec policy lint content/mondoo-cloudflare-security.mql.yaml` — clean.
- [x] `python3 content/validation/validate_remediation_commands.py cloudflare` — both new `curl` calls (`GET /accounts/<account-id>/members`, `PUT /accounts/<account-id>`) validated against the pinned Cloudflare OpenAPI spec.
- [ ] Smoke test against a real Cloudflare account once cnspec is built against an mql release containing #7812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)