### PR TITLE
content: add Terraform variants to GitLab security checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -332,6 +332,7 @@ getremoteappleevents
 getstealthmode
 ggml
 gguf
+gitlabhq
 glueetl
 gmail
 godo

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gitlab-security
     name: Mondoo GitLab Security
-    version: 1.7.0
+    version: 1.8.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -82,7 +82,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: gitlab.group.visibility != "public"
+    variants:
+      - uid: mondoo-gitlab-security-private-group-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Group
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-private-group-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-group-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-group-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the GitLab group visibility is set to private or internal, not public.
@@ -156,6 +172,21 @@ queries:
         title: GitLab Group Settings
       - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
         title: GitLab Visibility and Access Controls
+  - uid: mondoo-gitlab-security-private-group-gitlab
+    filters: asset.platform == "gitlab-group"
+    mql: gitlab.group.visibility != "public"
+  - uid: mondoo-gitlab-security-private-group-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_group")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_group").all(arguments["visibility_level"] != "public")
+  - uid: mondoo-gitlab-security-private-group-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_group").all(change.after.visibility_level != "public")
+  - uid: mondoo-gitlab-security-private-group-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_group")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_group").all(values.visibility_level != "public")
   - uid: mondoo-gitlab-security-require-two-factor
     title: Ensure two-factor authentication is required
     impact: 90
@@ -173,7 +204,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: gitlab.group.requireTwoFactorAuthentication == true
+    variants:
+      - uid: mondoo-gitlab-security-require-two-factor-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Group
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-require-two-factor-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-require-two-factor-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-require-two-factor-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that two-factor authentication is required for all members of the GitLab group.
@@ -249,6 +296,21 @@ queries:
         title: GitLab Two-Factor Authentication
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
+  - uid: mondoo-gitlab-security-require-two-factor-gitlab
+    filters: asset.platform == "gitlab-group"
+    mql: gitlab.group.requireTwoFactorAuthentication == true
+  - uid: mondoo-gitlab-security-require-two-factor-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_group")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_group").all(arguments["require_two_factor_authentication"] == true)
+  - uid: mondoo-gitlab-security-require-two-factor-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_group").all(change.after.require_two_factor_authentication == true)
+  - uid: mondoo-gitlab-security-require-two-factor-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_group")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_group").all(values.require_two_factor_authentication == true)
   - uid: mondoo-gitlab-security-private-projects
     title: Ensure all projects are private
     impact: 90
@@ -266,7 +328,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: gitlab.group.projects.none(visibility == "public")
+    variants:
+      - uid: mondoo-gitlab-security-private-projects-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Group
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-private-projects-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-projects-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-projects-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no projects within the GitLab group have public visibility.
@@ -375,6 +453,21 @@ queries:
         title: GitLab Visibility and Access Controls
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-private-projects-gitlab
+    filters: asset.platform == "gitlab-group"
+    mql: gitlab.group.projects.none(visibility == "public")
+  - uid: mondoo-gitlab-security-private-projects-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project").all(arguments["visibility_level"] != "public")
+  - uid: mondoo-gitlab-security-private-projects-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project").all(change.after.visibility_level != "public")
+  - uid: mondoo-gitlab-security-private-projects-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project").all(values.visibility_level != "public")
   - uid: mondoo-gitlab-security-private-project
     title: Ensure the project is private
     impact: 90
@@ -392,7 +485,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: gitlab.project.visibility != "public"
+    variants:
+      - uid: mondoo-gitlab-security-private-project-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-private-project-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-project-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-private-project-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the individual GitLab project visibility is set to private or internal, not public.
@@ -467,6 +576,29 @@ queries:
         title: GitLab Project Settings
       - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
         title: GitLab Visibility and Access Controls
