### PR TITLE
content: simplify UniFi policy MQL using the in() function

### DIFF
--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -273,19 +273,19 @@ queries:
   - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-unifi
     filters: asset.platform == "unifi"
     mql: |
-      unifi.wlans.where(enabled == true).all(security == "wpapsk" || security == "wpaeap")
+      unifi.wlans.where(enabled == true).all(security.in(["wpapsk", "wpaeap"]))
   - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
     mql: |
-      terraform.resources.where(nameLabel == "unifi_wlan").all(arguments["security"] == "wpapsk" || arguments["security"] == "wpaeap")
+      terraform.resources.where(nameLabel == "unifi_wlan").all(arguments["security"].in(["wpapsk", "wpaeap"]))
   - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
     mql: |
-      terraform.plan.resourceChanges.where(type == "unifi_wlan").all(change.after.security == "wpapsk" || change.after.security == "wpaeap")
+      terraform.plan.resourceChanges.where(type == "unifi_wlan").all(change.after.security.in(["wpapsk", "wpaeap"]))
   - uid: mondoo-unifi-security-wlans-use-wpa2-or-wpa3-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
     mql: |
-      terraform.state.resources.where(type == "unifi_wlan").all(values.security == "wpapsk" || values.security == "wpaeap")
+      terraform.state.resources.where(type == "unifi_wlan").all(values.security.in(["wpapsk", "wpaeap"]))
 
   - uid: mondoo-unifi-security-wlans-wpa3-enabled
     title: Ensure WPA3 support is enabled on wireless networks
@@ -475,19 +475,19 @@ queries:
   - uid: mondoo-unifi-security-wlans-pmf-enabled-unifi
     filters: asset.platform == "unifi"
     mql: |
-      unifi.wlans.where(enabled == true && security != "open").all(pmfMode == "required" || pmfMode == "optional")
+      unifi.wlans.where(enabled == true && security != "open").all(pmfMode.in(["required", "optional"]))
   - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_wlan")
     mql: |
-      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["security"] != "open").all(arguments["pmf_mode"] == "required" || arguments["pmf_mode"] == "optional")
+      terraform.resources.where(nameLabel == "unifi_wlan" && arguments["security"] != "open").all(arguments["pmf_mode"].in(["required", "optional"]))
   - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "unifi_wlan")
     mql: |
-      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.security != "open").all(change.after.pmf_mode == "required" || change.after.pmf_mode == "optional")
+      terraform.plan.resourceChanges.where(type == "unifi_wlan" && change.after.security != "open").all(change.after.pmf_mode.in(["required", "optional"]))
   - uid: mondoo-unifi-security-wlans-pmf-enabled-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "unifi_wlan")
     mql: |
-      terraform.state.resources.where(type == "unifi_wlan" && values.security != "open").all(values.pmf_mode == "required" || values.pmf_mode == "optional")
+      terraform.state.resources.where(type == "unifi_wlan" && values.security != "open").all(values.pmf_mode.in(["required", "optional"]))
 
   # No Terraform variants: the WPA encryption-cipher selector (`wpaEnc`, values like
   # `ccmp`/`gcmp256`) is not exposed on the ubiquiti-community/unifi unifi_wlan resource —
@@ -2096,7 +2096,7 @@ queries:
   - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-unifi
     filters: asset.platform == "unifi"
     mql: |
-      unifi.portForwards.where(enabled == true).none(fwdPort == "22" || fwdPort == "443" || fwdPort == "8443" || fwdPort == "8080" || dstPort == "22" || dstPort == "443" || dstPort == "8443" || dstPort == "8080")
+      unifi.portForwards.where(enabled == true).none(fwdPort.in(["22", "443", "8443", "8080"]) || dstPort.in(["22", "443", "8443", "8080"]))
   - uid: mondoo-unifi-security-no-port-forwards-to-mgmt-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "unifi_port_forward")
     mql: |
@@ -2366,7 +2366,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      unifi.vpnServers.where(enabled == true).all(protocol == "wireguard" || protocol == "ipsec")
+      unifi.vpnServers.where(enabled == true).all(protocol.in(["wireguard", "ipsec"]))
     docs:
       desc: |
         This check ensures that all enabled VPN servers use modern protocols such as WireGuard or IPsec rather than legacy protocols.
@@ -2482,7 +2482,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      unifi.vpnClients.where(enabled == true).all(protocol == "wireguard" || protocol == "ipsec")
+      unifi.vpnClients.where(enabled == true).all(protocol.in(["wireguard", "ipsec"]))
     docs:
       desc: |
         This check ensures that all enabled VPN client connections use modern protocols such as WireGuard or IPsec.


### PR DESCRIPTION
Collapse same-field two-value `== a || == b` OR-chains into `.in([a, b])` in the UniFi security policy. Behavior-preserving readability cleanup.

Checks changed:
- WLAN encryption (`security`) — runtime + Terraform HCL/plan/state variants
- WLAN Protected Management Frames (`pmfMode` / `pmf_mode`) — runtime + Terraform HCL/plan/state variants
- VPN server protocol — runtime
- VPN client protocol — runtime
- Port-forward management ports (`fwdPort` / `dstPort`, two `.in()` joined by `||`) — runtime

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)