### PR TITLE
content: simplify vSphere policy MQL using the none() function

### DIFF
--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -1652,7 +1652,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      vsphere.datacenters.all( vms.all( advancedSettings.where ( key.contains('pciPassthru')).length == 0 ) )
+      vsphere.datacenters.all( vms.all( advancedSettings.none( key.contains('pciPassthru') ) ) )
     docs:
       desc: |-
         This check ensures that no virtual machine has PCI or PCIe device pass-through configured, verified by the absence of any `pciPassthru` advanced parameter. Pass-through lets a VM access physical PCI hardware directly by bypassing the hypervisor, and it should be reserved for trusted workloads with a documented need.


### PR DESCRIPTION
Simplifies the PCI/PCIe passthrough check in `mondoo-vmware-vsphere` to use the built-in `none()` function instead of `where(...).length == 0`.

Behavior-preserving: `where(C).length == 0` is exactly `none(C)`. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)