### PR TITLE
content: simplify PAN-OS policy MQL using the in() function

### DIFF
--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -2047,7 +2047,7 @@ queries:
     mql: |
       panos.ikeGateways.
         where(disabled == false).
-        all(version == "ikev2" || version == "ikev2-preferred")
+        all(version.in(["ikev2", "ikev2-preferred"]))
     docs:
       desc: |
         This check verifies that all enabled IKE gateways use IKEv2 or IKEv2-preferred mode. IKEv2 provides significant security and performance improvements over IKEv1.


### PR DESCRIPTION
Simplifies the IKE version check in `mondoo-panos-security` to use the built-in `in()` function instead of a `==` OR-chain.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)