### PR TITLE
content: migrate AWS ECR/ECS/MQ/MSK/Route53/SageMaker checks to per-service platforms

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -356,6 +356,7 @@ hgfs
 Hostbased
 hostbasedauthentication
 hostbasedauthentication
+hostedzone
 hostpath
 hotlinking
 hpa
@@ -598,6 +599,7 @@ pricings
 privateca
 privkey
 privs
+processingjob
 PROJECTID
 protocolhandler
 proxmox
@@ -747,6 +749,7 @@ tacacs
 tailnets
 tailscale
 tallylog
+taskdefinition
 tbl
 tde
 TDS
@@ -766,6 +769,7 @@ toset
 totp
 Tpng
 trae
+trainingjob
 trayicon
 trojanized
 TSecurity

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -14596,7 +14596,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
   - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
-    filters: asset.platform == 'aws-ecr-repository'
+    filters: asset.platform == "aws-ecr-repository"
     mql: |
       aws.ecr.repository.imageScanOnPush == true
   - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl
@@ -14754,7 +14754,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
   - uid: mondoo-aws-security-ecr-tag-immutability-aws
-    filters: asset.platform == 'aws-ecr-repository'
+    filters: asset.platform == "aws-ecr-repository"
     mql: |
       aws.ecr.repository.imageTagMutability == "IMMUTABLE"
   - uid: mondoo-aws-security-ecr-tag-immutability-terraform-hcl
@@ -14928,7 +14928,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
-    filters: asset.platform == 'aws-ecs-taskdefinition'
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
       aws.ecs.taskDefinition.containerDefinitions.all(privileged != true)
   - uid: mondoo-aws-security-ecs-no-privileged-containers-terraform-hcl
@@ -15112,7 +15112,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
-    filters: asset.platform == 'aws-ecs-taskdefinition'
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
       aws.ecs.taskDefinition.containerDefinitions.all(readonlyRootFilesystem == true)
   - uid: mondoo-aws-security-ecs-readonly-root-filesystem-terraform-hcl
@@ -15311,7 +15311,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-logging-enabled-aws
-    filters: asset.platform == 'aws-ecs-taskdefinition'
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
       aws.ecs.taskDefinition.containerDefinitions.all(logConfiguration != empty)
   - uid: mondoo-aws-security-ecs-logging-enabled-terraform-hcl
@@ -20578,7 +20578,7 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
   - uid: mondoo-aws-security-ecs-container-non-root-user-aws
-    filters: asset.platform == 'aws-ecs-taskdefinition'
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
       aws.ecs.taskDefinition.containerDefinitions.all(user != empty && user != "root" && user != "0")
   - uid: mondoo-aws-security-ecs-container-non-root-user-terraform-hcl
@@ -20773,7 +20773,7 @@ queries:
       - url: https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
         title: AWS Documentation - Encrypting data in transit
   - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-aws
