### PR TITLE
content: migrate ECR/ECS/SageMaker/GCP checks to per-service platforms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -37666,15 +37666,13 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
         title: AWS IAM Best Practices
   - uid: mondoo-aws-security-sagemaker-training-hyperparameters-no-secrets-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sagemaker-trainingjob"
     mql: |
-      aws.sagemaker.trainingJobs.all(
-        hyperParameters.keys.none(
-          _.downcase == /^aws_access_key_id$|^aws_secret_access_key$|^aws_session_token$|^aws_security_token$/
-        ) &&
-        hyperParameters.values.none(
-          _.find(/(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/) != empty
-        )
+      aws.sagemaker.trainingjob.hyperParameters.keys.none(
+        _.downcase == /^aws_access_key_id$|^aws_secret_access_key$|^aws_session_token$|^aws_security_token$/
+      ) &&
+      aws.sagemaker.trainingjob.hyperParameters.values.none(
+        _.find(/(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/) != empty
       )
   # No Terraform variants: Hub content metadata is set via `ImportHubContent` API calls (no Terraform resource); the runtime check inspects content uploaded to a hub at scan time.
   - uid: mondoo-aws-security-sagemaker-hub-public-content-documented
@@ -46206,14 +46204,12 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html
         title: AWS Documentation - Passing sensitive data to a container
   - uid: mondoo-aws-security-ecs-task-definition-no-plaintext-secrets-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
-      aws.ecs.taskDefinitions.all(
-        containerDefinitions.all(
-          environment.none( name == /(?i)^(aws_secret_access_key|aws_access_key_id|db_password|database_password|master_password|admin_password|api_key|api_secret|private_key|secret_key|auth_token|access_token)$/ ) &&
-          environment.none( value == /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ ) &&
-          environment.none( value == /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ )
-        )
+      aws.ecs.taskDefinition.containerDefinitions.all(
+        environment.none( name == /(?i)^(aws_secret_access_key|aws_access_key_id|db_password|database_password|master_password|admin_password|api_key|api_secret|private_key|secret_key|auth_token|access_token)$/ ) &&
+        environment.none( value == /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/ ) &&
+        environment.none( value == /-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY/ )
       )
   # No Terraform variants: The default VPC is created by AWS automatically per region; `aws_default_vpc` adopts an existing default VPC for management but does not delete it. The runtime check walks every region's VPCs to find any with `isDefault == true`; this regional inventory does not have a clean Terraform analog.
   - uid: mondoo-aws-security-no-default-vpc
@@ -48490,22 +48486,16 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html
         title: AWS Documentation - Amazon ECR repository policies
   - uid: mondoo-aws-security-ecr-no-public-access-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-ecr-repository" && aws.ecr.repository.policy != empty
     mql: |
-      aws.ecr.privateRepositories.where(policy != empty).all(
-        policy['Statement'].none(
-          _['Principal'] == "*"
-        )
+      aws.ecr.repository.policy['Statement'].none(
+        _['Principal'] == "*"
       )
-      aws.ecr.privateRepositories.where(policy != empty).all(
-        policy['Statement'].none(
-          _['Principal']['AWS'] == "*"
-        )
+      aws.ecr.repository.policy['Statement'].none(
+        _['Principal']['AWS'] == "*"
       )
-      aws.ecr.privateRepositories.where(policy != empty).all(
-        policy['Statement'].none(
-          _['Principal']['AWS'].contains("*")
-        )
+      aws.ecr.repository.policy['Statement'].none(
+        _['Principal']['AWS'].contains("*")
       )
   - uid: mondoo-aws-security-ecr-no-public-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository_policy")
@@ -51599,9 +51589,9 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security.html
         title: AWS Documentation - Amazon ECS best practices - Security
   - uid: mondoo-aws-security-ecs-init-process-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-ecs-taskdefinition"
     mql: |
-      aws.ecs.taskDefinitions.all(containerDefinitions.all(initProcessEnabled == true))
+      aws.ecs.taskDefinition.containerDefinitions.all(initProcessEnabled == true)
   - uid: mondoo-aws-security-ecs-init-process-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecs_task_definition")
     mql: |
@@ -51954,12 +51944,10 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECR/latest/userguide/security.html
         title: AWS Documentation - Security in Amazon ECR
   - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-ecr-repository" && aws.ecr.repository.policy != empty
     mql: |
-      aws.ecr.privateRepositories.where(policy != empty).all(
-        policy['Statement'].where(_['Effect'] == "Allow").where(_['Condition'] == empty).none(
-          _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
-        )
+      aws.ecr.repository.policy['Statement'].where(_['Effect'] == "Allow").where(_['Condition'] == empty).none(
+        _['Principal'] == "*" || _['Principal']['AWS'] == "*" || _['Principal']['AWS'].contains("*")
       )
   - uid: mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository_policy")

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -25864,11 +25864,9 @@ queries:
       - url: https://cloud.google.com/sql/docs/mysql/iam-authentication
         title: Cloud SQL - IAM database authentication
   - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
     mql: |
-      gcp.project.sqlService.instances.all(
-        users.all(type != "BUILT_IN" || name == "root" || name == "postgres" || name == "sqlserver")
-      )
+      gcp.project.sqlService.instance.users.all(type != "BUILT_IN" || name == "root" || name == "postgres" || name == "sqlserver")
   - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_sql_user')
@@ -32307,12 +32305,10 @@ queries:
       - url: https://cloud.google.com/iam/docs/overview#allusers
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-compute-image-iam-no-public-principals-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-compute-image'
     mql: |
-      gcp.project.computeService.images.all(
-        iamPolicy.all(
-          members.none(_ == "allUsers" || _ == "allAuthenticatedUsers")
-        )
+      gcp.project.computeService.image.iamPolicy.all(
+        members.none(_ == "allUsers" || _ == "allAuthenticatedUsers")
       )
   - uid: mondoo-gcp-security-compute-image-iam-no-public-principals-terraform-hcl
     filters: |
@@ -32460,12 +32456,10 @@ queries:
       - url: https://cloud.google.com/iam/docs/understanding-roles#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-compute-image'
     mql: |
-      gcp.project.computeService.images.all(
-        iamPolicy.all(
-          role != "roles/owner" && role != "roles/editor" && role != "roles/viewer"
-        )
+      gcp.project.computeService.image.iamPolicy.all(
+        role != "roles/owner" && role != "roles/editor" && role != "roles/viewer"
       )
   - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles-terraform-hcl
     filters: |


### PR DESCRIPTION
## What

Continues the per-service platform migration from #2630 / #2633. Re-targets **8 checks** from the broad account/project platform to existing fine-grained platforms so each resource is scanned as its own asset with its own score.

Each check moves from iterating a collection on the account/project (`<svc>.<plural>.all(<pred>)`) to evaluating the singular asset (`<svc>.<singular>.<pred>`). Where the original used `where(<filter>).all(<pred>)`, the filter is lifted into the `filters:` clause so non-matching assets are excluded rather than vacuously passing the inner `.all()`.

| Target platform | Checks |
|---|---|
| `aws-ecr-repository` | `ecr-no-public-access`, `ecr-no-overly-permissive-policy` (lift `policy != empty` into filter) |
| `aws-ecs-taskdefinition` | `ecs-init-process-enabled`, `ecs-task-definition-no-plaintext-secrets` |
| `aws-sagemaker-trainingjob` | `sagemaker-training-hyperparameters-no-secrets` |
| `gcp-compute-image` | `compute-image-iam-no-public-principals`, `compute-image-iam-no-primitive-roles` |
| `gcp-sql-{mysql,postgresql,sqlserver}` | `cloud-sql-users-use-iam-auth` (filter ORs all three engines) |

Only the runtime variant's `filters:`/`mql:` change — Terraform variants and all `docs:`/compliance tags are untouched.

## Scope notes

This was an audit of **all four** cloud policies for top-level-platform filters that could move to fine-grained platforms:

- **Azure** and **OCI** are already fully migrated — every resource type with a fine-grained platform already filters on it.
- The bulk of remaining `aws`/`gcp` checks **cannot** migrate: the iterated resource type has no discovered per-asset platform, or the check is genuinely account/subscription/project-scoped (root user, password policy, org policies, audit config, CloudWatch metric-filter alarms).
- **EC2-instance checks intentionally stay on `aws`** — that asset is the OS host, not the AWS-API resource view.
- Three checks are reworkable only by *splitting* into multiple per-platform checks (new UIDs → new compliance mappings) and were left for a follow-up decision: `aws-no-default-vpc`, `aws-sagemaker-job-role-not-admin`, `gcp-vertex-ai-job-cmek-encryption`.

## Verification

`cnspec policy lint` passes on both bundles (remaining warnings are pre-existing deprecated-field notices on unrelated checks). Singular accessors and fields verified against the cnquery provider `.lr` definitions; both GCP singular `init` functions resolve from the scanned asset identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)