### PR TITLE
Fix mondoo-macos-profile query to iterate macos.profiles.list

### DIFF
--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -183,7 +183,7 @@ packs:
         title: Configuration Profile Data
         docs:
           desc: Returns installed Configuration Profiles, sourced from both MDM-delivered and manually installed payloads.
-        mql: macos.profiles { identifier uuid displayName description organization type removalDisallowed scope payloads }
+        mql: macos.profiles.list { identifier uuid displayName description organization type removalDisallowed scope payloads }
       - uid: mondoo-macos-timezone
         title: System timezone
         docs:


### PR DESCRIPTION
## Problem

The `mondoo-macos-profile` query in `mondoo-macos-inventory` opened a field block directly on the `macos.profiles` collection resource:

```mql
macos.profiles { identifier uuid displayName description organization type removalDisallowed scope payloads }
```

But `macos.profiles` only exposes `list() []macos.profile` — the selected fields (`identifier`, `uuid`, `displayName`, …) live on the singular `macos.profile` item. So the query fails to compile:

```
cannot find field or resource 'identifier' in block for type 'macos.profiles'
```

This surfaced as a **policy-bundle load failure** in the downstream `cnspec-enterprise-policies` bundle-update CI (Test Policy Loading → "Load policies from PR").

## Fix

Iterate the collection via `.list` so the field block applies to each `macos.profile`:

```mql
macos.profiles.list { identifier uuid displayName description organization type removalDisallowed scope payloads }
```

## Verification

- `cnspec policy lint content/querypacks/mondoo-macos-inventory.mql.yaml` → valid bundle.
- `mql run local -c 'macos.profiles { … }'` reproduces the exact compile error; the `.list` form compiles and executes (returns profile data with root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)