### PR TITLE
Add Manila, Magnum, Trove, and Keystone trust checks to OpenStack policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -145,6 +145,7 @@ cloudrun
 cloudservices
 cloudsql
 cloudtrailconfigchanges
+clustertemplate
 cmdline
 cmdshell
 cmek
@@ -164,6 +165,7 @@ confs
 consoleauthfailures
 consolesigninwithoutmfa
 containerengine
+containerinfra
 containerscanning
 continuedev
 contoso
@@ -710,6 +712,7 @@ setenv
 setglobalstate
 setxattr
 sfn
+sharedfilesystem
 shmcb
 shopt
 shosts

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure OpenStack projects across Keystone, Nova, Neutron, Cinder, Glance, Swift, and Octavia
+    summary: Secure OpenStack projects across Keystone, Nova, Neutron, Cinder, Glance, Swift, Octavia, Manila, Magnum, and Trove
     docs:
       desc: |
         The Mondoo OpenStack Security policy identifies critical misconfigurations that could leave your OpenStack project exposed to attackers. The policy focuses on security-relevant controls and helps organizations harden against unauthorized network access, weak credentials, unencrypted data, and accidental exposure of project-owned assets.

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.0.1
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -20,13 +20,16 @@ policies:
 
         This policy provides security checks across the following OpenStack services:
 
-        - Keystone (identity, users, application credentials)
+        - Keystone (identity, users, application credentials, trusts)
         - Nova (compute servers and keypairs)
         - Neutron (networks, ports, security groups)
         - Cinder (block-storage volumes)
         - Glance (images)
         - Swift (object-storage containers)
         - Octavia (load balancers and TLS termination)
+        - Manila (shared file systems)
+        - Magnum (container infrastructure clusters)
+        - Trove (managed databases)
 
         Learn more about scanning OpenStack in the [cnspec OpenStack documentation](https://mondoo.com/docs/cnspec/cloud/openstack).
 
@@ -36,6 +39,7 @@ policies:
         checks:
           - uid: mondoo-openstack-security-app-credentials-restricted
           - uid: mondoo-openstack-security-app-credentials-have-expiry
+          - uid: mondoo-openstack-security-trust-impersonation-expiry
       - title: Compute (Nova)
         checks:
           - uid: mondoo-openstack-security-server-uses-keypair
@@ -60,6 +64,17 @@ policies:
       - title: Load Balancers (Octavia)
         checks:
           - uid: mondoo-openstack-security-listener-modern-tls
+      - title: Shared File Systems (Manila)
+        checks:
+          - uid: mondoo-openstack-security-share-not-public
+          - uid: mondoo-openstack-security-share-no-world-access
+      - title: Container Infrastructure (Magnum)
+        checks:
+          - uid: mondoo-openstack-security-cluster-template-tls-enabled
+          - uid: mondoo-openstack-security-cluster-template-no-insecure-registry
+      - title: Databases (Trove)
+        checks:
+          - uid: mondoo-openstack-security-database-not-public
     scoring_system: highest impact
 queries:
   - uid: mondoo-openstack-security-app-credentials-restricted
@@ -1763,3 +1778,616 @@ queries:
           _ == "TLSv1.0" || _ == "TLSv1.1" || _ == "SSLv2" || _ == "SSLv3"
         )
       )
