### PR TITLE
fix: correct AWS Access Analyzer MQL in inventory querypack

### DIFF
--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -310,7 +310,7 @@ queries:
   - uid: mondoo-asset-inventory-aws-access-analyzer-all
     filters: asset.platform == "aws"
     mql: |
-      aws.accessAnalyzer.analyzers
+      aws.iam.accessAnalyzer.analyzer
 
   - uid: mondoo-asset-inventory-aws-acm-certificates
     title: Certificate Manager certificates


### PR DESCRIPTION
## Summary

Fixes the AWS Access Analyzer query in the `mondoo-aws-inventory` querypack. The query referenced `aws.accessAnalyzer.analyzers`, which is not a valid resource and fails to compile. Updated it to the correct `aws.iam.accessAnalyzer.analyzer`.

## Test plan

- `cnspec policy lint ./content/querypacks/mondoo-aws-inventory.mql.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)