### PR TITLE
content: simplify DNS policy MQL using the in() function

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -374,7 +374,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
-    mql: dns.records.where(type == "A" || type == "AAAA").all(ttl == null || ttl >= 60)
+    mql: dns.records.where(type.in(["A", "AAAA"])).all(ttl == null || ttl >= 60)
     docs:
       desc: |
         This check verifies that A and AAAA records do not carry suspiciously low TTL (Time-To-Live) values below 60 seconds. The TTL controls how long resolvers cache a record before querying the authoritative server again.


### PR DESCRIPTION
Simplifies one MQL check in `mondoo-dns-security` to use the built-in `in()` function instead of a repeated `==` OR-chain.

- `mondoo-dns-security-no-low-ttl-records`: `type == "A" || type == "AAAA"` → `type.in(["A", "AAAA"])`

Behavior-preserving: the `.where()` predicate selects the identical record subset. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)