### PR TITLE
content: simplify vLLM policy MQL using the in() function

### DIFF
--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -641,7 +641,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vllm.endpoints.where(path == "/tokenize" || path == "/detokenize").none(anonymousAccessible == true)
+      vllm.endpoints.where(path.in(["/tokenize", "/detokenize"])).none(anonymousAccessible == true)
     docs:
       desc: |
         This check ensures that the `/tokenize` and `/detokenize` routes are configured to reject anonymous requests. These helper routes expose tokenizer behavior and consume server resources without invoking the primary completion API.


### PR DESCRIPTION
Simplifies the tokenization-routes check in `mondoo-vllm-security` to use the built-in `in()` function in the `.where()` filter instead of a `==` OR-chain.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)