### PR TITLE
content: simplify Linux workstation policy MQL using the any() function

### DIFF
--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -414,7 +414,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
-      lsblk.list.where( fstype == /crypt/).length >= 1
+      lsblk.list.any( fstype == /crypt/ )
       lsblk.list.where( fstype == /crypt/).all(
         parse.json(
           content: command('cryptsetup --dump-json-metadata luksDump /dev/disk/by-uuid/' + uuid).stdout


### PR DESCRIPTION
Simplifies a disk-encryption check statement in `mondoo-linux-workstation-security` to use the built-in `any()` function instead of `where(...).length >= 1`.

Behavior-preserving: `where(C).length >= 1` is exactly `any(C)`. The sibling statement remains a separate datapoint. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)