### PR TITLE
content: simplify Microsoft 365 policy MQL using the any() function

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -1665,7 +1665,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt") != empty)
+      microsoft.domains.all(serviceConfigurationRecords.any(supportedService == "Email" && recordType == "Txt"))
       microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt").all(properties.text == "v=spf1 include:spf.protection.outlook.com -all"))
     docs:
       desc: |


### PR DESCRIPTION
Simplifies one statement in the SPF-records check in `mondoo-m365-security` to use the built-in `any()` function instead of `where(...) != empty`.

Behavior-preserving: `where(C) != empty` is exactly `any(C)`. The sibling statement (which asserts over a filtered subset) is unchanged. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)