### PR TITLE
content: simplify email policy MQL using any()/none()

### DIFF
--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -161,7 +161,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: dns.records.where(type == "TXT") != empty
+    mql: dns.records.any(type == "TXT")
     docs:
       desc: |
         This check confirms the presence of a TXT record, which provides additional domain ownership verification and policy information.
@@ -223,7 +223,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: dns.records.where(type == "A") != empty
+    mql: dns.records.any(type == "A")
     docs:
       desc: |
         This check ensures the existence of an anchor (A) record at the domain apex, which maps a domain name to an IPv4 address.
@@ -425,7 +425,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: dns.params['TXT']['rData'].where(/v=spf1/).where(/\s{2,}/) == empty
+    mql: dns.params['TXT']['rData'].where(/v=spf1/).none(/\s{2,}/)
     docs:
       desc: |
         Checks SPF records for absence of unnecessary whitespace.
@@ -594,7 +594,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: dns.records.where(type == "SPF") == empty
+    mql: dns.records.none(type == "SPF")
     docs:
       desc: |
         Ensures deprecated SPF DNS record types are not used, maintaining current standards compliance.


### PR DESCRIPTION
Simplifies four MQL checks in `mondoo-email-security` to use built-in `any()`/`none()` instead of `where(...) != empty` / `where(...) == empty`.

- `mondoo-email-security-txt-record`: `where(type == "TXT") != empty` → `any(type == "TXT")`
- `mondoo-email-security-a-record`: `where(type == "A") != empty` → `any(type == "A")`
- `mondoo-email-security-spf-dns-record`: `where(type == "SPF") == empty` → `none(type == "SPF")`
- `mondoo-email-security-spf-whitespaces`: trailing `where(/\s{2,}/) == empty` → `none(/\s{2,}/)`

Behavior-preserving: `where(C) != empty` ≡ `any(C)`, `where(C) == empty` ≡ `none(C)`. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)