### PR TITLE
content: migrate aws checks to per-service platforms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -18105,11 +18105,9 @@ queries:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SNS
   - uid: mondoo-aws-security-sns-topic-encrypted-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sns-topic"
     mql: |
-      aws.sns.topics.all(
-        attributes["KmsMasterKeyId"] != empty
-      )
+      aws.sns.topic.attributes["KmsMasterKeyId"] != empty
   - uid: mondoo-aws-security-sns-topic-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic")
     mql: |
@@ -18256,8 +18254,8 @@ queries:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html
         title: AWS Documentation - Verifying the signatures of Amazon SNS messages
   - uid: mondoo-aws-security-sns-topic-signature-version-aws
-    filters: asset.platform == "aws"
-    mql: aws.sns.topics.all(signatureVersion == "2")
+    filters: asset.platform == "aws-sns-topic"
+    mql: aws.sns.topic.signatureVersion == "2"
   - uid: mondoo-aws-security-sns-topic-signature-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic")
     mql: |
@@ -18404,8 +18402,8 @@ queries:
       - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SQS
   - uid: mondoo-aws-security-sqs-queue-encrypted-aws
-    filters: asset.platform == "aws"
-    mql: aws.sqs.queues.all(sqsManagedSseEnabled == true || kmsKey != empty)
+    filters: asset.platform == "aws-sqs-queue"
+    mql: aws.sqs.queue.sqsManagedSseEnabled == true || aws.sqs.queue.kmsKey != empty
   - uid: mondoo-aws-security-sqs-queue-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue")
     mql: |
@@ -18569,8 +18567,8 @@ queries:
       - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
         title: AWS Documentation - Amazon SQS dead-letter queues
   - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-aws
-    filters: asset.platform == "aws"
-    mql: aws.sqs.queues.all(deadLetterQueue != empty)
+    filters: asset.platform == "aws-sqs-queue"
+    mql: aws.sqs.queue.deadLetterQueue != empty
   - uid: mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue")
     mql: |
@@ -36476,11 +36474,9 @@ queries:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html
         title: AWS Documentation - Security best practices for Amazon SNS
   - uid: mondoo-aws-security-sns-subscription-https-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sns-topic"
     mql: |
-      aws.sns.topics.all(
-        subscriptions.where(protocol == "http").length == 0
-      )
+      aws.sns.topic.subscriptions.where(protocol == "http").length == 0
   - uid: mondoo-aws-security-sns-subscription-https-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_subscription")
     mql: |
@@ -38530,11 +38526,9 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege
         title: AWS IAM - Apply Least-Privilege Permissions
   - uid: mondoo-aws-security-sagemaker-notebook-role-not-admin-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sagemaker-notebookinstance" && aws.sagemaker.notebookinstance.details.iamRole != empty
     mql: |
-      aws.sagemaker.notebookInstances
-        .where(details.iamRole != empty)
-        .all(details.iamRole.attachedPolicies.none(name == "AdministratorAccess"))
+      aws.sagemaker.notebookinstance.details.iamRole.attachedPolicies.none(name == "AdministratorAccess")
   # No Terraform variants: SageMaker training/processing jobs are imperative API calls; the `iamRole` field is set per-job and dereferencing it back to its attached policies is a multi-resource correlation Terraform variants do not express.
   - uid: mondoo-aws-security-sagemaker-job-role-not-admin
     title: Ensure SageMaker training/processing job roles are not AdministratorAccess
@@ -46049,13 +46043,11 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/sqs-controls.html
         title: AWS Security Hub - SQS controls reference
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sqs-queue"
     mql: |
