### PR TITLE
content: simplify Arista EOS policy MQL using any()/in()

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -314,7 +314,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /^aaa authentication/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /^aaa authentication/)
     docs:
       desc: |
         This check verifies that Authentication, Authorization, and Accounting (AAA) is configured on the switch. AAA integrates with enterprise identity management systems to provide centralized authentication, access control, and audit logging.
@@ -1063,7 +1063,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /^logging host/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /^logging host/)
     docs:
       desc: |
         This check verifies that logs are sent to a remote syslog server for centralized management. Sending logs off-device protects them from loss due to device failure or compromise and enables correlation across the network.
@@ -1120,7 +1120,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /logging level/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /logging level/)
     docs:
       desc: |
         This check verifies that logging levels are configured for capturing important events. Setting appropriate logging levels ensures that security-relevant events are recorded without overwhelming the system with unnecessary detail.
@@ -1176,7 +1176,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /^banner login/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /^banner login/)
       arista.eos.runningConfig.content.contains("no banner login") == false
     docs:
       desc: |
@@ -1303,7 +1303,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /^banner motd/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /^banner motd/)
       arista.eos.runningConfig.content.contains("no banner motd") == false
     docs:
       desc: |
@@ -1533,7 +1533,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.where(_ == /^ntp server/).length > 0
+      arista.eos.runningConfig.content.lines.any(_ == /^ntp server/)
     docs:
       desc: |
         This check verifies that NTP servers are configured for time synchronization. Having explicitly configured NTP servers ensures the device synchronizes with trusted, reliable time sources.
@@ -2131,9 +2131,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      arista.eos.users.where(secret != "").all(
-        format == "sha512" || format == "sha256"
-      )
+      arista.eos.users.where(secret != "").all(format.in(["sha512", "sha256"]))
     docs:
       desc: |
         This check verifies that all user accounts use strong password encryption algorithms (SHA-512 or SHA-256). These cryptographically secure hash algorithms protect stored credentials from being recovered if the configuration is exposed.
@@ -2191,7 +2189,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      arista.eos.vlans.where(name.downcase != /^vlan/).length > 0
+      arista.eos.vlans.any(name.downcase != /^vlan/)
     docs:
       desc: |
         This check verifies that VLANs have descriptive names rather than default names. Descriptive VLAN names make the network configuration self-documenting, which is important for both operations and security.
@@ -2572,7 +2570,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       arista.eos.acls.all(
-        entries.where(action == "deny").length > 0
+        entries.any(action == "deny")
       )
     docs:
       desc: |


### PR DESCRIPTION
Behavior-preserving MQL simplifications to the Arista EOS security policy.

Checks changed:
- Running-config presence checks (`aaa authentication`, `logging host`, `logging level`, `banner login`, `banner motd`, `ntp server`) and the VLAN-name check: `where(C).length > 0` → `any(C)`
- ACL check: inner `entries.where(action == "deny").length > 0` → `entries.any(action == "deny")`
- Password format: `format == "sha512" || format == "sha256"` → `format.in(["sha512", "sha256"])`

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)