### PR TITLE
Use new macos resources (softwareupdate, profiles, mdm, filevault, gatekeeper) in policies and querypacks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -300,6 +300,7 @@ filebase
 fileless
 fileshare
 filestore
+filevault
 filipowm
 finetune
 fips

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -1472,7 +1472,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
-      command('fdesetup status').stdout.contains('FileVault is On')
+      macos.filevault.enabled == true
       users.where(name != /^_/ && shell != "/usr/bin/false" && name != "root") {
         name
         filePath = "/Library/Managed Preferences/" + name + "/complete.plist"
@@ -1789,7 +1789,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      command('spctl --status').stdout.contains("assessments enabled")
+      macos.gatekeeper.enabled == true
       users.where(name != /^_/ && shell != "/usr/bin/false" && name != "root") {
         name
         filePath1 = "/Library/Managed Preferences/" + name + "/complete.plist"

--- a/content/querypacks/mondoo-macos-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-macos-incident-response.mql.yaml
@@ -91,6 +91,16 @@ packs:
         docs:
           desc: Lists applications with firewall exceptions to identify software allowed to bypass the macOS Application Layer Firewall.
         mql: macos.alf.exceptions
+      - uid: mondoo-macos-incident-response-filevault
+        title: FileVault disk encryption status
+        docs:
+          desc: Returns FileVault encryption state and recovery-key configuration to confirm whether disk contents were protected at the time of the incident.
+        mql: macos.filevault { enabled status hasPersonalRecoveryKey hasInstitutionalRecoveryKey users }
+      - uid: mondoo-macos-incident-response-gatekeeper
+        title: Gatekeeper assessment status
+        docs:
+          desc: Returns Gatekeeper assessment state to confirm whether application-execution controls were enforced when the incident occurred.
+        mql: macos.gatekeeper { enabled status }
       - uid: mondoo-macos-incident-response-check-recommended-updates
         title: Recommended OS and application updates
         docs:

--- a/content/querypacks/mondoo-macos-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-macos-incident-response.mql.yaml
@@ -95,4 +95,4 @@ packs:
         title: Recommended OS and application updates
         docs:
           desc: Lists pending software updates to identify missing security patches and system updates.
-        mql: parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates']
+        mql: macos.softwareupdate.updates { label title version size recommended action }

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -199,3 +199,13 @@ packs:
         docs:
           desc: Lists installed system extensions with their activation status.
         mql: macos.systemExtensions { active enabled identifier state version }
+      - uid: mondoo-macos-filevault
+        title: FileVault disk encryption status
+        docs:
+          desc: Returns FileVault full-disk encryption state, status message, recovery key configuration, and the users authorized to unlock the encrypted volume.
+        mql: macos.filevault { enabled status hasPersonalRecoveryKey hasInstitutionalRecoveryKey users }
+      - uid: mondoo-macos-gatekeeper
+        title: Gatekeeper assessment status
+        docs:
+          desc: Returns Gatekeeper application-assessment state and the underlying status message reported by `spctl`.
+        mql: macos.gatekeeper { enabled status }

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -150,7 +150,7 @@ packs:
         title: Recommended software updates
         docs:
           desc: Lists pending macOS and application updates recommended by Apple.
-        mql: parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates']
+        mql: macos.softwareupdate.updates { label title version size recommended action }
       - uid: mondoo-macos-hardware-information
         title: Hardware information
         docs:
@@ -174,12 +174,16 @@ packs:
           desc: Returns network configuration from system profiler.
         mql: |
           parse.json(content: command('system_profiler SPNetworkDataType -json').stdout).params
+      - uid: mondoo-macos-mdm-enrollment
+        title: MDM enrollment status
+        docs:
+          desc: Returns Mobile Device Management enrollment details, including DEP and User Approved MDM status.
+        mql: macos.mdm { enrolled dep userApproved serverUrl }
       - uid: mondoo-macos-profile
         title: Configuration Profile Data
         docs:
-          desc: Returns installed MDM configuration profiles from system profiler.
-        mql: |
-          parse.json(content: command('system_profiler SPConfigurationProfileDataType -json').stdout).params
+          desc: Returns installed Configuration Profiles, sourced from both MDM-delivered and manually installed payloads.
+        mql: macos.profiles { identifier uuid displayName description organization type removalDisallowed scope payloads }
       - uid: mondoo-macos-timezone
         title: System timezone
         docs:


### PR DESCRIPTION
## Summary

The macOS policy and querypacks shell out to commands like `fdesetup`, `spctl`, `softwareupdate`, and `system_profiler` to surface data that new MQL resources from the os provider expose directly. This PR switches them over.

- **`mondoo-macos-security`**: FileVault and Gatekeeper checks now assert on `macos.filevault.enabled` / `macos.gatekeeper.enabled` instead of string-matching `command(...).stdout`. The managed-preferences plist assertions (`dontAllowFDEDisable`, `AllowIdentifiedDevelopers`, `EnableAssessment`) are unchanged — those enforce that the setting can't be toggled off, which the resources don't model.
- **`mondoo-macos-inventory`**: pending-updates query uses `macos.softwareupdate.updates`; the `SPConfigurationProfileDataType` shell-out is replaced with `macos.profiles`; adds `macos.mdm` enrollment-state query (DEP, UAMDM, server URL); adds `macos.filevault` and `macos.gatekeeper` queries.
- **`mondoo-macos-incident-response`**: pending-updates query uses `macos.softwareupdate.updates` instead of reading the cached `RecommendedUpdates` plist key; adds `macos.filevault` and `macos.gatekeeper` queries so responders can confirm protections were active at incident time.

Requires the next os provider release (PRs merged after v13.16.9).

## Test plan

- [ ] `cnspec policy lint` passes on all three files
- [ ] `cnspec scan local` on a macOS host returns expected results for the FileVault and Gatekeeper checks
- [ ] Inventory and IR querypacks render the new fields against a real macOS host

🤖 Generated with [Claude Code](https://claude.com/claude-code)