### PR TITLE
🐛 compile querypack MQL during bundle lint

### DIFF
--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -125,6 +125,12 @@ func LintPolicyBundle(schema resources.ResourcesSchema, filename string, data []
 
 	// check if the file is compilable
 	if policyBundleForCompilation != nil {
+		// Mirror the scan path: convert querypacks to policies and generate
+		// evidence so that pack/evidence MQL is compiled here. Without this,
+		// invalid MQL in querypacks slips past the linter and only fails on
+		// the server.
+		policyBundleForCompilation.Prepare()
+
 		ctx := context.Background()
 		features := mql.DefaultFeatures
 		features = append(features, byte(mql.FailIfNoEntryPoints))

--- a/internal/bundle/lint_test.go
+++ b/internal/bundle/lint_test.go
@@ -238,6 +238,19 @@ func TestLinter_Fail(t *testing.T) {
 		assert.Equal(t, "error", results.Entries[0].Level)
 	})
 
+	t.Run("fail-querypack-compile-error", func(t *testing.T) {
+		// Regression: invalid MQL inside a querypack must surface as
+		// bundle-compile-error at lint time (matches server-side compile).
+		file := "./testdata/fail-querypack-compile-error.mql.yaml"
+		results, err := Lint(schema, testLintOptions, file)
+		require.NoError(t, err)
+
+		result := findEntry(results.Entries, "bundle-compile-error")
+		require.NotNil(t, result, "expected bundle-compile-error entry")
+		assert.Equal(t, "error", result.Level)
+		assert.Contains(t, result.Message, "expected closing '}', got ':'")
+	})
+
 	t.Run("fail-bundle-unknown-field", func(t *testing.T) {
 		file := "./testdata/fail-bundle-unknown-field.mql.yaml"
 		results, err := Lint(schema, testLintOptions, file)

--- a/internal/bundle/testdata/fail-querypack-compile-error.mql.yaml
+++ b/internal/bundle/testdata/fail-querypack-compile-error.mql.yaml
@@ -1,0 +1,14 @@
+packs:
+  - uid: test-colon-pack
+    name: Test colon syntax in querypack
+    version: 1.0.0
+    require:
+      - provider: github
+    filters: asset.platform == "github-org"
+    queries:
+      - uid: test-query-colon
+        title: Test colon syntax
+        mql: |
+          github.organization {
+            counterSum: totalPublicRepos + totalPrivateRepos
+          }


### PR DESCRIPTION
## Summary

- `cnspec policy lint` parsed querypacks but never compiled their MQL, because `Bundle.CompileExt` only walks `p.Policies`/`p.Queries`/risk factors — it never iterates `p.Packs`.
- As a result, invalid MQL inside a querypack (e.g. using `:` instead of `=` for block-assignments like `org { counterSum: a + b }`) passed local lint and only failed server-side during `SetBundleMap` with `expected closing '}', got ':'`.
- Fix: call `Bundle.Prepare()` before `CompileExt` in the linter, mirroring what `apps/cnspec/cmd/scan.go` already does. `ConvertQuerypacks` turns packs into `DATA_ONLY` policies whose grouped queries then flow through the existing compile loop.

## Test plan

- [x] `go test ./internal/bundle/... -count=1`
- [x] New regression test `fail-querypack-compile-error` exercises a pack-only bundle with invalid MQL and asserts `bundle-compile-error` is raised with the same message the server compiler produces.
- [x] Manual repro: pack-only bundle with `counterSum: ...` now reports `expected closing '}', got ':'` at lint time instead of passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)