### PR TITLE
feat(scan): add --collect-support-bundle for issue analysis

### DIFF
--- a/apps/cnspec/cmd/aibom.go
+++ b/apps/cnspec/cmd/aibom.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -86,7 +87,9 @@ var aibomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *p
 	conf.Bundle = pb
 	conf.IsIncognito = true
 
-	report, err := RunScan(conf, scan.DisableProgressBar())
+	ctx := setupDebugDumps(context.Background(), "cnspec-aibom-debug")
+
+	report, err := RunScan(ctx, conf, scan.DisableProgressBar())
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}

--- a/apps/cnspec/cmd/sbom.go
+++ b/apps/cnspec/cmd/sbom.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -16,7 +17,7 @@ import (
 	"go.mondoo.com/cnspec/v13/internal/sbom"
 	"go.mondoo.com/cnspec/v13/internal/sbom/generator"
 	"go.mondoo.com/cnspec/v13/internal/sbom/pack"
-	"go.mondoo.com/mql/v13/logger"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -74,6 +75,9 @@ Note this command is experimental and may change in the future.
 
 var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
 	log.Info().Msg("This command is experimental. Please report any issues to https://github.com/mondoohq/cnspec.")
+
+	ctx := setupDebugDumps(context.Background(), "cnspec-sbom-debug")
+
 	pb, err := pack.QueryPack()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load query pack")
@@ -89,7 +93,7 @@ var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	conf.Bundle = pb
 	conf.IsIncognito = true
 
-	report, err := RunScan(conf)
+	report, err := RunScan(ctx, conf)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}
@@ -98,7 +102,7 @@ var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	if err == nil {
 		log.Debug().Msg("converted report to proto")
 		data, _ := cnspecReport.ToJSON()
-		logger.DebugDumpJSON("mondoo-sbom-report", data)
+		scandump.JSON(ctx, "sbom-report", data)
 	}
 
 	boms := generator.GenerateBom(cnspecReport.ToCnqueryReport())

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -18,6 +20,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnspec/v13/cli/reporter"
 	"go.mondoo.com/cnspec/v13/internal/datalakes/sqlite"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/cnspec/v13/internal/supportbundle"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/cnspec/v13/policy/scan"
@@ -162,8 +165,8 @@ To manually configure a policy, use this:
 var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
 	ctx := context.Background()
 
-	// Set up the support bundle BEFORE anything else so we capture early
-	// failures too. The bundle redirects DEBUG dumps and tees logs to a file.
+	// Wire up debug dumping: --collect-support-bundle takes precedence over
+	// DEBUG=1, which produces just the dump directory without manifest/log.
 	var support *supportbundle.Bundle
 	if viper.GetBool("collect-support-bundle") {
 		var err error
@@ -172,16 +175,18 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 			log.Fatal().Err(err).Msg("failed to prepare support bundle")
 		}
 		support.Args = os.Args
-		if err := support.Activate(); err != nil {
+		ctx, err = support.Activate(ctx)
+		if err != nil {
 			log.Fatal().Err(err).Msg("failed to activate support bundle")
 		}
-		// Wrap the logger to flush the bundle on any Fatal log. zerolog calls
-		// os.Exit(1) after Fatal hooks run, so this is our only chance to
-		// finalize on log.Fatal paths.
+		// zerolog calls os.Exit(1) after Fatal hooks run, so HookFatal is
+		// our only chance to flush on log.Fatal paths.
 		support.HookFatal()
-		// Defer catches panics and normal returns; explicit calls before
-		// os.Exit cover the exit-1 branches below.
+		// Defer covers panics and normal returns; the os.Exit branches below
+		// call FinalizeAndAnnounce directly.
 		defer support.FinalizeAndAnnounce(os.Stderr)
+	} else {
+		ctx = setupDebugDumps(ctx, "cnspec-debug")
 	}
 
 	conf, err := getCobraScanConfig(cmd, runtime, cliRes)
@@ -193,13 +198,18 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to resolve policies")
 	}
+	// Dump the aggregated bundle at the run level (used to fire inside
+	// policy.BundleLoader.BundleFromPaths via the mql logger; moved here so
+	// it can be ctx-aware and only fires for scan, not policy lint).
+	scandump.YAML(ctx, "resolved_mql_bundle.mql", conf.Bundle)
 
