### PR TITLE
content: simplify GitHub policy MQL using none()/in()

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -1779,7 +1779,7 @@ queries:
         .one( name == ".github" && type == "dir" )
       github.repository.files
         .where( path == ".github" )
-        .all( files.one( name == "dependabot.yaml" || name == "dependabot.yml" ) )
+        .all( files.one( name.in(["dependabot.yaml", "dependabot.yml"]) ) )
     docs:
       desc: |
         This check ensures the existence of a GitHub Actions workflow to run Dependabot checks on the repository by looking for the existence of a `.github/dependabot.yml` or `.github/dependabot.yaml` configuration file.
@@ -2996,7 +2996,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      github.repository.codeScanningAlerts.where(state == "open").length == 0
+      github.repository.codeScanningAlerts.none(state == "open")
     docs:
       desc: |
         This check ensures that the repository has no open code scanning alerts. Code scanning identifies security vulnerabilities and coding errors in your codebase using static analysis tools like CodeQL.
@@ -3087,7 +3087,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      github.repository.dependabotAlerts.where(state == "open" && securityVulnerability['severity'] == "critical").length == 0
+      github.repository.dependabotAlerts.none(state == "open" && securityVulnerability['severity'] == "critical")
     docs:
       desc: |
         This check ensures that the repository has no open Dependabot alerts with critical severity. Dependabot identifies known vulnerabilities in your project's dependencies.


### PR DESCRIPTION
Three behavior-preserving MQL simplifications in `content/mondoo-github-security.mql.yaml`.

- **`mondoo-github-repository-security-code-scanning-alerts-resolved`**: `codeScanningAlerts.where(state == "open").length == 0` → `codeScanningAlerts.none(state == "open")`.
- **`mondoo-github-repository-security-dependabot-alerts-resolved`**: `dependabotAlerts.where(state == "open" && securityVulnerability['severity'] == "critical").length == 0` → `dependabotAlerts.none(...)`.
- **Dependabot config check**: `name == "dependabot.yaml" || name == "dependabot.yml"` → `name.in(["dependabot.yaml", "dependabot.yml"])`, keeping the `files.one(...)` wrapper.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)