### PR TITLE
content: migrate OCI load-balancer/OKE/vault/API-gateway/Redis checks to per-service platforms

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3865,12 +3865,10 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingsslconfigs.htm
         title: OCI - Managing SSL Configurations
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-loadbalancer"
     mql: |
-      oci.loadBalancer.loadBalancers.all(
-        listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
-          sslProtocols.none(_ == "TLSv1" || _ == "TLSv1.1" || _ == "SSLv3")
-        )
+      oci.loadBalancer.loadBalancer.listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
+        sslProtocols.none(_ == "TLSv1" || _ == "TLSv1.1" || _ == "SSLv3")
       )
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-terraform-hcl
     filters: |
@@ -4030,12 +4028,10 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/References/predefinedsslciphersuites.htm
         title: OCI - Predefined SSL Cipher Suites
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-loadbalancer"
     mql: |
-      oci.loadBalancer.loadBalancers.all(
-        listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
-          sslCipherSuiteName.downcase == /^oci-modern-ssl-cipher-suite-v1$|^oci-tls-1-2-[a-z0-9-]+$|^oci-tls-1-3-[a-z0-9-]+$|^oci-default-ssl-cipher-suite-v1$/
-        )
+      oci.loadBalancer.loadBalancer.listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
+        sslCipherSuiteName.downcase == /^oci-modern-ssl-cipher-suite-v1$|^oci-tls-1-2-[a-z0-9-]+$|^oci-tls-1-3-[a-z0-9-]+$|^oci-default-ssl-cipher-suite-v1$/
       )
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-terraform-hcl
     filters: |
@@ -4082,7 +4078,9 @@ queries:
   - uid: mondoo-oci-security-loadbalancer-http-listener-has-https
     title: Ensure load balancers that run HTTP listeners also expose HTTPS
     impact: 70
-    filters: asset.platform == 'oci'
+    filters: |
+      asset.platform == "oci-loadbalancer"
+      oci.loadBalancer.loadBalancer.listeners.any(protocol == "HTTP")
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
@@ -4098,11 +4096,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      oci.loadBalancer.loadBalancers.where(
-        listeners.any(protocol == "HTTP")
-      ).all(
-        listeners.any(protocol == "HTTPS" || protocol == "HTTP2")
-      )
+      oci.loadBalancer.loadBalancer.listeners.any(protocol == "HTTPS" || protocol == "HTTP2")
     docs:
       desc: |
         This check ensures that every OCI load balancer exposing an HTTP listener also exposes at least one HTTPS or HTTP/2 listener. A load balancer that serves HTTP with no accompanying TLS listener provides no encrypted path for the service, meaning that traffic including credentials, session cookies, and form submissions travels in cleartext across any network between the client and the load balancer.
@@ -4283,9 +4277,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm
         title: OCI - OKE Network Configuration
   - uid: mondoo-oci-security-oke-public-endpoint-disabled-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-oke-cluster"
     mql: |
-      oci.oke.clusters.all(isPublicEndpointEnabled == false)
+      oci.oke.cluster.isPublicEndpointEnabled == false
   - uid: mondoo-oci-security-oke-public-endpoint-disabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_containerengine_cluster')
@@ -4321,7 +4315,7 @@ queries:
   - uid: mondoo-oci-security-oke-supported-kubernetes-version
     title: Ensure OKE clusters run a supported Kubernetes version
     impact: 70
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-oke-cluster"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
@@ -4337,7 +4331,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
-      oci.oke.clusters.all(availableKubernetesUpgrades.length < 3)
+      oci.oke.cluster.availableKubernetesUpgrades.length < 3
     docs:
       desc: |
         This check ensures that OCI Kubernetes Engine clusters are running a Kubernetes version that is not significantly behind Oracle's current supported releases. The check flags clusters with three or more available upgrades pending, which is a strong indicator that the cluster is running a version near or past its end-of-support window and is no longer receiving security patches from Oracle.
@@ -4507,9 +4501,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengsigningimages_topic-Signing_Container_Images_Using_OCI_Registry.htm
         title: OCI - Signing Container Images
   - uid: mondoo-oci-security-oke-image-policy-enabled-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-oke-cluster"
     mql: |
-      oci.oke.clusters.all(isImagePolicyEnabled == true)
+      oci.oke.cluster.isImagePolicyEnabled == true
   - uid: mondoo-oci-security-oke-image-policy-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_containerengine_cluster')