+
+  # No Terraform variants: terraform-provider-openstack has no Keystone trust resource. Trusts are created imperatively (CLI/API or by the Keystone-to-Keystone federation flow), so there is no HCL/plan/state representation to assert against. Re-evaluate if an openstack_identity_trust_v3 resource is added upstream.
+  - uid: mondoo-openstack-security-trust-impersonation-expiry
+    title: Ensure Keystone trusts allowing impersonation have an expiration
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.trusts.where(impersonation == true).all(expiresAt != null)
+    docs:
+      desc: |
+        This check ensures that every Keystone trust permitting impersonation carries an expiration timestamp. A trust that allows impersonation lets the trustee act fully as the trustor, and without an `expires_at` value that delegation never lapses on its own.
+
+        **Why this matters**
+
+        - **Standing impersonation is high-value:** An impersonating trust grants the trustee the trustor's identity for the delegated roles, so a non-expiring one is a permanent escalation path.
+        - **Forced review cycle:** An expiration date pushes each delegation through renewal, where trusts nobody owns naturally fall away.
+        - **Offboarding hygiene:** Non-expiring trusts survive the departure of the trustor or trustee and leave delegated access that no one is tracking.
+
+        **Risk mitigation**
+
+        - **Persistent escalation:** Prevents a leaked or forgotten trust from acting as a permanent way to assume another principal's roles.
+        - **Credential sprawl:** Limits the accumulation of long-lived delegations across the project over time.
+      audit: |
+        ### Audit via Horizon
+
+        The Horizon dashboard does not expose trust management. Use the CLI.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack trust list
+        openstack trust show <trust-id>
+        ```
+
+        A passing result shows every trust with `impersonation` set to `True` carrying a populated `expires_at` value; a failing result shows an impersonating trust with an empty `expires_at`.
+      remediation:
+        - id: console
+          desc: |
+            Horizon does not expose trust management; use the CLI to delete and re-create the trust with an expiration.
+        - id: cli
+          desc: |
+            ```bash
+            # Trusts are immutable; delete the offending trust and re-create it with an expiration
+            openstack trust delete <trust-id>
+            openstack trust create <trustor-user> <trustee-user> \
+              --project <project> --role <role> \
+              --impersonate --expiration 2026-12-31T00:00:00
+            ```
+        # No Terraform remediation: terraform-provider-openstack has no Keystone trust resource (see the note above the check). Trusts are managed only through the CLI/API.
+    refs:
+      - url: https://docs.openstack.org/keystone/latest/user/trusts.html
+        title: OpenStack Keystone trusts
+
+  - uid: mondoo-openstack-security-share-not-public
+    title: Ensure Manila shares are not visible to all projects
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-22
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-openstack-security-share-not-public-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-share-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-share-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-share-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Manila shared file system is created with `is_public = true`. A public share is visible to every project on the cloud, and any project that can see it can mount it within the access rules the share allows.
+
+        **Why this matters**
+
+        - **Shares hold working data:** Manila exports back home directories, application state, and shared datasets that are not meant for cloud-wide discovery.
+        - **Visibility widens the blast radius:** A public share is enumerable by every tenant, turning a single weak access rule into a cross-tenant exposure.
+        - **Safe defaults:** Shares should stay private to the owning project and be exposed deliberately, not advertised to the whole cloud.
+
+        **Risk mitigation**
+
+        - **Cross-tenant discovery:** Prevents other projects from listing and targeting the share.
+        - **Data disclosure:** Keeps the contents of file shares from being reachable by tenants that should never see them.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Share** then **Shares**.
+        3. Select each share and review its **Public** attribute.
+
+        A passing result shows **Public** set to **No** for every share; a failing result shows a share marked **Public: Yes**.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack share show <share>
+        ```
+
+        A passing result shows `is_public` set to `False`; a failing result shows `is_public` set to `True`.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Share → Shares** in Horizon.
+            2. Open the affected share and edit it so **Public** is unchecked.
+        - id: cli
+          desc: |
+            ```bash
+            openstack share set --no-public <share>
+            ```
+        - id: terraform
+          desc: |
+            Either omit `is_public` on `openstack_sharedfilesystem_share_v2` (the default is `false`) or set it explicitly:
+
+            ```hcl
+            resource "openstack_sharedfilesystem_share_v2" "data" {
+              name        = "data"
+              share_proto = "NFS"
+              size        = 10
+              is_public   = false
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/manila/latest/user/create-and-manage-shares.html
+        title: OpenStack Manila shared file systems
+
+  - uid: mondoo-openstack-security-share-not-public-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.shares.all(isPublic == false)
+  - uid: mondoo-openstack-security-share-not-public-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_sharedfilesystem_share_v2")
+    mql: |
+      terraform.resources.where(nameLabel == "openstack_sharedfilesystem_share_v2").all(
+        arguments['is_public'] != true
+      )
+  - uid: mondoo-openstack-security-share-not-public-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_sharedfilesystem_share_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_sharedfilesystem_share_v2").all(
+        change.after.is_public != true
+      )
+  - uid: mondoo-openstack-security-share-not-public-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_sharedfilesystem_share_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_sharedfilesystem_share_v2").all(
+        values.is_public != true
+      )
+
+  - uid: mondoo-openstack-security-share-no-world-access
+    title: Ensure Manila shares are not exported to all source IP addresses
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-share-no-world-access-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-share-no-world-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-share-no-world-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-share-no-world-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Manila share has an IP-based access rule whose `access_to` is `0.0.0.0/0` or `::/0`. An access rule covering every source address lets any host that can route to the share server mount the export, subject only to the protocol's own (often weak) authentication.
+
+        **Why this matters**
+
+        - **NFS trusts the network:** NFS access rules grant mount rights by source address, so an all-addresses rule effectively removes the access control entirely.
+        - **Designed for known clients:** Share access rules are meant to enumerate specific client CIDRs, not to publish the export to everything that can reach it.
+        - **Read-write exposure:** A world-scoped rule that grants read-write turns the export into shared, attacker-writable storage.
+
+        **Risk mitigation**
+
+        - **Unauthorized mounts:** Confines mount rights to the specific client networks that need the share.
+        - **Data tampering:** Stops untrusted hosts from reading or overwriting the contents of the export.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Share** then **Shares**.
+        3. Select each share, open its **Rules** tab, and review the IP access rules.
+
+        A passing result shows no IP access rule with **Access to** set to `0.0.0.0/0` or `::/0`; a failing result shows such a rule.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack share access list <share>
+        ```
+
+        A passing result shows no `ip` access rule whose **Access To** is `0.0.0.0/0` or `::/0`; a failing result shows one.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Share → Shares** in Horizon and open the share's **Rules** tab.
+            2. Delete the rule whose **Access to** is `0.0.0.0/0` or `::/0`.
+            3. Add a replacement rule scoped to the specific client CIDR that needs the share.
+        - id: cli
+          desc: |
+            ```bash
+            openstack share access delete <share> <access-rule-id>
+            openstack share access create <share> ip 203.0.113.0/24 --access-level ro
+            ```
+        - id: terraform
+          desc: |
+            Scope `access_to` on `openstack_sharedfilesystem_share_access_v2` to a specific trusted CIDR — never `0.0.0.0/0` or `::/0`:
+
+            ```hcl
+            resource "openstack_sharedfilesystem_share_access_v2" "clients" {
+              share_id     = openstack_sharedfilesystem_share_v2.data.id
+              access_type  = "ip"
+              access_to    = "203.0.113.0/24"
+              access_level = "ro"
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/manila/latest/user/share-management.html
+        title: OpenStack Manila share access rules
+
+  - uid: mondoo-openstack-security-share-no-world-access-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.shares.all(
+        accessRules.where(accessType == "ip").none(accessTo == "0.0.0.0/0" || accessTo == "::/0")
+      )
+  - uid: mondoo-openstack-security-share-no-world-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_sharedfilesystem_share_access_v2")
+    mql: |
+      terraform.resources.where(nameLabel == "openstack_sharedfilesystem_share_access_v2").where(arguments['access_type'] == "ip").none(
+        arguments['access_to'] == "0.0.0.0/0" || arguments['access_to'] == "::/0"
+      )
+  - uid: mondoo-openstack-security-share-no-world-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_sharedfilesystem_share_access_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_sharedfilesystem_share_access_v2").where(change.after.access_type == "ip").none(
+        change.after.access_to == "0.0.0.0/0" || change.after.access_to == "::/0"
+      )
+  - uid: mondoo-openstack-security-share-no-world-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_sharedfilesystem_share_access_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_sharedfilesystem_share_access_v2").where(values.access_type == "ip").none(
+        values.access_to == "0.0.0.0/0" || values.access_to == "::/0"
+      )
+
+  - uid: mondoo-openstack-security-cluster-template-tls-enabled
+    title: Ensure Magnum cluster templates do not disable control plane TLS
+    impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-openstack-security-cluster-template-tls-enabled-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Magnum cluster template sets `tls_disabled = true`. With TLS disabled, the cluster's orchestration API — the Kubernetes API server on a Kubernetes cluster — accepts unauthenticated, unencrypted connections, and every cluster built from the template inherits that posture.
+
+        **Why this matters**
+
+        - **The control plane is the keys to the cluster:** An unauthenticated orchestration API lets anyone who can reach it schedule workloads, read secrets, and take over every node.
+        - **Plaintext credentials:** Without TLS, client certificates and bearer tokens cross the network in the clear and can be captured on the path.
+        - **Template inheritance:** A single insecure template silently weakens every cluster created from it, so the fix belongs at the template.
+
+        **Risk mitigation**
+
+        - **Cluster takeover:** Prevents an attacker from issuing API calls against an unauthenticated control plane.
+        - **Credential interception:** Keeps API traffic encrypted so tokens and certificates cannot be sniffed in transit.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Container Infra** then **Cluster Templates**.
+        3. Select each template and review whether **Disable TLS** is set.
+
+        A passing result shows **Disable TLS** unset for every template; a failing result shows a template with TLS disabled.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack coe cluster template show <template>
+        ```
+
+        A passing result shows `tls_disabled` set to `False`; a failing result shows `tls_disabled` set to `True`.
+      remediation:
+        - id: console
+          desc: |
+            Cluster templates are immutable once clusters reference them. In Horizon, open **Container Infra → Cluster Templates**, create a replacement template with **Disable TLS** left unset, and migrate clusters onto it.
+        - id: cli
+          desc: |
+            ```bash
+            # Templates are immutable; create a TLS-enabled replacement (tls_disabled defaults to false)
+            openstack coe cluster template create secure-template \
+              --image <image> --keypair <keypair> \
+              --external-network <network> --coe kubernetes \
+              --flavor <flavor> --docker-volume-size 10
+            ```
+        - id: terraform
+          desc: |
+            Either omit `tls_disabled` on `openstack_containerinfra_clustertemplate_v1` (the default is `false`) or set it explicitly:
+
+            ```hcl
+            resource "openstack_containerinfra_clustertemplate_v1" "k8s" {
+              name                  = "k8s"
+              image                 = "fedora-coreos"
+              coe                   = "kubernetes"
+              external_network_id   = openstack_networking_network_v2.public.id
+              tls_disabled          = false
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/magnum/latest/user/index.html
+        title: OpenStack Magnum cluster templates
+
+  - uid: mondoo-openstack-security-cluster-template-tls-enabled-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.clusterTemplates.all(tlsDisabled == false)
+  - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.resources.where(nameLabel == "openstack_containerinfra_clustertemplate_v1").all(
+        arguments['tls_disabled'] != true
+      )
+  - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        change.after.tls_disabled != true
+      )
+  - uid: mondoo-openstack-security-cluster-template-tls-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.state.resources.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        values.tls_disabled != true
+      )
+
+  - uid: mondoo-openstack-security-cluster-template-no-insecure-registry
+    title: Ensure Magnum cluster templates do not allow insecure registries
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Magnum cluster template sets an `insecure_registry`. An insecure registry is one the cluster is allowed to pull container images from over plaintext HTTP with no certificate validation, and every cluster built from the template trusts it.
+
+        **Why this matters**
+
+        - **Images become attacker-controlled:** Pulling over an unvalidated channel lets a network attacker substitute a malicious image for the one the cluster expected.
+        - **No integrity guarantee:** Without TLS the cluster cannot confirm the registry's identity or that the image arrived unmodified.
+        - **Template inheritance:** Configuring this at the template level silently extends the trusted-registry list to every cluster created from it.
+
+        **Risk mitigation**
+
+        - **Supply-chain compromise:** Prevents tampered or impersonated images from being pulled into the cluster.
+        - **Man-in-the-middle:** Keeps image pulls on an authenticated, encrypted channel an attacker cannot transparently intercept.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Container Infra** then **Cluster Templates**.
+        3. Select each template and review the **Insecure Registry** field.
+
+        A passing result shows an empty **Insecure Registry** for every template; a failing result shows a template with an insecure registry set.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack coe cluster template show <template>
+        ```
+
+        A passing result shows `insecure_registry` empty; a failing result shows a host:port value in `insecure_registry`.
+      remediation:
+        - id: console
+          desc: |
+            Cluster templates are immutable once clusters reference them. In Horizon, open **Container Infra → Cluster Templates**, create a replacement template with **Insecure Registry** left empty, and migrate clusters onto it.
+        - id: cli
+          desc: |
+            ```bash
+            # Templates are immutable; create a replacement that omits --insecure-registry
+            openstack coe cluster template create secure-template \
+              --image <image> --keypair <keypair> \
+              --external-network <network> --coe kubernetes \
+              --flavor <flavor> --docker-volume-size 10
+            ```
+        - id: terraform
+          desc: |
+            Do not set `insecure_registry` on `openstack_containerinfra_clustertemplate_v1`; rely on a TLS-protected registry instead:
+
+            ```hcl
+            resource "openstack_containerinfra_clustertemplate_v1" "k8s" {
+              name                = "k8s"
+              image               = "fedora-coreos"
+              coe                 = "kubernetes"
+              external_network_id = openstack_networking_network_v2.public.id
+              # insecure_registry intentionally omitted — pull only from TLS-protected registries
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/magnum/latest/user/index.html
+        title: OpenStack Magnum cluster templates
+
+  - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.clusterTemplates.all(insecureRegistry == "")
+  - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.resources.where(nameLabel == "openstack_containerinfra_clustertemplate_v1").all(
+        arguments['insecure_registry'] == null || arguments['insecure_registry'] == ""
+      )
+  - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        change.after.insecure_registry == null || change.after.insecure_registry == ""
+      )
+  - uid: mondoo-openstack-security-cluster-template-no-insecure-registry-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.state.resources.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        values.insecure_registry == null || values.insecure_registry == ""
+      )
+
+  # No Terraform variants: this check inspects the runtime network addresses Trove assigned to the instance (operational telemetry), which has no configuration analog. The terraform-provider-openstack openstack_db_instance_v1 resource attaches the instance to a network by UUID, and whether that network is publicly reachable is a cross-resource property the check cannot assert from the resource alone. Re-evaluate if a first-class public/private toggle is added upstream.
+  - uid: mondoo-openstack-security-database-not-public
+    title: Ensure Trove database instances are not publicly reachable
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.databaseInstances.all(
+        addresses.none(_['type'] == "public")
+      )
+    docs:
+      desc: |
+        This check ensures that no Trove managed database instance has a network address of type `public`. A database with a public address is reachable from outside the tenant network, exposing the database engine's listener directly to untrusted clients.
+
+        **Why this matters**
+
+        - **Databases assume a private network:** Trove engine defaults for authentication and encryption are built for a trusted internal network, not direct internet exposure.
+        - **High-value target:** A publicly reachable database listener invites credential-stuffing and version-specific exploits against the engine.
+        - **Tiered architecture:** Managed databases belong behind an application tier and should accept connections only from the private network that hosts that tier.
+
+        **Risk mitigation**
+
+        - **Data exfiltration:** Prevents direct connections to the database from anywhere on the internet.
+        - **Targeted exploitation:** Removes the engine's listener from internet-wide scanning that probes for known vulnerable versions.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Database** then **Instances**.
+        3. Select each instance and review the addresses listed on its **Overview** tab.
+
+        A passing result shows only private addresses for every instance; a failing result shows an instance with a public address.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack database instance show <instance>
+        ```
+
+        A passing result shows no address of type `public`; a failing result shows a public address assigned to the instance.
+      remediation:
+        - id: console
+          desc: |
+            Trove cannot move a running instance off a public network. In Horizon, open **Database → Instances**, launch a replacement instance attached only to a private network, migrate the data, and delete the original.
+        - id: cli
+          desc: |
+            ```bash
+            # Launch a replacement bound to a private network, then migrate and delete the original
+            openstack database instance create db-private \
+              --flavor <flavor> --size 10 \
+              --datastore mysql --datastore-version 8.0 \
+              --nic net-id=<private-network-id>
+            ```
+        # No Terraform remediation: see the note above the check — the public/private posture is a property of the network the instance attaches to, not a setting on the openstack_db_instance_v1 resource itself.
+    refs:
+      - url: https://docs.openstack.org/trove/latest/user/index.html
+        title: OpenStack Trove database instances


