### PR TITLE
fix: correct AWS Access Analyzer field name in inventory querypack

### DIFF
--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -310,7 +310,7 @@ queries:
   - uid: mondoo-asset-inventory-aws-access-analyzer-all
     filters: asset.platform == "aws"
     mql: |
-      aws.iam.accessAnalyzer.analyzer
+      aws.iam.accessAnalyzer.analyzers
 
   - uid: mondoo-asset-inventory-aws-acm-certificates
     title: Certificate Manager certificates


### PR DESCRIPTION
## Summary

The `mondoo-asset-inventory-aws-access-analyzer-all` query referenced `aws.iam.accessAnalyzer.analyzer` (singular), which is not a valid field on the resource. This corrects it to the plural `analyzers` field so the inventory query returns IAM Access Analyzer data.

## Changes

- `content/querypacks/mondoo-aws-inventory.mql.yaml`: `aws.iam.accessAnalyzer.analyzer` → `aws.iam.accessAnalyzer.analyzers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)