### PR TITLE
content: simplify Cisco IOS-XR policy MQL using the notIn() function

### DIFF
--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -530,7 +530,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       cisco.iosxr.users.all(
-        secretType != "0" && secretType != ""
+        secretType.notIn(["0", ""])
       )
     docs:
       desc: |


### PR DESCRIPTION
Simplifies the user-password-encryption check in `mondoo-cisco-iosxr-security` to use the built-in `notIn()` function instead of a `!=` AND-chain.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)