### PR TITLE
content: simplify Phoenix PLCnext policy MQL using the one() function

### DIFF
--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -203,7 +203,7 @@ queries:
   - uid: phoenix-plcnext-06
     title: Ensure current system time is synchronized
     mql: |
-      processes.where( executable == /ntp/).length == 1
+      processes.one( executable == /ntp/)
       command('date -u --date="$(curl -v install.mondoo.com 2>&1 | grep Date: | cut -d" " -f3-9)"').stdout.trim <= command('date --date "1 min" -u').stdout.trim
       command('date -u --date="$(curl -v install.mondoo.com 2>&1 | grep Date: | cut -d" " -f3-9)"').stdout.trim >= command('date --date "1 min ago" -u').stdout.trim
     docs:


### PR DESCRIPTION
Simplifies one statement in the `phoenix-plcnext-06` query to use the built-in `one()` function instead of `where(...).length == 1`.

Behavior-preserving: `where(C).length == 1` is exactly `one(C)`. The two sibling statements remain separate datapoints. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)