### PR TITLE
:sparkles: tailscale: audit pre-auth keys, audit log export, and webhook TLS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -173,6 +173,7 @@ corosync
 cosmosdb
 countmax
 createinstance
+Cribl
 crio
 Crowdsourced
 crowdstrike
@@ -434,6 +435,7 @@ logname
 logons
 logprofiles
 logsize
+logstreams
 logtraffic
 lookalike
 LPE
@@ -632,6 +634,7 @@ rexec
 rfc
 Rfi
 ril
+rolearn
 roocode
 rootaccountusage
 rooveterinaryinc

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.1.1
+    version: 1.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -960,7 +960,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      tailscale.authKeys.where(revoked.unix == 0).all(expires.unix > 0)
+      tailscale.authKeys.where(invalid == false && revoked.unix == 0).all(expires.unix > 0)
     docs:
       desc: |
         This check ensures that every active pre-auth key has a non-zero `expires` timestamp. A pre-auth key with no expiration acts as a long-lived bearer credential that can enroll arbitrary devices into the tailnet for the life of the tailnet itself; a leaked copy stays valid indefinitely.

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -48,6 +48,16 @@ policies:
       - title: Tailscale ACL Policy
         checks:
           - uid: mondoo-tailscale-security-acl-no-allow-all
+      - title: Tailscale Authentication Keys
+        checks:
+          - uid: mondoo-tailscale-security-authkeys-have-expiration
+          - uid: mondoo-tailscale-security-authkeys-not-reusable
+      - title: Tailscale Audit Logging
+        checks:
+          - uid: mondoo-tailscale-security-configuration-logstream-configured
+      - title: Tailscale Webhooks
+        checks:
+          - uid: mondoo-tailscale-security-webhooks-use-https
     scoring_system: highest impact
 queries:
   - uid: mondoo-tailscale-security-devices-authorized
@@ -931,3 +941,343 @@ queries:
         title: Tailscale ACL policy documentation
       - url: https://tailscale.com/kb/1192/tailnet-policy
         title: Writing a tailnet policy file
