### PR TITLE
🐛 linux: qualify auditd.rules.files keyname with the named binding

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -6441,7 +6441,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "scope"
+          && f.keyname == "scope"
         )
       )
     docs:
@@ -6751,7 +6751,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "logins"
+          && f.keyname == "logins"
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
@@ -6761,7 +6761,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "logins"
+          && f.keyname == "logins"
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
@@ -6771,7 +6771,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "logins"
+          && f.keyname == "logins"
         )
       )
   - uid: mondoo-linux-security-session-initiation-information-is-collected
@@ -6795,14 +6795,14 @@ queries:
       // Check utmp with session key
       auditd.rules.files.contains( f:
         f.path == "/var/run/utmp" && f.permissions == "wa"
-        && keyname == "session"
+        && f.keyname == "session"
       )
       // Check wtmp and btmp with logins or session key
       sessionPaths = ["/var/log/wtmp", "/var/log/btmp"]
       sessionPaths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname.in(["logins", "session"])
+          && f.keyname.in(["logins", "session"])
         )
       )
     docs:
@@ -7486,7 +7486,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "system-locale"
+          && f.keyname == "system-locale"
         )
       )
 
@@ -7495,7 +7495,7 @@ queries:
       networkDirPaths.any(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "system-locale"
+          && f.keyname == "system-locale"
         )
       )
   - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-other
@@ -7524,7 +7524,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "system-locale"
+          && f.keyname == "system-locale"
         )
       )
   - uid: mondoo-linux-security-discretionary-access-control-permission-modification-events-are-collected
@@ -8005,7 +8005,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && keyname == "identity"
+          && f.keyname == "identity"
         )
       )
     docs:
@@ -8522,7 +8522,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "x"
-          && keyname == "modules"
+          && f.keyname == "modules"
         )
       )
 
@@ -8671,7 +8671,7 @@ queries:
     mql: |
       auditd.rules.files.contains( f:
         f.path == "/var/log/sudo.log" && f.permissions == "wa"
-        && keyname == "actions"
+        && f.keyname == "actions"
       )
     docs:
       desc: |


### PR DESCRIPTION
## Summary

mql v13.12.0 (picked up in #2627) ships [mondoohq/mql#7940](https://github.com/mondoohq/mql/pull/7940), which fixes a long-standing bug where named-binding blocks shadowed the global namespace. As a side effect, bare identifiers inside an explicitly-named block no longer auto-resolve to the bound resource's fields — they now resolve against the global namespace, and the bound resource is only reachable through its explicit name or `_`.

Twelve `auditd.rules.files.contains( f: … )` blocks in `mondoo-linux-security.mql.yaml` were referencing bare `keyname` rather than `f.keyname`. Post-#7940 they fail compilation with:

```
cannot find field or resource 'keyname' in block for type 'auditd.rule.file'
```

That single bundle-compile error breaks the SARIF output of the Lint Policies workflow, blocking every open PR that touches `content/**`. Example failure: https://github.com/mondoohq/cnspec/actions/runs/26454186546/job/77883274129

The Lint Policies workflow only runs on main when `content/**` changes, so #2627 (a `go.mod` bump) merged without ever exercising the new compiler against the policy bundles.

## Fix

Prefix `keyname` with the binding (`f.keyname`) in all twelve blocks. The same blocks already used `f.path` and `f.permissions` correctly — this just aligns the third field.

Anonymous blocks are unaffected:
- `auditd.rules.files.contains( path == … && keyname == … )` (one occurrence) — anonymous binding, bare identifiers still auto-resolve.
- `auditd.rules.syscalls.where( … && keyname == … )` / `.contains(…)` (many occurrences) — anonymous binding, unchanged.

## Test plan

- [x] `cnspec policy lint ./content/mondoo-linux-security.mql.yaml` — `valid policy bundle(s)`
- [x] `cnspec policy lint ./content` — all bundles compile (only the pre-existing `query-deprecated-symbol` warnings remain)
- [x] Local cnspec 13.12.0 (matches what the lint action ships in the cnspec:13 Docker image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)