+  - uid: mondoo-gitlab-security-private-project-gitlab
+    filters: asset.platform == "gitlab-project"
+    mql: gitlab.project.visibility != "public"
+  - uid: mondoo-gitlab-security-private-project-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project").all(arguments["visibility_level"] != "public")
+  - uid: mondoo-gitlab-security-private-project-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project").all(change.after.visibility_level != "public")
+  - uid: mondoo-gitlab-security-private-project-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project").all(values.visibility_level != "public")
+  # No Terraform variants: the runtime check inspects the legacy project-level
+  # approvalSettings.approvalsBeforeMerge integer (from GET /projects/:id/approvals). The
+  # gitlabhq/gitlab provider (v19.x) does not expose that field — neither gitlab_project nor
+  # gitlab_project_level_mr_approvals carries an approvals_before_merge count. The modern
+  # Terraform pattern is to declare gitlab_project_approval_rule resources with
+  # approvals_required, which is a different semantic (named rules with specific approvers)
+  # and would not 1:1 mirror the runtime check. The existing terraform remediation below
+  # correctly shows the rule-based pattern as the recommended fix.
   - uid: mondoo-gitlab-security-approvals-required
     title: Ensure merge request approvals are required
     impact: 90
@@ -583,9 +715,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
-    filters: gitlab.namespace.plan != "free"
-    mql: |
-      gitlab.project.approvalSettings.mergeRequestsAuthorApproval == false
+    variants:
+      - uid: mondoo-gitlab-security-no-author-approval-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-no-author-approval-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-author-approval-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-author-approval-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that merge request authors cannot approve their own merge requests. Allowing self-approval defeats the purpose of code review and eliminates the separation of duties control.
@@ -660,6 +806,22 @@ queries:
         title: GitLab Merge Request Approvals
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-no-author-approval-gitlab
+    filters: asset.platform == "gitlab-project" && gitlab.namespace.plan != "free"
+    mql: |
+      gitlab.project.approvalSettings.mergeRequestsAuthorApproval == false
+  - uid: mondoo-gitlab-security-no-author-approval-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project_level_mr_approvals").all(arguments["merge_requests_author_approval"] == false)
+  - uid: mondoo-gitlab-security-no-author-approval-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project_level_mr_approvals").all(change.after.merge_requests_author_approval == false)
+  - uid: mondoo-gitlab-security-no-author-approval-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project_level_mr_approvals").all(values.merge_requests_author_approval == false)
   - uid: mondoo-gitlab-security-reset-approvals-on-push
     title: Ensure approvals are reset when new commits are pushed
     impact: 80
@@ -677,9 +839,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
-    filters: gitlab.namespace.plan != "free"
-    mql: |
-      gitlab.project.approvalSettings.resetApprovalsOnPush == true
+    variants:
+      - uid: mondoo-gitlab-security-reset-approvals-on-push-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that merge request approvals are reset when new commits are pushed to the source branch. Without this setting, a developer could get a merge request approved and then add unapproved changes before merging.
@@ -754,6 +930,22 @@ queries:
         title: GitLab Merge Request Approvals
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-reset-approvals-on-push-gitlab
+    filters: asset.platform == "gitlab-project" && gitlab.namespace.plan != "free"
+    mql: |
+      gitlab.project.approvalSettings.resetApprovalsOnPush == true
+  - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project_level_mr_approvals").all(arguments["reset_approvals_on_push"] == true)
+  - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project_level_mr_approvals").all(change.after.reset_approvals_on_push == true)
+  - uid: mondoo-gitlab-security-reset-approvals-on-push-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project_level_mr_approvals").all(values.reset_approvals_on_push == true)
   - uid: mondoo-gitlab-security-no-committer-approval
     title: Ensure committers cannot approve merge requests they contributed to
     impact: 80
@@ -771,9 +963,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
-    filters: gitlab.namespace.plan != "free"
-    mql: |
-      gitlab.project.approvalSettings.mergeRequestsDisableCommittersApproval == true
+    variants:
+      - uid: mondoo-gitlab-security-no-committer-approval-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-no-committer-approval-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-committer-approval-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-committer-approval-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that users who have committed to a merge request cannot also approve it. This enforces separation between contributors and reviewers for each change.
@@ -848,6 +1054,22 @@ queries:
         title: GitLab Merge Request Approvals
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-no-committer-approval-gitlab
+    filters: asset.platform == "gitlab-project" && gitlab.namespace.plan != "free"
+    mql: |
+      gitlab.project.approvalSettings.mergeRequestsDisableCommittersApproval == true
+  - uid: mondoo-gitlab-security-no-committer-approval-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project_level_mr_approvals").all(arguments["merge_requests_disable_committers_approval"] == true)
+  - uid: mondoo-gitlab-security-no-committer-approval-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project_level_mr_approvals").all(change.after.merge_requests_disable_committers_approval == true)
+  - uid: mondoo-gitlab-security-no-committer-approval-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project_level_mr_approvals")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project_level_mr_approvals").all(values.merge_requests_disable_committers_approval == true)
   - uid: mondoo-gitlab-security-no-force-push-default-branch
     title: Ensure force push is disabled on the default branch
     impact: 90
