### PR TITLE
content: simplify kernel-module-disable checks with kernel.module resource

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -1411,8 +1411,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "atm")
     mql: |
-      modprobe.blacklists.contains(module == "atm")
-      modprobe.installs.contains(module == "atm" && command == "/bin/false")
+      kernel.module("atm").blacklisted
+      kernel.module("atm").installBypass
     docs:
       desc: |
         This check verifies that the ATM (Asynchronous Transfer Mode) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/atm.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1514,8 +1514,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "can")
     mql: |
-      modprobe.blacklists.contains(module == "can")
-      modprobe.installs.contains(module == "can" && command == "/bin/false")
+      kernel.module("can").blacklisted
+      kernel.module("can").installBypass
     docs:
       desc: |
         This check verifies that the CAN (Controller Area Network) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/can.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1616,8 +1616,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "dccp")
     mql: |
-      modprobe.blacklists.contains(module == "dccp")
-      modprobe.installs.contains(module == "dccp" && command == "/bin/false")
+      kernel.module("dccp").blacklisted
+      kernel.module("dccp").installBypass
     docs:
       desc: |
         This check verifies that the DCCP (Datagram Congestion Control Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/dccp.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1718,8 +1718,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "rds")
     mql: |
-      modprobe.blacklists.contains(module == "rds")
-      modprobe.installs.contains(module == "rds" && command == "/bin/false")
+      kernel.module("rds").blacklisted
+      kernel.module("rds").installBypass
     docs:
       desc: |
         This check verifies that the RDS (Reliable Datagram Sockets) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/rds.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1820,8 +1820,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "sctp")
     mql: |
-      modprobe.blacklists.contains(module == "sctp")
-      modprobe.installs.contains(module == "sctp" && command == "/bin/false")
+      kernel.module("sctp").blacklisted
+      kernel.module("sctp").installBypass
     docs:
       desc: |
         This check verifies that the SCTP (Stream Control Transmission Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/sctp.conf` that both blacklist the module and redirect its install to `/bin/false`.
@@ -1922,8 +1922,8 @@ queries:
       asset.runtime != "docker-container"
       kernel.modules.any(name == "tipc")
     mql: |
-      modprobe.blacklists.contains(module == "tipc")
-      modprobe.installs.contains(module == "tipc" && command == "/bin/false")
+      kernel.module("tipc").blacklisted
+      kernel.module("tipc").installBypass
     docs:
       desc: |
         This check verifies that the TIPC (Transparent Inter-Process Communication) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/tipc.conf` that both blacklist the module and redirect its install to `/bin/false`.


### PR DESCRIPTION
## What

Rewrites the six "Ensure loading of the `<module>` module is disabled" checks (`atm`, `can`, `dccp`, `rds`, `sctp`, `tipc`) to use the typed `kernel.module` resource instead of raw `modprobe` table lookups.

**Before (each check):**
```mql
modprobe.blacklists.contains(module == "atm")
modprobe.installs.contains(module == "atm" && command == "/bin/false")
```

**After:**
```mql
kernel.module("atm").blacklisted
kernel.module("atm").installBypass
```

## Why

`kernel.module(...).blacklisted` and `.installBypass` are purpose-built predicates over the same modprobe configuration the checks were inspecting by hand. The result reads as the control objective rather than as config-file plumbing.

Semantics are preserved: both assertions remain (the module must be **blacklisted AND** have an install short-circuit), which is the CIS requirement — kept as two separate datapoints so each surfaces independently in scan output.

One small correctness improvement: `installBypass` is true for `install <mod> /bin/true` as well as `/bin/false`. The old query only matched `/bin/false`, so a system using the equally-valid `/bin/true` form was incorrectly failed.

> Note: `kernel.module(name).disabled` exists as a single combined predicate (blacklisted **OR** installBypass), but that would weaken these checks from AND to OR, so it is intentionally not used here.

## Testing

- `cnspec policy lint content/mondoo-linux-security.mql.yaml` → `valid policy bundle(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)