### PR TITLE
content: simplify Junos policy MQL using containsNone()/in()

### DIFF
--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -184,14 +184,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      junos.sshConfig.ciphers.none(
-        _ == "arcfour" ||
-        _ == "arcfour128" ||
-        _ == "arcfour256" ||
-        _ == "3des-cbc" ||
-        _ == "blowfish-cbc" ||
-        _ == "cast128-cbc"
-      )
+      junos.sshConfig.ciphers.containsNone(["arcfour", "arcfour128", "arcfour256", "3des-cbc", "blowfish-cbc", "cast128-cbc"])
     docs:
       desc: |
         This check verifies that no weak or deprecated SSH ciphers are configured on the Junos device. Using only strong ciphers protects the confidentiality of SSH sessions against cryptographic attacks.
@@ -256,13 +249,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      junos.sshConfig.macs.none(
-        _ == "hmac-md5" ||
-        _ == "hmac-md5-96" ||
-        _ == "hmac-sha1-96" ||
-        _ == "hmac-md5-etm@openssh.com" ||
-        _ == "hmac-md5-96-etm@openssh.com"
-      )
+      junos.sshConfig.macs.containsNone(["hmac-md5", "hmac-md5-96", "hmac-sha1-96", "hmac-md5-etm@openssh.com", "hmac-md5-96-etm@openssh.com"])
     docs:
       desc: |
         This check verifies that no weak SSH message authentication codes (MACs) are configured. Strong MACs ensure that SSH session data has not been modified in transit.
@@ -326,10 +313,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      junos.sshConfig.keyExchanges.none(
-        _ == "diffie-hellman-group1-sha1" ||
-        _ == "diffie-hellman-group-exchange-sha1"
-      )
+      junos.sshConfig.keyExchanges.containsNone(["diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"])
     docs:
       desc: |
         This check verifies that weak SSH key exchange algorithms are not configured. Strong key exchange algorithms ensure that session keys are securely negotiated and that past sessions remain protected.
@@ -912,9 +896,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      junos.snmpCommunities.none(
-        name == "public" || name == "private"
-      )
+      junos.snmpCommunities.none(name.in(["public", "private"]))
     docs:
       desc: |
         This check verifies that default SNMP community strings ("public" and "private") are not configured. Default community strings are universally known and are the first credentials attackers attempt when probing SNMP services.
@@ -1363,14 +1345,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       junos.securityZones.where(name == "untrust").all(
-        hostInboundServices.none(
-          _ == "telnet" ||
-          _ == "ftp" ||
-          _ == "finger" ||
-          _ == "http" ||
-          _ == "snmp" ||
-          _ == "all"
-        )
+        hostInboundServices.containsNone(["telnet", "ftp", "finger", "http", "snmp", "all"])
       )
     docs:
       desc: |


### PR DESCRIPTION
This PR applies five behavior-preserving MQL simplifications to the Junos security policy, collapsing OR-chained denylists into list-membership helpers.

Checks changed:
- SSH ciphers denylist → `containsNone([...])`
- SSH MACs denylist → `containsNone([...])`
- SSH key-exchanges denylist → `containsNone([...])`
- untrust-zone inbound services denylist → `containsNone([...])` (outer `securityZones.where(name == "untrust").all(...)` wrapper unchanged)
- SNMP communities OR-chain → `name.in([...])`

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)