### PR TITLE
content: simplify Windows security policy MQL using the in() function

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -877,7 +877,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolFailure || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure1)
+      auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolFailure, props.mondooWindowsSecurityAuditpolSuccessFailure1]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1137,7 +1137,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE922F-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE922F-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess3 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure3)
+      auditpol.where(subcategoryguid == "0CCE922F-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess3, props.mondooWindowsSecurityAuditpolSuccessFailure3]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1260,7 +1260,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9230-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9230-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess4 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure4)
+      auditpol.where(subcategoryguid == "0CCE9230-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess4, props.mondooWindowsSecurityAuditpolSuccessFailure4]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1385,7 +1385,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9231-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9231-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess5 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure5)
+      auditpol.where(subcategoryguid == "0CCE9231-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess5, props.mondooWindowsSecurityAuditpolSuccessFailure5]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1622,7 +1622,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9244-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9244-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolFailure6 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure7)
+      auditpol.where(subcategoryguid == "0CCE9244-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolFailure6, props.mondooWindowsSecurityAuditpolSuccessFailure7]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1952,7 +1952,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9249-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9249-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess9 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure9)
+      auditpol.where(subcategoryguid == "0CCE9249-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess9, props.mondooWindowsSecurityAuditpolSuccessFailure9]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2193,7 +2193,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9216-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9216-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess11 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure11)
+      auditpol.where(subcategoryguid == "0CCE9216-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess11, props.mondooWindowsSecurityAuditpolSuccessFailure11]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3057,7 +3057,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9248-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9248-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess18 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure17)
+      auditpol.where(subcategoryguid == "0CCE9248-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess18, props.mondooWindowsSecurityAuditpolSuccessFailure17]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3173,7 +3173,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE922B-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE922B-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess19 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure18)
+      auditpol.where(subcategoryguid == "0CCE922B-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess19, props.mondooWindowsSecurityAuditpolSuccessFailure18]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3408,7 +3408,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9237-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9237-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess21 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure20)
+      auditpol.where(subcategoryguid == "0CCE9237-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess21, props.mondooWindowsSecurityAuditpolSuccessFailure20]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3538,7 +3538,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9210-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9210-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess22 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure21)
+      auditpol.where(subcategoryguid == "0CCE9210-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess22, props.mondooWindowsSecurityAuditpolSuccessFailure21]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3656,7 +3656,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE9211-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9211-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess23 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure22)
+      auditpol.where(subcategoryguid == "0CCE9211-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess23, props.mondooWindowsSecurityAuditpolSuccessFailure22]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -4004,7 +4004,7 @@ queries:
           }
     mql: |
       auditpol.where(subcategoryguid == "0CCE921B-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE921B-69AE-11D9-BED3-505054503030").all(inclusionsetting == props.mondooWindowsSecurityAuditpolSuccess25 || inclusionsetting == props.mondooWindowsSecurityAuditpolSuccessFailure24)
+      auditpol.where(subcategoryguid == "0CCE921B-69AE-11D9-BED3-505054503030").all(inclusionsetting.in([props.mondooWindowsSecurityAuditpolSuccess25, props.mondooWindowsSecurityAuditpolSuccessFailure24]))
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies


### PR DESCRIPTION
Simplifies 13 audit-policy checks in the Windows security policy. Each previously asserted a two-value `inclusionsetting == A || inclusionsetting == B` OR-chain inside `.all(...)`; these now use `inclusionsetting.in([A, B])`.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)