-    filters: asset.platform == 'aws-ecs-taskdefinition'
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
       aws.ecs.taskDefinition.volumes.where(efsVolumeConfiguration != empty).all(
         efsVolumeConfiguration.transitEncryption == "ENABLED"
@@ -27478,7 +27478,7 @@ queries:
         title: Configuring DNSSEC signing in Amazon Route 53
   - uid: mondoo-aws-security-route53-dnssec-enabled-aws
     filters: |
-      asset.platform == 'aws-route53-hostedzone'
+      asset.platform == "aws-route53-hostedzone"
       aws.route53.hostedZone.isPrivate == false
     mql: |
       aws.route53.hostedZone.dnssecStatus['serveSignature'] == "SIGNING"
@@ -27631,7 +27631,7 @@ queries:
         title: Logging DNS queries in Amazon Route 53
   - uid: mondoo-aws-security-route53-query-logging-enabled-aws
     filters: |
-      asset.platform == 'aws-route53-hostedzone'
+      asset.platform == "aws-route53-hostedzone"
       aws.route53.hostedZone.isPrivate == false
     mql: |
       aws.route53.hostedZone.queryLoggingConfig != null
@@ -36918,9 +36918,10 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
   - uid: mondoo-aws-security-sagemaker-training-job-network-isolation-aws
-    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    filters: asset.platform == "aws-sagemaker-trainingjob"
     mql: |
       aws.sagemaker.trainingjob.enableNetworkIsolation == true
+  # No Terraform variants: SageMaker training jobs are imperative API calls; the inter-container traffic encryption flag is set per-job via `CreateTrainingJob` and has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-training-job-encryption
     title: Ensure SageMaker training jobs encrypt inter-container traffic
     impact: 80
@@ -37018,9 +37019,10 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
   - uid: mondoo-aws-security-sagemaker-training-job-encryption-aws
-    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    filters: asset.platform == "aws-sagemaker-trainingjob"
     mql: |
       aws.sagemaker.trainingjob.enableInterContainerTrafficEncryption == true
+  # No Terraform variants: SageMaker training jobs are imperative API calls (`CreateTrainingJob`); the `vpc_config` attribute is per-job and has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured
     title: Ensure SageMaker training jobs are deployed within a VPC
     impact: 70
@@ -37118,9 +37120,10 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-vpc.html
         title: Amazon SageMaker - Give SageMaker Training Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
-    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    filters: asset.platform == "aws-sagemaker-trainingjob"
     mql: |
       aws.sagemaker.trainingjob.vpc != empty
+  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); there is no `aws_sagemaker_processing_job` Terraform resource that carries `enable_network_isolation`.
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation
     title: Ensure SageMaker processing jobs have network isolation enabled
     impact: 80
@@ -37215,9 +37218,10 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation-aws
-    filters: asset.platform == 'aws-sagemaker-processingjob'
+    filters: asset.platform == "aws-sagemaker-processingjob"
     mql: |
       aws.sagemaker.processingjob.enableNetworkIsolation == true
+  # No Terraform variants: SageMaker processing jobs are imperative API calls; the inter-container traffic encryption flag has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption
     title: Ensure SageMaker processing jobs encrypt inter-container traffic
     impact: 80
@@ -37311,9 +37315,10 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption-aws
-    filters: asset.platform == 'aws-sagemaker-processingjob'
+    filters: asset.platform == "aws-sagemaker-processingjob"
     mql: |
       aws.sagemaker.processingjob.enableInterContainerTrafficEncryption == true
+  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); per-job VPC configuration has no Terraform resource analog.
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured
     title: Ensure SageMaker processing jobs are deployed within a VPC
     impact: 70
@@ -37408,7 +37413,7 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/process-vpc.html
         title: Amazon SageMaker - Give SageMaker Processing Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured-aws
-    filters: asset.platform == 'aws-sagemaker-processingjob'
+    filters: asset.platform == "aws-sagemaker-processingjob"
     mql: |
       aws.sagemaker.processingjob.vpc != empty
   - uid: mondoo-aws-security-sagemaker-domain-kms-encryption
@@ -38761,7 +38766,7 @@ queries:
         title: Amazon MQ - Logging and Monitoring
   - uid: mondoo-aws-security-mq-audit-logging-aws
     filters: |
-      asset.platform == 'aws-mq-broker'
+      asset.platform == "aws-mq-broker"
       aws.mq.broker.engineType == "ACTIVEMQ"
     mql: |
       aws.mq.broker.auditLogsEnabled == true
@@ -38926,7 +38931,7 @@ queries:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring.html
         title: Amazon MQ - Logging and Monitoring
   - uid: mondoo-aws-security-mq-general-logging-aws
-    filters: asset.platform == 'aws-mq-broker'
+    filters: asset.platform == "aws-mq-broker"
     mql: |
       aws.mq.broker.generalLogsEnabled == true
   - uid: mondoo-aws-security-mq-general-logging-terraform-hcl
@@ -39100,7 +39105,7 @@ queries:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
   - uid: mondoo-aws-security-mq-no-public-access-aws
-    filters: asset.platform == 'aws-mq-broker'
+    filters: asset.platform == "aws-mq-broker"
     mql: |
       aws.mq.broker.publiclyAccessible == false
   - uid: mondoo-aws-security-mq-no-public-access-terraform-hcl
