### PR TITLE
Auto-discover inventory.yml for ad-hoc cnspec scan

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -276,11 +276,19 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	// scheduled scan cycle. We gate on config.LoadedConfig so a stray
 	// inventory.yml in $PWD does not get picked up by scans that have no
 	// managed-agent context.
+	//
+	// inventoryloader.ParseOrUse reads the path from the global viper
+	// "inventory-file" key, so the override is set just before the call and
+	// restored immediately after. Without the restore, repeated calls to
+	// getCobraScanConfig (notably from tests) would see the auto-discovered
+	// path on subsequent invocations and skip the discovery branch.
 	autoDiscoveredInventory := false
 	if config.LoadedConfig && viper.GetString("inventory-file") == "" {
 		if invPath, ok := config.InventoryPath(viper.ConfigFileUsed()); ok {
 			log.Info().Str("path", invPath).Msg("found inventory file")
+			previous := viper.GetString("inventory-file")
 			viper.Set("inventory-file", invPath)
+			defer viper.Set("inventory-file", previous)
 			autoDiscoveredInventory = true
 		}
 	}
@@ -455,7 +463,30 @@ func applyAutoDiscoveredInventory(target *inventory.Asset, inv *inventory.Invent
 		if len(target.IdDetector) == 0 && len(invAsset.IdDetector) > 0 {
 			target.IdDetector = append(target.IdDetector, invAsset.IdDetector...)
 		}
+		// First-match wins. The Windows installer writes exactly one
+		// local-scan asset, and we only care about lifting id_detector here;
+		// later matches would not contribute anything beyond what the first
+		// already provided. If inventories ever grow to carry multiple
+		// assets of the same connection type with *different* id_detector
+		// lists that should all apply, this loop needs to merge across
+		// matches instead of breaking.
 		break
+	}
+	// Auto-discovered inventories are treated as per-asset override libraries,
+	// not as the authoritative asset list, so any inventory asset that didn't
+	// match the CLI target is intentionally dropped here. Log it at debug so
+	// the dropped count is visible when troubleshooting unexpected scan
+	// targets.
+	dropped := 0
+	for _, a := range inv.Spec.GetAssets() {
+		if a != nil && a != target {
+			dropped++
+		}
+	}
+	if dropped > 0 {
+		log.Debug().
+			Int("count", dropped).
+			Msg("dropping inventory assets that did not match the CLI target")
 	}
 	inv.Spec.Assets = []*inventory.Asset{target}
 }

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -269,9 +269,38 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		cliRes.Asset.TraceId = traceId
 	}
 
+	// Auto-discover an inventory.yml next to the loaded mondoo.yml when
+	// --inventory-file was not set explicitly. This makes ad-hoc
+	// `cnspec scan local` see the same per-asset configuration (notably the
+	// id_detector list) that `cnspec serve` already auto-loads on each
+	// scheduled scan cycle. We gate on config.LoadedConfig so a stray
+	// inventory.yml in $PWD does not get picked up by scans that have no
+	// managed-agent context.
+	autoDiscoveredInventory := false
+	if config.LoadedConfig && viper.GetString("inventory-file") == "" {
+		if invPath, ok := config.InventoryPath(viper.ConfigFileUsed()); ok {
+			log.Info().Str("path", invPath).Msg("found inventory file")
+			viper.Set("inventory-file", invPath)
+			autoDiscoveredInventory = true
+		}
+	}
+
 	inv, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), optAnnotations)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse inventory")
+	}
+
+	// When the inventory file was auto-discovered (not user-supplied) and the
+	// CLI gave us a target asset, treat the inventory as a library of per-asset
+	// overrides rather than as the authoritative asset list. We copy the
+	// id_detector list from any inventory asset whose connection type overlaps
+	// the CLI asset's, then narrow inv.Spec.Assets to just the CLI asset. This
+	// keeps `cnspec scan local` picking up the id_detector configured by the
+	// Windows installer while leaving `cnspec scan aws account 123` and other
+	// non-local targets unaffected even though the same inventory.yml is on
+	// disk next to mondoo.yml.
+	if autoDiscoveredInventory && cliRes.Asset != nil {
+		applyAutoDiscoveredInventory(cliRes.Asset, inv)
 	}
 
 	riskThreshold := viper.GetInt("risk-threshold")
@@ -398,6 +427,52 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	}
 
 	return &conf, nil
