### PR TITLE
content: simplify Linux security policy MQL using in()/notIn()

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3591,7 +3591,7 @@ queries:
       asset.kind != "container-image"
     mql: |
       if( package("postfix").installed && service('postfix').running ) {
-        parse.ini("/etc/postfix/main.cf").params["inet_interfaces"] == "localhost" || parse.ini("/etc/postfix/main.cf").params["inet_interfaces"] == "loopback-only"
+        parse.ini("/etc/postfix/main.cf").params["inet_interfaces"].in(["localhost", "loopback-only"])
       }
       if( package("exim4").installed && service('exim4').running ) {
         parse.ini("/etc/exim4/update-exim4.conf.conf").params["dc_local_interfaces"] == "'127.0.0.1 ; ::1'"
@@ -7650,7 +7650,7 @@ queries:
         syscalls.in(syscalls_64bit)
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -7661,7 +7661,7 @@ queries:
         syscalls.in(syscalls_32bit)
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -7876,7 +7876,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "exit" && value == "-EPERM")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm64.containsAll(syscalls_64bit)
@@ -7887,7 +7887,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "exit" && value == "-EACCES")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces64.containsAll(syscalls_64bit)
@@ -7898,7 +7898,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "exit" && value == "-EPERM")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm32.containsAll(syscalls_64bit)
@@ -7909,7 +7909,7 @@ queries:
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "exit" && value == "-EACCES")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces32.containsAll(syscalls_64bit)
@@ -8259,13 +8259,13 @@ queries:
         syscalls.contains("mount")
         && fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "mounts"
       ) || auditd.rules.syscalls.contains(
         syscalls.contains("mount")
         && fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "mounts"
       )
     docs:
@@ -8412,14 +8412,14 @@ queries:
       deleteRules64 = auditd.rules.syscalls.where(
         fields.contains(key == "arch" && op == "=" && value == "b64")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "delete"
       ).map(syscalls).flat
 
       deleteRules32 = auditd.rules.syscalls.where(
         fields.contains(key == "arch" && op == "=" && value == "b32")
         && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value == "unset" || value == "4294967295" || value == "-1")
+        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
         && keyname == "delete"
       ).map(syscalls).flat
 
@@ -10925,7 +10925,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      sshd.config.params["PermitRootLogin"] == "no" || sshd.config.params["PermitRootLogin"] == "prohibit-password" || sshd.config.params["PermitRootLogin"] == "without-password"
+      sshd.config.params["PermitRootLogin"].in(["no", "prohibit-password", "without-password"])
     docs:
       desc: |
         This check ensures that the `PermitRootLogin` parameter in the SSH configuration is set to restrict root login access. Disabling root login enhances the security of the SSH server by preventing direct access to the root account.
@@ -13785,8 +13785,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: false
     mql: |
-      users.where( name != "root" && name != "sync" && name != "shutdown" && name != "halt" ).where( uid < 1000 ).list {
-        shell == "/usr/bin/nologin" || shell == "/sbin/nologin" || shell == "/usr/sbin/nologin"
+      users.where( name.notIn(["root", "sync", "shutdown", "halt"]) ).where( uid < 1000 ).list {
+        shell.in(["/usr/bin/nologin", "/sbin/nologin", "/usr/sbin/nologin"])
       }
     docs:
       desc: |
@@ -13912,7 +13912,7 @@ queries:
 
       suRestrictedPam != empty
       suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
-      suRestrictedGroups != empty || groups.any(name == "wheel" || name == "sudo")
+      suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
     docs:
       desc: |
         This check ensures that access to the `su` command is restricted to authorized users by configuring the `pam_wheel.so` module in the `/etc/pam.d/su` file. This configuration limits the use of the `su` command to members of the `wheel` or `sudo` group, enhancing system security.


### PR DESCRIPTION
Behavior-preserving MQL simplifications in `content/mondoo-linux-security.mql.yaml`, collapsing same-field `==` OR-chains into `in([...])` and `!=` AND-chains into `notIn([...])`.

Checks changed:

- SSH `PermitRootLogin` allowed values
- System-account shell check (`/usr/bin/nologin`, `/sbin/nologin`, `/usr/sbin/nologin`)
- System-account user filter (`name.notIn([...])`)
- auditd `auid` value check (`value.in(["unset", "4294967295", "-1"])`) — applied across ~10 datapoints, each kept as a separate top-level statement
- MTA loopback `inet_interfaces`
- su-restriction group membership (`wheel`/`sudo`)

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)