### PR TITLE
content: migrate Azure firewall/app-gateway/function-app/container-app checks to per-service platforms

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -15938,10 +15938,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/firewall/threat-intel
         title: Azure Firewall threat intelligence-based filtering
   - uid: mondoo-azure-security-firewall-threat-intel-deny-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-firewall"
     mql: |
-      azure.subscription.network.firewalls.all(threatIntelMode == "Deny")
+      azure.subscription.networkService.firewall.threatIntelMode == "Deny"
   - uid: mondoo-azure-security-firewall-threat-intel-deny-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall")
     mql: |
@@ -16087,10 +16086,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/firewall/premium-features
         title: Azure Firewall Premium features
   - uid: mondoo-azure-security-firewall-premium-sku-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-firewall"
     mql: |
-      azure.subscription.network.firewalls.all(skuTier == "Premium")
+      azure.subscription.networkService.firewall.skuTier == "Premium"
   - uid: mondoo-azure-security-firewall-premium-sku-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall")
     mql: |
@@ -16255,10 +16253,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/firewall/policy-rule-sets
         title: Azure Firewall Policy rule sets
   - uid: mondoo-azure-security-firewall-policy-configured-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-firewall"
     mql: |
-      azure.subscription.network.firewalls.all(policy != empty)
+      azure.subscription.networkService.firewall.policy != empty
   - uid: mondoo-azure-security-firewall-policy-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall")
     mql: |
@@ -16414,12 +16411,11 @@ queries:
         title: Azure Firewall Premium features
   - uid: mondoo-azure-security-firewall-idps-enabled-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-firewall" &&
+      azure.subscription.networkService.firewall.policy != empty
     mql: |
-      azure.subscription.network.firewallPolicies.all(
-        properties["intrusionDetection"] != null &&
-        properties["intrusionDetection"]["mode"] == "Deny"
-      )
+      azure.subscription.networkService.firewall.policy.properties["intrusionDetection"] != null &&
+      azure.subscription.networkService.firewall.policy.properties["intrusionDetection"]["mode"] == "Deny"
   - uid: mondoo-azure-security-firewall-idps-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall_policy")
     mql: |
@@ -18582,18 +18578,10 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview
         title: Application Gateway SSL policy overview
   - uid: mondoo-azure-security-appgw-ssl-policy-tls12-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.network.applicationGateways.where(
-        properties["sslPolicy"] != null
-      ).all(
-        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_2" ||
-        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_3"
-      )
-      azure.subscription.network.applicationGateways.none(
-        properties["sslPolicy"] == null
-      )
+      azure.subscription.networkService.applicationGateway.properties["sslPolicy"] != null
+      azure.subscription.networkService.applicationGateway.properties["sslPolicy"]["minProtocolVersion"].in(["TLSv1_2", "TLSv1_3"])
   - uid: mondoo-azure-security-appgw-ssl-policy-tls12-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
     mql: |
@@ -23778,12 +23766,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview
         title: Application Gateway SSL policy overview
   - uid: mondoo-azure-security-appgw-min-tls-version-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.network.applicationGateways.all(
-        sslMinProtocolVersion == "TLSv1_2" || sslMinProtocolVersion == "TLSv1_3"
-      )
+      azure.subscription.networkService.applicationGateway.sslMinProtocolVersion.in(["TLSv1_2", "TLSv1_3"])
   - uid: mondoo-azure-security-appgw-min-tls-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
     mql: |
@@ -23968,14 +23953,9 @@ queries:
         values['ssl_policy'] != empty
       )
   - uid: mondoo-azure-security-appgw-no-weak-ciphers-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.network.applicationGateways.all(
-        sslCipherSuites.none(
-          _ == /RC4/ || _ == /3DES/ || _ == /NULL/ || _ == /EXPORT/
-        )
-      )
+      azure.subscription.networkService.applicationGateway.sslCipherSuites.none(_ == /RC4|3DES|NULL|EXPORT/)
   - uid: mondoo-azure-security-public-ip-ddos-protection
     title: Ensure public IP addresses have DDoS protection
     impact: 70
@@ -33473,12 +33453,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
         title: Enforce HTTPS in Azure App Service
   - uid: mondoo-azure-security-function-app-https-only-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functions.functionApps.all(
-        httpsOnly == true
-      )
+      azure.subscription.functionsService.functionApp.httpsOnly == true
   - uid: mondoo-azure-security-function-app-https-only-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -33610,12 +33587,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
         title: Configure TLS mutual authentication for Azure App Service
   - uid: mondoo-azure-security-function-app-client-cert-required-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functions.functionApps.all(
-        clientCertEnabled == true && clientCertMode == "Required"
-      )
+      azure.subscription.functionsService.functionApp.clientCertEnabled == true && azure.subscription.functionsService.functionApp.clientCertMode == "Required"
   - uid: mondoo-azure-security-function-app-client-cert-required-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -33749,12 +33723,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity
         title: Managed identities for Azure App Service and Azure Functions
   - uid: mondoo-azure-security-function-app-managed-identity-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functions.functionApps.all(
-        managedServiceIdentityId != ""
-      )
+      azure.subscription.functionsService.functionApp.managedServiceIdentityId != empty
   - uid: mondoo-azure-security-function-app-managed-identity-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -34715,11 +34686,10 @@ queries:
         title: Ingress in Azure Container Apps
   - uid: mondoo-azure-security-container-app-https-ingress-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-app" &&