+}
+
+// applyAutoDiscoveredInventory narrows an auto-discovered inventory down to the
+// CLI-provided asset, after lifting per-asset fields (currently only the
+// id_detector list) from any inventory asset whose connection type overlaps
+// the target's. Auto-discovery happens only when --inventory-file was not set
+// by the user, so this function should never be reached for an inventory the
+// user explicitly pointed at.
+func applyAutoDiscoveredInventory(target *inventory.Asset, inv *inventory.Inventory) {
+	if target == nil || inv == nil || inv.Spec == nil {
+		return
+	}
+	targetConns := make(map[string]struct{}, len(target.Connections))
+	for _, c := range target.Connections {
+		if c != nil && c.Type != "" {
+			targetConns[c.Type] = struct{}{}
+		}
+	}
+	for _, invAsset := range inv.Spec.GetAssets() {
+		if invAsset == nil || invAsset == target {
+			continue
+		}
+		if !assetSharesConnectionType(invAsset, targetConns) {
+			continue
+		}
+		if len(target.IdDetector) == 0 && len(invAsset.IdDetector) > 0 {
+			target.IdDetector = append(target.IdDetector, invAsset.IdDetector...)
+		}
+		break
+	}
+	inv.Spec.Assets = []*inventory.Asset{target}
+}
+
+func assetSharesConnectionType(asset *inventory.Asset, want map[string]struct{}) bool {
+	if asset == nil || len(want) == 0 {
+		return false
+	}
+	for _, c := range asset.Connections {
+		if c == nil {
+			continue
+		}
+		if _, ok := want[c.Type]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *scanConfig) loadPolicies(ctx context.Context) error {

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -275,20 +275,16 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	// id_detector list) that `cnspec serve` already auto-loads on each
 	// scheduled scan cycle. We gate on config.LoadedConfig so a stray
 	// inventory.yml in $PWD does not get picked up by scans that have no
-	// managed-agent context.
-	//
-	// inventoryloader.ParseOrUse reads the path from the global viper
-	// "inventory-file" key, so the override is set just before the call and
-	// restored immediately after. Without the restore, repeated calls to
-	// getCobraScanConfig (notably from tests) would see the auto-discovered
-	// path on subsequent invocations and skip the discovery branch.
+	// managed-agent context. inventoryloader.ParseOrUse reads the path
+	// from the global viper "inventory-file" key, matching how serve.go
+	// performs the same lookup.
 	autoDiscoveredInventory := false
 	if config.LoadedConfig && viper.GetString("inventory-file") == "" {
 		if invPath, ok := config.InventoryPath(viper.ConfigFileUsed()); ok {
-			log.Info().Str("path", invPath).Msg("found inventory file")
-			previous := viper.GetString("inventory-file")
+			log.Info().
+				Str("path", invPath).
+				Msg("auto-discovered default inventory file next to mondoo.yml")
 			viper.Set("inventory-file", invPath)
-			defer viper.Set("inventory-file", previous)
 			autoDiscoveredInventory = true
 		}
 	}

--- a/apps/cnspec/cmd/scan_test.go
+++ b/apps/cnspec/cmd/scan_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/scan_test.go
+++ b/apps/cnspec/cmd/scan_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestApplyAutoDiscoveredInventory_MergesIdDetectorForMatchingConnection(t *testing.T) {
+	target := &inventory.Asset{
+		Name:        "local-cli",
+		Connections: []*inventory.Config{{Type: "local"}},
+	}
+	inv := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{
+		{
+			Name:        "local-scan",
+			Connections: []*inventory.Config{{Type: "local"}},
+			IdDetector:  []string{"hostname", "machine-id"},
+		},
+	}}}
+
+	applyAutoDiscoveredInventory(target, inv)
+
+	assert.Equal(t, []string{"hostname", "machine-id"}, target.IdDetector,
+		"id_detector should be lifted from the matching inventory asset onto the CLI target")
+	assert.Equal(t, []*inventory.Asset{target}, inv.Spec.Assets,
+		"inventory should be narrowed to the CLI target so non-CLI assets aren't scanned")
+}
+
+func TestApplyAutoDiscoveredInventory_SkipsMergeWhenConnectionTypesDiffer(t *testing.T) {
+	target := &inventory.Asset{
+		Name:        "aws-cli",
+		Connections: []*inventory.Config{{Type: "aws"}},
+	}
+	inv := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{
+		{
+			Name:        "local-scan",
+			Connections: []*inventory.Config{{Type: "local"}},
+			IdDetector:  []string{"hostname", "machine-id"},
+		},
+	}}}
+
+	applyAutoDiscoveredInventory(target, inv)
+
+	assert.Empty(t, target.IdDetector,
+		"`cnspec scan aws ...` must not inherit id_detector from a sibling local-scan inventory")
+	assert.Equal(t, []*inventory.Asset{target}, inv.Spec.Assets,
+		"sibling local-scan asset must be dropped so it does not replace the AWS target")
+}
+
+func TestApplyAutoDiscoveredInventory_PreservesExplicitTargetIdDetector(t *testing.T) {
+	target := &inventory.Asset{
+		Name:        "local-cli",
+		Connections: []*inventory.Config{{Type: "local"}},
+		IdDetector:  []string{"hostname"},
+	}
+	inv := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{
+		{
+			Name:        "local-scan",
+			Connections: []*inventory.Config{{Type: "local"}},
+			IdDetector:  []string{"machine-id"},
+		},
+	}}}
+
+	applyAutoDiscoveredInventory(target, inv)
+
+	assert.Equal(t, []string{"hostname"}, target.IdDetector,
+		"an id_detector list already on the CLI target wins over the auto-discovered inventory")
+}
+
+func TestApplyAutoDiscoveredInventory_HandlesEmptyInventory(t *testing.T) {
+	target := &inventory.Asset{
+		Name:        "local-cli",
+		Connections: []*inventory.Config{{Type: "local"}},
+	}
+	inv := &inventory.Inventory{Spec: &inventory.InventorySpec{}}
+
+	applyAutoDiscoveredInventory(target, inv)
+
+	assert.Empty(t, target.IdDetector)
+	assert.Equal(t, []*inventory.Asset{target}, inv.Spec.Assets)
+}
+
+func TestApplyAutoDiscoveredInventory_NilSafe(t *testing.T) {
+	// Should not panic on any nil argument.
+	applyAutoDiscoveredInventory(nil, nil)
+	applyAutoDiscoveredInventory(&inventory.Asset{}, nil)
+	applyAutoDiscoveredInventory(nil, &inventory.Inventory{Spec: &inventory.InventorySpec{}})
+	applyAutoDiscoveredInventory(&inventory.Asset{}, &inventory.Inventory{})
+}

