### PR TITLE
content: simplify OCI policy MQL using containsNone()/in()

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3867,8 +3867,8 @@ queries:
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-oci
     filters: asset.platform == "oci-loadbalancer"
     mql: |
-      oci.loadBalancer.loadBalancer.listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
-        sslProtocols.none(_ == "TLSv1" || _ == "TLSv1.1" || _ == "SSLv3")
+      oci.loadBalancer.loadBalancer.listeners.where(protocol.in(["HTTPS", "HTTP2"])).all(
+        sslProtocols.containsNone(["TLSv1", "TLSv1.1", "SSLv3"])
       )
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-terraform-hcl
     filters: |
@@ -3876,12 +3876,12 @@ queries:
     mql: |
       # HTTPS / HTTP2 listeners must declare an ssl_configuration block whose protocols list excludes legacy TLS / SSL versions.
       terraform.resources('oci_load_balancer_listener')
-        .where(arguments['protocol'] == 'HTTPS' || arguments['protocol'] == 'HTTP2')
+        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           blocks.where(type == 'ssl_configuration') != empty &&
           blocks.where(type == 'ssl_configuration').all(
             arguments['protocols'] != null &&
-            arguments['protocols'].none(_ == 'TLSv1' || _ == 'TLSv1.1' || _ == 'SSLv3')
+            arguments['protocols'].containsNone(['TLSv1', 'TLSv1.1', 'SSLv3'])
           )
         )
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-terraform-plan
@@ -3890,12 +3890,12 @@ queries:
     mql: |
       terraform.plan.resourceChanges
         .where(type == 'oci_load_balancer_listener')
