### PR TITLE
content: simplify Snowflake policy MQL using containsNone()

### DIFF
--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -1587,21 +1587,21 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'snowflake_network_policy')
     mql: |
       terraform.resources('snowflake_network_policy').all(
-        arguments['allowed_ip_list'] == null || arguments['allowed_ip_list'].none(_ == "0.0.0.0/0" || _ == "::/0")
+        arguments['allowed_ip_list'] == null || arguments['allowed_ip_list'].containsNone(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-snowflake-security-network-policies-no-unrestricted-access-terraform-plan
     filters: |
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'snowflake_network_policy')
     mql: |
       terraform.plan.resourceChanges.where(type == 'snowflake_network_policy').all(
-        change.after['allowed_ip_list'] == null || change.after['allowed_ip_list'].none(_ == "0.0.0.0/0" || _ == "::/0")
+        change.after['allowed_ip_list'] == null || change.after['allowed_ip_list'].containsNone(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-snowflake-security-network-policies-no-unrestricted-access-terraform-state
     filters: |
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'snowflake_network_policy')
     mql: |
       terraform.state.resources.where(type == 'snowflake_network_policy').all(
-        values['allowed_ip_list'] == null || values['allowed_ip_list'].none(_ == "0.0.0.0/0" || _ == "::/0")
+        values['allowed_ip_list'] == null || values['allowed_ip_list'].containsNone(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-snowflake-security-no-accountadmin-default-role-snowflake
     filters: asset.platform == 'snowflake'


### PR DESCRIPTION
Simplifies redundant denylist MQL in the Snowflake security policy without changing behavior.

- The network-policy unrestricted-access Terraform variants (hcl/plan/state) now use `containsNone(["0.0.0.0/0", "::/0"])` instead of `none(_ == "0.0.0.0/0" || _ == "::/0")`.
- The `allowed_ip_list == null` guards on each variant are preserved.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)