### PR TITLE
content: use sudoers resource for macOS sudo timeout check

### DIFF
--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -2867,8 +2867,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      command("sudo -V").stdout.contains("Authentication timestamp timeout: 0.0 minutes") ||
-        command("sudo -V").stdout.contains("Authentication timestamp timeout: 0,0 minutes")
+      sudoers.defaults.where(parameter == "timestamp_timeout") != empty
+      sudoers.defaults.where(parameter == "timestamp_timeout").all(value == "0")
     docs:
       desc: |
         This check ensures that the sudo timeout period is reduced to zero on macOS systems to minimize the risk of unauthorized access during the sudo grace period.


### PR DESCRIPTION
## What

Replaces the `sudo -V` shell-out in `mondoo-macos-security-reduce-the-sudo-timeout-period` with the typed `sudoers` resource.

**Before:**
```mql
command("sudo -V").stdout.contains("Authentication timestamp timeout: 0.0 minutes") ||
  command("sudo -V").stdout.contains("Authentication timestamp timeout: 0,0 minutes")
```

**After:**
```mql
sudoers.defaults.where(parameter == "timestamp_timeout") != empty
sudoers.defaults.where(parameter == "timestamp_timeout").all(value == "0")
```

## Why

- The old query parsed the human-readable `sudo -V` banner and needed a **second line purely to handle the locale decimal separator** (`0.0` vs `0,0`). The `sudoers` resource removes both problems.
- It reads the configuration the CIS control actually prescribes — the remediation for this very check tells users to add `Defaults timestamp_timeout=0` to sudoers — so the check now verifies exactly what the fix sets, across all sudoers files including `sudoers.d` drop-ins.
- The two-statement form keeps "timeout not set" and "timeout set to a non-zero value" as separate datapoints. macOS defaults to a 5-minute timeout, so an unset value correctly fails (the `!= empty` datapoint), which also avoids the vacuous-truth pitfall of `.all()` over an empty list.

> Note: `sudo -V` reports the *effective* timeout (including any compiled-in default), whereas `sudoers` reads the on-disk configuration. For this control they coincide — CIS requires the value to be explicitly set to `0` — and reading the config is the more precise expression of the control.

The `audit:` steps (which use the vendor-native `sudo -V`) and `remediation:` are unchanged.

## Testing

- `cnspec policy lint content/mondoo-macos-security.mql.yaml` → `valid policy bundle(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)