### PR TITLE
fix(serve): never write debug-dump files in serve mode

### DIFF
--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"slices"
 	"time"
 
@@ -68,6 +69,9 @@ var serveCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prof.InitProfiler()
+
+		// Serve is a long-running daemon: never write per-scan debug-dump files.
+		disableServeDebugArtifacts()
 
 		// prevent colors on windows
 		viper.Set("color", "none")
@@ -170,6 +174,28 @@ var serveCmd = &cobra.Command{
 		})
 		return nil
 	},
+}
+
+// disableServeDebugArtifacts stops cnquery's logger.DebugDumpJSON/YAML from
+// writing per-scan mondoo-debug-*.json/.yaml files in serve mode. Those helpers
+// fall back to a "./mondoo-debug-" prefix when DEBUG=1/TRACE=1 and
+// logger.DumpLocal is unset, rewriting files in the working directory on every
+// scan cycle. serve's PreRun has already captured the log level and applied it
+// to zerolog before RunE runs, so clearing these env vars here leaves debug
+// *logging* intact (provider plugins also keep their level — they receive it via
+// the --log-level flag, not the env) while routing the dump helpers down their
+// no-op path. The cnspec-side scandump system is already inert in serve (no
+// scandump.Run is attached to the scan ctx), and --collect-support-bundle is a
+// scan-only flag never wired into serve, so no support-bundle tar is produced
+// here either.
+//
+// Side effect: DEBUG/TRACE-gated diagnostics that run after this point also stop
+// seeing the variable. In practice that is limited to verbose k8s-discovery in
+// provider subprocesses; the prometheus debug-metrics server is started at
+// process boot (before serve dispatch) and is unaffected.
+func disableServeDebugArtifacts() {
+	_ = os.Unsetenv("DEBUG")
+	_ = os.Unsetenv("TRACE")
 }
 
 func getServeConfig() (*scanConfig, *cnspec_config.CliConfig, error) {

--- a/apps/cnspec/cmd/serve_test.go
+++ b/apps/cnspec/cmd/serve_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/logger"
+)
+
+// The support bundle (and its tar.gz packaging) is intentionally a scan-only
+// feature. serve is a long-running daemon and must never collect one. These
+// flags are registered and read only on scanCmd; guard against a future change
+// accidentally wiring them into serve.
+func TestServeCmd_HasNoSupportBundleFlags(t *testing.T) {
+	assert.Nil(t, serveCmd.Flags().Lookup("collect-support-bundle"),
+		"serve must not expose --collect-support-bundle; the support bundle is scan-only")
+	assert.Nil(t, serveCmd.Flags().Lookup("support-bundle-dir"),
+		"serve must not expose --support-bundle-dir; the support bundle is scan-only")
+}
+
+// disableServeDebugArtifacts must stop cnquery's logger dump helpers from
+// writing mondoo-debug-* files even when debug logging is enabled via the
+// DEBUG env var — the scenario a serve operator hits when troubleshooting.
+func TestDisableServeDebugArtifacts_SuppressesDumps(t *testing.T) {
+	prevLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() { zerolog.SetGlobalLevel(prevLevel) })
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+
+	t.Setenv("DEBUG", "1")
+	t.Setenv("TRACE", "1")
+
+	// DumpLocal must be empty so the helpers take the env-driven default path
+	// (a non-empty DumpLocal writes unconditionally and is not what serve hits).
+	prevDump := logger.DumpLocal
+	logger.DumpLocal = ""
+	t.Cleanup(func() { logger.DumpLocal = prevDump })
+
+	// Run in a temp dir so a stray "./mondoo-debug-*" write would be observable.
+	tmp := t.TempDir()
+	prevWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(prevWd) })
+
+	disableServeDebugArtifacts()
+
+	assert.Empty(t, os.Getenv("DEBUG"), "DEBUG must be cleared so dump helpers no-op")
+	assert.Empty(t, os.Getenv("TRACE"), "TRACE must be cleared so dump helpers no-op")
+
+	// With the env cleared and DumpLocal empty, this hits the no-op path.
+	logger.DebugDumpJSON("inventory-unresolved", map[string]string{"k": "v"})
+	logger.DebugDumpYAML("assetBundle", map[string]string{"k": "v"})
+
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no mondoo-debug-* file should be written in serve mode")
+}


### PR DESCRIPTION
## What

In `cnspec serve`, set `logger.DumpDisabled = true` at the start of `RunE` so no debug-dump files are written to disk, even under `DEBUG=1`. Debug *logging* still works. Adds a regression test guarding that the support-bundle flags are never wired into serve.

## Why

Follow-up to #2687 (`--collect-support-bundle` + the reworked per-asset debug-dump system). For the long-running serve daemon we want to be sure that feature can't interfere:

- **No tar in serve.** `--collect-support-bundle` / `--support-bundle-dir` are registered only on `scanCmd`, viper-bound only in `scanCmd.PreRun`, and read only in `scanCmdRun`. serve calls `RunScan` directly and never touches them, so a support-bundle tar can never be produced in serve. The new test locks this in.
- **No debug files filling disk.** The cnspec-side `scandump` system is already inert in serve (no `scandump.Run` is attached to the scan ctx). The remaining writers were the cnquery-side `logger.DebugDumpJSON/YAML` calls (e.g. `mondoo-debug-inventory-unresolved.json`), which under `DEBUG=1` defaulted to `./mondoo-debug-` and were rewritten in the process CWD on every scan cycle. Disabling them via `logger.DumpDisabled` stops that.

## Dependency

Requires the new `logger.DumpDisabled` symbol in mql (see the companion mql PR). The mql change must be released first, then this repo's `go.mod` bumped to that mql version. Locally it compiles via `go.work`.

## Test

- `apps/cnspec/cmd/serve_test.go`: asserts `serveCmd` exposes neither `--collect-support-bundle` nor `--support-bundle-dir`.
- mql side adds `logger/debug_test.go` covering the suppress behavior.