### PR TITLE
content: simplify BIG-IP policy MQL using the in() function

### DIFF
--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -744,12 +744,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      bigip.snmp.allowedAddresses.none(
-        _ == "0.0.0.0/0" ||
-        _ == "0.0.0.0" ||
-        _ == "::/0" ||
-        _ == "ALL"
-      )
+      bigip.snmp.allowedAddresses.none(_.in(["0.0.0.0/0", "0.0.0.0", "::/0", "ALL"]))
     docs:
       desc: |
         This check verifies that the SNMP allowed addresses list on the BIG-IP device does not permit unrestricted access. SNMP exposes detailed system configuration and operational data that attackers can use for reconnaissance and exploitation.


### PR DESCRIPTION
Simplifies the SNMP restricted-access check in `mondoo-bigip-security`. A four-way `_ == ...` OR inside `none()` folds to `none(_.in([...]))`.

Behavior-preserving (string matches, not IP-object checks). `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)