@@ -4545,7 +4539,7 @@ queries:
   - uid: mondoo-oci-security-oke-node-pool-private-subnets
     title: Ensure OKE node pool worker nodes are placed in private subnets
     impact: 80
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-oke-cluster"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -4561,10 +4555,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      oci.oke.clusters.all(
-        nodePools.all(
-          subnets.all(prohibitPublicIpOnVnic == true)
-        )
+      oci.oke.cluster.nodePools.all(
+        subnets.all(prohibitPublicIpOnVnic == true)
       )
     docs:
       desc: |
@@ -4792,11 +4784,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm
         title: OCI - Network resource configuration for Kubernetes clusters
   - uid: mondoo-oci-security-oke-node-pool-nsgs-attached-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-oke-cluster"
     mql: |
-      oci.oke.clusters.all(
-        nodePools.all(networkSecurityGroups.length > 0)
-      )
+      oci.oke.cluster.nodePools.all(networkSecurityGroups.length > 0)
   - uid: mondoo-oci-security-oke-node-pool-nsgs-attached-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_containerengine_node_pool')
@@ -5435,12 +5425,12 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingsecrets.htm
         title: OCI - Managing Secrets
   - uid: mondoo-oci-security-vault-secrets-rotation-enabled-oci
-    filters: asset.platform == 'oci'
+    filters: |
+      asset.platform == "oci-vault-secret"
+      oci.vault.secret.state == "ACTIVE"
+      time.now - oci.vault.secret.created > 365 * time.day
     mql: |
-      oci.vault.secrets.where(
-        state == "ACTIVE" &&
-        time.now - created > 365 * time.day
-      ).all(isScheduledRotationEnabled == true)
+      oci.vault.secret.isScheduledRotationEnabled == true
   - uid: mondoo-oci-security-vault-secrets-rotation-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_vault_secret')
@@ -5476,7 +5466,9 @@ queries:
   - uid: mondoo-oci-security-vault-secrets-not-expired
     title: Ensure OCI Vault active secret versions are not past their expiry time
     impact: 60
-    filters: asset.platform == 'oci'
+    filters: |
+      asset.platform == "oci-vault-secret"
+      oci.vault.secret.state == "ACTIVE"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-17
@@ -5492,10 +5484,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      oci.vault.secrets.where(state == "ACTIVE").all(
-        timeOfCurrentVersionExpiry == null ||
-        timeOfCurrentVersionExpiry > time.now
-      )
+      oci.vault.secret.timeOfCurrentVersionExpiry == null ||
+      oci.vault.secret.timeOfCurrentVersionExpiry > time.now
     docs:
       desc: |
         This check ensures that every active OCI Vault secret has a current version whose expiry timestamp is either unset or in the future. A secret whose current version has an expiry in the past indicates either that the rotation schedule failed to execute or that a consuming application is still using a version the operator intended to be invalidated, which is both an operational failure and a security signal.
@@ -7561,9 +7551,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingauthenticationpolicies.htm
         title: OCI - API Gateway Authentication Policies
   - uid: mondoo-oci-security-apigateway-deployment-no-anonymous-access-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-apigateway-deployment"
     mql: |
-      oci.apigateway.deployments.all(isAnonymousAccessAllowed != true)
+      oci.apigateway.deployment.isAnonymousAccessAllowed != true
   - uid: mondoo-oci-security-apigateway-deployment-no-anonymous-access-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_apigateway_deployment')
@@ -7734,9 +7724,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingauthenticationpolicies.htm
         title: OCI - API Gateway Authentication Policies
   - uid: mondoo-oci-security-apigateway-deployment-authentication-configured-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-apigateway-deployment"
     mql: |
-      oci.apigateway.deployments.all(authenticationType != null && authenticationType != "NONE")
+      oci.apigateway.deployment.authenticationType != null && oci.apigateway.deployment.authenticationType != "NONE"
   - uid: mondoo-oci-security-apigateway-deployment-authentication-configured-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_apigateway_deployment')
@@ -7917,11 +7907,11 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingmTLS.htm
         title: OCI - API Gateway Mutual TLS
   - uid: mondoo-oci-security-apigateway-deployment-mtls-verified-oci
-    filters: asset.platform == 'oci'
+    filters: |
+      asset.platform == "oci-apigateway-deployment"
+      oci.apigateway.deployment.mtlsAllowedSans.length > 0
     mql: |
-      oci.apigateway.deployments.where(mtlsAllowedSans.length > 0).all(
-        mtlsIsVerifiedCertificateRequired == true
-      )
+      oci.apigateway.deployment.mtlsIsVerifiedCertificateRequired == true
   - uid: mondoo-oci-security-apigateway-deployment-mtls-verified-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_apigateway_deployment')
