### PR TITLE
content: simplify Atlassian policy MQL using the any() function

### DIFF
--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -137,7 +137,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: false
     mql: |
-      atlassian.admin.organization.domains.where(type == "verified").length > 0
+      atlassian.admin.organization.domains.any(type == "verified")
     docs:
       desc: |
         This check ensures that the Atlassian organization has claimed and verified at least one email domain. Without a verified domain, the organization cannot claim accounts at that domain as managed identities, so administrators have no way to enforce single sign-on, password policy, or session controls on users who sign up with that email domain.


### PR DESCRIPTION
Simplifies one MQL check in `mondoo-atlassian-security` to use the built-in `any()` function instead of `where(...).length > 0`.

- verified-domains check: `where(type == "verified").length > 0` → `any(type == "verified")`

Behavior-preserving: `where(COND).length > 0` is exactly `any(COND)`. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)