@@ -39268,7 +39273,7 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html
         title: Amazon MSK - Encryption at Rest
   - uid: mondoo-aws-security-msk-encryption-at-rest-aws
-    filters: asset.platform == 'aws-msk-cluster'
+    filters: asset.platform == "aws-msk-cluster"
     mql: |
       aws.msk.cluster.kmsKey != empty
   - uid: mondoo-aws-security-msk-encryption-at-rest-terraform-hcl
@@ -39443,7 +39448,7 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html
         title: Amazon MSK - Encryption in Transit
   - uid: mondoo-aws-security-msk-encryption-in-transit-aws
-    filters: asset.platform == 'aws-msk-cluster'
+    filters: asset.platform == "aws-msk-cluster"
     mql: |
       aws.msk.cluster.encryptionInTransitClientBroker == "TLS"
   - uid: mondoo-aws-security-msk-encryption-in-transit-terraform-hcl
@@ -39621,7 +39626,7 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-logging.html
         title: Amazon MSK - Logging
   - uid: mondoo-aws-security-msk-logging-enabled-aws
-    filters: asset.platform == 'aws-msk-cluster'
+    filters: asset.platform == "aws-msk-cluster"
     mql: |
       aws.msk.cluster.cloudwatchLogsEnabled == true || aws.msk.cluster.s3LogsEnabled == true || aws.msk.cluster.firehoseLogsEnabled == true
   - uid: mondoo-aws-security-msk-logging-enabled-terraform-hcl
@@ -47659,7 +47664,7 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html
         title: AWS Documentation - Encryption at rest for Amazon ECR
   - uid: mondoo-aws-security-ecr-repository-cmk-encryption-aws
-    filters: asset.platform == 'aws-ecr-repository'
+    filters: asset.platform == "aws-ecr-repository"
     mql: |
       aws.ecr.repository.encryptionType == "KMS"
   - uid: mondoo-aws-security-ecr-repository-cmk-encryption-terraform-hcl

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -14596,8 +14596,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
   - uid: mondoo-aws-security-ecr-image-scan-on-push-aws
-    filters: asset.platform == "aws"
-    mql: aws.ecr.privateRepositories.all(imageScanOnPush == true)
+    filters: asset.platform == 'aws-ecr-repository'
+    mql: |
+      aws.ecr.repository.imageScanOnPush == true
   - uid: mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository")
     mql: |
@@ -14753,8 +14754,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecr-controls.html
         title: AWS Documentation - ECR controls
   - uid: mondoo-aws-security-ecr-tag-immutability-aws
-    filters: asset.platform == "aws"
-    mql: aws.ecr.privateRepositories.all(imageTagMutability == "IMMUTABLE")
+    filters: asset.platform == 'aws-ecr-repository'
+    mql: |
+      aws.ecr.repository.imageTagMutability == "IMMUTABLE"
   - uid: mondoo-aws-security-ecr-tag-immutability-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository")
     mql: |
@@ -14926,11 +14928,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-ecs-taskdefinition'
     mql: |
-      aws.ecs.taskDefinitions.all(
-        containerDefinitions.all(privileged != true)
-      )
+      aws.ecs.taskDefinition.containerDefinitions.all(privileged != true)
   - uid: mondoo-aws-security-ecs-no-privileged-containers-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
     mql: |
@@ -15112,11 +15112,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-ecs-taskdefinition'
     mql: |
-      aws.ecs.taskDefinitions.all(
-        containerDefinitions.all(readonlyRootFilesystem == true)
-      )
+      aws.ecs.taskDefinition.containerDefinitions.all(readonlyRootFilesystem == true)
   - uid: mondoo-aws-security-ecs-readonly-root-filesystem-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
     mql: |
@@ -15313,11 +15311,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-logging-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-ecs-taskdefinition'
     mql: |
-      aws.ecs.taskDefinitions.all(
-        containerDefinitions.all(logConfiguration != empty)
-      )
+      aws.ecs.taskDefinition.containerDefinitions.all(logConfiguration != empty)
   - uid: mondoo-aws-security-ecs-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
     mql: |
