### PR TITLE
:sparkles: Record per-query execution time in scan database

### DIFF
--- a/internal/datalakes/inmemory/inmemory.go
+++ b/internal/datalakes/inmemory/inmemory.go
@@ -38,6 +38,12 @@ type DataStore interface {
 	// no-op; the SQLite scandb wrapper persists the code_ids so a
 	// captured scan db carries enough state for offline replay.
 	SetAssetFilters(ctx context.Context, assetMrn string, filters *policy.Mqueries) error
+	// WriteQueryDuration records the wall-clock time a single query spent
+	// in the MQL executor. codeId is the value the caller wants persisted
+	// — typically the llx query checksum, or a resolved query MRN. The
+	// default in-memory cache treats it as a no-op; the SQLite scandb
+	// wrapper persists it so a captured scan db carries per-query timings.
+	WriteQueryDuration(ctx context.Context, assetMrn string, codeId string, durationMs int64) error
 }
 
 type cacheDataWriter struct {
@@ -126,6 +132,13 @@ func (n *cacheDataWriter) SetAssetFilters(_ context.Context, _ string, _ *policy
 	return nil
 }
 
+// WriteQueryDuration is a no-op for the cache writer — per-query timings
+// only matter when the scan database is being persisted (i.e. the scandb
+// wrapper).
+func (n *cacheDataWriter) WriteQueryDuration(_ context.Context, _ string, _ string, _ int64) error {
+	return nil
+}
+
 func (n *cacheDataWriter) WriteResource(ctx context.Context, assetMrn string, resource *llx.ResourceRecording) error {
 	return nil
 }
@@ -208,6 +221,16 @@ func (db *Db) SetAssetFilters(ctx context.Context, assetMrn string, filters *pol
 		return nil
 	}
 	return db.writer.SetAssetFilters(ctx, assetMrn, filters)
+}
+
+// WriteQueryDuration delegates per-query timing capture to the underlying
+// writer. The default in-memory cache is a no-op; the scandb wrapper
+// persists the row so a captured scan db carries per-query timings.
+func (db *Db) WriteQueryDuration(ctx context.Context, assetMrn string, codeId string, durationMs int64) error {
+	if db.writer == nil {
+		return nil
+	}
+	return db.writer.WriteQueryDuration(ctx, assetMrn, codeId, durationMs)
 }
 
 func (db *Db) SetNowProvider(f func() time.Time) {

--- a/policy/datalake.go
+++ b/policy/datalake.go
@@ -114,4 +114,13 @@ type DataLake interface {
 	// scan database is being captured, so offline replay can call
 	// ResolveAndUpdateJobs without re-deriving the filter set.
 	SetAssetFilters(ctx context.Context, assetMrn string, filters *Mqueries) error
+
+	// WriteQueryDuration records the wall-clock time the MQL executor
+	// spent on a single query. codeId is the value the caller wants
+	// persisted — typically the llx query checksum, or a resolved query
+	// MRN. Implementations that don't need per-query timings (e.g. the
+	// server's persistent datalake) can return nil. The cnspec
+	// client-side datalake persists the row when a scan database is
+	// being captured.
+	WriteQueryDuration(ctx context.Context, assetMrn string, codeId string, durationMs int64) error
 }

--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -24,6 +24,11 @@ type GraphExecutor interface {
 // for callers of RescoreResolvedPolicy.
 type ScoreCollector = internal.ScoreCollector
 
+// DurationCollector receives the wall-clock execution time of each query
+// the graph executor runs. Re-exported so callers of ExecuteResolvedPolicy
+// can register a sink without importing the internal package.
+type DurationCollector = internal.DurationCollector
+
 // RescoreResolvedPolicy rolls up pre-computed leaf scores through the graph
 // executor without running any queries. Reporting jobs whose QrId is a key
 // in scores are built as static nodes holding the supplied score; aggregate
@@ -50,6 +55,7 @@ func RescoreResolvedPolicy(
 
 func ExecuteResolvedPolicy(ctx context.Context, runtime llx.Runtime, collectorSvc policy.PolicyResolver, assetMrn string,
 	resolvedPolicy *policy.ResolvedPolicy, features mql.Features, progressReporter progress.Progress,
+	durationCollectors ...DurationCollector,
 ) error {
 	var opts []internal.BufferedCollectorOpt
 
@@ -70,6 +76,11 @@ func ExecuteResolvedPolicy(ctx context.Context, runtime llx.Runtime, collectorSv
 	builder := builderFromResolvedPolicy(resolvedPolicy)
 	builder.AddDatapointCollector(collector)
 	builder.AddScoreCollector(collector)
+	for _, dc := range durationCollectors {
+		if dc != nil {
+			builder.AddDurationCollector(dc)
+		}
+	}
 	if progressReporter != nil {
 		builder.WithProgressReporter(progressReporter)
 	}

--- a/policy/executor/internal/builder.go
+++ b/policy/executor/internal/builder.go
@@ -33,6 +33,9 @@ type GraphBuilder struct {
 	// scoreCollectors contains the collectors which will receive
 	// scores
 	scoreCollectors []ScoreCollector
+	// durationCollectors contains the collectors which will receive
+	// per-query wall-clock execution times
+	durationCollectors []DurationCollector
 	// reportingJobs is a list of reporting jobs, sourced from the
 	// resolved policy
 	reportingJobs []*policy.ReportingJob
@@ -138,6 +141,12 @@ func (b *GraphBuilder) AddDatapointCollector(c DatapointCollector) {
 	b.datapointCollectors = append(b.datapointCollectors, c)
 }
 
+// AddDurationCollector adds a per-query duration collector. The executor
+// invokes SinkDuration once for every ExecutionQuery it runs.
+func (b *GraphBuilder) AddDurationCollector(c DurationCollector) {
+	b.durationCollectors = append(b.durationCollectors, c)
+}
+
 // WithProgressReporter sets the interface which will receive progress updates
 func (b *GraphBuilder) WithProgressReporter(r progress.Progress) {
 	b.progressReporter = r
@@ -190,7 +199,7 @@ func (b *GraphBuilder) Build(runtime llx.Runtime, assetMrn string) (*GraphExecut
 		resultChan := make(chan *llx.RawResult, 128)
 		ge.resultChan = resultChan
 		ge.executionManager = newExecutionManager(runtime, make(chan runQueueItem, len(queries)),
-			resultChan, b.queryTimeout, b.dumpDatapoints)
+			resultChan, b.queryTimeout, b.dumpDatapoints, b.durationCollectors)
 	}
 
 	ge.nodes[DatapointCollectorID] = &Node{

--- a/policy/executor/internal/collector.go
+++ b/policy/executor/internal/collector.go
@@ -36,6 +36,13 @@ type ScoreCollector interface {
 	SinkScore([]*policy.Score)
 }
 
+// DurationCollector receives the wall-clock time the MQL executor spent
+// on a query, keyed by its llx code_id. Invoked once per ExecutionQuery
+// from the executionManager after the executor returns.
+type DurationCollector interface {
+	SinkDuration(codeID string, duration time.Duration)
+}
+
 type Collector interface {
 	DatapointCollector
 	ScoreCollector

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -43,6 +43,10 @@ type executionManager struct {
 	wg       sync.WaitGroup
 
 	dumpDatapoints bool
+
+	// durationCollectors receive the wall-clock execution time of each
+	// query after the executor returns
+	durationCollectors []DurationCollector
 }
 
 type runQueueItem struct {
@@ -52,15 +56,17 @@ type runQueueItem struct {
 
 func newExecutionManager(runtime llx.Runtime, runQueue chan runQueueItem,
 	resultChan chan *llx.RawResult, timeout time.Duration, dumpDatapoints bool,
+	durationCollectors []DurationCollector,
 ) *executionManager {
 	return &executionManager{
-		runQueue:       runQueue,
-		runtime:        runtime,
-		resultChan:     resultChan,
-		errChan:        make(chan error, 1),
-		stopChan:       make(chan struct{}),
-		timeout:        timeout,
-		dumpDatapoints: dumpDatapoints,
+		runQueue:           runQueue,
+		runtime:            runtime,
+		resultChan:         resultChan,
+		errChan:            make(chan error, 1),
+		stopChan:           make(chan struct{}),
+		timeout:            timeout,
+		dumpDatapoints:     dumpDatapoints,
+		durationCollectors: durationCollectors,
 	}
 }
 
@@ -176,10 +182,14 @@ func (em *executionManager) executeCodeBundle(codeBundle *llx.CodeBundle, props 
 	startTime := time.Now()
 	log.Debug().Str("qrid", codeID).Msg("starting query execution")
 	defer func() {
+		duration := time.Since(startTime)
 		log.Debug().
 			Str("qrid", codeID).
-			Dur("duration", time.Since(startTime)).
+			Dur("duration", duration).
 			Msg("finished query execution")
+		for _, c := range em.durationCollectors {
+			c.SinkDuration(codeID, duration)
+		}
 	}()
 	// TODO(jaym): sendResult may not be correct. We may need to fill in the
 	// checksum

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1203,7 +1203,8 @@ func (s *localAssetScanner) runPolicy() (*policy.ResolvedPolicy, error) {
 	logger.DebugDumpJSON("resolvedPolicy", resolvedPolicy)
 
 	features := mql.GetFeatures(s.job.Ctx)
-	err = executor.ExecuteResolvedPolicy(s.job.Ctx, s.Runtime, resolver, s.job.Asset.Mrn, resolvedPolicy, features, s.ProgressReporter)
+	durationCollector := newQueryDurationCollector(s.job.Ctx, s.services.DataLake, s.job.Asset.Mrn, resolvedPolicy)
+	err = executor.ExecuteResolvedPolicy(s.job.Ctx, s.Runtime, resolver, s.job.Asset.Mrn, resolvedPolicy, features, s.ProgressReporter, durationCollector)
 	if err != nil {
 		return nil, err
 	}
@@ -1316,4 +1317,77 @@ func createProgressBar(disableProgressBar bool) (progress.MultiProgress, error) 
 		return progress.NewTodoList(progress.WithScore())
 	}
 	return progress.NoopMultiProgress{}, nil
+}
+
+// queryDurationCollector forwards per-query execution times to the
+// DataLake. Most datalakes treat WriteQueryDuration as a no-op; the
+// SQLite scandb path persists the row so a captured scan db carries
+// per-query timings. The collector swaps the llx code_id for a query
+// MRN when the resolved policy unambiguously maps the code_id to a
+// single MRN.
+type queryDurationCollector struct {
+	ctx         context.Context
+	dataLake    policy.DataLake
+	assetMrn    string
+	codeIDToMrn map[string]string
+}
+
+func newQueryDurationCollector(ctx context.Context, dataLake policy.DataLake, assetMrn string, resolvedPolicy *policy.ResolvedPolicy) *queryDurationCollector {
+	return &queryDurationCollector{
+		ctx:         ctx,
+		dataLake:    dataLake,
+		assetMrn:    assetMrn,
+		codeIDToMrn: buildCodeIDToMrn(resolvedPolicy),
+	}
+}
+
+func (c *queryDurationCollector) SinkDuration(codeID string, duration time.Duration) {
+	if c == nil || c.dataLake == nil || codeID == "" {
+		return
+	}
+	id := codeID
+	if mrn, ok := c.codeIDToMrn[codeID]; ok {
+		id = mrn
+	}
+	if err := c.dataLake.WriteQueryDuration(c.ctx, c.assetMrn, id, duration.Milliseconds()); err != nil {
+		log.Debug().Err(err).Str("codeID", codeID).Msg("failed to record query duration")
+	}
+}
+
+// buildCodeIDToMrn walks the resolved policy's CollectorJob to find a
+// 1:1 mapping from query checksum (code_id) to query MRN. Code_ids that
+// resolve to multiple MRNs (deduped across policies) are skipped so
+// callers fall back to the raw code_id rather than picking arbitrarily.
+func buildCodeIDToMrn(resolvedPolicy *policy.ResolvedPolicy) map[string]string {
+	out := map[string]string{}
+	if resolvedPolicy == nil || resolvedPolicy.CollectorJob == nil {
+		return out
+	}
+	jobs := resolvedPolicy.CollectorJob.ReportingJobs
+	for codeID, arr := range resolvedPolicy.CollectorJob.ReportingQueries {
+		if arr == nil {
+			continue
+		}
+		mrns := map[string]struct{}{}
+		for _, uuid := range arr.Items {
+			rj, ok := jobs[uuid]
+			if !ok {
+				continue
+			}
+			if rj.QrId != "" && rj.QrId != "root" {
+				mrns[rj.QrId] = struct{}{}
+			}
+			for _, m := range rj.Mrns {
+				if m != "" {
+					mrns[m] = struct{}{}
+				}
+			}
+		}
+		if len(mrns) == 1 {
+			for m := range mrns {
+				out[codeID] = m
+			}
+		}
+	}
+	return out
 }

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1322,22 +1322,23 @@ func createProgressBar(disableProgressBar bool) (progress.MultiProgress, error) 
 // queryDurationCollector forwards per-query execution times to the
 // DataLake. Most datalakes treat WriteQueryDuration as a no-op; the
 // SQLite scandb path persists the row so a captured scan db carries
-// per-query timings. The collector swaps the llx code_id for a query
-// MRN when the resolved policy unambiguously maps the code_id to a
-// single MRN.
+// per-query timings. When the resolved policy maps a code_id to one or
+// more query MRNs the collector writes one row per MRN (with the same
+// duration); when no MRN is known it writes a single row keyed by the
+// raw llx code_id.
 type queryDurationCollector struct {
-	ctx         context.Context
-	dataLake    policy.DataLake
-	assetMrn    string
-	codeIDToMrn map[string]string
+	ctx          context.Context
+	dataLake     policy.DataLake
+	assetMrn     string
+	codeIDToMrns map[string][]string
 }
 
 func newQueryDurationCollector(ctx context.Context, dataLake policy.DataLake, assetMrn string, resolvedPolicy *policy.ResolvedPolicy) *queryDurationCollector {
 	return &queryDurationCollector{
-		ctx:         ctx,
-		dataLake:    dataLake,
-		assetMrn:    assetMrn,
-		codeIDToMrn: buildCodeIDToMrn(resolvedPolicy),
+		ctx:          ctx,
+		dataLake:     dataLake,
+		assetMrn:     assetMrn,
+		codeIDToMrns: buildCodeIDToMrns(resolvedPolicy),
 	}
 }
 
@@ -1345,47 +1346,73 @@ func (c *queryDurationCollector) SinkDuration(codeID string, duration time.Durat
 	if c == nil || c.dataLake == nil || codeID == "" {
 		return
 	}
-	id := codeID
-	if mrn, ok := c.codeIDToMrn[codeID]; ok {
-		id = mrn
+	ms := duration.Milliseconds()
+	ids := c.codeIDToMrns[codeID]
+	if len(ids) == 0 {
+		ids = []string{codeID}
 	}
-	if err := c.dataLake.WriteQueryDuration(c.ctx, c.assetMrn, id, duration.Milliseconds()); err != nil {
-		log.Debug().Err(err).Str("codeID", codeID).Msg("failed to record query duration")
+	for _, id := range ids {
+		if err := c.dataLake.WriteQueryDuration(c.ctx, c.assetMrn, id, ms); err != nil {
+			log.Debug().Err(err).Str("codeID", codeID).Str("id", id).Msg("failed to record query duration")
+		}
 	}
 }
 
-// buildCodeIDToMrn walks the resolved policy's CollectorJob to find a
-// 1:1 mapping from query checksum (code_id) to query MRN. Code_ids that
-// resolve to multiple MRNs (deduped across policies) are skipped so
-// callers fall back to the raw code_id rather than picking arbitrarily.
-func buildCodeIDToMrn(resolvedPolicy *policy.ResolvedPolicy) map[string]string {
-	out := map[string]string{}
+// buildCodeIDToMrns walks the resolved policy's CollectorJob to map
+// each query checksum (code_id) to the MRNs the policy bundle attaches
+// to it. The traversal mirrors the collector graph: every
+// ReportingJob whose qr_id is an MRN reports up from one or more
+// EXECUTION_QUERY child jobs whose qr_id is the code_id. A single
+// code_id can appear under multiple MRN-bearing reporting jobs
+// (deduped MQL across policies), so each (code_id, mrn) pair is
+// recorded and de-duplicated.
+func buildCodeIDToMrns(resolvedPolicy *policy.ResolvedPolicy) map[string][]string {
+	out := map[string][]string{}
 	if resolvedPolicy == nil || resolvedPolicy.CollectorJob == nil {
 		return out
 	}
 	jobs := resolvedPolicy.CollectorJob.ReportingJobs
-	for codeID, arr := range resolvedPolicy.CollectorJob.ReportingQueries {
-		if arr == nil {
+	seen := map[string]map[string]struct{}{}
+	add := func(codeID, mrn string) {
+		if codeID == "" || mrn == "" {
+			return
+		}
+		bucket, ok := seen[codeID]
+		if !ok {
+			bucket = map[string]struct{}{}
+			seen[codeID] = bucket
+		}
+		if _, dup := bucket[mrn]; dup {
+			return
+		}
+		bucket[mrn] = struct{}{}
+		out[codeID] = append(out[codeID], mrn)
+	}
+	for _, rj := range jobs {
+		if rj == nil {
 			continue
 		}
-		mrns := map[string]struct{}{}
-		for _, uuid := range arr.Items {
-			rj, ok := jobs[uuid]
-			if !ok {
+		// Source of truth for an MRN-bearing reporting job is its
+		// mrns list; fall back to qr_id when the list is missing but
+		// the qr_id itself is recognizably an MRN.
+		mrns := rj.Mrns
+		if len(mrns) == 0 && strings.HasPrefix(rj.QrId, "//") {
+			mrns = []string{rj.QrId}
+		}
+		if len(mrns) == 0 {
+			continue
+		}
+		for childUUID := range rj.ChildJobs {
+			child, ok := jobs[childUUID]
+			if !ok || child == nil {
 				continue
 			}
-			if rj.QrId != "" && rj.QrId != "root" {
-				mrns[rj.QrId] = struct{}{}
+			if child.Type != policy.ReportingJob_EXECUTION_QUERY {
+				continue
 			}
-			for _, m := range rj.Mrns {
-				if m != "" {
-					mrns[m] = struct{}{}
-				}
-			}
-		}
-		if len(mrns) == 1 {
-			for m := range mrns {
-				out[codeID] = m
+			codeID := child.QrId
+			for _, mrn := range mrns {
+				add(codeID, mrn)
 			}
 		}
 	}

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -614,3 +614,117 @@ func TestNewLocalScannerWithOptions(t *testing.T) {
 		assert.False(t, rt.AutoUpdate.Enabled, "should not be modified if a custom runtime is provided")
 	})
 }
+
+func TestBuildCodeIDToMrns(t *testing.T) {
+	mrnA := "//policy.api.mondoo.app/queries/check-a"
+	mrnB := "//policy.api.mondoo.app/queries/check-b"
+	codeID := "RNQ4JIDDCic="
+	otherCodeID := "OTHER="
+
+	t.Run("single MRN parent via mrns array", func(t *testing.T) {
+		rp := &policy.ResolvedPolicy{CollectorJob: &policy.CollectorJob{
+			ReportingJobs: map[string]*policy.ReportingJob{
+				"parent": {
+					Uuid:      "parent",
+					QrId:      mrnA,
+					Type:      policy.ReportingJob_CHECK,
+					Mrns:      []string{mrnA},
+					ChildJobs: map[string]*policy.Impact{"child": {}},
+				},
+				"child": {
+					Uuid: "child",
+					QrId: codeID,
+					Type: policy.ReportingJob_EXECUTION_QUERY,
+				},
+			},
+		}}
+		got := buildCodeIDToMrns(rp)
+		assert.Equal(t, map[string][]string{codeID: {mrnA}}, got)
+	})
+
+	t.Run("falls back to qr_id when mrns array is empty", func(t *testing.T) {
+		rp := &policy.ResolvedPolicy{CollectorJob: &policy.CollectorJob{
+			ReportingJobs: map[string]*policy.ReportingJob{
+				"parent": {
+					Uuid:      "parent",
+					QrId:      mrnA,
+					Type:      policy.ReportingJob_CHECK,
+					ChildJobs: map[string]*policy.Impact{"child": {}},
+				},
+				"child": {
+					Uuid: "child",
+					QrId: codeID,
+					Type: policy.ReportingJob_EXECUTION_QUERY,
+				},
+			},
+		}}
+		got := buildCodeIDToMrns(rp)
+		assert.Equal(t, map[string][]string{codeID: {mrnA}}, got)
+	})
+
+	t.Run("one code_id shared by two MRN-bearing parents", func(t *testing.T) {
+		rp := &policy.ResolvedPolicy{CollectorJob: &policy.CollectorJob{
+			ReportingJobs: map[string]*policy.ReportingJob{
+				"parentA": {
+					Uuid:      "parentA",
+					QrId:      mrnA,
+					Type:      policy.ReportingJob_CHECK,
+					Mrns:      []string{mrnA},
+					ChildJobs: map[string]*policy.Impact{"child": {}},
+				},
+				"parentB": {
+					Uuid:      "parentB",
+					QrId:      mrnB,
+					Type:      policy.ReportingJob_CHECK,
+					Mrns:      []string{mrnB},
+					ChildJobs: map[string]*policy.Impact{"child": {}},
+				},
+				"child": {
+					Uuid: "child",
+					QrId: codeID,
+					Type: policy.ReportingJob_EXECUTION_QUERY,
+				},
+			},
+		}}
+		got := buildCodeIDToMrns(rp)
+		require.Len(t, got[codeID], 2)
+		assert.ElementsMatch(t, []string{mrnA, mrnB}, got[codeID])
+	})
+
+	t.Run("ignores non-MRN parents and non-EXECUTION_QUERY children", func(t *testing.T) {
+		rp := &policy.ResolvedPolicy{CollectorJob: &policy.CollectorJob{
+			ReportingJobs: map[string]*policy.ReportingJob{
+				"root": {
+					Uuid:      "root",
+					QrId:      "root", // not an MRN
+					Type:      policy.ReportingJob_POLICY,
+					ChildJobs: map[string]*policy.Impact{"child": {}},
+				},
+				"parent": {
+					Uuid:      "parent",
+					QrId:      mrnA,
+					Type:      policy.ReportingJob_CHECK,
+					Mrns:      []string{mrnA},
+					ChildJobs: map[string]*policy.Impact{"check-child": {}, "exec-child": {}},
+				},
+				"check-child": { // non-execution-query child, must be ignored
+					Uuid: "check-child",
+					QrId: otherCodeID,
+					Type: policy.ReportingJob_CHECK,
+				},
+				"exec-child": {
+					Uuid: "exec-child",
+					QrId: codeID,
+					Type: policy.ReportingJob_EXECUTION_QUERY,
+				},
+			},
+		}}
+		got := buildCodeIDToMrns(rp)
+		assert.Equal(t, map[string][]string{codeID: {mrnA}}, got)
+	})
+
+	t.Run("nil resolved policy returns empty map", func(t *testing.T) {
+		assert.Empty(t, buildCodeIDToMrns(nil))
+		assert.Empty(t, buildCodeIDToMrns(&policy.ResolvedPolicy{}))
+	})
+}

--- a/policy/scandb/query.sql
+++ b/policy/scandb/query.sql
@@ -71,3 +71,13 @@ INSERT OR REPLACE INTO asset_filters (code_id) VALUES (?);
 
 -- name: StreamAssetFilters :many
 SELECT code_id FROM asset_filters ORDER BY code_id;
+
+-- Query duration operations
+-- name: InsertQueryDuration :exec
+INSERT OR REPLACE INTO query_durations (code_id, duration_ms) VALUES (?, ?);
+
+-- name: GetQueryDuration :one
+SELECT duration_ms FROM query_durations WHERE code_id = ?;
+
+-- name: StreamQueryDurations :many
+SELECT code_id, duration_ms FROM query_durations ORDER BY code_id;

--- a/policy/scandb/scan_data_store.go
+++ b/policy/scandb/scan_data_store.go
@@ -40,6 +40,7 @@ type ScanDataStoreReader interface {
 	StreamData(ctx context.Context, callback func(string, *llx.Result) error) error
 	StreamRisks(ctx context.Context, callback func(*policy.ScoredRiskFactor) error) error
 	StreamResources(ctx context.Context, callback func(*llx.ResourceRecording) error) error
+	StreamQueryDurations(ctx context.Context, callback func(codeId string, durationMs int64) error) error
 
 	// Reader methods for specific items
 	GetScore(ctx context.Context, qrId string) (*policy.Score, error)
@@ -54,6 +55,7 @@ type ScanDataStoreWriter interface {
 	WriteData(ctx context.Context, data []*llx.Result) error
 	WriteRisk(ctx context.Context, risk *policy.ScoredRiskFactor) error
 	WriteResource(ctx context.Context, resource *llx.ResourceRecording) error
+	WriteQueryDuration(ctx context.Context, codeId string, durationMs int64) error
 	Finalize() (string, error)
 	Close() error
 }
@@ -282,6 +284,47 @@ func (s *SqliteScanDataStore) WriteAsset(ctx context.Context, asset *inventory.A
 		return fmt.Errorf("failed to write asset: %w", err)
 	}
 	return nil
+}
+
+// WriteQueryDuration records the wall-clock time the MQL executor spent on
+// a single query. codeId is normally the llx query checksum, but callers
+// may substitute a resolved query MRN when one is available — see the
+// scandb-wrapper helper that performs the conversion.
+func (s *SqliteScanDataStore) WriteQueryDuration(ctx context.Context, codeId string, durationMs int64) error {
+	if s.readOnly {
+		return fmt.Errorf("cannot write query duration in read-only mode")
+	}
+	if codeId == "" {
+		return nil
+	}
+	if err := s.queries.InsertQueryDuration(ctx, sqlc.InsertQueryDurationParams{
+		CodeID:     codeId,
+		DurationMs: durationMs,
+	}); err != nil {
+		return fmt.Errorf("failed to write query duration %s: %w", codeId, err)
+	}
+	return nil
+}
+
+// StreamQueryDurations iterates over recorded per-query execution times.
+func (s *SqliteScanDataStore) StreamQueryDurations(ctx context.Context, callback func(codeId string, durationMs int64) error) error {
+	rows, err := s.queries.StreamQueryDurations(ctx)
+	if err != nil {
+		if isMissingQueryDurationsTable(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to query query_durations: %w", err)
+	}
+	for _, row := range rows {
+		if err := callback(row.CodeID, row.DurationMs); err != nil {
+			return fmt.Errorf("callback error for query duration %s: %w", row.CodeID, err)
+		}
+	}
+	return nil
+}
+
+func isMissingQueryDurationsTable(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no such table: query_durations")
 }
 
 // WriteRisk writes a single risk factor

--- a/policy/scandb/scan_data_store_test.go
+++ b/policy/scandb/scan_data_store_test.go
@@ -239,6 +239,32 @@ func TestSqliteScanDataStore(t *testing.T) {
 	})
 }
 
+func TestQueryDurations(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test_durations.db")
+	assetMrn := "//assets.api.mondoo.com/spaces/test-space/assets/durations"
+
+	store, err := NewSqliteScanDataStore(dbPath, assetMrn)
+	require.NoError(t, err)
+	defer store.Close()
+
+	ctx := context.Background()
+
+	require.NoError(t, store.WriteQueryDuration(ctx, "code-a", 17))
+	require.NoError(t, store.WriteQueryDuration(ctx, "code-b", 250))
+	// upsert: a second write replaces the row
+	require.NoError(t, store.WriteQueryDuration(ctx, "code-a", 42))
+	// empty code_id is a no-op
+	require.NoError(t, store.WriteQueryDuration(ctx, "", 99))
+
+	got := map[string]int64{}
+	require.NoError(t, store.StreamQueryDurations(ctx, func(codeID string, ms int64) error {
+		got[codeID] = ms
+		return nil
+	}))
+	assert.Equal(t, map[string]int64{"code-a": 42, "code-b": 250}, got)
+}
+
 func TestStreamingReads(t *testing.T) {
 	// Create a temporary file for testing
 	tempDir := t.TempDir()

--- a/policy/scandb/scan_data_store_wrapper.go
+++ b/policy/scandb/scan_data_store_wrapper.go
@@ -134,6 +134,17 @@ func (w *ScanDataStoreWrapper) Finalize() (string, error) {
 	return w.store.Finalize()
 }
 
+// WriteQueryDuration validates the asset MRN and forwards a per-query
+// execution time to the underlying scan data store. codeId is the value
+// the caller wants persisted in the query_durations.code_id column —
+// typically the llx query checksum, or a resolved query MRN.
+func (w *ScanDataStoreWrapper) WriteQueryDuration(ctx context.Context, assetMrn string, codeId string, durationMs int64) error {
+	if err := w.validate(assetMrn); err != nil {
+		return err
+	}
+	return w.store.WriteQueryDuration(ctx, codeId, durationMs)
+}
+
 // SetAssetFilters records the code_ids of the filters the scanner sent to
 // ResolveAndUpdateJobs into the scan database. Verifies the asset MRN
 // matches and pulls just the code_ids from the proto — no MQL/text is

--- a/policy/scandb/scan_db.sql
+++ b/policy/scandb/scan_db.sql
@@ -71,6 +71,15 @@ CREATE TABLE asset_filters (
     code_id TEXT NOT NULL PRIMARY KEY
 );
 
+-- Query execution durations - one row per query executed during the scan.
+-- code_id holds the llx query checksum, or the query MRN when the scanner
+-- can resolve one from the resolved policy. duration_ms is the wall-clock
+-- time the underlying MQL executor spent on the query.
+CREATE TABLE query_durations (
+    code_id TEXT NOT NULL PRIMARY KEY,
+    duration_ms INTEGER NOT NULL
+);
+
 -- Primary key indexes are automatically created for scores(qr_id) and data(code_id)
 -- No additional indexes needed since we're using the primary keys for lookups
 

--- a/policy/scandb/sqlc/db.go
+++ b/policy/scandb/sqlc/db.go
@@ -36,6 +36,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getMetadataByKeyStmt, err = db.PrepareContext(ctx, getMetadataByKey); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMetadataByKey: %w", err)
 	}
+	if q.getQueryDurationStmt, err = db.PrepareContext(ctx, getQueryDuration); err != nil {
+		return nil, fmt.Errorf("error preparing query GetQueryDuration: %w", err)
+	}
 	if q.getResourceStmt, err = db.PrepareContext(ctx, getResource); err != nil {
 		return nil, fmt.Errorf("error preparing query GetResource: %w", err)
 	}
@@ -57,6 +60,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.insertMetadataStmt, err = db.PrepareContext(ctx, insertMetadata); err != nil {
 		return nil, fmt.Errorf("error preparing query InsertMetadata: %w", err)
 	}
+	if q.insertQueryDurationStmt, err = db.PrepareContext(ctx, insertQueryDuration); err != nil {
+		return nil, fmt.Errorf("error preparing query InsertQueryDuration: %w", err)
+	}
 	if q.insertResourceStmt, err = db.PrepareContext(ctx, insertResource); err != nil {
 		return nil, fmt.Errorf("error preparing query InsertResource: %w", err)
 	}
@@ -71,6 +77,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.streamDataStmt, err = db.PrepareContext(ctx, streamData); err != nil {
 		return nil, fmt.Errorf("error preparing query StreamData: %w", err)
+	}
+	if q.streamQueryDurationsStmt, err = db.PrepareContext(ctx, streamQueryDurations); err != nil {
+		return nil, fmt.Errorf("error preparing query StreamQueryDurations: %w", err)
 	}
 	if q.streamResourcesStmt, err = db.PrepareContext(ctx, streamResources); err != nil {
 		return nil, fmt.Errorf("error preparing query StreamResources: %w", err)
@@ -104,6 +113,11 @@ func (q *Queries) Close() error {
 	if q.getMetadataByKeyStmt != nil {
 		if cerr := q.getMetadataByKeyStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getMetadataByKeyStmt: %w", cerr)
+		}
+	}
+	if q.getQueryDurationStmt != nil {
+		if cerr := q.getQueryDurationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getQueryDurationStmt: %w", cerr)
 		}
 	}
 	if q.getResourceStmt != nil {
@@ -141,6 +155,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing insertMetadataStmt: %w", cerr)
 		}
 	}
+	if q.insertQueryDurationStmt != nil {
+		if cerr := q.insertQueryDurationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing insertQueryDurationStmt: %w", cerr)
+		}
+	}
 	if q.insertResourceStmt != nil {
 		if cerr := q.insertResourceStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing insertResourceStmt: %w", cerr)
@@ -164,6 +183,11 @@ func (q *Queries) Close() error {
 	if q.streamDataStmt != nil {
 		if cerr := q.streamDataStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing streamDataStmt: %w", cerr)
+		}
+	}
+	if q.streamQueryDurationsStmt != nil {
+		if cerr := q.streamQueryDurationsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing streamQueryDurationsStmt: %w", cerr)
 		}
 	}
 	if q.streamResourcesStmt != nil {
@@ -218,51 +242,57 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 }
 
 type Queries struct {
-	db                     DBTX
-	tx                     *sql.Tx
-	getAssetStmt           *sql.Stmt
-	getDataStmt            *sql.Stmt
-	getMetadataStmt        *sql.Stmt
-	getMetadataByKeyStmt   *sql.Stmt
-	getResourceStmt        *sql.Stmt
-	getRiskFactorStmt      *sql.Stmt
-	getScoreStmt           *sql.Stmt
-	insertAssetStmt        *sql.Stmt
-	insertAssetFilterStmt  *sql.Stmt
-	insertDataStmt         *sql.Stmt
-	insertMetadataStmt     *sql.Stmt
-	insertResourceStmt     *sql.Stmt
-	insertRiskFactorStmt   *sql.Stmt
-	insertScoreStmt        *sql.Stmt
-	streamAssetFiltersStmt *sql.Stmt
-	streamDataStmt         *sql.Stmt
-	streamResourcesStmt    *sql.Stmt
-	streamRiskFactorsStmt  *sql.Stmt
-	streamScoresStmt       *sql.Stmt
+	db                       DBTX
+	tx                       *sql.Tx
+	getAssetStmt             *sql.Stmt
+	getDataStmt              *sql.Stmt
+	getMetadataStmt          *sql.Stmt
+	getMetadataByKeyStmt     *sql.Stmt
+	getQueryDurationStmt     *sql.Stmt
+	getResourceStmt          *sql.Stmt
+	getRiskFactorStmt        *sql.Stmt
+	getScoreStmt             *sql.Stmt
+	insertAssetStmt          *sql.Stmt
+	insertAssetFilterStmt    *sql.Stmt
+	insertDataStmt           *sql.Stmt
+	insertMetadataStmt       *sql.Stmt
+	insertQueryDurationStmt  *sql.Stmt
+	insertResourceStmt       *sql.Stmt
+	insertRiskFactorStmt     *sql.Stmt
+	insertScoreStmt          *sql.Stmt
+	streamAssetFiltersStmt   *sql.Stmt
+	streamDataStmt           *sql.Stmt
+	streamQueryDurationsStmt *sql.Stmt
+	streamResourcesStmt      *sql.Stmt
+	streamRiskFactorsStmt    *sql.Stmt
+	streamScoresStmt         *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
-		db:                     tx,
-		tx:                     tx,
-		getAssetStmt:           q.getAssetStmt,
-		getDataStmt:            q.getDataStmt,
-		getMetadataStmt:        q.getMetadataStmt,
-		getMetadataByKeyStmt:   q.getMetadataByKeyStmt,
-		getResourceStmt:        q.getResourceStmt,
-		getRiskFactorStmt:      q.getRiskFactorStmt,
-		getScoreStmt:           q.getScoreStmt,
-		insertAssetStmt:        q.insertAssetStmt,
-		insertAssetFilterStmt:  q.insertAssetFilterStmt,
-		insertDataStmt:         q.insertDataStmt,
-		insertMetadataStmt:     q.insertMetadataStmt,
-		insertResourceStmt:     q.insertResourceStmt,
-		insertRiskFactorStmt:   q.insertRiskFactorStmt,
-		insertScoreStmt:        q.insertScoreStmt,
-		streamAssetFiltersStmt: q.streamAssetFiltersStmt,
-		streamDataStmt:         q.streamDataStmt,
-		streamResourcesStmt:    q.streamResourcesStmt,
-		streamRiskFactorsStmt:  q.streamRiskFactorsStmt,
-		streamScoresStmt:       q.streamScoresStmt,
+		db:                       tx,
+		tx:                       tx,
+		getAssetStmt:             q.getAssetStmt,
+		getDataStmt:              q.getDataStmt,
+		getMetadataStmt:          q.getMetadataStmt,
+		getMetadataByKeyStmt:     q.getMetadataByKeyStmt,
+		getQueryDurationStmt:     q.getQueryDurationStmt,
+		getResourceStmt:          q.getResourceStmt,
+		getRiskFactorStmt:        q.getRiskFactorStmt,
+		getScoreStmt:             q.getScoreStmt,
+		insertAssetStmt:          q.insertAssetStmt,
+		insertAssetFilterStmt:    q.insertAssetFilterStmt,
+		insertDataStmt:           q.insertDataStmt,
+		insertMetadataStmt:       q.insertMetadataStmt,
+		insertQueryDurationStmt:  q.insertQueryDurationStmt,
+		insertResourceStmt:       q.insertResourceStmt,
+		insertRiskFactorStmt:     q.insertRiskFactorStmt,
+		insertScoreStmt:          q.insertScoreStmt,
+		streamAssetFiltersStmt:   q.streamAssetFiltersStmt,
+		streamDataStmt:           q.streamDataStmt,
+		streamQueryDurationsStmt: q.streamQueryDurationsStmt,
+		streamResourcesStmt:      q.streamResourcesStmt,
+		streamRiskFactorsStmt:    q.streamRiskFactorsStmt,
+		streamScoresStmt:         q.streamScoresStmt,
 	}
 }

--- a/policy/scandb/sqlc/models.go
+++ b/policy/scandb/sqlc/models.go
@@ -27,6 +27,11 @@ type Metadata struct {
 	Value string `json:"value"`
 }
 
+type QueryDuration struct {
+	CodeID     string `json:"code_id"`
+	DurationMs int64  `json:"duration_ms"`
+}
+
 type Resource struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`

--- a/policy/scandb/sqlc/querier.go
+++ b/policy/scandb/sqlc/querier.go
@@ -13,6 +13,7 @@ type Querier interface {
 	GetData(ctx context.Context, codeID string) ([]byte, error)
 	GetMetadata(ctx context.Context) ([]Metadata, error)
 	GetMetadataByKey(ctx context.Context, key string) (string, error)
+	GetQueryDuration(ctx context.Context, codeID string) (int64, error)
 	GetResource(ctx context.Context, arg GetResourceParams) ([]byte, error)
 	GetRiskFactor(ctx context.Context, mrn string) (ScoredRiskFactor, error)
 	GetScore(ctx context.Context, qrID string) (Score, error)
@@ -26,6 +27,8 @@ type Querier interface {
 	// SPDX-License-Identifier: BUSL-1.1
 	// Metadata operations
 	InsertMetadata(ctx context.Context, arg InsertMetadataParams) error
+	// Query duration operations
+	InsertQueryDuration(ctx context.Context, arg InsertQueryDurationParams) error
 	// Resource operations
 	InsertResource(ctx context.Context, arg InsertResourceParams) error
 	// Risk factor operations
@@ -34,6 +37,7 @@ type Querier interface {
 	InsertScore(ctx context.Context, arg InsertScoreParams) error
 	StreamAssetFilters(ctx context.Context) ([]string, error)
 	StreamData(ctx context.Context) ([]Datum, error)
+	StreamQueryDurations(ctx context.Context) ([]QueryDuration, error)
 	StreamResources(ctx context.Context) ([]Resource, error)
 	StreamRiskFactors(ctx context.Context) ([]ScoredRiskFactor, error)
 	StreamScores(ctx context.Context) ([]Score, error)

--- a/policy/scandb/sqlc/query.sql.go
+++ b/policy/scandb/sqlc/query.sql.go
@@ -70,6 +70,17 @@ func (q *Queries) GetMetadataByKey(ctx context.Context, key string) (string, err
 	return value, err
 }
 
+const getQueryDuration = `-- name: GetQueryDuration :one
+SELECT duration_ms FROM query_durations WHERE code_id = ?
+`
+
+func (q *Queries) GetQueryDuration(ctx context.Context, codeID string) (int64, error) {
+	row := q.queryRow(ctx, q.getQueryDurationStmt, getQueryDuration, codeID)
+	var duration_ms int64
+	err := row.Scan(&duration_ms)
+	return duration_ms, err
+}
+
 const getResource = `-- name: GetResource :one
 SELECT data FROM resources WHERE name = ? AND id = ?
 `
@@ -174,6 +185,21 @@ type InsertMetadataParams struct {
 // Metadata operations
 func (q *Queries) InsertMetadata(ctx context.Context, arg InsertMetadataParams) error {
 	_, err := q.exec(ctx, q.insertMetadataStmt, insertMetadata, arg.Key, arg.Value)
+	return err
+}
+
+const insertQueryDuration = `-- name: InsertQueryDuration :exec
+INSERT OR REPLACE INTO query_durations (code_id, duration_ms) VALUES (?, ?)
+`
+
+type InsertQueryDurationParams struct {
+	CodeID     string `json:"code_id"`
+	DurationMs int64  `json:"duration_ms"`
+}
+
+// Query duration operations
+func (q *Queries) InsertQueryDuration(ctx context.Context, arg InsertQueryDurationParams) error {
+	_, err := q.exec(ctx, q.insertQueryDurationStmt, insertQueryDuration, arg.CodeID, arg.DurationMs)
 	return err
 }
 
@@ -289,6 +315,33 @@ func (q *Queries) StreamData(ctx context.Context) ([]Datum, error) {
 	for rows.Next() {
 		var i Datum
 		if err := rows.Scan(&i.CodeID, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const streamQueryDurations = `-- name: StreamQueryDurations :many
+SELECT code_id, duration_ms FROM query_durations ORDER BY code_id
+`
+
+func (q *Queries) StreamQueryDurations(ctx context.Context) ([]QueryDuration, error) {
+	rows, err := q.query(ctx, q.streamQueryDurationsStmt, streamQueryDurations)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []QueryDuration
+	for rows.Next() {
+		var i QueryDuration
+		if err := rows.Scan(&i.CodeID, &i.DurationMs); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## What

Adds a `query_durations` table to the SQLite scandb schema with one row per query the MQL executor runs:

```sql
CREATE TABLE query_durations (
    code_id TEXT NOT NULL PRIMARY KEY,
    duration_ms INTEGER NOT NULL
);
```

A new `DurationCollector` interface in `policy/executor/internal` is wired through `GraphBuilder` and `executionManager`. The executor already measured per-query wall time inside `executeCodeBundle`'s defer (it was being logged at debug only) — collectors now receive the same `time.Duration` once per `ExecutionQuery`.

`policy.DataLake` gets a `WriteQueryDuration(ctx, assetMrn, codeId, durationMs)` method (mirroring the existing `SetAssetFilters` pattern); the in-memory cache writer no-ops, the scandb wrapper persists. `local_scanner` constructs a `queryDurationCollector` per asset and hands it to `ExecuteResolvedPolicy` via a new variadic option.

When the resolved policy unambiguously maps a `code_id` to a single MRN (via `CollectorJob.ReportingQueries` → `ReportingJobs[uuid].{QrId, Mrns}`), the MRN is stored in the `code_id` column instead of the raw llx checksum. Ambiguous mappings (deduped queries shared across policies) fall back to the raw checksum rather than picking arbitrarily.

## Why

Query timings have only existed as debug log lines. Persisting them in the scan database lets consumers (replay tooling, perf analysis) attribute time without re-running scans, and the optional MRN substitution makes the data interpretable without also carrying the resolved policy.

## Test plan

- [x] `go test ./policy/scandb/... ./policy/executor/... ./policy/scan/... ./internal/datalakes/...`
- [x] New `TestQueryDurations` covers write/upsert/empty-code_id/stream on the SQLite store
- [x] Full `go test ./...` — only pre-existing `TestOsProviderSharedTests/local/packages` failure (host package-manager probe, reproduces on `main`)