### PR TITLE
content: simplify AI security policy MQL using notIn()/none()

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -2978,12 +2978,12 @@ queries:
         mql: |
           return /(?i)^$/
     mql: |
-      claude.code.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0 &&
-      openai.codex.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0 &&
-      cursor.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0 &&
-      github.copilot.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0 &&
-      windsurf.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0 &&
-      gemini.mcpServers.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0
+      claude.code.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      openai.codex.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      cursor.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      github.copilot.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      windsurf.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      gemini.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
     docs:
       desc: |
         Model Context Protocol servers grant AI agents tool access to internal systems such as email, source control, databases, and messaging platforms. Only MCP servers reviewed and approved by the security team should be configured across Claude Code, OpenAI Codex, Cursor, GitHub Copilot, Windsurf, and Gemini CLI. The `mondooAiSecurityApprovedMcpServers` property defines a single centralized allow-list and can be customized for your environment, for example `return /(?i)(mondoo|github|jira)/`.
@@ -3180,7 +3180,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      ports.listening.where(address != "127.0.0.1" && address != "[::1]").none(
+      ports.listening.where(address.notIn(["127.0.0.1", "[::1]"])).none(
         port == 11434 || port == 1234 || port == 1337
       )
     docs:


### PR DESCRIPTION
Behavior-preserving MQL simplifications in `content/mondoo-ai-security.mql.yaml`.

- `mondoo-ai-security-local-llm-server-not-network-exposed`: collapse the address `!=` AND-chain into `address.notIn(["127.0.0.1", "[::1]"])`.
- `mondoo-ai-security-approved-mcp-servers-only`: convert each of the 6 `.where(name != props.mondooAiSecurityApprovedMcpServers).length == 0` clauses into `.none(name != props.mondooAiSecurityApprovedMcpServers)`, keeping the single top-level `&&`-joined statement intact.

Note: the planned `port == 11434 || ... → port.in([...])` change was dropped — MQL has no `.in()` on `int` (`cannot find field 'in' in int`), so the port OR-chain is left unchanged.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)