### PR TITLE
🐛 Send panic asset tags as structured tags, not in the message

### DIFF
--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -318,9 +318,13 @@ func (d *scanDispatcher) reportPanic(tracked *discovery.TrackedAsset) {
 				Build:   build,
 			},
 			Error: &health.ErrorInfo{
-				Message:    "panic: " + fmt.Sprintf("%v -- %v", r, tags),
+				Message:    "panic: " + fmt.Sprintf("%v", r),
 				Stacktrace: string(stacktrace),
 			},
+			// Send asset identification as structured tags so the platform
+			// can attribute the panic to a specific asset, rather than
+			// burying the map in the message string.
+			Tags: tags,
 		}
 
 		sendErrorToMondooPlatform(serviceAccount, event)


### PR DESCRIPTION
## What

`reportPanic` (policy/scan/scan_pipeline.go) built an asset-identifying tag map (`assetMrn`, `assetName`, `assetPlatform`, `assetPlatformVersion`, `platformIDs`) but never attached it to the `SendErrorReq` — it embedded the Go map in the error message via `fmt.Sprintf("%v -- %v", r, tags)`.

This sets `event.Tags = tags` and trims the message back to `"panic: <value>"` (matching the SDK's own `sendPanic`).

## Why

The platform's obslog health handler reads `req.Tags` to attribute reports to a specific asset. Because panics never set `Tags`, `panic.received` records showed only the agent MRN — which can't identify the asset, since one agent scans many. With structured tags, the server now emits `mondoo.asset.*` attributes on panic records too.

Companion to the server change on branch `jdm/obslog-full-stacktrace` (which removes the stacktrace truncation and adds the `mondoo.asset.*` attributes).