@@ -865,8 +1087,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
       compliance/vda-isa-5: false
-    mql: |
-      gitlab.project.protectedBranches.where(defaultBranch == true).all(allowForcePush == false)
+    variants:
+      - uid: mondoo-gitlab-security-no-force-push-default-branch-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that force push is disabled on the default (protected) branch. Force pushing allows rewriting Git history, which can be used to remove audit trails, overwrite security fixes, or inject malicious code.
@@ -946,6 +1183,22 @@ queries:
         title: GitLab Project Settings
       - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
         title: GitLab Visibility and Access Controls
+  - uid: mondoo-gitlab-security-no-force-push-default-branch-gitlab
+    filters: asset.platform == "gitlab-project"
+    mql: |
+      gitlab.project.protectedBranches.where(defaultBranch == true).all(allowForcePush == false)
+  - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_branch_protection")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_branch_protection").all(arguments["allow_force_push"] != true)
+  - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_branch_protection")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_branch_protection").all(change.after.allow_force_push != true)
+  - uid: mondoo-gitlab-security-no-force-push-default-branch-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_branch_protection")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_branch_protection").all(values.allow_force_push != true)
   - uid: mondoo-gitlab-security-pipeline-must-succeed
     title: Ensure pipeline must succeed before merging
     impact: 80
@@ -963,8 +1216,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      gitlab.project.onlyAllowMergeIfPipelineSucceeds == true
+    variants:
+      - uid: mondoo-gitlab-security-pipeline-must-succeed-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that merge requests can only be merged when the CI/CD pipeline succeeds. Without this requirement, code that fails tests, security scans, or other automated checks can be merged into protected branches.
@@ -1040,6 +1308,22 @@ queries:
         title: GitLab CI/CD Security
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-pipeline-must-succeed-gitlab
+    filters: asset.platform == "gitlab-project"
+    mql: |
+      gitlab.project.onlyAllowMergeIfPipelineSucceeds == true
+  - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project").all(arguments["only_allow_merge_if_pipeline_succeeds"] == true)
+  - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project").all(change.after.only_allow_merge_if_pipeline_succeeds == true)
+  - uid: mondoo-gitlab-security-pipeline-must-succeed-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project").all(values.only_allow_merge_if_pipeline_succeeds == true)
   - uid: mondoo-gitlab-security-group-prevent-forking-outside
     title: Ensure group prevents forking projects outside the group
     impact: 80
@@ -1057,9 +1341,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    filters: gitlab.namespace.plan != "free"
-    mql: |
-      gitlab.group.preventForkingOutsideGroup == true
+    variants:
+      - uid: mondoo-gitlab-security-group-prevent-forking-outside-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Group
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the GitLab group prevents members from forking projects to namespaces outside the group. Without this restriction, users can fork private repositories to personal namespaces where group-level security controls do not apply.
@@ -1134,6 +1432,22 @@ queries:
         title: GitLab Group Settings
       - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
         title: GitLab Visibility and Access Controls
+  - uid: mondoo-gitlab-security-group-prevent-forking-outside-gitlab
+    filters: asset.platform == "gitlab-group" && gitlab.namespace.plan != "free"
+    mql: |
+      gitlab.group.preventForkingOutsideGroup == true
+  - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_group")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_group").all(arguments["prevent_forking_outside_group"] == true)
+  - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_group").all(change.after.prevent_forking_outside_group == true)
+  - uid: mondoo-gitlab-security-group-prevent-forking-outside-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_group")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_group").all(values.prevent_forking_outside_group == true)
   - uid: mondoo-gitlab-security-project-access-tokens-have-expiry
     title: Ensure project access tokens have expiration dates
     impact: 80
