### PR TITLE
🧹 kubernetes: use typed accessors from k8s provider

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -6252,7 +6252,6 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      // podSpec['serviceAccount'] reads the deprecated string field; cnquery's typed k8s.pod.serviceAccount returns the ServiceAccount resource, not the legacy string.
       k8s.pod.podSpec['serviceAccount'] == null || k8s.pod.podSpec['serviceAccount'] == k8s.pod.serviceAccountName
       k8s.pod.serviceAccountName != '' || k8s.pod.automountServiceAccountToken == false
       k8s.pod.serviceAccountName != 'default' || k8s.pod.automountServiceAccountToken == false

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -6252,6 +6252,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
+      // podSpec['serviceAccount'] reads the deprecated string field; cnquery's typed k8s.pod.serviceAccount returns the ServiceAccount resource, not the legacy string.
       k8s.pod.podSpec['serviceAccount'] == null || k8s.pod.podSpec['serviceAccount'] == k8s.pod.serviceAccountName
       k8s.pod.serviceAccountName != '' || k8s.pod.automountServiceAccountToken == false
       k8s.pod.serviceAccountName != 'default' || k8s.pod.automountServiceAccountToken == false

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -5033,7 +5033,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: k8s.pod.podSpec['hostNetwork'] != true
+    mql: k8s.pod.hostNetwork != true
     docs:
       desc: |
         This check ensures that pods are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
@@ -5462,7 +5462,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: k8s.pod.podSpec['hostPID'] != true
+    mql: k8s.pod.hostPID != true
     docs:
       desc: |
         This check ensures that pods are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
@@ -5877,7 +5877,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      k8s.pod.podSpec['hostIPC'] != true
+      k8s.pod.hostIPC != true
     docs:
       desc: |
         This check ensures that pods are not configured to use the `hostIPC` namespace. Setting `hostIPC: true` allows containers to share the host's IPC namespace, which can be used to break container isolation.
@@ -6252,9 +6252,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.pod.podSpec['serviceAccount'] == null || k8s.pod.podSpec['serviceAccount'] == k8s.pod.podSpec['serviceAccountName']
-      k8s.pod.podSpec['serviceAccountName'] != '' || k8s.pod.podSpec['automountServiceAccountToken'] == false
-      k8s.pod.podSpec['serviceAccountName'] != 'default' || k8s.pod.podSpec['automountServiceAccountToken'] == false
+      k8s.pod.podSpec['serviceAccount'] == null || k8s.pod.podSpec['serviceAccount'] == k8s.pod.serviceAccountName
+      k8s.pod.serviceAccountName != '' || k8s.pod.automountServiceAccountToken == false
+      k8s.pod.serviceAccountName != 'default' || k8s.pod.automountServiceAccountToken == false
     docs:
       desc: |
         Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
