### PR TITLE
✨ content: add security checks for new mql resource fields

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -227,6 +227,7 @@ deployers
 desiredv
 detokenize
 devtmpfs
+dga
 dhe
 DICOM
 diffie
@@ -281,6 +282,7 @@ ESKMS
 etcsshsshd
 ethertype
 etm
+eventarc
 eventhub
 exampledb
 exampleregistry
@@ -333,6 +335,7 @@ gbs
 GCMAES
 gcmp
 gcs
+genai
 getblockall
 getenforce
 getenv
@@ -348,6 +351,7 @@ glueetl
 gmail
 godo
 gpt
+gradientai
 grafana
 Graphviz
 grouplist
@@ -388,6 +392,7 @@ igmp
 iis
 ikev
 imds
+impersonatable
 inboxes
 inodes
 insertafter
@@ -655,6 +660,7 @@ rescans
 resourced
 respout
 restrictremotesam
+resyncs
 rexec
 rfc
 Rfi

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -69731,7 +69731,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-4
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      aws.route53.resolver.firewallRuleGroups != empty
+      aws.route53.resolver.firewallRuleGroups != empty &&
       aws.route53.resolver.firewallRuleGroups.all(
         firewallRules.any(dnsThreatProtection != null && dnsThreatProtection != "")
       )

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -483,6 +483,7 @@ policies:
           - uid: mondoo-aws-security-route53-health-check-not-disabled
           - uid: mondoo-aws-security-route53-health-check-https
           - uid: mondoo-aws-security-route53-resolver-query-logging-enabled
+          - uid: mondoo-aws-security-route53-resolver-dns-firewall-threat-protection
       - title: Route 53 Domains
         checks:
           - uid: mondoo-aws-security-route53-domain-transfer-lock
@@ -69706,3 +69707,102 @@ queries:
       cloudformation.template.resources.where(type == "AWS::CodeArtifact::Domain").all(
         properties['EncryptionKey'] != empty
       )
+  # No Terraform variants: DNS Firewall Advanced threat-protection rules (DGA / DNS-tunneling
+  # detection) are configured through the dnsThreatProtection and confidenceThreshold settings,
+  # which the AWS Terraform provider's aws_route53resolver_firewall_rule resource does not yet
+  # expose. The capability is reachable only through the API, CLI, and console. Revisit if the
+  # provider adds advanced-rule arguments.
+  - uid: mondoo-aws-security-route53-resolver-dns-firewall-threat-protection
+    title: Ensure Route 53 Resolver DNS Firewall enables DNS threat protection
+    impact: 70
+    filters: asset.platform == "aws"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/pci-dss-4: pcidss-requirement-5-2-2
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      aws.route53.resolver.firewallRuleGroups != empty
+      aws.route53.resolver.firewallRuleGroups.all(
+        firewallRules.any(dnsThreatProtection != null && dnsThreatProtection != "")
+      )
+    docs:
+      desc: |
+        This check ensures that Route 53 Resolver DNS Firewall is deployed and that each rule group includes at least one rule with advanced DNS threat protection enabled. DNS Firewall Advanced inspects query patterns to detect and block domain-generation-algorithm (DGA) malware command-and-control domains and DNS tunneling — exfiltration and C2 techniques that static domain block-lists do not catch.
+
+        **Why this matters**
+
+        - **DNS as a C2 and exfiltration channel:** Outbound DNS is rarely blocked at the egress firewall, making it a favored channel for command-and-control beacons and data exfiltration; advanced threat protection inspects the query stream for these behaviors.
+        - **Beyond static block-lists:** Domain-list rules only block known-bad domains; DGA malware generates thousands of fresh domains that no static list covers, which is exactly what threat protection is designed to detect.
+        - **Inline blocking:** Threat protection acts on the resolution path, so malicious lookups are blocked before the workload ever connects to the malicious infrastructure.
+        - **VPC-wide coverage:** A rule group associated with a VPC applies to every workload in it, providing consistent protection without per-host agents.
+
+        **Risk mitigation**
+
+        - **Add threat-protection rules to every rule group:** Configure DGA and DNS-tunneling protection on each rule group so all associated VPCs are covered.
+        - **Set rules to block:** Use a blocking action (rather than alert-only) for high-confidence detections so malicious resolutions are actually prevented.
+        - **Associate rule groups with all VPCs:** Ensure every VPC carrying workloads is associated with a rule group that includes threat protection.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Route 53** console and choose **DNS Firewall** then **Rule groups**.
+        2. Select each rule group and review its rules.
+        3. Confirm at least one rule has **DNS threat protection** configured (DGA or DNS tunneling).
+
+        A passing account has at least one DNS Firewall rule group, and every rule group contains a threat-protection rule. A failing account has no rule groups, or has a rule group with no threat-protection rule.
+
+        ### Audit via CLI
+
+        1. List the DNS Firewall rule groups, then list the rules in each and inspect their threat-protection settings:
+
+        ```bash
+        aws route53resolver list-firewall-rule-groups \
+          --query 'FirewallRuleGroups[*].{Id:Id,Name:Name}' --output table
+
+        aws route53resolver list-firewall-rules \
+          --firewall-rule-group-id <rule-group-id> \
+          --query 'FirewallRules[*].{Name:Name,DnsThreatProtection:DnsThreatProtection,Action:Action}' \
+          --output table
+        ```
+
+        A passing rule group returns at least one rule with a non-empty `DnsThreatProtection` value. A failing rule group returns no rules with threat protection, or no rule groups exist.
+      remediation:
+        - id: console
+          desc: |
+            To enable DNS threat protection using the AWS Console:
+
+            1. Open the **Route 53** console and choose **DNS Firewall** then **Rule groups**.
+            2. Select a rule group (or create one) and choose **Add rule**.
+            3. Choose **DNS Firewall Advanced** and select the threat type (DGA or DNS tunneling) and a confidence threshold.
+            4. Set the action to **Block** for high-confidence detections.
+            5. Associate the rule group with the VPCs that should be protected.
+        - id: cli
+          desc: |
+            To add a DNS Firewall Advanced threat-protection rule using the AWS CLI:
+
+            ```bash
+            aws route53resolver create-firewall-rule \
+              --firewall-rule-group-id <rule-group-id> \
+              --name dga-protection \
+              --priority 100 \
+              --action BLOCK \
+              --dns-threat-protection DGA \
+              --confidence-threshold HIGH
+            ```
+        # No Terraform remediation: the aws_route53resolver_firewall_rule resource does not expose
+        # the advanced threat-protection arguments (dns_threat_protection, confidence_threshold);
+        # configure these rules through the console or CLI above.
+        # No CloudFormation remediation: AWS::Route53Resolver::FirewallRule does not support the
+        # advanced threat-protection properties; use the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-advanced.html
+        title: DNS Firewall Advanced threat protection

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3033,15 +3033,7 @@ queries:
 
         A passing account shows a completed scan with no critical findings. A failing account has no scan, or its latest scan lists one or more critical findings.
 
-        ### Audit via CLI
-
-        1. Retrieve the latest security scan and its findings:
-
-        ```bash
-        doctl projects list
-        ```
-
-        Review the most recent managed security scan in the control panel; a passing account's latest scan returns no findings with `severity` equal to `critical`. A failing account returns one or more critical findings, or has never run a scan.
+        The `doctl` CLI has no command for managed security scans, so this check has no CLI audit step; review the latest scan in the control panel.
       remediation:
         - id: console
           desc: |

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -90,6 +90,15 @@ policies:
         filters: asset.platform == "digitalocean"
         checks:
           - uid: mondoo-digitalocean-security-app-platform-https
+      - title: Security Scanning
+        filters: asset.platform == "digitalocean"
+        checks:
+          - uid: mondoo-digitalocean-security-scan-no-critical-findings
+      - title: GenAI (GradientAI)
+        filters: asset.platform == "digitalocean"
+        checks:
+          - uid: mondoo-digitalocean-security-gradientai-agent-not-publicly-deployed
+          - uid: mondoo-digitalocean-security-gradientai-knowledge-base-not-public
     scoring_system: highest impact
 queries:
   # No CLI remediation: email verification is a one-time interactive flow — the
@@ -2978,3 +2987,216 @@ queries:
     refs:
       - url: https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/
         title: Manage App Platform domains and certificates
