### PR TITLE
content: simplify FreeBSD policy MQL using the in() function

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -2473,7 +2473,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      sshd.config.params["PermitRootLogin"] == "no" || sshd.config.params["PermitRootLogin"] == "prohibit-password" || sshd.config.params["PermitRootLogin"] == "without-password"
+      sshd.config.params["PermitRootLogin"].in(["no", "prohibit-password", "without-password"])
     docs:
       refs:
         - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config


### PR DESCRIPTION
Simplifies the SSH `PermitRootLogin` check in `mondoo-freebsd-security` to use the built-in `in()` function instead of a three-way `==` OR-chain.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)