### PR TITLE
content: add Terraform variants to UniFi security checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -298,6 +298,7 @@ filebase
 fileless
 fileshare
 filestore
+filipowm
 finetune
 fips
 firefox
@@ -345,7 +346,6 @@ Graphviz
 grouplist
 groupname
 grouppolicy
-groq
 grundschutz
 GTK
 guestlib
@@ -480,7 +480,6 @@ misconfigures
 misrouted
 mknod
 MLE
-mlflow
 mmap
 MMK
 mongodb
@@ -529,7 +528,6 @@ ntalk
 NTE
 ntpserver
 ntpsync
-nvidia
 nullglob
 nxos
 Nxxxx
@@ -561,6 +559,7 @@ opensearch
 openssh
 openssl
 openstack
+openvpn
 oper
 operationalized
 opscode
@@ -572,6 +571,7 @@ otp
 Overprivilege
 oversharing
 Paa
+pablovarela
 pagerduty
 paloaltonetworks
 panos
@@ -658,6 +658,7 @@ rooveterinaryinc
 routetablechanges
 rsasha
 rstp
+rsyslogd
 rtadv
 rulebase
 runbook
@@ -781,7 +782,6 @@ tmpfiles
 tmsh
 TNS
 toset
-togetherai
 totp
 Tpng
 trae
@@ -793,6 +793,7 @@ tsuki
 tvm
 twofactor
 typosquatting
+ubiquiti
 UDRs
 uefi
 uem
@@ -810,11 +811,13 @@ upnp
 usb
 usepam
 userdel
+usergroup
 userlist
 userns
 userpassphrase
 USERPROFILE
 userspace
+usg
 USLACKBOT
 utm
 uvx
@@ -854,13 +857,14 @@ webauthn
 webfilter
 webui
 widescale
-WIFI
+wifi
 winget
 winhttp
 Winlogon
 winnuke
 WITHECDSA
 WITHRSA
+wlan
 wlans
 wordlist
 workdir

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-unifi-security
     name: Mondoo Ubiquiti UniFi Security
-    version: 1.1.0
+    version: 1.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -104,8 +104,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      unifi.wlans.where(enabled == true).all(security != "open")
+    variants:
+      - uid: mondoo-unifi-security-no-open-wlans-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-no-open-wlans-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-no-open-wlans-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-no-open-wlans-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that no enabled wireless networks on the UniFi controller use open (no encryption) authentication.
@@ -135,9 +150,39 @@ queries:
             3. Change the **Security** setting to **WPA2** or **WPA3**.
             4. Set a strong passphrase or configure enterprise (802.1X) authentication.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To declare a wireless network with WPA encryption in Terraform using the `ubiquiti-community/unifi` provider, set `security` to a non-open value (`wpapsk` for personal, `wpaeap` for enterprise) on every `unifi_wlan` resource:
+
+            ```hcl
+            resource "unifi_wlan" "secure" {
+              name       = "internal"
+              security   = "wpapsk"
+              passphrase = var.wifi_passphrase
+              network_id = unifi_network.lan.id
+              user_group_id = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
+
+  - uid: mondoo-unifi-security-no-open-wlans-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true).all(security != "open")
+  - uid: mondoo-unifi-security-no-open-wlans-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan").all(arguments["security"] != "open")
+  - uid: mondoo-unifi-security-no-open-wlans-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan").all(change.after.security != "open")
+  - uid: mondoo-unifi-security-no-open-wlans-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan").all(values.security != "open")
 
   - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3
     title: Ensure wireless networks use WPA2 or WPA3 encryption
@@ -156,8 +201,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: |
-      unifi.wlans.where(enabled == true).all(security == "wpapsk" || security == "wpaeap")
+    variants:
+      - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that all enabled wireless networks use WPA-PSK or WPA-Enterprise security modes, which provide WPA2 or WPA3 encryption.
@@ -193,9 +253,39 @@ queries:
             3. Set **Security** to **WPA Personal** or **WPA Enterprise**.
             4. Ensure WPA mode is set to **WPA2** or higher.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To declare a wireless network with WPA2/WPA3 encryption in Terraform, set `security` to `wpapsk` (Personal) or `wpaeap` (Enterprise) on every `unifi_wlan` resource:
+
+            ```hcl
+            resource "unifi_wlan" "personal" {
+              name       = "internal"
+              security   = "wpapsk"
+              passphrase = var.wifi_passphrase
+              network_id = unifi_network.lan.id
+              user_group_id = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
+
+  - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true).all(security == "wpapsk" || security == "wpaeap")
+  - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan").all(arguments["security"] == "wpapsk" || arguments["security"] == "wpaeap")
+  - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan").all(change.after.security == "wpapsk" || change.after.security == "wpaeap")
+  - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan").all(values.security == "wpapsk" || values.security == "wpaeap")
 
   - uid: mondoo-unifi-security-wlans-wpa3-enabled
     title: Ensure WPA3 support is enabled on wireless networks
