### PR TITLE
content: simplify core-dumps check using the limits resource

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -562,13 +562,7 @@ queries:
       asset.kind != "container-image"
       asset.runtime != "docker-container"
     mql: |
-      securityLimitFiles = files.find(from: '/etc/security/limits.d/', type: 'file')
-        .list.where(basename == /\.(conf)$/)
-        .map(path)
-
-      securityLimitAllFiles = securityLimitFiles + ["/etc/security/limits.conf"]
-
-      securityLimitAllFiles.map(file(_).content.lines.where( _ == /^[^#]/ )).flat.one(_ == /\*\s+hard\s+core\s+0/)
+      limits.entries.any(domain == "*" && type == "hard" && item == "core" && value == "0")
 
       kernel.parameters['fs.suid_dumpable'] == 0
       if(service("coredump").enabled || service("coredump").running) {


### PR DESCRIPTION
## What

Replaces the hand-rolled `/etc/security/limits.*` parser in `mondoo-linux-security-core-dumps-are-restricted` with the typed `limits` resource.

**Before:**
```mql
securityLimitFiles = files.find(from: '/etc/security/limits.d/', type: 'file')
  .list.where(basename == /\.(conf)$/)
  .map(path)
securityLimitAllFiles = securityLimitFiles + ["/etc/security/limits.conf"]
securityLimitAllFiles.map(file(_).content.lines.where( _ == /^[^#]/ )).flat.one(_ == /\*\s+hard\s+core\s+0/)
```

**After:**
```mql
limits.entries.any(domain == "*" && type == "hard" && item == "core" && value == "0")
```

## Why

The `limits` resource (os provider) already parses every file that makes up the limits configuration into `entries[]` with `domain`, `type`, `item`, and `value` fields — exactly what this check was reconstructing by hand.

Besides being far more readable, this **fixes a latent false-negative**: the old `.one(...)` required *exactly one* matching line, so a system that set `* hard core 0` in both `/etc/security/limits.conf` and a `limits.d` drop-in would fail the check. `.any(...)` matches the real intent (the limit is present).

The `fs.suid_dumpable` kernel-parameter assertion and the `coredump.conf` block are unchanged.

## Testing

- `cnspec policy lint content/mondoo-linux-security.mql.yaml` → `valid policy bundle(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)