+  - uid: mondoo-tailscale-security-authkeys-have-expiration
+    title: Ensure active pre-auth keys have an expiration set
+    impact: 90
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      tailscale.authKeys.where(revoked.unix == 0).all(expires.unix > 0)
+    docs:
+      desc: |
+        This check ensures that every active pre-auth key has a non-zero `expires` timestamp. A pre-auth key with no expiration acts as a long-lived bearer credential that can enroll arbitrary devices into the tailnet for the life of the tailnet itself; a leaked copy stays valid indefinitely.
+
+        **Why this matters**
+
+        - **Indefinite blast radius:** A non-expiring pre-auth key in a CI pipeline, container image, or shared credential store remains usable years after the original use case is gone, so a single leak can re-enroll attacker-controlled nodes long after the team rotated other secrets.
+        - **Provisioning-lifecycle drift:** Pre-auth keys are issued for specific automation runs; without an expiration the credential outlives the workflow that needed it, accumulating dormant access.
+        - **Audit visibility gap:** Tailscale does not warn on keys that simply never expire. Expired keys disappear from the active set; non-expiring keys must be enumerated manually.
+        - **Compliance hard requirement:** Most authentication-credential controls require a documented lifetime on every secret used to authenticate devices or services. A non-expiring key cannot satisfy that.
+
+        **Risk mitigation**
+
+        - **Bounded credential lifetime:** Setting an explicit expiration means a leaked key automatically becomes useless after the configured window, capping the damage from any single exposure event.
+        - **Forces rotation discipline:** A finite lifetime requires operators to reissue keys on a defined cadence, which surfaces unused automation and keeps the active-key list honest.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin).
+        2. Open the **Keys** tab and review the **Auth keys** section.
+        3. For each key whose **Revoked** column is empty, confirm the **Expires** column shows a future date.
+
+        A passing tailnet shows a finite expiration on every active key. A failing tailnet shows at least one active key with **Expires: never**.
+
+        ### Audit via API
+
+        1. List active auth keys via the Tailscale API:
+
+        ```bash
+        curl -s -u "$TAILSCALE_API_KEY:" \
+          "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys?all=true"
+        ```
+
+        2. Then retrieve each individual key:
+
+        ```bash
+        curl -s -u "$TAILSCALE_API_KEY:" \
+          "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys/<key-id>"
+        ```
+
+        A passing key has `revoked` set or `expires` set to a future RFC 3339 timestamp. A failing key has `revoked` empty and `expires` equal to the zero value (`"0001-01-01T00:00:00Z"`).
+      remediation:
+        - id: console
+          desc: |
+            To replace a non-expiring pre-auth key from the admin console:
+
+            1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin) and open **Settings** > **Keys**.
+            2. Generate a replacement key with an explicit expiration (the **Expires** picker offers fixed windows up to 90 days; pick the shortest that satisfies the automation that consumes it).
+            3. Update every consumer of the old key to use the new value.
+            4. Revoke the old non-expiring key on the same page.
+        - id: cli
+          desc: |
+            To replace a non-expiring pre-auth key via the Tailscale API:
+
+            ```bash
+            # Create a replacement key with an explicit 90-day expiration (seconds).
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -H "Content-Type: application/json" \
+              -X POST "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys" \
+              --data '{
+                "capabilities": {
+                  "devices": { "create": { "reusable": false, "ephemeral": true, "preauthorized": true, "tags": ["tag:ci"] } }
+                },
+                "expirySeconds": 7776000
+              }'
+
+            # Update consumers, then revoke the old key.
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -X DELETE "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys/<old-key-id>"
+            ```
+    refs:
+      - url: https://tailscale.com/kb/1085/auth-keys
+        title: Tailscale auth keys
+  - uid: mondoo-tailscale-security-authkeys-not-reusable
+    title: Ensure active pre-auth keys are not marked reusable
+    impact: 80
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      tailscale.authKeys.where(invalid == false && revoked.unix == 0).none(reusable)
+    docs:
+      desc: |
+        This check ensures that no active, valid pre-auth key is marked `reusable`. A reusable key can enroll an unbounded number of devices for as long as it remains valid; a single-use key burns itself the moment the first device authenticates, capping the damage of a leak to one enrollment.
+
+        **Why this matters**
+
+        - **Multiplication of leak impact:** A reusable key that ends up in source control or a CI log can enroll dozens or hundreds of attacker-controlled nodes before anyone notices the exposure. A single-use key allows at most one rogue enrollment per leak event.
+        - **Lost provenance:** Devices enrolled with the same reusable key share no distinguishing per-device origin metadata; investigating which enrollment was malicious becomes harder when the credential is shared across legitimate uses.
+        - **Convenience trap:** Reusable keys are tempting for CI scenarios where many runners need to join, but the right pattern is short-lived ephemeral keys issued per job, not one long-lived shared credential.
+        - **Defence in depth on top of expiry:** Even if every key has an expiration, a reusable key remains exploitable across many enrollments within its window; non-reusable narrows the window from "many uses for N days" to "one use for N days".
+
+        **Risk mitigation**
+
+        - **Per-enrollment accountability:** A single-use key produces exactly one device record, making credential-to-device attribution unambiguous.
+        - **Damage cap on leak:** With reusability disabled, a leaked key compromises at most one enrollment slot, not every machine the credential could ever onboard.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin) and open **Settings** > **Keys**.
+        2. For each active key (not revoked, not invalid), inspect the **Reusable** column.
+
+        A passing tailnet shows **Reusable: No** on every active key. A failing tailnet shows at least one active key marked **Reusable: Yes**.
+
+        ### Audit via API
+
+        1. Pull each key's metadata:
+
+        ```bash
+        curl -s -u "$TAILSCALE_API_KEY:" \
+          "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys/<key-id>"
+        ```
+
+        A passing key returns `capabilities.devices.create.reusable: false`. A failing key returns `capabilities.devices.create.reusable: true` while `invalid` is `false` and `revoked` is unset.
+      remediation:
+        - id: console
+          desc: |
+            To replace a reusable pre-auth key:
+
+            1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin) and open **Settings** > **Keys**.
+            2. Generate a replacement key with **Reusable** disabled. If the consuming workflow truly requires many enrollments, generate the new key per job from the CI pipeline using a short-lived API access token instead of issuing one reusable key.
+            3. Update consumers to fetch a fresh single-use key per enrollment, then revoke the reusable key on the same page.
+        - id: cli
+          desc: |
+            To create a single-use pre-auth key and retire the reusable one via the Tailscale API:
+
+            ```bash
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -H "Content-Type: application/json" \
+              -X POST "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys" \
+              --data '{
+                "capabilities": {
+                  "devices": { "create": { "reusable": false, "ephemeral": true, "preauthorized": true, "tags": ["tag:ci"] } }
+                },
+                "expirySeconds": 86400
+              }'
+
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -X DELETE "https://api.tailscale.com/api/v2/tailnet/<tailnet>/keys/<old-reusable-key-id>"
+            ```
+    refs:
+      - url: https://tailscale.com/kb/1085/auth-keys
+        title: Tailscale auth keys
+  - uid: mondoo-tailscale-security-configuration-logstream-configured
+    title: Ensure the tailnet exports the configuration audit log
+    impact: 80
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-lo-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-de-cm-1
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-3-1
+    mql: |
+      tailscale.logstreams.one(logType == "configuration")
+    docs:
+      desc: |
+        This check ensures that the tailnet has at least one logstream configured for the `configuration` log type — Tailscale's admin audit log. Without an export, the audit trail of administrative actions lives only in the Tailscale console and is unavailable to a SIEM, retention policy, or off-platform incident responder.
+
+        **Why this matters**
+
+        - **No external audit record:** Membership changes, ACL edits, key creation and revocation, and tailnet lock changes are recorded in the configuration log. Without an export, any forensic investigation depends entirely on Tailscale's UI being reachable and on Tailscale retaining the data.
+        - **Insider-action visibility:** Detecting a malicious or coerced administrator requires correlating Tailscale events with SIEM data from identity, endpoint, and network sources. The only mechanism for that correlation is the logstream export.
+        - **Compliance evidence:** Frameworks that mandate audit log retention require the events to be held outside the system that generated them and outside the control of the same administrators whose actions are being recorded.
+        - **Incident-response timeline:** Reconstructing the chronology of a tailnet incident after the fact (who added the rogue device, who broadened the ACL, who issued the long-lived key) is impossible without persistent off-platform copies of the configuration log.
+
+        **Risk mitigation**
+
+        - **Independent retention:** A SIEM or object-store destination keeps audit events under retention rules that the auditing administrator cannot edit.
+        - **Cross-source correlation:** Once tailnet events sit alongside identity-provider, endpoint, and cloud-audit data, abnormal sequences (key creation followed by ACL widening, for example) can be detected with existing detection rules.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin).
+        2. Open **Settings** > **Logs** > **Configuration log streaming**.
+        3. Confirm a destination (Splunk, Elastic, Panther, Cribl, Datadog, Axiom, or S3) is configured and the toggle is on.
+
+        A passing tailnet shows an enabled configuration logstream with a destination URL or S3 bucket. A failing tailnet shows the section as **Not configured**.
+
+        ### Audit via API
+
+        1. Query the configuration logstream endpoint:
+
+        ```bash
+        curl -s -u "$TAILSCALE_API_KEY:" \
+          "https://api.tailscale.com/api/v2/tailnet/<tailnet>/logging/configuration/stream"
+        ```
+
+        A passing tailnet returns a JSON body describing the destination. A failing tailnet returns HTTP 404 (or an empty object) indicating no logstream is configured for `configuration`.
+      remediation:
+        - id: console
+          desc: |
+            To configure the configuration audit log export from the admin console:
+
+            1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin) and open **Settings** > **Logs**.
+            2. Under **Configuration log streaming**, click **Add destination** and choose Splunk, Elastic, Panther, Cribl, Datadog, Axiom, or S3.
+            3. Provide the destination endpoint plus the auth credential the destination requires (token, basic auth, IAM access key, or assumed role for S3).
+            4. Save and confirm the test event lands in the receiver.
+        - id: cli
+          desc: |
+            To configure the configuration audit log export via the Tailscale API. The exact body depends on the destination; the example below configures an S3 bucket using an assumed role:
+
+            ```bash
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -H "Content-Type: application/json" \
+              -X PUT "https://api.tailscale.com/api/v2/tailnet/<tailnet>/logging/configuration/stream" \
+              --data '{
+                "destinationType": "s3",
+                "s3Bucket": "<bucket>",
+                "s3Region": "<region>",
+                "s3KeyPrefix": "tailscale-config/",
+                "s3AuthenticationType": "rolearn",
+                "s3RoleArn": "arn:aws:iam::<account>:role/<tailscale-export-role>",
+                "s3ExternalId": "<external-id>"
+              }'
+            ```
+
+            Verify the configuration with `GET .../logging/configuration/stream` and confirm new events appear in the destination.
+    refs:
+      - url: https://tailscale.com/kb/1255/log-streaming
+        title: Tailscale log streaming
+      - url: https://tailscale.com/kb/1156/audit-logs
+        title: Tailscale audit logging
+  - uid: mondoo-tailscale-security-webhooks-use-https
+    title: Ensure tailnet webhook endpoints use HTTPS
+    impact: 80
+    filters: asset.platform == 'tailscale'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      tailscale.webhooks.all(endpointUrl == /^https:\/\//)
+    docs:
+      desc: |
+        This check ensures that every tailnet webhook endpoint URL uses the `https://` scheme. Tailscale webhooks deliver configuration-change events (device approval requests, ACL updates, key expiry warnings, user provisioning) to the receiver; sending those events over plaintext HTTP leaks sensitive operational metadata to anyone on the network path.
+
+        **Why this matters**
+
+        - **Plaintext leak of operational signals:** A webhook payload carries the email of the user who needs approval, the device ID and OS, the action that triggered the event, and the tailnet identifier. Sent over HTTP, every entry on the network path can read or modify it.
+        - **HMAC alone is not confidentiality:** Tailscale signs webhook payloads, but the signature only authenticates the sender; it does not encrypt the body. HTTPS is what protects the body from disclosure.
+        - **Phishing and social-engineering material:** Tailnet event payloads contain enough internal context to craft convincing phishing of the same administrators who would normally see those events in the console.
+        - **Compliance hard requirement:** Frameworks that mandate encryption in transit treat outbound webhook traffic as in-scope; an `http://` webhook is a direct violation.
+
+        **Risk mitigation**
+
+        - **Confidentiality on the wire:** Switching every receiver to `https://` keeps the payload encrypted between Tailscale and the receiver, eliminating passive read by anyone on the path.
+        - **Tamper resistance:** HTTPS protects the request from in-flight modification, so an attacker on the path cannot rewrite the body in a way that the signature alone would catch but that downstream automation might mishandle.
+      audit: |
+        ### Audit via Admin Console
+
+        1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin).
+        2. Open **Settings** > **Webhooks** and review the **Endpoint URL** column for each subscription.
+
+        A passing tailnet shows `https://` for every endpoint. A failing tailnet shows at least one endpoint with `http://`.
+
+        ### Audit via API
+
+        1. List the webhooks:
+
+        ```bash
+        curl -s -u "$TAILSCALE_API_KEY:" \
+          "https://api.tailscale.com/api/v2/tailnet/<tailnet>/webhooks"
+        ```
+
+        A passing tailnet returns every entry with `endpointUrl` starting with `https://`. A failing tailnet returns at least one entry whose `endpointUrl` starts with `http://`.
+      remediation:
+        - id: console
+          desc: |
+            To switch a plaintext webhook to HTTPS from the admin console:
+
+            1. Sign in to the [Tailscale admin console](https://login.tailscale.com/admin) and open **Settings** > **Webhooks**.
+            2. Provision (or expose) the receiver behind an HTTPS endpoint; if it lives behind an internal service, front it with a reverse proxy that terminates TLS using a certificate signed by a CA Tailscale's outbound traffic trusts.
+            3. Edit the affected webhook and change the **Endpoint URL** to the `https://` form.
+            4. Trigger a test event and confirm the receiver still accepts it; rotate the shared secret if the URL change is part of a migration.
+        - id: cli
+          desc: |
+            To switch a plaintext webhook to HTTPS via the Tailscale API:
+
+            ```bash
+            curl -s -u "$TAILSCALE_API_KEY:" \
+              -H "Content-Type: application/json" \
+              -X PATCH "https://api.tailscale.com/api/v2/tailnet/<tailnet>/webhooks/<endpoint-id>" \
+              --data '{ "endpointUrl": "https://<receiver-host>/<path>" }'
+            ```
+
+            Then send a synthetic test event from the admin console or the API and confirm the receiver records the new URL.
+    refs:
+      - url: https://tailscale.com/kb/1213/webhooks
+        title: Tailscale webhooks


### PR DESCRIPTION
## Summary

Adds four checks to `mondoo-tailscale-security` covering the credential-hygiene, audit-log-export, and webhook-TLS gaps opened up by the new `tailscale.authKey`, `tailscale.webhook`, and `tailscale.logstream` resources introduced in [mondoohq/mql#7809](https://github.com/mondoohq/mql/pull/7809). All four checks file under three new groups (`Tailscale Authentication Keys`, `Tailscale Audit Logging`, `Tailscale Webhooks`). Policy version bumped to `1.2.0`.

### Checks

| UID | Impact | MQL |
|-----|--------|-----|
| `authkeys-have-expiration` | 90 | `tailscale.authKeys.where(invalid == false && revoked.unix == 0).all(expires.unix > 0)` |
| `authkeys-not-reusable` | 80 | `tailscale.authKeys.where(invalid == false && revoked.unix == 0).none(reusable)` |
| `configuration-logstream-configured` | 80 | `tailscale.logstreams.one(logType == "configuration")` |
| `webhooks-use-https` | 80 | `tailscale.webhooks.all(endpointUrl == /^https:\/\//)` |

Both auth-key checks filter on `invalid == false && revoked.unix == 0` so consumed single-use keys aren't flagged for missing expiry or reusable flags.

### Compliance tag mapping

- Auth-key checks: anchored to `mondoo-tailscale-security-devices-key-expiry-enabled` (credential lifecycle: ISO 27001 A.5.17, NIST SP 800-53 IA-5, NIST CSF 2 PR.AA-01, SOC 2 CC6.1.9, NIST SP 800-171 3.5.6).
- Logstream check: audit-record family (ISO 27001 A.8.15, NIST SP 800-53 AU-6, NIST CSF 2 DE.CM-09, PCI DSS 10.2.1, SOC 2 CC7.2.1).
- Webhook HTTPS check: transmission-encryption family (ISO 27001 A.8.24, NIST SP 800-53 SC-8, NIST CSF 2 PR.DS-02, PCI DSS 4.2.1, SOC 2 CC6.7.2). Same family as the existing `cert-not-expired` check on other policies.

### MQL notes

- MQL does not accept the `!field` prefix-negation form; the reusable check uses `invalid == false` instead (caught by lint on first pass).
- The webhook check filters with a regex literal (`/^https:\/\//`) rather than `startsWith` so the comparison is anchored.
- The `tailscale.logstream` resource returns at most two entries (configuration + network); `.one(...)` is the natural existence check for the configuration log type.

## Test plan

- [x] `cnspec policy lint content/mondoo-tailscale-security.mql.yaml` — clean.
- [ ] Smoke test against a real tailnet once cnspec is built against an mql release containing #7809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)