+  # No Terraform variants: this check inspects the findings of the most recent
+  # DigitalOcean-managed security scan — runtime telemetry produced by the platform
+  # scanner. The digitalocean Terraform provider has no resource representing a scan
+  # or its findings, so there is nothing to assert against in HCL, plan, or state.
+  - uid: mondoo-digitalocean-security-scan-no-critical-findings
+    title: Ensure the DigitalOcean security scan reports no critical findings
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
+      compliance/dora: dora-art-25
+      compliance/hipaa: hipaa-security-ss164-308-a-1-ii-b-security-management-process-risk-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-id-ra-1
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: pcidss-requirement-11-3-1
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    mql: |
+      digitalocean.latestSecurityScan != null && digitalocean.latestSecurityScan.findings.none(severity == "critical")
+    docs:
+      desc: |
+        This check ensures that a DigitalOcean managed security scan has run and that its most recent results report no findings with a severity of `critical`. The DigitalOcean security scanner inspects account resources for misconfigurations and weaknesses; a critical finding represents a vulnerability that should be remediated promptly.
+
+        **Why this matters**
+
+        - **Vulnerability visibility:** A critical finding flags a concrete, high-severity weakness in the account's resources that an attacker could exploit.
+        - **Scan coverage:** The absence of any scan means the account has no automated assurance that its resources have been assessed for known weaknesses.
+        - **Remediation tracking:** Resolving critical findings and keeping the latest scan clean demonstrates that high-severity issues are being addressed rather than accumulating.
+
+        **Risk mitigation**
+
+        - **Reduced exposure window:** Promptly clearing critical findings limits the time a known weakness remains exploitable.
+        - **Continuous assurance:** Keeping a recent, clean scan provides ongoing evidence that the account's posture has been evaluated.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the security scanning area and review the most recent scan.
+        3. Confirm the scan has completed and that it lists no findings with a **critical** severity.
+
+        A passing account shows a completed scan with no critical findings. A failing account has no scan, or its latest scan lists one or more critical findings.
+
+        ### Audit via CLI
+
+        1. Retrieve the latest security scan and its findings:
+
+        ```bash
+        doctl projects list
+        ```
+
+        Review the most recent managed security scan in the control panel; a passing account's latest scan returns no findings with `severity` equal to `critical`. A failing account returns one or more critical findings, or has never run a scan.
+      remediation:
+        - id: console
+          desc: |
+            To resolve critical security-scan findings using the DigitalOcean Cloud Control Panel:
+
+            1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+            2. Open the security scanning area and select the most recent scan.
+            3. For each critical finding, follow the listed mitigation steps to remediate the affected resource.
+            4. Re-run the scan and confirm the critical findings are cleared.
+        # No CLI remediation: remediation is per-finding and resource-specific — the
+        # `doctl` CLI exposes no command to act on security-scan findings; follow the
+        # mitigation steps surfaced for each finding in the control panel.
+        # No Terraform remediation: security-scan findings are runtime telemetry with
+        # no Terraform resource; remediate the underlying resource each finding identifies.
+    refs:
+      - url: https://docs.digitalocean.com/products/
+        title: DigitalOcean product documentation
+  # No Terraform variants: GradientAI agents are managed through the GradientAI API and
+  # control panel; the digitalocean Terraform provider has no resource representing a
+  # GradientAI agent or its deployment visibility, so there is nothing to assert in HCL,
+  # plan, or state.
+  - uid: mondoo-digitalocean-security-gradientai-agent-not-publicly-deployed
+    title: Ensure GradientAI agents are not deployed with public visibility
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.gradientai.agents.all(deploymentVisibility != "VISIBILITY_PUBLIC")
+    docs:
+      desc: |
+        This check ensures that no GradientAI agent is deployed with public visibility. An agent deployed with `VISIBILITY_PUBLIC` exposes its chat endpoint to anyone with the URL, with no authentication, allowing unauthenticated users to interact with the agent and the data and tools it can reach.
+
+        **Why this matters**
+
+        - **Unauthenticated access:** A public agent can be queried by anyone on the internet, exposing its system prompt behavior, connected knowledge bases, and any functions it can call.
+        - **Data leakage:** Agents grounded on private knowledge bases can surface that content to anonymous users when deployed publicly.
+        - **Abuse and cost:** Public agents are subject to unrestricted prompting, enabling prompt-injection attempts and consumption-driven cost abuse.
+
+        **Risk mitigation**
+
+        - **Restrict visibility:** Deploy agents with private or organization-scoped visibility so only authenticated principals can reach them.
+        - **Front with authentication:** Where external access is required, place the agent behind an authenticating proxy or application rather than exposing it directly.
+        - **Review guardrails:** Ensure agents that must be public have guardrails and citation settings appropriate for an untrusted audience.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the **GradientAI** platform and review each agent's deployment settings.
+        3. Confirm no agent has its deployment visibility set to **Public**.
+
+        A passing account has every agent deployed with non-public visibility. A failing account has one or more agents with public deployment visibility.
+
+        ### Audit via CLI
+
+        1. List the GradientAI agents and review their deployment visibility:
+
+        ```bash
+        doctl genai agent list
+        ```
+
+        A passing account returns no agent with a public deployment visibility. A failing account returns one or more agents whose visibility is `VISIBILITY_PUBLIC`.
+      remediation:
+        - id: console
+          desc: |
+            To restrict a GradientAI agent's deployment visibility using the DigitalOcean Cloud Control Panel:
+
+            1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+            2. Open the **GradientAI** platform and select the agent.
+            3. Edit the deployment settings and change the visibility from **Public** to a private or organization-scoped option.
+            4. Redeploy the agent.
+        # No CLI remediation: `doctl genai` exposes agent listing but no stable command to
+        # change an existing agent's deployment visibility; use the control panel above.
+        # No Terraform remediation: GradientAI agents have no digitalocean Terraform resource.
+    refs:
+      - url: https://docs.digitalocean.com/products/gradientai-platform/
+        title: DigitalOcean GradientAI platform
+  # No Terraform variants: GradientAI knowledge bases are managed through the GradientAI
+  # API and control panel; the digitalocean Terraform provider has no resource representing
+  # a knowledge base or its public flag, so there is nothing to assert in HCL, plan, or state.
+  - uid: mondoo-digitalocean-security-gradientai-knowledge-base-not-public
+    title: Ensure GradientAI knowledge bases are not public
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.gradientai.knowledgeBases.all(isPublic == false)
+    docs:
+      desc: |
+        This check ensures that no GradientAI knowledge base is marked public. A public knowledge base makes its indexed content readable beyond the account, exposing the source documents used to ground agents — which frequently include proprietary or sensitive material.
+
+        **Why this matters**
+
+        - **Data exposure:** A public knowledge base can expose the documents, embeddings, and source data it indexes to parties outside the account.
+        - **Grounding leakage:** Agents retrieve from knowledge bases at query time; a public base widens who can reach that content indirectly through any connected agent.
+        - **Intellectual property:** Knowledge bases commonly hold internal documentation, support content, or other proprietary data that should not be publicly readable.
+
+        **Risk mitigation**
+
+        - **Keep knowledge bases private:** Leave the public flag disabled unless the indexed content is explicitly intended for public consumption.
+        - **Classify before publishing:** Review the source data of any knowledge base before making it public to confirm it contains no sensitive material.
+        - **Audit periodically:** Re-check knowledge base visibility as their source data changes over time.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the **GradientAI** platform and review each knowledge base.
+        3. Confirm no knowledge base is marked **Public**.
+
+        A passing account has every knowledge base set to non-public. A failing account has one or more public knowledge bases.
+
+        ### Audit via CLI
+
+        1. List the GradientAI knowledge bases and review their public flag:
+
+        ```bash
+        doctl genai knowledge-base list
+        ```
+
+        A passing account returns no knowledge base with a public flag set to true. A failing account returns one or more public knowledge bases.
+      remediation:
+        - id: console
+          desc: |
+            To make a GradientAI knowledge base private using the DigitalOcean Cloud Control Panel:
+
+            1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+            2. Open the **GradientAI** platform and select the knowledge base.
+            3. Disable the **Public** setting.
+            4. Save the change.
+        # No CLI remediation: `doctl genai` exposes knowledge-base listing but no stable
+        # command to toggle the public flag on an existing knowledge base; use the control panel above.
+        # No Terraform remediation: GradientAI knowledge bases have no digitalocean Terraform resource.
+    refs:
+      - url: https://docs.digitalocean.com/products/gradientai-platform/
+        title: DigitalOcean GradientAI platform

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -86,6 +86,7 @@ policies:
           - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location
           - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured
           - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict
+          - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible
       - title: Cloud DNS
         checks:
           - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled
@@ -140,6 +141,8 @@ policies:
           - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles
           - uid: mondoo-gcp-security-compute-image-iam-no-public-principals
           - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles
+          - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption
+          - uid: mondoo-gcp-security-compute-image-cmek-encryption
       - title: Compute Forwarding Rules
         checks:
           - uid: mondoo-gcp-security-forwarding-rule-not-all-ports
@@ -230,6 +233,7 @@ policies:
           - uid: mondoo-gcp-security-iam-default-service-accounts-disabled
           - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days
           - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys
+          - uid: mondoo-gcp-security-iam-service-account-not-impersonatable
       - title: Cloud Logging
         checks:
           - uid: mondoo-gcp-security-logging-bucket-retention-30-days
@@ -260,6 +264,7 @@ policies:
           - uid: mondoo-gcp-security-cloud-functions-cmek-encryption
           - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars
           - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured
