### PR TITLE
content: simplify Hetzner policy MQL using containsNone()/notIn()

### DIFF
--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -541,7 +541,7 @@ queries:
           arguments['direction'] != "in" ||
           arguments['protocol'] != "tcp" ||
           arguments['port'] != "22" ||
-          arguments['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          arguments['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh-terraform-plan
@@ -552,7 +552,7 @@ queries:
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
           _['port'] != "22" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh-terraform-state
@@ -563,7 +563,7 @@ queries:
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
           _['port'] != "22" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
 
@@ -690,7 +690,7 @@ queries:
           arguments['direction'] != "in" ||
           arguments['protocol'] != "tcp" ||
           arguments['port'] != "3389" ||
-          arguments['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          arguments['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp-terraform-plan
@@ -701,7 +701,7 @@ queries:
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
           _['port'] != "3389" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp-terraform-state
@@ -712,7 +712,7 @@ queries:
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
           _['port'] != "3389" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
 
@@ -843,8 +843,8 @@ queries:
         blocks.where(type == "rule").all(
           arguments['direction'] != "in" ||
           arguments['protocol'] != "tcp" ||
-          arguments['port'] != "3306" && arguments['port'] != "5432" && arguments['port'] != "27017" && arguments['port'] != "6379" && arguments['port'] != "9092" && arguments['port'] != "9200" && arguments['port'] != "1433" ||
-          arguments['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          arguments['port'].notIn(["3306", "5432", "27017", "6379", "9092", "9200", "1433"]) ||
+          arguments['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports-terraform-plan
@@ -854,8 +854,8 @@ queries:
         change.after.rule == null || change.after.rule.all(
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
-          _['port'] != "3306" && _['port'] != "5432" && _['port'] != "27017" && _['port'] != "6379" && _['port'] != "9092" && _['port'] != "9200" && _['port'] != "1433" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['port'].notIn(["3306", "5432", "27017", "6379", "9092", "9200", "1433"]) ||
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports-terraform-state
@@ -865,8 +865,8 @@ queries:
         values.rule == null || values.rule.all(
           _['direction'] != "in" ||
           _['protocol'] != "tcp" ||
-          _['port'] != "3306" && _['port'] != "5432" && _['port'] != "27017" && _['port'] != "6379" && _['port'] != "9092" && _['port'] != "9200" && _['port'] != "1433" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['port'].notIn(["3306", "5432", "27017", "6379", "9092", "9200", "1433"]) ||
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
 
@@ -992,8 +992,8 @@ queries:
       terraform.resources.where(nameLabel == "hcloud_firewall").all(
         blocks.where(type == "rule").all(
           arguments['direction'] != "in" ||
-          arguments['port'] != "any" && arguments['port'] != "1-65535" && arguments['port'] != "0-65535" ||
-          arguments['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          arguments['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          arguments['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-all-ports-open-terraform-plan
@@ -1002,8 +1002,8 @@ queries:
       terraform.plan.resourceChanges.where(type == "hcloud_firewall").all(
         change.after.rule == null || change.after.rule.all(
           _['direction'] != "in" ||
-          _['port'] != "any" && _['port'] != "1-65535" && _['port'] != "0-65535" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
   - uid: mondoo-hetzner-security-firewall-no-all-ports-open-terraform-state
@@ -1012,8 +1012,8 @@ queries:
       terraform.state.resources.where(type == "hcloud_firewall").all(
         values.rule == null || values.rule.all(
           _['direction'] != "in" ||
-          _['port'] != "any" && _['port'] != "1-65535" && _['port'] != "0-65535" ||
-          _['source_ips'].none(_ == "0.0.0.0/0" || _ == "::/0")
+          _['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
 


### PR DESCRIPTION
Behavior-preserving MQL simplifications to the Hetzner firewall Terraform variants in `content/mondoo-hetzner-security.mql.yaml`.

- **no-unrestricted-ssh / no-unrestricted-rdp**: collapsed `source_ips.none(_ == "0.0.0.0/0" || _ == "::/0")` source-IP denylists to `source_ips.containsNone(["0.0.0.0/0", "::/0"])` across the HCL/plan/state Terraform variants.
- **no-unrestricted-db-ports**: same source-IP collapse, plus the negated `port != ...` AND-chain (`3306`/`5432`/`27017`/`6379`/`9092`/`9200`/`1433`) to `port.notIn([...])` across the Terraform variants.
- **no-all-ports-open**: same source-IP collapse, plus the negated `port != ...` AND-chain (`any`/`1-65535`/`0-65535`) to `port.notIn([...])` across the Terraform variants.

The `arguments['...']` (HCL) and `_['...']` (plan/state) accessors are preserved per variant, and the surrounding `||`-chains are unchanged.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)