### PR DESCRIPTION
## Summary

Adds six Tier-1 security checks to `mondoo-openstack-security` covering services and fields the openstack provider now exposes but the policy did not previously assess: **Manila** shared file systems, **Magnum** container infrastructure, **Trove** managed databases, and **Keystone** trusts.

| Check | Impact | Field |
|---|---|---|
| `cluster-template-tls-enabled` (Magnum) | 95 | `clusterTemplate.tlsDisabled` |
| `share-no-world-access` (Manila) | 90 | `share.accessRules` IP rules `0.0.0.0/0` / `::/0` |
| `database-not-public` (Trove) | 90 | `db.instance.addresses[].type == "public"` |
| `share-not-public` (Manila) | 85 | `share.isPublic` |
| `cluster-template-no-insecure-registry` (Magnum) | 80 | `clusterTemplate.insecureRegistry` |
| `trust-impersonation-expiry` (Keystone) | 80 | `trust.impersonation` + `expiresAt` |

## Variants & remediation

- **Manila and Magnum** checks ship runtime + Terraform HCL/plan/state variants, each with a `terraform` remediation entry (`openstack_sharedfilesystem_share_v2`, `openstack_sharedfilesystem_share_access_v2`, `openstack_containerinfra_clustertemplate_v1`).
- **Trove** (`database-not-public`) is runtime-only — public reachability is runtime telemetry / cross-resource, not a config field. Carries the required `# No Terraform variants:` / `# No Terraform remediation:` comments.
- **Keystone trust** (`trust-impersonation-expiry`) is runtime-only — terraform-provider-openstack has no trust resource. Same explanatory comments.

