### PR TITLE
content: simplify Proxmox policy MQL using in()/none()/any()

### DIFF
--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -530,9 +530,7 @@ queries:
       - title: Proxmox VE Cluster SSH Requirements
         url: https://pve.proxmox.com/wiki/Cluster_Manager#_preparation
     mql: |
-      sshd.config.params["PermitRootLogin"] == "prohibit-password" ||
-      sshd.config.params["PermitRootLogin"] == "without-password" ||
-      sshd.config.params["PermitRootLogin"] == "forced-commands-only"
+      sshd.config.params["PermitRootLogin"].in(["prohibit-password", "without-password", "forced-commands-only"])
     docs:
       desc: |
         This check ensures that SSH root login on Proxmox nodes is permitted only with a key and never with a password. Proxmox VE relies on root SSH access for cluster operations and live migration, so the standard Linux baseline value of PermitRootLogin no would break the cluster, while prohibit-password keeps key-based access working safely.
@@ -867,7 +865,7 @@ queries:
       - title: CWE-258 Empty Password in Configuration File
         url: https://cwe.mitre.org/data/definitions/258.html
     mql: |
-      file("/etc/shadow").content.lines.where(_ == /^[^:]+::/).length == 0
+      file("/etc/shadow").content.lines.none(_ == /^[^:]+::/)
     docs:
       desc: |
         This check ensures that no account in /etc/shadow has an empty password field on a Proxmox node. An empty hash lets the account authenticate with no credential at all, which is one of the most direct routes onto a host.
@@ -985,7 +983,7 @@ queries:
     mql: |
       file("/etc/pve/firewall/cluster.fw") {
         exists
-        content.lines.where(_ == /^enable:\s*1/).length > 0
+        content.lines.any(_ == /^enable:\s*1/)
       }
     docs:
       desc: |
@@ -1084,7 +1082,7 @@ queries:
     mql: |
       file("/etc/pve/firewall/cluster.fw") {
         exists
-        content.lines.where(_ == /^policy_in:\s*DROP/).length > 0
+        content.lines.any(_ == /^policy_in:\s*DROP/)
       }
     docs:
       desc: |
@@ -1211,7 +1209,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       files.find(from: "/etc/pve/nodes", regex: "host.fw$", type: "file").list.all(
-        file(_.path).content.lines.where(_ == /^enable:\s*1/).length > 0
+        file(_.path).content.lines.any(_ == /^enable:\s*1/)
       )
     docs:
       desc: |
@@ -1312,7 +1310,7 @@ queries:
     mql: |
       file("/etc/pve/firewall/cluster.fw") {
         exists
-        content.lines.where(_ == /^(IN|OUT|GROUP)/).length > 0
+        content.lines.any(_ == /^(IN|OUT|GROUP)/)
       }
     docs:
       desc: |
@@ -2472,7 +2470,7 @@ queries:
         url: https://cwe.mitre.org/data/definitions/400.html
     mql: |
       files.find(from: "/etc/pve/lxc", regex: "[0-9]+.conf$", type: "file").list.all(
-        file(_.path).content.lines.where(_ == /^memory:/).length > 0
+        file(_.path).content.lines.any(_ == /^memory:/)
       )
     docs:
       desc: |
@@ -2857,7 +2855,7 @@ queries:
         url: https://cwe.mitre.org/data/definitions/94.html
     mql: |
       files.find(from: "/etc/pve/qemu-server", regex: "[0-9]+.conf$", type: "file").list.all(
-        file(_.path).content.lines.where(_ == /^args:/).length == 0
+        file(_.path).content.lines.none(_ == /^args:/)
       )
     docs:
       desc: |
@@ -4407,8 +4405,7 @@ queries:
       - title: CVE-2022-23222 eBPF privilege escalation
         url: https://nvd.nist.gov/vuln/detail/CVE-2022-23222
     mql: |
-      kernel.parameters["kernel.unprivileged_bpf_disabled"] == 1 ||
-      kernel.parameters["kernel.unprivileged_bpf_disabled"] == 2
+      kernel.parameters["kernel.unprivileged_bpf_disabled"].inRange(1, 2)
     docs:
       desc: |
         This check ensures that the kernel is configured to disable BPF for unprivileged users by setting `kernel.unprivileged_bpf_disabled` to `1` or `2`. Unprivileged BPF has been a recurring source of privilege-escalation flaws, and a value of `2` also makes the setting itself immutable until reboot.
@@ -5223,8 +5220,7 @@ queries:
       - title: CWE-916 Use of Password Hash With Insufficient Computational Effort
         url: https://cwe.mitre.org/data/definitions/916.html
     mql: |
-      logindefs.params["ENCRYPT_METHOD"].trim == "SHA512" ||
-      logindefs.params["ENCRYPT_METHOD"].trim == "YESCRYPT"
+      logindefs.params["ENCRYPT_METHOD"].trim.in(["SHA512", "YESCRYPT"])
     docs:
       desc: |
         This check ensures that `/etc/login.defs` is configured with an `ENCRYPT_METHOD` of `SHA512` or `YESCRYPT` so that new password hashes use a strong algorithm. This setting controls the algorithm used by `passwd` and `chpasswd`, and weaker choices such as DES or MD5 must not be used. Existing hashes are not rewritten until each user changes their password.


### PR DESCRIPTION
Behavior-preserving MQL simplifications in `content/mondoo-proxmox-security.mql.yaml`. No control objectives change.

**String OR-chains collapsed into `in([...])`:**
- SSH `PermitRootLogin` allowed values
- `ENCRYPT_METHOD` password-hashing algorithm

**`where(C).length > 0` converted to `any(C)`:**
- cluster firewall enabled (`enable: 1`)
- cluster default-deny input policy (`policy_in: DROP`)
- per-node host firewall enabled (`enable: 1`)
- cluster firewall rules present (`IN|OUT|GROUP`)
- LXC memory limit present (`memory:`)

**`where(C).length == 0` converted to `none(C)`:**
- `/etc/shadow` empty-password lines
- qemu-server `args:` lines

**Integer kernel-parameter check:**
- `kernel.unprivileged_bpf_disabled == 1 || == 2` rewritten as `inRange(1, 2)`. Applied as `inRange` (not `.in`, which is string-only); lint accepts it.

Behavior-preserving. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)