### PR TITLE
content: add NFS root-squash check and simplify sudo logging check

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -91,6 +91,7 @@ blockinfile
 blockstorage
 bluetooth
 bmcastecho
+bno
 bootkit
 botocore
 bpf
@@ -279,6 +280,7 @@ examplestorage
 examplestorageaccount
 examplestorageacct
 exim
+exportfs
 faillock
 faillog
 failovers

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -106,6 +106,7 @@ policies:
           - uid: mondoo-linux-security-imap-and-pop3-server-is-not-enabled
           - uid: mondoo-linux-security-ldap-server-is-not-enabled
           - uid: mondoo-linux-security-nfs-and-rpc-are-not-enabled
+          - uid: mondoo-linux-security-nfs-exports-root-squash
           - uid: mondoo-linux-security-nis-server-is-not-enabled
           - uid: mondoo-linux-security-rsh-server-is-not-enabled
           - uid: mondoo-linux-security-rsync-service-is-not-enabled
@@ -2743,6 +2744,110 @@ queries:
     refs:
       - url: https://www.freedesktop.org/wiki/Software/systemd/
         title: systemd System and Service Manager
+  - uid: mondoo-linux-security-nfs-exports-root-squash
+    title: Ensure NFS exports do not disable root squashing
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: false
+    filters: |
+      asset.kind != "container-image"
+      nfs.exports.length > 0
+    mql: |
+      nfs.exports.all(noRootSquash == false)
+    docs:
+      desc: |
+        This check verifies that no NFS export uses the `no_root_squash` option. With root squashing enabled, which is the default, the root user on a client is mapped to the unprivileged `nfsnobody` account when accessing the export. The `no_root_squash` option turns that protection off and lets a remote root user act as root on the exported files.
+
+        **Why this matters**
+
+        NFS authenticates clients by network address and trusts the user and group IDs they present. When `no_root_squash` is set, a user with root on any permitted client, or anyone able to impersonate one, gains root-equivalent control over the exported data.
+
+        With root squashing disabled, an attacker can:
+          - Create setuid-root binaries inside the export and execute them to escalate privileges.
+          - Read, modify, or delete any file in the export regardless of its ownership.
+          - Overwrite ownership and permissions to establish persistence.
+
+        Leaving root squashing enabled keeps remote root access mapped to an unprivileged account and preserves the principle of least privilege for networked file systems.
+      audit: |
+        Run this command to review the active export options:
+
+        ```bash
+        exportfs -v
+        ```
+
+        A passing result shows `root_squash` on every export. A failing result shows `no_root_squash` on any export.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            1. Edit the export definition in `/etc/exports` or the relevant file in `/etc/exports.d/` and remove the `no_root_squash` option. Replace it with `root_squash` to be explicit:
+
+                ```text
+                /srv/share 192.0.2.0/24(rw,root_squash)
+                ```
+
+            2. Reapply the export table:
+
+                ```bash
+                exportfs -ra
+                ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to replace `no_root_squash` with `root_squash` in all export definitions and reapply the export table.
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            echo "Enabling root squashing on NFS export definitions..."
+            sed -i 's/\bno_root_squash\b/root_squash/g' /etc/exports
+            if [ -d /etc/exports.d ]; then
+              sed -i 's/\bno_root_squash\b/root_squash/g' /etc/exports.d/*.exports 2>/dev/null || true
+            fi
+            exportfs -ra
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to replace `no_root_squash` with `root_squash` in the export definitions and reapply the export table:
+
+            ```yaml
+            ---
+            - name: Enable root squashing on NFS exports
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Replace no_root_squash with root_squash in /etc/exports
+                  ansible.builtin.replace:
+                    path: /etc/exports
+                    regexp: '\bno_root_squash\b'
+                    replace: root_squash
+                  register: exports_updated
+
+                - name: Reapply the NFS export table
+                  ansible.builtin.command: exportfs -ra
+                  when: exports_updated.changed
+            ```
+    refs:
+      - url: https://man7.org/linux/man-pages/man5/exports.5.html
+        title: exports(5) - NFS server export table
   - uid: mondoo-linux-security-dns-server-is-not-enabled
     title: Ensure DNS server is stopped and not enabled
     impact: 60
@@ -8935,19 +9040,8 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    props:
-      - uid: mondooLinuxSecuritySudoersFiles
-        title: Return the files from /etc/sudoers.d
-        mql: |
-          # Missing sudoers paths return an empty list so the outer check fails without file read errors.
-          sudoersD = ["/etc/sudoers.d/"].where(file(_).exists).map(files.find(from: _, type: 'file').list.map(path)).flat
-          sudoersFiles = sudoersD + ["/etc/sudoers"].where(file(_).exists)
-          return sudoersFiles.map(file(_).content.lines.where(_ == /^[^#]/)).flat
     mql: |
-      ["/etc/sudoers", "/etc/sudoers.d/"].any(file(_).exists) &&
-        props.mondooLinuxSecuritySudoersFiles
-          .where(_ == /Defaults/)
-          .any(_ == /logfile=\"\/var\/log\/sudo\.log\"/)
+      sudoers.defaults.where(parameter == "logfile").any(value == "/var/log/sudo.log")
     docs:
       desc: |
         This check ensures that sudo logs all events to a dedicated log file instead of the default `/var/log/auth.log` file, which contains all authentication events system-wide. Configuring a dedicated log file for sudo events improves the ability to audit and monitor sudo usage effectively.


### PR DESCRIPTION
## Summary

Two changes to `mondoo-linux-security.mql.yaml`, both leveraging os-provider resource improvements ([mql#7997](https://github.com/mondoohq/mql/pull/7997), os 13.20.0):

### New check: `mondoo-linux-security-nfs-exports-root-squash`
Fails when any NFS export uses `no_root_squash`. With root squashing disabled, the root user on a permitted client maps to local root on the export, making it a direct privilege-escalation path (create setuid-root binaries, modify any file, overwrite ownership).

- Uses the new **`nfs`** resource: `nfs.exports.all(noRootSquash == false)`.
- Gated on `nfs.exports.length > 0` so it only applies to hosts that actually serve NFS — applicability, not pass/fail logic.
- Complements the existing `nfs-and-rpc-are-not-enabled` check: that one is for hosts that shouldn't run NFS at all; this one hardens hosts that legitimately do.
- Compliance tags were verified against each framework's control text (least privilege / access enforcement: NIST 800-53 AC-6, 800-171 3.1.5, CSF PR.AA-05 / PR.AC-4, ISO A.8.2, PCI 7.2.1, SOC2 CC6.1.3, HIPAA 164.312(a)(1), NIS-2 21.2(i)). Frameworks without a clean mapping are set to `false`.

### Simplified: `mondoo-linux-security-sudo-logging-is-enabled`
Replaced hand-parsing of sudoers files (a prop plus escaped regex over file contents) with the typed **`sudoers`** resource:

```mql
sudoers.defaults.where(parameter == "logfile").any(value == "/var/log/sudo.log")
```

The parser auto-discovers `/etc/sudoers` and `/etc/sudoers.d`, handles continuations and `+=`/`-=`, and strips surrounding quotes (confirmed in the provider's `ParseDefaultsLine` tests), so this drops the prop, the file-discovery dance, and the brittle regex while preserving the check's pass/fail semantics.

## Testing
- `make cnspec/build`
- `cnspec policy lint ./content/mondoo-linux-security.mql.yaml` → valid policy bundle(s)

Both MQL expressions compile against the bundled os schema (lint compiles all queries). The `nfs` and `sudoers` resources/fields are present in the installed os provider.

> [!NOTE]
> The `nfs` resource ships in os 13.20.0. cnspec must bundle that provider version (or newer) for the new check to evaluate at scan time; the `sudoers`-based rewrite works on the currently shipped provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)