@@ -20582,11 +20578,9 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
   - uid: mondoo-aws-security-ecs-container-non-root-user-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-ecs-taskdefinition'
     mql: |
-      aws.ecs.taskDefinitions.all(
-        containerDefinitions.all(user != empty && user != "root" && user != "0")
-      )
+      aws.ecs.taskDefinition.containerDefinitions.all(user != empty && user != "root" && user != "0")
   - uid: mondoo-aws-security-ecs-container-non-root-user-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
     mql: |
@@ -20779,12 +20773,10 @@ queries:
       - url: https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
         title: AWS Documentation - Encrypting data in transit
   - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-ecs-taskdefinition'
     mql: |
-      aws.ecs.taskDefinitions.all(
-        volumes.where(efsVolumeConfiguration != empty).all(
-          efsVolumeConfiguration.transitEncryption == "ENABLED"
-        )
+      aws.ecs.taskDefinition.volumes.where(efsVolumeConfiguration != empty).all(
+        efsVolumeConfiguration.transitEncryption == "ENABLED"
       )
   - uid: mondoo-aws-security-ecs-efs-volume-transit-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
@@ -27485,11 +27477,11 @@ queries:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec.html
         title: Configuring DNSSEC signing in Amazon Route 53
   - uid: mondoo-aws-security-route53-dnssec-enabled-aws
-    filters: asset.platform == "aws"
+    filters: |
+      asset.platform == 'aws-route53-hostedzone'
+      aws.route53.hostedZone.isPrivate == false
     mql: |
-      aws.route53.hostedZones.where(isPrivate == false).all(
-        dnssecStatus['serveSignature'] == "SIGNING"
-      )
+      aws.route53.hostedZone.dnssecStatus['serveSignature'] == "SIGNING"
   - uid: mondoo-aws-security-route53-dnssec-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53_hosted_zone_dnssec")
     mql: |
@@ -27638,11 +27630,11 @@ queries:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html
         title: Logging DNS queries in Amazon Route 53
   - uid: mondoo-aws-security-route53-query-logging-enabled-aws
-    filters: asset.platform == "aws"
+    filters: |
+      asset.platform == 'aws-route53-hostedzone'
+      aws.route53.hostedZone.isPrivate == false
     mql: |
-      aws.route53.hostedZones.where(isPrivate == false).all(
-        queryLoggingConfig != null
-      )
+      aws.route53.hostedZone.queryLoggingConfig != null
   - uid: mondoo-aws-security-route53-query-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_route53_query_log")
     mql: |
@@ -36926,9 +36918,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
   - uid: mondoo-aws-security-sagemaker-training-job-network-isolation-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.trainingJobs.all(enableNetworkIsolation == true)
-  # No Terraform variants: SageMaker training jobs are imperative API calls; the inter-container traffic encryption flag is set per-job via `CreateTrainingJob` and has no Terraform resource analog.
+    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    mql: |
+      aws.sagemaker.trainingjob.enableNetworkIsolation == true
   - uid: mondoo-aws-security-sagemaker-training-job-encryption
     title: Ensure SageMaker training jobs encrypt inter-container traffic
     impact: 80
@@ -37026,9 +37018,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
   - uid: mondoo-aws-security-sagemaker-training-job-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.trainingJobs.all(enableInterContainerTrafficEncryption == true)
-  # No Terraform variants: SageMaker training jobs are imperative API calls (`CreateTrainingJob`); the `vpc_config` attribute is per-job and has no Terraform resource analog.
+    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    mql: |
+      aws.sagemaker.trainingjob.enableInterContainerTrafficEncryption == true
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured
     title: Ensure SageMaker training jobs are deployed within a VPC
     impact: 70
@@ -37126,9 +37118,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-vpc.html
         title: Amazon SageMaker - Give SageMaker Training Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-training-job-vpc-configured-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.trainingJobs.all(vpc != empty)
-  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); there is no `aws_sagemaker_processing_job` Terraform resource that carries `enable_network_isolation`.
+    filters: asset.platform == 'aws-sagemaker-trainingjob'
+    mql: |
+      aws.sagemaker.trainingjob.vpc != empty
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation
     title: Ensure SageMaker processing jobs have network isolation enabled
     impact: 80
