### PR TITLE
content: document Slack Terraform-coverage gaps

### DIFF
--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.5.1
+    version: 1.6.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -44,6 +44,11 @@ policies:
           - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
           - uid: mondoo-slack-security-users-email-confirmed
 queries:
+  # No Terraform variants: workspace admin role assignment is not exposed by the
+  # pablovarela/slack Terraform provider (v1.2.x has only slack_conversation and
+  # slack_usergroup resources). The is_admin / is_owner state on a Slack user is managed
+  # via the UI or the Slack admin API, not as a Terraform-declared attribute, so HCL/plan/state
+  # cannot count or assert privileged accounts.
   - uid: mondoo-slack-security-limit-admin-accounts
     title: Ensure that between 2 and 4 users have admin permissions
     impact: 60
@@ -105,6 +110,10 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
+  # No Terraform variants: per-user 2FA configuration (has_2fa, two_factor_type) is runtime
+  # account state held by Slack — users enable 2FA from their own account settings. The
+  # pablovarela/slack provider exposes no user resource and no 2FA enforcement argument,
+  # so HCL/plan/state cannot evaluate this.
   - uid: mondoo-slack-security-admins-secure-2fa-methods
     title: Ensure that admins use the most secure 2FA method
     impact: 70
@@ -167,6 +176,10 @@ queries:
         title: Slack Two-Factor Authentication
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
+  # No Terraform variants: per-user 2FA state is set by each user in their Slack account
+  # settings. The pablovarela/slack provider has no user resource and no workspace-level
+  # 2FA-required setting, so HCL/plan/state cannot assert whether every user has 2FA
+  # enabled.
   - uid: mondoo-slack-security-use-strong-factors
     title: Ensure all users use 2FA
     impact: 60
@@ -228,6 +241,13 @@ queries:
         title: Slack Two-Factor Authentication
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
+  # No Terraform variants: the runtime check filters channels by isExtShared (a runtime
+  # Slack Connect property reflecting whether the channel is currently shared with an
+  # external workspace) and then asserts a naming pattern. The pablovarela/slack provider
+  # exposes is_shared / is_ext_shared / is_org_shared on slack_conversation only as
+  # read-only exported attributes, not as configurable arguments — sharing is initiated
+  # via the Slack UI or Slack Connect API, not through Terraform — so HCL/plan/state cannot
+  # identify which declared channels are externally shared.
   - uid: mondoo-slack-security-name-external-channels
     title: Use clear naming for external channels
     impact: 30
@@ -295,6 +315,12 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
+  # No Terraform variants: this is a workspace-posture existence check (the workspace has
+  # at least one purely-internal channel). The relevant predicates (is_shared,
+  # is_ext_shared, is_org_shared, is_pending_ext_shared) are read-only attributes on
+  # slack_conversation, not configurable arguments. A per-module variant gated on
+  # slack_conversation being declared would also be vacuous and false-positive on modules
+  # that manage channels elsewhere — same pattern as the GCP VPC-SC existence checks.
   - uid: mondoo-slack-security-at-least-one-workspace-internal-channel
     title: Ensure there is at least one internal channel per workspace
     impact: 20
@@ -362,6 +388,11 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/help/articles/360000281563
         title: Slack Enterprise Grid Administration
+  # No Terraform variants: even though slack_conversation.permanent_members lists member
+  # user IDs, the runtime check filters those members on per-user runtime properties
+  # (is_stranger, is_restricted, is_ultra_restricted) that are not Terraform-managed —
+  # there is no slack_user resource in the provider. Combined with the is_ext_shared
+  # filtering this becomes a cross-state correlation that HCL/plan/state cannot express.
   - uid: mondoo-slack-security-at-least-one-workspace-internal-channel-no-ext-members
     title: Ensure at least one internal channel exists with no external members
     impact: 50
