### PR TITLE
content: simplify GCP policy MQL using the in() function

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3380,7 +3380,7 @@ queries:
     filters: |
       asset.platform == 'gcp-sql-postgresql'
     mql: |
-      gcp.sql.instance.settings.databaseFlags['log_error_verbosity'] == 'verbose' || gcp.sql.instance.settings.databaseFlags['log_error_verbosity'] == 'default'
+      gcp.sql.instance.settings.databaseFlags['log_error_verbosity'].in(['verbose', 'default'])
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_sql_database_instance' && arguments['database_version'].contains('POSTGRES'))
@@ -3392,7 +3392,7 @@ queries:
         blocks.where(type == 'settings').all(
           blocks.where(type == 'database_flags').where(arguments['name'] == 'log_error_verbosity') != empty &&
           blocks.where(type == 'database_flags').where(arguments['name'] == 'log_error_verbosity').all(
-            arguments['value'] == 'verbose' || arguments['value'] == 'default'
+            arguments['value'].in(['verbose', 'default'])
           )
         )
       )
@@ -3408,7 +3408,7 @@ queries:
         // Verify correct value
         change.after['settings'].all(
           _['database_flags'].where(name == 'log_error_verbosity').all(
-            _['value'] == 'verbose' || _['value'] == 'default'
+            _['value'].in(['verbose', 'default'])
           )
         )
       )
@@ -3424,7 +3424,7 @@ queries:
         // Verify correct value
         values['settings'].all(
           _['database_flags'].where(name == 'log_error_verbosity').all(
-            _['value'] == 'verbose' || _['value'] == 'default'
+            _['value'].in(['verbose', 'default'])
           )
         )
       )
@@ -16693,19 +16693,19 @@ queries:
     filters: asset.platform == 'gcp-sql-mysql'
     mql: |
       gcp.sql.instance.settings.ipConfiguration.authorizedNetworks.none(
-        _['value'] == "0.0.0.0/0" || _['value'] == "::/0"
+        _['value'].in(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-postgresql
     filters: asset.platform == 'gcp-sql-postgresql'
     mql: |
       gcp.sql.instance.settings.ipConfiguration.authorizedNetworks.none(
-        _['value'] == "0.0.0.0/0" || _['value'] == "::/0"
+        _['value'].in(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-sqlserver
     filters: asset.platform == 'gcp-sql-sqlserver'
     mql: |
       gcp.sql.instance.settings.ipConfiguration.authorizedNetworks.none(
-        _['value'] == "0.0.0.0/0" || _['value'] == "::/0"
+        _['value'].in(["0.0.0.0/0", "::/0"])
       )
   - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-terraform-hcl
     filters: |
@@ -16730,7 +16730,7 @@ queries:
           _['ip_configuration'].all(
             _['authorized_networks'] == empty ||
             _['authorized_networks'].none(
-              _['value'] == '0.0.0.0/0' || _['value'] == '::/0'
+              _['value'].in(['0.0.0.0/0', '::/0'])
             )
           )
         )
@@ -16744,7 +16744,7 @@ queries:
           _['ip_configuration'].all(
             _['authorized_networks'] == empty ||
             _['authorized_networks'].none(
-              _['value'] == '0.0.0.0/0' || _['value'] == '::/0'
+              _['value'].in(['0.0.0.0/0', '::/0'])
             )
           )
         )


### PR DESCRIPTION
Collapse same-field `== a || == b` OR-chains into `.in([...])` in two Cloud SQL check families in `content/mondoo-gcp-security.mql.yaml`.

- **Authorized-networks** (`...no-overly-permissive-authorized-networks...`): the `0.0.0.0/0` / `::/0` CIDR-string comparisons inside `.none(...)`, across the runtime variants (MySQL, PostgreSQL, SQL Server) and the Terraform plan/state variants.
- **Postgres `log_error_verbosity`** (`...log-error-verbosity-default-verbose...`): the `verbose` / `default` value comparisons, across the runtime variant and the Terraform HCL/plan/state variants.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)