@@ -214,8 +304,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: |
-      unifi.wlans.where(enabled == true && security != "open").all(wpa3Support == true || wpa3Transition == true)
+    variants:
+      - uid: mondoo-unifi-security-wlans-wpa3-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that WPA3 support or WPA3 transition mode is enabled on all secured wireless networks.
@@ -246,9 +351,41 @@ queries:
             3. Enable **WPA3** or **WPA2/WPA3 Transition** mode.
             4. Verify that all critical client devices support WPA3 or transition mode before disabling WPA2 entirely.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable WPA3 support on a wireless network in Terraform, set `wpa3_support = true` (and optionally `wpa3_transition = true` for backward-compatible mode) on every secured `unifi_wlan` resource:
+
+            ```hcl
+            resource "unifi_wlan" "modern" {
+              name            = "internal"
+              security        = "wpapsk"
+              passphrase      = var.wifi_passphrase
+              wpa3_support    = true
+              wpa3_transition = true
+              network_id      = unifi_network.lan.id
+              user_group_id   = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
+
+  - uid: mondoo-unifi-security-wlans-wpa3-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true && security != "open").all(wpa3Support == true || wpa3Transition == true)
+  - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["security"] != "open").all(arguments["wpa3_support"] == true || arguments["wpa3_transition"] == true)
+  - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.security != "open").all(change.after.wpa3_support == true || change.after.wpa3_transition == true)
+  - uid: mondoo-unifi-security-wlans-wpa3-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan" && values.security != "open").all(values.wpa3_support == true || values.wpa3_transition == true)
 
   - uid: mondoo-unifi-security-wlans-pmf-enabled
     title: Ensure Protected Management Frames are enabled
@@ -267,8 +404,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.wlans.where(enabled == true && security != "open").all(pmfMode == "required" || pmfMode == "optional")
+    variants:
+      - uid: mondoo-unifi-security-wlans-pmf-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Protected Management Frames (PMF / IEEE 802.11w) are enabled on all secured wireless networks.
@@ -302,10 +454,45 @@ queries:
             3. Under advanced settings, set **PMF** to **Optional** or **Required**.
             4. Note: Setting PMF to **Required** may cause connectivity issues with older clients that do not support 802.11w.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable Protected Management Frames on a wireless network in Terraform, set `pmf_mode` to `"required"` or `"optional"` on every secured `unifi_wlan` resource:
+
+            ```hcl
+            resource "unifi_wlan" "with_pmf" {
+              name          = "internal"
+              security      = "wpapsk"
+              passphrase    = var.wifi_passphrase
+              pmf_mode      = "optional"
+              network_id    = unifi_network.lan.id
+              user_group_id = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
 
+  - uid: mondoo-unifi-security-wlans-pmf-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true && security != "open").all(pmfMode == "required" || pmfMode == "optional")
+  - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["security"] != "open").all(arguments["pmf_mode"] == "required" || arguments["pmf_mode"] == "optional")
+  - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.security != "open").all(change.after.pmf_mode == "required" || change.after.pmf_mode == "optional")
+  - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan" && values.security != "open").all(values.pmf_mode == "required" || values.pmf_mode == "optional")
+
+  # No Terraform variants: the WPA encryption-cipher selector (`wpaEnc`, values like
+  # `ccmp`/`gcmp256`) is not exposed on the ubiquiti-community/unifi unifi_wlan resource —
+  # there is no `wpa_enc` top-level attribute and no nested encryption block. The cipher
+  # can only be selected in the controller UI under WLAN advanced settings.
   - uid: mondoo-unifi-security-wlans-strong-encryption-cipher
     title: Ensure WLANs use strong WPA encryption ciphers
     impact: 70
@@ -358,6 +545,10 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
 
+  # No Terraform variants: the WPA group-rekey / GTK rotation interval
+  # (`groupRekeyInterval`) is not exposed on the ubiquiti-community/unifi unifi_wlan
+  # resource — no top-level attribute and no nested encryption block carries the field.
+  # The setting is only configurable via the controller UI under WLAN advanced settings.
   - uid: mondoo-unifi-security-wlans-group-rekey-interval
     title: Ensure WPA group rekey interval is configured
     impact: 50
