### PR TITLE
content: simplify Google Workspace policy MQL using the in() function

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -383,7 +383,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       googleworkspace.connectedApps.none(
-        scopes.any(_ == "https://mail.google.com/") || scopes.any(_ == "https://www.googleapis.com/auth/drive")
+        scopes.any(_.in(["https://mail.google.com/", "https://www.googleapis.com/auth/drive"]))
       )
     docs:
       desc: |


### PR DESCRIPTION
Simplifies the connected-apps full-access check in `mondoo-google-workspace-security`. `scopes.any(_ == a) || scopes.any(_ == b)` over the same list folds to `scopes.any(_.in([a, b]))`.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)