@@ -1151,8 +1465,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      gitlab.project.accessTokens.where(active == true && revoked == false).all(expiresAt != null)
+    variants:
+      - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all active project access tokens have expiration dates configured. Tokens without expiration dates provide indefinite access to the project, increasing the risk of unauthorized access if the token is compromised.
@@ -1233,6 +1562,22 @@ queries:
         title: GitLab Project Access Tokens
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-gitlab
+    filters: asset.platform == "gitlab-project"
+    mql: |
+      gitlab.project.accessTokens.where(active == true && revoked == false).all(expiresAt != null)
+  - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_project_access_token")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_project_access_token").all(arguments["expires_at"] != empty)
+  - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_project_access_token")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_project_access_token").all(change.after.expires_at != empty)
+  - uid: mondoo-gitlab-security-project-access-tokens-have-expiry-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_project_access_token")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_project_access_token").all(values.expires_at != empty)
   - uid: mondoo-gitlab-security-group-access-tokens-have-expiry
     title: Ensure group access tokens have expiration dates
     impact: 80
@@ -1250,8 +1595,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      gitlab.group.accessTokens.where(active == true && revoked == false).all(expiresAt != null)
+    variants:
+      - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Group
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all active group access tokens have expiration dates configured. Group tokens provide access to all projects within the group, making non-expiring tokens an even greater risk.
@@ -1332,6 +1692,22 @@ queries:
         title: GitLab Group Access Tokens
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
+  - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-gitlab
+    filters: asset.platform == "gitlab-group"
+    mql: |
+      gitlab.group.accessTokens.where(active == true && revoked == false).all(expiresAt != null)
+  - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_group_access_token")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_group_access_token").all(arguments["expires_at"] != empty)
+  - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_group_access_token")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_group_access_token").all(change.after.expires_at != empty)
+  - uid: mondoo-gitlab-security-group-access-tokens-have-expiry-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_group_access_token")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_group_access_token").all(values.expires_at != empty)
   - uid: mondoo-gitlab-security-deploy-keys-no-push-access
     title: Ensure project deploy keys do not have push access
     impact: 80
@@ -1349,8 +1725,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: |
-      gitlab.project.deployKeys.all(canPush == false)
+    variants:
+      - uid: mondoo-gitlab-security-deploy-keys-no-push-access-gitlab
+        tags:
+          mondoo.com/filter-title: GitLab Project
+          mondoo.com/filter-icon: gitlab
+      - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that deploy keys configured for the project do not have push (write) access. Deploy keys with push access can be used to modify repository contents, which violates the principle of least privilege.
@@ -1427,6 +1818,28 @@ queries:
         title: GitLab Deploy Keys
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
+  - uid: mondoo-gitlab-security-deploy-keys-no-push-access-gitlab
+    filters: asset.platform == "gitlab-project"
+    mql: |
+      gitlab.project.deployKeys.all(canPush == false)
+  - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "gitlab_deploy_key")
+    mql: |
+      terraform.resources.where(nameLabel == "gitlab_deploy_key").all(arguments["can_push"] != true)
+  - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "gitlab_deploy_key")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "gitlab_deploy_key").all(change.after.can_push != true)
+  - uid: mondoo-gitlab-security-deploy-keys-no-push-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "gitlab_deploy_key")
+    mql: |
+      terraform.state.resources.where(type == "gitlab_deploy_key").all(values.can_push != true)
+  # No Terraform variants: the gitlabhq/gitlab provider (v19.x) does not expose
+  # continuous_vulnerability_scans_enabled on any resource — there is no
+  # gitlab_project_security_setting resource and no equivalent argument on gitlab_project.
+  # The setting can be configured via the GitLab UI, the GraphQL API, or by attaching a
+  # security policy project; none of these surface as a Terraform-declared field that an
+  # HCL/plan/state variant could evaluate.
   - uid: mondoo-gitlab-security-continuous-vulnerability-scanning
     title: Ensure continuous vulnerability scanning is enabled
     impact: 80
