### PR TITLE
content: simplify DigitalOcean policy MQL using the notIn() function

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -1307,39 +1307,39 @@ queries:
   - uid: mondoo-digitalocean-security-db-engine-supported-version-digitalocean
     filters: asset.platform == "digitalocean"
     mql: |
-      digitalocean.databases.where(engine == "pg").all(version != "9" && version != "9.5" && version != "9.6" && version != "10" && version != "11" && version != "12" && version != "13")
-      digitalocean.databases.where(engine == "mysql").all(version != "5.6" && version != "5.7")
-      digitalocean.databases.where(engine == "redis").all(version != "4" && version != "5" && version != "6")
-      digitalocean.databases.where(engine == "mongodb").all(version != "3.6" && version != "4.0" && version != "4.2" && version != "4.4" && version != "5.0")
-      digitalocean.databases.where(engine == "kafka").all(version != "2.8" && version != "3.0" && version != "3.1" && version != "3.2" && version != "3.3" && version != "3.4")
-      digitalocean.databases.where(engine == "opensearch").all(version != "1.0" && version != "1.1" && version != "1.2" && version != "1.3")
+      digitalocean.databases.where(engine == "pg").all(version.notIn(["9", "9.5", "9.6", "10", "11", "12", "13"]))
+      digitalocean.databases.where(engine == "mysql").all(version.notIn(["5.6", "5.7"]))
+      digitalocean.databases.where(engine == "redis").all(version.notIn(["4", "5", "6"]))
+      digitalocean.databases.where(engine == "mongodb").all(version.notIn(["3.6", "4.0", "4.2", "4.4", "5.0"]))
+      digitalocean.databases.where(engine == "kafka").all(version.notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"]))
+      digitalocean.databases.where(engine == "opensearch").all(version.notIn(["1.0", "1.1", "1.2", "1.3"]))
   - uid: mondoo-digitalocean-security-db-engine-supported-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_database_cluster")
     mql: |
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "pg").all(arguments["version"] != "9" && arguments["version"] != "9.5" && arguments["version"] != "9.6" && arguments["version"] != "10" && arguments["version"] != "11" && arguments["version"] != "12" && arguments["version"] != "13")
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "mysql").all(arguments["version"] != "5.6" && arguments["version"] != "5.7")
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "redis").all(arguments["version"] != "4" && arguments["version"] != "5" && arguments["version"] != "6")
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "mongodb").all(arguments["version"] != "3.6" && arguments["version"] != "4.0" && arguments["version"] != "4.2" && arguments["version"] != "4.4" && arguments["version"] != "5.0")
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "kafka").all(arguments["version"] != "2.8" && arguments["version"] != "3.0" && arguments["version"] != "3.1" && arguments["version"] != "3.2" && arguments["version"] != "3.3" && arguments["version"] != "3.4")
-      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "opensearch").all(arguments["version"] != "1.0" && arguments["version"] != "1.1" && arguments["version"] != "1.2" && arguments["version"] != "1.3")
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "pg").all(arguments["version"].notIn(["9", "9.5", "9.6", "10", "11", "12", "13"]))
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "mysql").all(arguments["version"].notIn(["5.6", "5.7"]))
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "redis").all(arguments["version"].notIn(["4", "5", "6"]))
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "mongodb").all(arguments["version"].notIn(["3.6", "4.0", "4.2", "4.4", "5.0"]))
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "kafka").all(arguments["version"].notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"]))
+      terraform.resources.where(nameLabel == "digitalocean_database_cluster" && arguments["engine"] == "opensearch").all(arguments["version"].notIn(["1.0", "1.1", "1.2", "1.3"]))
   - uid: mondoo-digitalocean-security-db-engine-supported-version-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_database_cluster")
     mql: |
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "pg").all(change.after.version != "9" && change.after.version != "9.5" && change.after.version != "9.6" && change.after.version != "10" && change.after.version != "11" && change.after.version != "12" && change.after.version != "13")
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "mysql").all(change.after.version != "5.6" && change.after.version != "5.7")
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "redis").all(change.after.version != "4" && change.after.version != "5" && change.after.version != "6")
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "mongodb").all(change.after.version != "3.6" && change.after.version != "4.0" && change.after.version != "4.2" && change.after.version != "4.4" && change.after.version != "5.0")
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "kafka").all(change.after.version != "2.8" && change.after.version != "3.0" && change.after.version != "3.1" && change.after.version != "3.2" && change.after.version != "3.3" && change.after.version != "3.4")
-      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "opensearch").all(change.after.version != "1.0" && change.after.version != "1.1" && change.after.version != "1.2" && change.after.version != "1.3")
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "pg").all(change.after.version.notIn(["9", "9.5", "9.6", "10", "11", "12", "13"]))
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "mysql").all(change.after.version.notIn(["5.6", "5.7"]))
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "redis").all(change.after.version.notIn(["4", "5", "6"]))
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "mongodb").all(change.after.version.notIn(["3.6", "4.0", "4.2", "4.4", "5.0"]))
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "kafka").all(change.after.version.notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"]))
+      terraform.plan.resourceChanges.where(type == "digitalocean_database_cluster" && change.after.engine == "opensearch").all(change.after.version.notIn(["1.0", "1.1", "1.2", "1.3"]))
   - uid: mondoo-digitalocean-security-db-engine-supported-version-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_database_cluster")
     mql: |
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "pg").all(values.version != "9" && values.version != "9.5" && values.version != "9.6" && values.version != "10" && values.version != "11" && values.version != "12" && values.version != "13")
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "mysql").all(values.version != "5.6" && values.version != "5.7")
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "redis").all(values.version != "4" && values.version != "5" && values.version != "6")
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "mongodb").all(values.version != "3.6" && values.version != "4.0" && values.version != "4.2" && values.version != "4.4" && values.version != "5.0")
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "kafka").all(values.version != "2.8" && values.version != "3.0" && values.version != "3.1" && values.version != "3.2" && values.version != "3.3" && values.version != "3.4")
-      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "opensearch").all(values.version != "1.0" && values.version != "1.1" && values.version != "1.2" && values.version != "1.3")
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "pg").all(values.version.notIn(["9", "9.5", "9.6", "10", "11", "12", "13"]))
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "mysql").all(values.version.notIn(["5.6", "5.7"]))
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "redis").all(values.version.notIn(["4", "5", "6"]))
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "mongodb").all(values.version.notIn(["3.6", "4.0", "4.2", "4.4", "5.0"]))
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "kafka").all(values.version.notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"]))
+      terraform.state.resources.where(type == "digitalocean_database_cluster" && values.engine == "opensearch").all(values.version.notIn(["1.0", "1.1", "1.2", "1.3"]))
 
   # No Terraform variants: the check inspects the validity window of the CA certificate the cluster currently advertises — runtime telemetry that has no analog in digitalocean_database_cluster HCL. Terraform expresses desired cluster configuration; the CA is managed and rotated by DigitalOcean and only exposed by the live API.
   - uid: mondoo-digitalocean-security-db-ca-certificate-not-expired
@@ -2557,15 +2557,15 @@ queries:
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
     mql: |
-      terraform.resources.where(nameLabel == "digitalocean_spaces_bucket").all(arguments.acl != "public-read" && arguments.acl != "public-read-write")
+      terraform.resources.where(nameLabel == "digitalocean_spaces_bucket").all(arguments.acl.notIn(["public-read", "public-read-write"]))
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_spaces_bucket")
     mql: |
-      terraform.plan.resourceChanges.where(type == "digitalocean_spaces_bucket").all(change.after.acl != "public-read" && change.after.acl != "public-read-write")
+      terraform.plan.resourceChanges.where(type == "digitalocean_spaces_bucket").all(change.after.acl.notIn(["public-read", "public-read-write"]))
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_bucket")
     mql: |
-      terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(values.acl != "public-read" && values.acl != "public-read-write")
+      terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(values.acl.notIn(["public-read", "public-read-write"]))
 
   # No Terraform variants: the DigitalOcean Terraform provider's `digitalocean_spaces_bucket.acl` argument exposes only `"private"` and `"public-read"` — the S3-compatible `public-read-write` ACL must be applied through the runtime S3 API, so there is no HCL surface to inspect for it. The runtime variant catches buckets where it was set out of band.
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-writable


### PR DESCRIPTION
Simplifies negated `!= a && != b && ...` AND-chains into `notIn([...])` calls in the DigitalOcean security policy. Each chain tests a single string field, so the collapse is behavior-preserving.

- **`db-engine-supported-version`**: six per-engine version chains (pg, mysql, redis, mongodb, kafka, opensearch) across the runtime check and all three Terraform variants (HCL, plan, state).
- **`spaces-bucket-not-publicly-readable`**: the ACL chain across the three Terraform variants (HCL, plan, state).

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)