All `audit`/`remediation` steps use OpenStack-native tooling (Horizon + the `openstack` CLI); no Mondoo tooling referenced.

## Compliance tags

Verified against the framework text in `cnspec-enterprise-policies/frameworks/` (not copied from neighbors). Anchored to four objective clusters:

- **Encryption in transit** (Magnum TLS, insecure registry) → `nist-sp-800-53-rev5-sc-8` *Transmission Confidentiality and Integrity*, `iso-27001-2022-a-8-24` *Use of cryptography*, `pcidss-requirement-4-2-1` — same objective as the existing `listener-modern-tls`.
- **Public exposure** (Manila public share) → `nist-sp-800-53-rev5-ac-3` *Access Enforcement*, `iso-27001-2022-a-8-3` *Information access restriction* — same objective as `image-not-public` / `container-not-public`.
- **Network boundary** (Trove public DB, Manila world-export) → `nist-sp-800-53-rev5-sc-7` *Boundary Protection*, `iso-27001-2022-a-8-20` *Networks security* — same objective as `no-unrestricted-db-ports`.
- **Credential lifetime** (trust expiry) → `nist-sp-800-53-rev5-ia-5` *Authenticator Management*, `iso-27001-2022-a-5-17` *Authentication information* — same objective as `app-credentials-have-expiry`.

Impact values anchor to those siblings (e.g. `database-not-public` at 90 mirrors the `no-unrestricted-db-ports` network-exposure band; `trust-impersonation-expiry` at 80 mirrors the credential-lifetime checks).

## Other changes

- Policy `version` bumped `1.0.1` → `1.1.0`.
- New policy groups: Shared File Systems (Manila), Container Infrastructure (Magnum), Databases (Trove); trust check added under Identity (Keystone).
- Services list in the policy `desc` extended accordingly.

## Testing

`cnspec policy lint content/mondoo-openstack-security.mql.yaml` → `valid policy bundle(s)` (all runtime MQL compiles against the installed OpenStack provider schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)