@@ -426,8 +617,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.wlans.where(enabled == true && isGuest == true).all(l2Isolation == true)
+    variants:
+      - uid: mondoo-unifi-security-guest-wlans-l2-isolation-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Layer 2 client isolation is enabled on all guest wireless networks, preventing direct communication between wireless clients.
@@ -461,9 +667,41 @@ queries:
             2. Select each guest wireless network.
             3. Under advanced settings, enable **L2 Isolation** (Client Isolation).
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable Layer 2 isolation on a guest wireless network in Terraform, set `l2_isolation = true` on every `unifi_wlan` resource that uses `is_guest = true`:
+
+            ```hcl
+            resource "unifi_wlan" "guest" {
+              name          = "guest"
+              security      = "wpapsk"
+              passphrase    = var.guest_passphrase
+              is_guest      = true
+              l2_isolation  = true
+              network_id    = unifi_network.guest.id
+              user_group_id = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
         title: UniFi wireless network configuration
+
+  - uid: mondoo-unifi-security-guest-wlans-l2-isolation-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true && isGuest == true).all(l2Isolation == true)
+  - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["is_guest"] == true).all(arguments["l2_isolation"] == true)
+  - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.is_guest == true).all(change.after.l2_isolation == true)
+  - uid: mondoo-unifi-security-guest-wlans-l2-isolation-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan" && values.is_guest == true).all(values.l2_isolation == true)
 
   - uid: mondoo-unifi-security-guest-wlans-isolated
     title: Ensure guest wireless networks use guest mode
@@ -482,8 +720,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.wlans.where(enabled == true && name == /guest/i).all(isGuest == true)
+    variants:
+      - uid: mondoo-unifi-security-guest-wlans-isolated-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that wireless networks with "guest" in the name are configured with guest mode enabled, which provides client isolation.
@@ -517,11 +770,47 @@ queries:
             3. Enable the **Guest** toggle to activate guest policies.
             4. Optionally configure a captive portal under **Settings > Hotspot**.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To mark a wireless network with a `guest`-style name as a guest network in Terraform, set `is_guest = true` on the `unifi_wlan` resource so guest network policy applies:
+
+            ```hcl
+            resource "unifi_wlan" "guest" {
+              name          = "guest-wifi"
+              security      = "wpapsk"
+              passphrase    = var.guest_passphrase
+              is_guest      = true
+              network_id    = unifi_network.guest.id
+              user_group_id = data.unifi_user_group.default.id
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115000166827
         title: UniFi guest network configuration
 
+  - uid: mondoo-unifi-security-guest-wlans-isolated-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.wlans.where(enabled == true && name == /guest/i).all(isGuest == true)
+  - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["name"] == /guest/i).all(arguments["is_guest"] == true)
+  - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.name == /guest/i).all(change.after.is_guest == true)
+  - uid: mondoo-unifi-security-guest-wlans-isolated-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
+    mql: |
+      terraform.state.resources.where(type == "unifi_wlan" && values.name == /guest/i).all(values.is_guest == true)
+
   # ─── Threat Management ───────────────────────────────────────────────────────
+  # No Terraform variants: the IPS/IDS toggle and `ipsMode` field live under UniFi's
+  # Threat Management settings (`siteSettings.threatManagement.enabled` / `.ipsMode`).
+  # The ubiquiti-community/unifi provider exposes no threat-management settings —
+  # unifi_setting carries only `mgmt`, `radius`, and `usg` nested attributes. IPS can
+  # only be enabled in the controller UI under Settings > Security > Threat Management.
   - uid: mondoo-unifi-security-ips-enabled
     title: Ensure Intrusion Prevention System is enabled
     impact: 80
@@ -579,6 +868,10 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
 
+  # No Terraform variants: DNS filtering is part of UniFi's Threat Management feature
+  # (`siteSettings.threatManagement.dnsFiltering`). The ubiquiti-community/unifi provider
+  # exposes no threat-management settings — unifi_setting carries only `mgmt`, `radius`,
+  # and `usg`. The setting can only be toggled via the controller UI.
   - uid: mondoo-unifi-security-dns-filtering-enabled
     title: Ensure DNS filtering is enabled
     impact: 60
@@ -631,6 +924,11 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
 
+  # No Terraform variants: the internal honeypot is part of UniFi's Threat Management
+  # feature (`siteSettings.threatManagement.honeypotEnabled`). The ubiquiti-community/unifi
+  # provider exposes no threat-management settings — unifi_setting only carries `mgmt`,
+  # `radius`, and `usg` nested attributes. The honeypot can only be enabled in the
+  # controller UI under Settings > Security.
   - uid: mondoo-unifi-security-honeypot-enabled
     title: Ensure the internal honeypot is enabled
     impact: 40
@@ -699,8 +997,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      unifi.siteSettings.gateway.upnpEnabled == false
+    variants:
+      - uid: mondoo-unifi-security-upnp-disabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-upnp-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-upnp-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-upnp-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Universal Plug and Play (UPnP) is disabled on the UniFi gateway.
@@ -734,9 +1047,39 @@ queries:
             2. Disable **UPnP**.
             3. Manually configure any required port forwarding rules under **Settings > Routing > Port Forwarding**.
         # No cli remediation: gateway security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To disable UPnP on the gateway in Terraform, set `upnp_enabled = false` inside the `usg` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "gateway" {
+              site = "default"
+
+              usg = {
+                upnp_enabled = false
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
+
+  - uid: mondoo-unifi-security-upnp-disabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.gateway.upnpEnabled == false
+  - uid: mondoo-unifi-security-upnp-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["usg"] != empty).all(arguments["usg"]["upnp_enabled"] == false)
+  - uid: mondoo-unifi-security-upnp-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.usg != empty).all(change.after.usg.upnp_enabled == false)
+  - uid: mondoo-unifi-security-upnp-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.usg != empty).all(values.usg.upnp_enabled == false)
 
   - uid: mondoo-unifi-security-broadcast-ping-disabled
     title: Ensure broadcast ping response is disabled
