### PR TITLE
✨ Annotate Grafana on GitHub release

### DIFF
--- a/.github/workflows/grafana-annotation.yml
+++ b/.github/workflows/grafana-annotation.yml
@@ -1,0 +1,40 @@
+name: Grafana Release Annotation
+
+# Emit an org-level Grafana annotation whenever a cnspec GitHub release is
+# published, so releases show up on any dashboard via a tag-filtered annotation
+# query (tags: release, cnspec).
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to annotate (manual test only)"
+        required: false
+        default: "test"
+
+permissions:
+  contents: read
+
+jobs:
+  annotate:
+    name: Annotate Grafana
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create org-level Grafana annotation
+        # Non-blocking: a Grafana failure must never fail the release, but we
+        # still want the step to go red so a broken token/URL is visible.
+        continue-on-error: true
+        env:
+          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+          GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          # Build JSON with jq so an unusual VERSION can't break the payload
+          # (ubuntu-latest ships jq).
+          payload=$(jq -nc --arg v "$VERSION" '{text: "cnspec \($v) released", tags: ["release","cnspec"]}')
+          curl -sS --fail -X POST "${GRAFANA_URL%/}/api/annotations" \
+            -H "Authorization: Bearer ${GRAFANA_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            || { echo "::warning::Failed to create Grafana annotation"; exit 1; }


### PR DESCRIPTION
## What

Add a standalone workflow `.github/workflows/grafana-annotation.yml` that emits an **org-level Grafana annotation** when a cnspec GitHub release is published.

- triggers on `release: published` (plus `workflow_dispatch` with a `version` input for manual testing)
- `POST ${GRAFANA_URL}/api/annotations` (no dashboardUID → organization-scoped)
- tags: `release`, `cnspec`
- text: `cnspec <version> released` (version from `github.event.release.tag_name`)
- best-effort: a Grafana failure logs a `::warning::` and never fails the job

Standalone (rather than a job in `goreleaser.yml`) so it's isolated, fires exactly once, and cannot affect the release pipeline.

## Why

We want a unified, org-wide timeline of what shipped when, usable from any dashboard via tag-filtered annotation queries.

## Secrets (org-level, provided out of band)

- `GRAFANA_URL` — base URL, e.g. `https://mondoo.grafana.net`
- `GRAFANA_API_TOKEN` — service-account token with `annotations:write`