### PR TITLE
🎫 Replace PATs and SSH deploy key with mondoo-mergebot tokens

### DIFF
--- a/.github/workflows/bump-cnspec-in-deps.yaml
+++ b/.github/workflows/bump-cnspec-in-deps.yaml
@@ -15,10 +15,21 @@ jobs:
       matrix:
         repo: [packer-plugin-cnspec]
     steps:
+      # Mint a short-lived installation token from the mondoo-mergebot
+      # GitHub App, scoped to the matrix target only. Replaces the
+      # long-lived RELEASR_ACTION_TOKEN PAT.
+      - name: Generate mergebot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: ${{ matrix.repo }}
       - name: Trigger cnspec bump in server
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: "mondoohq/${{ matrix.repo }}"
           event-type: update-cnspec
           client-payload: >-

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -35,16 +35,23 @@ jobs:
           fi
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      # Use SSH keys for checking out the code
-      # https://github.com/peter-evans/create-pull-request/issues/48
-      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
-      # tl;dr:
-      # The GITHUB_TOKEN is limited when creating PRs from a workflow because of that we use SSH keys for which the
-      # limitations do not apply
+      # Mint a short-lived installation token from the mondoo-mergebot
+      # GitHub App. App tokens bypass the same "PRs created by GITHUB_TOKEN
+      # don't trigger downstream workflows" limit that motivated the old
+      # CNSPEC_DEPLOY_KEY_PRIV SSH deploy key, so the checkout and the
+      # subsequent peter-evans/create-pull-request can both use it.
+      - name: Generate mergebot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: cnspec
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ssh-key: ${{ secrets.CNSPEC_DEPLOY_KEY_PRIV }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -77,6 +84,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           base: main
           labels: dependencies,go
           committer: "Mondoo Tools <tools@mondoo.com>"

--- a/.github/workflows/content-update.yaml
+++ b/.github/workflows/content-update.yaml
@@ -14,10 +14,28 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # MONDOO_POLICY_REPO is stored as "owner/repo"; create-github-app-token's
+      # repositories: input takes just the repo name. Strip the owner so the
+      # minted token is scoped to that single repo.
+      - name: Extract policy repo name
+        id: policy-repo
+        env:
+          POLICY_REPO: ${{ secrets.MONDOO_POLICY_REPO }}
+        run: echo "name=${POLICY_REPO##*/}" >> "$GITHUB_OUTPUT"
+      # Mint a short-lived installation token from the mondoo-mergebot
+      # GitHub App. Replaces the long-lived RELEASR_ACTION_TOKEN PAT.
+      - name: Generate mergebot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: ${{ steps.policy-repo.outputs.name }}
       - name: Notify about content updates
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ secrets.MONDOO_POLICY_REPO }}
           event-type: content-updated
           client-payload: >-

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -258,10 +258,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: goreleaser
     steps:
+      # Mint a short-lived installation token from the mondoo-mergebot
+      # GitHub App, scoped to mondoo-operator only. Replaces the long-lived
+      # REPO_DISPATCH_TOKEN PAT.
+      - name: Generate mergebot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: mondoo-operator
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: mondoohq/mondoo-operator
           event-type: update
           client-payload: >-


### PR DESCRIPTION
## Summary

Replaces the four remaining long-lived GitHub credentials in this repo's workflows with short-lived installation tokens minted from the `mondoo-mergebot` GitHub App — same pattern `goreleaser.yml` already uses for the `mondoohq/installer` dispatch, and `enterprise-operator/bump-deployments.yaml` uses for `mondoo-deployments`.

| Workflow | Was | Now | Scope |
|---|---|---|---|
| `bump-cnspec-in-deps.yaml` | `secrets.RELEASR_ACTION_TOKEN` PAT | mergebot token | `${{ matrix.repo }}` (currently `packer-plugin-cnspec`) |
| `content-update.yaml` | `secrets.RELEASR_ACTION_TOKEN` PAT | mergebot token | repo name parsed out of `secrets.MONDOO_POLICY_REPO` |
| `cnquery-update.yml` | `secrets.CNSPEC_DEPLOY_KEY_PRIV` SSH key | mergebot token (used by both `checkout` and `peter-evans/create-pull-request`) | `cnspec` |
| `goreleaser.yml` (job `mondoo-operator-cnspec`) | `secrets.REPO_DISPATCH_TOKEN` PAT | mergebot token | `mondoo-operator` |

App tokens bypass the "PRs from `GITHUB_TOKEN` don't trigger downstream workflows" limit that motivated `CNSPEC_DEPLOY_KEY_PRIV` in the first place — the comment in `cnquery-update.yml` is rewritten to reflect that.

## Prerequisite

`mondoo-mergebot` must be installed with `Contents: write` (and `Pull requests: write` for `cnquery-update.yml`) on:

- `mondoohq/packer-plugin-cnspec`
- `mondoohq/cnspec` (self — for the PR-create flow)
- `mondoohq/mondoo-operator`
- Whatever `MONDOO_POLICY_REPO` resolves to (likely `cnspec-enterprise-policies`)

If any install is missing, the corresponding `Generate mergebot token` step will fail with a clear "Not Found" error, which is much easier to diagnose than an expired-PAT failure.

## Follow-up

After this merges and each workflow has had a successful run, these secrets become unreferenced and can be deleted from Settings → Secrets and variables → Actions:

- `RELEASR_ACTION_TOKEN`
- `CNSPEC_DEPLOY_KEY_PRIV`
- `REPO_DISPATCH_TOKEN`

(`REPO_API_TOKEN` is still referenced elsewhere — leave it.)

## Test plan

- [ ] `cnquery-update.yml`: trigger via `workflow_dispatch` with a known mql version — confirm the PR is created and that the PR's own CI runs (the key behavior we needed App tokens for).
- [ ] `content-update.yaml`: push a no-op change under `content/` to `main` — confirm the dispatch step succeeds.
- [ ] `bump-cnspec-in-deps.yaml`: next release will exercise it naturally.
- [ ] `goreleaser.yml` `mondoo-operator-cnspec` job: next release will exercise it naturally; can also be validated by `gh workflow run` against a pre-release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