@@ -755,8 +1098,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.siteSettings.gateway.broadcastPing == false
+    variants:
+      - uid: mondoo-unifi-security-broadcast-ping-disabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the gateway does not respond to broadcast ICMP ping requests.
@@ -785,9 +1143,39 @@ queries:
             1. Go to **Settings > Security > Gateway**.
             2. Disable **Broadcast Ping**.
         # No cli remediation: gateway security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To disable broadcast ping response on the gateway in Terraform, set `broadcast_ping = false` inside the `usg` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "gateway" {
+              site = "default"
+
+              usg = {
+                broadcast_ping = false
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
+
+  - uid: mondoo-unifi-security-broadcast-ping-disabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.gateway.broadcastPing == false
+  - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["usg"] != empty).all(arguments["usg"]["broadcast_ping"] == false)
+  - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.usg != empty).all(change.after.usg.broadcast_ping == false)
+  - uid: mondoo-unifi-security-broadcast-ping-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.usg != empty).all(values.usg.broadcast_ping == false)
 
   - uid: mondoo-unifi-security-icmp-redirects-disabled
     title: Ensure ICMP redirects are disabled
@@ -806,8 +1194,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.siteSettings.gateway.receiveRedirects == false
+    variants:
+      - uid: mondoo-unifi-security-icmp-redirects-disabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that the gateway does not accept ICMP redirect messages.
@@ -836,9 +1239,39 @@ queries:
             1. Go to **Settings > Security > Gateway**.
             2. Disable **Receive Redirects** under the ICMP settings.
         # No cli remediation: gateway security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To disable receiving ICMP redirects on the gateway in Terraform, set `receive_redirects = false` inside the `usg` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "gateway" {
+              site = "default"
+
+              usg = {
+                receive_redirects = false
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
+
+  - uid: mondoo-unifi-security-icmp-redirects-disabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.gateway.receiveRedirects == false
+  - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["usg"] != empty).all(arguments["usg"]["receive_redirects"] == false)
+  - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.usg != empty).all(change.after.usg.receive_redirects == false)
+  - uid: mondoo-unifi-security-icmp-redirects-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.usg != empty).all(values.usg.receive_redirects == false)
 
   - uid: mondoo-unifi-security-syn-cookies-enabled
     title: Ensure SYN cookies are enabled
@@ -857,8 +1290,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.siteSettings.gateway.synCookies == true
+    variants:
+      - uid: mondoo-unifi-security-syn-cookies-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SYN cookies are enabled on the UniFi gateway to protect against SYN flood denial-of-service attacks.
@@ -885,11 +1333,47 @@ queries:
             1. Go to **Settings > Security > Gateway**.
             2. Enable **SYN Cookies**.
         # No cli remediation: gateway security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable SYN cookies on the gateway in Terraform, set `syn_cookies = true` inside the `usg` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "gateway" {
+              site = "default"
+
+              usg = {
+                syn_cookies = true
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings
 
+  - uid: mondoo-unifi-security-syn-cookies-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.gateway.synCookies == true
+  - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["usg"] != empty).all(arguments["usg"]["syn_cookies"] == true)
+  - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.usg != empty).all(change.after.usg.syn_cookies == true)
+  - uid: mondoo-unifi-security-syn-cookies-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.usg != empty).all(values.usg.syn_cookies == true)
+
   # ─── Switch Security ─────────────────────────────────────────────────────────
+  # No Terraform variants: the runtime check inspects the site-wide global-switch DHCP
+  # snooping toggle (`siteSettings.globalSwitch.dhcpSnoop`), which is a controller-level
+  # setting. The ubiquiti-community/unifi provider has no site-wide switch-globals
+  # resource; it exposes only per-network `dhcp_guarding.enabled` (a different feature
+  # that's set per individual network). Asserting the per-network attribute would catch a
+  # different misconfiguration than the runtime check, so this stays runtime-only.
   - uid: mondoo-unifi-security-dhcp-snooping-enabled
     title: Ensure DHCP snooping is enabled
     impact: 60
@@ -961,8 +1445,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.siteSettings.globalSwitch.stpVersion == "rstp"
+    variants:
+      - uid: mondoo-unifi-security-stp-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-stp-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-stp-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-stp-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Rapid Spanning Tree Protocol (RSTP) is enabled on UniFi switches.
@@ -994,9 +1493,37 @@ queries:
             1. Go to **Settings > Networks > Global Switch Settings**.
             2. Set **STP Version** to **RSTP**.
         # No cli remediation: global switch settings are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To set the STP version to RSTP in Terraform, set `stp_version = "rstp"` on each `unifi_device` resource managing a switch. Note that the runtime check inspects the site-wide global switch STP version via `unifi.siteSettings.globalSwitch.stpVersion`; the ubiquiti-community/unifi provider only exposes STP per-device, so the variant scope is each declared switch device rather than the site default:
+
+            ```hcl
+            resource "unifi_device" "switch" {
+              mac          = "aa:bb:cc:dd:ee:ff"
+              stp_version  = "rstp"
+              stp_priority = 32768
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
         title: UniFi switch configuration
+
+  - uid: mondoo-unifi-security-stp-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.globalSwitch.stpVersion == "rstp"
+  - uid: mondoo-unifi-security-stp-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_device")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_device" && arguments["stp_version"] != empty).all(arguments["stp_version"] == "rstp")
+  - uid: mondoo-unifi-security-stp-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_device")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_device" && change.after.stp_version != empty).all(change.after.stp_version == "rstp")
+  - uid: mondoo-unifi-security-stp-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_device")
+    mql: |
+      terraform.state.resources.where(type == "unifi_device" && values.stp_version != empty).all(values.stp_version == "rstp")
 
   # ─── Management & Controller ─────────────────────────────────────────────────
   - uid: mondoo-unifi-security-ssh-disabled
@@ -1016,8 +1543,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      unifi.siteSettings.mgmt.sshEnabled == false
+    variants:
+      - uid: mondoo-unifi-security-ssh-disabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-ssh-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-ssh-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-ssh-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that SSH access to UniFi devices is disabled when not actively needed for troubleshooting.
@@ -1051,10 +1593,45 @@ queries:
             2. Disable **SSH**.
             3. If SSH is required for troubleshooting, enable it temporarily and disable it when done.
         # No cli remediation: the device SSH setting is a controller-managed site setting; the device SSH CLI cannot durably change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To disable SSH access to UniFi devices in Terraform, set `ssh_enabled = false` inside the `mgmt` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "mgmt" {
+              site = "default"
+
+              mgmt = {
+                ssh_enabled = false
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi device SSH access
 
+  - uid: mondoo-unifi-security-ssh-disabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.mgmt.sshEnabled == false
+  - uid: mondoo-unifi-security-ssh-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["mgmt"] != empty).all(arguments["mgmt"]["ssh_enabled"] == false)
+  - uid: mondoo-unifi-security-ssh-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.mgmt != empty).all(change.after.mgmt.ssh_enabled == false)
+  - uid: mondoo-unifi-security-ssh-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.mgmt != empty).all(values.mgmt.ssh_enabled == false)
+
+  # No Terraform variants: the SSH password-auth toggle (`mgmt.sshPasswordAuthEnabled`)
+  # is not exposed by the ubiquiti-community/unifi provider — the unifi_setting mgmt block
+  # carries only `auto_upgrade`, `ssh_enabled`, and `ssh_keys` (key-based auth list). To
+  # express this as IaC the operator must enroll keys via `ssh_keys` and disable password
+  # auth in the controller UI, since the provider has no Terraform-declared field for it.
   - uid: mondoo-unifi-security-ssh-password-auth-disabled
     title: Ensure SSH password authentication is disabled
     impact: 70
@@ -1107,6 +1684,10 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi device SSH access
 
+  # No Terraform variants: the controller's debug-tools toggle lives on the management
+  # site setting (`mgmt.debugToolsEnabled`), but the ubiquiti-community/unifi unifi_setting
+  # mgmt block only exposes `auto_upgrade`, `ssh_enabled`, and `ssh_keys`. The provider
+  # does not surface the debug-tools flag, so HCL/plan/state cannot evaluate it.
   - uid: mondoo-unifi-security-debug-tools-disabled
     title: Ensure debug tools are disabled
     impact: 60
@@ -1157,6 +1738,11 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi advanced system settings
 
+  # No Terraform variants: controller automatic backups are a controller-wide setting
+  # (controllerSettings.autobackupEnabled), not a site setting. The ubiquiti-community/unifi
+  # provider exposes no `auto_backup` or `autobackup_enabled` attribute on any resource —
+  # unifi_setting covers per-site mgmt/radius/usg only. Backups are configured via the
+  # controller's System Settings UI.
   - uid: mondoo-unifi-security-autobackup-enabled
     title: Ensure automatic backups are enabled
     impact: 70
@@ -1225,8 +1811,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      unifi.siteSettings.mgmt.autoUpgrade == true
+    variants:
+      - uid: mondoo-unifi-security-auto-upgrade-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that automatic firmware upgrades are enabled for UniFi devices.
@@ -1259,10 +1860,45 @@ queries:
             2. Enable **Auto Update**.
             3. Configure the update window to a low-traffic period.
         # No cli remediation: the auto-update setting is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable automatic firmware upgrades in Terraform, set `auto_upgrade = true` inside the `mgmt` nested attribute on a `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "mgmt" {
+              site = "default"
+
+              mgmt = {
+                auto_upgrade = true
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204911424
         title: UniFi firmware management
 
+  - uid: mondoo-unifi-security-auto-upgrade-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.siteSettings.mgmt.autoUpgrade == true
+  - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_setting")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_setting" && arguments["mgmt"] != empty).all(arguments["mgmt"]["auto_upgrade"] == true)
+  - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_setting" && change.after.mgmt != empty).all(change.after.mgmt.auto_upgrade == true)
+  - uid: mondoo-unifi-security-auto-upgrade-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_setting")
+    mql: |
+      terraform.state.resources.where(type == "unifi_setting" && values.mgmt != empty).all(values.mgmt.auto_upgrade == true)
+
+  # No Terraform variants: the analytics/telemetry opt-out is a controller-wide setting
+  # (controllerSettings.enableAnalytics), not a site setting. The ubiquiti-community/unifi
+  # unifi_setting resource only exposes the per-site `mgmt`, `radius`, and `usg` blocks —
+  # no analytics/telemetry toggle on either the unifi_setting resource or the unifi_site
+  # resource. The setting can only be changed in the controller UI.
   - uid: mondoo-unifi-security-analytics-disabled
     title: Ensure analytics data collection is disabled
     impact: 30
@@ -1312,6 +1948,12 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/204909374
         title: UniFi system settings
 
+  # No Terraform variants: remote syslog is configured under a `remoteSyslog` site setting,
+  # but the ubiquiti-community/unifi unifi_setting resource only exposes `mgmt`, `radius`,
+  # and `usg` nested attributes — no `remote_syslog` or `rsyslogd` block. (The
+  # filipowm/unifi provider, a separate fork, does expose unifi_setting_rsyslogd from
+  # controller 8.5+; if cnspec ever standardizes on that provider this check could be
+  # implemented.)
   - uid: mondoo-unifi-security-remote-syslog-enabled
     title: Ensure remote syslog is configured
     impact: 50
@@ -1387,8 +2029,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.portForwards.where(enabled == true).none(fwdPort == "22" || fwdPort == "443" || fwdPort == "8443" || fwdPort == "8080" || dstPort == "22" || dstPort == "443" || dstPort == "8443" || dstPort == "8080")
+    variants:
+      - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that no enabled port forwarding rules expose common management ports (SSH, HTTPS, UniFi controller) to the internet. Both the forwarded (external) port and the destination (internal) port are checked.
@@ -1420,10 +2077,52 @@ queries:
             3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
             4. Use a VPN to access management interfaces remotely instead of port forwarding.
         # No cli remediation: port forwarding rules are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To avoid forwarding management ports in Terraform, ensure no `unifi_port_forward` resource exposes ports 22, 443, 8443, or 8080 on either the WAN-facing port (`wan.port`) or the internal forward port (`forward.port`):
+
+            ```hcl
+            resource "unifi_port_forward" "web" {
+              name     = "Web"
+              protocol = "tcp"
+              wan      = { port = "80" }
+              forward  = { ip = "192.168.1.100", port = "8000" }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi port forwarding settings
 
+  - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.portForwards.where(enabled == true).none(fwdPort == "22" || fwdPort == "443" || fwdPort == "8443" || fwdPort == "8080" || dstPort == "22" || dstPort == "443" || dstPort == "8443" || dstPort == "8080")
+  - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_port_forward")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_port_forward").all(
+        arguments["wan"]["port"] != "22" && arguments["wan"]["port"] != "443" && arguments["wan"]["port"] != "8443" && arguments["wan"]["port"] != "8080" &&
+        arguments["forward"]["port"] != "22" && arguments["forward"]["port"] != "443" && arguments["forward"]["port"] != "8443" && arguments["forward"]["port"] != "8080"
+      )
+  - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_port_forward")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_port_forward").all(
+        change.after.wan.port != "22" && change.after.wan.port != "443" && change.after.wan.port != "8443" && change.after.wan.port != "8080" &&
+        change.after.forward.port != "22" && change.after.forward.port != "443" && change.after.forward.port != "8443" && change.after.forward.port != "8080"
+      )
+  - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_port_forward")
+    mql: |
+      terraform.state.resources.where(type == "unifi_port_forward").all(
+        values.wan.port != "22" && values.wan.port != "443" && values.wan.port != "8443" && values.wan.port != "8080" &&
+        values.forward.port != "22" && values.forward.port != "443" && values.forward.port != "8443" && values.forward.port != "8080"
+      )
+
+  # No Terraform variants: DNS-over-HTTPS is configured under a `doh` site setting in the
+  # UniFi controller, but the ubiquiti-community/unifi unifi_setting resource only exposes
+  # `mgmt`, `radius`, and `usg` nested attributes — there is no `doh` block. The setting
+  # can only be toggled through the controller UI or the network-application API.
   - uid: mondoo-unifi-security-dns-over-https-enabled
     title: Ensure DNS over HTTPS is enabled
     impact: 40
@@ -1478,6 +2177,11 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/360052224054
         title: UniFi DNS settings
 
+  # No Terraform variants: the runtime check filters networks by `purpose == "guest"`,
+  # but the ubiquiti-community/unifi unifi_network resource has no `purpose` attribute.
+  # The schema uses `gateway_type` (`default`/`switch`) and `third_party_gateway` instead,
+  # neither of which expresses "this is a guest network." Without a way to identify guest
+  # networks from HCL/plan/state, a variant cannot replicate the runtime's targeting.
   - uid: mondoo-unifi-security-guest-network-isolation
     title: Ensure network isolation is enabled on guest networks
     impact: 70
@@ -1552,8 +2256,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      unifi.networks.where(networkGroup == "LAN").all(igmpSnooping == true)
+    variants:
+      - uid: mondoo-unifi-security-igmp-snooping-enabled-unifi
+        tags:
+          mondoo.com/filter-title: UniFi Controller
+          mondoo.com/filter-icon: unifi
+      - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that IGMP snooping is enabled on all LAN networks to control multicast traffic flooding.
@@ -1587,11 +2306,48 @@ queries:
             2. Select each LAN network.
             3. Under advanced settings, enable **IGMP Snooping**.
         # No cli remediation: network configuration is controller-managed; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable IGMP snooping in Terraform, set `igmp_snooping = true` on each `unifi_network` resource. Note that the runtime check filters by `networkGroup == "LAN"`; the ubiquiti-community/unifi provider has no `network_group` argument, so the variant applies the assertion to every declared network — keep that in mind for non-LAN networks where snooping may not be desired:
+
+            ```hcl
+            resource "unifi_network" "lan" {
+              name           = "Default"
+              purpose        = "corporate"
+              subnet         = "10.0.0.0/24"
+              vlan_id        = 1
+              igmp_snooping  = true
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
         title: UniFi switch configuration
 
+  - uid: mondoo-unifi-security-igmp-snooping-enabled-unifi
+    filters: asset.platform == "unifi"
+    mql: |
+      unifi.networks.where(networkGroup == "LAN").all(igmpSnooping == true)
+  - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_network")
+    mql: |
+      terraform.resources.where(nameLabel == "unifi_network").all(arguments["igmp_snooping"] == true)
+  - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_network")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "unifi_network").all(change.after.igmp_snooping == true)
+  - uid: mondoo-unifi-security-igmp-snooping-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_network")
+    mql: |
+      terraform.state.resources.where(type == "unifi_network").all(values.igmp_snooping == true)
+
   # ─── VPN Security ─────────────────────────────────────────────────────────────
+  # No Terraform variants: the unifi_vpn_server resource has no `protocol`/`purpose`/`type`
+  # selector — the protocol is determined by which of the three nested attributes
+  # (`wireguard`, `l2tp`, `openvpn`) is present, with exactly one required. The runtime
+  # check uses a string equality (`protocol == "wireguard" || protocol == "ipsec"`) that
+  # does not map cleanly to "exactly one of these blocks is non-empty"; a faithful variant
+  # would also need to allow `l2tp` (IPsec-over-L2TP) but flag plain `openvpn`, and the
+  # semantic mismatch produces both false positives and false negatives.
   - uid: mondoo-unifi-security-vpn-servers-modern-protocol
     title: Ensure VPN servers use modern protocols
     impact: 60
@@ -1644,6 +2400,11 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
         title: UniFi VPN configuration
 
+  # No Terraform variants: VPN tunnel connection status (the `status == "connected"`
+  # assertion) is runtime telemetry from the UniFi controller about whether the tunnel is
+  # actively up. It is not a configuration field — there is no `status` argument on
+  # unifi_vpn_client or any resource that expresses tunnel-up state, because that's
+  # observed-only data.
   - uid: mondoo-unifi-security-vpn-tunnels-active
     title: Ensure enabled VPN tunnels are connected
     impact: 50
@@ -1697,6 +2458,12 @@ queries:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
         title: UniFi VPN configuration
 
+  # No Terraform variants: the ubiquiti-community/unifi unifi_vpn_client resource is
+  # WireGuard-only — `wireguard` is a Required nested attribute and there is no protocol
+  # selector. Any declared client is implicitly WireGuard, so a variant that asserts
+  # `protocol == "wireguard" || protocol == "ipsec"` would be vacuously true on every
+  # declared client and would not surface ipsec/openvpn/l2tp clients (which can only be
+  # configured through the UI). Better to keep this runtime-only.
   - uid: mondoo-unifi-security-vpn-clients-modern-protocol
     title: Ensure VPN clients use modern protocols
     impact: 60
@@ -1750,6 +2517,12 @@ queries:
         title: UniFi VPN configuration
 
   # ─── Device Hardening ─────────────────────────────────────────────────────────
+  # No Terraform variants: device firmware version is runtime telemetry — the
+  # ubiquiti-community/unifi provider's unifi_device resource only exposes `adopted`,
+  # `state`, `type`, `model`, etc. and has no `upgradable`, `firmware_version`, or
+  # `latest_firmware` attribute. The runtime check inspects whether each device is on the
+  # latest firmware available from the Ubiquiti update server, which is not a
+  # Terraform-declared property.
   - uid: mondoo-unifi-security-devices-firmware-uptodate
     title: Ensure all devices are running latest firmware
     impact: 60


### PR DESCRIPTION
## Summary

Brings `mondoo-unifi-security.mql.yaml` from 0% to 47% Terraform-variant coverage (15 of 32 checks). The remaining 17 checks get documented `# No Terraform variants:` skip comments with the specific provider gap each one hits.

Field names verified against the **`ubiquiti-community/unifi`** provider v0.41.25 via the Terraform MCP (GitHub: ubiquiti-community/terraform-provider-unifi). Initial schema sweep also checked the historical `paultyng/unifi` and `filipowm/unifi` forks; this is the community-maintained successor.

### Implemented variants (15)

**WLAN-level (6)** — top-level attributes on `unifi_wlan`:

| Check | Field |
|---|---|
| `no-open-wlans` | `security` |
| `wlans-use-wpa2-or-wpa3` | `security` |
| `wlans-wpa3-enabled` | `wpa3_support`, `wpa3_transition` |
| `wlans-pmf-enabled` | `pmf_mode` |
| `guest-wlans-isolated` | `is_guest` (filtered by name regex) |
| `guest-wlans-l2-isolation` | `l2_isolation` (filtered by `is_guest`) |

**Gateway USG hardening (4)** — `unifi_setting.usg` nested attribute:

| Check | Field |
|---|---|
| `upnp-disabled` | `upnp_enabled` |
| `broadcast-ping-disabled` | `broadcast_ping` |
| `icmp-redirects-disabled` | `receive_redirects` |
| `syn-cookies-enabled` | `syn_cookies` |

**Management (2)** — `unifi_setting.mgmt` nested attribute:

| Check | Field |
|---|---|
| `ssh-disabled` | `ssh_enabled` |
| `auto-upgrade-enabled` | `auto_upgrade` |

**Partial-scope variants (3)** — variants apply where the runtime predicate has no direct TF analog:

| Check | Scope mismatch |
|---|---|
| `igmp-snooping-enabled` | Runtime filters by `networkGroup == "LAN"`; provider has no `network_group` attribute → variant applies to every declared `unifi_network` |
| `stp-enabled` | Runtime checks site-wide `globalSwitch.stpVersion`; provider only exposes `stp_version` per `unifi_device` → variant scope is each declared switch device |
| `no-port-forwards-to-mgmt` | Uses nested `wan.port` / `forward.port` on `unifi_port_forward`; runtime's `enabled` filter has no TF analog (the resource's `enabled` is deprecated) → variant applies to every declared port-forward |

### Documented skips (17)

Each carries a `# No Terraform variants:` comment citing the specific provider gap:

- **Threat management (3)** — no `threatManagement` settings block on `unifi_setting`: `ips-enabled`, `dns-filtering-enabled`, `honeypot-enabled`
- **WLAN fields without TF analog (2)**: `wlans-strong-encryption-cipher` (no `wpa_enc`), `wlans-group-rekey-interval` (no `groupRekeyInterval`)
- **VPN (3)**: `vpn-servers-modern-protocol` (no protocol selector; protocol identified by presence of nested `wireguard`/`l2tp`/`openvpn` attribute, doesn't map to runtime's string equality), `vpn-clients-modern-protocol` (resource is WireGuard-only, variant would be vacuously true), `vpn-tunnels-active` (runtime connection status, not config)
- **Management `mgmt` block fields not exposed (4)**: `ssh-password-auth-disabled`, `debug-tools-disabled`, `autobackup-enabled`, `analytics-disabled` — the `mgmt` block carries only `ssh_enabled`, `ssh_keys`, `auto_upgrade`
- **Other (5)**: `dhcp-snooping-enabled` (per-network `dhcp_guarding.enabled` is a different semantic than site-wide `globalSwitch.dhcpSnoop`), `devices-firmware-uptodate` (no `upgradable`/`firmware_version` attribute), `remote-syslog-enabled` (no `remote_syslog` block), `dns-over-https-enabled` (no `doh` block), `guest-network-isolation` (no `purpose` attribute on `unifi_network`)

## Notable details

- `unifi_setting` is one resource with nested **attributes** (HCL object syntax `mgmt = { ... }`), not nested blocks. The MQL accesses these as `arguments["mgmt"]["ssh_enabled"]` (HCL) / `change.after.mgmt.ssh_enabled` (plan/state).
- The variant queries guard the nested-attribute access with `arguments["usg"] != empty` etc. so a `unifi_setting` resource that doesn't declare a given block doesn't false-fail.
- The HCL example in `wlans-pmf-enabled`'s terraform remediation matches the schema-verified `pmf_mode` enum (`"required"`/`"optional"`/`"disabled"`).
- Two community forks of this provider exist (`paultyng/unifi` and `filipowm/unifi`) with different resource coverage. The `filipowm` fork exposes additional resources (IPS, DPI, SSL inspection, switch globals, rsyslog) that would let several skip-commented checks gain variants — flagged in the skip comment for `remote-syslog-enabled`. This PR targets the `ubiquiti-community` provider only.

Policy `version` bumped `1.1.0` → `1.2.0`.

## Test plan

- [x] `cnspec policy lint content/mondoo-unifi-security.mql.yaml` → valid bundle
- [x] Coverage re-check: 0 undocumented gaps; hcl/plan/state parity 15/15/15; every variant query present with filters
- [x] Provider schema verified against `ubiquiti-community/unifi` v0.41.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)