+      azure.subscription.containerAppService.containerApp.ingressEnabled
     mql: |
-      azure.subscription.containerApp.containerApps.where(ingressEnabled).all(
-        httpsOnly == true
-      )
+      azure.subscription.containerAppService.containerApp.httpsOnly == true
   - uid: mondoo-azure-security-container-app-https-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
     mql: |
@@ -34913,11 +34883,10 @@ queries:
         title: Pull images from Azure Container Registry using managed identity
   - uid: mondoo-azure-security-container-app-managed-identity-registries-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-container-app" &&
+      azure.subscription.containerAppService.containerApp.registries.length > 0
     mql: |
-      azure.subscription.containerApp.containerApps.where(registries.length > 0).all(
-        registryAuthUsesIdentity == true
-      )
+      azure.subscription.containerAppService.containerApp.registryAuthUsesIdentity == true
   - uid: mondoo-azure-security-container-app-managed-identity-registries-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
     mql: |
@@ -35071,12 +35040,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/container-apps/containers
         title: Containers in Azure Container Apps
   - uid: mondoo-azure-security-container-app-image-digest-pinned-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-container-app"
     mql: |
-      azure.subscription.containerApp.containerApps.all(
-        containers.all(imagePinned == true)
-      )
+      azure.subscription.containerAppService.containerApp.containers.all(imagePinned == true)
   - uid: mondoo-azure-security-container-app-image-digest-pinned-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
     mql: |
@@ -35714,12 +35680,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
         title: Azure Functions networking options
   - uid: mondoo-azure-security-function-app-public-network-access-disabled-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functions.functionApps.all(
-        properties["publicNetworkAccess"] == "Disabled"
-      )
+      azure.subscription.functionsService.functionApp.properties["publicNetworkAccess"] == "Disabled"
   - uid: mondoo-azure-security-function-app-public-network-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -36430,13 +36393,10 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/application-gateway/configuration-front-end-ip
         title: Application Gateway frontend IP address configuration
   - uid: mondoo-azure-security-application-gateway-no-public-frontend-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.network.applicationGateways.all(
-        properties["frontendIPConfigurations"].any(
-          _["properties"]["subnet"] != null
-        )
+      azure.subscription.networkService.applicationGateway.properties["frontendIPConfigurations"].any(
+        _["properties"]["subnet"] != null
       )
   - uid: mondoo-azure-security-application-gateway-no-public-frontend-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
@@ -37196,13 +37156,10 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
         title: Use Key Vault references for App Service and Azure Functions
   - uid: mondoo-azure-security-function-app-cmk-encryption-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functions.functionApps.all(
-        properties["keyVaultReferenceIdentity"] != null &&
-        properties["keyVaultReferenceIdentity"] != ""
-      )
+      azure.subscription.functionsService.functionApp.properties["keyVaultReferenceIdentity"] != null &&
+      azure.subscription.functionsService.functionApp.properties["keyVaultReferenceIdentity"] != ""
   - uid: mondoo-azure-security-function-app-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |


### PR DESCRIPTION
## Summary

Migrates the runtime (`-azure`) variants for four Azure services off the generic `azure` platform onto their per-service platforms, reworking each query from subscription-wide `.all()` iteration to the singular per-asset resource.

| Platform | Resource | Checks |
|---|---|---|
| `azure-firewall` | `azure.subscription.networkService.firewall` | threat-intel-deny, premium-sku, policy-configured, idps-enabled |
| `azure-application-gateway` | `azure.subscription.networkService.applicationGateway` | ssl-policy-tls12, min-tls-version, no-weak-ciphers, no-public-frontend |
| `azure-function-app` | `azure.subscription.functionsService.functionApp` | https-only, client-cert-required, managed-identity, public-network-access-disabled, cmk-encryption |
| `azure-container-app` | `azure.subscription.containerAppService.containerApp` | https-ingress, managed-identity-registries, image-digest-pinned |

**16 checks** migrated.

### Notes for review
- **Firewall IDPS** (`firewall-idps-enabled`) previously iterated subscription-wide `network.firewallPolicies`. It now reaches the policy through the firewall's own `policy()` accessor (`firewall.policy.properties["intrusionDetection"]…`), scoped in `filters` to firewalls that actually have a policy attached.
- **`.where(...)` → filter scoping** for Container App ingress (`ingressEnabled`) and registry (`registries.length > 0`) checks, so out-of-scope apps are skipped rather than passing.
- **`appgw-ssl-policy-tls12`** is kept as two separate statements (sslPolicy present; min version is TLS1.2/1.3) rather than one `&&`-joined expression — MQL's parser rejects parenthesized grouping (`A && (B || C)`), and two datapoints preserves the original check's structure.

## Testing
`cnspec policy lint ./content/mondoo-azure-security.mql.yaml` → valid policy bundle(s).

> Verified resource names/fields against the azure provider `.lr` (the singular per-asset resources `azure.subscription.networkService.firewall`, `.applicationGateway`, `.functionsService.functionApp`, `.containerAppService.containerApp` all exist with the referenced fields). Confirm with a real scan in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)