### PR TITLE
:sparkles: digitalocean: audit Spaces bucket exposure and database CA expiry

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -222,6 +222,7 @@ devtmpfs
 dhe
 DICOM
 diffie
+digitaloceanspaces
 directoryservice
 disableforwarding
 dlp
@@ -679,6 +680,7 @@ sentineld
 sentinelone
 servicebus
 serviceprincipals
+setacl
 setblockall
 setenv
 setglobalstate

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -57,6 +57,7 @@ policies:
           - uid: mondoo-digitalocean-security-db-firewall-configured
           - uid: mondoo-digitalocean-security-db-in-private-network
           - uid: mondoo-digitalocean-security-db-engine-supported-version
+          - uid: mondoo-digitalocean-security-db-ca-certificate-not-expired
       - title: Load Balancers
         filters: asset.platform == "digitalocean"
         checks:
@@ -81,6 +82,10 @@ policies:
         filters: asset.platform == "digitalocean"
         checks:
           - uid: mondoo-digitalocean-security-spaces-key-has-scoped-grants
+          - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable
+          - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-writable
+          - uid: mondoo-digitalocean-security-spaces-bucket-encryption-enabled
+          - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled
       - title: App Platform
         filters: asset.platform == "digitalocean"
         checks:
@@ -923,6 +928,98 @@ queries:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/upgrade-major-version/
         title: Upgrade a managed database major version
 
+  # No Terraform variants: the check inspects the validity window of the CA certificate the cluster currently advertises — runtime telemetry that has no analog in digitalocean_database_cluster HCL. Terraform expresses desired cluster configuration; the CA is managed and rotated by DigitalOcean and only exposed by the live API.
+  - uid: mondoo-digitalocean-security-db-ca-certificate-not-expired
+    title: Ensure managed database CA certificates are not expired
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-12
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      digitalocean.databases.all(certificates(pem: caCertificate).all(notAfter > time.now))
+    docs:
+      desc: |
+        This check ensures that every managed database cluster advertises a CA certificate whose validity window has not passed. Clients verify the cluster's TLS endpoint by pinning to this CA; once it expires, every connection that performs TLS verification fails its handshake.
+
+        **Why this matters**
+
+        - **Connection failure cascade:** A managed database whose CA has expired fails every TLS-verifying client at the handshake, taking the cluster offline from the application's perspective even though the cluster itself is healthy.
+        - **Silent verification bypass:** Operators under pressure to restore service often disable TLS verification rather than rotate the CA, downgrading future connections to unauthenticated TLS that is vulnerable to man-in-the-middle interception.
+        - **Audit and forensics gap:** A revoked or expired CA pinned in application configuration breaks the only signal that distinguishes a legitimate cluster endpoint from a replacement under an attacker's control.
+        - **Renewal blind spot:** Managed database CA certificates are rotated by the platform on long cycles, so expiry is easy to miss in the operator's calendar; an automated check catches the renewal need before the outage.
+
+        **Risk mitigation**
+
+        - **Outage prevention:** Detecting CA expiry before it lapses gives operators time to pull the updated CA from the DigitalOcean Cloud Control Panel and distribute it to every client.
+        - **TLS posture preservation:** Renewing rather than disabling verification keeps the cluster's authenticated TLS path intact, preventing operators from being pushed into a less-secure fallback.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Databases** and open each cluster.
+        3. On the **Overview** tab, locate the **CA Certificate** download and inspect the certificate's **Valid Until** field.
+
+        A passing cluster shows a future **Valid Until** date. A failing cluster shows a date that has already passed.
+
+        ### Audit via CLI
+
+        1. List clusters:
+
+        ```bash
+        doctl databases list --format ID,Name,Engine
+        ```
+
+        2. Download each cluster's CA and inspect the validity window with `openssl`:
+
+        ```bash
+        doctl databases get-ca <database-id> --format Certificate --no-header | base64 -d \
+          | openssl x509 -noout -enddate
+        ```
+
+        A passing cluster prints a `notAfter=` date in the future. A failing cluster prints a date in the past.
+      remediation:
+        - id: console
+          desc: |
+            DigitalOcean rotates managed database CA certificates on the platform side; the operator action when a CA is approaching or past expiry is to fetch the new certificate and distribute it to every client:
+
+            1. In the Cloud Control Panel, open the cluster's **Overview** tab.
+            2. Click **Download CA Certificate** to retrieve the current `ca-certificate.crt`.
+            3. Update every application configuration, Kubernetes secret, and CI pipeline that pins the old CA to use the new file.
+            4. Restart connecting services so the new CA is loaded.
+
+            If the download still returns an expired certificate, open a DigitalOcean support ticket from the cluster page so the platform can issue a replacement.
+        - id: cli
+          desc: |
+            Pull the new CA with `doctl` and roll it out to every consumer:
+
+            ```bash
+            doctl databases get-ca <database-id> --format Certificate --no-header \
+              | base64 -d > ca-certificate.crt
+            ```
+
+            Verify the new validity window before distribution:
+
+            ```bash
+            openssl x509 -in ca-certificate.crt -noout -enddate -subject
+            ```
+
+            Replace the certificate file in every client trust store, restart services, and confirm new connections succeed.
+        # No Terraform remediation: the CA certificate is provisioned and rotated by DigitalOcean, not declared in digitalocean_database_cluster HCL. Terraform-managed clusters still pull the active CA via the runtime API; remediation is to refresh the trust store on consumers, which is a deployment-time concern outside Terraform.
+    refs:
+      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure-cluster/
+        title: Secure a managed database cluster with TLS
+
   - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
     title: Ensure load balancers redirect HTTP traffic to HTTPS
     impact: 80