@@ -1505,7 +1918,7 @@ queries:
             This setting requires a GitLab Ultimate subscription.
 
             For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
-          # No Terraform remediation: the GitLab Terraform provider exposes no resource for the project security setting that toggles continuous vulnerability scanning.
+        # No Terraform remediation: the GitLab Terraform provider exposes no resource for the project security setting that toggles continuous vulnerability scanning.
     refs:
       - url: https://docs.gitlab.com/user/application_security/continuous_vulnerability_scanning/
         title: GitLab Continuous Vulnerability Scanning


### PR DESCRIPTION
## Summary

Brings `mondoo-gitlab-security.mql.yaml` from 0% to 87% Terraform-variant coverage (13 of 15 checks). The remaining 2 checks get documented `# No Terraform variants:` skip comments with the technical reason.

Field names verified against `gitlabhq/gitlab` provider v19.0.0 via the Terraform MCP.

### Implemented variants (13)

**Group-level (5):**

| Check | TF resource / field |
|---|---|
| `private-group` | `gitlab_group.visibility_level` |
| `private-projects` | `gitlab_project.visibility_level` (per-resource scope on any declared project) |
| `require-two-factor` | `gitlab_group.require_two_factor_authentication` |
| `group-prevent-forking-outside` | `gitlab_group.prevent_forking_outside_group` |
| `group-access-tokens-have-expiry` | `gitlab_group_access_token.expires_at` |

**Project-level (8):**

| Check | TF resource / field |
|---|---|
| `private-project` | `gitlab_project.visibility_level` |
| `no-author-approval` | `gitlab_project_level_mr_approvals.merge_requests_author_approval` |
| `reset-approvals-on-push` | `.reset_approvals_on_push` |
| `no-committer-approval` | `.merge_requests_disable_committers_approval` |
| `pipeline-must-succeed` | `gitlab_project.only_allow_merge_if_pipeline_succeeds` |
| `no-force-push-default-branch` | `gitlab_branch_protection.allow_force_push` |
| `project-access-tokens-have-expiry` | `gitlab_project_access_token.expires_at` |
| `deploy-keys-no-push-access` | `gitlab_deploy_key.can_push` |

### Documented skips (2)

- **`approvals-required`** — the runtime checks the legacy project-level `approvalSettings.approvalsBeforeMerge` integer from `GET /projects/:id/approvals`. The provider exposes **no equivalent field** (neither `gitlab_project` nor `gitlab_project_level_mr_approvals` has an `approvals_before_merge` count). The modern Terraform pattern uses `gitlab_project_approval_rule` (named rules with `approvals_required`) — that's a different semantic, so a variant would not 1:1 mirror the runtime. The existing terraform remediation already correctly shows the rule-based pattern.
- **`continuous-vulnerability-scanning`** — no `gitlab_project_security_setting` resource exists in the provider (v19.x), and no equivalent argument on `gitlab_project`. The setting is configurable only via the UI, GraphQL, or by attaching a security policy project. The existing "No Terraform remediation" comment was already in place; this PR just re-indents it to match the `- id:` entries per CLAUDE.md.

## Notable details

- Three project-level approval-setting checks (`no-author-approval`, `reset-approvals-on-push`, `no-committer-approval`) carry an extra `gitlab.namespace.plan != "free"` filter (the approval-settings features require non-free GitLab plan). That filter is preserved on the runtime `-gitlab` variant; the terraform variants don't carry it since IaC scans don't know the namespace plan.
- The `gitlab_branch_protection` argument is `branch` (not `name`) and `allow_force_push` is top-level.
- Deploy-key resource is `gitlab_deploy_key`, not `gitlab_project_deploy_key`.
- `expires_at` is a YYYY-MM-DD string for access tokens and an RFC3339 string for deploy keys; the variant uses `!= empty` so any non-empty value passes.

Policy `version` bumped `1.7.0` → `1.8.0`.

## Test plan

- [x] `cnspec policy lint content/mondoo-gitlab-security.mql.yaml` → valid bundle
- [x] Coverage re-check: **0 undocumented gaps**; hcl/plan/state parity 13/13/13; every variant query present with filters
- [x] Provider schema verified against `gitlabhq/gitlab` v19.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)