### PR TITLE
content: simplify Cisco NX-OS policy MQL using the in() function

### DIFF
--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -123,7 +123,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
-      cisco.nxos.ssh.algorithm == "rsa" || cisco.nxos.ssh.algorithm == "ecdsa"
+      cisco.nxos.ssh.algorithm.in(["rsa", "ecdsa"])
     docs:
       desc: |
         This check verifies that the SSH key uses a strong algorithm such as RSA or ECDSA. DSA keys are considered cryptographically weak and should not be used.


### PR DESCRIPTION
Simplifies the SSH key-algorithm check in `mondoo-cisco-nxos-security` to use the built-in `in()` function instead of a `==` OR-chain.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)