-	report, err := RunScan(conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")))
+	report, err := RunScan(ctx, conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}
 
-	logger.DebugDumpJSON("report", report)
+	scandump.JSON(ctx, "report", report)
+	recordResolvedAssets(ctx, report)
 
 	handlerConf := reporter.HandlerConfig{
 		Format:        conf.OutputFormat,
@@ -217,12 +227,8 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Fatal().Err(err).Msg("failed to write report to output target")
 	}
 
-	if support != nil {
-		support.RecordResolvedAssets(report)
-	}
-
-	// if we had asset errors, we return a non-zero exit code
-	// asset errors are only connection issues
+	// If we had asset errors or the worst-case score exceeds the threshold,
+	// return non-zero. Flush the support bundle first so the user gets it.
 	if report != nil {
 		if len(report.Errors) > 0 {
 			if support != nil {
@@ -238,6 +244,50 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 			os.Exit(1)
 		}
 	}
+}
+
+// isDebugDumpEnabled mirrors the gate the cnspec logger uses to flip into
+// debug level (DEBUG=1 or DEBUG=true). TRACE=1 also flips logging but doesn't
+// need to imply dump capture — DEBUG is the user's "I want files" signal.
+func isDebugDumpEnabled() bool {
+	v := os.Getenv("DEBUG")
+	return v == "1" || v == "true"
+}
+
+// setupDebugDumps wires a scandump.Run when DEBUG=1 is set and returns the
+// augmented context. The dirPrefix is the directory name to use ("cnspec-debug",
+// "cnspec-sbom-debug", etc.) — a timestamp is appended. Used by sbom and vuln
+// which don't have the --collect-support-bundle flag but should still
+// benefit from the per-asset folder layout when DEBUG=1.
+func setupDebugDumps(ctx context.Context, dirPrefix string) context.Context {
+	if !isDebugDumpEnabled() {
+		return ctx
+	}
+	runDir := dirPrefix + "-" + time.Now().UTC().Format("20060102T150405Z")
+	run, err := scandump.NewRun(runDir)
+	if err != nil {
+		log.Warn().Err(err).Str("dir", runDir).Msg("failed to set up debug dumps; continuing without")
+		return ctx
+	}
+	logger.DumpLocal = filepath.Join(run.Dir, "mondoo-debug-")
+	log.Info().Str("dir", run.Dir).Msg("debug dumps will be written here")
+	return scandump.WithRun(ctx, run)
+}
+
+// recordResolvedAssets dumps the asset list as the scan saw them, so support
+// can see what got resolved from the inventory.
+func recordResolvedAssets(ctx context.Context, report *policy.ReportCollection) {
+	if report == nil {
+		return
+	}
+	resolved := struct {
+		Assets map[string]*inventory.Asset `json:"assets"`
+		Errors map[string]string           `json:"errors,omitempty"`
+	}{
+		Assets: report.Assets,
+		Errors: report.Errors,
+	}
+	scandump.JSON(ctx, "assets-resolved", resolved)
 }
 
 // helper method to retrieve the list of policies for autocomplete
@@ -585,7 +635,7 @@ func (c *scanConfig) loadPolicies(ctx context.Context) error {
 	return nil
 }
 
-func RunScan(config *scanConfig, scannerOpts ...scan.ScannerOption) (*policy.ReportCollection, error) {
+func RunScan(parentCtx context.Context, config *scanConfig, scannerOpts ...scan.ScannerOption) (*policy.ReportCollection, error) {
 	opts := scannerOpts
 	if config.runtime.UpstreamConfig != nil {
 		opts = append(opts, scan.WithUpstream(config.runtime.UpstreamConfig))
@@ -593,7 +643,10 @@ func RunScan(config *scanConfig, scannerOpts ...scan.ScannerOption) (*policy.Rep
 	opts = append(opts, scan.WithRecording(config.runtime.Recording()))
 
 	scanner := scan.NewLocalScanner(opts...)
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// parentCtx carries scandump.WithRun (when debug dumping is on) plus
+	// anything the caller wants surfaced; signal.NotifyContext layers
+	// interrupt cancellation on top.
+	ctx, stop := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	ctx = mql.SetFeatures(ctx, config.Features)
 	// Carry --output-scan-db through ctx so the SQLite datalake knows where

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnspec/v13/cli/reporter"
 	"go.mondoo.com/cnspec/v13/internal/datalakes/sqlite"
+	"go.mondoo.com/cnspec/v13/internal/supportbundle"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/cnspec/v13/policy/scan"
 	"go.mondoo.com/mql/v13"
@@ -83,6 +84,8 @@ func init() {
 	_ = scanCmd.Flags().Int("parallelism", 1, "Set the number of assets to scan in parallel. A value of 0 or 1 means sequential")
 	_ = scanCmd.Flags().String("output-scan-db", "", "Save each asset's scan database (SQLite) to this directory in addition to uploading. Used to capture seeds for the cnspec loadtest tool")
 	_ = scanCmd.Flags().MarkHidden("output-scan-db")
+	_ = scanCmd.Flags().Bool("collect-support-bundle", false, "Collect a support bundle (debug logs, asset bundle, inventory, resolved policy, report, provider versions) for sharing with Mondoo support. By default writes to a timestamped directory in the current working dir; override with --support-bundle-dir.")
+	_ = scanCmd.Flags().String("support-bundle-dir", "", "Directory to write the support bundle into. Only used when --collect-support-bundle is set. Defaults to ./cnspec-support-bundle-<timestamp>/.")
 }
 
 var scanCmd = &cobra.Command{
@@ -143,6 +146,8 @@ To manually configure a policy, use this:
 		_ = viper.BindPFlag("output-target", cmd.Flags().Lookup("output-target"))
 		_ = viper.BindPFlag("parallelism", cmd.Flags().Lookup("parallelism"))
 		_ = viper.BindPFlag("output-scan-db", cmd.Flags().Lookup("output-scan-db"))
+		_ = viper.BindPFlag("collect-support-bundle", cmd.Flags().Lookup("collect-support-bundle"))
+		_ = viper.BindPFlag("support-bundle-dir", cmd.Flags().Lookup("support-bundle-dir"))
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -156,6 +161,28 @@ To manually configure a policy, use this:
 
 var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
 	ctx := context.Background()
+
+	// Set up the support bundle BEFORE anything else so we capture early
+	// failures too. The bundle redirects DEBUG dumps and tees logs to a file.
+	var support *supportbundle.Bundle
+	if viper.GetBool("collect-support-bundle") {
+		var err error
+		support, err = supportbundle.New(viper.GetString("support-bundle-dir"))
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to prepare support bundle")
+		}
+		support.Args = os.Args
+		if err := support.Activate(); err != nil {
+			log.Fatal().Err(err).Msg("failed to activate support bundle")
+		}
+		// Wrap the logger to flush the bundle on any Fatal log. zerolog calls
+		// os.Exit(1) after Fatal hooks run, so this is our only chance to
+		// finalize on log.Fatal paths.
+		support.HookFatal()
+		// Defer catches panics and normal returns; explicit calls before
+		// os.Exit cover the exit-1 branches below.
+		defer support.FinalizeAndAnnounce(os.Stderr)
+	}
 
 	conf, err := getCobraScanConfig(cmd, runtime, cliRes)
 	if err != nil {
@@ -190,14 +217,24 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Fatal().Err(err).Msg("failed to write report to output target")
 	}
 
+	if support != nil {
+		support.RecordResolvedAssets(report)
+	}
+
 	// if we had asset errors, we return a non-zero exit code
 	// asset errors are only connection issues
 	if report != nil {
 		if len(report.Errors) > 0 {
+			if support != nil {
+				support.FinalizeAndAnnounce(os.Stderr)
+			}
 			os.Exit(1)
 		}
 
 		if (100 - report.GetWorstScore()) >= uint32(conf.RiskThreshold) {
+			if support != nil {
+				support.FinalizeAndAnnounce(os.Stderr)
+			}
 			os.Exit(1)
 		}
 	}

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -154,7 +154,7 @@ var serveCmd = &cobra.Command{
 				}
 			}
 			// TODO: check in every 5 min via timer, init time in Background job
-			result, err := RunScan(scanConf, scan.DisableProgressBar(), scan.WithReportType(scan.ReportType_ERROR))
+			result, err := RunScan(ctx, scanConf, scan.DisableProgressBar(), scan.WithReportType(scan.ReportType_ERROR))
 			if err != nil {
 				return cli_errors.NewCommandError(errors.Wrap(err, "could not successfully complete scan"), 1)
 			}

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -4,13 +4,15 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnspec/v13/cli/reporter"
 	"go.mondoo.com/cnspec/v13/internal/sbom/generator"
 	"go.mondoo.com/cnspec/v13/internal/sbom/pack"
-	"go.mondoo.com/mql/v13/logger"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/mvd"
@@ -44,6 +46,8 @@ var vulnCmd = &cobra.Command{
 }
 
 var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
+	dumpCtx := setupDebugDumps(context.Background(), "cnspec-vuln-debug")
+
 	pb, err := pack.QueryPack()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load sbom query pack")
@@ -64,7 +68,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Fatal().Err(err).Msg("failed to parse config for reporter")
 	}
 
-	report, err := RunScan(conf)
+	report, err := RunScan(dumpCtx, conf)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}
@@ -73,7 +77,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	if err == nil {
 		log.Debug().Msg("converted report to proto")
 		data, _ := cnspecReport.ToJSON()
-		logger.DebugDumpJSON("mondoo-sbom-report", data)
+		scandump.JSON(dumpCtx, "sbom-report", data)
 	}
 
 	boms := generator.GenerateBom(cnspecReport.ToCnqueryReport())
@@ -134,7 +138,7 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 
 	// print the output using the specified output format
 	r := reporter.NewReporter(printConf, false)
-	logger.DebugDumpJSON("vulnReport", report)
+	scandump.JSON(dumpCtx, "vulnReport", report)
 	if err := r.PrintVulns(vulnReport, bom.Asset.Name); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")
 	}

--- a/internal/scandump/scandump.go
+++ b/internal/scandump/scandump.go
@@ -1,0 +1,238 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package scandump captures the per-scan debug artifacts (asset bundle,
+// inventory, resolved policy, report, graph .dot files, …) into a single
+// directory tree organized per asset. A scan can target many assets in one
+// invocation; each asset gets its own subdirectory so files from concurrent
+// or sequential assets don't overwrite each other.
+//
+// The target directory is plumbed through context.Context. Call WithRun at
+// the entry point of the command, then WithAsset before per-asset work
+// begins. JSON, YAML, and Create are no-ops when no Run is attached.
+package scandump
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"sigs.k8s.io/yaml"
+)
+
+// Run owns a per-scan-invocation output directory. The Dir field is what
+// callers want when constructing paths for things scandump doesn't write
+// itself (e.g. the support bundle's debug.log).
+type Run struct {
+	Dir string
+
+	mu        sync.Mutex
+	usedNames map[string]int
+}
+
+// NewRun creates a Run rooted at dir. An empty dir returns an inactive Run
+// — every helper is a no-op against it — which lets callers feed in their
+// "do we want dumps?" decision without scattering nil checks.
+func NewRun(dir string) (*Run, error) {
+	if dir == "" {
+		return &Run{}, nil
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to resolve scandump path")
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return nil, errors.Wrap(err, "failed to create scandump directory")
+	}
+	return &Run{Dir: abs, usedNames: map[string]int{}}, nil
+}
+
+// Active reports whether the Run will write files. Useful for skipping
+// expensive work (e.g. fetching the asset bundle) when dumping is off.
+func (r *Run) Active() bool {
+	return r != nil && r.Dir != ""
+}
+
+// AssetDir reserves a subdirectory for the given asset name. The first call
+// for a name returns "<root>/<name>"; subsequent calls return "<name>-1",
+// "<name>-2", …. The directory is created before returning.
+//
+// Names go through sanitize to keep the filesystem happy.
+func (r *Run) AssetDir(name string) (string, error) {
+	if !r.Active() {
+		return "", nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	base := sanitize(name)
+	if base == "" {
+		base = "asset"
+	}
+	n := r.usedNames[base]
+	final := base
+	if n > 0 {
+		final = base + "-" + strconv.Itoa(n)
+	}
+	r.usedNames[base] = n + 1
+
+	dir := filepath.Join(r.Dir, final)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", errors.Wrapf(err, "failed to create asset dump directory %q", dir)
+	}
+	return dir, nil
+}
+
+type ctxKey struct{}
+
+// scope is what the context carries: the Run (so children can register more
+// assets) plus the current writeDir. writeDir empty means "fall back to
+// Run.Dir" — useful for run-level dumps like the final report.
+type scope struct {
+	run      *Run
+	writeDir string
+}
+
+// WithRun attaches r to ctx. Run-level dump calls (no per-asset scope) will
+// write to r.Dir.
+func WithRun(ctx context.Context, r *Run) context.Context {
+	if !r.Active() {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, &scope{run: r})
+}
+
+// WithAsset reserves a per-asset directory and returns a ctx whose dump
+// helpers write into it. If ctx has no Run attached, WithAsset is a no-op
+// and returns ctx unchanged.
+//
+// The returned (string, error) is the asset directory path (useful for
+// logging) and any mkdir failure. A nil error with empty path means dumps
+// are disabled in this ctx.
+func WithAsset(ctx context.Context, name string) (context.Context, string, error) {
+	s, _ := ctx.Value(ctxKey{}).(*scope)
+	if s == nil || !s.run.Active() {
+		return ctx, "", nil
+	}
+	dir, err := s.run.AssetDir(name)
+	if err != nil {
+		return ctx, "", err
+	}
+	return context.WithValue(ctx, ctxKey{}, &scope{run: s.run, writeDir: dir}), dir, nil
+}
+
+// FromContext returns the active dump directory and whether dumping is on.
+// Most callers should prefer JSON/YAML/Create; this is for tests and for
+// callers that need to hand a path to other code (e.g. a graph writer).
+func FromContext(ctx context.Context) (string, bool) {
+	s, _ := ctx.Value(ctxKey{}).(*scope)
+	if s == nil {
+		return "", false
+	}
+	if s.writeDir != "" {
+		return s.writeDir, true
+	}
+	if s.run.Active() {
+		return s.run.Dir, true
+	}
+	return "", false
+}
+
+// Active reports whether ctx has a writable Run/Asset scope attached.
+func Active(ctx context.Context) bool {
+	_, ok := FromContext(ctx)
+	return ok
+}
+
+// JSON writes obj as pretty JSON to <scope>/<name>.json. No-op when ctx has
+// no active scope. Errors are intentionally swallowed (logged as warnings)
+// — dump failures should not abort a scan.
+func JSON(ctx context.Context, name string, obj any) {
+	dir, ok := FromContext(ctx)
+	if !ok {
+		return
+	}
+	raw, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		warn(name, errors.Wrap(err, "marshal JSON"))
+		return
+	}
+	path := filepath.Join(dir, name+".json")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		warn(name, errors.Wrap(err, "write JSON"))
+	}
+}
+
+// YAML writes obj as YAML to <scope>/<name>.yaml. No-op when ctx has no
+// active scope.
+func YAML(ctx context.Context, name string, obj any) {
+	dir, ok := FromContext(ctx)
+	if !ok {
+		return
+	}
+	raw, err := yaml.Marshal(obj)
+	if err != nil {
+		warn(name, errors.Wrap(err, "marshal YAML"))
+		return
+	}
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		warn(name, errors.Wrap(err, "write YAML"))
+	}
+}
+
+// Create opens <scope>/<filename> for writing. Returns (nil, nil) when ctx
+// has no active scope — the typical caller pattern is:
+//
+//	f, err := scandump.Create(ctx, "graph.dot")
+//	if err != nil { … }
+//	if f == nil { return }
+//	defer f.Close()
+//	// …
+//
+// Caller is responsible for closing the file.
+func Create(ctx context.Context, filename string) (*os.File, error) {
+	dir, ok := FromContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+	return os.Create(filepath.Join(dir, filename))
+}
+
+// sanitize keeps letters, digits, and "._-"; everything else becomes "_".
+// We want stable, predictable directory names — asset names can contain
+// slashes, colons (MRNs), spaces, etc.
+func sanitize(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.' || r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// warn is the central place to deal with dump failures. We don't import
+// zerolog here because importing it pulls in side-effecting init code; the
+// dump helpers should be safe to use from anywhere. Failures end up on
+// stderr.
+var warn = func(name string, err error) {
+	// Best-effort logging; ignore errors writing to stderr.
+	_, _ = os.Stderr.WriteString("scandump: " + name + ": " + err.Error() + "\n")
+}

--- a/internal/scandump/scandump_test.go
+++ b/internal/scandump/scandump_test.go
@@ -1,0 +1,236 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scandump
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRun_EmptyPath_ReturnsInactive(t *testing.T) {
+	r, err := NewRun("")
+	require.NoError(t, err)
+	assert.False(t, r.Active(), "empty path should produce an inactive Run that no-ops")
+}
+
+func TestNewRun_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "run")
+	r, err := NewRun(dir)
+	require.NoError(t, err)
+	assert.True(t, r.Active())
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestAssetDir_DedupesDuplicateNames(t *testing.T) {
+	r, err := NewRun(t.TempDir())
+	require.NoError(t, err)
+
+	d1, err := r.AssetDir("webserver")
+	require.NoError(t, err)
+	d2, err := r.AssetDir("webserver")
+	require.NoError(t, err)
+	d3, err := r.AssetDir("webserver")
+	require.NoError(t, err)
+
+	assert.Equal(t, "webserver", filepath.Base(d1),
+		"first occurrence of a name should keep the bare name")
+	assert.Equal(t, "webserver-1", filepath.Base(d2),
+		"second occurrence should get -1 suffix")
+	assert.Equal(t, "webserver-2", filepath.Base(d3),
+		"third occurrence should get -2 suffix")
+}
+
+func TestAssetDir_DifferentNamesNoCollision(t *testing.T) {
+	r, err := NewRun(t.TempDir())
+	require.NoError(t, err)
+
+	d1, err := r.AssetDir("alpha")
+	require.NoError(t, err)
+	d2, err := r.AssetDir("beta")
+	require.NoError(t, err)
+	d3, err := r.AssetDir("alpha")
+	require.NoError(t, err)
+
+	assert.Equal(t, "alpha", filepath.Base(d1))
+	assert.Equal(t, "beta", filepath.Base(d2))
+	assert.Equal(t, "alpha-1", filepath.Base(d3),
+		"name reuse counts independently per base name")
+}
+
+func TestAssetDir_SanitizesProblematicCharacters(t *testing.T) {
+	r, err := NewRun(t.TempDir())
+	require.NoError(t, err)
+
+	// Asset names can contain slashes (paths), colons (MRNs), spaces, etc.
+	dir, err := r.AssetDir("//policy.api.mondoo.com/assets/abc:def 123")
+	require.NoError(t, err)
+	base := filepath.Base(dir)
+	// No path-separating runes left.
+	assert.NotContains(t, base, "/")
+	assert.NotContains(t, base, ":")
+	assert.NotContains(t, base, " ")
+}
+
+func TestAssetDir_EmptyNameFallsBackToAsset(t *testing.T) {
+	r, err := NewRun(t.TempDir())
+	require.NoError(t, err)
+
+	dir, err := r.AssetDir("")
+	require.NoError(t, err)
+	assert.Equal(t, "asset", filepath.Base(dir),
+		"empty asset name should fall back to a generic placeholder")
+}
+
+func TestAssetDir_InactiveRunReturnsEmpty(t *testing.T) {
+	r, err := NewRun("")
+	require.NoError(t, err)
+
+	dir, err := r.AssetDir("anything")
+	require.NoError(t, err)
+	assert.Empty(t, dir, "inactive Run must not pretend to allocate directories")
+}
+
+func TestContext_NoRun_DumpsAreNoOps(t *testing.T) {
+	ctx := context.Background()
+	// Should not panic, should not write anywhere.
+	JSON(ctx, "anything", map[string]string{"x": "y"})
+	YAML(ctx, "anything", map[string]string{"x": "y"})
+	f, err := Create(ctx, "anything.dot")
+	require.NoError(t, err)
+	assert.Nil(t, f, "Create with no scope should return (nil, nil)")
+	assert.False(t, Active(ctx))
+}
+
+func TestContext_RunOnly_WritesAtRunRoot(t *testing.T) {
+	dir := t.TempDir()
+	r, err := NewRun(dir)
+	require.NoError(t, err)
+	ctx := WithRun(context.Background(), r)
+
+	JSON(ctx, "manifest", map[string]string{"hello": "world"})
+
+	raw, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	require.NoError(t, err)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, "world", got["hello"])
+}
+
+func TestContext_PerAsset_WritesUnderAssetDir(t *testing.T) {
+	root := t.TempDir()
+	r, err := NewRun(root)
+	require.NoError(t, err)
+
+	ctx := WithRun(context.Background(), r)
+	ctx, assetDir, err := WithAsset(ctx, "webserver")
+	require.NoError(t, err)
+	require.NotEmpty(t, assetDir)
+
+	JSON(ctx, "report", map[string]int{"score": 80})
+
+	raw, err := os.ReadFile(filepath.Join(assetDir, "report.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"score": 80`)
+
+	// And nothing was written at the run root.
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.True(t, e.IsDir(), "run root should only contain asset dirs, found file %q", e.Name())
+	}
+}
+
+func TestContext_MultipleAssets_Isolated(t *testing.T) {
+	root := t.TempDir()
+	r, err := NewRun(root)
+	require.NoError(t, err)
+	parent := WithRun(context.Background(), r)
+
+	ctxA, _, err := WithAsset(parent, "alpha")
+	require.NoError(t, err)
+	ctxB, _, err := WithAsset(parent, "beta")
+	require.NoError(t, err)
+
+	JSON(ctxA, "report", map[string]string{"who": "alpha"})
+	JSON(ctxB, "report", map[string]string{"who": "beta"})
+
+	rawA, err := os.ReadFile(filepath.Join(root, "alpha", "report.json"))
+	require.NoError(t, err)
+	rawB, err := os.ReadFile(filepath.Join(root, "beta", "report.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(rawA), "alpha")
+	assert.Contains(t, string(rawB), "beta")
+}
+
+func TestContext_DuplicateAssetNames_Isolated(t *testing.T) {
+	root := t.TempDir()
+	r, err := NewRun(root)
+	require.NoError(t, err)
+	parent := WithRun(context.Background(), r)
+
+	ctx1, dir1, err := WithAsset(parent, "node")
+	require.NoError(t, err)
+	ctx2, dir2, err := WithAsset(parent, "node")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, dir1, dir2)
+	JSON(ctx1, "marker", map[string]int{"i": 1})
+	JSON(ctx2, "marker", map[string]int{"i": 2})
+
+	raw1, err := os.ReadFile(filepath.Join(dir1, "marker.json"))
+	require.NoError(t, err)
+	raw2, err := os.ReadFile(filepath.Join(dir2, "marker.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw1), `"i": 1`)
+	assert.Contains(t, string(raw2), `"i": 2`)
+}
+
+func TestCreate_WritesAtScope(t *testing.T) {
+	root := t.TempDir()
+	r, err := NewRun(root)
+	require.NoError(t, err)
+	ctx := WithRun(context.Background(), r)
+	ctx, assetDir, err := WithAsset(ctx, "h1")
+	require.NoError(t, err)
+
+	f, err := Create(ctx, "graph.dot")
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	_, err = f.WriteString("digraph {}")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	raw, err := os.ReadFile(filepath.Join(assetDir, "graph.dot"))
+	require.NoError(t, err)
+	assert.Equal(t, "digraph {}", string(raw))
+}
+
+func TestActive_TrueWhenScoped(t *testing.T) {
+	r, err := NewRun(t.TempDir())
+	require.NoError(t, err)
+	ctx := WithRun(context.Background(), r)
+	assert.True(t, Active(ctx))
+
+	assert.False(t, Active(context.Background()))
+}
+
+func TestWithAsset_InactiveRunIsNoOp(t *testing.T) {
+	r, err := NewRun("")
+	require.NoError(t, err)
+	ctx := WithRun(context.Background(), r)
+
+	out, dir, err := WithAsset(ctx, "anything")
+	require.NoError(t, err)
+	assert.Empty(t, dir)
+	assert.False(t, Active(out))
+}

--- a/internal/supportbundle/archive.go
+++ b/internal/supportbundle/archive.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package supportbundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/errors"
+)
+
+// archiveDir writes a gzip-compressed tarball of srcDir to destPath. Entries
+// are stored relative to srcDir's parent, so the archive unpacks into a single
+// top-level directory whose name matches the bundle directory (e.g.
+// cnspec-support-bundle-<ts>/manifest.json).
+//
+// Only regular files and directories are archived; symlinks and other special
+// files are skipped (the bundle never writes them, and we don't want to follow
+// links out of the tree).
+func archiveDir(srcDir, destPath string) (retErr error) {
+	out, err := os.Create(destPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create archive file")
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && retErr == nil {
+			retErr = errors.Wrap(cerr, "failed to close archive file")
+		}
+	}()
+
+	gz := gzip.NewWriter(out)
+	defer func() {
+		if cerr := gz.Close(); cerr != nil && retErr == nil {
+			retErr = errors.Wrap(cerr, "failed to close gzip writer")
+		}
+	}()
+
+	tw := tar.NewWriter(gz)
+	defer func() {
+		if cerr := tw.Close(); cerr != nil && retErr == nil {
+			retErr = errors.Wrap(cerr, "failed to close tar writer")
+		}
+	}()
+
+	// base is the bundle's parent dir; relative names therefore include the
+	// bundle directory name as their first path component.
+	base := filepath.Dir(srcDir)
+
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		// Skip anything that isn't a regular file or directory.
+		if !info.Mode().IsRegular() && !info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(base, path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute archive path for %s", path)
+		}
+		name := filepath.ToSlash(rel)
+
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return errors.Wrapf(err, "failed to build tar header for %s", path)
+		}
+		hdr.Name = name
+		if info.IsDir() {
+			hdr.Name += "/"
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return errors.Wrapf(err, "failed to write tar header for %s", name)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open %s", path)
+		}
+		defer f.Close()
+
+		if _, err := io.Copy(tw, f); err != nil {
+			return errors.Wrapf(err, "failed to copy %s into archive", name)
+		}
+		return nil
+	})
+}