--- a/apps/cnspec/cmd/scan_test.go
+++ b/apps/cnspec/cmd/scan_test.go
@@ -92,3 +92,34 @@ func TestApplyAutoDiscoveredInventory_NilSafe(t *testing.T) {
 	applyAutoDiscoveredInventory(nil, &inventory.Inventory{Spec: &inventory.InventorySpec{}})
 	applyAutoDiscoveredInventory(&inventory.Asset{}, &inventory.Inventory{})
 }
+
+func TestApplyAutoDiscoveredInventory_OnlyFirstMatchingAssetIsMergedIntoTarget(t *testing.T) {
+	// Locks in the documented first-match-wins semantics on the break:
+	// when multiple inventory assets share the CLI target's connection
+	// type, only the first one's id_detector is lifted. If this behavior
+	// ever changes (e.g. to merge across matches), the test should be
+	// updated together with the comment in scan.go.
+	target := &inventory.Asset{
+		Name:        "local-cli",
+		Connections: []*inventory.Config{{Type: "local"}},
+	}
+	inv := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{
+		{
+			Name:        "first-local",
+			Connections: []*inventory.Config{{Type: "local"}},
+			IdDetector:  []string{"hostname"},
+		},
+		{
+			Name:        "second-local",
+			Connections: []*inventory.Config{{Type: "local"}},
+			IdDetector:  []string{"machine-id", "bios-uuid"},
+		},
+	}}}
+
+	applyAutoDiscoveredInventory(target, inv)
+
+	assert.Equal(t, []string{"hostname"}, target.IdDetector,
+		"only the first matching inventory asset's id_detector should be lifted")
+	assert.Equal(t, []*inventory.Asset{target}, inv.Spec.Assets,
+		"second-local and all other inventory assets should be discarded")
+}


### PR DESCRIPTION
cnspec serve already auto-discovers an inventory.yml sitting next to the loaded mondoo.yml (apps/cnspec/cmd/serve.go:75-82). Ad-hoc `cnspec scan local` does not, which means per-asset config the Windows installer writes to C:\ProgramData\Mondoo\inventory.yml (notably the id_detector list set by -IdDetector) is silently ignored by manual scans even though the scheduled service uses it.

Mirror the serve auto-discovery in scan, gated on config.LoadedConfig so a stray inventory.yml in $PWD does not get picked up by scans without managed-agent context. To avoid the existing
inventoryloader.ParseOrUse behavior of letting the inventory replace the CLI asset (which would silently redirect `cnspec scan aws ...` to the local inventory asset), narrow the auto-discovered inventory to just the CLI target after lifting id_detector from any inventory asset whose connection type overlaps. User-supplied --inventory-file is unaffected.

related:

https://github.com/mondoohq/installer/pull/717