@@ -1741,6 +1838,446 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_key")
     mql: |
       terraform.state.resources.where(type == "digitalocean_spaces_key").all(values["grant"] != empty)
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable
+    title: Ensure Spaces buckets do not grant anonymous read access
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-digitalocean
+        tags:
+          mondoo.com/filter-title: DigitalOcean
+          mondoo.com/filter-icon: digitalocean
+      - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Spaces bucket grants the `READ` permission to the `AllUsers` group, which would make every object in the bucket readable by anyone on the internet without authentication. DigitalOcean Spaces is S3-compatible, so the same `public-read` ACL semantics as Amazon S3 apply: a single grant turns the bucket into an open object store.
+
+        **Why this matters**
+
+        - **Unauthenticated exposure:** A `public-read` bucket allows any client to enumerate object keys and download contents over the predictable `https://<bucket>.<region>.digitaloceanspaces.com/` URL pattern, requiring no DigitalOcean account or credentials.
+        - **Accidental data leak:** Buckets created for development or one-off asset hosting commonly inherit `public-read` and accumulate logs, backups, customer uploads, or build artifacts that were never reviewed for public release.
+        - **Compliance breach:** Frameworks that govern customer data, PII, or cardholder data prohibit storage in world-readable locations; a single `public-read` Spaces bucket creates an audit finding regardless of bucket contents.
+        - **Crawler and indexing exposure:** Search engines and security scanners actively index publicly readable Spaces buckets, increasing the speed at which leaked content is discovered and reused.
+
+        **Risk mitigation**
+
+        - **Authenticated access only:** Removing the anonymous `READ` grant forces every retrieval through Spaces access keys or pre-signed URLs, restoring auditability and access control.
+        - **CDN-fronted distribution:** When content genuinely needs to be public, serving it through a DigitalOcean CDN endpoint or a custom signed-URL pattern provides rate limiting, access logs, and revocation that the raw bucket URL cannot.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Spaces Object Storage** and open each bucket.
+        3. On the **Settings** tab, inspect the **File Listing** section.
+
+        A passing bucket shows **Restricted (Signed URLs only)**. A failing bucket shows **Enabled (Public)** or any indication that listing is allowed without authentication.
+
+        ### Audit via CLI
+
+        1. List the buckets and use `s3cmd` or the AWS CLI against the Spaces endpoint to inspect each bucket's ACL:
+
+        ```bash
+        doctl spaces buckets list
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-acl --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns grants only to the bucket owner. A failing bucket returns a grant where `Grantee.URI` is `http://acs.amazonaws.com/groups/global/AllUsers` and `Permission` is `READ` or `FULL_CONTROL`.
+      remediation:
+        - id: console
+          desc: |
+            To remove anonymous read access from the Cloud Control Panel:
+
+            1. Navigate to **Spaces Object Storage** and open the affected bucket.
+            2. Open the **Settings** tab.
+            3. Under **File Listing**, switch the setting from **Enabled (Public)** to **Restricted (Signed URLs only)**.
+            4. Audit existing objects that have individual public ACLs and reset them with the API or `s3cmd setacl --acl-private`.
+            5. If the bucket must serve public content, route requests through a DigitalOcean CDN endpoint or a Worker-equivalent pattern that enforces auth or rate limits.
+        - id: cli
+          desc: |
+            To remove anonymous read access using the S3-compatible API:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-acl --bucket <bucket> --acl private \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            For per-object public ACLs left over from previous configuration, iterate and reset:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3 ls s3://<bucket> --recursive --endpoint-url https://<region>.digitaloceanspaces.com \
+              | awk '{print $4}' \
+              | xargs -I{} aws s3api put-object-acl --bucket <bucket> --key {} --acl private \
+                  --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+        - id: terraform
+          desc: |
+            To declare the bucket as private with Terraform, set `acl = "private"` on `digitalocean_spaces_bucket` (the default) and avoid any `digitalocean_spaces_bucket_policy` or `_acl` resource that grants `AllUsers` read:
+
+            ```hcl
+            resource "digitalocean_spaces_bucket" "example" {
+              name   = "example-bucket"
+              region = "nyc3"
+              acl    = "private"
+            }
+            ```
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/how-to/manage-access/
+        title: Manage Spaces bucket access
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-digitalocean
+    filters: asset.platform == "digitalocean"
+    mql: |
+      digitalocean.spacesBuckets.none(publicReadAcl)
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.resources.where(nameLabel == "digitalocean_spaces_bucket").all(arguments.acl != "public-read" && arguments.acl != "public-read-write")
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "digitalocean_spaces_bucket").all(change.after.acl != "public-read" && change.after.acl != "public-read-write")
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(values.acl != "public-read" && values.acl != "public-read-write")
+
+  # No Terraform variants: the DigitalOcean Terraform provider's `digitalocean_spaces_bucket.acl` argument exposes only `"private"` and `"public-read"` — the S3-compatible `public-read-write` ACL must be applied through the runtime S3 API, so there is no HCL surface to inspect for it. The runtime variant catches buckets where it was set out of band.
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-writable
+    title: Ensure Spaces buckets do not grant anonymous write access
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.spacesBuckets.none(publicWriteAcl)
+    docs:
+      desc: |
+        This check ensures that no Spaces bucket grants the `WRITE` permission to the `AllUsers` group. An anonymously writable bucket lets any unauthenticated caller upload, overwrite, or delete objects, turning the bucket into a free hosting and laundering point for malicious payloads.
+
+        **Why this matters**
+
+        - **Malicious content hosting:** Writable buckets are routinely abused to stage phishing pages, malware downloads, and command-and-control payloads under a legitimate-looking domain that customers and security tools may trust.
+        - **Object replacement and tampering:** An attacker who can write the bucket can overwrite legitimate assets (configuration files, JavaScript bundles, signed artifacts) and serve modified versions to every consumer.
+        - **Billing and quota abuse:** Anonymous writes accumulate uncontrolled storage and bandwidth charges that are billed to the bucket owner; high-volume abuse can also push the account against service quotas.
+        - **No legitimate use case:** Unlike `public-read`, which has legitimate static-hosting patterns, `public-read-write` essentially has no defensible reason to exist on a production bucket; its presence is almost always a misconfiguration.
+
+        **Risk mitigation**
+
+        - **Authenticated writes only:** Removing the anonymous `WRITE` grant forces every upload through Spaces access keys or pre-signed URLs, restoring accountability.
+        - **Per-object policies:** When third parties must upload content, gate the workflow through short-lived pre-signed PUT URLs issued by application code instead of a permanently writable bucket.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the affected bucket under **Spaces Object Storage**.
+        3. Inspect the **Settings** tab and review any bucket policy attached to the bucket for a statement granting `s3:PutObject` to `Principal: "*"`.
+
+        A passing bucket has no bucket policy or no policy statement granting write to anonymous callers. A failing bucket grants `s3:PutObject` (or equivalent) to `*`.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket ACL and policy with the S3-compatible API:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-acl --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns no grant with `Grantee.URI = http://acs.amazonaws.com/groups/global/AllUsers` and `Permission` in (`WRITE`, `WRITE_ACP`, `FULL_CONTROL`). A failing bucket returns at least one such grant.
+      remediation:
+        - id: console
+          desc: |
+            To remove anonymous write access from the Cloud Control Panel:
+
+            1. Open the bucket under **Spaces Object Storage**.
+            2. Inspect the **Settings** tab for any bucket policy and remove statements that grant `s3:PutObject`, `s3:DeleteObject`, or `s3:*` to `Principal: "*"`.
+            3. If the bucket genuinely needs third-party uploads, replace the anonymous policy with a workflow that issues pre-signed `PUT` URLs from application code.
+        - id: cli
+          desc: |
+            To remove anonymous write access using the S3-compatible API:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-acl --bucket <bucket> --acl private \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            If a bucket policy grants writes to `*`, delete it:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api delete-bucket-policy --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+        # No Terraform remediation: the DigitalOcean Terraform provider's `digitalocean_spaces_bucket.acl` argument accepts only `"private"` and `"public-read"`. Anonymous writes are configured through the runtime S3 API (`PutBucketPolicy` granting `s3:PutObject` to `Principal: "*"`), which has no Terraform analog.
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/how-to/manage-access/
+        title: Manage Spaces bucket access
+
+  # No Terraform variants: the DigitalOcean Terraform provider's `digitalocean_spaces_bucket` resource does not expose server-side encryption configuration. SSE is configured through the runtime S3-compatible `PutBucketEncryption` call, which Terraform does not currently model.
+  - uid: mondoo-digitalocean-security-spaces-bucket-encryption-enabled
+    title: Ensure Spaces buckets have server-side encryption enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      digitalocean.spacesBuckets.all(encryptionEnabled)
+    docs:
+      desc: |
+        This check ensures that every Spaces bucket has a default server-side encryption configuration set. When default encryption is configured, every object written to the bucket is encrypted at rest by the platform, removing the need for clients to remember to apply per-request encryption.
+
+        **Why this matters**
+
+        - **Encryption-at-rest guarantee:** Without a default encryption configuration, individual `PutObject` callers can write unencrypted objects whenever they forget the per-request encryption header, leaving sensitive data on disk in plaintext.
+        - **Defense in depth:** Bucket-level default encryption is the last line of defense if access controls fail and an attacker gains read access to underlying storage media or backups.
+        - **Audit and compliance evidence:** Frameworks that mandate encryption at rest expect a single platform-enforced control rather than a per-call discipline that depends on developer behavior.
+        - **Lifecycle and replication safety:** Objects produced by lifecycle transitions, replication, and multipart uploads inherit the bucket default; without a configured default these derived objects also land unencrypted.
+
+        **Risk mitigation**
+
+        - **Plaintext-on-disk prevention:** A bucket with default encryption configured encrypts every new object server-side, so a future media exposure does not equal a content exposure.
+        - **Operational simplicity:** Centralising the encryption decision at the bucket removes the per-call configuration burden from every client SDK and CI pipeline.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the affected bucket under **Spaces Object Storage**.
+        3. Inspect the **Settings** tab for the **Default Encryption** section.
+
+        A passing bucket shows **AES-256** (or a configured KMS algorithm). A failing bucket shows **Not configured**.
+
+        ### Audit via CLI
+
+        1. Use the S3-compatible API to query the bucket's encryption configuration:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-encryption --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns a `ServerSideEncryptionConfiguration` document. A failing bucket returns `ServerSideEncryptionConfigurationNotFoundError`.
+      remediation:
+        - id: console
+          desc: |
+            Spaces does not expose default-encryption configuration in the Cloud Control Panel for every region. Apply the configuration with the CLI or S3-compatible API instead; see the CLI remediation below.
+        - id: cli
+          desc: |
+            Apply a bucket-level default encryption configuration with the S3-compatible API:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-encryption \
+                --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com \
+                --server-side-encryption-configuration '{
+                  "Rules": [{
+                    "ApplyServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" }
+                  }]
+                }'
+            ```
+
+            Re-encrypt existing objects so they pick up the new default:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3 cp s3://<bucket>/ s3://<bucket>/ \
+                --recursive --sse AES256 \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+        # No Terraform remediation: the digitalocean_spaces_bucket resource has no server_side_encryption_configuration argument; Spaces SSE must be applied at runtime via the S3-compatible PutBucketEncryption call.
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled
+    title: Ensure Spaces buckets have object versioning enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
+    variants:
+      - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-digitalocean
+        tags:
+          mondoo.com/filter-title: DigitalOcean
+          mondoo.com/filter-icon: digitalocean
+      - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Spaces bucket has object versioning enabled. Versioning preserves every revision of an object — including deletions, which become delete markers — so that accidental overwrites or ransomware-style mass deletes can be reversed by reading the prior version.
+
+        **Why this matters**
+
+        - **Accidental overwrite recovery:** A misconfigured deployment that pushes an empty file to the wrong key still leaves the previous version recoverable, turning what would be a data-loss incident into a roll-back.
+        - **Ransomware containment:** Attackers who obtain Spaces credentials and re-encrypt the contents of a bucket cannot remove the prior versions with a simple `DELETE`; versioned buckets force them to also issue per-version deletes, slowing exfiltration and increasing forensic evidence.
+        - **Auditability of changes:** Versioning provides a tamper-resistant record of every change to an object, which downstream compliance evidence and incident response rely on.
+        - **Replication and lifecycle dependencies:** Cross-region replication and certain lifecycle transitions on S3-compatible storage require versioning to be enabled; turning it on early avoids re-architecting later.
+
+        **Risk mitigation**
+
+        - **Data-loss recovery:** Enabling versioning means that single-object recovery is a `GET` of the prior version rather than a restore from external backups.
+        - **Defense against credential abuse:** A leaked write-capable key cannot quietly empty the bucket; the operator can roll forward to the prior versions while the credential is rotated.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the affected bucket under **Spaces Object Storage**.
+        3. Inspect the **Settings** tab for the **Versioning** section.
+
+        A passing bucket shows **Enabled**. A failing bucket shows **Disabled** or **Suspended**.
+
+        ### Audit via CLI
+
+        1. Query the bucket's versioning state via the S3-compatible API:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-versioning --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns `"Status": "Enabled"`. A failing bucket returns no status, `"Suspended"`, or an empty response.
+      remediation:
+        - id: console
+          desc: |
+            To enable versioning from the Cloud Control Panel:
+
+            1. Open the bucket under **Spaces Object Storage**.
+            2. Open the **Settings** tab.
+            3. Under **Versioning**, switch the setting to **Enabled**.
+            4. Pair versioning with a lifecycle rule that expires noncurrent versions after a defined retention window so the bucket does not grow unbounded.
+        - id: cli
+          desc: |
+            To enable versioning using the S3-compatible API:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-versioning --bucket <bucket> \
+                --versioning-configuration Status=Enabled \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            Verify the new state:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api get-bucket-versioning --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+        - id: terraform
+          desc: |
+            To enable versioning with Terraform, declare a `versioning` block on `digitalocean_spaces_bucket` with `enabled = true`:
+
+            ```hcl
+            resource "digitalocean_spaces_bucket" "example" {
+              name   = "example-bucket"
+              region = "nyc3"
+              acl    = "private"
+
+              versioning {
+                enabled = true
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/how-to/enable-versioning/
+        title: Enable Spaces bucket versioning
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-digitalocean
+    filters: asset.platform == "digitalocean"
+    mql: |
+      digitalocean.spacesBuckets.all(versioningStatus == "Enabled")
+  - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.resources.where(nameLabel == "digitalocean_spaces_bucket").all(blocks.where(type == "versioning").any(arguments.enabled == true))
+  - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "digitalocean_spaces_bucket").all(change.after["versioning"] != null && change.after["versioning"].any(_["enabled"] == true))
+  - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(values["versioning"] != null && values["versioning"].any(_["enabled"] == true))
 
   # No Terraform variants: this check inspects the scheme of each app's live_url,
   # which is a read-only computed attribute. App Platform always provisions managed


### PR DESCRIPTION
## Summary

Adds five checks to `mondoo-digitalocean-security` covering the audit gaps opened up by the new `digitalocean.spacesBucket` resource and the `database.caCertificate`/`database.latestBackupAt` accessors introduced in [mondoohq/mql#7799](https://github.com/mondoohq/mql/pull/7799). The DigitalOcean policy previously had zero Spaces bucket coverage; this PR brings it to parity with the existing R2 (Cloudflare) and OCI Object Storage checks.

### Checks

| UID | Impact | Variants | Anchor |
|-----|--------|----------|--------|
| `spaces-bucket-not-publicly-readable` | 100 | DO + TF HCL/plan/state | `mondoo-cloudflare-security-r2-buckets-not-public`, `mondoo-oci-security-object-storage-buckets-not-publicly-accessible` |
| `spaces-bucket-not-publicly-writable` | 100 | DO only — TF `digitalocean_spaces_bucket.acl` cannot express `public-read-write` | same control family as above |
| `spaces-bucket-encryption-enabled` | 80 | DO only — TF resource has no `server_side_encryption_configuration` argument | `mondoo-oci-security-object-storage-buckets-customer-managed-encryption` (encryption-at-rest family: NIST SC-28, ISO A.8.24, PCI 3.5.1) |
| `spaces-bucket-versioning-enabled` | 70 | DO + TF HCL/plan/state | `mondoo-oci-security-object-storage-buckets-versioning-enabled` (backup family: NIST CP-9, ISO A.8.13) |
| `db-ca-certificate-not-expired` | 80 | DO only — CA validity is runtime telemetry, no TF analog | `mondoo-digitalocean-security-cert-not-expired` (TLS lifecycle family: NIST SC-12, ISO A.8.24, PCI 4.2.1) |

### MQL notes

- `spaces-bucket-not-publicly-readable` TF HCL/plan/state variants check both `public-read` and `public-read-write` even though the DO provider only documents `public-read`; that catches users who set the ACL out of band through a TF wrapper or via the runtime API.
- `db-ca-certificate-not-expired` uses the core network provider's `certificates(pem: ...)` constructor to parse the cluster's PEM CA and assert `notAfter > time.now`. Verified locally with `cnspec run local -c 'certificates(pem: "...")'`.
- Each runtime-only check carries a `# No Terraform variants:` comment with a concrete technical reason, per `content/CLAUDE.md`.

## Test plan

- [x] `cnspec policy lint content/mondoo-digitalocean-security.mql.yaml` — clean.
- [x] `python3 content/validation/validate_remediation_commands.py digitalocean` — every `doctl` call passes against the live `doctl --help` tree (caught and fixed the original `doctl databases ca` → `doctl databases get-ca` while writing).
- [ ] Smoke test against a real DigitalOcean account once cnspec is built against an mql release containing #7799, especially that the `cnspec scan digitalocean` flow tolerates `DIGITALOCEAN_SPACES_KEY`/`SECRET` being unset (per the upstream PR, the spaces accessor should return an empty list in that case so the checks pass vacuously).

🤖 Generated with [Claude Code](https://claude.com/claude-code)