@@ -37223,9 +37215,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
   - uid: mondoo-aws-security-sagemaker-processing-job-network-isolation-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.processingJobs.all(enableNetworkIsolation == true)
-  # No Terraform variants: SageMaker processing jobs are imperative API calls; the inter-container traffic encryption flag has no Terraform resource analog.
+    filters: asset.platform == 'aws-sagemaker-processingjob'
+    mql: |
+      aws.sagemaker.processingjob.enableNetworkIsolation == true
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption
     title: Ensure SageMaker processing jobs encrypt inter-container traffic
     impact: 80
@@ -37319,9 +37311,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html
         title: Amazon SageMaker - Protect Communications Between ML Compute Instances
   - uid: mondoo-aws-security-sagemaker-processing-job-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.processingJobs.all(enableInterContainerTrafficEncryption == true)
-  # No Terraform variants: SageMaker processing jobs are imperative API calls (`CreateProcessingJob`); per-job VPC configuration has no Terraform resource analog.
+    filters: asset.platform == 'aws-sagemaker-processingjob'
+    mql: |
+      aws.sagemaker.processingjob.enableInterContainerTrafficEncryption == true
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured
     title: Ensure SageMaker processing jobs are deployed within a VPC
     impact: 70
@@ -37416,8 +37408,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/process-vpc.html
         title: Amazon SageMaker - Give SageMaker Processing Jobs Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-processing-job-vpc-configured-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.processingJobs.all(vpc != empty)
+    filters: asset.platform == 'aws-sagemaker-processingjob'
+    mql: |
+      aws.sagemaker.processingjob.vpc != empty
   - uid: mondoo-aws-security-sagemaker-domain-kms-encryption
     title: Ensure SageMaker domains are encrypted with a KMS key
     impact: 70
@@ -38767,9 +38760,11 @@ queries:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring.html
         title: Amazon MQ - Logging and Monitoring
   - uid: mondoo-aws-security-mq-audit-logging-aws
-    filters: asset.platform == "aws"
+    filters: |
+      asset.platform == 'aws-mq-broker'
+      aws.mq.broker.engineType == "ACTIVEMQ"
     mql: |
-      aws.mq.brokers.where(engineType == "ACTIVEMQ").all(auditLogsEnabled == true)
+      aws.mq.broker.auditLogsEnabled == true
   - uid: mondoo-aws-security-mq-audit-logging-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_mq_broker")
     mql: |
@@ -38931,9 +38926,9 @@ queries:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring.html
         title: Amazon MQ - Logging and Monitoring
   - uid: mondoo-aws-security-mq-general-logging-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-mq-broker'
     mql: |
-      aws.mq.brokers.all(generalLogsEnabled == true)
+      aws.mq.broker.generalLogsEnabled == true
   - uid: mondoo-aws-security-mq-general-logging-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_mq_broker")
     mql: |
@@ -39105,9 +39100,9 @@ queries:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
   - uid: mondoo-aws-security-mq-no-public-access-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-mq-broker'
     mql: |
-      aws.mq.brokers.all(publiclyAccessible == false)
+      aws.mq.broker.publiclyAccessible == false
   - uid: mondoo-aws-security-mq-no-public-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_mq_broker")
     mql: |
@@ -39273,9 +39268,9 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html
         title: Amazon MSK - Encryption at Rest
   - uid: mondoo-aws-security-msk-encryption-at-rest-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-msk-cluster'
     mql: |
-      aws.msk.clusters.all(kmsKey != empty)
+      aws.msk.cluster.kmsKey != empty
   - uid: mondoo-aws-security-msk-encryption-at-rest-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_msk_cluster")
     mql: |
@@ -39448,9 +39443,9 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html
         title: Amazon MSK - Encryption in Transit
   - uid: mondoo-aws-security-msk-encryption-in-transit-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-msk-cluster'
     mql: |
-      aws.msk.clusters.all(encryptionInTransitClientBroker == "TLS")
+      aws.msk.cluster.encryptionInTransitClientBroker == "TLS"
   - uid: mondoo-aws-security-msk-encryption-in-transit-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_msk_cluster")
     mql: |
