### PR TITLE
docs: link MQL operator precedence reference for policy reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Never edit these files manually. Regenerate with `make cnspec/generate`:
 
 - [cnspec Documentation](https://mondoo.com/docs/cnspec/)
 - [MQL Documentation](https://mondoo.com/docs/mql/) · [Built-in Functions](https://mondoo.com/docs/mql/functions) · [Resources by Provider](https://mondoo.com/docs/mql/resources/)
+- [MQL operator precedence](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) — reference for operator precedence during policy reviews
 - [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro/)
 - [cnquery Repository](https://github.com/mondoohq/cnquery)
 - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt)


### PR DESCRIPTION
## Summary
- Adds a link to `mqlc/parser/operators.go` in the cnquery/MQL repo under CLAUDE.md's Resources section so policy reviews have a canonical reference for operator precedence.

## Test plan
- [x] `git diff` shows only the new bullet in the Resources section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)