@@ -8307,12 +8307,12 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.pod.podSpec['ephemeralContainers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.pod.podSpec['ephemeralContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.pod.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.pod.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.pod.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.pod.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.ephemeralContainers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.ephemeralContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.initContainers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.pod.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that pods are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8391,8 +8391,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.daemonset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.daemonset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.daemonset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.daemonset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that DaemonSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8475,8 +8475,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.replicaset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.replicaset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.replicaset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.replicaset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that ReplicaSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8559,7 +8559,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.deployment.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.deployment.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that Jobs are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8642,8 +8642,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.deployment.podSpec['containers'].all( _['securityContext']['capabilities'].none( _['add'].contains("NET_RAW") ))
-      k8s.deployment.podSpec['containers'].all( _['securityContext']['capabilities'].none( _['add'].contains("ALL") ))
+      k8s.deployment.containers.all( securityContext['capabilities'].none( _['add'].contains("NET_RAW") ))
+      k8s.deployment.containers.all( securityContext['capabilities'].none( _['add'].contains("ALL") ))
     docs:
       desc: |
         This check ensures that Deployments are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8726,8 +8726,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.statefulset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.statefulset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.statefulset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.statefulset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that StatefulSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8810,8 +8810,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.cronjob.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
-      k8s.cronjob.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.cronjob.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^NET_RAW$|^ALL$/ ) } )
+      k8s.cronjob.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == /^NET_RAW$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that CronJobs are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -8898,9 +8898,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.pod.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
-      k8s.pod.podSpec['ephemeralContainers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
-      k8s.pod.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.pod.initContainers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.pod.ephemeralContainers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.pod.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that pods are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -8959,7 +8959,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.daemonset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.daemonset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that DaemonSets are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -9020,7 +9020,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.replicaset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.replicaset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         ReplicaSets should not run with SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls.
@@ -9071,7 +9071,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.job.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.job.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that Jobs are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -9131,7 +9131,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: k8s.deployment.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+    mql: k8s.deployment.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that Deployments are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -9192,7 +9192,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.statefulset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.statefulset.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that StatefulSets are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -9253,7 +9253,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.cronjob.podSpec['containers'].all( _['securityContext']['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
+      k8s.cronjob.containers.all( securityContext['capabilities'] { _['add'] == null || _['add'].none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) } )
     docs:
       desc: |
         This check ensures that CronJobs are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
@@ -9316,8 +9316,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.pod.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
-      k8s.pod.podSpec['initContainers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.pod.containers.all( ports == null || ports.none( _['hostPort']))
+      k8s.pod.initContainers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that pods do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9380,7 +9380,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.daemonset.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.daemonset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that DaemonSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9445,7 +9445,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.replicaset.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.replicaset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that ReplicaSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9510,7 +9510,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.job.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.job.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that Jobs do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9575,7 +9575,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.deployment.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.deployment.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that Deployments do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9640,7 +9640,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.statefulset.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.statefulset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that StatefulSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -9705,7 +9705,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.cronjob.podSpec['containers'].all( _['ports'] == null || _['ports'].none( _['hostPort']))
+      k8s.cronjob.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
         This check ensures that CronJobs do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
@@ -10373,7 +10373,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.deployment.podSpec["containers"].none( _["image"].contains("tiller") )
+      k8s.deployment.containers.none( imageName.contains("tiller") )
     docs:
       desc: |
         This check ensures that deployments are not running Tiller (the in-cluster component for the Helm v2 package manager). Tiller communicates directly with the Kubernetes API and has broad RBAC permissions, which can expose the cluster to significant security risks if not properly controlled.
@@ -10417,9 +10417,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.pod.podSpec["containers"].none( _["image"].contains("tiller") )
-      k8s.pod.podSpec["initContainers"].none( _["image"].contains("tiller") )
-      k8s.pod.podSpec["ephemeralContainers"].none( _["image"].contains("tiller") )
+      k8s.pod.containers.none( imageName.contains("tiller") )
+      k8s.pod.initContainers.none( imageName.contains("tiller") )
+      k8s.pod.ephemeralContainers.none( imageName.contains("tiller") )
     docs:
       desc: |
         This check ensures that pods are not running Tiller (the in-cluster component for the Helm v2 package manager). Tiller communicates directly with the Kubernetes API and has broad RBAC permissions, which can expose the cluster to significant security risks if not properly controlled.
@@ -10463,7 +10463,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.deployment.podSpec["containers"].none( _["image"].contains("kubernetes-dashboard") || _["image"].contains("kubernetesui") )
+      k8s.deployment.containers.none( imageName.contains("kubernetes-dashboard") || imageName.contains("kubernetesui") )
       k8s.deployment.labels["app"] == null || k8s.deployment.labels["app"] != "kubernetes-dashboard"
       k8s.deployment.labels["k8s-app"] == null || k8s.deployment.labels["k8s-app"] != "kubernetes-dashboard"
     docs:
@@ -10509,9 +10509,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.pod.podSpec["containers"].none( _["image"].contains("kubernetes-dashboard") || _["image"].contains("kubernetesui") )
-      k8s.pod.podSpec["initContainers"].none( _["image"].contains("kubernetes-dashboard") || _["image"].contains("kubernetesui") )
-      k8s.pod.podSpec["ephemeralContainers"].none( _["image"].contains("kubernetes-dashboard") || _["image"].contains("kubernetesui") )
+      k8s.pod.containers.none( imageName.contains("kubernetes-dashboard") || imageName.contains("kubernetesui") )
+      k8s.pod.initContainers.none( imageName.contains("kubernetes-dashboard") || imageName.contains("kubernetesui") )
+      k8s.pod.ephemeralContainers.none( imageName.contains("kubernetes-dashboard") || imageName.contains("kubernetesui") )
       k8s.pod.labels["app"] == null || k8s.pod.labels["app"] != "kubernetes-dashboard"
       k8s.pod.labels["k8s-app"] == null || k8s.pod.labels["k8s-app"] != "kubernetes-dashboard"
     docs:
@@ -10557,9 +10557,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.pod.podSpec['ephemeralContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.pod.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.pod.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.pod.ephemeralContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.pod.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.pod.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in pods explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10617,8 +10617,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.daemonset.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.daemonset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.daemonset.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.daemonset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in DaemonSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10678,8 +10678,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.replicaset.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.replicaset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.replicaset.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.replicaset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in ReplicaSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10739,8 +10739,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.job.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.job.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.job.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.job.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in Jobs explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10800,8 +10800,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.deployment.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.deployment.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.deployment.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.deployment.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in Deployments explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10861,8 +10861,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.statefulset.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.statefulset.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.statefulset.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.statefulset.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in StatefulSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
@@ -10922,8 +10922,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      k8s.cronjob.podSpec['initContainers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
-      k8s.cronjob.podSpec['containers'].all( _['securityContext']['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.cronjob.initContainers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
+      k8s.cronjob.containers.all( securityContext['capabilities'] { _['drop'].any( _.upcase == "ALL" ) } )
     docs:
       desc: |
         This check ensures that all containers in CronJobs explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.


### PR DESCRIPTION
## Summary

Refactor the Mondoo Kubernetes security policy to use the strongly-typed accessors that the cnquery [k8s provider](https://github.com/mondoohq/cnquery/tree/main/providers/k8s) exposes on `k8s.pod`, `k8s.container`, `k8s.initContainer`, `k8s.ephemeralContainer`, and the workload resources, instead of reaching through the raw `podSpec` dict.

- Container iteration on every workload kind switches from `<workload>.podSpec['containers']` (and `initContainers` / `ephemeralContainers`) to the typed `<workload>.containers` / `.initContainers` / `.ephemeralContainers` accessors.
- Inside typed iteration, container-level dict access is dropped:
  - `_['image']` → `imageName` (typed field; renamed)
  - `_['securityContext']` → `securityContext`
  - `_['ports']` → `ports`
- Pod-level scalars on `k8s.pod` move off `podSpec[...]` and onto the typed accessors: `hostNetwork`, `hostPID`, `hostIPC`, `serviceAccountName`, `automountServiceAccountToken`.
- The legacy `podSpec['serviceAccount']` alias has no typed equivalent (cnquery only exposes `serviceAccountName`) and remains as dict access.
- Dict-iteration blocks (the `k8s.pod.podSpec { _['containers'] { ... } }` style used for the host-path read-only checks) are intentionally left untouched — bracket access stays where the parent scope is a dict, not a typed resource.

## Test plan

- [x] `cnspec policy lint ./content` → valid
- [x] `cnspec policy lint ./content/querypacks` → valid
- [x] `cnspec scan k8s content/testdata/mondoo-kubernetes-security-pass/pod.yaml -f content/mondoo-kubernetes-security.mql.yaml` → LOW (pass)
- [x] `cnspec scan k8s content/testdata/mondoo-kubernetes-security-fail/daemonset.yaml -f content/mondoo-kubernetes-security.mql.yaml` → CRITICAL (fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)