@@ -39626,9 +39621,9 @@ queries:
       - url: https://docs.aws.amazon.com/msk/latest/developerguide/msk-logging.html
         title: Amazon MSK - Logging
   - uid: mondoo-aws-security-msk-logging-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == 'aws-msk-cluster'
     mql: |
-      aws.msk.clusters.all(cloudwatchLogsEnabled == true || s3LogsEnabled == true || firehoseLogsEnabled == true)
+      aws.msk.cluster.cloudwatchLogsEnabled == true || aws.msk.cluster.s3LogsEnabled == true || aws.msk.cluster.firehoseLogsEnabled == true
   - uid: mondoo-aws-security-msk-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_msk_cluster")
     mql: |
@@ -47664,8 +47659,9 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html
         title: AWS Documentation - Encryption at rest for Amazon ECR
   - uid: mondoo-aws-security-ecr-repository-cmk-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.ecr.privateRepositories.all( encryptionType == "KMS" )
+    filters: asset.platform == 'aws-ecr-repository'
+    mql: |
+      aws.ecr.repository.encryptionType == "KMS"
   - uid: mondoo-aws-security-ecr-repository-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository")
     mql: |


### PR DESCRIPTION
## Summary

Migrates the runtime (`-aws`) variants for seven AWS services off the generic `aws` platform onto their per-service platforms, reworking each query from account-wide `.all()` iteration to the singular per-asset resource (same pattern as the GCP per-service migration).

| Platform | Resource | Checks |
|---|---|---|
| `aws-ecr-repository` | `aws.ecr.repository` | image-scan-on-push, tag-immutability, cmk-encryption |
| `aws-ecs-taskdefinition` | `aws.ecs.taskDefinition` | no-privileged-containers, readonly-root-filesystem, logging-enabled, container-non-root-user, efs-volume-transit-encryption |
| `aws-mq-broker` | `aws.mq.broker` | audit-logging, general-logging, no-public-access |
| `aws-msk-cluster` | `aws.msk.cluster` | encryption-at-rest, encryption-in-transit, logging-enabled |
| `aws-route53-hostedzone` | `aws.route53.hostedZone` | dnssec-enabled, query-logging-enabled |
| `aws-sagemaker-trainingjob` | `aws.sagemaker.trainingjob` | network-isolation, encryption, vpc-configured |
| `aws-sagemaker-processingjob` | `aws.sagemaker.processingjob` | network-isolation, encryption, vpc-configured |

**22 checks** migrated. Example: `aws.ecs.taskDefinitions.all(containerDefinitions.all(privileged != true))` → `aws.ecs.taskDefinition.containerDefinitions.all(privileged != true)`.

### Notes for review
- **`.where(...)` → filter scoping:** for MQ ActiveMQ-only audit logging and Route 53 public-zone DNSSEC/query-logging, the subset condition moves into `filters` so out-of-scope assets are skipped rather than passing (consistent with the GCP migration).
- **`mondoo-aws-security-sagemaker-job-role-not-admin-aws` left on `aws`:** it correlates *both* `aws.sagemaker.trainingJobs` and `aws.sagemaker.processingJobs` in one query, which a single per-asset platform can't express. Splitting it into two per-platform checks is a separate decision — flagging rather than guessing.
- **`route53-dnssec-enabled`** keeps the existing `dnssecStatus['serveSignature']` accessor (marked deprecated in `aws.lr` in favor of `dnssec`); preserving the original semantics, modernization left out of scope.
- Out of scope (still on `aws`, no matching platform in this set): `msk-replicator-external-kafka-tls` (uses `aws.msk.replicators`) and `sagemaker-monitoring-job-network-config` (uses job-definition resources).

## Testing
`cnspec policy lint ./content/mondoo-aws-security.mql.yaml` → valid policy bundle(s).

> Verified resource paths/fields against the aws provider `.lr` whose discovery defines these platforms. The linter doesn't hard-fail on unknown nested paths and the locally installed provider may predate this migration, so confirm with a real scan in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)