@@ -8090,9 +8080,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingcorspolicies.htm
         title: OCI - API Gateway CORS Policies
   - uid: mondoo-oci-security-apigateway-deployment-no-wildcard-cors-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-apigateway-deployment"
     mql: |
-      oci.apigateway.deployments.all(corsAllowedOrigins.none(_ == "*"))
+      oci.apigateway.deployment.corsAllowedOrigins.none(_ == "*")
   - uid: mondoo-oci-security-apigateway-deployment-no-wildcard-cors-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_apigateway_deployment')
@@ -8897,7 +8887,7 @@ queries:
   - uid: mondoo-oci-security-redis-cluster-private-subnet
     title: Ensure OCI Cache clusters are deployed in private subnets
     impact: 90
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-redis-cluster"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -8913,7 +8903,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      oci.redis.clusters.all(subnet.prohibitPublicIpOnVnic == true)
+      oci.redis.cluster.subnet.prohibitPublicIpOnVnic == true
     docs:
       desc: |
         This check ensures that every OCI Cache cluster is deployed in a subnet configured to prohibit public IP addresses on VNICs. By default, OCI subnets allow public IP assignment, and a cache cluster placed in such a subnet can be assigned a public IP that exposes the in-memory store to internet scanning with no application-layer authentication between the attacker and the data.
@@ -9122,9 +9112,9 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/Content/ocicache/connecttocluster.htm
         title: OCI Cache - Connect to a Cluster
   - uid: mondoo-oci-security-redis-cluster-nsg-attached-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-redis-cluster"
     mql: |
-      oci.redis.clusters.all(networkSecurityGroups.length > 0)
+      oci.redis.cluster.networkSecurityGroups.length > 0
   - uid: mondoo-oci-security-redis-cluster-nsg-attached-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_redis_redis_cluster')
@@ -9253,10 +9243,10 @@ queries:
         title: OCI Cache Overview
   # The supported version literal `["VALKEY_7_2", "VALKEY_8_1"]` is repeated in all four variant queries below. cnspec policy YAML does not support anchors inside MQL block scalars and the OCI policy file does not use `props:`, so the list cannot be defined once. When Oracle adds or deprecates a version, update the literal in all four variants together.
   - uid: mondoo-oci-security-redis-cluster-supported-version-oci
-    filters: asset.platform == 'oci'
+    filters: asset.platform == "oci-redis-cluster"
     mql: |
       # MAINTAIN-TOGETHER: keep this version list in sync with the other three variants of mondoo-oci-security-redis-cluster-supported-version
-      oci.redis.clusters.all(softwareVersion.in(["VALKEY_7_2", "VALKEY_8_1"]))
+      oci.redis.cluster.softwareVersion.in(["VALKEY_7_2", "VALKEY_8_1"])
   - uid: mondoo-oci-security-redis-cluster-supported-version-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_redis_redis_cluster')


### PR DESCRIPTION
## Summary

Migrates checks for five OCI services off the generic `oci` platform onto their per-service platforms, reworking each query from tenancy-wide `.all()` iteration to the singular per-asset resource.

| Platform | Resource | Checks |
|---|---|---|
| `oci-loadbalancer` | `oci.loadBalancer.loadBalancer` | tls-minimum-1-2, no-weak-cipher-suites, http-listener-has-https |
| `oci-oke-cluster` | `oci.oke.cluster` | public-endpoint-disabled, supported-kubernetes-version, image-policy-enabled, node-pool-private-subnets, node-pool-nsgs-attached |
| `oci-vault-secret` | `oci.vault.secret` | secrets-rotation-enabled, secrets-not-expired |
| `oci-apigateway-deployment` | `oci.apigateway.deployment` | no-anonymous-access, authentication-configured, mtls-verified, no-wildcard-cors |
| `oci-redis-cluster` | `oci.redis.cluster` | private-subnet, nsg-attached, supported-version |

**17 checks** migrated (a mix of `-oci` runtime variants and single-platform checks; for the single-platform ones the filter/mql edit lands on the parent check directly).

### Notes for review
- **`.where(...)` → filter scoping:** load balancer HTTP-listener-has-https (`listeners.any(protocol == "HTTP")`), vault secret rotation (ACTIVE + older than 365 days), and API gateway mTLS (`mtlsAllowedSans.length > 0`) move their subset conditions into `filters` so out-of-scope assets are skipped rather than passing.
- The `redis-cluster-supported-version` `# MAINTAIN-TOGETHER` comment is preserved.

## Testing
`cnspec policy lint ./content/mondoo-oci-security.mql.yaml` → valid policy bundle(s).

> Verified resource paths/fields against the oci provider `.lr` whose discovery defines these platforms. Confirm with a real scan in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)