-        .where(change.after['protocol'] == 'HTTPS' || change.after['protocol'] == 'HTTP2')
+        .where(change.after['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           change.after['ssl_configuration'] != null && change.after['ssl_configuration'].length > 0 &&
           change.after['ssl_configuration'].all(
             _['protocols'] != null &&
-            _['protocols'].none(_ == 'TLSv1' || _ == 'TLSv1.1' || _ == 'SSLv3')
+            _['protocols'].containsNone(['TLSv1', 'TLSv1.1', 'SSLv3'])
           )
         )
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-terraform-state
@@ -3904,12 +3904,12 @@ queries:
     mql: |
       terraform.state.resources
         .where(type == 'oci_load_balancer_listener')
-        .where(values['protocol'] == 'HTTPS' || values['protocol'] == 'HTTP2')
+        .where(values['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           values['ssl_configuration'] != null && values['ssl_configuration'].length > 0 &&
           values['ssl_configuration'].all(
             _['protocols'] != null &&
-            _['protocols'].none(_ == 'TLSv1' || _ == 'TLSv1.1' || _ == 'SSLv3')
+            _['protocols'].containsNone(['TLSv1', 'TLSv1.1', 'SSLv3'])
           )
         )
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites
@@ -4030,7 +4030,7 @@ queries:
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-oci
     filters: asset.platform == "oci-loadbalancer"
     mql: |
-      oci.loadBalancer.loadBalancer.listeners.where(protocol == "HTTPS" || protocol == "HTTP2").all(
+      oci.loadBalancer.loadBalancer.listeners.where(protocol.in(["HTTPS", "HTTP2"])).all(
         sslCipherSuiteName.downcase == /^oci-modern-ssl-cipher-suite-v1$|^oci-tls-1-2-[a-z0-9-]+$|^oci-tls-1-3-[a-z0-9-]+$|^oci-default-ssl-cipher-suite-v1$/
       )
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-terraform-hcl
@@ -4038,7 +4038,7 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_load_balancer_listener')
     mql: |
       terraform.resources('oci_load_balancer_listener')
-        .where(arguments['protocol'] == 'HTTPS' || arguments['protocol'] == 'HTTP2')
+        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           blocks.where(type == 'ssl_configuration') != empty &&
           blocks.where(type == 'ssl_configuration').all(
@@ -4052,7 +4052,7 @@ queries:
     mql: |
       terraform.plan.resourceChanges
         .where(type == 'oci_load_balancer_listener')
-        .where(change.after['protocol'] == 'HTTPS' || change.after['protocol'] == 'HTTP2')
+        .where(change.after['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           change.after['ssl_configuration'] != null && change.after['ssl_configuration'].length > 0 &&
           change.after['ssl_configuration'].all(
@@ -4066,7 +4066,7 @@ queries:
     mql: |
       terraform.state.resources
         .where(type == 'oci_load_balancer_listener')
-        .where(values['protocol'] == 'HTTPS' || values['protocol'] == 'HTTP2')
+        .where(values['protocol'].in(['HTTPS', 'HTTP2']))
         .all(
           values['ssl_configuration'] != null && values['ssl_configuration'].length > 0 &&
           values['ssl_configuration'].all(
@@ -4096,7 +4096,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      oci.loadBalancer.loadBalancer.listeners.any(protocol == "HTTPS" || protocol == "HTTP2")
+      oci.loadBalancer.loadBalancer.listeners.any(protocol.in(["HTTPS", "HTTP2"]))
     docs:
       desc: |
         This check ensures that every OCI load balancer exposing an HTTP listener also exposes at least one HTTPS or HTTP/2 listener. A load balancer that serves HTTP with no accompanying TLS listener provides no encrypted path for the service, meaning that traffic including credentials, session cookies, and form submissions travels in cleartext across any network between the client and the load balancer.
@@ -6995,7 +6995,7 @@ queries:
       oci.network.securityList.ingressSecurityRules.where(
         _['source'] == "0.0.0.0/0" && _['icmpOptions'] == empty
       ).none(
-        _['protocol'] == "1" || _['protocol'] == "58" || _['protocol'] == "all"
+        _['protocol'].in(["1", "58", "all"])
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-icmp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -7012,7 +7012,7 @@ queries:
     mql: |
       terraform.plan.resourceChanges.where(type == "oci_core_security_list").all(
         change.after.ingress_security_rules.where(_['source'] == "0.0.0.0/0" && _['icmp_options'] == empty).none(
-          _['protocol'] == "1" || _['protocol'] == "58" || _['protocol'] == "all"
+          _['protocol'].in(["1", "58", "all"])
         )
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-icmp-ingress-terraform-state
@@ -7020,7 +7020,7 @@ queries:
     mql: |
       terraform.state.resources.where(type == "oci_core_security_list").all(
         values.ingress_security_rules.where(_['source'] == "0.0.0.0/0" && _['icmp_options'] == empty).none(
-          _['protocol'] == "1" || _['protocol'] == "58" || _['protocol'] == "all"
+          _['protocol'].in(["1", "58", "all"])
         )
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ipv6-ingress


### PR DESCRIPTION
Behavior-preserving MQL simplifications in `content/mondoo-oci-security.mql.yaml`, collapsing repetitive same-field `==` OR-chains into `containsNone()` / `in()` list forms.

- **Load-balancer TLS protocol denylists** → `containsNone([...])`: the `sslProtocols`/`protocols` checks that previously enumerated `none(_ == "TLSv1" || _ == "TLSv1.1" || _ == "SSLv3")` now use `containsNone(["TLSv1", "TLSv1.1", "SSLv3"])`.
- **ICMP ingress protocol** → `in([...])`: `_['protocol'] == "1" || _['protocol'] == "58" || _['protocol'] == "all"` collapsed to `_['protocol'].in(["1", "58", "all"])` in the VCN unrestricted-ICMP-ingress check.
- **Load-balancer listener protocol filters** → `in([...])`: `protocol == "HTTPS" || protocol == "HTTP2"` (and the `arguments['protocol']` / `change.after['protocol']` / `values['protocol']` accessor forms) collapsed to `.in(["HTTPS", "HTTP2"])` across the tls-minimum, no-weak-cipher-suites, and https-listener checks.

These changes span both the runtime checks and their Terraform HCL/plan/state variants.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)