### PR TITLE
✨ Tag scanned assets with scan source (interactive vs service)

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -203,7 +203,7 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	// it can be ctx-aware and only fires for scan, not policy lint).
 	scandump.YAML(ctx, "resolved_mql_bundle.mql", conf.Bundle)
 
-	report, err := RunScan(ctx, conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")))
+	report, err := RunScan(ctx, conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")), scan.WithScanSource(scan.ScanSourceInteractive))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}

--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -203,7 +203,7 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	// it can be ctx-aware and only fires for scan, not policy lint).
 	scandump.YAML(ctx, "resolved_mql_bundle.mql", conf.Bundle)
 
-	report, err := RunScan(ctx, conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")), scan.WithScanSource(scan.ScanSourceInteractive))
+	report, err := RunScan(ctx, conf, scan.WithReportType(conf.ReportType), scan.WithAutoUpdate(viper.GetBool("auto-update")))
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to run scan")
 	}
@@ -636,7 +636,10 @@ func (c *scanConfig) loadPolicies(ctx context.Context) error {
 }
 
 func RunScan(parentCtx context.Context, config *scanConfig, scannerOpts ...scan.ScannerOption) (*policy.ReportCollection, error) {
-	opts := scannerOpts
+	// RunScan is the entry point for the interactive CLI scan commands (scan,
+	// vuln, sbom, aibom, ...), so default the scan source to interactive. It is
+	// prepended so callers (e.g. `serve`) can override it via WithScanSource.
+	opts := append([]scan.ScannerOption{scan.WithScanSource(scan.ScanSourceInteractive)}, scannerOpts...)
 	if config.runtime.UpstreamConfig != nil {
 		opts = append(opts, scan.WithUpstream(config.runtime.UpstreamConfig))
 	}

--- a/apps/cnspec/cmd/serve.go
+++ b/apps/cnspec/cmd/serve.go
@@ -154,7 +154,7 @@ var serveCmd = &cobra.Command{
 				}
 			}
 			// TODO: check in every 5 min via timer, init time in Background job
-			result, err := RunScan(ctx, scanConf, scan.DisableProgressBar(), scan.WithReportType(scan.ReportType_ERROR))
+			result, err := RunScan(ctx, scanConf, scan.DisableProgressBar(), scan.WithReportType(scan.ReportType_ERROR), scan.WithScanSource(scan.ScanSourceService))
 			if err != nil {
 				return cli_errors.NewCommandError(errors.Wrap(err, "could not successfully complete scan"), 1)
 			}

--- a/apps/cnspec/cmd/serve_api.go
+++ b/apps/cnspec/cmd/serve_api.go
@@ -80,6 +80,7 @@ var serveApiCmd = &cobra.Command{
 			scan.WithUpstream(&upstreamConfig),
 			scan.DisableProgressBar(),
 			scan.WithRecording(recording.Null{}),
+			scan.WithScanSource(scan.ScanSourceService),
 		)
 		if err := scanner.EnableQueue(); err != nil {
 			log.Fatal().Err(err).Msg("could not enable scan queue")

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -68,7 +68,20 @@ type LocalScanner struct {
 	reportType          ReportType
 	autoUpdate          bool
 	refreshInterval     int
+	// scanSource records how the scan was triggered (e.g. "interactive" or
+	// "service"). When set, it is applied as a label to every scanned asset.
+	scanSource string
 }
+
+const (
+	// LabelScanSource is the asset label that records how a scan was triggered.
+	LabelScanSource = "mondoo.com/scan-source"
+	// ScanSourceInteractive marks scans started interactively via `cnspec scan`.
+	ScanSourceInteractive = "interactive"
+	// ScanSourceService marks scans started by a long-running service, e.g.
+	// `cnspec serve` or the scan REST API.
+	ScanSourceService = "service"
+)
 
 type ScannerOption func(*LocalScanner)
 
@@ -117,6 +130,15 @@ func WithRefreshInterval(refreshInterval int) ScannerOption {
 func WithRuntime(r *providers.Runtime) ScannerOption {
 	return func(s *LocalScanner) {
 		s.runtime = r
+	}
+}
+
+// WithScanSource records how scans run by this scanner were triggered. The
+// value (e.g. ScanSourceInteractive or ScanSourceService) is stamped onto every
+// scanned asset as the LabelScanSource label so it can be aggregated upstream.
+func WithScanSource(source string) ScannerOption {
+	return func(s *LocalScanner) {
+		s.scanSource = source
 	}
 }
 
@@ -315,7 +337,22 @@ func createReporter(ctx context.Context, job *Job, upstream *upstream.UpstreamCo
 	return reporter, nil
 }
 
+// stampScanSource applies the configured scan source (e.g. "interactive" or
+// "service") as the LabelScanSource label to every asset in the job inventory.
+// It is a no-op when no scan source was configured or there is no inventory.
+func (s *LocalScanner) stampScanSource(job *Job) {
+	if s.scanSource == "" || job == nil || job.Inventory == nil {
+		return
+	}
+	job.Inventory.ApplyLabels(map[string]string{LabelScanSource: s.scanSource})
+}
+
 func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *upstream.UpstreamConfig) (*ScanResult, error) {
+	// Stamp the scan source (interactive vs. service) onto every asset so it can
+	// be aggregated upstream. This is the single chokepoint for Run/RunIncognito
+	// and the admission-review and queue paths.
+	s.stampScanSource(job)
+
 	reporter, err := createReporter(ctx, job, upstream)
 	if err != nil {
 		return nil, err

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -644,6 +644,14 @@ func TestNewLocalScannerWithOptions(t *testing.T) {
 		assert.Equal(t, ScanSourceInteractive, scanner.scanSource)
 	})
 
+	t.Run("later scan source overrides earlier default", func(t *testing.T) {
+		// RunScan prepends an interactive default; callers like `serve` append
+		// their own source, which must win.
+		scanner := NewLocalScanner(WithScanSource(ScanSourceInteractive), WithScanSource(ScanSourceService))
+		require.NotNil(t, scanner)
+		assert.Equal(t, ScanSourceService, scanner.scanSource)
+	})
+
 	t.Run("with custom runtime ignores auto-update option", func(t *testing.T) {
 		// Create a new runtime instance for this test to ensure isolation.
 		customRuntime := &providers.Runtime{

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -554,6 +554,49 @@ func TestLocalScannerSuite(t *testing.T) {
 	suite.Run(t, new(LocalScannerSuite))
 }
 
+func TestStampScanSource(t *testing.T) {
+	newJob := func() *Job {
+		return &Job{
+			Inventory: &inventory.Inventory{
+				Spec: &inventory.InventorySpec{
+					Assets: []*inventory.Asset{
+						{Name: "asset-1"},
+						{Name: "asset-2", Labels: map[string]string{"existing": "value"}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("stamps every asset", func(t *testing.T) {
+		scanner := NewLocalScanner(WithScanSource(ScanSourceService))
+		job := newJob()
+		scanner.stampScanSource(job)
+
+		for _, a := range job.Inventory.Spec.Assets {
+			assert.Equal(t, ScanSourceService, a.Labels[LabelScanSource], "asset %q", a.Name)
+		}
+		// pre-existing labels are preserved
+		assert.Equal(t, "value", job.Inventory.Spec.Assets[1].Labels["existing"])
+	})
+
+	t.Run("no-op without a scan source", func(t *testing.T) {
+		scanner := NewLocalScanner()
+		job := newJob()
+		scanner.stampScanSource(job)
+
+		for _, a := range job.Inventory.Spec.Assets {
+			_, ok := a.Labels[LabelScanSource]
+			assert.False(t, ok, "asset %q should not be labeled", a.Name)
+		}
+	})
+
+	t.Run("no-op without an inventory", func(t *testing.T) {
+		scanner := NewLocalScanner(WithScanSource(ScanSourceService))
+		assert.NotPanics(t, func() { scanner.stampScanSource(&Job{}) })
+	})
+}
+
 func TestNewLocalScannerWithOptions(t *testing.T) {
 	t.Run("default values", func(t *testing.T) {
 		scanner := NewLocalScanner()
@@ -593,6 +636,12 @@ func TestNewLocalScannerWithOptions(t *testing.T) {
 		require.True(t, ok)
 		assert.True(t, rt.AutoUpdate.Enabled)
 		assert.Equal(t, 1234, rt.AutoUpdate.RefreshInterval)
+	})
+
+	t.Run("with scan source", func(t *testing.T) {
+		scanner := NewLocalScanner(WithScanSource(ScanSourceInteractive))
+		require.NotNil(t, scanner)
+		assert.Equal(t, ScanSourceInteractive, scanner.scanSource)
 	})
 
 	t.Run("with custom runtime ignores auto-update option", func(t *testing.T) {


### PR DESCRIPTION
## What

Records how each scan was triggered so the two can be tracked and counted upstream. Every scanned asset gets a `mondoo.com/scan-source` label with value `interactive` or `service`.

## Why

We want to distinguish **interactive** scans (a person running `cnspec scan`) from **scan-as-a-service** runs (`cnspec serve`, scan REST API), and aggregate counts on the platform side. There was previously no explicit, persisted marker for this — only implicit signals (TTY detection, report type, execution model).

## How

- New `WithScanSource(source string)` scanner option and a `scanSource` field on `LocalScanner`.
- Stamping happens in `distributeJob` — the single chokepoint shared by `Run`, `RunIncognito`, the disk queue, and the admission-review path — so all flows are covered. This mirrors the existing CI/CD `ApplyLabels` semantics: the label lands on every asset, is retained in the `ReportCollection`, and syncs upstream.
- Exported constants: `LabelScanSource`, `ScanSourceInteractive`, `ScanSourceService`.

Wiring **by subcommand**:

| Command | scan source |
|---|---|
| `cnspec scan` | `interactive` |
| `cnspec serve` | `service` |
| `cnspec serve-api` | `service` |

## Counting

Per the design decision, counts are surfaced **upstream/platform-side**: the per-asset label syncs upstream exactly like CI/CD labels today, so the platform can group by `mondoo.com/scan-source` to count interactive vs service across scans. No CLI-side summary was added.

## Notes / follow-ups

- Discovered child assets inherit labels via the same mechanism as the existing CI/CD labeling; this matches established behavior in the codebase.
- Pre-existing latent issue (not addressed here): the CI/CD `ApplyLabels` block in `serve.go` runs before `conf.Inventory` is populated, so it's currently a no-op there. Happy to fix in a follow-up if desired.

## Test plan

- [x] `go build ./policy/scan/... ./apps/cnspec/...`
- [x] `go test ./policy/scan/ -run 'TestStampScanSource|TestNewLocalScannerWithOptions'` — added unit tests covering stamping every asset, preserving existing labels, and no-op cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)