--- a/internal/supportbundle/supportbundle.go
+++ b/internal/supportbundle/supportbundle.go
@@ -1,0 +1,406 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package supportbundle gathers the artifacts a cnspec scan produces under
+// DEBUG=1 (asset bundle, inventory, resolved policy, report, graph dot files,
+// etc.) into a single directory that users can hand to Mondoo support for
+// analysis. Activated via the --collect-support-bundle flag on `cnspec scan`.
+package supportbundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/v13"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/logger"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// dumpPrefix is the prefix the upstream logger.DebugDumpJSON/YAML helpers,
+// the cnspec graph executor, and the cnquery graph executor use when writing
+// debug artifacts. We rely on it here to sweep any files written to CWD into
+// the bundle directory at finalize time.
+const dumpPrefix = "mondoo-debug-"
+
+// Bundle owns a support-bundle output directory. Activate switches the global
+// debug-dump prefix and forces debug-level logging; Finalize collects the
+// final artifacts (manifest, provider versions, leftover files) and restores
+// any global state we touched.
+type Bundle struct {
+	// Dir is the absolute path the bundle is written to.
+	Dir string
+	// Args are the command-line arguments recorded in the manifest.
+	Args []string
+
+	started    time.Time
+	cwd        string
+	logFile    *os.File
+	prevDump   string
+	prevLogger zerolog.Logger
+	prevLevel  zerolog.Level
+	finalizeMu sync.Mutex
+	finalized  bool
+	announced  bool
+}
+
+// New creates a bundle directory at the given path. If path is empty, a
+// timestamped directory under the current working directory is used. The
+// returned Bundle is not active yet; call Activate before running the scan.
+func New(path string) (*Bundle, error) {
+	started := time.Now().UTC()
+
+	if path == "" {
+		path = "cnspec-support-bundle-" + started.Format("20060102T150405Z")
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to resolve support-bundle path")
+	}
+
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return nil, errors.Wrap(err, "failed to create support-bundle directory")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to determine working directory")
+	}
+
+	return &Bundle{
+		Dir:     abs,
+		started: started,
+		cwd:     cwd,
+	}, nil
+}
+
+// Activate redirects DebugDumpJSON/YAML output, the cnspec graph .dot file,
+// and a tee'd debug log into the bundle directory, and forces debug-level
+// logging if a more restrictive level was set. Must be paired with Finalize.
+func (b *Bundle) Activate() error {
+	// Force debug level so the dump helpers actually fire. Remember the prior
+	// level so Finalize can restore it.
+	b.prevLevel = zerolog.GlobalLevel()
+	if b.prevLevel > zerolog.DebugLevel {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+
+	// logger.DumpLocal is a "prefix" — DebugDumpJSON writes DumpLocal+name+".json".
+	// Setting it to "<dir>/mondoo-debug-" lands every existing call inside the
+	// bundle dir without changing their hardcoded names.
+	b.prevDump = logger.DumpLocal
+	logger.DumpLocal = filepath.Join(b.Dir, dumpPrefix)
+
+	// Tee zerolog output: keep writing to the existing console destination
+	// (LogOutputWriter — the buffered stderr the CLI uses) and also write
+	// to debug.log with RFC3339Nano timestamps. The CLI's compact ConsoleWriter
+	// suppresses timestamps; the file writer reinstates them so support can
+	// reconstruct timing.
+	//
+	// Note: when active, we use a plain ConsoleWriter for the console rather
+	// than cnquery's custom-formatted one. That trades the cute level glyphs
+	// (→, !, x) for a working fan-out. The file is what support needs anyway.
+	logPath := filepath.Join(b.Dir, "debug.log")
+	f, err := os.Create(logPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create support-bundle debug log")
+	}
+	b.logFile = f
+
+	consoleSink := zerolog.ConsoleWriter{
+		Out:        logger.LogOutputWriter,
+		NoColor:    false,
+		TimeFormat: time.Kitchen, // short timestamps for console; full ones go to file
+	}
+	fileSink := zerolog.ConsoleWriter{
+		Out:        f,
+		NoColor:    true,
+		TimeFormat: time.RFC3339Nano,
+	}
+	b.prevLogger = log.Logger
+	log.Logger = zerolog.New(zerolog.MultiLevelWriter(consoleSink, fileSink)).
+		Level(zerolog.GlobalLevel()).
+		With().Timestamp().Logger()
+
+	log.Debug().Str("dir", b.Dir).Msg("support bundle collection started")
+	return nil
+}
+
+// HookFatal attaches a zerolog hook that finalizes the bundle when a Fatal
+// event fires. zerolog runs Done hooks before its ExitFunc, so this gives
+// us a deterministic flush even when scanCmdRun calls log.Fatal().
+func (b *Bundle) HookFatal() {
+	log.Logger = log.Logger.Hook(zerolog.HookFunc(func(_ *zerolog.Event, level zerolog.Level, _ string) {
+		if level == zerolog.FatalLevel {
+			// Best-effort: errors here will be swallowed because the
+			// process is about to exit anyway.
+			_ = b.Finalize()
+			fmt.Fprintf(os.Stderr, "support bundle written to: %s\n", b.Dir)
+		}
+	}))
+}
+
+// FinalizeAndAnnounce wraps Finalize with a user-visible note on the bundle
+// path. Safe to call multiple times; subsequent calls are no-ops.
+func (b *Bundle) FinalizeAndAnnounce(w io.Writer) {
+	if b == nil {
+		return
+	}
+	if err := b.Finalize(); err != nil {
+		// Don't fail the scan over a bundle write error; just complain loudly.
+		log.Warn().Err(err).Msg("support bundle finalize had errors")
+	}
+	if !b.announced {
+		fmt.Fprintf(w, "support bundle written to: %s\n", b.Dir)
+		b.announced = true
+	}
+}
+
+// RecordResolvedAssets dumps the asset list from the scan report so support
+// can see which assets actually got resolved/scanned. The unresolved inventory
+// is captured separately by the cnquery inventory manager via DebugDumpJSON.
+func (b *Bundle) RecordResolvedAssets(report *policy.ReportCollection) {
+	if report == nil {
+		return
+	}
+	// Pull the bits that identify each asset; the full report.Assets values
+	// include scoring state we already dump elsewhere via "report.json".
+	resolved := struct {
+		Assets map[string]*inventory.Asset `json:"assets"`
+		Errors map[string]string           `json:"errors,omitempty"`
+	}{
+		Assets: report.Assets,
+		Errors: report.Errors,
+	}
+	raw, err := json.MarshalIndent(resolved, "", "  ")
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to marshal resolved assets")
+		return
+	}
+	if err := os.WriteFile(filepath.Join(b.Dir, "assets-resolved.json"), raw, 0o644); err != nil {
+		log.Warn().Err(err).Msg("failed to write resolved assets")
+	}
+}
+
+// Finalize writes manifest.json + providers.json, sweeps any leftover
+// ./mondoo-debug-* files into the bundle dir, restores global logger state,
+// and closes the debug log. Safe to call more than once.
+func (b *Bundle) Finalize() error {
+	b.finalizeMu.Lock()
+	defer b.finalizeMu.Unlock()
+	if b.finalized {
+		return nil
+	}
+	b.finalized = true
+
+	var errs []error
+
+	if err := b.writeManifest(); err != nil {
+		errs = append(errs, errors.Wrap(err, "manifest"))
+	}
+	if err := b.writeProviders(); err != nil {
+		errs = append(errs, errors.Wrap(err, "providers"))
+	}
+	if err := b.sweepCWD(); err != nil {
+		errs = append(errs, errors.Wrap(err, "sweep"))
+	}
+
+	log.Debug().Str("dir", b.Dir).Msg("support bundle collection finished")
+
+	// Restore global state.
+	logger.DumpLocal = b.prevDump
+	log.Logger = b.prevLogger
+	zerolog.SetGlobalLevel(b.prevLevel)
+
+	if b.logFile != nil {
+		if err := b.logFile.Close(); err != nil {
+			errs = append(errs, errors.Wrap(err, "close log"))
+		}
+	}
+
+	if len(errs) > 0 {
+		// Return all errors joined so callers see every failure.
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Error()
+		}
+		return errors.New("support bundle finalize encountered errors: " + strings.Join(msgs, "; "))
+	}
+	return nil
+}
+
+// Manifest is the metadata blob written to manifest.json. It captures the
+// versions of the binaries involved and basic host info so support can
+// reproduce the environment.
+type Manifest struct {
+	CreatedAt  time.Time         `json:"created_at"`
+	CnspecInfo string            `json:"cnspec"`
+	CnquerySDK string            `json:"cnquery_sdk"`
+	GoVersion  string            `json:"go_version"`
+	OS         string            `json:"os"`
+	Arch       string            `json:"arch"`
+	Hostname   string            `json:"hostname,omitempty"`
+	Args       []string          `json:"args,omitempty"`
+	Env        map[string]string `json:"env"`
+}
+
+func (b *Bundle) writeManifest() error {
+	host, _ := os.Hostname() // best effort
+
+	m := Manifest{
+		CreatedAt:  b.started,
+		CnspecInfo: cnspec.Info(),
+		CnquerySDK: mql.Info(),
+		GoVersion:  runtime.Version(),
+		OS:         runtime.GOOS,
+		Arch:       runtime.GOARCH,
+		Hostname:   host,
+		Args:       b.Args,
+		Env:        collectRelevantEnv(),
+	}
+
+	raw, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(b.Dir, "manifest.json"), raw, 0o644)
+}
+
+// collectRelevantEnv records only the env vars that affect cnspec behavior.
+// We deliberately do NOT dump os.Environ() — it may contain credentials.
+var loggedEnvVars = []string{
+	"DEBUG", "TRACE", "MONDOO_CONFIG_PATH", "MONDOO_CONFIG_HOME",
+	"MONDOO_HOME", "MONDOO_AUTO_UPDATE", "NO_COLOR", "HTTP_PROXY",
+	"HTTPS_PROXY", "NO_PROXY", "MEM_DEBUG",
+}
+
+func collectRelevantEnv() map[string]string {
+	out := map[string]string{}
+	for _, k := range loggedEnvVars {
+		if v, ok := os.LookupEnv(k); ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// ProvidersDoc is the on-disk shape of providers.json. We keep the list
+// alphabetized for deterministic diffs across captures.
+type ProvidersDoc struct {
+	Providers []ProviderEntry `json:"providers"`
+}
+
+type ProviderEntry struct {
+	Name       string   `json:"name"`
+	Version    string   `json:"version"`
+	ID         string   `json:"id,omitempty"`
+	Connectors []string `json:"connectors,omitempty"`
+	Path       string   `json:"path,omitempty"`
+	Builtin    bool     `json:"builtin"`
+}
+
+func (b *Bundle) writeProviders() error {
+	all, err := providers.ListAll()
+	if err != nil {
+		// Don't fail the whole bundle if provider listing chokes — record what
+		// we got and surface the error in the file itself.
+		entry := struct {
+			Error string `json:"error"`
+		}{Error: err.Error()}
+		raw, _ := json.MarshalIndent(entry, "", "  ")
+		return os.WriteFile(filepath.Join(b.Dir, "providers.json"), raw, 0o644)
+	}
+
+	doc := ProvidersDoc{}
+	for _, p := range all {
+		if p == nil {
+			continue
+		}
+		connectors := make([]string, 0, len(p.Connectors))
+		for _, c := range p.Connectors {
+			connectors = append(connectors, c.Name)
+		}
+		doc.Providers = append(doc.Providers, ProviderEntry{
+			Name:       p.Name,
+			Version:    p.Version,
+			ID:         p.ID,
+			Connectors: connectors,
+			Path:       p.Path,
+			Builtin:    p.HasBinary == false,
+		})
+	}
+
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(b.Dir, "providers.json"), raw, 0o644)
+}
+
+// sweepCWD moves any leftover ./mondoo-debug-* files from the working dir
+// the process started in into the bundle. This catches debug artifacts
+// written by code that hardcodes the prefix without honoring DumpLocal —
+// notably the cnquery-side graph executor's .dot file.
+func (b *Bundle) sweepCWD() error {
+	entries, err := os.ReadDir(b.cwd)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, dumpPrefix) {
+			continue
+		}
+		src := filepath.Join(b.cwd, name)
+		dst := filepath.Join(b.Dir, name)
+		if src == dst {
+			continue
+		}
+		if err := moveFile(src, dst); err != nil {
+			log.Warn().Err(err).Str("file", name).Msg("failed to move debug artifact into support bundle")
+		}
+	}
+	return nil
+}
+
+// moveFile renames src → dst when both are on the same filesystem, falling
+// back to copy+remove across devices. We don't worry about partial copies on
+// failure — the original stays put for the user to inspect.
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}