-      aws.sqs.queues.all(
-        policy == empty ||
-        policy['Statement'].where(_['Effect'] == "Allow").none(
-          _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
-        )
+      aws.sqs.queue.policy == empty ||
+      aws.sqs.queue.policy['Statement'].where(_['Effect'] == "Allow").none(
+        _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
       )
 
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-hcl
@@ -48875,9 +48867,9 @@ queries:
       - url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-and-update-a-trail.html
         title: AWS Documentation - Creating and updating a trail
   - uid: mondoo-aws-security-cloudtrail-is-logging-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cloudtrail-trail" && aws.cloudtrail.trail.isMultiRegionTrail == true
     mql: |
-      aws.cloudtrail.trails.where(isMultiRegionTrail == true).all(isLogging == true)
+      aws.cloudtrail.trail.isLogging == true
   - uid: mondoo-aws-security-ec2-snapshot-not-public
     title: Ensure EBS snapshots are not publicly shared
     impact: 90
@@ -58209,12 +58201,11 @@ queries:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-use-cases.html
         title: Amazon SNS access policy use cases
   - uid: mondoo-aws-security-sns-no-public-access-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sns-topic"
     mql: |
-      aws.sns.topics.all(
-        policy == empty || policy['Statement'].where(_['Effect'] == "Allow").none(
-          _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
-        )
+      aws.sns.topic.policy == empty ||
+      aws.sns.topic.policy['Statement'].where(_['Effect'] == "Allow").none(
+        _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
       )
   - uid: mondoo-aws-security-sns-no-public-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")
@@ -61670,12 +61661,10 @@ queries:
       - url: https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SNS
   - uid: mondoo-aws-security-sns-topic-cmk-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sns-topic"
     mql: |
-      aws.sns.topics.all(
-        attributes["KmsMasterKeyId"] != empty &&
-        attributes["KmsMasterKeyId"] != "alias/aws/sns"
-      )
+      aws.sns.topic.attributes["KmsMasterKeyId"] != empty &&
+      aws.sns.topic.attributes["KmsMasterKeyId"] != "alias/aws/sns"
   - uid: mondoo-aws-security-sns-topic-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic")
     mql: |
@@ -61833,11 +61822,9 @@ queries:
       - url: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html
         title: AWS Documentation - Encryption at rest for Amazon SQS
   - uid: mondoo-aws-security-sqs-queue-cmk-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sqs-queue"
     mql: |
-      aws.sqs.queues.all(
-        kmsKey != null && kmsKey.keyManager == "CUSTOMER"
-      )
+      aws.sqs.queue.kmsKey != null && aws.sqs.queue.kmsKey.keyManager == "CUSTOMER"
   - uid: mondoo-aws-security-sqs-queue-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue")
     mql: |
@@ -62313,13 +62300,11 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
         title: Amazon CloudFront - Origin mutual TLS
   - uid: mondoo-aws-security-cloudfront-origin-mtls-cert-not-expired-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cloudfront-distribution"
     mql: |
-      aws.cloudfront.distributions.all(
-        origins.all(
-          originMtlsClientCertificate == null ||
-          originMtlsClientCertificate.notAfter > time.now + 30 * time.day
-        )
+      aws.cloudfront.distribution.origins.all(
+        originMtlsClientCertificate == null ||
+        originMtlsClientCertificate.notAfter > time.now + 30 * time.day
       )
   - uid: mondoo-aws-security-cloudfront-trust-store-not-empty
     title: Ensure CloudFront trust stores contain at least one CA certificate
@@ -62537,14 +62522,12 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
         title: Amazon CloudFront - Origin mutual TLS
   - uid: mondoo-aws-security-cloudfront-private-origin-mtls-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cloudfront-distribution"
     mql: |
-      aws.cloudfront.distributions.all(
-        origins.where(
-          domainName.contains(".elb.amazonaws.com") ||
-          domainName.contains(".internal")
-        ).all(originMtlsClientCertificate != null)
-      )
+      aws.cloudfront.distribution.origins.where(
+        domainName.contains(".elb.amazonaws.com") ||
+        domainName.contains(".internal")
+      ).all(originMtlsClientCertificate != null)
   # No Terraform variants: trust store rotation cadence is operational telemetry derived from `lastModifiedAt` and has no Terraform configuration analog.
   - uid: mondoo-aws-security-cloudfront-trust-store-recently-updated
     title: Ensure CloudFront trust stores have been refreshed within the last year
@@ -68122,14 +68105,12 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
         title: Restricting access to S3 origins with OAC
   - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cloudfront-distribution"
     mql: |
-      aws.cloudfront.distributions.all(
-        origins.where(
-          domainName == /\.s3[.-][a-z0-9.-]*amazonaws\.com$/ &&
-          domainName != /\.s3-website/
-        ).all(originAccessControlId != "")
-      )
+      aws.cloudfront.distribution.origins.where(
+        domainName == /\.s3[.-][a-z0-9.-]*amazonaws\.com$/ &&
+        domainName != /\.s3-website/
+      ).all(originAccessControlId != "")
   - uid: mondoo-aws-security-cloudfront-s3-origin-oac-with-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudfront_distribution")
     mql: |
@@ -69583,12 +69564,10 @@ queries:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-network-rqmts.html
         title: Network requirements for rotation Lambda functions
   - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-secretsmanager-secret" && aws.secretsmanager.secret.rotationEnabled == true
     mql: |
-      aws.secretsmanager.secrets.where(rotationEnabled == true).all(
-        rotationLambda != null &&
-        rotationLambda.subnets != empty
-      )
+      aws.secretsmanager.secret.rotationLambda != null &&
+      aws.secretsmanager.secret.rotationLambda.subnets != empty
   - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_function")
     mql: |


### PR DESCRIPTION
## Summary

Re-targets 15 checks in the AWS security policy from the broad `aws` account platform to the existing per-service platforms. Each check now evaluates the singular asset directly (`aws.<svc>.<singular>.<pred>`) instead of iterating a collection on the account.

## Migrations

| Platform | # checks | UIDs |
|---|---|---|
| `aws-cloudfront-distribution` | 3 | `cloudfront-origin-mtls-cert-not-expired-aws`, `cloudfront-private-origin-mtls-aws`, `cloudfront-s3-origin-oac-with-encryption-aws` |
| `aws-sns-topic` | 5 | `sns-topic-encrypted-aws`, `sns-topic-signature-version-aws`, `sns-no-public-access-aws`, `sns-topic-cmk-encryption-aws`, `sns-subscription-https-aws` |
| `aws-sqs-queue` | 4 | `sqs-queue-encrypted-aws`, `sqs-queue-dead-letter-queue-aws`, `sqs-no-wildcard-policy-aws`, `sqs-queue-cmk-encryption-aws` |
| `aws-cloudtrail-trail` | 1 | `cloudtrail-is-logging-aws` (filter widened with `isMultiRegionTrail == true`) |
| `aws-sagemaker-notebookinstance` | 1 | `sagemaker-notebook-role-not-admin-aws` (filter widened with `details.iamRole != empty`) |
| `aws-secretsmanager-secret` | 1 | `secretsmanager-rotation-lambda-in-vpc-aws` (filter widened with `rotationEnabled == true`) |

Where the original MQL used a `where(<cond>).all(<pred>)` shape, the `<cond>` was lifted into the `filters:` clause so non-matching assets are excluded from scoring rather than silently passing the inner `.all()` on an empty collection.

## Not migrated

- CloudFront trust-store checks (`trust-store-not-empty-aws`, `trust-store-recently-updated-aws`) — no `aws-cloudfront-truststore` platform exists yet.
- CloudWatch metric-filter alarm checks (16 checks, `mondoo-aws-security-cloudwatch-*`) — these assert "ANY log group has metric filter X with alarm Y". Moving to a per-loggroup platform inverts the semantic (would require *every* log group to have the filter). Worth a design discussion separately.

## Test plan

- [x] `cnspec policy lint content/mondoo-aws-security.mql.yaml` — valid policy bundle, no new warnings
- [ ] Run an `aws` scan with one of the migrated checks (e.g. SNS encryption) on a tenant with a mix of compliant/non-compliant resources and confirm per-asset scoring
- [ ] Spot-check that variant lists (`-terraform-hcl`, `-terraform-plan`, etc.) still resolve correctly in the rendered report

🤖 Generated with [Claude Code](https://claude.com/claude-code)