+          - uid: mondoo-gcp-security-cloud-functions-no-public-invocation
       - title: API Gateway
         checks:
           - uid: mondoo-gcp-security-apigateway-config-requires-authentication
@@ -278,6 +283,7 @@ policies:
         checks:
           - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress
           - uid: mondoo-gcp-security-appengine-handler-secure-always
+          - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress
       - title: Dataproc
         checks:
           - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured
@@ -392,6 +398,7 @@ policies:
           - uid: mondoo-gcp-security-vertexai-custom-job-cmek-encryption
           - uid: mondoo-gcp-security-vertexai-custom-job-private-network
           - uid: mondoo-gcp-security-vertexai-custom-job-web-access-disabled
+          - uid: mondoo-gcp-security-vertexai-additional-resources-cmek-encryption
       - title: Cloud Workstations
         checks:
           - uid: mondoo-gcp-security-workstations-cluster-private-cluster
@@ -421,6 +428,12 @@ policies:
         checks:
           - uid: mondoo-gcp-security-scc-notification-configs
           - uid: mondoo-gcp-security-scc-bigquery-exports
+      - title: Certificate Authority Service
+        checks:
+          - uid: mondoo-gcp-security-ca-pool-cmek-encryption
+      - title: Eventarc
+        checks:
+          - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption
     scoring_system: highest impact
 queries:
   - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account
@@ -36564,6 +36577,1179 @@ queries:
         )
       )
   # Skipped: Filestore in-transit encryption is not a resource-level configuration. NFSv3 mounts traverse the customer VPC unencrypted at the protocol level; Enterprise tier with Kerberos can encrypt mounts but neither cnquery nor the Terraform google_filestore_instance resource expose Kerberos config. Revisit if Filestore adds a configurable encrypt-in-transit field or if the cnquery gcp provider exposes the underlying network mode in a way that distinguishes private-service-access from a direct, untrusted peering.