--- a/internal/supportbundle/supportbundle.go
+++ b/internal/supportbundle/supportbundle.go
@@ -1,13 +1,32 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-// Package supportbundle gathers the artifacts a cnspec scan produces under
-// DEBUG=1 (asset bundle, inventory, resolved policy, report, graph dot files,
-// etc.) into a single directory that users can hand to Mondoo support for
-// analysis. Activated via the --collect-support-bundle flag on `cnspec scan`.
+// Package supportbundle gathers the artifacts a cnspec scan produces into a
+// single directory that users can hand to Mondoo support for analysis.
+// Activated via --collect-support-bundle on `cnspec scan`.
+//
+// Layout produced:
+//
+//	<bundle>/
+//	  manifest.json           # cnspec/cnquery versions, OS/arch, scan args, host
+//	  providers.json          # installed providers + versions
+//	  debug.log               # zerolog tee with RFC3339Nano timestamps
+//	  debug/                  # the scandump.Run directory
+//	    mondoo-debug-inventory-unresolved.json   # cnquery side (via logger.DumpLocal)
+//	    report.json                              # run-level cnspec
+//	    assets-resolved.json
+//	    resolved_mql_bundle.mql.yaml
+//	    <asset>/                                  # one directory per scanned asset
+//	      assetBundle.yaml
+//	      policyFilters.yaml
+//	      assetFilters.yaml
+//	      resolvedPolicy.json
+//	      resolved-policy.dot
+//	      filter-queries.dot
 package supportbundle
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,43 +41,40 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13"
-	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
-// dumpPrefix is the prefix the upstream logger.DebugDumpJSON/YAML helpers,
-// the cnspec graph executor, and the cnquery graph executor use when writing
-// debug artifacts. We rely on it here to sweep any files written to CWD into
-// the bundle directory at finalize time.
-const dumpPrefix = "mondoo-debug-"
+// debugSubdir is the directory under the bundle root that holds per-run /
+// per-asset debug artifacts. It's the path cnquery-side dumps are pointed at
+// via logger.DumpLocal, and is where scandump.Run is rooted.
+const debugSubdir = "debug"
 
-// Bundle owns a support-bundle output directory. Activate switches the global
-// debug-dump prefix and forces debug-level logging; Finalize collects the
-// final artifacts (manifest, provider versions, leftover files) and restores
-// any global state we touched.
+// Bundle owns a support-bundle output directory. Activate stands up the dump
+// pipeline and global-state mutations; Finalize writes the metadata files
+// and restores everything Activate touched.
 type Bundle struct {
-	// Dir is the absolute path the bundle is written to.
+	// Dir is the absolute bundle root.
 	Dir string
 	// Args are the command-line arguments recorded in the manifest.
 	Args []string
 
 	started    time.Time
-	cwd        string
+	debugDir   string
 	logFile    *os.File
 	prevDump   string
 	prevLogger zerolog.Logger
 	prevLevel  zerolog.Level
+	run        *scandump.Run
 	finalizeMu sync.Mutex
 	finalized  bool
 	announced  bool
 }
 
 // New creates a bundle directory at the given path. If path is empty, a
-// timestamped directory under the current working directory is used. The
-// returned Bundle is not active yet; call Activate before running the scan.
+// timestamped directory under the current working directory is used.
 func New(path string) (*Bundle, error) {
 	started := time.Now().UTC()
 
@@ -70,60 +86,58 @@ func New(path string) (*Bundle, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve support-bundle path")
 	}
-
 	if err := os.MkdirAll(abs, 0o755); err != nil {
 		return nil, errors.Wrap(err, "failed to create support-bundle directory")
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to determine working directory")
-	}
-
 	return &Bundle{
-		Dir:     abs,
-		started: started,
-		cwd:     cwd,
+		Dir:      abs,
+		started:  started,
+		debugDir: filepath.Join(abs, debugSubdir),
 	}, nil
 }
 
