### PR TITLE
content: simplify Cloudflare policy MQL using the in() function

### DIFF
--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -2513,27 +2513,27 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.minTlsVersion == "1.2" || cloudflare.zone.settings.minTlsVersion == "1.3"
+      cloudflare.zone.settings.minTlsVersion.in(["1.2", "1.3"])
   - uid: mondoo-cloudflare-security-min-tls-1-2-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
     mql: |
       terraform.resources('cloudflare_zone_setting').where(arguments['setting_id'] == 'min_tls_version').all(
-        arguments['value'] == '1.2' || arguments['value'] == '1.3'
+        arguments['value'].in(['1.2', '1.3'])
       )
   - uid: mondoo-cloudflare-security-min-tls-1-2-terraform-plan
     filters: |
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'cloudflare_zone_setting')
     mql: |
       terraform.plan.resourceChanges.where(type == 'cloudflare_zone_setting').where(change.after['setting_id'] == 'min_tls_version').all(
-        change.after['value'] == '1.2' || change.after['value'] == '1.3'
+        change.after['value'].in(['1.2', '1.3'])
       )
   - uid: mondoo-cloudflare-security-min-tls-1-2-terraform-state
     filters: |
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'cloudflare_zone_setting')
     mql: |
       terraform.state.resources.where(type == 'cloudflare_zone_setting').where(values['setting_id'] == 'min_tls_version').all(
-        values['value'] == '1.2' || values['value'] == '1.3'
+        values['value'].in(['1.2', '1.3'])
       )
   - uid: mondoo-cloudflare-security-tls-1-3-enabled-cloudflare
     filters: |


### PR DESCRIPTION
Simplifies the min-TLS-version check in the Cloudflare security policy by collapsing same-field `==` OR-chains into the `in([...])` function.

- The min-TLS check (runtime + terraform-hcl/plan/state) now uses `minTlsVersion.in(["1.2", "1.3"])` instead of `== "1.2" || == "1.3"`.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)