### PR TITLE
content: simplify Okta policy MQL using the in() function

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -949,7 +949,7 @@ queries:
   - uid: mondoo-okta-security-okta-auth-openid-saml-api
     filters: asset.platform == "okta-org"
     mql: |
-      okta.applications.where(signOnMode != "BOOKMARK" && name != "active_directory" && status == "ACTIVE").all(_.signOnMode == "OPENID_CONNECT" || _.signOnMode == "SAML_2_0")
+      okta.applications.where(signOnMode != "BOOKMARK" && name != "active_directory" && status == "ACTIVE").all(_.signOnMode.in(["OPENID_CONNECT", "SAML_2_0"]))
     docs:
       desc: |
         This check explicitly skips Okta Bookmark apps and Active Directory integration apps, which cannot be configured with SAML or OIDC authentication by design.


### PR DESCRIPTION
Simplifies one MQL check in `mondoo-okta-security` to use the built-in `in()` function instead of a `==` OR-chain on `signOnMode`.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)