-// Activate redirects DebugDumpJSON/YAML output, the cnspec graph .dot file,
-// and a tee'd debug log into the bundle directory, and forces debug-level
-// logging if a more restrictive level was set. Must be paired with Finalize.
-func (b *Bundle) Activate() error {
-	// Force debug level so the dump helpers actually fire. Remember the prior
-	// level so Finalize can restore it.
+// Activate stands up the dump pipeline:
+//
+//   - forces zerolog to debug level so dump helpers fire,
+//   - creates a scandump.Run under <bundle>/debug and attaches it to ctx,
+//   - points cnquery's logger.DumpLocal at the same dir so its
+//     inventory-unresolved dump lands in the bundle,
+//   - tees zerolog output to <bundle>/debug.log with RFC3339Nano timestamps.
+//
+// Returns the augmented context. Must be paired with Finalize.
+func (b *Bundle) Activate(parent context.Context) (context.Context, error) {
+	// Force debug level so dump helpers and cnquery's gated DebugDumpJSON
+	// actually fire.
 	b.prevLevel = zerolog.GlobalLevel()
 	if b.prevLevel > zerolog.DebugLevel {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
-	// logger.DumpLocal is a "prefix" — DebugDumpJSON writes DumpLocal+name+".json".
-	// Setting it to "<dir>/mondoo-debug-" lands every existing call inside the
-	// bundle dir without changing their hardcoded names.
-	b.prevDump = logger.DumpLocal
-	logger.DumpLocal = filepath.Join(b.Dir, dumpPrefix)
+	run, err := scandump.NewRun(b.debugDir)
+	if err != nil {
+		return parent, errors.Wrap(err, "failed to create scandump run")
+	}
+	b.run = run
 
-	// Tee zerolog output: keep writing to the existing console destination
-	// (LogOutputWriter — the buffered stderr the CLI uses) and also write
-	// to debug.log with RFC3339Nano timestamps. The CLI's compact ConsoleWriter
-	// suppresses timestamps; the file writer reinstates them so support can
-	// reconstruct timing.
-	//
-	// Note: when active, we use a plain ConsoleWriter for the console rather
-	// than cnquery's custom-formatted one. That trades the cute level glyphs
-	// (→, !, x) for a working fan-out. The file is what support needs anyway.
+	// Point cnquery's mql/logger.DebugDumpJSON at the same directory. It
+	// writes "<DumpLocal><name>.json", so the trailing prefix is intentional.
+	b.prevDump = logger.DumpLocal
+	logger.DumpLocal = filepath.Join(run.Dir, "mondoo-debug-")
+
+	// Tee logs to debug.log with full timestamps; the CLI console writer
+	// strips them.
 	logPath := filepath.Join(b.Dir, "debug.log")
 	f, err := os.Create(logPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to create support-bundle debug log")
+		return parent, errors.Wrap(err, "failed to create support-bundle debug log")
 	}
 	b.logFile = f
 
 	consoleSink := zerolog.ConsoleWriter{
 		Out:        logger.LogOutputWriter,
 		NoColor:    false,
-		TimeFormat: time.Kitchen, // short timestamps for console; full ones go to file
+		TimeFormat: time.Kitchen,
 	}
 	fileSink := zerolog.ConsoleWriter{
 		Out:        f,
@@ -136,17 +150,15 @@ func (b *Bundle) Activate() error {
 		With().Timestamp().Logger()
 
 	log.Debug().Str("dir", b.Dir).Msg("support bundle collection started")
-	return nil
+	return scandump.WithRun(parent, run), nil
 }
 
 // HookFatal attaches a zerolog hook that finalizes the bundle when a Fatal
-// event fires. zerolog runs Done hooks before its ExitFunc, so this gives
-// us a deterministic flush even when scanCmdRun calls log.Fatal().
+// event fires. zerolog runs hooks before its ExitFunc, so this is our only
+// chance to flush when callers reach log.Fatal().
 func (b *Bundle) HookFatal() {
 	log.Logger = log.Logger.Hook(zerolog.HookFunc(func(_ *zerolog.Event, level zerolog.Level, _ string) {
 		if level == zerolog.FatalLevel {
-			// Best-effort: errors here will be swallowed because the
-			// process is about to exit anyway.
 			_ = b.Finalize()
 			fmt.Fprintf(os.Stderr, "support bundle written to: %s\n", b.Dir)
 		}
@@ -154,13 +166,12 @@ func (b *Bundle) HookFatal() {
 }
 
 // FinalizeAndAnnounce wraps Finalize with a user-visible note on the bundle
-// path. Safe to call multiple times; subsequent calls are no-ops.
+// path. Safe to call multiple times; only announces once.
 func (b *Bundle) FinalizeAndAnnounce(w io.Writer) {
 	if b == nil {
 		return
 	}
 	if err := b.Finalize(); err != nil {
-		// Don't fail the scan over a bundle write error; just complain loudly.
 		log.Warn().Err(err).Msg("support bundle finalize had errors")
 	}
 	if !b.announced {
@@ -169,35 +180,8 @@ func (b *Bundle) FinalizeAndAnnounce(w io.Writer) {
 	}
 }
 
-// RecordResolvedAssets dumps the asset list from the scan report so support
-// can see which assets actually got resolved/scanned. The unresolved inventory
-// is captured separately by the cnquery inventory manager via DebugDumpJSON.
-func (b *Bundle) RecordResolvedAssets(report *policy.ReportCollection) {
-	if report == nil {
-		return
-	}
-	// Pull the bits that identify each asset; the full report.Assets values
-	// include scoring state we already dump elsewhere via "report.json".
-	resolved := struct {
-		Assets map[string]*inventory.Asset `json:"assets"`
-		Errors map[string]string           `json:"errors,omitempty"`
-	}{
-		Assets: report.Assets,
-		Errors: report.Errors,
-	}
-	raw, err := json.MarshalIndent(resolved, "", "  ")
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to marshal resolved assets")
-		return
-	}
-	if err := os.WriteFile(filepath.Join(b.Dir, "assets-resolved.json"), raw, 0o644); err != nil {
-		log.Warn().Err(err).Msg("failed to write resolved assets")
-	}
-}
-
-// Finalize writes manifest.json + providers.json, sweeps any leftover
-// ./mondoo-debug-* files into the bundle dir, restores global logger state,
-// and closes the debug log. Safe to call more than once.
+// Finalize writes manifest.json + providers.json, restores global logger
+// state, and closes the debug log. Safe to call more than once.
 func (b *Bundle) Finalize() error {
 	b.finalizeMu.Lock()
 	defer b.finalizeMu.Unlock()
@@ -214,9 +198,6 @@ func (b *Bundle) Finalize() error {
 	if err := b.writeProviders(); err != nil {
 		errs = append(errs, errors.Wrap(err, "providers"))
 	}
-	if err := b.sweepCWD(); err != nil {
-		errs = append(errs, errors.Wrap(err, "sweep"))
-	}
 
 	log.Debug().Str("dir", b.Dir).Msg("support bundle collection finished")
 
@@ -232,7 +213,6 @@ func (b *Bundle) Finalize() error {
 	}
 
 	if len(errs) > 0 {
-		// Return all errors joined so callers see every failure.
 		msgs := make([]string, len(errs))
 		for i, e := range errs {
 			msgs[i] = e.Error()
@@ -242,9 +222,7 @@ func (b *Bundle) Finalize() error {
 	return nil
 }
 
-// Manifest is the metadata blob written to manifest.json. It captures the
-// versions of the binaries involved and basic host info so support can
-// reproduce the environment.
+// Manifest is the metadata blob written to manifest.json.
 type Manifest struct {
 	CreatedAt  time.Time         `json:"created_at"`
 	CnspecInfo string            `json:"cnspec"`
@@ -258,7 +236,7 @@ type Manifest struct {
 }
 
 func (b *Bundle) writeManifest() error {
-	host, _ := os.Hostname() // best effort
+	host, _ := os.Hostname()
 
 	m := Manifest{
 		CreatedAt:  b.started,
@@ -279,8 +257,9 @@ func (b *Bundle) writeManifest() error {
 	return os.WriteFile(filepath.Join(b.Dir, "manifest.json"), raw, 0o644)
 }
 
-// collectRelevantEnv records only the env vars that affect cnspec behavior.
-// We deliberately do NOT dump os.Environ() — it may contain credentials.
+// loggedEnvVars is the curated list of environment variables we record in
+// the manifest. We deliberately do NOT dump os.Environ() — it may contain
+// credentials.
 var loggedEnvVars = []string{
 	"DEBUG", "TRACE", "MONDOO_CONFIG_PATH", "MONDOO_CONFIG_HOME",
 	"MONDOO_HOME", "MONDOO_AUTO_UPDATE", "NO_COLOR", "HTTP_PROXY",
@@ -297,8 +276,7 @@ func collectRelevantEnv() map[string]string {
 	return out
 }
 
-// ProvidersDoc is the on-disk shape of providers.json. We keep the list
-// alphabetized for deterministic diffs across captures.
+// ProvidersDoc is the on-disk shape of providers.json.
 type ProvidersDoc struct {
 	Providers []ProviderEntry `json:"providers"`
 }
@@ -315,8 +293,6 @@ type ProviderEntry struct {
 func (b *Bundle) writeProviders() error {
 	all, err := providers.ListAll()
 	if err != nil {
-		// Don't fail the whole bundle if provider listing chokes — record what
-		// we got and surface the error in the file itself.
 		entry := struct {
 			Error string `json:"error"`
 		}{Error: err.Error()}
@@ -339,7 +315,7 @@ func (b *Bundle) writeProviders() error {
 			ID:         p.ID,
 			Connectors: connectors,
 			Path:       p.Path,
-			Builtin:    p.HasBinary == false,
+			Builtin:    !p.HasBinary,
 		})
 	}
 
@@ -348,59 +324,4 @@ func (b *Bundle) writeProviders() error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(b.Dir, "providers.json"), raw, 0o644)
-}
-
-// sweepCWD moves any leftover ./mondoo-debug-* files from the working dir
-// the process started in into the bundle. This catches debug artifacts
-// written by code that hardcodes the prefix without honoring DumpLocal —
-// notably the cnquery-side graph executor's .dot file.
-func (b *Bundle) sweepCWD() error {
-	entries, err := os.ReadDir(b.cwd)
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasPrefix(name, dumpPrefix) {
-			continue
-		}
-		src := filepath.Join(b.cwd, name)
-		dst := filepath.Join(b.Dir, name)
-		if src == dst {
-			continue
-		}
-		if err := moveFile(src, dst); err != nil {
-			log.Warn().Err(err).Str("file", name).Msg("failed to move debug artifact into support bundle")
-		}
-	}
-	return nil
-}
-
-// moveFile renames src → dst when both are on the same filesystem, falling
-// back to copy+remove across devices. We don't worry about partial copies on
-// failure — the original stays put for the user to inspect.
-func moveFile(src, dst string) error {
-	if err := os.Rename(src, dst); err == nil {
-		return nil
-	}
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	if err := out.Close(); err != nil {
-		return err
-	}
-	return os.Remove(src)
 }

--- a/internal/supportbundle/supportbundle.go
+++ b/internal/supportbundle/supportbundle.go
@@ -5,7 +5,10 @@
 // single directory that users can hand to Mondoo support for analysis.
 // Activated via --collect-support-bundle on `cnspec scan`.
 //
-// Layout produced:
+// On Finalize the directory is packed into a sibling <bundle>.tar.gz and the
+// directory itself is removed, leaving a single archive to share.
+//
+// Layout produced (inside the tarball, under a single <bundle>/ root):
 //
 //	<bundle>/
 //	  manifest.json           # cnspec/cnquery versions, OS/arch, scan args, host
@@ -56,8 +59,12 @@ const debugSubdir = "debug"
 // pipeline and global-state mutations; Finalize writes the metadata files
 // and restores everything Activate touched.
 type Bundle struct {
-	// Dir is the absolute bundle root.
+	// Dir is the absolute bundle root. After Finalize it is removed in favor
+	// of the tarball (see Archive).
 	Dir string
+	// Archive is the absolute path to the <bundle>.tar.gz produced by Finalize.
+	// Empty until Finalize succeeds in packing the directory.
+	Archive string
 	// Args are the command-line arguments recorded in the manifest.
 	Args []string
 
@@ -160,7 +167,7 @@ func (b *Bundle) HookFatal() {
 	log.Logger = log.Logger.Hook(zerolog.HookFunc(func(_ *zerolog.Event, level zerolog.Level, _ string) {
 		if level == zerolog.FatalLevel {
 			_ = b.Finalize()
-			fmt.Fprintf(os.Stderr, "support bundle written to: %s\n", b.Dir)
+			fmt.Fprintf(os.Stderr, "support bundle written to: %s\n", b.outputPath())
 		}
 	}))
 }
@@ -175,9 +182,19 @@ func (b *Bundle) FinalizeAndAnnounce(w io.Writer) {
 		log.Warn().Err(err).Msg("support bundle finalize had errors")
 	}
 	if !b.announced {
-		fmt.Fprintf(w, "support bundle written to: %s\n", b.Dir)
+		fmt.Fprintf(w, "support bundle written to: %s\n", b.outputPath())
 		b.announced = true
 	}
+}
+
+// outputPath is the user-facing artifact path: the tarball once Finalize has
+// packed it, otherwise the bundle directory (e.g. when archiving failed and we
+// kept the directory).
+func (b *Bundle) outputPath() string {
+	if b.Archive != "" {
+		return b.Archive
+	}
+	return b.Dir
 }
 
 // Finalize writes manifest.json + providers.json, restores global logger
@@ -209,6 +226,20 @@ func (b *Bundle) Finalize() error {
 	if b.logFile != nil {
 		if err := b.logFile.Close(); err != nil {
 			errs = append(errs, errors.Wrap(err, "close log"))
+		}
+	}
+
+	// Pack the bundle into a single .tar.gz for easy sharing, then drop the
+	// directory. On failure we keep the directory so the collected data isn't
+	// lost, and leave Archive empty so callers announce the directory instead.
+	archivePath := b.Dir + ".tar.gz"
+	if err := archiveDir(b.Dir, archivePath); err != nil {
+		errs = append(errs, errors.Wrap(err, "archive"))
+		_ = os.Remove(archivePath) // discard any partial archive
+	} else {
+		b.Archive = archivePath
+		if err := os.RemoveAll(b.Dir); err != nil {
+			errs = append(errs, errors.Wrap(err, "cleanup bundle dir"))
 		}
 	}
 

--- a/internal/supportbundle/supportbundle_test.go
+++ b/internal/supportbundle/supportbundle_test.go
@@ -4,7 +4,9 @@
 package supportbundle
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -20,6 +22,36 @@ import (
 	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/mql/v13/logger"
 )
+
+// readTarGz reads every regular-file entry from a .tar.gz into a map keyed by
+// the archive entry name (forward-slash paths, e.g. "<bundle>/manifest.json").
+func readTarGz(t *testing.T, path string) map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	defer gz.Close()
+
+	out := map[string]string{}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = string(data)
+	}
+	return out
+}
 
 // resetGlobals saves and restores the package-level state that Activate
 // mutates so sequential tests don't interfere.
@@ -75,7 +107,7 @@ func TestActivate_AttachesScandumpRunToContext(t *testing.T) {
 
 	ctx, err := b.Activate(context.Background())
 	require.NoError(t, err)
-	defer b.Finalize()
+	defer func() { _ = b.Finalize() }()
 
 	assert.True(t, scandump.Active(ctx),
 		"Activate must return a ctx that carries a scandump.Run")
@@ -96,7 +128,7 @@ func TestActivate_DoesNotLowerVerbosityIfTraceAlready(t *testing.T) {
 	require.NoError(t, err)
 	_, err = b.Activate(context.Background())
 	require.NoError(t, err)
-	defer b.Finalize()
+	defer func() { _ = b.Finalize() }()
 
 	assert.Equal(t, zerolog.TraceLevel, zerolog.GlobalLevel(),
 		"Activate must not downgrade from trace to debug")
@@ -115,9 +147,8 @@ func TestActivate_TeesLogsToFileWithTimestamps(t *testing.T) {
 
 	require.NoError(t, b.Finalize())
 
-	raw, err := os.ReadFile(filepath.Join(b.Dir, "debug.log"))
-	require.NoError(t, err)
-	contents := string(raw)
+	entries := readTarGz(t, b.Archive)
+	contents := entries[filepath.Base(b.Dir)+"/debug.log"]
 	assert.Contains(t, contents, "hello support bundle")
 	assert.Contains(t, contents, "k=v")
 	// RFC3339Nano timestamps always include "T".
@@ -156,10 +187,13 @@ func TestFinalize_WritesManifestAndProviders(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, b.Finalize())
 
-	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
-	require.NoError(t, err)
+	entries := readTarGz(t, b.Archive)
+	name := filepath.Base(b.Dir)
+
+	raw, ok := entries[name+"/manifest.json"]
+	require.True(t, ok, "tarball should contain manifest.json")
 	var m Manifest
-	require.NoError(t, json.Unmarshal(raw, &m))
+	require.NoError(t, json.Unmarshal([]byte(raw), &m))
 	assert.NotEmpty(t, m.CnspecInfo)
 	assert.NotEmpty(t, m.CnquerySDK)
 	assert.NotEmpty(t, m.GoVersion)
@@ -168,8 +202,8 @@ func TestFinalize_WritesManifestAndProviders(t *testing.T) {
 	assert.Equal(t, []string{"cnspec", "scan", "local", "--collect-support-bundle"}, m.Args)
 	assert.False(t, m.CreatedAt.IsZero())
 
-	pRaw, err := os.ReadFile(filepath.Join(b.Dir, "providers.json"))
-	require.NoError(t, err)
+	pRaw, ok := entries[name+"/providers.json"]
+	require.True(t, ok, "tarball should contain providers.json")
 	assert.NotEmpty(t, pRaw, "providers.json should be written even when no providers configured")
 }
 
@@ -186,9 +220,8 @@ func TestFinalize_DoesNotLeakCredentialEnvVars(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, b.Finalize())
 
-	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
-	require.NoError(t, err)
-	contents := string(raw)
+	entries := readTarGz(t, b.Archive)
+	contents := entries[filepath.Base(b.Dir)+"/manifest.json"]
 	assert.NotContains(t, contents, "AWS_SECRET_ACCESS_KEY",
 		"manifest must NOT dump arbitrary env vars — only the curated list")
 	assert.NotContains(t, contents, "should-not-leak")
@@ -216,6 +249,52 @@ func TestFinalizeAndAnnounce_PrintsPathOnce(t *testing.T) {
 
 	count := strings.Count(buf.String(), "support bundle written to:")
 	assert.Equal(t, 1, count, "path should only be announced once across multiple FinalizeAndAnnounce calls")
+	assert.Contains(t, buf.String(), b.Archive,
+		"announce should point at the tarball, not the removed directory")
+	assert.True(t, strings.HasSuffix(b.Archive, ".tar.gz"))
+}
+
+func TestFinalize_ArchivesAndRemovesDir(t *testing.T) {
+	resetGlobals(t)
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, b.Finalize())
+
+	assert.Equal(t, b.Dir+".tar.gz", b.Archive, "Archive should be the sibling .tar.gz of the bundle dir")
+
+	info, err := os.Stat(b.Archive)
+	require.NoError(t, err, "tarball should exist after finalize")
+	assert.Greater(t, info.Size(), int64(0), "tarball should not be empty")
+
+	_, err = os.Stat(b.Dir)
+	assert.True(t, os.IsNotExist(err), "bundle directory should be removed once archived")
+
+	entries := readTarGz(t, b.Archive)
+	name := filepath.Base(b.Dir)
+	_, ok := entries[name+"/manifest.json"]
+	assert.True(t, ok, "tarball should contain manifest.json under the bundle dir")
+	_, ok = entries[name+"/providers.json"]
+	assert.True(t, ok, "tarball should contain providers.json under the bundle dir")
+}
+
+func TestArchiveDir_PreservesTreeAndContent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "cnspec-support-bundle-xyz")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "debug", "webserver"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "manifest.json"), []byte(`{"ok":true}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "debug", "report.json"), []byte("report"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "debug", "webserver", "resolvedPolicy.json"), []byte("policy"), 0o644))
+
+	dest := src + ".tar.gz"
+	require.NoError(t, archiveDir(src, dest))
+
+	entries := readTarGz(t, dest)
+	assert.Equal(t, `{"ok":true}`, entries["cnspec-support-bundle-xyz/manifest.json"])
+	assert.Equal(t, "report", entries["cnspec-support-bundle-xyz/debug/report.json"])
+	assert.Equal(t, "policy", entries["cnspec-support-bundle-xyz/debug/webserver/resolvedPolicy.json"])
 }
 
 func TestActivate_DumpsLandInDebugSubdir(t *testing.T) {
@@ -226,7 +305,7 @@ func TestActivate_DumpsLandInDebugSubdir(t *testing.T) {
 	require.NoError(t, err)
 	ctx, err := b.Activate(context.Background())
 	require.NoError(t, err)
-	defer b.Finalize()
+	defer func() { _ = b.Finalize() }()
 
 	// Run-level dump
 	scandump.JSON(ctx, "run-level", map[string]int{"x": 1})

--- a/internal/supportbundle/supportbundle_test.go
+++ b/internal/supportbundle/supportbundle_test.go
@@ -5,6 +5,7 @@ package supportbundle
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -16,23 +17,12 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/mql/v13/logger"
 )
 
-// chdir switches into dir for the duration of the test and restores cwd after.
-// We need this because Bundle.sweepCWD reads files from the working directory
-// the bundle was created in, and we want isolation between tests.
-func chdir(t *testing.T, dir string) {
-	t.Helper()
-	prev, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(prev) })
-}
-
 // resetGlobals saves and restores the package-level state that Activate
-// mutates (logger.DumpLocal, log.Logger, zerolog.GlobalLevel) so concurrent
-// or sequential tests don't interfere with each other.
+// mutates so sequential tests don't interfere.
 func resetGlobals(t *testing.T) {
 	t.Helper()
 	prevDump := logger.DumpLocal
@@ -46,8 +36,10 @@ func resetGlobals(t *testing.T) {
 }
 
 func TestNew_DefaultPath_CreatesTimestampedDir(t *testing.T) {
-	dir := t.TempDir()
-	chdir(t, dir)
+	prevWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(t.TempDir()))
+	t.Cleanup(func() { _ = os.Chdir(prevWd) })
 
 	b, err := New("")
 	require.NoError(t, err)
@@ -72,7 +64,7 @@ func TestNew_ExplicitPath_IsUsedVerbatim(t *testing.T) {
 	assert.True(t, info.IsDir())
 }
 
-func TestActivate_SetsDumpLocalAndForcesDebugLevel(t *testing.T) {
+func TestActivate_AttachesScandumpRunToContext(t *testing.T) {
 	resetGlobals(t)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	logger.DumpLocal = ""
@@ -80,24 +72,30 @@ func TestActivate_SetsDumpLocalAndForcesDebugLevel(t *testing.T) {
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+
+	ctx, err := b.Activate(context.Background())
+	require.NoError(t, err)
 	defer b.Finalize()
 
+	assert.True(t, scandump.Active(ctx),
+		"Activate must return a ctx that carries a scandump.Run")
 	assert.Equal(t, zerolog.DebugLevel, zerolog.GlobalLevel(),
-		"Activate must force debug level so DebugDumpJSON/YAML helpers fire")
-	assert.Equal(t, filepath.Join(b.Dir, "mondoo-debug-"), logger.DumpLocal,
-		"DumpLocal should be set to the bundle prefix so existing dump calls land in the bundle dir")
+		"Activate must force debug level so dump helpers fire")
+	assert.True(t, strings.HasSuffix(logger.DumpLocal, "mondoo-debug-"),
+		"DumpLocal should be set so cnquery-side dumps land in the bundle; got %q", logger.DumpLocal)
+	assert.True(t, strings.Contains(logger.DumpLocal, "debug"),
+		"DumpLocal must point inside the bundle's debug/ subdirectory; got %q", logger.DumpLocal)
 }
 
 func TestActivate_DoesNotLowerVerbosityIfTraceAlready(t *testing.T) {
 	resetGlobals(t)
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
-	logger.DumpLocal = ""
 
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 	defer b.Finalize()
 
 	assert.Equal(t, zerolog.TraceLevel, zerolog.GlobalLevel(),
@@ -110,7 +108,8 @@ func TestActivate_TeesLogsToFileWithTimestamps(t *testing.T) {
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 
 	log.Debug().Str("k", "v").Msg("hello support bundle")
 
@@ -121,7 +120,7 @@ func TestActivate_TeesLogsToFileWithTimestamps(t *testing.T) {
 	contents := string(raw)
 	assert.Contains(t, contents, "hello support bundle")
 	assert.Contains(t, contents, "k=v")
-	// RFC3339Nano timestamps always include "T" and one of "Z" or a tz offset.
+	// RFC3339Nano timestamps always include "T".
 	assert.Contains(t, contents, "T", "expected an RFC3339Nano timestamp in the log file")
 }
 
@@ -134,15 +133,15 @@ func TestFinalize_RestoresGlobalsAndIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 
-	// Mutate globals through Activate, then verify Finalize restores them.
 	require.NoError(t, b.Finalize())
 	assert.Equal(t, "/preset-prefix-", logger.DumpLocal, "DumpLocal must be restored")
 	assert.Equal(t, zerolog.WarnLevel, zerolog.GlobalLevel(), "global level must be restored")
 	assert.Equal(t, originalLogger, log.Logger, "log.Logger must be restored")
 
-	// Second call is a no-op and must not panic.
+	// Second call is a no-op.
 	require.NoError(t, b.Finalize())
 }
 
@@ -153,10 +152,10 @@ func TestFinalize_WritesManifestAndProviders(t *testing.T) {
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
 	b.Args = []string{"cnspec", "scan", "local", "--collect-support-bundle"}
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 	require.NoError(t, b.Finalize())
 
-	// Manifest contents
 	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
 	require.NoError(t, err)
 	var m Manifest
@@ -169,7 +168,6 @@ func TestFinalize_WritesManifestAndProviders(t *testing.T) {
 	assert.Equal(t, []string{"cnspec", "scan", "local", "--collect-support-bundle"}, m.Args)
 	assert.False(t, m.CreatedAt.IsZero())
 
-	// Providers file is present even when provider listing returns nothing.
 	pRaw, err := os.ReadFile(filepath.Join(b.Dir, "providers.json"))
 	require.NoError(t, err)
 	assert.NotEmpty(t, pRaw, "providers.json should be written even when no providers configured")
@@ -184,7 +182,8 @@ func TestFinalize_DoesNotLeakCredentialEnvVars(t *testing.T) {
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 	require.NoError(t, b.Finalize())
 
 	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
@@ -195,47 +194,6 @@ func TestFinalize_DoesNotLeakCredentialEnvVars(t *testing.T) {
 	assert.NotContains(t, contents, "should-not-leak")
 	assert.Contains(t, contents, `"DEBUG": "1"`,
 		"manifest should record DEBUG since it's on the curated env-var list")
-}
-
-func TestSweepCWD_MovesLeftoverDebugFiles(t *testing.T) {
-	resetGlobals(t)
-	dir := t.TempDir()
-	chdir(t, dir)
-
-	// Plant a file that some non-cnspec code might write to CWD (e.g. cnquery
-	// graph executor) before the bundle finalizes.
-	leftover := filepath.Join(dir, "mondoo-debug-resolved-policy.dot")
-	require.NoError(t, os.WriteFile(leftover, []byte("digraph {}"), 0o644))
-
-	b, err := New(filepath.Join(dir, "bundle"))
-	require.NoError(t, err)
-	require.NoError(t, b.Activate())
-	require.NoError(t, b.Finalize())
-
-	_, err = os.Stat(leftover)
-	assert.True(t, os.IsNotExist(err), "leftover file should have been swept into bundle")
-
-	moved := filepath.Join(b.Dir, "mondoo-debug-resolved-policy.dot")
-	raw, err := os.ReadFile(moved)
-	require.NoError(t, err)
-	assert.Equal(t, "digraph {}", string(raw))
-}
-
-func TestSweepCWD_IgnoresUnrelatedFiles(t *testing.T) {
-	resetGlobals(t)
-	dir := t.TempDir()
-	chdir(t, dir)
-
-	unrelated := filepath.Join(dir, "policy-bundle.yaml")
-	require.NoError(t, os.WriteFile(unrelated, []byte("policies: []"), 0o644))
-
-	b, err := New(filepath.Join(dir, "bundle"))
-	require.NoError(t, err)
-	require.NoError(t, b.Activate())
-	require.NoError(t, b.Finalize())
-
-	_, err = os.Stat(unrelated)
-	assert.NoError(t, err, "unrelated files must not be moved")
 }
 
 func TestFinalizeAndAnnounce_NilSafe(t *testing.T) {
@@ -249,7 +207,8 @@ func TestFinalizeAndAnnounce_PrintsPathOnce(t *testing.T) {
 	dir := t.TempDir()
 	b, err := New(filepath.Join(dir, "bundle"))
 	require.NoError(t, err)
-	require.NoError(t, b.Activate())
+	_, err = b.Activate(context.Background())
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
 	b.FinalizeAndAnnounce(&buf)
@@ -257,4 +216,28 @@ func TestFinalizeAndAnnounce_PrintsPathOnce(t *testing.T) {
 
 	count := strings.Count(buf.String(), "support bundle written to:")
 	assert.Equal(t, 1, count, "path should only be announced once across multiple FinalizeAndAnnounce calls")
+}
+
+func TestActivate_DumpsLandInDebugSubdir(t *testing.T) {
+	resetGlobals(t)
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	ctx, err := b.Activate(context.Background())
+	require.NoError(t, err)
+	defer b.Finalize()
+
+	// Run-level dump
+	scandump.JSON(ctx, "run-level", map[string]int{"x": 1})
+	// Per-asset dump
+	ctx2, _, err := scandump.WithAsset(ctx, "webserver")
+	require.NoError(t, err)
+	scandump.JSON(ctx2, "report", map[string]int{"y": 2})
+
+	debugDir := filepath.Join(b.Dir, "debug")
+	_, err = os.Stat(filepath.Join(debugDir, "run-level.json"))
+	assert.NoError(t, err, "run-level dump should land under <bundle>/debug/")
+	_, err = os.Stat(filepath.Join(debugDir, "webserver", "report.json"))
+	assert.NoError(t, err, "per-asset dump should land under <bundle>/debug/<asset>/")
 }

--- a/internal/supportbundle/supportbundle_test.go
+++ b/internal/supportbundle/supportbundle_test.go
@@ -1,0 +1,260 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package supportbundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/logger"
+)
+
+// chdir switches into dir for the duration of the test and restores cwd after.
+// We need this because Bundle.sweepCWD reads files from the working directory
+// the bundle was created in, and we want isolation between tests.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+// resetGlobals saves and restores the package-level state that Activate
+// mutates (logger.DumpLocal, log.Logger, zerolog.GlobalLevel) so concurrent
+// or sequential tests don't interfere with each other.
+func resetGlobals(t *testing.T) {
+	t.Helper()
+	prevDump := logger.DumpLocal
+	prevLogger := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		logger.DumpLocal = prevDump
+		log.Logger = prevLogger
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+}
+
+func TestNew_DefaultPath_CreatesTimestampedDir(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	b, err := New("")
+	require.NoError(t, err)
+
+	info, err := os.Stat(b.Dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	assert.True(t, strings.HasPrefix(filepath.Base(b.Dir), "cnspec-support-bundle-"),
+		"default path should include the cnspec-support-bundle prefix; got %q", b.Dir)
+}
+
+func TestNew_ExplicitPath_IsUsedVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "my-bundle")
+
+	b, err := New(target)
+	require.NoError(t, err)
+	assert.Equal(t, target, b.Dir)
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestActivate_SetsDumpLocalAndForcesDebugLevel(t *testing.T) {
+	resetGlobals(t)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	logger.DumpLocal = ""
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+	defer b.Finalize()
+
+	assert.Equal(t, zerolog.DebugLevel, zerolog.GlobalLevel(),
+		"Activate must force debug level so DebugDumpJSON/YAML helpers fire")
+	assert.Equal(t, filepath.Join(b.Dir, "mondoo-debug-"), logger.DumpLocal,
+		"DumpLocal should be set to the bundle prefix so existing dump calls land in the bundle dir")
+}
+
+func TestActivate_DoesNotLowerVerbosityIfTraceAlready(t *testing.T) {
+	resetGlobals(t)
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	logger.DumpLocal = ""
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+	defer b.Finalize()
+
+	assert.Equal(t, zerolog.TraceLevel, zerolog.GlobalLevel(),
+		"Activate must not downgrade from trace to debug")
+}
+
+func TestActivate_TeesLogsToFileWithTimestamps(t *testing.T) {
+	resetGlobals(t)
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+
+	log.Debug().Str("k", "v").Msg("hello support bundle")
+
+	require.NoError(t, b.Finalize())
+
+	raw, err := os.ReadFile(filepath.Join(b.Dir, "debug.log"))
+	require.NoError(t, err)
+	contents := string(raw)
+	assert.Contains(t, contents, "hello support bundle")
+	assert.Contains(t, contents, "k=v")
+	// RFC3339Nano timestamps always include "T" and one of "Z" or a tz offset.
+	assert.Contains(t, contents, "T", "expected an RFC3339Nano timestamp in the log file")
+}
+
+func TestFinalize_RestoresGlobalsAndIsIdempotent(t *testing.T) {
+	resetGlobals(t)
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	logger.DumpLocal = "/preset-prefix-"
+	originalLogger := log.Logger
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+
+	// Mutate globals through Activate, then verify Finalize restores them.
+	require.NoError(t, b.Finalize())
+	assert.Equal(t, "/preset-prefix-", logger.DumpLocal, "DumpLocal must be restored")
+	assert.Equal(t, zerolog.WarnLevel, zerolog.GlobalLevel(), "global level must be restored")
+	assert.Equal(t, originalLogger, log.Logger, "log.Logger must be restored")
+
+	// Second call is a no-op and must not panic.
+	require.NoError(t, b.Finalize())
+}
+
+func TestFinalize_WritesManifestAndProviders(t *testing.T) {
+	resetGlobals(t)
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	b.Args = []string{"cnspec", "scan", "local", "--collect-support-bundle"}
+	require.NoError(t, b.Activate())
+	require.NoError(t, b.Finalize())
+
+	// Manifest contents
+	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
+	require.NoError(t, err)
+	var m Manifest
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.NotEmpty(t, m.CnspecInfo)
+	assert.NotEmpty(t, m.CnquerySDK)
+	assert.NotEmpty(t, m.GoVersion)
+	assert.NotEmpty(t, m.OS)
+	assert.NotEmpty(t, m.Arch)
+	assert.Equal(t, []string{"cnspec", "scan", "local", "--collect-support-bundle"}, m.Args)
+	assert.False(t, m.CreatedAt.IsZero())
+
+	// Providers file is present even when provider listing returns nothing.
+	pRaw, err := os.ReadFile(filepath.Join(b.Dir, "providers.json"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, pRaw, "providers.json should be written even when no providers configured")
+}
+
+func TestFinalize_DoesNotLeakCredentialEnvVars(t *testing.T) {
+	resetGlobals(t)
+
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak")
+	t.Setenv("DEBUG", "1")
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+	require.NoError(t, b.Finalize())
+
+	raw, err := os.ReadFile(filepath.Join(b.Dir, "manifest.json"))
+	require.NoError(t, err)
+	contents := string(raw)
+	assert.NotContains(t, contents, "AWS_SECRET_ACCESS_KEY",
+		"manifest must NOT dump arbitrary env vars — only the curated list")
+	assert.NotContains(t, contents, "should-not-leak")
+	assert.Contains(t, contents, `"DEBUG": "1"`,
+		"manifest should record DEBUG since it's on the curated env-var list")
+}
+
+func TestSweepCWD_MovesLeftoverDebugFiles(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	// Plant a file that some non-cnspec code might write to CWD (e.g. cnquery
+	// graph executor) before the bundle finalizes.
+	leftover := filepath.Join(dir, "mondoo-debug-resolved-policy.dot")
+	require.NoError(t, os.WriteFile(leftover, []byte("digraph {}"), 0o644))
+
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+	require.NoError(t, b.Finalize())
+
+	_, err = os.Stat(leftover)
+	assert.True(t, os.IsNotExist(err), "leftover file should have been swept into bundle")
+
+	moved := filepath.Join(b.Dir, "mondoo-debug-resolved-policy.dot")
+	raw, err := os.ReadFile(moved)
+	require.NoError(t, err)
+	assert.Equal(t, "digraph {}", string(raw))
+}
+
+func TestSweepCWD_IgnoresUnrelatedFiles(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	unrelated := filepath.Join(dir, "policy-bundle.yaml")
+	require.NoError(t, os.WriteFile(unrelated, []byte("policies: []"), 0o644))
+
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+	require.NoError(t, b.Finalize())
+
+	_, err = os.Stat(unrelated)
+	assert.NoError(t, err, "unrelated files must not be moved")
+}
+
+func TestFinalizeAndAnnounce_NilSafe(t *testing.T) {
+	var b *Bundle
+	b.FinalizeAndAnnounce(io.Discard) // must not panic
+}
+
+func TestFinalizeAndAnnounce_PrintsPathOnce(t *testing.T) {
+	resetGlobals(t)
+
+	dir := t.TempDir()
+	b, err := New(filepath.Join(dir, "bundle"))
+	require.NoError(t, err)
+	require.NoError(t, b.Activate())
+
+	var buf bytes.Buffer
+	b.FinalizeAndAnnounce(&buf)
+	b.FinalizeAndAnnounce(&buf)
+
+	count := strings.Count(buf.String(), "support bundle written to:")
+	assert.Equal(t, 1, count, "path should only be announced once across multiple FinalizeAndAnnounce calls")
+}

--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/checksums"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/mqlc"
 	"go.mondoo.com/mql/v13/mrn"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
@@ -85,7 +84,10 @@ func (l *BundleLoader) BundleFromPaths(paths ...string) (*Bundle, error) {
 		aggregatedBundle = Merge(aggregatedBundle, bundle)
 	}
 
-	logger.DebugDumpYAML("resolved_mql_bundle.mql", aggregatedBundle)
+	// The caller (cnspec scan) is responsible for dumping the resolved bundle
+	// when --collect-support-bundle / DEBUG=1 is on; we used to do it here
+	// via the mql logger, but that wrote to CWD with no asset context and
+	// fired for every BundleFromPaths consumer (policy lint, etc.).
 	return aggregatedBundle, nil
 }
 

--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -83,12 +83,12 @@ func ExecuteResolvedPolicy(ctx context.Context, runtime llx.Runtime, collectorSv
 		return err
 	}
 
-	ge.Debug("resolved-policy")
+	ge.Debug(ctx, "resolved-policy")
 
 	return ge.Execute()
 }
 
-func ExecuteFilterQueries(runtime llx.Runtime, queries []*policy.Mquery, timeout time.Duration) ([]*policy.Mquery, []error) {
+func ExecuteFilterQueries(ctx context.Context, runtime llx.Runtime, queries []*policy.Mquery, timeout time.Duration) ([]*policy.Mquery, []error) {
 	log.Debug().Msg("executing filter queries")
 	queryMap := map[string]*policy.Mquery{}
 
@@ -141,7 +141,7 @@ func ExecuteFilterQueries(runtime llx.Runtime, queries []*policy.Mquery, timeout
 	}
 	log.Debug().Msg("finished executing filter queries")
 
-	ge.Debug("filter-queries")
+	ge.Debug(ctx, "filter-queries")
 
 	filteredQueries := []*policy.Mquery{}
 	for id, query := range queryMap {

--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -5,14 +5,14 @@ package internal
 
 import (
 	"container/heap"
+	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/logger"
 )
 
 type (
@@ -209,23 +209,14 @@ OUTER:
 	return err
 }
 
-func (ge *GraphExecutor) Debug(name string) {
-	// Honor logger.DumpLocal first so --collect-support-bundle catches the
-	// graph regardless of DEBUG/TRACE env vars; fall back to the env-var gate
-	// + CWD prefix for users who set DEBUG=1 directly.
-	var path string
-	if logger.DumpLocal != "" {
-		path = logger.DumpLocal + name + ".dot"
-	} else if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
-		path = fmt.Sprintf("mondoo-debug-%s.dot", name)
-	} else if val, ok := os.LookupEnv("TRACE"); ok && (val == "1" || val == "true") {
-		path = fmt.Sprintf("mondoo-debug-%s.dot", name)
-	} else {
-		return
-	}
-	f, err := os.Create(path)
+func (ge *GraphExecutor) Debug(ctx context.Context, name string) {
+	f, err := scandump.Create(ctx, name+".dot")
 	if err != nil {
 		log.Error().Err(err).Msg("failed to write debug graph")
+		return
+	}
+	if f == nil {
+		// No scandump.Run attached — debug graphs are off for this scan.
 		return
 	}
 	defer f.Close()

--- a/policy/executor/internal/graph.go
+++ b/policy/executor/internal/graph.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/logger"
 )
 
 type (
@@ -209,12 +210,20 @@ OUTER:
 }
 
 func (ge *GraphExecutor) Debug(name string) {
-	if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
+	// Honor logger.DumpLocal first so --collect-support-bundle catches the
+	// graph regardless of DEBUG/TRACE env vars; fall back to the env-var gate
+	// + CWD prefix for users who set DEBUG=1 directly.
+	var path string
+	if logger.DumpLocal != "" {
+		path = logger.DumpLocal + name + ".dot"
+	} else if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
+		path = fmt.Sprintf("mondoo-debug-%s.dot", name)
 	} else if val, ok := os.LookupEnv("TRACE"); ok && (val == "1" || val == "true") {
+		path = fmt.Sprintf("mondoo-debug-%s.dot", name)
 	} else {
 		return
 	}
-	f, err := os.Create(fmt.Sprintf("mondoo-debug-%s.dot", name))
+	f, err := os.Create(path)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to write debug graph")
 		return

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -22,6 +22,7 @@ import (
 	"go.mondoo.com/cnspec/v13/cli/progress"
 	"go.mondoo.com/cnspec/v13/internal/datalakes/inmemory"
 	"go.mondoo.com/cnspec/v13/internal/datalakes/sqlite"
+	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/cnspec/v13/policy/executor"
 	"go.mondoo.com/mql/v13"
@@ -768,6 +769,19 @@ func (s *LocalScanner) runMotorizedAsset(job *AssetJob) (*AssetReport, error) {
 		// stack injected (e.g. sqlite.WithOutputDir for --output-scan-db)
 		// flow into runPolicy via job.Ctx.
 		job.Ctx = ctx
+		// Reserve a per-asset debug dump directory; downstream dump calls
+		// (assetBundle, resolvedPolicy, graph dot files, etc.) write here.
+		// No-op when no scandump.Run is attached.
+		var assetDir string
+		var assetErr error
+		job.Ctx, assetDir, assetErr = scandump.WithAsset(job.Ctx, job.Asset.Name)
+		if assetErr != nil {
+			log.Warn().Err(assetErr).Str("asset", job.Asset.Name).
+				Msg("failed to reserve asset debug-dump directory; continuing without dumps for this asset")
+		} else if assetDir != "" {
+			log.Debug().Str("asset", job.Asset.Name).Str("dir", assetDir).
+				Msg("debug dumps for this asset will be written here")
+		}
 		scanner := &localAssetScanner{
 			services:         services,
 			job:              job,
@@ -1158,8 +1172,10 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	var hub policy.PolicyHub = s.services
 	var resolver policy.PolicyResolver = s.services
 
-	// If we run in debug mode, download the asset bundle and dump it to disk
-	if val, ok := os.LookupEnv("DEBUG"); ok && (val == "1" || val == "true") {
+	// If a scandump.Run is attached to ctx, fetch + dump the asset bundle.
+	// The fetch is an RPC, so we gate it on scandump.Active to avoid the
+	// round-trip when dumps are off.
+	if scandump.Active(s.job.Ctx) {
 		log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> request policies bundle for asset")
 		assetBundle, err := hub.GetBundle(s.job.Ctx, &policy.Mrn{Mrn: s.job.Asset.Mrn})
 		if err != nil {
@@ -1167,7 +1183,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 		}
 		log.Debug().Msg("client> got policy bundle")
 		logger.TraceJSON(assetBundle)
-		logger.DebugDumpYAML("assetBundle", assetBundle)
+		scandump.YAML(s.job.Ctx, "assetBundle", assetBundle)
 	}
 
 	rawFilters, err := hub.GetPolicyFilters(s.job.Ctx, &policy.Mrn{Mrn: s.job.Asset.Mrn})
@@ -1176,7 +1192,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	}
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> got policy filters")
 	logger.TraceJSON(rawFilters)
-	logger.DebugDumpYAML("policyFilters", rawFilters)
+	scandump.YAML(s.job.Ctx, "policyFilters", rawFilters)
 
 	filters, err := s.UpdateFilters(&policy.Mqueries{Items: rawFilters.Items}, 5*time.Second)
 	if err != nil {
@@ -1184,7 +1200,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	}
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> shell update filters")
 	logger.DebugJSON(filters)
-	logger.DebugDumpYAML("assetFilters", filters)
+	scandump.YAML(s.job.Ctx, "assetFilters", filters)
 
 	// Surface the filters to the datalake so persistent stores (e.g. the
 	// SQLite scandb) can record them. Server-side datalakes can no-op.
@@ -1200,7 +1216,7 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 		return resolvedPolicy, err
 	}
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> got resolved policy bundle for asset")
-	logger.DebugDumpJSON("resolvedPolicy", resolvedPolicy)
+	scandump.JSON(s.job.Ctx, "resolvedPolicy", resolvedPolicy)
 
 	features := mql.GetFeatures(s.job.Ctx)
 	err = executor.ExecuteResolvedPolicy(s.job.Ctx, s.Runtime, resolver, s.job.Asset.Mrn, resolvedPolicy, features, s.ProgressReporter)
@@ -1243,7 +1259,7 @@ func (s *localAssetScanner) getReport(resolvedPolicy *policy.ResolvedPolicy) (*p
 
 // FilterQueries returns all queries whose result is truthy
 func (s *localAssetScanner) FilterQueries(queries []*policy.Mquery, timeout time.Duration) ([]*policy.Mquery, []error) {
-	return executor.ExecuteFilterQueries(s.Runtime, queries, timeout)
+	return executor.ExecuteFilterQueries(s.job.Ctx, s.Runtime, queries, timeout)
 }
 
 // UpdateFilters takes a list of test filters and runs them against the backend

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -21,6 +21,7 @@ Available Commands:
 Flags:
       --annotation stringToString     Add an annotation to the asset in the form KEY=VALUE (default [])
       --asset-name string             Override the asset name
+      --collect-support-bundle        Collect a support bundle (debug logs, asset bundle, inventory, resolved policy, report, provider versions) for sharing with Mondoo support. By default writes to a timestamped directory in the current working dir; override with --support-bundle-dir.
       --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd' (default true)
   -h, --help                          help for scan
       --incognito                     Run in incognito mode. Do not report scan results to Mondoo Platform
@@ -36,6 +37,7 @@ Flags:
   -f, --policy-bundle strings         Set the path to a policy file. Supports local paths, s3:// URIs, and http(s):// URLs
       --props stringToString          Set custom values for properties (default [])
       --risk-threshold int            Set the risk threshold. Exit with status 1 if any risk meets or exceeds this value (default 101)
+      --support-bundle-dir string     Directory to write the support bundle into. Only used when --collect-support-bundle is set. Defaults to ./cnspec-support-bundle-<timestamp>/.
       --trace-id string               Set a trace identifier
 
 Global Flags:


### PR DESCRIPTION
Closes #1011.

## What

Adds `cnspec scan --collect-support-bundle [--support-bundle-dir PATH]` — a single flag that gathers everything we currently ask users to collect by hand with `DEBUG=1` into one directory they can hand to support.

## Why

Today, when a customer hits a scan issue, we walk them through `DEBUG=1 cnspec scan ...` and then ask them to find/zip a scattered set of `./mondoo-debug-*` files plus the resolved policy graph, plus tell us their provider versions. Several files don't have timestamps, which makes correlating events hard. Issue #1011 asks for a one-flag path that does all of this.

## What lands in the bundle

```
cnspec-support-bundle-<RFC3339>/
├── manifest.json              # cnspec/cnquery versions, OS/arch, scan args, host, curated env
├── providers.json             # installed providers + versions + paths + connectors
├── debug.log                  # zerolog output with RFC3339Nano timestamps
├── assets-resolved.json       # asset list as the scan saw them
├── mondoo-debug-assetBundle.yaml
├── mondoo-debug-policyFilters.yaml
├── mondoo-debug-assetFilters.yaml
├── mondoo-debug-inventory-unresolved.json
├── mondoo-debug-resolvedPolicy.json
├── mondoo-debug-report.json
├── mondoo-debug-resolvedpolicy.dot      # cnspec graph executor
├── mondoo-debug-resolved-policy.dot     # cnquery graph executor
└── mondoo-debug-filter-queries.dot
```

## How it works

- `internal/supportbundle.Bundle` owns the output directory and global-state mutation.
- `Activate()`:
  - Forces zerolog level to debug (so existing `logger.DebugDumpJSON/YAML` calls fire).
  - Redirects `logger.DumpLocal` to `<dir>/mondoo-debug-`, which lands every existing dump-site call into the bundle without touching their call sites.
  - Tees zerolog to `debug.log` with `RFC3339Nano` timestamps (the CLI's compact `ConsoleWriter` strips timestamps; the file writer reinstates them).
- `policy/executor/internal/graph.go` now honors `logger.DumpLocal` for its `.dot` file (was hardcoded to CWD).
- `Finalize()`:
  - Writes `manifest.json` and `providers.json`.
  - Sweeps any leftover `./mondoo-debug-*` files from the working dir into the bundle (catches the cnquery-side `.dot` file we don't own here).
  - Restores `logger.DumpLocal`, `log.Logger`, and the global zerolog level.
- `HookFatal()` ensures `log.Fatal` paths flush the bundle before `os.Exit(1)`. Zerolog hooks run before the FatalExit func.

## What's NOT in the bundle

- `os.Environ()` — we curate `DEBUG`, `TRACE`, `MONDOO_*`, proxy vars, etc. and skip the rest to avoid leaking credentials.
- A tarball — printing the directory path keeps the implementation small; `tar -czf` is a one-liner if support asks for it.

## Behavior of existing paths

- No flag: identical to today (no bundle, nothing written to CWD).
- `DEBUG=1` alone: identical to today (`./mondoo-debug-*` files in CWD).
- `--collect-support-bundle` with no `--support-bundle-dir`: writes to `./cnspec-support-bundle-<RFC3339>/`.

## Tests

- `internal/supportbundle/supportbundle_test.go` covers: default and explicit paths, debug-level forcing, trace-not-downgraded, log file timestamps, idempotent finalize + global state restore, manifest contents, env-var curation (no `AWS_SECRET_ACCESS_KEY` leakage), CWD sweep behavior, nil-safe announce.
- Existing `policy/executor` tests pass against the modified `Debug(name)` function.

## Manual smoke test

```
$ cnspec scan local --collect-support-bundle --incognito
...
support bundle written to: /tmp/cnspec-support-bundle-20260527T172224Z

$ ls /tmp/cnspec-support-bundle-20260527T172224Z
assets-resolved.json   mondoo-debug-assetFilters.yaml         mondoo-debug-policyFilters.yaml
debug.log              mondoo-debug-filter-queries.dot        mondoo-debug-report.json
manifest.json          mondoo-debug-inventory-unresolved.json mondoo-debug-resolved-policy.dot
providers.json         mondoo-debug-resolvedPolicy.json
```

## Follow-ups (out of scope)

- The `inventory-resolved-assets` dump in cnquery's manager.go is currently behind a `panic("NEED TO RESOLVE")`. We capture resolved assets via the `ReportCollection.Assets` map (sufficient for support today). Re-enabling the cnquery-side dump can land separately.
- Could add a `--collect-support-bundle` flag to `cnspec shell` / `cnspec vuln` if support starts using it there too.