### PR TITLE
✨ Port over MQL discover subcommand.

### DIFF
--- a/apps/cnspec/cmd/discover.go
+++ b/apps/cnspec/cmd/discover.go
@@ -1,0 +1,12 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	cnquery_app "go.mondoo.com/mql/v13/apps/mql/cmd"
+)
+
+func init() {
+	rootCmd.AddCommand(cnquery_app.DiscoverCmd)
+}

--- a/apps/cnspec/cmd/root.go
+++ b/apps/cnspec/cmd/root.go
@@ -81,6 +81,11 @@ func BuildRootCmd() (*cobra.Command, error) {
 			Action:  "Run a query with ",
 		},
 		&providers.Command{
+			Command: cnquery_app.DiscoverCmd,
+			Run:     cnquery_app.DiscoverCmdRun,
+			Action:  "Discover assets with ",
+		},
+		&providers.Command{
 			Command: scanCmd,
 			Run:     scanCmdRun,
 			Action:  "Scan ",

--- a/test/cli/testdata/cnspec.ct
+++ b/test/cli/testdata/cnspec.ct
@@ -12,6 +12,7 @@ Usage:
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
+  discover    Discover assets
   framework   Manage local and Mondoo Platform hosted compliance frameworks
   help        Help about any command
   login       Register with Mondoo Platform


### PR DESCRIPTION
#### In this PR
- Bumped mql version to the commit that introduced the `discover` cmd.
- Ported over the `discover` cmd into cnspec's root cmd.