@@ -437,6 +468,11 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
+  # No Terraform variants: this check asserts each channel member's profile.email matches
+  # an allowlisted domain. User profiles (including email addresses) are not Terraform-
+  # managed in the pablovarela/slack provider — there is no slack_user resource. The
+  # workspace-level email-domain allowlist setting (Manage members > Domain allowlisting)
+  # is also not exposed by the provider.
   - uid: mondoo-slack-domain-allowlisting-enforced-on-internal-channels
     title: Ensure domain is enforced on internal channels
     impact: 75
@@ -503,6 +539,10 @@ queries:
         title: Slack Workspace Administration Guide
       - url: https://slack.com/help/articles/203772216
         title: Slack Single Sign-On
+  # No Terraform variants: per-user email-confirmation state (is_email_confirmed) is
+  # runtime account state set when a user completes their Slack signup. It is not a
+  # configurable attribute — there is no slack_user resource in the pablovarela/slack
+  # provider, and the workspace has no Terraform-managed setting that toggles confirmation.
   - uid: mondoo-slack-security-users-email-confirmed
     title: Ensure all active users have confirmed their email address
     impact: 60


### PR DESCRIPTION
## Summary

Unlike the other policies in this sweep, the Slack policy ends up with **0% implemented variants** — not because of process gaps, but because the **`pablovarela/slack` Terraform provider exposes only two resources** (`slack_conversation` and `slack_usergroup`), and **none** of the eight existing check assertions map to a Terraform-configurable field. Verified via the Terraform MCP against the public registry (v1.2.x).

This PR closes the coverage-tracking question for the Slack policy by adding a precise `# No Terraform variants:` comment to each check, citing the specific provider-capability gap so a future pass doesn't re-investigate.

### All 8 checks → documented skips

| Check | Why no Terraform variant |
|---|---|
| `limit-admin-accounts` | No admin/owner role assignment resource in the provider |
| `admins-secure-2fa-methods` | Per-user 2FA is runtime account state; no `slack_user` resource |
| `use-strong-factors` | Same — 2FA state isn't TF-configurable |
| `name-external-channels` | `is_ext_shared` is a read-only attribute on `slack_conversation`, not a configurable argument; sharing is initiated via Slack Connect |
| `at-least-one-workspace-internal-channel` | Workspace-posture existence check; per-module variant would be vacuous (same rationale as the GCP VPC-SC existence checks) |
| `at-least-one-workspace-internal-channel-no-ext-members` | Although `permanent_members` lists user IDs, the per-user filter predicates (`is_stranger`, `is_restricted`, `is_ultra_restricted`) aren't TF-managed |
| `domain-allowlisting-enforced-on-internal-channels` | User profile email isn't TF-managed; the workspace domain-allowlist setting isn't exposed by the provider |
| `users-email-confirmed` | `is_email_confirmed` is runtime account state set when a user completes signup |

## Format note

This policy uses an older single-string `remediation:` format rather than the structured `- id: <method>` list used by the other policies in this sweep. Because there are no `- id:` entries, this PR does not add any `# No Terraform remediation:` comments inside the remediation field — there's no list to add them to. Migrating the remediation format to the structured shape would be a separate, larger PR.

Policy `version` bumped `1.5.1` → `1.6.0`.

## Test plan

- [x] `cnspec policy lint content/mondoo-slack-security.mql.yaml` → valid bundle
- [x] Coverage script: **0 undocumented gaps** (was 8); 0 hcl/plan/state variants (none feasible)
- [x] Provider surface verified against `pablovarela/slack` v1.2.2 — only two resources exist (`slack_conversation`, `slack_usergroup`), and the agent confirmed none of the runtime check fields have a Terraform analog

## Sweep complete

With this PR, the original "do we have terraform variants for all possible checks in aws, gcp, oci, azure, digitalocean, github, gitlab, hetzner, kubernetes, okta, slack, tailscale, and snowflake" question has its definitive answer across every provider you asked about (except Kubernetes which is manifest-based and not in scope):

| Policy | Implemented coverage | Documented gaps |
|---|---|---|
| **azure / aws / gcp / oci / digitalocean / hetzner / okta / snowflake / tailscale / github / gitlab / slack** | varying (0–97%, capped by what each TF provider actually exposes) | **0 undocumented** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)