+  - uid: mondoo-gcp-security-cloud-functions-no-public-invocation
+    title: Ensure Cloud Functions cannot be invoked by unauthenticated principals
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-gcp
+        tags:
+          mondoo.com/filter-title: GCP Cloud Function
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Cloud Functions do not grant the `roles/cloudfunctions.invoker` or `roles/run.invoker` role to the special principals `allUsers` or `allAuthenticatedUsers`. Either binding makes the function callable without credentials (`allUsers`) or by any Google account holder (`allAuthenticatedUsers`), turning the function endpoint into an open entry point regardless of its ingress settings.
+
+        **Why this matters**
+
+        - **Unauthenticated execution:** An `allUsers` invoker binding lets anyone on the internet trigger the function's code path, including any backend calls, database access, or secret usage it performs.
+        - **Non-attributable invocation:** Calls made through public bindings are not tied to a specific identity, so abuse cannot be attributed to an actor during investigation.
+        - **Distinct from ingress controls:** Restricting ingress limits the network path, but a public invoker binding still authorizes execution for any caller that reaches the endpoint; both layers must be locked down.
+        - **Cost and abuse exposure:** Publicly invocable functions are trivially targeted for high-volume invocation, exhausting quota and generating unexpected billing.
+
+        **Risk mitigation**
+
+        - **Grant invoker to specific identities:** Bind the invoker role only to the named service accounts, users, or groups that must call the function.
+        - **Front external traffic with authentication:** Place externally reachable functions behind API Gateway, Identity-Aware Proxy, or a load balancer that enforces authentication.
+        - **Audit invoker bindings regularly:** Review the function IAM policy for `allUsers` and `allAuthenticatedUsers` and remove them immediately.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the [Google Cloud Console](https://console.cloud.google.com) and select the project.
+        2. Navigate to **Cloud Functions** and select a function.
+        3. Open the **Permissions** tab.
+        4. Review the principals granted the **Cloud Functions Invoker** or **Cloud Run Invoker** role.
+        5. Repeat for each function.
+
+        A passing function shows no `allUsers` or `allAuthenticatedUsers` principals with an invoker role. A failing function lists `allUsers` or `allAuthenticatedUsers` as an invoker.
+
+        ### Audit via CLI
+
+        1. Retrieve the IAM policy for each function and check for public invoker bindings:
+
+        ```bash
+        gcloud functions get-iam-policy FUNCTION_NAME --format=json | grep -E 'allUsers|allAuthenticatedUsers' || echo "No public invokers"
+        ```
+
+        A passing function returns no bindings containing `allUsers` or `allAuthenticatedUsers`. A failing function returns one or more invoker bindings with `allUsers` or `allAuthenticatedUsers`.
+      remediation:
+        - id: console
+          desc: |
+            To remove public invocation from a Cloud Function using the Google Cloud Console:
+
+            1. Navigate to **Cloud Functions** and select the function.
+            2. Open the **Permissions** tab.
+            3. Locate the `allUsers` or `allAuthenticatedUsers` principal with an invoker role.
+            4. Select the delete (trash) icon next to the binding and confirm removal.
+        - id: cli
+          desc: |
+            To remove public invoker bindings from a Cloud Function using the Google Cloud CLI:
+
+            ```bash
+            gcloud functions remove-iam-policy-binding FUNCTION_NAME \
+              --member="allUsers" \
+              --role="roles/cloudfunctions.invoker"
+
+            gcloud functions remove-iam-policy-binding FUNCTION_NAME \
+              --member="allAuthenticatedUsers" \
+              --role="roles/cloudfunctions.invoker"
+            ```
+        - id: terraform
+          desc: |
+            To keep Cloud Functions private in Terraform, grant the invoker role only to specific identities and never to `allUsers` or `allAuthenticatedUsers`:
+
+            ```hcl
+            resource "google_cloudfunctions2_function_iam_member" "invoker" {
+              project        = google_cloudfunctions2_function.example.project
+              location       = google_cloudfunctions2_function.example.location
+              cloud_function = google_cloudfunctions2_function.example.name
+              role           = "roles/run.invoker"
+              member         = "serviceAccount:caller@example-project.iam.gserviceaccount.com"
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/functions/docs/securing/managing-access-iam
+        title: Authorizing access to Cloud Functions
+  - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-gcp
+    filters: asset.platform == 'gcp-cloud-function'
+    mql: |
+      gcp.project.cloudFunction.allowsUnauthenticated == false
+  - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_cloudfunctions_function_iam_member' || nameLabel == 'google_cloudfunctions_function_iam_binding' || nameLabel == 'google_cloudfunctions2_function_iam_member' || nameLabel == 'google_cloudfunctions2_function_iam_binding')
+    mql: |
+      terraform.resources('google_cloudfunctions_function_iam_member').all(
+        arguments['member'] != "allUsers" && arguments['member'] != "allAuthenticatedUsers"
+      )
+      terraform.resources('google_cloudfunctions_function_iam_binding').all(
+        arguments['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+      terraform.resources('google_cloudfunctions2_function_iam_member').all(
+        arguments['member'] != "allUsers" && arguments['member'] != "allAuthenticatedUsers"
+      )
+      terraform.resources('google_cloudfunctions2_function_iam_binding').all(
+        arguments['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+  - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_cloudfunctions_function_iam_member' || type == 'google_cloudfunctions_function_iam_binding' || type == 'google_cloudfunctions2_function_iam_member' || type == 'google_cloudfunctions2_function_iam_binding')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_cloudfunctions_function_iam_member').all(
+        change.after['member'] != "allUsers" && change.after['member'] != "allAuthenticatedUsers"
+      )
+      terraform.plan.resourceChanges.where(type == 'google_cloudfunctions_function_iam_binding').all(
+        change.after['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+      terraform.plan.resourceChanges.where(type == 'google_cloudfunctions2_function_iam_member').all(
+        change.after['member'] != "allUsers" && change.after['member'] != "allAuthenticatedUsers"
+      )
+      terraform.plan.resourceChanges.where(type == 'google_cloudfunctions2_function_iam_binding').all(
+        change.after['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+  - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_cloudfunctions_function_iam_member' || type == 'google_cloudfunctions_function_iam_binding' || type == 'google_cloudfunctions2_function_iam_member' || type == 'google_cloudfunctions2_function_iam_binding')
+    mql: |
+      terraform.state.resources.where(type == 'google_cloudfunctions_function_iam_member').all(
+        values['member'] != "allUsers" && values['member'] != "allAuthenticatedUsers"
+      )
+      terraform.state.resources.where(type == 'google_cloudfunctions_function_iam_binding').all(
+        values['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+      terraform.state.resources.where(type == 'google_cloudfunctions2_function_iam_member').all(
+        values['member'] != "allUsers" && values['member'] != "allAuthenticatedUsers"
+      )
+      terraform.state.resources.where(type == 'google_cloudfunctions2_function_iam_binding').all(
+        values['members'].none(_ == "allUsers" || _ == "allAuthenticatedUsers")
+      )
+  - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption
+    title: Ensure Compute Engine snapshots are encrypted with CMEK
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Compute Engine disk snapshots are encrypted using customer-managed encryption keys (CMEK) through Cloud KMS rather than the default Google-managed keys. Snapshots preserve a complete copy of disk data at rest, so the key custody applied to the source disk should extend to its snapshots.
+
+        **Why this matters**
+
+        - **Key lifecycle ownership:** CMEK grants the organization independent control over rotation, suspension, and destruction of the keys protecting snapshot data, instead of leaving that entirely to Google.
+        - **Crypto shredding capability:** Destroying the Cloud KMS key renders the snapshot permanently unrecoverable, satisfying verifiable data-destruction requirements when decommissioning backups.
+        - **Consistent protection for backups:** A CMEK-encrypted disk does not guarantee CMEK-encrypted snapshots; snapshots created without an explicit key fall back to Google-managed encryption, creating an unmanaged copy of sensitive data.
+        - **Audit trail for key usage:** Cloud KMS logs every encrypt and decrypt operation against the snapshot's CMEK key, supporting forensic investigation of backup access.
+
+        **Risk mitigation**
+
+        - **Specify a key at snapshot creation:** Provide the CMEK key when creating a snapshot, since encryption cannot be changed after the snapshot exists.
+        - **Restrict KMS key access:** Limit IAM bindings on the snapshot encryption keys to the compute service agent and designated key administrators.
+        - **Re-create unmanaged snapshots:** Replace Google-managed-key snapshots of sensitive disks with CMEK-encrypted snapshots and delete the originals.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, navigate to **Compute Engine > Snapshots**.
+        2. Click each snapshot name to open its details.
+        3. Review the **Encryption type** field.
+
+        A passing snapshot shows **Customer-managed key** with a Cloud KMS key resource path. A failing snapshot shows **Google-managed key**.
+
+        ### Audit via CLI
+
+        1. List all snapshots and their encryption key information:
+
+        ```bash
+        gcloud compute snapshots list \
+          --format="table(name,snapshotEncryptionKey.kmsKeyName)"
+        ```
+
+        A passing snapshot returns a non-empty `kmsKeyName` value. A failing snapshot returns an empty or absent `kmsKeyName`.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt a Compute Engine snapshot with CMEK using the Google Cloud Console:
+
+            1. Navigate to **Compute Engine > Snapshots** and select **Create snapshot**.
+            2. Choose the source disk.
+            3. Under **Encryption**, select **Customer-managed key** and choose or create a Cloud KMS key.
+            4. Create the snapshot.
+
+            Note: Existing snapshots cannot be converted. Create a new CMEK-encrypted snapshot and delete the original.
+        - id: cli
+          desc: |
+            To create a CMEK-encrypted snapshot using the Google Cloud CLI, encrypt the source disk with a customer-managed key; snapshots inherit the customer-managed key of the disk they are taken from:
+
+            ```bash
+            gcloud compute disks create DISK_NAME \
+              --zone=ZONE \
+              --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
+
+            gcloud compute snapshots create SNAPSHOT_NAME \
+              --source-disk=DISK_NAME \
+              --source-disk-zone=ZONE
+            ```
+        - id: terraform
+          desc: |
+            To encrypt a Compute Engine snapshot with CMEK in Terraform:
+
+            ```hcl
+            resource "google_compute_snapshot" "example" {
+              name        = "example-snapshot"
+              source_disk = google_compute_disk.example.id
+              zone        = "us-central1-a"
+
+              snapshot_encryption_key {
+                kms_key_self_link = google_kms_crypto_key.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+        title: Protecting resources with Cloud KMS keys
+  - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.snapshots.all(
+        snapshotEncryptionKey != empty &&
+        snapshotEncryptionKey['kmsKeyName'] != empty
+      )
+  - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_snapshot')
+    mql: |
+      terraform.resources('google_compute_snapshot').all(
+        blocks.where(type == 'snapshot_encryption_key') != empty &&
+        blocks.where(type == 'snapshot_encryption_key').all(
+          arguments.kms_key_self_link != empty
+        )
+      )
+  - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_snapshot')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_snapshot').all(
+        change.after['snapshot_encryption_key'] != empty &&
+        change.after['snapshot_encryption_key'].any(_['kms_key_self_link'] != empty)
+      )
+  - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_snapshot')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_snapshot').all(
+        values['snapshot_encryption_key'] != empty &&
+        values['snapshot_encryption_key'].any(_['kms_key_self_link'] != empty)
+      )
+  - uid: mondoo-gcp-security-compute-image-cmek-encryption
+    title: Ensure Compute Engine images are encrypted with CMEK
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that custom Compute Engine images are encrypted using customer-managed encryption keys (CMEK) through Cloud KMS rather than the default Google-managed keys. Custom images often contain a fully provisioned operating system, baked-in credentials, and application code, so they warrant the same key custody as the disks they are built from.
+
+        **Why this matters**
+
+        - **Key lifecycle ownership:** CMEK lets the organization rotate, disable, or destroy the keys protecting image data independently of Google.
+        - **Crypto shredding capability:** Destroying the Cloud KMS key renders the image permanently unrecoverable, supporting verifiable data destruction for decommissioned golden images.
+        - **Protection of embedded secrets:** Custom images frequently embed configuration, agents, or credentials; CMEK ensures that copy of sensitive material is encrypted under a key the organization controls.
+        - **Audit trail for key usage:** Cloud KMS logs every encrypt and decrypt operation against the image's CMEK key, providing a record of access to the image.
+
+        **Risk mitigation**
+
+        - **Specify a key at image creation:** Provide the CMEK key when creating an image, since encryption cannot be changed afterward.
+        - **Restrict KMS key access:** Limit IAM bindings on the image encryption keys to the compute service agent and designated key administrators.
+        - **Re-create unmanaged images:** Replace Google-managed-key images with CMEK-encrypted images and delete the originals.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, navigate to **Compute Engine > Images** and select the **Custom images** tab.
+        2. Click each image name to open its details.
+        3. Review the **Encryption type** field.
+
+        A passing image shows **Customer-managed key** with a Cloud KMS key resource path. A failing image shows **Google-managed key**.
+
+        ### Audit via CLI
+
+        1. List all custom images and their encryption key information:
+
+        ```bash
+        gcloud compute images list --no-standard-images \
+          --format="table(name,imageEncryptionKey.kmsKeyName)"
+        ```
+
+        A passing image returns a non-empty `kmsKeyName` value. A failing image returns an empty or absent `kmsKeyName`.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt a Compute Engine image with CMEK using the Google Cloud Console:
+
+            1. Navigate to **Compute Engine > Images** and select **Create image**.
+            2. Choose the source disk, snapshot, or image.
+            3. Under **Encryption**, select **Customer-managed key** and choose or create a Cloud KMS key.
+            4. Create the image.
+
+            Note: Existing images cannot be converted. Create a new CMEK-encrypted image and delete the original.
+        - id: cli
+          desc: |
+            To create a CMEK-encrypted image using the Google Cloud CLI:
+
+            ```bash
+            gcloud compute images create IMAGE_NAME \
+              --source-disk=DISK_NAME \
+              --source-disk-zone=ZONE \
+              --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
+            ```
+        - id: terraform
+          desc: |
+            To encrypt a Compute Engine image with CMEK in Terraform:
+
+            ```hcl
+            resource "google_compute_image" "example" {
+              name        = "example-image"
+              source_disk = google_compute_disk.example.id
+
+              image_encryption_key {
+                kms_key_self_link = google_kms_crypto_key.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+        title: Protecting resources with Cloud KMS keys
+  - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.computeService.images.all(
+        imageEncryptionKey != empty &&
+        imageEncryptionKey['kmsKeyName'] != empty
+      )
+  - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_image')
+    mql: |
+      terraform.resources('google_compute_image').all(
+        blocks.where(type == 'image_encryption_key') != empty &&
+        blocks.where(type == 'image_encryption_key').all(
+          arguments.kms_key_self_link != empty
+        )
+      )
+  - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_image')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_image').all(
+        change.after['image_encryption_key'] != empty &&
+        change.after['image_encryption_key'].any(_['kms_key_self_link'] != empty)
+      )
+  - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_image')
+    mql: |
+      terraform.state.resources.where(type == 'google_compute_image').all(
+        values['image_encryption_key'] != empty &&
+        values['image_encryption_key'].any(_['kms_key_self_link'] != empty)
+      )
+  - uid: mondoo-gcp-security-iam-service-account-not-impersonatable
+    title: Ensure service accounts cannot be impersonated by other principals
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no principal is granted the `roles/iam.serviceAccountTokenCreator`, `roles/iam.serviceAccountUser`, or `roles/iam.workloadIdentityUser` role on a service account's own resource IAM policy. These roles let a principal mint tokens for, or act as, the service account — the primary privilege-escalation and lateral-movement path in GCP IAM.
+
+        **Why this matters**
+
+        - **Privilege escalation:** A principal with `serviceAccountTokenCreator` on a higher-privileged service account can mint access tokens for it and inherit all of its permissions, bypassing its own narrower grants.
+        - **Lateral movement:** Impersonation chains let an attacker who compromises one identity pivot to more privileged identities without ever obtaining a key.
+        - **Non-attributable actions:** Actions taken via impersonation appear as the impersonated service account, obscuring the originating principal during investigation.
+        - **Standing exposure:** Unlike short-lived workload bindings, broad impersonation grants persist until explicitly removed, leaving a durable escalation path.
+
+        **Risk mitigation**
+
+        - **Remove unnecessary impersonation grants:** Strip `serviceAccountTokenCreator`, `serviceAccountUser`, and `workloadIdentityUser` from service accounts that do not require delegated access.
+        - **Scope grants tightly:** Where impersonation is required, bind the role to specific named principals and the specific service account, never at the project level or to broad groups.
+        - **Prefer Workload Identity Federation with conditions:** Constrain `workloadIdentityUser` bindings with attribute conditions so only the intended external workload can impersonate the account.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the [Google Cloud Console](https://console.cloud.google.com) and navigate to **IAM & Admin > Service Accounts**.
+        2. Select a service account and open the **Permissions** tab.
+        3. Review the principals listed with **Service Account Token Creator**, **Service Account User**, or **Workload Identity User** roles.
+        4. Repeat for each service account.
+
+        A passing service account shows no principals granted those impersonation roles. A failing service account lists one or more principals able to impersonate it.
+
+        ### Audit via CLI
+
+        1. Retrieve the IAM policy for each service account and check for impersonation roles:
+
+        ```bash
+        gcloud iam service-accounts get-iam-policy SA_EMAIL --format=json | grep -E 'serviceAccountTokenCreator|serviceAccountUser|workloadIdentityUser' || echo "Not impersonatable"
+        ```
+
+        A passing service account returns no bindings for those roles. A failing service account returns one or more bindings granting them.
+      remediation:
+        - id: console
+          desc: |
+            To remove impersonation access from a service account using the Google Cloud Console:
+
+            1. Navigate to **IAM & Admin > Service Accounts** and select the service account.
+            2. Open the **Permissions** tab.
+            3. Locate principals granted **Service Account Token Creator**, **Service Account User**, or **Workload Identity User**.
+            4. Remove any binding that is not strictly required.
+        - id: cli
+          desc: |
+            To remove an impersonation binding using the Google Cloud CLI:
+
+            ```bash
+            gcloud iam service-accounts remove-iam-policy-binding SA_EMAIL \
+              --member="user:person@example.com" \
+              --role="roles/iam.serviceAccountTokenCreator"
+            ```
+        - id: terraform
+          desc: |
+            To avoid granting impersonation in Terraform, do not bind the token-creator, user, or workload-identity-user roles broadly; scope them to specific principals only when required:
+
+            ```hcl
+            # Grant impersonation only to a specific, named principal — never allUsers/allAuthenticatedUsers
+            resource "google_service_account_iam_member" "impersonation" {
+              service_account_id = google_service_account.target.name
+              role               = "roles/iam.serviceAccountTokenCreator"
+              member             = "serviceAccount:trusted-caller@example-project.iam.gserviceaccount.com"
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/iam/docs/service-account-impersonation
+        title: Service account impersonation
+  - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.iamService.serviceAccounts.all(
+        canBeImpersonated == false
+      )
+  - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_iam_member' || nameLabel == 'google_service_account_iam_binding')
+    mql: |
+      terraform.resources('google_service_account_iam_member').all(
+        arguments['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        arguments['role'] != "roles/iam.serviceAccountUser" &&
+        arguments['role'] != "roles/iam.workloadIdentityUser"
+      )
+      terraform.resources('google_service_account_iam_binding').all(
+        arguments['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        arguments['role'] != "roles/iam.serviceAccountUser" &&
+        arguments['role'] != "roles/iam.workloadIdentityUser"
+      )
+  - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_service_account_iam_member' || type == 'google_service_account_iam_binding')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_service_account_iam_member').all(
+        change.after['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        change.after['role'] != "roles/iam.serviceAccountUser" &&
+        change.after['role'] != "roles/iam.workloadIdentityUser"
+      )
+      terraform.plan.resourceChanges.where(type == 'google_service_account_iam_binding').all(
+        change.after['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        change.after['role'] != "roles/iam.serviceAccountUser" &&
+        change.after['role'] != "roles/iam.workloadIdentityUser"
+      )
+  - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_service_account_iam_member' || type == 'google_service_account_iam_binding')
+    mql: |
+      terraform.state.resources.where(type == 'google_service_account_iam_member').all(
+        values['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        values['role'] != "roles/iam.serviceAccountUser" &&
+        values['role'] != "roles/iam.workloadIdentityUser"
+      )
+      terraform.state.resources.where(type == 'google_service_account_iam_binding').all(
+        values['role'] != "roles/iam.serviceAccountTokenCreator" &&
+        values['role'] != "roles/iam.serviceAccountUser" &&
+        values['role'] != "roles/iam.workloadIdentityUser"
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible
+    title: Ensure Cloud KMS key rings are not anonymously or publicly accessible
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Cloud KMS key rings do not grant access to the special principals `allUsers` or `allAuthenticatedUsers` in their resource IAM policy. A public binding at the key-ring level cascades to every cryptographic key in the ring, exposing encrypt, decrypt, and key-management operations to anyone on the internet or any Google account holder.
+
+        **Why this matters**
+
+        - **Cascading exposure:** Key-ring IAM bindings are inherited by all cryptokeys in the ring, so a single public binding exposes every current and future key it contains.
+        - **Bypasses per-key controls:** A ring-level public grant authorizes use of keys even when each key's own IAM policy contains no public members, defeating key-level review.
+        - **Direct path to data compromise:** Public decrypt access lets an unauthorized party read any data the keys protect; public key-management access can disable or destroy keys, denying access to encrypted data.
+        - **Non-attributable key operations:** Operations performed through public bindings are not tied to an identity, preventing meaningful investigation.
+
+        **Risk mitigation**
+
+        - **Remove public bindings immediately:** Audit key-ring IAM policies and delete any binding containing `allUsers` or `allAuthenticatedUsers`.
+        - **Grant at the narrowest scope:** Bind key roles to specific service accounts at the individual key level rather than the ring level where possible.
+        - **Separate keys by sensitivity:** Group keys into rings by trust boundary so that any future ring-level grant has a limited, well-understood blast radius.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the [Google Cloud Console](https://console.cloud.google.com) and navigate to **Security > Key Management**.
+        2. Select a key ring and open the **Permissions** (info) panel.
+        3. Confirm no entries for `allUsers` or `allAuthenticatedUsers` appear.
+        4. Repeat for each key ring.
+
+        A passing key ring shows no public principals. A failing key ring lists `allUsers` or `allAuthenticatedUsers` with any role.
+
+        ### Audit via CLI
+
+        1. Retrieve the IAM policy for each key ring and check for public members:
+
+        ```bash
+        gcloud kms keyrings get-iam-policy KEYRING_NAME --location=LOCATION --format=json | grep -E 'allUsers|allAuthenticatedUsers' || echo "No public access"
+        ```
+
+        A passing key ring returns no bindings containing `allUsers` or `allAuthenticatedUsers`. A failing key ring returns one or more such bindings.
+      remediation:
+        - id: console
+          desc: |
+            To remove public access from a Cloud KMS key ring using the Google Cloud Console:
+
+            1. Navigate to **Security > Key Management** and select the key ring.
+            2. Open the **Permissions** (info) panel.
+            3. Locate the `allUsers` or `allAuthenticatedUsers` principal.
+            4. Remove the binding and save.
+        - id: cli
+          desc: |
+            To remove a public binding from a Cloud KMS key ring using the Google Cloud CLI:
+
+            ```bash
+            gcloud kms keyrings remove-iam-policy-binding KEYRING_NAME \
+              --location=LOCATION \
+              --member="allUsers" \
+              --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+            ```
+        - id: terraform
+          desc: |
+            To keep a Cloud KMS key ring private in Terraform, grant key-ring roles only to specific identities and never to `allUsers` or `allAuthenticatedUsers`:
+
+            ```hcl
+            resource "google_kms_key_ring_iam_member" "example" {
+              key_ring_id = google_kms_key_ring.example.id
+              role        = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+              member      = "serviceAccount:app@example-project.iam.gserviceaccount.com"
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/kms/docs/iam
+        title: Cloud KMS permissions and roles
+  - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.kmsService.keyrings.all(
+        public == false
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' &&
+        terraform.resources.where( nameLabel.in(['google_kms_key_ring_iam_policy', 'google_kms_key_ring_iam_binding', 'google_kms_key_ring_iam_member'])) != empty
+    mql: |
+      terraform.resources.where(nameLabel == 'google_kms_key_ring_iam_policy' || nameLabel == 'google_kms_key_ring_iam_binding')
+        .all(
+          arguments.members == empty || arguments.members.none(_ == 'allUsers' || _ == 'allAuthenticatedUsers')
+        )
+      terraform.resources('google_kms_key_ring_iam_member').all(
+        arguments.member != 'allUsers' && arguments.member != 'allAuthenticatedUsers'
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_kms_key_ring_iam_policy' || type == 'google_kms_key_ring_iam_binding' || type == 'google_kms_key_ring_iam_member')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_kms_key_ring_iam_policy' || type == 'google_kms_key_ring_iam_binding').all(
+        change.after['members'] == empty || change.after['members'].none(_ == 'allUsers' || _ == 'allAuthenticatedUsers')
+      )
+      terraform.plan.resourceChanges.where(type == 'google_kms_key_ring_iam_member').all(
+        change.after['member'] != 'allUsers' && change.after['member'] != 'allAuthenticatedUsers'
+      )
+  - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_kms_key_ring_iam_policy' || type == 'google_kms_key_ring_iam_binding' || type == 'google_kms_key_ring_iam_member')
+    mql: |
+      terraform.state.resources.where(type == 'google_kms_key_ring_iam_policy' || type == 'google_kms_key_ring_iam_binding').all(
+        values['members'] == empty || values['members'].none(_ == 'allUsers' || _ == 'allAuthenticatedUsers')
+      )
+      terraform.state.resources.where(type == 'google_kms_key_ring_iam_member').all(
+        values['member'] != 'allUsers' && values['member'] != 'allAuthenticatedUsers'
+      )
+  - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress
+    title: Ensure App Engine firewall does not allow ingress from all source ranges
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that the App Engine application firewall does not have an `ALLOW` rule whose source range is `*` (every IP address). The App Engine firewall is the application's only IP-perimeter control, and by default it ships with a single catch-all rule that allows all traffic; leaving that default in place exposes the application to the entire internet.
+
+        **Why this matters**
+
+        - **Whole-internet exposure:** An `ALLOW` rule with source range `*` permits requests from any address, so the application has no network perimeter at all.
+        - **Only IP perimeter App Engine offers:** App Engine standard environment has no VPC firewall in front of it; this rule set is the sole network access control, so a permissive default leaves the app fully open.
+        - **Defense-in-depth:** Even when the application enforces its own authentication, an IP allow-list reduces the attack surface reachable by scanners, brute-force tools, and exploit attempts.
+        - **Abuse and cost:** Unrestricted ingress invites high-volume automated traffic that drives up instance hours and cost.
+
+        **Risk mitigation**
+
+        - **Set the default rule to deny:** Change the lowest-priority catch-all rule to `DENY`, then add specific `ALLOW` rules for the source ranges that must reach the app.
+        - **Allow only known ranges:** Restrict ingress to corporate egress IPs, a load balancer, or Identity-Aware Proxy ranges rather than `*`.
+        - **Review rules regularly:** Audit the firewall rule set so a temporary `*` allow rule is not left in place.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the [Google Cloud Console](https://console.cloud.google.com) and navigate to **App Engine > Firewall rules**.
+        2. Review the rule list, including the default rule.
+        3. Confirm no rule with action **Allow** has source range `*`.
+
+        A passing application has its catch-all (`*`) rule set to **Deny** with specific allow rules for known ranges. A failing application has an **Allow** rule whose source range is `*`.
+
+        ### Audit via CLI
+
+        1. List the App Engine firewall rules and their actions and source ranges:
+
+        ```bash
+        gcloud app firewall-rules list \
+          --format="table(priority,action,sourceRange)"
+        ```
+
+        A passing application returns no rule with `ACTION = ALLOW` and `SOURCE_RANGE = *`. A failing application returns at least one `ALLOW` rule with source range `*`.
+      remediation:
+        - id: console
+          desc: |
+            To restrict App Engine firewall ingress using the Google Cloud Console:
+
+            1. Navigate to **App Engine > Firewall rules**.
+            2. Edit the default `*` rule and set its action to **Deny**.
+            3. Add specific **Allow** rules for the source ranges that must reach the application.
+            4. Save the changes.
+        - id: cli
+          desc: |
+            To restrict App Engine firewall ingress using the Google Cloud CLI, set the default rule to deny and add specific allow rules:
+
+            ```bash
+            gcloud app firewall-rules update default --action=deny
+
+            gcloud app firewall-rules create 100 \
+              --action=allow \
+              --source-range="203.0.113.0/24"
+            ```
+        - id: terraform
+          desc: |
+            To restrict App Engine firewall ingress in Terraform, set the catch-all rule to `DENY` and allow only specific ranges:
+
+            ```hcl
+            resource "google_app_engine_firewall_rule" "default_deny" {
+              priority     = 2147483647
+              action       = "DENY"
+              source_range = "*"
+            }
+
+            resource "google_app_engine_firewall_rule" "allow_office" {
+              priority     = 100
+              action       = "ALLOW"
+              source_range = "203.0.113.0/24"
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/appengine/docs/standard/creating-firewalls
+        title: Creating App Engine firewalls
+  - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.appEngineService.firewallRules.none(
+        action == "ALLOW" && sourceRange == "*"
+      )
+  - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_app_engine_firewall_rule')
+    mql: |
+      terraform.resources('google_app_engine_firewall_rule').all(
+        arguments['action'] != "ALLOW" || arguments['source_range'] != "*"
+      )
+  - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_app_engine_firewall_rule')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_app_engine_firewall_rule').all(
+        change.after['action'] != "ALLOW" || change.after['source_range'] != "*"
+      )
+  - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_app_engine_firewall_rule')
+    mql: |
+      terraform.state.resources.where(type == 'google_app_engine_firewall_rule').all(
+        values['action'] != "ALLOW" || values['source_range'] != "*"
+      )
+  - uid: mondoo-gcp-security-ca-pool-cmek-encryption
+    title: Ensure Certificate Authority Service CA pools are encrypted with CMEK
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    # No Terraform variants: the google_privateca_ca_pool resource does not expose a
+    # customer-managed encryption-key argument for the issued-certificate content
+    # encryption surfaced by CaPool.EncryptionSpec; the setting is configured through
+    # the API and console. Revisit if the provider adds an encryption_spec argument.
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.certificateAuthorityService.caPools.all(kmsKey != null)
+    docs:
+      desc: |
+        This check ensures that Certificate Authority Service CA pools encrypt issued-certificate content with a customer-managed encryption key (CMEK). The CA pool's encryption key protects the Subject, Subject Alternative Names, and PEM-encoded certificate of every certificate the pool issues at rest; without it, that data is protected only by Google-managed keys.
+
+        **Why this matters**
+
+        - **Key control:** CMEK lets the organization rotate, disable, or destroy the key that protects issued-certificate content independently of Google.
+        - **Sensitive PKI metadata:** Certificate subjects and SANs reveal internal hostnames, identities, and topology that should be encrypted under a customer-controlled key.
+        - **Compliance alignment:** Regulated PKI workloads frequently require demonstrable customer control over the keys protecting certificate data at rest.
+
+        **Risk mitigation**
+
+        - **Access revocation:** Disabling the CMEK key prevents access to the protected certificate content after a security incident.
+        - **Separation of duties:** Storing the key in a separate KMS project enforces a boundary between CA operators and key custodians.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, navigate to **Security > Certificate Authority Service > CA pools**.
+        2. Select each CA pool and open its details.
+        3. Review the encryption configuration.
+
+        A passing CA pool shows a Cloud KMS key configured for issued-certificate encryption. A failing CA pool shows only Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. Describe each CA pool and review its encryption specification:
+
+        ```bash
+        gcloud privateca pools describe POOL_NAME \
+          --location=LOCATION \
+          --format="value(encryptionSpec.cloudKmsKey)"
+        ```
+
+        A passing CA pool returns a Cloud KMS key resource name. A failing CA pool returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt CA pool issued-certificate content with CMEK using the Google Cloud Console:
+
+            CMEK must be set when the CA pool is created.
+
+            1. Navigate to **Security > Certificate Authority Service** and select **Create CA pool**.
+            2. Configure the pool, and under encryption select a customer-managed Cloud KMS key.
+            3. Complete the CA pool creation and migrate certificate authorities as needed.
+        - id: cli
+          desc: |
+            The `gcloud privateca pools create` command configures the CA pool; specify the customer-managed key for issued-certificate encryption through the API where the standard CLI does not expose it:
+
+            ```bash
+            curl -X POST \
+              -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              -H "Content-Type: application/json" \
+              "https://privateca.googleapis.com/v1/projects/PROJECT/locations/LOCATION/caPools?caPoolId=POOL_NAME" \
+              -d '{
+                "tier": "ENTERPRISE",
+                "encryptionSpec": {
+                  "cloudKmsKey": "projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY"
+                }
+              }'
+            ```
+    refs:
+      - url: https://cloud.google.com/certificate-authority-service/docs/cmek
+        title: Customer-managed encryption keys for Certificate Authority Service
+  - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption
+    title: Ensure Eventarc channels are encrypted with CMEK
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Eventarc channels are encrypted with a customer-managed encryption key (CMEK). A third-party Eventarc channel's CMEK key encrypts the event payloads buffered on the channel at rest, giving the organization control over the key protecting that event data.
+
+        **Why this matters**
+
+        - **Key control:** CMEK lets the organization rotate, disable, or destroy the key protecting buffered event data independently of Google.
+        - **Event payload sensitivity:** Events routed through a channel can carry application data, identifiers, or other sensitive content that should be encrypted under a customer-controlled key.
+        - **Compliance alignment:** Encryption-at-rest mandates expect customer key custody for buffered data in event-routing services.
+
+        **Risk mitigation**
+
+        - **Access revocation:** Disabling the CMEK key prevents access to buffered event data after a security incident.
+        - **Auditability:** CMEK key use is recorded in Cloud KMS audit logs, providing a record of access to channel data.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, navigate to **Eventarc > Channels**.
+        2. Select each channel and open its details.
+        3. Review the encryption key configuration.
+
+        A passing channel shows a Cloud KMS key configured. A failing channel shows only Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. List Eventarc channels and review their crypto key:
+
+        ```bash
+        gcloud eventarc channels list \
+          --location=LOCATION \
+          --format="table(name,cryptoKeyName)"
+        ```
+
+        A passing channel returns a Cloud KMS key resource name in the `CRYPTO_KEY_NAME` column. A failing channel returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt an Eventarc channel with CMEK using the Google Cloud Console:
+
+            1. Navigate to **Eventarc > Channels** and select **Create channel** (or edit an existing third-party channel).
+            2. Under encryption, select a customer-managed Cloud KMS key.
+            3. Save the channel.
+        - id: cli
+          desc: |
+            To create an Eventarc channel with CMEK using the Google Cloud CLI:
+
+            ```bash
+            gcloud eventarc channels create CHANNEL_NAME \
+              --location=LOCATION \
+              --provider=PROVIDER \
+              --crypto-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
+            ```
+        - id: terraform
+          desc: |
+            To encrypt an Eventarc channel with CMEK in Terraform:
+
+            ```hcl
+            resource "google_eventarc_channel" "example" {
+              location        = "us-central1"
+              name            = "example-channel"
+              third_party_provider = "projects/PROJECT/locations/us-central1/providers/PROVIDER"
+              crypto_key_name = google_kms_crypto_key.example.id
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/eventarc/docs/use-cmek
+        title: Use customer-managed encryption keys with Eventarc
+  - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-gcp
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.eventarcService.channels.all(kmsKey != null)
+  - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_eventarc_channel')
+    mql: |
+      terraform.resources('google_eventarc_channel').all(
+        arguments.crypto_key_name != empty &&
+        arguments.crypto_key_name != ""
+      )
+  - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_eventarc_channel')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_eventarc_channel').all(
+        change.after['crypto_key_name'] != empty &&
+        change.after['crypto_key_name'] != ""
+      )
+  - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_eventarc_channel')
+    mql: |
+      terraform.state.resources.where(type == 'google_eventarc_channel').all(
+        values['crypto_key_name'] != empty &&
+        values['crypto_key_name'] != ""
+      )
+  - uid: mondoo-gcp-security-vertexai-additional-resources-cmek-encryption
+    title: Ensure Vertex AI indexes, metadata stores, and tensorboards use CMEK
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    # No Terraform variants: encryption_spec coverage for these Vertex AI resource types is
+    # inconsistent across the google Terraform provider; the check evaluates the live
+    # encryption key reference on each resource. Revisit per-resource as provider support stabilizes.
+    filters: asset.platform == 'gcp'
+    mql: |
+      gcp.project.vertexaiService.indexes.all(kmsKey != null)
+      gcp.project.vertexaiService.indexEndpoints.all(kmsKey != null)
+      gcp.project.vertexaiService.metadataStores.all(kmsKey != null)
+      gcp.project.vertexaiService.tensorboards.all(kmsKey != null)
+    docs:
+      desc: |
+        This check ensures that Vertex AI indexes, index endpoints, metadata stores, and tensorboards are encrypted with customer-managed encryption keys (CMEK). These resources hold vector indexes, ML metadata, and experiment data derived from training inputs; CMEK gives the organization control over the keys protecting that data at rest, complementing the existing CMEK checks on Vertex AI datasets, models, endpoints, and feature stores.
+
+        **Why this matters**
+
+        - **Key control:** CMEK lets the organization rotate, disable, or destroy the keys protecting index, metadata, and tensorboard data independently of Google.
+        - **Derived-data sensitivity:** Vector indexes and ML metadata are derived from training data that frequently contains regulated or proprietary content.
+        - **Consistent coverage:** Encrypting only some Vertex AI resource types leaves unmanaged copies of related data; CMEK should apply across the resources that hold derived data.
+
+        **Risk mitigation**
+
+        - **Access revocation:** Disabling a CMEK key prevents access to the protected resource data after a security incident.
+        - **Separation of duties:** Storing keys in a separate KMS project enforces a boundary between ML operators and key custodians.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, navigate to **Vertex AI** and review **Vector Search** indexes and index endpoints, **Metadata**, and **Experiments / Tensorboards**.
+        2. Open each resource's details and review its encryption configuration.
+
+        A passing resource shows a Cloud KMS key under encryption. A failing resource shows only Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. List the resources and review their encryption specification, for example indexes:
+
+        ```bash
+        gcloud ai indexes list \
+          --region=REGION \
+          --format="table(name,displayName,encryptionSpec.kmsKeyName)"
+        ```
+
+        A passing resource returns a Cloud KMS key name in the `KMS_KEY_NAME` column. A failing resource returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            To encrypt Vertex AI indexes, metadata stores, and tensorboards with CMEK using the Google Cloud Console:
+
+            CMEK must be configured when the resource is created.
+
+            1. Go to the **Vertex AI** page and select the resource type to create.
+            2. Under **Encryption**, select **Customer-managed encryption key (CMEK)**.
+            3. Select or create a Cloud KMS key, then complete creation.
+        - id: cli
+          desc: |
+            Create these Vertex AI resources with a CMEK key through the Vertex AI REST API, which accepts an `encryptionSpec`, for example a metadata store:
+
+            ```bash
+            curl -X POST \
+              -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              -H "Content-Type: application/json" \
+              "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT/locations/REGION/metadataStores?metadataStoreId=STORE_ID" \
+              -d '{
+                "encryptionSpec": {
+                  "kmsKeyName": "projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY"
+                }
+              }'
+            ```
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+        title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-pubsub-topic-schema-validation-enabled
     title: Ensure Pub/Sub topics enforce a message schema
     impact: 50

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -5014,6 +5014,7 @@ queries:
       terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
         values['extra_config']['log.rotateSize'] == "1024000"
       )
+  # No Terraform variants: the vsphere_compute_cluster resource exposes no vSAN data-at-rest encryption argument. At-rest encryption is applied through a configured key provider, not the cluster resource.
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-at-rest-encryption-is-enabled
     title: Ensure vSAN data-at-rest encryption is enabled
     impact: 80
@@ -5109,12 +5110,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: |
-      vsphere.datacenters.all(
-        clusters.where(vsan != null).all(
-          vsan.inTransitEncryptionEnabled == true
-        )
-      )
+    variants:
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-vsphere
+        tags:
+          mondoo.com/filter-title: VMware vSphere
+          mondoo.com/filter-icon: vmware
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that vSAN data-in-transit encryption is enabled on every vSAN-enabled cluster. Data-in-transit encryption encrypts vSAN traffic as it moves between hosts in the cluster over the vSAN network, protecting replica writes and resync traffic from interception on the storage fabric.
@@ -5169,3 +5181,32 @@ queries:
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-D8E5550C-8C0A-43AB-A3C9-4F4F0F0D6C9C.html
         title: Using Data-in-Transit Encryption in vSAN
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-vsphere
+    filters: asset.platform == 'vmware-vsphere'
+    mql: |
+      vsphere.datacenters.all(
+        clusters.where(vsan != null).all(
+          vsan.inTransitEncryptionEnabled == true
+        )
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_compute_cluster')
+    mql: |
+      terraform.resources('vsphere_compute_cluster').all(
+        arguments['vsan_dit_encryption_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-plan
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'vsphere_compute_cluster')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'vsphere_compute_cluster').all(
+        change.after['vsan_dit_encryption_enabled'] == true
+      )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-terraform-state
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'vsphere_compute_cluster')
+    mql: |
+      terraform.state.resources.where(type == 'vsphere_compute_cluster').all(
+        values['vsan_dit_encryption_enabled'] == true
+      )

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -76,6 +76,8 @@ policies:
           - uid: mondoo-vmware-vsphere-security-baseline-ensure-uefi-secure-boot-is-enabled-for-virtual-machines
           - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtual-machine-encryption-is-enabled
           - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-at-rest-encryption-is-enabled
+          - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled
       - title: Resources
         filters: |
           asset.platform == "vmware-vsphere"
@@ -5012,3 +5014,158 @@ queries:
       terraform.state.resources.where(type == 'vsphere_virtual_machine').all(
         values['extra_config']['log.rotateSize'] == "1024000"
       )
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-at-rest-encryption-is-enabled
+    title: Ensure vSAN data-at-rest encryption is enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      vsphere.datacenters.all(
+        clusters.where(vsan != null).all(
+          vsan.encryptionEnabled == true
+        )
+      )
+    docs:
+      desc: |
+        This check ensures that vSAN data-at-rest encryption is enabled on every vSAN-enabled cluster. vSAN data-at-rest encryption encrypts all objects in the vSAN datastore using keys supplied by a configured key provider, protecting guest data, swap, and metadata on the physical capacity devices.
+
+        **Why this matters**
+
+        - **Data confidentiality:** Encryption keeps vSAN datastore contents unreadable if a capacity device is removed, decommissioned, or stolen.
+        - **Key custody:** A configured key provider (Native Key Provider or an external KMS) gives the organization control over the keys that protect cluster storage.
+        - **Regulatory alignment:** Frameworks that mandate encryption of data at rest expect storage-tier encryption for sensitive virtualized workloads.
+
+        **Risk mitigation**
+
+        - **Theft resistance:** Removing or copying a capacity disk does not expose guest data once the disk groups are encrypted.
+        - **Verifiable destruction:** Retiring the encryption key cryptographically shreds the data the cluster stored.
+      audit: |
+        ### Audit via the vSphere Client
+
+        1. Select the cluster and choose **Configure** > **vSAN** > **Services**.
+        2. Expand the **Data-At-Rest Encryption** section.
+        3. Confirm encryption is enabled and a key provider is assigned.
+
+        The check passes when every vSAN-enabled cluster reports data-at-rest encryption as enabled. It fails for any vSAN cluster with data-at-rest encryption disabled.
+
+        ### Audit via PowerCLI
+
+        1. Connect to vCenter Server with `Connect-VIServer`.
+        2. Run the following command:
+
+        ```powershell
+        Get-Cluster | Get-VsanClusterConfiguration | Select-Object Cluster, EncryptionEnabled
+        ```
+
+        The check passes when every vSAN-enabled cluster returns `EncryptionEnabled` as `True`. It fails for any cluster returning `False`.
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable vSAN data-at-rest encryption using the vSphere Client:
+
+            A key provider (Native Key Provider or a registered KMS) must be configured in vCenter Server first.
+
+            1. Ensure a key provider is configured under `vCenter` > `Configure` > `Key Providers`.
+            2. Select the cluster and choose `Configure` > `vSAN` > `Services`.
+            3. Edit the `Data-At-Rest Encryption` service and enable it.
+            4. Select the key provider and apply the change. A rolling disk-group reformat may occur.
+        - id: powershell
+          desc: |
+            To enable vSAN data-at-rest encryption using PowerCLI:
+
+            ```powershell
+            Get-Cluster -Name "CLUSTER_NAME" |
+              Set-VsanClusterConfiguration -DataEncryptionEnabled $true -KmsCluster "KMS_CLUSTER_NAME"
+            ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-F3B2714F-3406-48E7-AC2D-3677355C94D3.html
+        title: Using Data-at-Rest Encryption in vSAN
+  - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled
+    title: Ensure vSAN data-in-transit encryption is enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      vsphere.datacenters.all(
+        clusters.where(vsan != null).all(
+          vsan.inTransitEncryptionEnabled == true
+        )
+      )
+    docs:
+      desc: |
+        This check ensures that vSAN data-in-transit encryption is enabled on every vSAN-enabled cluster. Data-in-transit encryption encrypts vSAN traffic as it moves between hosts in the cluster over the vSAN network, protecting replica writes and resync traffic from interception on the storage fabric.
+
+        **Why this matters**
+
+        - **Confidentiality on the wire:** vSAN replicates and resyncs object data between hosts; without in-transit encryption that traffic crosses the network in cleartext.
+        - **Defense-in-depth:** Encrypting the vSAN network protects data even when the storage fabric is shared or not fully physically isolated.
+        - **Independent of at-rest:** Data-at-rest and data-in-transit encryption are separate controls; enabling one does not enable the other.
+
+        **Risk mitigation**
+
+        - **Eavesdropping resistance:** An attacker with access to the vSAN network segment cannot read intercepted host-to-host traffic.
+        - **Tamper resistance:** Encrypted transport protects replica and resync traffic from on-path modification.
+      audit: |
+        ### Audit via the vSphere Client
+
+        1. Select the cluster and choose **Configure** > **vSAN** > **Services**.
+        2. Expand the **Data-In-Transit Encryption** section.
+        3. Confirm data-in-transit encryption is enabled.
+
+        The check passes when every vSAN-enabled cluster reports data-in-transit encryption as enabled. It fails for any vSAN cluster with it disabled.
+
+        ### Audit via PowerCLI
+
+        1. Connect to vCenter Server with `Connect-VIServer`.
+        2. Run the following command:
+
+        ```powershell
+        Get-Cluster | Get-VsanClusterConfiguration | Select-Object Cluster, DataInTransitEncryptionEnabled
+        ```
+
+        The check passes when every vSAN-enabled cluster returns `DataInTransitEncryptionEnabled` as `True`. It fails for any cluster returning `False`.
+      remediation:
+        - id: vsphere-client
+          desc: |
+            To enable vSAN data-in-transit encryption using the vSphere Client:
+
+            1. Select the cluster and choose `Configure` > `vSAN` > `Services`.
+            2. Edit the `Data-In-Transit Encryption` service and enable it.
+            3. Optionally set the rekey interval, then apply the change.
+
+            Data-in-transit encryption does not require an external key provider; vSAN manages the keys internally.
+        - id: powershell
+          desc: |
+            To enable vSAN data-in-transit encryption using PowerCLI:
+
+            ```powershell
+            Get-Cluster -Name "CLUSTER_NAME" |
+              Set-VsanClusterConfiguration -DataInTransitEncryptionEnabled $true
+            ```
+    refs:
+      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-D8E5550C-8C0A-43AB-A3C9-4F4F0F0D6C9C.html
+        title: Using Data-in-Transit Encryption in vSAN


### PR DESCRIPTION
## What

Adds **15 net-new security checks** across four policies, leveraging new resource fields/resources added in the cnquery provider PRs `mondoohq/mql` #8096, #8099, #8100, #8102, #8105, #8109, and #8110.

| Policy | Checks | Source PRs |
|---|---|---|
| **GCP** (9) | `cloud-functions-no-public-invocation`, `compute-snapshot-cmek-encryption`, `compute-image-cmek-encryption`, `iam-service-account-not-impersonatable`, `cloud-kms-keyring-not-publicly-accessible`, `appengine-firewall-no-public-ingress`, `ca-pool-cmek-encryption`, `eventarc-channel-cmek-encryption`, `vertexai-additional-resources-cmek-encryption` | 8105, 8109, 8100 |
| **AWS** (1) | `route53-resolver-dns-firewall-threat-protection` | 8096 |
| **vSphere** (2) | `vsan-data-at-rest-encryption`, `vsan-data-in-transit-encryption` | 8110 |
| **DigitalOcean** (3) | `security-scan-no-critical-findings`, `gradientai-agent-not-publicly-deployed`, `gradientai-knowledge-base-not-public` | 8102, 8099 |

## Coverage per check

- Full `desc` / `audit` / `remediation` blocks (vendor-native audit steps; every supported remediation surface).
- Terraform `variants:` where the provider exposes the setting; a documented `# No Terraform variants:` comment where it does not (operational telemetry, GenAI resources with no TF resource, advanced rule types not yet in the provider).
- **Compliance tags verified against the framework definitions** in `cnspec-enterprise-policies/frameworks/`: same-objective mappings reused for the CMEK / public-access / KMS checks; fresh mappings researched and cited for service-account impersonation (least privilege → AC-6), DNS threat protection (malicious-code → SI-3), and managed vulnerability scanning (→ RA-5). NIS-2 is intentionally `false` on the DNS-firewall check (no genuine control fit).

## Validation

- `cnspec policy lint` — **all four bundles valid** (remaining warnings are pre-existing deprecated-field usages in other checks).
- `validate_remediation_commands.py gcp` / `digitalocean` — **0 failures**; AWS commands validate against the bundled botocore.

## Notes / dependencies

- The GCP, vSphere, and DigitalOcean checks depend on provider versions that include the referenced PRs (GCP 8109/8100, vSphere 8110, DigitalOcean 8102/8099). They lint against those provider builds.
- A couple of runtime assumptions could not be verified without a live target (lint-clean regardless): project-level enumeration platform/location behavior for `kmsService.keyrings` / `caPools` / `vertexaiService.*`, and a few enum string values (App Engine firewall `action`, GradientAI `VISIBILITY_PUBLIC`, scan severity `critical`).
- OCI PR 8108 (bucket pre-authenticated requests, public connection URLs) was out of scope here — those fields are not yet in a built provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)