### PR TITLE
content: add Bicep IaC variants to Azure and M365 security policies

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -11,6 +11,7 @@ policies:
     require:
       - provider: azure
       - provider: terraform
+      - provider: bicep
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
@@ -414,6 +415,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure virtual machine OS disks are configured to use Customer Managed Keys (CMK) for encryption at rest. By default, Azure encrypts OS disks with platform-managed keys, but CMK gives organizations direct control over the cryptographic material via Azure Key Vault, enabling key rotation and revocation capabilities.
@@ -635,6 +640,15 @@ queries:
           values['encryption_at_host_enabled'] == true
         )
       }
+  - uid: mondoo-azure-security-ensure-os-disk-are-encrypted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines" || type == "Microsoft.Compute/disks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["securityProfile"]["encryptionAtHost"] == true
+      )
+      bicep.resources.where(type == "Microsoft.Compute/disks").all(
+        properties["encryptionSettingsCollection"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-ssh-access-restricted-from-internet
     title: Ensure that SSH access is restricted from the internet
     impact: 80
@@ -669,6 +683,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ssh-access-restricted-from-internet-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     props:
       - uid: mondooAzureSecurityDisallowedPortsSSH
         title: A list of disallowed TCP ports, by default SSH listens only on TCP port 22. Add more ports as needed.
@@ -849,6 +867,18 @@ queries:
           _['destination_port_range'] == "22"
         )
       )
+  - uid: mondoo-azure-security-ssh-access-restricted-from-internet-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == /Tcp|\*/i &&
+          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["destinationPortRange"] == "22"
+        )
+      )
   - uid: mondoo-azure-security-rdp-access-restricted-from-internet
     title: Ensure that RDP access is restricted from the internet
     impact: 80
@@ -883,6 +913,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-rdp-access-restricted-from-internet-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     props:
       - uid: mondooAzureSecurityDisallowedPortsRDP
         title: a list of disallowed TCP ports, by default RDP listens only on TCP port 3389. Add more ports as needed.
@@ -1062,6 +1096,18 @@ queries:
           _['destination_port_range'] == "3389"
         )
       )
+  - uid: mondoo-azure-security-rdp-access-restricted-from-internet-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == /Tcp|\*/i &&
+          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["destinationPortRange"] == "3389"
+        )
+      )
   - uid: mondoo-azure-security-vnc-access-restricted-from-internet
     title: Ensure that VNC access is restricted from the internet
     impact: 80
@@ -1096,6 +1142,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vnc-access-restricted-from-internet-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     props:
       - uid: mondooAzureSecurityDisallowedPortsVNC
         title: a list of disallowed TCP ports, by default VNC listens only on TCP port 5900. Add more ports as needed.
@@ -1275,6 +1325,18 @@ queries:
           _['destination_port_range'] == /^590[0-3]$/
         )
       )
+  - uid: mondoo-azure-security-vnc-access-restricted-from-internet-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == /Tcp|\*/i &&
+          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["destinationPortRange"] == /590[0-3]/
+        )
+      )
   - uid: mondoo-azure-security-secure-transfer-required-enabled
     title: Mandate HTTPS for Secure Data Transfer to Azure storage accounts
     impact: 80
@@ -1309,6 +1371,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-secure-transfer-required-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure storage accounts are configured to require HTTPS for all data transfer operations. By default, Azure storage accounts accept both HTTP and HTTPS connections, leaving data in transit vulnerable to interception on unencrypted paths.
@@ -1418,6 +1484,12 @@ queries:
         values['https_traffic_only_enabled'] == true ||
         values['enable_https_traffic_only'] == true
       )
+  - uid: mondoo-azure-security-secure-transfer-required-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["supportsHttpsTrafficOnly"] == true
+      )
   - uid: mondoo-azure-security-public-access-level-private-blob-containers
     title: Ensure blob anonymous access and storage public access are disabled
     impact: 80
@@ -1452,6 +1524,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-public-access-level-private-blob-containers-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure storage accounts are configured to deny anonymous blob access and disable public network access at the account level. By default, Azure storage accounts allow public network access, and blob containers can be individually configured for anonymous read access.
@@ -1593,6 +1669,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.allow_nested_items_to_be_public == false
       )
+  - uid: mondoo-azure-security-public-access-level-private-blob-containers-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["allowBlobPublicAccess"] == false
+      )
   - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny
     title: Enforce Deny as Default Network Access for Azure Storage Accounts
     impact: 80
@@ -1627,6 +1709,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure storage accounts are configured with a default network action of Deny, so that only explicitly allowlisted networks, IP addresses, or service endpoints can reach the account. By default, Azure storage accounts allow access from all networks, requiring administrators to actively add deny rules rather than allowlist rules.
@@ -1764,6 +1850,12 @@ queries:
         values.network_rules != empty &&
         values.network_rules.all(_['default_action'] == "Deny")
       )
+  - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["networkAcls"]["defaultAction"] == "Deny"
+      )
   - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access
     title: Ensure "Trusted Microsoft Services" have access to Azure storage accounts
     impact: 80
@@ -1798,6 +1890,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure storage accounts are configured to allow the trusted Microsoft services bypass, permitting first-party Azure services to access storage even when network rules would otherwise block them. By default, strict network deny rules block all traffic including traffic from Azure services such as Azure Defender, Azure Monitor, and Azure Backup.
@@ -1925,6 +2021,13 @@ queries:
           _['default_action'] == "Deny"
         )
       )
+  - uid: mondoo-azure-security-trusted-microsoft-services-enabled-for-storage-account-access-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["networkAcls"]["bypass"] == /AzureServices/ &&
+        properties["networkAcls"]["defaultAction"] == "Deny"
+      )
   - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days
     title: Ensure minimum 30-Day retention for SQL server Audit Logs
     impact: 80
@@ -1959,6 +2062,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL server audit log retention is configured for a minimum of 30 days. By default, Azure SQL auditing retains logs for zero days when configured to use a storage account destination, meaning logs are overwritten immediately unless a retention period is explicitly set.
@@ -2097,6 +2204,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL, PostgreSQL Flexible Server, and MySQL Flexible Server instances are not configured with firewall rules that allow ingress from 0.0.0.0/0, which permits connections from any internet address. By default, Azure managed database services create a firewall with no rules, but administrators frequently add 0.0.0.0/0 rules to resolve connectivity issues without understanding the scope of access granted.
@@ -2282,6 +2393,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service instances are configured with a system-assigned or user-assigned managed identity, allowing them to authenticate to Microsoft Entra ID and downstream Azure services without storing credentials. By default, App Service instances do not have a managed identity assigned and must use connection strings, keys, or secrets to authenticate to backend services.
@@ -2429,6 +2544,12 @@ queries:
           values.identity.all(_["type"] != empty)
         )
       }
+  - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        body["identity"]["type"] != empty
+      )
   - uid: mondoo-azure-security-ensure-the-kv-is-recoverable
     title: Ensure Key Vaults are configured with Recovery features
     impact: 80
@@ -2463,6 +2584,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Key Vaults are configured with purge protection enabled, which enforces a mandatory retention period before a deleted vault or its contents can be permanently destroyed. By default, Key Vault enables soft delete but does not enable purge protection, allowing anyone with sufficient permissions to permanently delete a vault and all its keys, secrets, and certificates immediately after the soft-delete operation.
@@ -2587,6 +2712,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Services are configured to require a minimum TLS version of 1.2 for all inbound connections. By default, Azure App Service accepts TLS 1.0 and 1.1 connections for backward compatibility, exposing web applications to protocol-level downgrade attacks that exploit weaknesses in those older versions.
@@ -2737,6 +2866,12 @@ queries:
           values.site_config.all(_["minimum_tls_version"] == "1.2")
         )
       }
+  - uid: mondoo-azure-security-ensure-web-app-is-using-the-latest-tls-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["minTlsVersion"] == "1.2"
+      )
   - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv
     title: Ensure expiration dates are set for all Key Vault keys and secrets
     impact: 80
@@ -2771,6 +2906,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all keys and secrets stored in Azure Key Vaults have expiration dates configured, enforcing automatic key lifecycle management and preventing the indefinite use of cryptographic material. By default, Azure Key Vault creates keys and secrets without expiration dates, meaning they remain valid and usable indefinitely unless manually revoked.
@@ -2958,6 +3097,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-logging-enabled-kv-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Key Vault instances have diagnostic logging enabled, sending audit and operational logs to a Storage Account, Log Analytics workspace, or Event Hub. By default, Key Vault does not emit diagnostic logs, meaning that key, secret, and certificate access operations are invisible to security monitoring systems.
@@ -3156,6 +3299,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_monitor_diagnostic_setting").any(
         values['target_resource_id'] != empty
       )
+  - uid: mondoo-azure-security-ensure-logging-enabled-kv-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/diagnosticSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").all(
+        properties["logs"].any(_["enabled"] == true)
+      )
   - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group
     title: Ensure activity log alerts exist for NSG create, update, and delete
     impact: 80
@@ -3190,6 +3339,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Monitor activity log alerts are configured to fire on NSG create, update, and delete operations, providing real-time notification when network security group configurations change. By default, Azure does not create any activity log alerts, meaning NSG changes go undetected unless administrators proactively configure alerting.
@@ -3391,6 +3544,15 @@ queries:
         values['criteria'] != empty &&
         values['criteria'].any(_['operation_name'] == "Microsoft.Network/networkSecurityGroups/delete")
       )
+  - uid: mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/activityLogAlerts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/activityLogAlerts").any(
+        properties["condition"]["allOf"].any(_["equals"] == "Microsoft.Network/networkSecurityGroups/write")
+      )
+      bicep.resources.where(type == "Microsoft.Insights/activityLogAlerts").any(
+        properties["condition"]["allOf"].any(_["equals"] == "Microsoft.Network/networkSecurityGroups/delete")
+      )
   - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on
     title: Ensure that "Notify about alerts with high severity" is enabled
     impact: 80
@@ -3425,6 +3587,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Cloud is configured to send email notifications for high-severity security alerts. By default, Defender for Cloud generates alerts in the portal but does not send proactive email notifications unless security contacts and alert notification settings are explicitly configured.
@@ -3569,6 +3735,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_security_center_contact").all(
         values['alert_notifications'] == true
       )
+  - uid: mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/securityContacts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/securityContacts").all(
+        properties["alertNotifications"]["state"] == "On"
+      )
   - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql
     title: Ensure SSL connection enabled for PostgreSQL database servers
     impact: 80
@@ -3603,6 +3775,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL Flexible Server is configured to enforce SSL/TLS for all incoming connections. By default, the `require_secure_transport` server parameter is set to `ON`, but it can be disabled, leaving connections unencrypted over the network.
@@ -3771,6 +3947,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL Flexible Server is configured to enforce SSL connections and to require TLS 1.2 or later for all client connections. By default the `require_secure_transport` parameter is `ON`, but the minimum TLS version defaults to a value that permits older protocol versions.
@@ -3944,6 +4124,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ensure-disabled-public-access-sql-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL servers are configured with public network access disabled or restricted to selected networks. By default, new Azure SQL servers allow public internet connections, meaning any IP address can attempt to reach the SQL endpoint over port 1433.
@@ -4076,6 +4260,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-keyvault-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Key Vault is configured with public network access disabled or restricted to selected networks. By default, Key Vault allows connections from any public IP address; an attacker who obtains a valid token can reach vault secrets directly from any internet-connected host.
@@ -4215,6 +4403,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-audit-on-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL Server auditing is enabled so that all database activity is captured and forwarded to a durable log destination. Auditing is disabled by default on SQL servers and must be explicitly configured to write logs to Storage, Log Analytics, or an Event Hub.
@@ -4357,6 +4549,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-tde-on-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Transparent Data Encryption (TDE) is enabled for Azure SQL Server databases to encrypt database files, log files, and backups at rest. TDE is enabled by default on new Azure SQL databases, but it can be disabled, leaving stored data unencrypted on the underlying storage infrastructure.
@@ -4487,6 +4683,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-diagnostic-settings-exist-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that at least one diagnostic setting is configured for the Azure subscription, forwarding activity logs to a durable destination such as a Log Analytics workspace, Storage account, or Event Hub. Without a diagnostic setting, subscription-level activity logs are retained in Azure Monitor for only 90 days and are inaccessible from SIEM tools or cross-subscription queries.
@@ -4639,6 +4839,14 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_monitor_diagnostic_setting")
     mql: |
       terraform.state.resources.where(type == "azurerm_monitor_diagnostic_setting").length > 0
+  - uid: mondoo-azure-security-diagnostic-settings-exist-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/diagnosticSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").all(
+        properties["workspaceId"] != empty ||
+        properties["storageAccountId"] != empty ||
+        properties["eventHubAuthorizationRuleId"] != empty
+      )
   - uid: mondoo-azure-security-diagnostic-settings-essential-categories
     title: Ensure that diagnostic settings collect essential security categories
     impact: 80
@@ -4673,6 +4881,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-diagnostic-settings-essential-categories-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure subscription diagnostic settings are configured to collect the Administrative, Security, Alert, and Policy log categories. A diagnostic setting can exist but omit categories; missing categories create blind spots even when log forwarding is otherwise enabled.
@@ -4872,6 +5084,21 @@ queries:
         values['enabled_log'] != empty &&
         values['enabled_log'].any(_['category'] == "Policy")
       )
+  - uid: mondoo-azure-security-diagnostic-settings-essential-categories-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/diagnosticSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").any(
+        properties["logs"].any(_["category"] == "Administrative" && _["enabled"] == true)
+      )
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").any(
+        properties["logs"].any(_["category"] == "Security" && _["enabled"] == true)
+      )
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").any(
+        properties["logs"].any(_["category"] == "Alert" && _["enabled"] == true)
+      )
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").any(
+        properties["logs"].any(_["category"] == "Policy" && _["enabled"] == true)
+      )
   - uid: mondoo-azure-security-disable-udp-virtualmachines
     title: Ensure direct UDP access to Resources from the internet is restricted
     impact: 80
@@ -4906,6 +5133,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-disable-udp-virtualmachines-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     props:
       - uid: mondooAzureSecurityDisallowedPortsUDP
         title: A list of disallowed UDP ports, by default covering common UDP services. Add more as needed.
@@ -5106,6 +5337,18 @@ queries:
           _['destination_port_range'] == /^(53|123|161|389|1900)$/
         )
       )
+  - uid: mondoo-azure-security-disable-udp-virtualmachines-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == /Udp|\*/i &&
+          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["destinationPortRange"] == /^(\*|53|123|161|389|1900)$/
+        )
+      )
   - uid: mondoo-azure-security-storage-blob-soft-delete-enabled
     title: Ensure blob soft delete is enabled for Azure Storage accounts
     impact: 80
@@ -5140,6 +5383,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that blob soft delete is enabled for Azure Storage accounts, retaining deleted blobs for a configurable period so they can be recovered. By default, soft delete is disabled, meaning any deleted blob is immediately and permanently destroyed with no recovery path.
@@ -5250,6 +5497,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.blob_properties[0].delete_retention_policy[0].days > 0
       )
+  - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/blobServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/blobServices").all(
+        properties["deleteRetentionPolicy"]["days"] > 0
+      )
   - uid: mondoo-azure-security-storage-container-soft-delete-enabled
     title: Ensure container soft delete is enabled for Azure Storage accounts
     impact: 80
@@ -5284,6 +5537,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-soft-delete-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that container soft delete is enabled for Azure Storage accounts, retaining deleted containers and their blobs for a configurable period so they can be recovered. By default, container soft delete is disabled, meaning a single container delete operation permanently destroys every blob within it with no recovery path.
@@ -5394,6 +5651,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.blob_properties[0].container_delete_retention_policy[0].days > 0
       )
+  - uid: mondoo-azure-security-storage-container-soft-delete-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/blobServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/blobServices").all(
+        properties["containerDeleteRetentionPolicy"]["days"] > 0
+      )
   - uid: mondoo-azure-security-storage-min-tls-version
     title: Ensure Azure Storage accounts enforce minimum TLS 1.2
     impact: 80
@@ -5428,6 +5691,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage accounts are configured to enforce TLS 1.2 as the minimum protocol version for all client connections. By default, new storage accounts accept connections using TLS 1.0 and 1.1, which contain known cryptographic weaknesses that can be exploited on networks where traffic can be observed.
@@ -5529,6 +5796,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.min_tls_version == "TLS1_2"
       )
+  - uid: mondoo-azure-security-storage-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["minimumTlsVersion"] == "TLS1_2"
+      )
   - uid: mondoo-azure-security-sql-threat-detection-enabled
     title: Ensure threat detection is enabled on Azure SQL servers
     impact: 80
@@ -5563,6 +5836,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-threat-detection-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for SQL (Advanced Threat Protection) is enabled on Azure SQL servers to detect anomalous database activities and generate alerts on potential attacks. Defender for SQL is disabled by default and must be explicitly enabled at the server level.
@@ -5669,6 +5946,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-ad-admin-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that an Entra ID (formerly Azure Active Directory) administrator is configured for Azure SQL servers, enabling centralized identity-based access and eliminating dependence on SQL-only authentication for administrative access. By default, SQL servers are created without an Entra ID admin, relying solely on SQL authentication credentials.
@@ -5783,6 +6064,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-keyvault-rbac-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Key Vault is configured to use Azure Role-Based Access Control (RBAC) for authorization rather than the legacy vault access policy model. Vault access policies are assigned at the vault level and grant broad permissions across all keys, secrets, and certificates within the vault; RBAC provides object-level granularity managed through Azure's central IAM system.
@@ -5892,6 +6177,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-keyvault-key-auto-rotation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all enabled keys in Azure Key Vault have an automatic rotation policy configured. Keys without auto-rotation remain valid indefinitely; a compromised key version retains decryption capability for all data it protects until the key is manually rotated or deleted.
@@ -6032,6 +6321,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-keyvault-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Key Vault instances have at least one private endpoint connection configured, routing all vault access over a private IP within the virtual network rather than over the public internet. Without a private endpoint, Key Vault traffic traverses the public internet even when firewall rules restrict which IPs can connect.
@@ -6169,6 +6462,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-data-disks-encrypted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that data disks attached to Azure virtual machines are encrypted with Customer Managed Keys (CMK). By default Azure encrypts managed disks with platform-managed keys, but CMK gives you full ownership of the encryption keys through Azure Key Vault, enabling key rotation and revocation.
@@ -6276,6 +6573,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_managed_disk").all(
         values['disk_encryption_set_id'] != empty
       )
+  - uid: mondoo-azure-security-compute-data-disks-encrypted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/disks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/disks").all(
+        properties["encryption"]["diskEncryptionSetId"] != empty
+      )
   - uid: mondoo-azure-security-network-watcher-flow-logs-enabled
     title: Ensure Network Watcher flow logs are enabled
     impact: 80
@@ -6310,6 +6613,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Network Watcher flow logs are enabled to capture IP traffic flowing through network security groups. By default flow logs are disabled when a Network Watcher is provisioned, leaving network activity unrecorded and unavailable for security review or forensic investigation.
@@ -6422,6 +6729,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_network_watcher_flow_log").all(
         values['enabled'] == true
       )
+  - uid: mondoo-azure-security-network-watcher-flow-logs-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkWatchers/flowLogs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkWatchers/flowLogs").all(
+        properties["enabled"] == true
+      )
   - uid: mondoo-azure-security-defender-for-servers-enabled
     title: Ensure Microsoft Defender for Servers is enabled
     impact: 80
@@ -6456,6 +6769,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-servers-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Servers is enabled at the subscription level to provide continuous threat protection for Azure virtual machines and Arc-connected servers. Without it, no server-level security alerts are generated regardless of the activity on the machines.
@@ -6551,6 +6868,12 @@ queries:
         where(values['resource_type'] == "VirtualMachines").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-servers-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "VirtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "VirtualMachines").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-app-services-enabled
     title: Ensure Microsoft Defender for App Service is enabled
     impact: 80
@@ -6585,6 +6908,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-app-services-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for App Service is enabled at the subscription level to provide continuous threat detection for applications hosted on Azure App Service. Without this plan enabled, suspicious runtime behavior and infrastructure-level attacks against App Service resources go undetected.
@@ -6679,6 +7006,12 @@ queries:
         where(values['resource_type'] == "AppServices").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-app-services-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "AppServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "AppServices").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-sql-databases-enabled
     title: Ensure Microsoft Defender for Azure SQL Databases is enabled
     impact: 80
@@ -6713,6 +7046,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-sql-databases-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Azure SQL Databases is enabled at the subscription level to provide continuous threat monitoring for Azure SQL Database instances. Without this plan, SQL-level attacks and anomalous access patterns are not surfaced as security alerts.
@@ -6807,6 +7144,12 @@ queries:
         where(values['resource_type'] == "SqlServers").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-sql-databases-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "SqlServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "SqlServers").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-storage-enabled
     title: Ensure Microsoft Defender for Storage is enabled
     impact: 80
@@ -6841,6 +7184,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-storage-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Storage is enabled at the subscription level to provide continuous threat monitoring for Azure Storage accounts. Without this plan, malicious uploads, anomalous access patterns, and data exfiltration attempts against storage resources go undetected.
@@ -6935,6 +7282,12 @@ queries:
         where(values['resource_type'] == "StorageAccounts").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-storage-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "StorageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "StorageAccounts").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-keyvault-enabled
     title: Ensure Microsoft Defender for Key Vault is enabled
     impact: 80
@@ -6969,6 +7322,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-keyvault-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Key Vault is enabled at the subscription level to detect unusual or potentially malicious access to Azure Key Vault resources. Key Vault holds secrets, keys, and certificates that are foundational to the security of all other Azure services; unauthorized access to it can compromise an entire environment.
@@ -7063,6 +7420,12 @@ queries:
         where(values['resource_type'] == "KeyVaults").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-keyvault-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "KeyVaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "KeyVaults").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-containers-enabled
     title: Ensure Microsoft Defender for Containers is enabled
     impact: 80
@@ -7097,6 +7460,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-containers-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Containers is enabled at the subscription level to provide continuous threat protection for Azure Kubernetes Service clusters and containerized workloads. Without this plan, runtime attacks, image vulnerabilities, and Kubernetes API abuse go undetected.
@@ -7191,6 +7558,12 @@ queries:
         where(values['resource_type'] == "Containers").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-containers-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "Containers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "Containers").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-resource-manager-enabled
     title: Ensure Microsoft Defender for Resource Manager is enabled
     impact: 80
@@ -7225,6 +7598,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-resource-manager-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Resource Manager is enabled at the subscription level to monitor Azure management plane operations for suspicious activity. Every resource creation, modification, and deletion passes through Azure Resource Manager, making it a high-value target for attackers who have gained initial access to the environment.
@@ -7319,6 +7696,12 @@ queries:
         where(values['resource_type'] == "Arm").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-resource-manager-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "Arm")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "Arm").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-auto-provisioning-enabled
     title: Ensure auto-provisioning of the monitoring agent is enabled
     impact: 80
@@ -7353,6 +7736,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-auto-provisioning-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that auto-provisioning of the monitoring agent is enabled in Microsoft Defender for Cloud so that all virtual machines in the subscription are automatically instrumented for security data collection. Without auto-provisioning, VMs deployed after Defender plans are enabled do not receive agents, creating monitoring gaps.
@@ -7445,6 +7832,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_security_center_auto_provisioning").all(
         values['auto_provision'] == "On"
       )
+  - uid: mondoo-azure-security-defender-auto-provisioning-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/autoProvisioningSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/autoProvisioningSettings").all(
+        properties["autoProvision"] == "On"
+      )
   - uid: mondoo-azure-security-aks-rbac-enabled
     title: Ensure RBAC is enabled on Azure Kubernetes Service clusters
     impact: 80
@@ -7479,6 +7872,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-rbac-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Role-Based Access Control is enabled on Azure Kubernetes Service clusters to enforce fine-grained access policies for Kubernetes resources. When RBAC is disabled, any authenticated user can perform any action within the cluster regardless of their intended role.
@@ -7588,6 +7985,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.role_based_access_control_enabled == true
       )
+  - uid: mondoo-azure-security-aks-rbac-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["enableRBAC"] == true
+      )
   - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges
     title: Ensure AKS API server has authorized IP ranges configured
     impact: 80
@@ -7622,6 +8025,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that non-private AKS clusters have API server authorized IP ranges configured to restrict which source networks can reach the Kubernetes API server. Private clusters are excluded because they use private endpoints for API server access, which inherently provides network isolation.
@@ -7743,6 +8150,12 @@ queries:
         values.api_server_access_profile != empty &&
         values.api_server_access_profile.all(authorized_ip_ranges != empty)
       )
+  - uid: mondoo-azure-security-aks-api-server-authorized-ip-ranges-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["apiServerAccessProfile"]["authorizedIPRanges"] != empty
+      )
   - uid: mondoo-azure-security-aks-network-policy-enabled
     title: Ensure AKS clusters have a network policy configured
     impact: 80
@@ -7777,6 +8190,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-network-policy-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters have a network policy engine configured to control pod-to-pod traffic. Supported engines include Azure Network Policy Manager and Calico. Without a network policy engine present, Kubernetes network policies cannot be enforced even if they are defined in manifests.
@@ -7895,6 +8312,12 @@ queries:
         values.network_profile != empty &&
         values.network_profile.all(network_policy != empty)
       )
+  - uid: mondoo-azure-security-aks-network-policy-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["networkProfile"]["networkPolicy"] != empty
+      )
   - uid: mondoo-azure-security-app-service-https-only
     title: Ensure App Service web apps enforce HTTPS
     impact: 80
@@ -7929,6 +8352,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-https-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service web applications are configured to enforce HTTPS-only access, automatically redirecting any HTTP request to its HTTPS equivalent. By default, App Service allows both HTTP and HTTPS traffic, meaning unencrypted connections are possible unless the HTTPS-only setting is explicitly enabled.
@@ -8043,6 +8470,12 @@ queries:
           values['https_only'] == true
         )
       }
+  - uid: mondoo-azure-security-app-service-https-only-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["httpsOnly"] == true
+      )
   - uid: mondoo-azure-security-app-service-ftp-disabled
     title: Ensure App Service FTP basic auth publishing credentials are disabled
     impact: 80
@@ -8077,6 +8510,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-ftp-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that FTP basic authentication publishing credentials are disabled on Azure App Service web apps. Basic auth for FTP relies on static username and password credentials that are shared at the subscription level, making them difficult to rotate and easy to leak.
@@ -8193,6 +8630,12 @@ queries:
           values['ftp_publish_basic_authentication_enabled'] == false
         )
       }
+  - uid: mondoo-azure-security-app-service-ftp-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["ftpsState"] == "Disabled"
+      )
   - uid: mondoo-azure-security-app-service-scm-disabled
     title: Ensure App Service SCM basic auth publishing credentials are disabled
     impact: 80
@@ -8227,6 +8670,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-scm-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that basic authentication for the SCM (Kudu) publishing endpoint is disabled on Azure App Service web apps. The SCM site provides access to deployment logs, file system browsing, process inspection, and remote code execution capabilities; protecting it with Azure AD authentication rather than static credentials is essential.
@@ -8343,6 +8790,12 @@ queries:
         values['type'] == /basicPublishingCredentialsPolicies/ &&
         values['output'].properties.allow == false
       )
+  - uid: mondoo-azure-security-app-service-scm-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/basicPublishingCredentialsPolicies" && name == "scm")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/basicPublishingCredentialsPolicies" && name == "scm").all(
+        properties["allow"] == false
+      )
   - uid: mondoo-azure-security-redis-ssl-only
     title: Ensure Azure Cache for Redis disables the non-SSL port
     impact: 80
@@ -8377,6 +8830,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-ssl-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the non-SSL port (6379) is disabled on Azure Cache for Redis instances, requiring all client connections to use TLS-encrypted communication on port 6380. By default, Azure Cache for Redis enables both the SSL and non-SSL ports, allowing unencrypted connections unless the non-SSL port is explicitly disabled.
@@ -8495,6 +8952,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are configured to disable public network access, requiring all connections to route through private endpoints. By default, Redis instances are reachable over the public internet; disabling public access eliminates that exposure entirely.
@@ -8612,6 +9073,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-private-cluster-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters are configured as private clusters, making the Kubernetes API server accessible only through private endpoints within the virtual network. By default, AKS provisions a public API server endpoint reachable from the internet; private cluster mode removes that endpoint entirely.
@@ -8735,6 +9200,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.private_cluster_enabled == true
       )
+  - uid: mondoo-azure-security-aks-private-cluster-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["apiServerAccessProfile"]["enablePrivateCluster"] == true
+      )
   - uid: mondoo-azure-security-aks-run-command-disabled
     title: Ensure run command is disabled on AKS clusters
     impact: 60
@@ -8769,6 +9240,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-run-command-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the run command feature is disabled on AKS clusters, preventing remote command execution through the Azure control plane API. The run command is enabled by default and allows anyone with sufficient Azure RBAC permissions to run arbitrary commands inside the cluster without going through Kubernetes RBAC or network policies.
@@ -8892,6 +9367,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.run_command_enabled == false
       )
+  - uid: mondoo-azure-security-aks-run-command-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["apiServerAccessProfile"]["disableRunCommand"] == true
+      )
   - uid: mondoo-azure-security-aks-azure-policy-addon-enabled
     title: Ensure Azure Policy add-on is enabled for AKS clusters
     impact: 60
@@ -8926,6 +9407,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the Azure Policy add-on is enabled on AKS clusters, allowing organizational governance policies to be evaluated and enforced at the cluster level using Open Policy Agent Gatekeeper. Without the add-on, Kubernetes workloads can be deployed without policy guardrails enforced at the control-plane level.
@@ -9052,6 +9537,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.azure_policy_enabled == true
       )
+  - uid: mondoo-azure-security-aks-azure-policy-addon-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["addonProfiles"]["azurepolicy"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled
     title: Ensure private AKS clusters do not expose a public FQDN
     impact: 60
@@ -9086,6 +9577,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that private AKS clusters are configured to disable the public FQDN, preventing the Kubernetes API server's DNS name from being resolvable outside the private network. When private cluster mode is enabled, Azure optionally still creates a public DNS entry for the API server by default; disabling the public FQDN removes that entry and restricts resolution to private DNS zones only.
@@ -9212,6 +9707,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.private_cluster_public_fqdn_enabled == false
       )
+  - uid: mondoo-azure-security-aks-private-cluster-public-fqdn-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["apiServerAccessProfile"]["enablePrivateClusterPublicFQDN"] == false
+      )
   - uid: mondoo-azure-security-aks-defender-enabled
     title: Ensure Microsoft Defender profile is enabled for AKS clusters
     impact: 70
@@ -9246,6 +9747,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-defender-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the Microsoft Defender profile is enabled on AKS clusters, integrating Defender for Containers to provide runtime threat detection, environment hardening recommendations, and vulnerability assessment for container workloads. The Defender profile is disabled by default and must be explicitly enabled per cluster.
@@ -9353,6 +9858,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values['microsoft_defender'] != empty
       )
+  - uid: mondoo-azure-security-aks-defender-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["securityProfile"]["defender"]["securityMonitoring"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-aks-image-cleaner-enabled
     title: Ensure Image Cleaner is enabled for AKS clusters
     impact: 50
@@ -9387,6 +9898,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-image-cleaner-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the Image Cleaner feature is enabled on AKS clusters, automatically scanning for and removing stale, unused, and potentially vulnerable container images that accumulate on node disks. By default, images pulled to nodes persist indefinitely even after the workloads that used them are deleted.
@@ -9491,6 +10006,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.image_cleaner_enabled == true
       )
+  - uid: mondoo-azure-security-aks-image-cleaner-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["securityProfile"]["imageCleaner"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-aks-workload-identity-enabled
     title: Ensure workload identity is enabled for AKS clusters
     impact: 60
@@ -9525,6 +10046,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-workload-identity-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that workload identity is enabled on AKS clusters, allowing pods to authenticate to Azure services using short-lived Azure AD federated tokens rather than long-lived secrets stored in the cluster. Workload identity is disabled by default and requires both the OIDC issuer and the workload identity webhook to be activated.
@@ -9631,6 +10156,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.workload_identity_enabled == true
       )
+  - uid: mondoo-azure-security-aks-workload-identity-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["securityProfile"]["workloadIdentity"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-aks-encryption-at-host-enabled
     title: Ensure AKS agent pool nodes have encryption at host enabled
     impact: 60
@@ -9665,6 +10196,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-encryption-at-host-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that host-based encryption is enabled on all AKS agent pool nodes, encrypting temporary disks, OS disk caches, and data flows between the VM host and Azure Storage. Standard Azure disk encryption does not cover the VM host's temporary disk or OS disk caches; encryption at host fills that gap.
@@ -9783,6 +10318,12 @@ queries:
         values.default_node_pool != empty &&
         values.default_node_pool.all(host_encryption_enabled == true)
       )
+  - uid: mondoo-azure-security-aks-encryption-at-host-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["agentPoolProfiles"].all(_["enableEncryptionAtHost"] == true)
+      )
   - uid: mondoo-azure-security-aks-no-kubenet
     title: Ensure AKS clusters use Azure CNI or overlay networking instead of kubenet
     impact: 50
@@ -9817,6 +10358,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-no-kubenet-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters use Azure CNI or Azure CNI Overlay instead of kubenet for pod networking. Kubenet is the default network plugin but assigns pods IP addresses from a separate RFC 1918 range managed by user-defined routes, which limits network policy enforcement and NSG integration compared to Azure CNI.
@@ -9916,6 +10461,12 @@ queries:
         values.network_profile != empty &&
         values.network_profile.all(network_plugin != "kubenet")
       )
+  - uid: mondoo-azure-security-aks-no-kubenet-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["networkProfile"]["networkPlugin"] != "kubenet"
+      )
   - uid: mondoo-azure-security-aks-container-insights-enabled
     title: Ensure Container Insights monitoring is enabled for AKS clusters
     impact: 60
@@ -9950,6 +10501,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-container-insights-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Container Insights is enabled on AKS clusters via the OMS agent add-on, collecting container logs, performance metrics, and Kubernetes events into Azure Monitor. Without this add-on, container-level telemetry is unavailable, leaving incident responders blind to activity inside running pods.
@@ -10052,6 +10607,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.oms_agent != empty
       )
+  - uid: mondoo-azure-security-aks-container-insights-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["addonProfiles"]["omsagent"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled
     title: Ensure Azure Key Vault Secrets Provider add-on is enabled for AKS clusters
     impact: 50
@@ -10086,6 +10647,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the Azure Key Vault Secrets Provider add-on (Secrets Store CSI Driver) is enabled on AKS clusters, allowing pods to mount secrets, keys, and certificates directly from Azure Key Vault as files or environment variables. Without this add-on, applications commonly fall back to storing credentials as Kubernetes Secrets, which are only base64-encoded and unencrypted in etcd by default.
@@ -10187,6 +10752,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.key_vault_secrets_provider != empty
       )
+  - uid: mondoo-azure-security-aks-keyvault-secrets-provider-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["addonProfiles"]["azureKeyvaultSecretsProvider"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-app-service-client-cert-enabled
     title: Ensure client certificate auth is enabled for App Service web apps
     impact: 60
@@ -10221,6 +10792,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-client-cert-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that client certificate authentication is enabled for Azure App Service web apps, requiring incoming clients to present a valid TLS certificate before the application layer is reached. By default, App Service does not require client certificates, accepting any HTTPS connection without verifying the caller's identity at the transport level.
@@ -10350,6 +10925,12 @@ queries:
           values['client_certificate_enabled'] == true
         )
       }
+  - uid: mondoo-azure-security-app-service-client-cert-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["clientCertEnabled"] == true
+      )
   - uid: mondoo-azure-security-app-service-remote-debugging-disabled
     title: Ensure remote debugging is disabled for App Service web apps
     impact: 80
@@ -10384,6 +10965,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-remote-debugging-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that remote debugging is disabled for Azure App Service web apps, preventing debugging ports from being opened and exposed on running application instances. Remote debugging is disabled by default but is commonly enabled temporarily during troubleshooting and left on inadvertently in production.
@@ -10516,6 +11101,12 @@ queries:
           values.site_config.all(_["remote_debugging_enabled"] != true)
         )
       }
+  - uid: mondoo-azure-security-app-service-remote-debugging-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["remoteDebuggingEnabled"] != true
+      )
   - uid: mondoo-azure-security-app-service-http20-enabled
     title: Ensure HTTP 2.0 is enabled for App Service web apps
     impact: 40
@@ -10550,6 +11141,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-http20-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that HTTP 2.0 is enabled for Azure App Service web apps, providing protocol-level improvements over HTTP 1.1 that reduce exposure to a class of request-manipulation attacks. HTTP 1.1 is the default; HTTP 2.0 must be explicitly enabled in App Service configuration.
@@ -10682,6 +11277,12 @@ queries:
           values.site_config.all(_["http2_enabled"] == true)
         )
       }
+  - uid: mondoo-azure-security-app-service-http20-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["http20Enabled"] == true
+      )
   - uid: mondoo-azure-security-app-service-ftps-required
     title: Ensure App Service apps require FTPS for file deployment
     impact: 80
@@ -10716,6 +11317,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-ftps-required-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service apps are configured to require FTPS or to disable FTP entirely, preventing unencrypted file transfer connections to the deployment endpoint. The default `AllAllowed` setting permits plain FTP, which transmits files and credentials in cleartext over the network.
@@ -10835,6 +11440,13 @@ queries:
           values.site_config.all(_["ftps_state"] == "FtpsOnly" || _["ftps_state"] == "Disabled")
         )
       }
+  - uid: mondoo-azure-security-app-service-ftps-required-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["ftpsState"] == "FtpsOnly" ||
+        properties["ftpsState"] == "Disabled"
+      )
   - uid: mondoo-azure-security-app-service-cors-no-wildcard
     title: Ensure App Service apps do not allow CORS access from all origins
     impact: 80
@@ -10869,6 +11481,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-cors-no-wildcard-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service apps are not configured with a CORS wildcard (`*`) origin, which would allow any website to make credentialed cross-origin requests to the application. When App Service's built-in CORS is enabled with `*`, it overrides more restrictive CORS headers that the application itself might set.
@@ -11000,6 +11616,13 @@ queries:
           values.site_config.all(_["cors"] == empty || _["cors"].all(_["allowed_origins"].none(_ == "*")))
         )
       }
+  - uid: mondoo-azure-security-app-service-cors-no-wildcard-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["cors"] == empty ||
+        properties["cors"]["allowedOrigins"].none(_ == "*")
+      )
   - uid: mondoo-azure-security-function-app-authentication-enabled
     title: Ensure Azure Function apps have authentication enabled
     impact: 80
@@ -11034,6 +11657,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-authentication-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function apps have App Service Authentication (Easy Auth) enabled, requiring callers to authenticate before reaching the function endpoints. By default, Function app HTTP endpoints are publicly accessible to anyone who knows the URL, making authentication a critical control for preventing unauthorized invocations.
@@ -11151,6 +11778,12 @@ queries:
       terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
         values.auth_settings_v2 != empty
       )
+  - uid: mondoo-azure-security-function-app-authentication-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config" && name == "authsettingsV2")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config" && name == "authsettingsV2").all(
+        properties["globalValidation"]["requireAuthentication"] == true
+      )
   - uid: mondoo-azure-security-function-app-private-endpoints
     title: Ensure Azure Function apps use private endpoints
     impact: 60
@@ -11185,6 +11818,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function apps are configured with private endpoints, restricting network access to only traffic from within the virtual network. By default, Function apps accept connections from the public internet, which exposes them to opportunistic scanning and exploitation attempts.
@@ -11307,6 +11944,14 @@ queries:
         values.private_service_connection != empty &&
         values.private_service_connection.any(_["subresource_names"].any(_ == "sites"))
       )
+  - uid: mondoo-azure-security-function-app-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "sites")
+        )
+      )
   - uid: mondoo-azure-security-redis-min-tls-version
     title: Ensure Azure Cache for Redis uses minimum TLS version 1.2
     impact: 80
@@ -11341,6 +11986,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are configured to require a minimum TLS version of 1.2 for all connections. Azure allows TLS 1.0 and 1.1 by default, which have known protocol vulnerabilities such as BEAST and POODLE that can be exploited to intercept or manipulate encrypted traffic.
@@ -11471,6 +12120,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-latest-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances are running a supported version (version 6 or later). Older Redis versions no longer receive security patches from the upstream project, leaving them exposed to known vulnerabilities that have since been fixed.
@@ -11602,6 +12255,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-auth-required-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cache for Redis instances require authentication for all connections. Microsoft explicitly states that disabling authentication is highly discouraged; without it, any client that can reach the Redis endpoint can read, modify, or delete cached data without credentials.
@@ -11722,6 +12379,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that cross-tenant replication is disabled for Azure Storage accounts, preventing data from being replicated to storage accounts in different Microsoft Entra ID tenants. By default, Azure allows object replication rules that target storage accounts in external tenants, which can enable data to silently leave the organization's trust boundary.
@@ -11838,6 +12499,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.cross_tenant_replication_enabled == false
       )
+  - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["allowCrossTenantReplication"] == false
+      )
   - uid: mondoo-azure-security-storage-sftp-disabled
     title: Ensure SFTP is disabled on Azure Storage accounts unless required
     impact: 60
@@ -11872,6 +12539,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-sftp-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that SFTP is disabled on Azure Storage accounts unless there is a specific business requirement for it. SFTP is disabled by default, but when enabled it opens an additional authentication pathway that uses local user accounts rather than Microsoft Entra ID, bypassing tenant-wide identity controls.
@@ -11988,6 +12659,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.sftp_enabled == false
       )
+  - uid: mondoo-azure-security-storage-sftp-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["isSftpEnabled"] == false
+      )
   - uid: mondoo-azure-security-storage-shared-key-access-disabled
     title: Ensure shared key access is disabled for Azure Storage accounts
     impact: 60
@@ -12022,6 +12699,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-shared-key-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that shared key access is disabled for Azure Storage accounts, requiring all requests to be authorized using Microsoft Entra ID. By default, Azure Storage accounts allow shared key authentication, which grants full data-plane access to anyone in possession of the storage account key.
@@ -12138,6 +12819,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.shared_access_key_enabled == false
       )
+  - uid: mondoo-azure-security-storage-shared-key-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["allowSharedKeyAccess"] == false
+      )
   - uid: mondoo-azure-security-compute-vm-no-public-ip
     title: Ensure virtual machines do not have public IP addresses directly attached
     impact: 80
@@ -12172,6 +12859,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-vm-no-public-ip-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure virtual machines do not have public IP addresses directly attached to their network interfaces. Directly attaching a public IP makes the VM reachable from any source on the internet, exposing all listening services to port scanning, brute-force attacks, and exploitation of unpatched vulnerabilities.
@@ -12327,6 +13018,12 @@ queries:
           values['public_ip_address'] == null || values['public_ip_address'] == ""
         )
       }
+  - uid: mondoo-azure-security-compute-vm-no-public-ip-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkInterfaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkInterfaces").all(
+        properties["ipConfigurations"].none(_["properties"]["publicIPAddress"] != empty)
+      )
   - uid: mondoo-azure-security-compute-managed-disks-only
     title: Ensure virtual machines use managed disks
     impact: 60
@@ -12361,6 +13058,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-managed-disks-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure virtual machines use managed disks instead of unmanaged disks. Unmanaged disks store VHD files in customer-managed Azure Storage accounts, creating a shared attack surface where a single storage account key grants raw access to the disk images of every VM stored in that account.
@@ -12517,6 +13218,12 @@ queries:
           values['os_disk'] != null
         )
       }
+  - uid: mondoo-azure-security-compute-managed-disks-only-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["storageProfile"]["osDisk"]["managedDisk"] != empty
+      )
   - uid: mondoo-azure-security-compute-unattached-disks-encrypted
     title: Ensure unattached disks are encrypted with Customer Managed Keys
     impact: 80
@@ -12551,6 +13258,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-unattached-disks-encrypted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that unattached Azure managed disks are encrypted with Customer Managed Keys (CMK) stored in Azure Key Vault. Unattached disks retain data from previous workloads and are often overlooked during security reviews, yet they remain accessible at rest without a VM to enforce OS-level access controls.
@@ -12678,6 +13389,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_managed_disk").all(
         values['disk_encryption_set_id'] != "" && values['disk_encryption_set_id'] != null
       )
+  - uid: mondoo-azure-security-compute-unattached-disks-encrypted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/disks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/disks").all(
+        properties["encryption"]["diskEncryptionSetId"] != empty
+      )
   - uid: mondoo-azure-security-network-ddos-protection-enabled
     title: Ensure DDoS Protection is enabled on virtual networks
     impact: 40
@@ -12712,6 +13429,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-ddos-protection-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure DDoS Protection is enabled on all virtual networks to defend against distributed denial-of-service attacks. Azure provides basic DDoS infrastructure protection to all customers at no cost, but the Standard tier adds adaptive tuning, attack telemetry, and rapid response capabilities that the basic tier does not provide.
@@ -12853,6 +13574,12 @@ queries:
         values.ddos_protection_plan != null &&
         values.ddos_protection_plan.any(_['enable'] == true)
       )
+  - uid: mondoo-azure-security-network-ddos-protection-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworks").all(
+        properties["enableDdosProtection"] == true
+      )
   - uid: mondoo-azure-security-network-vnet-vm-protection-enabled
     title: Ensure VM protection is enabled on virtual networks
     impact: 40
@@ -12887,6 +13614,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that VM protection is enabled on all Azure virtual networks. VM protection requires that all subnets in the virtual network have a network security group associated, preventing virtual machines from being deployed into subnets that lack traffic filtering controls.
@@ -13005,6 +13736,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_virtual_network").all(
         values.vm_protection_enabled == true
       )
+  - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworks").all(
+        properties["enableVmProtection"] == true
+      )
   - uid: mondoo-azure-security-network-subnet-default-outbound-disabled
     title: Ensure default outbound access is disabled on subnets
     impact: 60
@@ -13039,6 +13776,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that default outbound access is disabled on all subnets within Azure virtual networks. Default outbound access is a legacy mechanism that allows resources in a subnet to initiate connections to the internet without any explicit outbound configuration; Microsoft has announced that this behavior will be retired and recommends disabling it proactively.
@@ -13156,6 +13897,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_subnet").all(
         values.default_outbound_access_enabled == false
       )
+  - uid: mondoo-azure-security-network-subnet-default-outbound-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworks/subnets")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworks/subnets").all(
+        properties["defaultOutboundAccess"] == false
+      )
   - uid: mondoo-azure-security-network-database-ports-restricted
     title: Ensure database ports are restricted from the internet
     impact: 80
@@ -13190,6 +13937,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-database-ports-restricted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     props:
       - uid: mondooAzureSecurityDisallowedPortsDB
         title: A list of disallowed TCP database ports. Add more ports as needed.
@@ -13379,6 +14130,18 @@ queries:
           _['destination_port_range'] == /^(1433|3306|5432|27017)$/
         )
       )
+  - uid: mondoo-azure-security-network-database-ports-restricted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == /Tcp|\*/i &&
+          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["destinationPortRange"] == /^(1433|3306|5432|27017)$/
+        )
+      )
   - uid: mondoo-azure-security-defender-for-cosmosdb-enabled
     title: Ensure Microsoft Defender for Cosmos DB is enabled
     impact: 80
@@ -13413,6 +14176,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Cosmos DB is enabled to detect threats targeting Azure Cosmos DB accounts. Defender for Cosmos DB is not enabled by default; without it, there is no Azure-native layer of behavioral threat detection for anomalous queries, credential misuse, or unusual access patterns against Cosmos DB.
@@ -13521,6 +14288,12 @@ queries:
         where(values['resource_type'] == "CosmosDbs").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-cosmosdb-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "CosmosDbs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "CosmosDbs").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-for-open-source-databases-enabled
     title: Ensure Microsoft Defender for open-source relational databases is enabled
     impact: 80
@@ -13555,6 +14328,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for open-source relational databases is enabled to provide threat protection for Azure Database for MySQL, PostgreSQL, and MariaDB. This plan is not enabled by default; without it, there is no Azure-native behavioral threat detection layer monitoring these database services for suspicious access or query patterns.
@@ -13663,6 +14440,12 @@ queries:
         where(values['resource_type'] == "OpenSourceRelationalDatabases").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-open-source-databases-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "OpenSourceRelationalDatabases")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "OpenSourceRelationalDatabases").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-defender-cspm-enabled
     title: Ensure Microsoft Defender Cloud Security Posture Management is enabled
     impact: 80
@@ -13697,6 +14480,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-cspm-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender Cloud Security Posture Management (CSPM) is enabled to provide advanced security posture capabilities beyond the foundational free-tier CSPM features. By default, subscriptions receive only the free foundational tier, which lacks attack path analysis and agentless scanning; enabling the paid Defender CSPM plan unlocks these capabilities.
@@ -13807,6 +14594,12 @@ queries:
         where(values['resource_type'] == "CloudPosture").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-cspm-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "CloudPosture")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "CloudPosture").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-cosmosdb-public-access-disabled
     title: Ensure public network access is disabled for Azure Cosmos DB accounts
     impact: 80
@@ -13841,6 +14634,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Cosmos DB accounts, requiring all connections to route through private endpoints or approved virtual networks. By default, Cosmos DB accounts are created with public network access enabled, exposing the account endpoint to the internet.
@@ -13954,6 +14751,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["public_network_access_enabled"] == false
       )
+  - uid: mondoo-azure-security-cosmosdb-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-cosmosdb-local-auth-disabled
     title: Ensure local authentication is disabled for Azure Cosmos DB accounts
     impact: 80
@@ -13988,6 +14791,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that local authentication is disabled on Azure Cosmos DB accounts, requiring Microsoft Entra ID for all data-plane access instead of account keys. By default, Cosmos DB accounts allow both Entra ID and key-based authentication; disabling local auth removes the key-based path entirely.
@@ -14101,6 +14908,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["local_authentication_disabled"] == true
       )
+  - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["disableLocalAuth"] == true
+      )
   - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled
     title: Ensure virtual network filtering is enabled for Azure Cosmos DB accounts
     impact: 60
@@ -14135,6 +14948,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that virtual network filtering is enabled on Azure Cosmos DB accounts that allow public network access, restricting connections to traffic from approved virtual networks and subnets. When public access is enabled without VNet filtering, the account accepts connections from any IP address that can reach the public endpoint.
@@ -14260,6 +15077,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["is_virtual_network_filter_enabled"] == true
       )
+  - uid: mondoo-azure-security-cosmosdb-vnet-filter-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["isVirtualNetworkFilterEnabled"] == true
+      )
   - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled
     title: Ensure key-based metadata write access is disabled for Cosmos DB
     impact: 60
@@ -14294,6 +15117,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that key-based metadata write access is disabled on Azure Cosmos DB accounts, preventing applications authenticated with account keys from creating, replacing, or deleting databases and containers. By default, account key holders have both data-plane and control-plane write access; disabling metadata writes via keys restricts structural changes to Azure Resource Manager, Terraform, or Bicep.
@@ -14406,6 +15233,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["access_key_metadata_writes_enabled"] == false
       )
+  - uid: mondoo-azure-security-cosmosdb-key-based-metadata-write-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["disableKeyBasedMetadataWriteAccess"] == true
+      )
   - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled
     title: Ensure automatic failover is enabled for Azure Cosmos DB accounts
     impact: 60
@@ -14440,6 +15273,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that automatic failover is enabled on Azure Cosmos DB accounts configured with multiple regions, so the service promotes a secondary region without manual intervention when the primary region becomes unavailable. By default, automatic failover is disabled even when multiple read regions are configured.
@@ -14563,6 +15400,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["automatic_failover_enabled"] == true
       )
+  - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["enableAutomaticFailover"] == true
+      )
   - uid: mondoo-azure-security-cosmosdb-min-tls-version
     title: Ensure Azure Cosmos DB accounts use minimum TLS version 1.2
     impact: 80
@@ -14597,6 +15440,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured to require a minimum TLS version of 1.2 for all client connections, rejecting handshakes from clients using older protocol versions. By default, the `minimalTlsVersion` property is set to `Tls` (TLS 1.0), which allows insecure connections.
@@ -14709,6 +15556,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["minimal_tls_version"] == "Tls12"
       )
+  - uid: mondoo-azure-security-cosmosdb-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["minimalTlsVersion"] == "Tls12"
+      )
   - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none
     title: Ensure Azure Cosmos DB network ACL bypass is set to None
     impact: 60
@@ -14743,6 +15596,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts have the network ACL bypass property set to `None`, so that all traffic, including traffic originating from trusted Azure services, must pass through the configured firewall and virtual network rules. By default, the bypass is set to `AzureServices`, which allows any Azure service in any tenant to bypass network controls.
@@ -14855,6 +15712,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["network_acl_bypass_for_azure_services"] == false
       )
+  - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["networkAclBypass"] == "None"
+      )
   - uid: mondoo-azure-security-cosmosdb-cmk-encryption
     title: Ensure Azure Cosmos DB accounts use customer-managed keys for encryption
     impact: 60
@@ -14889,6 +15752,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with customer-managed keys via Azure Key Vault for data-at-rest encryption, rather than relying on the default Microsoft-managed keys. By default, Cosmos DB encrypts data using Microsoft-managed keys, which means the cloud provider retains control over the encryption material.
@@ -15002,6 +15869,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["key_vault_key_id"] != empty
       )
+  - uid: mondoo-azure-security-cosmosdb-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["keyVaultKeyUri"] != empty
+      )
   - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured
     title: Ensure public Cosmos DB accounts have IP firewall rules configured
     impact: 80
@@ -15036,6 +15909,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts with public network access enabled have IP firewall rules configured to restrict which IP addresses or CIDR ranges can connect. An account with public access enabled and no IP rules accepts connections from any IP address on the internet.
@@ -15142,6 +16019,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["ip_range_filter"] != empty
+      )
+  - uid: mondoo-azure-security-cosmosdb-ip-firewall-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["ipRules"] != empty
       )
   # No Terraform variants: Cosmos DB private-endpoint correlation across resources is not expressible cleanly
   # No Terraform remediation: same reason
@@ -15280,6 +16163,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts do not have Cross-Origin Resource Sharing (CORS) configured with a wildcard origin (`*`), which permits any web page from any domain to make cross-origin requests to the Cosmos DB HTTP API. Wildcard CORS is the permissive default when CORS is enabled without specifying allowed origins.
@@ -15395,6 +16282,13 @@ queries:
         values["cors_rule"] == empty ||
         values["cors_rule"].all(_["allowed_origins"].none(_ == "*"))
       )
+  - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["cors"] == empty ||
+        properties["cors"].none(_["allowedOrigins"] == "*")
+      )
   - uid: mondoo-azure-security-cosmosdb-continuous-backup
     title: Ensure Azure Cosmos DB accounts use continuous backup policy
     impact: 50
@@ -15429,6 +16323,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-continuous-backup-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with a continuous backup policy, enabling point-in-time restore to any second within the retention window. By default, Cosmos DB accounts use a periodic backup policy with discrete snapshot intervals, which limits restore granularity and leaves gaps between snapshots.
@@ -15534,6 +16432,12 @@ queries:
         values["backup"] != empty &&
         values["backup"].all(_["type"] == "Continuous")
       )
+  - uid: mondoo-azure-security-cosmosdb-continuous-backup-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["backupPolicy"]["type"] == "Continuous"
+      )
   - uid: mondoo-azure-security-cosmosdb-multi-region-write
     title: Ensure multi-region Cosmos DB accounts have multi-region write enabled
     impact: 40
@@ -15568,6 +16472,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-multi-region-write-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts distributed across multiple regions have multi-region write enabled, so write operations are not funneled through a single primary region. By default, even multi-region accounts use a single-write-region model where all writes go to one designated region.
@@ -15681,6 +16589,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cosmosdb_account").all(
         values["multiple_write_locations_enabled"] == true
       )
+  - uid: mondoo-azure-security-cosmosdb-multi-region-write-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["enableMultipleWriteLocations"] == true
+      )
   - uid: mondoo-azure-security-cosmosdb-strong-consistency
     title: Ensure Azure Cosmos DB accounts use bounded staleness or strong consistency
     impact: 30
@@ -15715,6 +16629,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cosmosdb-strong-consistency-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cosmos DB accounts are configured with strong or bounded staleness consistency, providing stronger read guarantees for security-sensitive workloads. By default, new Cosmos DB accounts are created with session consistency, which allows reads to observe stale data in certain scenarios.
@@ -15818,6 +16736,13 @@ queries:
         values["consistency_policy"] != empty &&
         values["consistency_policy"].all(_["consistency_level"].in(["BoundedStaleness", "Strong"]))
       )
+  - uid: mondoo-azure-security-cosmosdb-strong-consistency-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DocumentDB/databaseAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DocumentDB/databaseAccounts").all(
+        properties["consistencyPolicy"]["defaultConsistencyLevel"] == "BoundedStaleness" ||
+        properties["consistencyPolicy"]["defaultConsistencyLevel"] == "Strong"
+      )
   - uid: mondoo-azure-security-firewall-threat-intel-deny
     title: Ensure Azure Firewall threat intelligence is set to Deny mode
     impact: 80
@@ -15852,6 +16777,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-threat-intel-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Firewall threat intelligence-based filtering is set to Deny mode, actively blocking traffic to and from IP addresses and domains identified as malicious by Microsoft's threat intelligence feeds. By default, threat intelligence mode is set to Alert, which logs matches but does not block them.
@@ -15970,6 +16899,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_firewall").all(
         values.threat_intel_mode == "Deny"
       )
+  - uid: mondoo-azure-security-firewall-threat-intel-deny-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/azureFirewalls")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/azureFirewalls").all(
+        properties["threatIntelMode"] == "Deny"
+      )
   - uid: mondoo-azure-security-firewall-premium-sku
     title: Ensure Azure Firewall uses Premium SKU for advanced threat protection
     impact: 40
@@ -16004,6 +16939,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-premium-sku-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Firewall instances use the Premium SKU, which provides advanced threat protection capabilities including TLS inspection, intrusion detection and prevention, and enhanced URL filtering that are not available in the Standard SKU. The Standard SKU is often provisioned by default and lacks these deep packet inspection features.
@@ -16118,6 +17057,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_firewall").all(
         values.sku_tier == "Premium"
       )
+  - uid: mondoo-azure-security-firewall-premium-sku-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/azureFirewalls")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/azureFirewalls").all(
+        properties["sku"]["tier"] == "Premium"
+      )
   - uid: mondoo-azure-security-firewall-policy-configured
     title: Ensure Azure Firewall has a firewall policy attached
     impact: 60
@@ -16152,6 +17097,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-policy-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Firewall instances are configured to have a firewall policy attached. Without a policy, firewall rules are managed through the legacy classic rules API, which does not support Premium features and does not allow rule sharing across multiple firewalls.
@@ -16288,6 +17237,12 @@ queries:
         values.firewall_policy_id != null &&
         values.firewall_policy_id != ""
       )
+  - uid: mondoo-azure-security-firewall-policy-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/azureFirewalls")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/azureFirewalls").all(
+        properties["firewallPolicy"]["id"] != empty
+      )
   - uid: mondoo-azure-security-firewall-idps-enabled
     title: Ensure Azure Firewall Policy has IDPS set to Deny mode
     impact: 80
@@ -16322,6 +17277,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-idps-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Firewall Policy is configured to have Intrusion Detection and Prevention System (IDPS) set to Deny mode. Alert-only mode logs threats but does not prevent them from reaching protected resources, leaving the network exposed to known attack patterns.
@@ -16447,6 +17406,12 @@ queries:
         values.intrusion_detection != null &&
         values.intrusion_detection.any(_['mode'] == "Deny")
       )
+  - uid: mondoo-azure-security-firewall-idps-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/firewallPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/firewallPolicies").all(
+        properties["intrusionDetection"]["mode"] == "Deny"
+      )
   - uid: mondoo-azure-security-batch-public-access-disabled
     title: Ensure public network access is disabled for Azure Batch accounts
     impact: 80
@@ -16481,6 +17446,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch accounts are configured to have public network access disabled, requiring all connections to go through private endpoints. By default, Azure Batch accounts accept connections from the public internet, exposing the management and task submission API to unauthenticated network probing.
@@ -16592,6 +17561,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_batch_account").all(
         values.public_network_access_enabled == false
       )
+  - uid: mondoo-azure-security-batch-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Batch/batchAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Batch/batchAccounts").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-batch-aad-auth-only
     title: Ensure Azure Batch accounts use Entra ID authentication
     impact: 80
@@ -16626,6 +17601,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-aad-auth-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch accounts are configured to disallow Shared Key authentication, requiring all operations to authenticate through Microsoft Entra ID. By default, Batch accounts accept both Shared Key and Entra ID authentication, leaving static credentials as an active attack surface.
@@ -16748,6 +17727,13 @@ queries:
         values.allowed_authentication_modes.none(_ == "SharedKey") &&
         values.allowed_authentication_modes.any(_ == "AAD")
       )
+  - uid: mondoo-azure-security-batch-aad-auth-only-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Batch/batchAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Batch/batchAccounts").all(
+        properties["allowedAuthenticationModes"].none(_ == "SharedKey") &&
+        properties["allowedAuthenticationModes"].any(_ == "AAD")
+      )
   - uid: mondoo-azure-security-batch-encryption-configured
     title: Ensure Azure Batch accounts use customer-managed encryption keys
     impact: 60
@@ -16782,6 +17768,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-encryption-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch accounts are configured to use customer-managed encryption keys (CMK) sourced from Azure Key Vault. By default, Batch accounts use Microsoft-managed platform keys, which do not give customers control over key lifecycle, rotation, or revocation.
@@ -16909,6 +17899,12 @@ queries:
         values.encryption != null &&
         values.encryption.any(_['key_vault_key_id'] != null && _['key_vault_key_id'] != "")
       )
+  - uid: mondoo-azure-security-batch-encryption-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Batch/batchAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Batch/batchAccounts").all(
+        properties["encryption"] != empty
+      )
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled
     title: Ensure Azure Batch accounts have diagnostic settings enabled
     impact: 60
@@ -16943,6 +17939,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch accounts are configured to have diagnostic settings enabled, routing job execution events, authentication records, and service logs to a centralized destination such as a Log Analytics workspace. Without diagnostic settings, Batch account activity generates no persistent audit trail.
@@ -17078,6 +18078,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_monitor_diagnostic_setting").any(
         values['target_resource_id'].contains("/batchAccounts/")
       )
+  - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/diagnosticSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/diagnosticSettings").any(
+        properties["logs"].any(_["enabled"] == true)
+      )
   - uid: mondoo-azure-security-batch-private-endpoints-configured
     title: Ensure Azure Batch accounts have private endpoint connections configured
     impact: 70
@@ -17112,6 +18118,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-private-endpoints-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch accounts are configured to have at least one private endpoint connection, enabling access over a private IP address within the virtual network. Without private endpoints, Batch account API traffic may traverse the public internet depending on client network configuration.
@@ -17244,6 +18254,14 @@ queries:
           _['subresource_names'].any(_ == "batchAccount")
         )
       )
+  - uid: mondoo-azure-security-batch-private-endpoints-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "batchAccount")
+        )
+      )
   - uid: mondoo-azure-security-batch-pool-disk-encryption
     title: Ensure Azure Batch pools have disk encryption enabled
     impact: 60
@@ -17278,6 +18296,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-batch-pool-disk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Batch pool compute nodes are configured to have disk encryption enabled on the OS disk and temporary disk. Without disk encryption, task output files, temporary processing data, and cached credentials stored on node disks are exposed if the underlying storage media is accessed outside the VM.
@@ -17414,6 +18436,12 @@ queries:
         values.disk_encryption != null &&
         values.disk_encryption != empty
       )
+  - uid: mondoo-azure-security-batch-pool-disk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Batch/batchAccounts/pools")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Batch/batchAccounts/pools").all(
+        properties["deploymentConfiguration"]["virtualMachineConfiguration"]["diskEncryptionConfiguration"] != empty
+      )
   - uid: mondoo-azure-security-sql-server-min-tls-12
     title: Ensure Azure SQL servers enforce minimal TLS version 1.2
     impact: 80
@@ -17448,6 +18476,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-min-tls-12-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL servers enforce a minimum TLS version of 1.2 for all connections, preventing the use of older, less secure TLS versions. By default, Azure SQL Server permits connections using TLS 1.0 and 1.1, which have known cryptographic weaknesses.
@@ -17556,6 +18588,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for PostgreSQL flexible servers, restricting connections to private endpoints only. By default, PostgreSQL flexible servers can be configured to allow public internet connections, but disabling public access and routing traffic exclusively through private endpoints eliminates direct internet exposure of the database service.
@@ -17667,6 +18703,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys. By default, Azure encrypts data at rest with Microsoft-managed keys; switching to CMK gives the organization ownership of the cryptographic material and the ability to revoke access at any time.
@@ -17791,6 +18831,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL single servers enforce a minimum TLS version of 1.2 for all connections. By default, PostgreSQL servers may accept older protocol versions; requiring TLS 1.2 or later closes known protocol-level weaknesses and aligns the server with current security baselines.
@@ -17896,6 +18940,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-ssl-enforcement-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL single servers require SSL for all client connections. By default, SSL enforcement can be disabled on PostgreSQL single servers; enabling it guarantees that all data transmitted between clients and the database is encrypted in transit.
@@ -18001,6 +19049,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for PostgreSQL single servers, restricting connections to private endpoints only. By default, PostgreSQL single servers can be configured with public internet access; disabling this eliminates direct exposure of the database to external networks.
@@ -18107,6 +19159,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-infrastructure-encryption-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL single servers have infrastructure double encryption enabled, providing an additional layer of encryption on top of the standard service-managed encryption. When enabled, data is encrypted twice using different encryption algorithms, adding defense in depth for data at rest.
@@ -18209,6 +19265,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-firewall-no-public-ingress-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that no firewall rule on an Azure Database for PostgreSQL single server allows access from all IP addresses (start IP 0.0.0.0 to end IP 255.255.255.255). Firewall rules that span the full IP range expose the database to connection attempts from the entire public internet.
@@ -18315,6 +19375,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-log-checkpoints-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `log_checkpoints` parameter is enabled on Azure Database for PostgreSQL single servers. When enabled, the server logs each checkpoint to the PostgreSQL log, providing visibility into write-ahead log (WAL) activity and database recovery events.
@@ -18419,6 +19483,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-log-connections-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `log_connections` parameter is enabled on Azure Database for PostgreSQL single servers. When enabled, the server logs each attempted connection as well as successful client authentication, providing an audit trail of who is connecting to the database.
@@ -18523,6 +19591,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-log-disconnections-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `log_disconnections` parameter is enabled on Azure Database for PostgreSQL single servers. When enabled, the server logs the end of each client session, including the session duration, giving a complete picture of database access activity alongside `log_connections`.
@@ -18627,6 +19699,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-server-connection-throttling-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `connection_throttling` parameter is enabled on Azure Database for PostgreSQL single servers. When enabled, the server temporarily throttles connections from IP addresses with too many invalid password failures, reducing the effectiveness of brute-force and credential-stuffing attacks.
@@ -18731,6 +19807,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for MySQL flexible servers, restricting connections to private endpoints only. By default, MySQL flexible servers can be configured with public internet access; disabling this and routing traffic through private endpoints eliminates direct exposure of the database to external networks.
@@ -18843,6 +19923,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL flexible servers use customer-managed keys (CMK) for data encryption instead of service-managed keys. By default, Azure encrypts data at rest with Microsoft-managed keys; switching to CMK gives the organization ownership of the cryptographic material and the ability to revoke access independently of Azure.
@@ -18967,6 +20051,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL single servers enforce a minimum TLS version of 1.2 for all connections. By default, MySQL servers may accept older protocol versions; requiring TLS 1.2 or later closes known protocol-level weaknesses and aligns the server with current security baselines.
@@ -19072,6 +20160,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-ssl-enforcement-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL single servers require SSL for all client connections. By default, SSL enforcement can be disabled on MySQL single servers; enabling it guarantees that all data transmitted between clients and the database is encrypted in transit.
@@ -19177,6 +20269,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Database for MySQL single servers, restricting connections to private endpoints only. By default, MySQL single servers can be configured with public internet access; disabling this eliminates direct exposure of the database to external networks.
@@ -19283,6 +20379,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-infrastructure-encryption-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL single servers have infrastructure double encryption enabled, providing an additional layer of encryption on top of the standard service-managed encryption. When enabled, data is encrypted twice using different encryption algorithms, adding defense in depth for data at rest.
@@ -19385,6 +20485,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-firewall-no-public-ingress-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that no firewall rule on an Azure Database for MySQL single server allows access from all IP addresses (start IP 0.0.0.0 to end IP 255.255.255.255). Firewall rules that span the full IP range expose the database to connection attempts from the entire public internet.
@@ -19491,6 +20595,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for SQL Servers on Machines is enabled to provide advanced threat detection for SQL Server instances running on Azure VMs, on-premises, and in hybrid environments. By default the plan is not enabled for SQL Server Virtual Machines, leaving those workloads without active threat monitoring.
@@ -19580,6 +20688,12 @@ queries:
         where(values['resource_type'] == "SqlServerVirtualMachines").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-sql-on-machines-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "SqlServerVirtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "SqlServerVirtualMachines").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-aks-disk-encryption-set
     title: Ensure AKS clusters have disk CSI driver enabled for node pool encryption
     impact: 60
@@ -19614,6 +20728,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-disk-encryption-set-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters have the disk CSI driver enabled in the storage profile. The disk CSI driver is required to apply customer-managed key encryption and disk encryption sets to node pool disks. By default, AKS enables the disk CSI driver for new clusters, but older clusters or clusters with custom storage profiles may have it disabled, preventing encryption set configurations from taking effect.
@@ -19724,6 +20842,12 @@ queries:
         values.storage_profile != empty &&
         values.storage_profile.all(disk_driver_enabled == true)
       )
+  - uid: mondoo-azure-security-aks-disk-encryption-set-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["storageProfile"]["diskCSIDriver"]["enabled"] == true
+      )
   - uid: mondoo-azure-security-appgw-ssl-policy-tls12
     title: Ensure Application Gateways enforce TLS 1.2 or higher
     impact: 80
@@ -19758,6 +20882,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-ssl-policy-tls12-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all Azure Application Gateways have an SSL policy configured that enforces TLS 1.2 or higher as the minimum protocol version, preventing the use of deprecated TLS versions. By default, newly created Application Gateways may allow TLS 1.0 and 1.1 unless a predefined or custom SSL policy is explicitly set.
@@ -19878,6 +21006,14 @@ queries:
           _['policy_name'] == /AppGwSslPolicy2022/
         )
       )
+  - uid: mondoo-azure-security-appgw-ssl-policy-tls12-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_2" ||
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_3" ||
+        properties["sslPolicy"]["policyName"] == /AppGwSslPolicy2022/
+      )
   - uid: mondoo-azure-security-vpn-gateway-ikev2
     title: Ensure VPN gateways use route-based type for IKEv2 protocol support
     impact: 60
@@ -19912,6 +21048,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vpn-gateway-ikev2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure VPN gateways are configured to use the route-based VPN type, which supports the IKEv2 protocol. Policy-based VPN gateways only support IKEv1, which has known cryptographic weaknesses and is considered deprecated by modern security standards.
@@ -20030,6 +21170,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_virtual_network_gateway").where(values.type == "Vpn").all(
         values.vpn_type == "RouteBased"
       )
+  - uid: mondoo-azure-security-vpn-gateway-ikev2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworkGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworkGateways").all(
+        properties["gatewayType"] != "Vpn" ||
+        properties["vpnType"] == "RouteBased"
+      )
   - uid: mondoo-azure-security-databricks-public-access-disabled
     title: Ensure Azure Databricks workspaces disable public network access
     impact: 80
@@ -20064,6 +21211,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-databricks-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Databricks workspaces have public network access disabled, restricting connectivity to private endpoints only. By default, Databricks workspaces allow public internet access to the workspace web application and REST API, making them reachable by any client with valid credentials.
@@ -20169,6 +21320,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_databricks_workspace").all(
         values.public_network_access_enabled == false
       )
+  - uid: mondoo-azure-security-databricks-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Databricks/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Databricks/workspaces").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-defender-for-endpoint-enabled
     title: Ensure Microsoft Defender for Endpoint integration is enabled
     impact: 80
@@ -20203,6 +21360,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-endpoint-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for Endpoint integration is enabled in Microsoft Defender for Cloud, providing endpoint detection and response capabilities for Azure virtual machines and arc-connected servers. By default the integration is disabled, leaving servers without behavioral threat detection even when other Defender plans are active.
@@ -20301,6 +21462,12 @@ queries:
         where(values['setting_name'] == "WDATP").all(
           values['enabled'] == true
         )
+  - uid: mondoo-azure-security-defender-for-endpoint-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/settings" && name == "WDATP")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/settings" && name == "WDATP").all(
+        properties["enabled"] == true
+      )
   - uid: mondoo-azure-security-defender-for-apis-enabled
     title: Ensure Microsoft Defender for APIs is enabled
     impact: 70
@@ -20335,6 +21502,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-defender-for-apis-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Defender for APIs is enabled to provide threat protection for APIs published through Azure API Management. By default the plan is not enabled, leaving API traffic unmonitored for injection attacks, anomalous usage, and sensitive data exposure.
@@ -20430,6 +21601,12 @@ queries:
         where(values['resource_type'] == "Api").all(
           values['tier'] == "Standard"
         )
+  - uid: mondoo-azure-security-defender-for-apis-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "Api")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/pricings" && name == "Api").all(
+        properties["pricingTier"] == "Standard"
+      )
   - uid: mondoo-azure-security-app-service-min-tls-cipher-suite
     title: Ensure App Service web apps use a strong minimum TLS cipher suite
     impact: 70
@@ -20464,6 +21641,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service web applications are configured with a strong minimum TLS cipher suite, specifically TLS_AES_256_GCM_SHA384. By default, App Service permits a broader range of cipher suites including weaker options, and the minimum cipher suite setting is not configured unless explicitly set.
@@ -20584,6 +21765,12 @@ queries:
           values.site_config.all(_["minimum_tls_cipher_suite"] == "TLS_AES_256_GCM_SHA384")
         )
       }
+  - uid: mondoo-azure-security-app-service-min-tls-cipher-suite-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["minTlsCipherSuite"] == "TLS_AES_256_GCM_SHA384"
+      )
   # No Terraform variants: end-to-end FE->worker encryption has no azurerm_linux_web_app / azurerm_windows_web_app argument
   # No Terraform remediation: same reason
   - uid: mondoo-azure-security-app-service-e2e-encryption-enabled
@@ -20704,6 +21891,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters are configured to have node OS auto-upgrade enabled, which automatically applies security patches to the underlying node operating system. By default, AKS does not automatically upgrade node OS images, leaving nodes running unpatched kernels and system packages until manually refreshed.
@@ -20810,6 +22001,14 @@ queries:
         values.node_os_upgrade_channel != "Unmanaged" &&
         values.node_os_upgrade_channel != empty
       )
+  - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["autoUpgradeProfile"]["nodeOSUpgradeChannel"] != "None" &&
+        properties["autoUpgradeProfile"]["nodeOSUpgradeChannel"] != "Unmanaged" &&
+        properties["autoUpgradeProfile"]["nodeOSUpgradeChannel"] != empty
+      )
   - uid: mondoo-azure-security-aks-local-accounts-disabled
     title: Ensure local accounts are disabled on AKS clusters
     impact: 70
@@ -20844,6 +22043,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-local-accounts-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that local accounts are disabled on Azure Kubernetes Service (AKS) clusters, requiring all authentication to go through Microsoft Entra ID. By default, AKS creates local cluster administrator and user credentials that bypass Entra ID and do not support MFA or conditional access enforcement.
@@ -20962,6 +22165,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.local_account_disabled == true
       )
+  - uid: mondoo-azure-security-aks-local-accounts-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["disableLocalAccounts"] == true
+      )
   - uid: mondoo-azure-security-aks-public-network-access-disabled
     title: Ensure public network access is disabled on AKS clusters
     impact: 80
@@ -20996,6 +22205,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Kubernetes Service (AKS) clusters are configured to have public network access disabled, restricting API server connectivity to private networks only. Even when a private cluster is enabled, the public FQDN and endpoint may remain active; disabling public network access removes this endpoint entirely.
@@ -21120,6 +22333,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values.public_network_access_enabled == false
       )
+  - uid: mondoo-azure-security-aks-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-aks-auto-upgrade-enabled
     title: Ensure AKS clusters have auto-upgrade enabled
     impact: 70
@@ -21154,6 +22373,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-auto-upgrade-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters are configured to have auto-upgrade enabled, automatically delivering Kubernetes version updates including security patches for the API server, kubelet, and core components. By default, AKS clusters are created with the upgrade channel set to none, requiring manual intervention to apply security releases.
@@ -21256,6 +22479,13 @@ queries:
         values.automatic_upgrade_channel != "none" &&
         values.automatic_upgrade_channel != empty
       )
+  - uid: mondoo-azure-security-aks-auto-upgrade-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["autoUpgradeProfile"]["upgradeChannel"] != "none" &&
+        properties["autoUpgradeProfile"]["upgradeChannel"] != empty
+      )
   - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled
     title: Ensure password-only auth is disabled on PostgreSQL flexible servers
     impact: 70
@@ -21290,6 +22520,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that password-based authentication is disabled on Azure Database for PostgreSQL flexible servers, enforcing Microsoft Entra ID as the sole authentication method. By default, PostgreSQL flexible servers allow password authentication; disabling it requires all clients to authenticate through Entra ID, eliminating static database credentials entirely.
@@ -21400,6 +22634,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-smb-versions-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage accounts restrict SMB file share access to SMB 3.0 and later versions only, blocking older protocol versions that have known security vulnerabilities.
@@ -21512,6 +22750,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.share_properties[0].smb[0].versions.none(_ == /SMB2/)
       )
+  - uid: mondoo-azure-security-storage-smb-versions-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/fileServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/fileServices").all(
+        properties["protocolSettings"]["smb"]["versions"] != /SMB2/
+      )
   - uid: mondoo-azure-security-storage-smb-channel-encryption
     title: Ensure Azure Storage accounts use strong SMB channel encryption
     impact: 70
@@ -21546,6 +22790,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-smb-channel-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage accounts are configured to use strong SMB channel encryption, specifically requiring AES-256-GCM support for file share connections.
@@ -21658,6 +22906,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values.share_properties[0].smb[0].channel_encryption_type.any(_ == "AES-256-GCM")
       )
+  - uid: mondoo-azure-security-storage-smb-channel-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/fileServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/fileServices").all(
+        properties["protocolSettings"]["smb"]["channelEncryption"] == /AES-256-GCM/
+      )
   - uid: mondoo-azure-security-vpn-gateway-generation2
     title: Ensure VPN gateways use Generation2 for stronger cryptographic standards
     impact: 60
@@ -21692,6 +22946,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vpn-gateway-generation2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure VPN gateways use the Generation2 SKU, which supports higher throughput, more tunnels, and stronger cryptographic standards compared to Generation1 gateways.
@@ -21813,6 +23071,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_virtual_network_gateway").where(values.type == "Vpn").all(
         values.generation == "Generation2"
       )
+  - uid: mondoo-azure-security-vpn-gateway-generation2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworkGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworkGateways").all(
+        properties["gatewayType"] != "Vpn" ||
+        properties["vpnGatewayGeneration"] == "Generation2"
+      )
   - uid: mondoo-azure-security-compute-disk-public-access-disabled
     title: Ensure public network access is disabled for Azure managed disks
     impact: 80
@@ -21847,6 +23112,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-disk-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled for all Azure managed disks, preventing disk data from being accessed over the public internet during export or upload operations. By default, managed disks allow public network access, meaning anyone with a valid SAS URI can download disk contents from any internet-connected location.
@@ -21958,6 +23227,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_managed_disk").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-compute-disk-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/disks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/disks").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-azure
     filters: |
       asset.platform == "azure-keyvault-vault"
@@ -21980,6 +23255,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_key_vault").all(
         values['purge_protection_enabled'] == true
+      )
+  - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults").all(
+        properties["enablePurgeProtection"] == true
       )
   - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-azure
     filters: |
@@ -22026,6 +23307,15 @@ queries:
           values['expiration_date'] != empty
         )
       }
+  - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/vaults/keys" || type == "Microsoft.KeyVault/vaults/secrets")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults/keys").all(
+        properties["attributes"]["exp"] != empty
+      )
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults/secrets").all(
+        properties["attributes"]["exp"] != empty
+      )
   - uid: mondoo-azure-security-keyvault-public-access-disabled-azure
     filters: |
       asset.platform == "azure-keyvault-vault"
@@ -22051,6 +23341,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_key_vault").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-keyvault-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-keyvault-rbac-enabled-azure
     filters: |
       asset.platform == "azure-keyvault-vault"
@@ -22074,6 +23370,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_key_vault").all(
         values['enable_rbac_authorization'] == true
       )
+  - uid: mondoo-azure-security-keyvault-rbac-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults").all(
+        properties["enableRbacAuthorization"] == true
+      )
   - uid: mondoo-azure-security-keyvault-key-auto-rotation-azure
     filters: |
       asset.platform == "azure-keyvault-vault"
@@ -22096,6 +23398,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_key_vault_key").all(
         values['rotation_policy'] != empty
+      )
+  - uid: mondoo-azure-security-keyvault-key-auto-rotation-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/vaults/keys")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/vaults/keys").all(
+        properties["rotationPolicy"] != empty
       )
   - uid: mondoo-azure-security-keyvault-private-endpoints-azure
     filters: |
@@ -22128,6 +23436,14 @@ queries:
           _['subresource_names'].any(_ == "vault")
         )
       )
+  - uid: mondoo-azure-security-keyvault-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "vault")
+        )
+      )
   - uid: mondoo-azure-security-redis-ssl-only-azure
     filters: |
       asset.platform == "azure-cache-redis-instance"
@@ -22150,6 +23466,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_redis_cache").all(
         values['enable_non_ssl_port'] == false
+      )
+  - uid: mondoo-azure-security-redis-ssl-only-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["enableNonSslPort"] == false
       )
   - uid: mondoo-azure-security-redis-public-access-disabled-azure
     filters: |
@@ -22174,6 +23496,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_redis_cache").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-redis-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-redis-min-tls-version-azure
     filters: |
       asset.platform == "azure-cache-redis-instance"
@@ -22197,6 +23525,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_redis_cache").all(
         values['minimum_tls_version'] == "1.2"
       )
+  - uid: mondoo-azure-security-redis-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["minimumTlsVersion"] == "1.2"
+      )
   - uid: mondoo-azure-security-redis-latest-version-azure
     filters: |
       asset.platform == "azure-cache-redis-instance"
@@ -22219,6 +23553,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_redis_cache").all(
         values['redis_version'] >= "6"
+      )
+  - uid: mondoo-azure-security-redis-latest-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["redisVersion"] >= 6
       )
   - uid: mondoo-azure-security-redis-auth-required-azure
     filters: |
@@ -22252,6 +23592,12 @@ queries:
           _['enable_authentication'] != false
         )
       )
+  - uid: mondoo-azure-security-redis-auth-required-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["redisConfiguration"]["authnotrequired"] != "true"
+      )
   - uid: mondoo-azure-security-sql-server-audit-on-azure
     filters: |
       asset.platform == "azure-sql-server"
@@ -22269,6 +23615,12 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_mssql_server_extended_auditing_policy")
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_server_extended_auditing_policy").length > 0
+  - uid: mondoo-azure-security-sql-server-audit-on-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/auditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/auditingSettings").all(
+        properties["state"] == "Enabled"
+      )
   - uid: mondoo-azure-security-sql-server-tde-on-azure
     filters: |
       asset.platform == "azure-sql-server" && azure.subscription.sql.server.databases.any(name != "master")
@@ -22291,6 +23643,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_database").all(
         values['transparent_data_encryption_enabled'] != false
+      )
+  - uid: mondoo-azure-security-sql-server-tde-on-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/databases/transparentDataEncryption")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/databases/transparentDataEncryption").all(
+        properties["state"] == "Enabled"
       )
   - uid: mondoo-azure-security-ensure-disabled-public-access-sql-azure
     filters: |
@@ -22315,6 +23673,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_server").all(
         values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ensure-disabled-public-access-sql-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers").all(
+        properties["publicNetworkAccess"] == "Disabled"
       )
   - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-azure
     filters: |
@@ -22344,6 +23708,13 @@ queries:
         values['retention_in_days'] >= 30 ||
         values['retention_in_days'] == 0
       )
+  - uid: mondoo-azure-security-ensure-auditing-retention-greater-than-30-days-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/auditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/auditingSettings").all(
+        properties["retentionDays"] >= 30 ||
+        properties["retentionDays"] == 0
+      )
   - uid: mondoo-azure-security-sql-threat-detection-enabled-azure
     filters: |
       asset.platform == "azure-sql-server"
@@ -22366,6 +23737,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_server_security_alert_policy").all(
         values['state'] == "Enabled"
+      )
+  - uid: mondoo-azure-security-sql-threat-detection-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/securityAlertPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/securityAlertPolicies").all(
+        properties["state"] == "Enabled"
       )
   - uid: mondoo-azure-security-sql-ad-admin-configured-azure
     filters: |
@@ -22390,6 +23767,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mssql_server").all(
         values['azuread_administrator'] != empty
       )
+  - uid: mondoo-azure-security-sql-ad-admin-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/administrators")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/administrators").all(
+        properties["administratorType"] == "ActiveDirectory"
+      )
   - uid: mondoo-azure-security-sql-server-min-tls-12-azure
     filters: |
       asset.platform == "azure-sql-server"
@@ -22412,6 +23795,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_server").all(
         values['minimum_tls_version'] == "1.2"
+      )
+  - uid: mondoo-azure-security-sql-server-min-tls-12-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers").all(
+        properties["minimalTlsVersion"] == "1.2"
       )
   - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-azure
     filters: |
@@ -22439,6 +23828,14 @@ queries:
       // Flexible Server enforces SSL by default; verify require_secure_transport is not disabled
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server_configuration" && values['name'] == "require_secure_transport").all(
         values['value'].downcase == "on"
+      )
+  - uid: mondoo-azure-security-ensure-that-ssl-enabled-postgresql-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        resources.where(type == "configurations" && name == "require_secure_transport").all(
+          properties["value"] == /^on$/i
+        )
       )
   - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-azure
     filters: |
@@ -22484,6 +23881,17 @@ queries:
         values['name'] == "require_secure_transport" &&
         values['value'] == "OFF"
       )
+  - uid: mondoo-azure-security-ensure-that-ssl-enabled-latest-version-mysql-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/flexibleServers" || type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers").all(
+        resources.where(type == "configurations" && name == "require_secure_transport").all(
+          properties["value"] == /^on$/i
+        )
+      )
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["sslEnforcement"] == /^enabled$/i
+      )
   - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_firewall_rule" || nameLabel == "azurerm_postgresql_flexible_server_firewall_rule" || nameLabel == "azurerm_mysql_flexible_server_firewall_rule")
     mql: |
@@ -22520,6 +23928,18 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_flexible_server_firewall_rule").all(
         values['start_ip_address'] != "0.0.0.0"
       )
+  - uid: mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/firewallRules" || type == "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules" || type == "Microsoft.DBforMySQL/flexibleServers/firewallRules")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0"
+      )
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0"
+      )
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0"
+      )
   - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-azure
     filters: |
       asset.platform == "azure-postgresql-flexible-server"
@@ -22542,6 +23962,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server").all(
         values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        properties["network"]["publicNetworkAccess"] == "Disabled"
       )
   - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-azure
     filters: |
@@ -22566,6 +23992,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        properties["dataEncryption"]["type"] == "AzureKeyVault"
+      )
   - uid: mondoo-azure-security-postgresql-server-min-tls-version-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22588,6 +24020,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_postgresql_server").all(
         values['ssl_minimal_tls_version_enforced'] == "TLS1_2"
+      )
+  - uid: mondoo-azure-security-postgresql-server-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers").all(
+        properties["minimalTlsVersion"] == "TLS1_2"
       )
   - uid: mondoo-azure-security-postgresql-server-ssl-enforcement-enabled-azure
     filters: |
@@ -22612,6 +24050,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_server").all(
         values['ssl_enforcement_enabled'] == true
       )
+  - uid: mondoo-azure-security-postgresql-server-ssl-enforcement-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers").all(
+        properties["sslEnforcement"] == "Enabled"
+      )
   - uid: mondoo-azure-security-postgresql-server-public-network-access-disabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22635,6 +24079,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_server").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-postgresql-server-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-postgresql-server-infrastructure-encryption-enabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22657,6 +24107,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_postgresql_server").all(
         values['infrastructure_encryption_enabled'] == true
+      )
+  - uid: mondoo-azure-security-postgresql-server-infrastructure-encryption-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers").all(
+        properties["infrastructureEncryption"] == "Enabled"
       )
   - uid: mondoo-azure-security-postgresql-server-firewall-no-public-ingress-azure
     filters: |
@@ -22683,6 +24139,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_firewall_rule").all(
         values['start_ip_address'] != "0.0.0.0" || values['end_ip_address'] != "255.255.255.255"
       )
+  - uid: mondoo-azure-security-postgresql-server-firewall-no-public-ingress-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers/firewallRules")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0" ||
+        properties["endIpAddress"] != "255.255.255.255"
+      )
   - uid: mondoo-azure-security-postgresql-server-log-checkpoints-enabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22706,6 +24169,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_configuration").where(
         values['name'] == "log_checkpoints"
       ).all(values['value'] == "on")
+  - uid: mondoo-azure-security-postgresql-server-log-checkpoints-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_checkpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_checkpoints").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-postgresql-server-log-connections-enabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22729,6 +24198,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_configuration").where(
         values['name'] == "log_connections"
       ).all(values['value'] == "on")
+  - uid: mondoo-azure-security-postgresql-server-log-connections-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_connections")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_connections").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-postgresql-server-log-disconnections-enabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22752,6 +24227,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_configuration").where(
         values['name'] == "log_disconnections"
       ).all(values['value'] == "on")
+  - uid: mondoo-azure-security-postgresql-server-log-disconnections-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_disconnections")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "log_disconnections").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-postgresql-server-connection-throttling-enabled-azure
     filters: |
       asset.platform == "azure-postgresql-server"
@@ -22775,6 +24256,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_configuration").where(
         values['name'] == "connection_throttling"
       ).all(values['value'] == "on")
+  - uid: mondoo-azure-security-postgresql-server-connection-throttling-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "connection_throttling")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/servers/configurations" && name == "connection_throttling").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-azure
     filters: |
       asset.platform == "azure-mysql-flexible-server"
@@ -22801,6 +24288,13 @@ queries:
         values['delegated_subnet_id'] != empty ||
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers").all(
+        properties["network"]["publicNetworkAccess"] == "Disabled" ||
+        properties["network"]["delegatedSubnetResourceId"] != empty
+      )
   - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-azure
     filters: |
       asset.platform == "azure-mysql-flexible-server"
@@ -22825,6 +24319,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_flexible_server").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers").all(
+        properties["dataEncryption"]["type"] == "AzureKeyVault"
+      )
   - uid: mondoo-azure-security-mysql-server-min-tls-version-azure
     filters: |
       asset.platform == "azure-mysql-server"
@@ -22847,6 +24347,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mysql_server").all(
         values['ssl_minimal_tls_version_enforced'] == "TLS1_2"
+      )
+  - uid: mondoo-azure-security-mysql-server-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["minimalTlsVersion"] == "TLS1_2"
       )
   - uid: mondoo-azure-security-mysql-server-ssl-enforcement-enabled-azure
     filters: |
@@ -22871,6 +24377,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_server").all(
         values['ssl_enforcement_enabled'] == true
       )
+  - uid: mondoo-azure-security-mysql-server-ssl-enforcement-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["sslEnforcement"] == "Enabled"
+      )
   - uid: mondoo-azure-security-mysql-server-public-network-access-disabled-azure
     filters: |
       asset.platform == "azure-mysql-server"
@@ -22894,6 +24406,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_server").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-mysql-server-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-mysql-server-infrastructure-encryption-enabled-azure
     filters: |
       asset.platform == "azure-mysql-server"
@@ -22916,6 +24434,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mysql_server").all(
         values['infrastructure_encryption_enabled'] == true
+      )
+  - uid: mondoo-azure-security-mysql-server-infrastructure-encryption-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["infrastructureEncryption"] == "Enabled"
       )
   - uid: mondoo-azure-security-mysql-server-firewall-no-public-ingress-azure
     filters: |
@@ -22941,6 +24465,13 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_mysql_firewall_rule").all(
         values['start_ip_address'] != "0.0.0.0" || values['end_ip_address'] != "255.255.255.255"
+      )
+  - uid: mondoo-azure-security-mysql-server-firewall-no-public-ingress-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers/firewallRules")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0" ||
+        properties["endIpAddress"] != "255.255.255.255"
       )
   - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-azure
     filters: |
@@ -22973,6 +24504,12 @@ queries:
         values['authentication'].all(
           _['password_auth_enabled'] == false
         )
+      )
+  - uid: mondoo-azure-security-postgresql-flexible-server-password-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        properties["authConfig"]["passwordAuth"] == "Disabled"
       )
   - uid: mondoo-azure-security-aks-node-resource-group-restricted
     title: Ensure AKS node resource group access is restricted
@@ -23008,6 +24545,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-node-resource-group-restricted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters have node resource group access restricted to read-only, preventing direct modification of managed infrastructure resources in the node resource group. By default, AKS places no restriction on the node resource group, leaving NICs, load balancers, disks, and public IPs writable to anyone with Azure Contributor access to that resource group.
@@ -23125,6 +24666,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values['node_resource_group_profile'] != empty &&
         values['node_resource_group_profile'].all(_['restrictions'] == "ReadOnly")
+      )
+  - uid: mondoo-azure-security-aks-node-resource-group-restricted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["nodeResourceGroupProfile"]["restrictionLevel"] == "ReadOnly"
       )
   # No Terraform variants: WireGuard transit encryption for AKS is controlled by the
   # advancedNetworking.transitEncryptionType property, which the azurerm_kubernetes_cluster
@@ -23270,6 +24817,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-aks-etcd-kms-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that AKS clusters have Azure Key Vault KMS encryption configured for etcd, providing envelope encryption for Kubernetes secrets at rest.
@@ -23383,6 +24934,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_kubernetes_cluster").all(
         values['azure_key_vault_kms'] != empty
+      )
+  - uid: mondoo-azure-security-aks-etcd-kms-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerService/managedClusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerService/managedClusters").all(
+        properties["securityProfile"]["azureKeyVaultKms"]["enabled"] == true
       )
   # No Terraform variants: SSH availability on Linux App Service is determined by the
   # container image (whether the image bundles an SSH daemon) rather than by a property on
@@ -23517,6 +25074,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service instances have public network access disabled, requiring all traffic to flow through private endpoints or VNet integration.
@@ -23623,6 +25184,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_linux_web_app" || type == "azurerm_windows_web_app").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-app-service-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-app-service-scm-min-tls
     title: Ensure App Service SCM endpoint uses TLS 1.2+
     impact: 70
@@ -23657,6 +25224,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-scm-min-tls-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the SCM (Kudu) endpoint for Azure App Service uses TLS 1.2 or higher, preventing credential interception during deployment operations.
@@ -23768,6 +25339,12 @@ queries:
         values['site_config'] != empty &&
         values['site_config'].all(_['scm_minimum_tls_version'] == "1.2")
       )
+  - uid: mondoo-azure-security-app-service-scm-min-tls-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["scmMinTlsVersion"] == "1.2"
+      )
   - uid: mondoo-azure-security-app-service-vnet-route-all
     title: Ensure App Service routes all traffic through VNet
     impact: 80
@@ -23802,6 +25379,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-vnet-route-all-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service instances route all outbound traffic through VNet integration, subjecting it to network security controls such as NSGs and Azure Firewall.
@@ -23917,6 +25498,12 @@ queries:
         values['site_config'] != empty &&
         values['site_config'].all(_['vnet_route_all_enabled'] == true)
       )
+  - uid: mondoo-azure-security-app-service-vnet-route-all-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["vnetRouteAllEnabled"] == true
+      )
   - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny
     title: Ensure App Service IP restrictions default to deny
     impact: 80
@@ -23951,6 +25538,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Service instances have IP restriction default action set to deny, blocking traffic from any IP address that is not explicitly allowed.
@@ -24078,6 +25669,12 @@ queries:
           values['site_config'].all(_['ip_restriction_default_action'] == "Deny")
         )
       }
+  - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config").all(
+        properties["ipSecurityRestrictionsDefaultAction"] == "Deny"
+      )
   - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-azure
     filters: |
       asset.platform == "azure-appsite"
@@ -24117,6 +25714,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage accounts use customer-managed keys (CMK) for encryption, providing key lifecycle control beyond the default Microsoft-managed encryption.
@@ -24249,6 +25850,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_account").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-storage-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts").all(
+        properties["encryption"]["keySource"] == /Microsoft.Keyvault/i
+      )
   - uid: mondoo-azure-security-sql-ad-only-authentication
     title: Ensure SQL Server uses Azure AD-only authentication
     impact: 80
@@ -24283,6 +25890,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-ad-only-authentication-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL Server is configured with Microsoft Entra ID (formerly Azure AD) only authentication, disabling SQL authentication entirely.
@@ -24399,6 +26010,12 @@ queries:
         values['azuread_administrator'] != empty &&
         values['azuread_administrator'].all(_['azuread_authentication_only'] == true)
       )
+  - uid: mondoo-azure-security-sql-ad-only-authentication-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers").all(
+        properties["administrators"]["azureADOnlyAuthentication"] == true
+      )
   - uid: mondoo-azure-security-sql-tde-cmk-encryption
     title: Ensure SQL Server TDE uses customer-managed keys
     impact: 70
@@ -24433,6 +26050,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-tde-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL Server Transparent Data Encryption (TDE) uses customer-managed keys stored in Azure Key Vault, providing key lifecycle control for data-at-rest encryption.
@@ -24536,6 +26157,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mssql_server_transparent_data_encryption").all(
         values['key_vault_key_id'] != empty
       )
+  - uid: mondoo-azure-security-sql-tde-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/encryptionProtector")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/encryptionProtector").all(
+        properties["serverKeyType"] == "AzureKeyVault"
+      )
   - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption
     title: Ensure PostgreSQL Flexible Server uses CMK encryption
     impact: 70
@@ -24570,6 +26197,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL Flexible Server uses customer-managed keys for data encryption, providing customer-controlled encryption for data at rest. By default, Azure manages encryption with service-managed keys for PostgreSQL Flexible Server, but customer-managed keys provide additional control over the encryption lifecycle.
@@ -24686,6 +26317,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        properties["dataEncryption"]["type"] == "AzureKeyVault"
+      )
   - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-azure
     filters: |
       asset.platform == "azure-postgresql-flexible-server"
@@ -24725,6 +26362,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-flexible-geo-backup-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for PostgreSQL Flexible Server has geo-redundant backup enabled. By default, backups may be stored only in the primary region; enabling geo-redundancy replicates backups to an Azure paired region, ensuring recovery remains possible even if the primary region is unavailable or compromised.
@@ -24838,6 +26479,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server").all(
         values['geo_redundant_backup_enabled'] == true
       )
+  - uid: mondoo-azure-security-postgresql-flexible-geo-backup-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers").all(
+        properties["backup"]["geoRedundantBackup"] == "Enabled"
+      )
   - uid: mondoo-azure-security-mysql-flexible-cmk-encryption
     title: Ensure MySQL Flexible Server uses CMK encryption
     impact: 70
@@ -24872,6 +26519,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL Flexible Server uses customer-managed keys for data encryption, providing customer-controlled encryption for data at rest. By default, Azure manages encryption with service-managed keys for MySQL Flexible Server, but customer-managed keys provide additional control over the encryption lifecycle.
@@ -24991,6 +26642,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_flexible_server").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers").all(
+        properties["dataEncryption"]["type"] == "AzureKeyVault"
+      )
   - uid: mondoo-azure-security-mysql-flexible-cmk-encryption-azure
     filters: |
       asset.platform == "azure-mysql-flexible-server"
@@ -25030,6 +26687,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-redis-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cache for Redis uses customer-managed keys for encryption, providing key lifecycle control for cached data at rest.
@@ -25177,6 +26838,12 @@ queries:
         values['redis_configuration'] != empty &&
         values['redis_configuration'].all(_['customer_managed_key_id'] != empty)
       )
+  - uid: mondoo-azure-security-redis-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cache/redis")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cache/redis").all(
+        properties["redisConfiguration"]["customer-managed-key-encryption"] != empty
+      )
   - uid: mondoo-azure-security-appgw-min-tls-version
     title: Ensure Application Gateway enforces TLS 1.2+
     impact: 80
@@ -25211,6 +26878,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-min-tls-version-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all Azure Application Gateways enforce TLS 1.2 or higher as the minimum protocol version for SSL connections.
@@ -25335,6 +27006,13 @@ queries:
         values['ssl_policy'] != empty &&
         values['ssl_policy'].all(_['min_protocol_version'] == "TLSv1_2" || _['min_protocol_version'] == "TLSv1_3")
       )
+  - uid: mondoo-azure-security-appgw-min-tls-version-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_2" ||
+        properties["sslPolicy"]["minProtocolVersion"] == "TLSv1_3"
+      )
   - uid: mondoo-azure-security-appgw-no-weak-ciphers
     title: Ensure Application Gateway has no weak SSL ciphers
     impact: 80
@@ -25369,6 +27047,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-no-weak-ciphers-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Application Gateways do not use weak SSL cipher suites such as RC4, 3DES, NULL, or EXPORT ciphers that allow decryption of intercepted traffic.
@@ -25497,6 +27179,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_application_gateway").all(
         values['ssl_policy'] != empty
       )
+  - uid: mondoo-azure-security-appgw-no-weak-ciphers-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["sslPolicy"] != empty
+      )
   - uid: mondoo-azure-security-appgw-no-weak-ciphers-azure
     filters: asset.platform == "azure-application-gateway"
     mql: |
@@ -25535,6 +27223,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-public-ip-ddos-protection-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all Azure public IP addresses have DDoS protection enabled, either through a DDoS Protection plan or inherited from the virtual network. By default, Azure provides only basic infrastructure-level DDoS protection; Standard DDoS Protection must be explicitly enabled to gain adaptive tuning, telemetry, and attack mitigation.
@@ -25658,6 +27350,13 @@ queries:
         values['ddos_protection_mode'] == "Enabled" ||
         values['ddos_protection_mode'] == "VirtualNetworkInherited"
       )
+  - uid: mondoo-azure-security-public-ip-ddos-protection-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/publicIPAddresses")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/publicIPAddresses").all(
+        properties["ddosSettings"]["protectionMode"] == "Enabled" ||
+        properties["ddosSettings"]["protectionMode"] == "VirtualNetworkInherited"
+      )
   - uid: mondoo-azure-security-public-ip-ddos-protection-azure
     filters: |
       asset.platform == "azure"
@@ -25699,6 +27398,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-nsg-no-unrestricted-egress-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that network security group rules do not allow unrestricted outbound traffic to the internet on all ports and protocols. Unrestricted egress rules allow compromised resources to exfiltrate data, establish command-and-control channels, or participate in attacks against external targets without network-level controls.
@@ -25869,6 +27572,18 @@ queries:
         values['destination_address_prefix'] == "*" &&
         values['destination_port_range'] == "*"
       )
+  - uid: mondoo-azure-security-nsg-no-unrestricted-egress-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Outbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["protocol"] == "*" &&
+          _["properties"]["destinationAddressPrefix"] == "*" &&
+          _["properties"]["destinationPortRange"] == "*"
+        )
+      )
   - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled
     title: Ensure network interface IP forwarding is disabled
     impact: 50
@@ -25903,6 +27618,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure network interfaces do not have IP forwarding enabled unless explicitly required. IP forwarding allows a network interface to send and receive traffic not destined for its own IP address, which is typically only needed for network virtual appliances (firewalls, load balancers).
@@ -26025,6 +27744,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_network_interface").all(
         values['enable_ip_forwarding'] != true
       )
+  - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkInterfaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkInterfaces").all(
+        properties["enableIPForwarding"] != true
+      )
   - uid: mondoo-azure-security-nsg-sensitive-ports-restricted
     title: Ensure sensitive ports are not exposed to the entire network
     impact: 80
@@ -26059,6 +27784,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that network security groups do not expose sensitive management and database ports (Telnet/23, SMB/445, RPC/135, MSSQL/1433, MySQL/3306, PostgreSQL/5432) to the internet. The check identifies inbound allow rules with a source of `*` or `Internet`, which permit traffic from any internet source to reach these sensitive ports.
@@ -26236,6 +27965,17 @@ queries:
         values['destination_port_range'] == "3306" ||
         values['destination_port_range'] == "5432"
       )
+  - uid: mondoo-azure-security-nsg-sensitive-ports-restricted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/networkSecurityGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/networkSecurityGroups").all(
+        properties["securityRules"].none(
+          _["properties"]["direction"] == "Inbound" &&
+          _["properties"]["access"] == "Allow" &&
+          _["properties"]["sourceAddressPrefix"] == "*" &&
+          _["properties"]["destinationPortRange"] == /^(\*|23|135|445|1433|3306|5432)$/
+        )
+      )
   - uid: mondoo-azure-security-compute-vm-password-auth-disabled
     title: Ensure password authentication is disabled on Linux VMs
     impact: 70
@@ -26270,6 +28010,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-vm-password-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Linux virtual machines have password authentication disabled in favor of SSH key-based authentication. Password authentication is vulnerable to brute-force attacks, credential stuffing, and password spraying.
@@ -26405,6 +28149,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_linux_virtual_machine").all(
         values['disable_password_authentication'] == true
       )
+  - uid: mondoo-azure-security-compute-vm-password-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["osProfile"]["linuxConfiguration"] == empty ||
+        properties["osProfile"]["linuxConfiguration"]["disablePasswordAuthentication"] == true
+      )
   - uid: mondoo-azure-security-postgresql-log-connections-enabled
     title: Ensure PostgreSQL 'log_connections' is enabled
     impact: 60
@@ -26439,6 +28190,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-log-connections-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `log_connections` server parameter is set to `ON` for Azure Database for PostgreSQL. By default, this parameter may be off; enabling it causes every attempted connection to be logged, including successful and failed authentication attempts, providing visibility into who is accessing the database.
@@ -26549,6 +28304,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server_configuration" && values['name'] == "log_connections").all(
         values['value'] == "on"
       )
+  - uid: mondoo-azure-security-postgresql-log-connections-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "log_connections")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "log_connections").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled
     title: Ensure PostgreSQL 'log_checkpoints' is enabled
     impact: 60
@@ -26583,6 +28344,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `log_checkpoints` server parameter is set to `ON` for Azure Database for PostgreSQL. By default, this parameter may be off; enabling it records when database checkpoints occur, providing insight into write patterns that can reveal attacker activity or anomalous data modification.
@@ -26693,6 +28458,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server_configuration" && values['name'] == "log_checkpoints").all(
         values['value'] == "on"
       )
+  - uid: mondoo-azure-security-postgresql-log-checkpoints-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "log_checkpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "log_checkpoints").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-postgresql-connection-throttling-enabled
     title: Ensure PostgreSQL 'connection_throttling' is enabled
     impact: 60
@@ -26727,6 +28498,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the `connection_throttle.enable` server parameter is set to `ON` for Azure Database for PostgreSQL Flexible Server. By default, this parameter may be off; enabling it causes the server to temporarily block connections from IP addresses that accumulate too many failed login attempts, providing built-in protection against brute-force attacks.
@@ -26837,6 +28612,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server_configuration" && values['name'] == "connection_throttle.enable").all(
         values['value'] == "on"
       )
+  - uid: mondoo-azure-security-postgresql-connection-throttling-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "connection_throttle.enable")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforPostgreSQL/flexibleServers/configurations" && name == "connection_throttle.enable").all(
+        properties["value"] == /^on$/i
+      )
   - uid: mondoo-azure-security-sql-audit-retention-90-days
     title: Ensure SQL audit log retention is at least 90 days
     impact: 60
@@ -26871,6 +28652,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-audit-retention-90-days-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL Server audit log retention is configured for at least 90 days. By default, Azure SQL auditing retention is set to 0 days (unlimited) when using Storage as the destination, but this can be changed by administrators. Shorter retention windows destroy evidence before threats are typically detected.
@@ -26983,6 +28768,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_mssql_server_extended_auditing_policy").all(
         values['retention_in_days'] >= 90 || values['retention_in_days'] == 0
       )
+  - uid: mondoo-azure-security-sql-audit-retention-90-days-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/auditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/auditingSettings").all(
+        properties["retentionDays"] >= 90 ||
+        properties["retentionDays"] == 0
+      )
   - uid: mondoo-azure-security-sql-threat-alert-emails-configured
     title: Ensure SQL threat alert email addresses are configured
     impact: 50
@@ -27017,6 +28809,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-threat-alert-emails-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that at least one email address is configured to receive SQL threat detection alerts. Without notification recipients, threat detection alerts are generated but never seen by security teams, making detection functionally equivalent to no detection at all.
@@ -27134,6 +28930,13 @@ queries:
         values['state'] == "Enabled" &&
         values['email_addresses'] != empty
       )
+  - uid: mondoo-azure-security-sql-threat-alert-emails-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/securityAlertPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/securityAlertPolicies").all(
+        properties["state"] == "Enabled" &&
+        properties["emailAddresses"] != empty
+      )
   - uid: mondoo-azure-security-sql-threat-detection-types-configured
     title: Ensure SQL threat detection types are configured
     impact: 60
@@ -27168,6 +28971,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-threat-detection-types-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that all SQL threat detection alert types are enabled and none have been disabled. Azure SQL threat detection monitors for SQL injection, SQL injection vulnerabilities, anomalous client login, access from unusual locations, and other threat patterns. By default all detection types are active; administrators can selectively disable specific categories.
@@ -27281,6 +29088,13 @@ queries:
         values['state'] == "Enabled" &&
         values['disabled_alerts'] == empty
       )
+  - uid: mondoo-azure-security-sql-threat-detection-types-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/securityAlertPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/securityAlertPolicies").all(
+        properties["state"] == "Enabled" &&
+        properties["disabledAlerts"] == empty
+      )
   - uid: mondoo-azure-security-activity-log-retention-365-days
     title: Ensure activity log retention is at least 365 days
     impact: 60
@@ -27315,6 +29129,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-activity-log-retention-365-days-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles retain activity logs for at least 365 days. Activity logs record control plane operations across the subscription and are critical for long-term security investigations and compliance audits. By default, Azure Monitor log profiles retain logs for only 90 days, which is insufficient for most regulatory and forensic requirements.
@@ -27453,6 +29271,14 @@ queries:
         values['retention_policy'][0]['enabled'] == true &&
         values['retention_policy'][0]['days'] >= 365 || values['retention_policy'][0]['days'] == 0
       )
+  - uid: mondoo-azure-security-activity-log-retention-365-days-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/logprofiles")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/logprofiles").all(
+        properties["retentionPolicy"]["enabled"] == true &&
+        properties["retentionPolicy"]["days"] >= 365 ||
+        properties["retentionPolicy"]["days"] == 0
+      )
   - uid: mondoo-azure-security-log-profile-all-locations
     title: Ensure activity logs capture events from all locations
     impact: 50
@@ -27487,6 +29313,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-profile-all-locations-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles capture activity log events from all Azure locations, including the special `global` location. By default, a log profile may be configured to capture only selected regions; omitting any location creates blind spots where management-plane operations go unlogged.
@@ -27624,6 +29454,12 @@ queries:
         values['locations'] != empty &&
         values['locations'].contains("global")
       )
+  - uid: mondoo-azure-security-log-profile-all-locations-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/logprofiles")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/logprofiles").all(
+        properties["locations"].any(_ == "global")
+      )
   - uid: mondoo-azure-security-log-profile-all-categories
     title: Ensure log profile captures all activity categories
     impact: 50
@@ -27658,6 +29494,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-profile-all-categories-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Monitor log profiles capture all activity log categories: Write, Delete, and Action. Missing any category creates blind spots in the audit trail where management-plane operations go unrecorded. Modern diagnostic settings capture all categories by default; legacy log profiles require explicit category selection.
@@ -27798,6 +29638,14 @@ queries:
         values['categories'].contains("Delete") &&
         values['categories'].contains("Action")
       )
+  - uid: mondoo-azure-security-log-profile-all-categories-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Insights/logprofiles")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Insights/logprofiles").all(
+        properties["categories"].any(_ == "Write") &&
+        properties["categories"].any(_ == "Delete") &&
+        properties["categories"].any(_ == "Action")
+      )
   - uid: mondoo-azure-security-security-contact-emails-configured
     title: Ensure security contact notification emails are configured
     impact: 60
@@ -27832,6 +29680,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-security-contact-emails-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that at least one security contact has email addresses configured for receiving security alert notifications. Without configured email recipients, Defender for Cloud alerts are visible only in the portal, which may not be actively monitored.
@@ -27944,6 +29796,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_security_center_contact").all(
         values['email'] != empty
       )
+  - uid: mondoo-azure-security-security-contact-emails-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/securityContacts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/securityContacts").all(
+        properties["emails"] != empty
+      )
   - uid: mondoo-azure-security-security-contact-enabled
     title: Ensure security contacts are enabled and active
     impact: 70
@@ -27978,6 +29836,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-security-contact-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that at least one security contact is enabled in Microsoft Defender for Cloud. A disabled security contact means no one receives notifications about security findings, even if email addresses are configured.
@@ -28090,6 +29952,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_security_center_contact").all(
         values['alert_notifications'] == true
       )
+  - uid: mondoo-azure-security-security-contact-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/securityContacts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Security/securityContacts").all(
+        properties["alertNotifications"]["state"] == "On"
+      )
   - uid: mondoo-azure-security-rbac-custom-roles-least-privilege
     title: Ensure custom RBAC roles use least privilege actions
     impact: 50
@@ -28124,6 +29992,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that custom RBAC role definitions do not grant wildcard (`*`) action permissions. Custom roles with `*` actions provide the same effective access as the built-in Owner or Contributor roles, defeating the purpose of creating a scoped custom role.
@@ -28268,6 +30140,12 @@ queries:
         values['permissions'] != empty &&
         values['permissions'].all(_['actions'].none(_ == "*"))
       )
+  - uid: mondoo-azure-security-rbac-custom-roles-least-privilege-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Authorization/roleDefinitions")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Authorization/roleDefinitions").all(
+        properties["permissions"].all(_["actions"].none(_ == "*"))
+      )
   - uid: mondoo-azure-security-rbac-no-custom-role-creation
     title: Ensure custom roles do not allow role creation
     impact: 60
@@ -28302,6 +30180,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-rbac-no-custom-role-creation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that custom RBAC role definitions do not include the `Microsoft.Authorization/roleDefinitions/write` permission, which allows creating new custom roles. Granting this permission enables privilege escalation by allowing users to define roles with arbitrary permissions and assign them to any principal.
@@ -28444,6 +30326,15 @@ queries:
       terraform.state.resources.where(type == "azurerm_role_definition").all(
         values['permissions'] != empty &&
         values['permissions'].all(_['actions'].none(_ == "Microsoft.Authorization/roleDefinitions/write"))
+      )
+  # No Bicep variant: Storage queue logging (queue_properties.logging) is classic Storage Analytics configured via the data plane; there is no Microsoft.Storage ARM resource property to assert in Bicep source.
+  - uid: mondoo-azure-security-rbac-no-custom-role-creation-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Authorization/roleDefinitions")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Authorization/roleDefinitions").all(
+        properties["permissions"].all(
+          _["actions"].none(_ == "Microsoft.Authorization/roleDefinitions/write")
+        )
       )
   - uid: mondoo-azure-security-storage-queue-logging-enabled
     title: Ensure Queue Services logging is enabled for storage
@@ -28646,6 +30537,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-datafactory-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Data Factory instances have public network access disabled.
@@ -28756,6 +30651,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_data_factory").all(
         values.public_network_access_enabled == false
       )
+  - uid: mondoo-azure-security-datafactory-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DataFactory/factories")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DataFactory/factories").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-datafactory-cmk-encryption
     title: Ensure Data Factory uses customer-managed key encryption
     impact: 70
@@ -28790,6 +30691,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-datafactory-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Data Factory instances are configured with customer-managed key (CMK) encryption.
@@ -28920,6 +30825,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_data_factory").all(
         values['customer_managed_key_id'] != empty
       )
+  - uid: mondoo-azure-security-datafactory-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DataFactory/factories")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DataFactory/factories").all(
+        properties["encryption"] != empty
+      )
   - uid: mondoo-azure-security-datafactory-managed-identity
     title: Ensure Data Factory uses managed identity
     impact: 70
@@ -28954,6 +30865,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-datafactory-managed-identity-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Data Factory instances are configured with a managed identity.
@@ -29068,6 +30983,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_data_factory").all(
         values['identity'] != empty
       )
+  - uid: mondoo-azure-security-datafactory-managed-identity-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DataFactory/factories")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DataFactory/factories").all(
+        body["identity"] != empty
+      )
   - uid: mondoo-azure-security-synapse-public-access-disabled
     title: Ensure Synapse Analytics disables public network access
     impact: 80
@@ -29102,6 +31023,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces have public network access disabled.
@@ -29225,6 +31150,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_synapse_workspace").all(
         values.public_network_access_enabled == false
       )
+  - uid: mondoo-azure-security-synapse-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-synapse-managed-vnet
     title: Ensure Synapse Analytics uses managed virtual network
     impact: 80
@@ -29259,6 +31190,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-managed-vnet-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured with a managed virtual network.
@@ -29385,6 +31320,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_synapse_workspace").all(
         values.managed_virtual_network_enabled == true
       )
+  - uid: mondoo-azure-security-synapse-managed-vnet-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        properties["managedVirtualNetwork"] == "default"
+      )
   - uid: mondoo-azure-security-synapse-aad-only-auth
     title: Ensure Synapse uses Azure AD-only authentication
     impact: 80
@@ -29419,6 +31360,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-aad-only-auth-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured to use Azure Active Directory (Azure AD) only authentication, disabling local SQL authentication.
@@ -29554,6 +31499,12 @@ queries:
         values['aad_admin'] != empty &&
         values['sql_aad_authentication_only'] == true
       )
+  - uid: mondoo-azure-security-synapse-aad-only-auth-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        properties["azureADOnlyAuthentication"] == true
+      )
   - uid: mondoo-azure-security-synapse-cmk-encryption
     title: Ensure Synapse uses customer-managed key encryption
     impact: 70
@@ -29588,6 +31539,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Synapse Analytics workspaces are configured with customer-managed key (CMK) encryption.
@@ -29727,6 +31682,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_synapse_workspace").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-synapse-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        properties["encryption"]["cmk"] != empty
+      )
   - uid: mondoo-azure-security-acr-admin-user-disabled
     title: Ensure ACR admin user is disabled
     impact: 80
@@ -29761,6 +31722,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-admin-user-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the admin user account is disabled on Azure Container Registry instances. The admin account provides unrestricted push and pull access using a shared username and password, which cannot be individually tracked or audited.
@@ -29861,6 +31826,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['admin_enabled'] == false || values['admin_enabled'] == null
       )
+  - uid: mondoo-azure-security-acr-admin-user-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["adminUserEnabled"] != true
+      )
   - uid: mondoo-azure-security-acr-public-access-disabled
     title: Ensure ACR public network access is disabled
     impact: 80
@@ -29895,6 +31866,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Container Registry instances. Disabling public access forces all registry traffic through private endpoints, preventing unauthorized access from the internet.
@@ -29995,6 +31970,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-acr-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-acr-content-trust-enabled
     title: Ensure ACR content trust is enabled
     impact: 70
@@ -30029,6 +32010,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-content-trust-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that content trust (image signing via Docker Notary) is enabled on Azure Container Registry instances. Content trust allows image publishers to sign images and image consumers to verify that pulled images have not been tampered with.
@@ -30127,6 +32112,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['trust_policy_enabled'] == true
       )
+  - uid: mondoo-azure-security-acr-content-trust-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["policies"]["trustPolicy"]["status"] == "enabled"
+      )
   - uid: mondoo-azure-security-acr-cmk-encryption
     title: Ensure ACR uses customer-managed key encryption
     impact: 70
@@ -30161,6 +32152,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Container Registry instances use customer-managed keys (CMK) for encryption at rest. By default, ACR uses Microsoft-managed keys, but CMK provides additional control over key lifecycle and access policies.
@@ -30297,6 +32292,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['encryption'] != empty
       )
+  - uid: mondoo-azure-security-acr-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["encryption"] != empty
+      )
   - uid: mondoo-azure-security-acr-network-default-deny
     title: Ensure ACR network rule default action is Deny
     impact: 80
@@ -30331,6 +32332,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-network-default-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the network rule set default action is set to Deny for Azure Container Registry instances. A default Deny action blocks all network access except explicitly allowed IP ranges and virtual networks.
@@ -30442,6 +32447,12 @@ queries:
         values['network_rule_set'] != empty &&
         values['network_rule_set'].all(_['default_action'] == "Deny")
       )
+  - uid: mondoo-azure-security-acr-network-default-deny-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["networkRuleSet"]["defaultAction"] == "Deny"
+      )
   - uid: mondoo-azure-security-acr-private-endpoints
     title: Ensure ACR has private endpoint connections configured
     impact: 70
@@ -30476,6 +32487,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Container Registry instances have at least one private endpoint connection configured. Private endpoints enable secure access through private network connectivity using Azure Private Link.
@@ -30612,6 +32627,14 @@ queries:
           _['subresource_names'].any(_ == "registry")
         )
       )
+  - uid: mondoo-azure-security-acr-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "registry")
+        )
+      )
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled
     title: Ensure ACR quarantine policy is enabled
     impact: 60
@@ -30646,6 +32669,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-quarantine-policy-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the quarantine policy is enabled on Azure Container Registry instances. When enabled, newly pushed images are quarantined by default and are not available for pull until they have been validated and approved.
@@ -30763,6 +32790,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['quarantine_policy_enabled'] == true
       )
+  - uid: mondoo-azure-security-acr-quarantine-policy-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["policies"]["quarantinePolicy"]["status"] == "enabled"
+      )
   - uid: mondoo-azure-security-acr-export-policy-disabled
     title: Ensure ACR export policy is disabled
     impact: 70
@@ -30797,6 +32830,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-export-policy-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the export policy is disabled on Azure Container Registry instances. Disabling the export policy prevents images from being exported out of the registry, reducing the risk of data exfiltration.
@@ -30919,6 +32956,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['export_policy_enabled'] == false
       )
+  - uid: mondoo-azure-security-acr-export-policy-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["policies"]["exportPolicy"]["status"] == "disabled"
+      )
   - uid: mondoo-azure-security-acr-retention-policy-enabled
     title: Ensure ACR retention policy is enabled
     impact: 50
@@ -30953,6 +32996,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-retention-policy-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that the retention policy is enabled on Azure Container Registry instances. A retention policy automatically removes untagged manifests after a configured number of days, reducing the attack surface from accumulated vulnerable images.
@@ -31072,6 +33119,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_container_registry").all(
         values['retention_policy_in_days'] != null && values['retention_policy_in_days'] > 0
       )
+  - uid: mondoo-azure-security-acr-retention-policy-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["policies"]["retentionPolicy"]["status"] == "enabled" &&
+        properties["policies"]["retentionPolicy"]["days"] > 0
+      )
   - uid: mondoo-azure-security-acr-encryption-key-rotation
     title: Ensure ACR encryption key auto-rotation is enabled
     impact: 60
@@ -31106,6 +33160,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-acr-encryption-key-rotation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Container Registry instances with customer-managed key encryption have automatic key rotation enabled. Key rotation ensures that encryption keys are periodically updated, limiting the impact of a compromised key.
@@ -31246,6 +33304,13 @@ queries:
           _['key_vault_key_id'] == /^https:\/\/[^\/]+\/keys\/[^\/]+\/?$/
         )
       )
+  - uid: mondoo-azure-security-acr-encryption-key-rotation-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerRegistry/registries")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerRegistry/registries").all(
+        properties["encryption"] == empty ||
+        properties["encryption"]["keyVaultProperties"]["keyIdentifier"] == /\/keys\/[^\/]+\/?$/
+      )
   - uid: mondoo-azure-security-storage-encryption-scope-cmk
     title: Ensure storage encryption scopes use customer-managed keys
     impact: 70
@@ -31280,6 +33345,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-encryption-scope-cmk-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage account encryption scopes use customer-managed keys (CMK) stored in Azure Key Vault. Encryption scopes allow different containers within the same storage account to use different encryption keys, and using CMK provides organizational control over key lifecycle.
@@ -31398,6 +33467,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_encryption_scope").all(
         values['source'] == "Microsoft.KeyVault"
       )
+  - uid: mondoo-azure-security-storage-encryption-scope-cmk-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/encryptionScopes")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/encryptionScopes").all(
+        properties["source"] == "Microsoft.KeyVault"
+      )
   - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption
     title: Ensure storage encryption scopes require infra encryption
     impact: 60
@@ -31432,6 +33507,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Storage encryption scopes have infrastructure encryption enabled. Infrastructure encryption adds a second layer of encryption at the storage infrastructure level using a different algorithm, providing double encryption for defense in depth.
@@ -31534,6 +33613,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_storage_encryption_scope").all(
         values['infrastructure_encryption_required'] == true
       )
+  - uid: mondoo-azure-security-storage-encryption-scope-infra-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/encryptionScopes")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/encryptionScopes").all(
+        properties["requireInfrastructureEncryption"] == true
+      )
   - uid: mondoo-azure-security-compute-disk-encryption-set-cmk
     title: Ensure disk encryption sets use customer-managed keys
     impact: 70
@@ -31568,6 +33653,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-disk-encryption-set-cmk-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure disk encryption sets are configured to use customer-managed keys (CMK) for encrypting managed disks. Disk encryption sets centralize key management for multiple managed disks using a single Azure Key Vault key.
@@ -31685,6 +33774,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_disk_encryption_set").all(
         values['key_vault_key_id'] != empty
       )
+  - uid: mondoo-azure-security-compute-disk-encryption-set-cmk-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/diskEncryptionSets")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/diskEncryptionSets").all(
+        properties["activeKey"]["keyUrl"] != empty
+      )
   - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation
     title: Ensure disk encryption sets have auto key rotation enabled
     impact: 60
@@ -31719,6 +33814,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure disk encryption sets have automatic key rotation enabled. When enabled, the disk encryption set automatically updates all managed disks, snapshots, and images associated with it to use the new key version within one hour.
@@ -31828,6 +33927,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_disk_encryption_set").all(
         values['auto_key_rotation_enabled'] == true
       )
+  - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/diskEncryptionSets")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/diskEncryptionSets").all(
+        properties["rotationToLatestKeyVersionEnabled"] == true
+      )
   - uid: mondoo-azure-security-managed-hsm-soft-delete
     title: Ensure Managed HSM has soft delete enabled
     impact: 80
@@ -31862,6 +33967,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Managed HSM instances have soft delete enabled. Soft delete allows recovery of deleted HSM pools and their contents during a configurable retention period, defending against ransomware and insider threat scenarios.
@@ -31970,6 +34079,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
         values['soft_delete_retention_days'] != empty
       )
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs").all(
+        properties["softDeleteRetentionInDays"] != empty
+      )
   - uid: mondoo-azure-security-managed-hsm-purge-protection
     title: Ensure Managed HSM has purge protection enabled
     impact: 80
@@ -32004,6 +34119,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-purge-protection-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Managed HSM instances have purge protection enabled. Purge protection prevents permanent deletion of a soft-deleted HSM until the retention period expires, even by privileged administrators.
@@ -32116,6 +34235,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
         values['purge_protection_enabled'] == true
       )
+  - uid: mondoo-azure-security-managed-hsm-purge-protection-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs").all(
+        properties["enablePurgeProtection"] == true
+      )
   - uid: mondoo-azure-security-managed-hsm-public-access-disabled
     title: Ensure Managed HSM public network access is disabled
     impact: 80
@@ -32150,6 +34275,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Managed HSM instances. Managed HSMs contain the most sensitive cryptographic key material and should only be accessible through private network paths.
@@ -32257,6 +34386,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-managed-hsm-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-managed-hsm-private-endpoints
     title: Ensure Managed HSM has private endpoints configured
     impact: 70
@@ -32291,6 +34426,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Managed HSM instances have at least one private endpoint connection configured. Private endpoints enable secure, private network connectivity to the HSM using Azure Private Link.
@@ -32430,6 +34569,14 @@ queries:
           _['subresource_names'].any(_ == "managedhsm")
         )
       )
+  - uid: mondoo-azure-security-managed-hsm-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "managedhsm")
+        )
+      )
   - uid: mondoo-azure-security-compute-disk-access-private-endpoints
     title: Ensure disk access resources have private endpoints
     impact: 70
@@ -32464,6 +34611,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-disk-access-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure disk access resources have at least one private endpoint connection configured. Disk access resources enable private endpoint connectivity for managed disk import/export operations, ensuring that disk data transfers do not traverse the public internet.
@@ -32617,6 +34768,14 @@ queries:
           _['subresource_names'].any(_ == "disks")
         )
       )
+  - uid: mondoo-azure-security-compute-disk-access-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "disks")
+        )
+      )
   - uid: mondoo-azure-security-log-analytics-local-auth-disabled
     title: Ensure Log Analytics workspaces disable local authentication
     impact: 80
@@ -32651,6 +34810,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-analytics-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that local authentication is disabled on Azure Log Analytics workspaces. When local authentication is enabled, clients can use workspace keys or shared access signatures to authenticate, bypassing Azure AD identity controls and conditional access policies.
@@ -32759,6 +34922,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_log_analytics_workspace").all(
         values['local_authentication_disabled'] == true
       )
+  - uid: mondoo-azure-security-log-analytics-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.OperationalInsights/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.OperationalInsights/workspaces").all(
+        properties["features"]["disableLocalAuth"] == true
+      )
   - uid: mondoo-azure-security-log-analytics-public-ingestion-disabled
     title: Ensure Log Analytics workspaces disable public ingestion
     impact: 80
@@ -32793,6 +34962,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-analytics-public-ingestion-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access for log ingestion is disabled on Azure Log Analytics workspaces. Disabling public ingestion ensures that log data can only be sent to the workspace through private network paths.
@@ -32892,6 +35065,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_log_analytics_workspace").all(
         values['internet_ingestion_enabled'] == false
       )
+  - uid: mondoo-azure-security-log-analytics-public-ingestion-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.OperationalInsights/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.OperationalInsights/workspaces").all(
+        properties["publicNetworkAccessForIngestion"] == "Disabled"
+      )
   - uid: mondoo-azure-security-log-analytics-public-query-disabled
     title: Ensure Log Analytics workspaces disable public query access
     impact: 70
@@ -32926,6 +35105,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-analytics-public-query-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access for queries is disabled on Azure Log Analytics workspaces. Disabling public query access prevents log data from being queried over the public internet.
@@ -33024,6 +35207,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_log_analytics_workspace").all(
         values['internet_query_enabled'] == false
       )
+  - uid: mondoo-azure-security-log-analytics-public-query-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.OperationalInsights/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.OperationalInsights/workspaces").all(
+        properties["publicNetworkAccessForQuery"] == "Disabled"
+      )
   - uid: mondoo-azure-security-log-analytics-cmk-for-query
     title: Ensure Log Analytics workspaces enforce CMK for queries
     impact: 60
@@ -33058,6 +35247,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-analytics-cmk-for-query-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Log Analytics workspaces are configured to enforce customer-managed keys (CMK) for saved queries and query-based log alerts. When enabled, all saved searches and alerts are encrypted with a customer-managed key.
@@ -33160,6 +35353,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_log_analytics_workspace").all(
         values['cmk_for_query_forced'] == true
       )
+  - uid: mondoo-azure-security-log-analytics-cmk-for-query-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.OperationalInsights/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.OperationalInsights/workspaces").all(
+        properties["forceCmkForQuery"] == true
+      )
   - uid: mondoo-azure-security-recovery-vault-soft-delete
     title: Ensure Recovery Services Vaults have soft delete enabled
     impact: 80
@@ -33194,6 +35393,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-soft-delete-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have soft delete enabled. Soft delete retains backup data for 14 additional days after deletion, allowing recovery from accidental or malicious deletion of backup items.
@@ -33301,6 +35504,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_recovery_services_vault").all(
         values['soft_delete_enabled'] != false
       )
+  - uid: mondoo-azure-security-recovery-vault-soft-delete-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["securitySettings"]["softDeleteSettings"]["softDeleteState"] != "Disabled"
+      )
   - uid: mondoo-azure-security-recovery-vault-immutability
     title: Ensure Recovery Services Vaults have immutability enabled
     impact: 80
@@ -33335,6 +35544,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-immutability-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have immutability enabled. Immutable vaults prevent any operation that could lead to loss of backup data, including stopping protection with delete data, reducing retention, and deleting the vault before data expires.
@@ -33440,6 +35653,13 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_recovery_services_vault").all(
         values['immutability'] == "Unlocked" || values['immutability'] == "Locked"
+      )
+  - uid: mondoo-azure-security-recovery-vault-immutability-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["securitySettings"]["immutabilitySettings"]["state"] == "Unlocked" ||
+        properties["securitySettings"]["immutabilitySettings"]["state"] == "Locked"
       )
   # No Terraform variants: azurerm_recovery_services_vault does not expose the
   # securitySettings.enhancedSecurityState property. Enhanced security is controlled via the
@@ -33574,6 +35794,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that public network access is disabled on Azure Recovery Services Vaults. Disabling public access forces all backup and restore traffic through private endpoints.
@@ -33672,6 +35896,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_recovery_services_vault").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-recovery-vault-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-recovery-vault-private-endpoints
     title: Ensure Recovery Services Vaults have private endpoints
     impact: 70
@@ -33706,6 +35936,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-private-endpoints-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have at least one private endpoint connection configured. Private endpoints enable secure, private connectivity for backup and restore operations.
@@ -33841,6 +36075,14 @@ queries:
           _['subresource_names'].any(_ == "AzureBackup")
         )
       )
+  - uid: mondoo-azure-security-recovery-vault-private-endpoints-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateEndpoints").any(
+        properties["privateLinkServiceConnections"].any(
+          _["properties"]["groupIds"].any(_ == "AzureBackup")
+        )
+      )
   - uid: mondoo-azure-security-recovery-vault-cmk-encryption
     title: Ensure Recovery Services Vaults use CMK encryption
     impact: 70
@@ -33875,6 +36117,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults use customer-managed keys (CMK) for encryption with infrastructure encryption enabled. CMK provides control over the encryption keys protecting backup data, while infrastructure encryption adds a second encryption layer.
@@ -34004,6 +36250,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_recovery_services_vault").all(
         values['encryption'] != empty
       )
+  - uid: mondoo-azure-security-recovery-vault-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["encryption"]["infrastructureEncryption"] == "Enabled"
+      )
   - uid: mondoo-azure-security-recovery-vault-job-failure-alerts
     title: Ensure Recovery Services Vaults alert on job failures
     impact: 60
@@ -34038,6 +36290,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have monitoring alerts enabled for all backup job failures. Without alerts, failed backup jobs go unnoticed while attackers prepare destructive operations.
@@ -34150,6 +36406,12 @@ queries:
         values['monitoring'] == empty ||
         values['monitoring'].all(_['alerts_for_all_job_failures_enabled'] != false)
       )
+  - uid: mondoo-azure-security-recovery-vault-job-failure-alerts-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["monitoringSettings"]["azureMonitorAlertSettings"]["alertsForAllJobFailures"] != "Disabled"
+      )
   - uid: mondoo-azure-security-recovery-vault-backup-policies
     title: Ensure Recovery Services Vaults have backup policies
     impact: 60
@@ -34184,6 +36446,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-backup-policies-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have at least one backup policy configured. Backup policies define the schedule, retention, and scope of backup operations.
@@ -34342,6 +36608,12 @@ queries:
         type == "azurerm_backup_policy_vm_workload" ||
         type == "azurerm_backup_policy_file_share"
       ).length > 0
+  - uid: mondoo-azure-security-recovery-vault-backup-policies-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults/backupPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults/backupPolicies").all(
+        properties["backupManagementType"] != empty
+      )
   - uid: mondoo-azure-security-recovery-vault-critical-op-alerts
     title: Ensure Recovery Vaults alert on critical operations
     impact: 70
@@ -34376,6 +36648,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Recovery Services Vaults have monitoring alerts enabled for critical operations such as stopping protection, deleting backup data, and modifying security settings.
@@ -34488,6 +36764,12 @@ queries:
         values['monitoring'] == empty ||
         values['monitoring'].all(_['alerts_for_critical_operation_failures_enabled'] != false)
       )
+  - uid: mondoo-azure-security-recovery-vault-critical-op-alerts-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.RecoveryServices/vaults")
+    mql: |
+      bicep.resources.where(type == "Microsoft.RecoveryServices/vaults").all(
+        properties["monitoringSettings"]["classicAlertSettings"]["alertsForCriticalOperations"] != "Disabled"
+      )
   - uid: mondoo-azure-security-servicebus-local-auth-disabled
     title: Ensure Service Bus namespaces disable local authentication
     impact: 80
@@ -34522,6 +36804,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-servicebus-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that local authentication (shared access signatures and SAS keys) is disabled on Azure Service Bus namespaces, requiring Microsoft Entra ID authentication instead. By default, Azure Service Bus enables local SAS-based authentication, meaning any client with a connection string can authenticate without individual identity accountability.
@@ -34621,6 +36907,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_servicebus_namespace").all(
         values['local_auth_enabled'] == false
       )
+  - uid: mondoo-azure-security-servicebus-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ServiceBus/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ServiceBus/namespaces").all(
+        properties["disableLocalAuth"] == true
+      )
   - uid: mondoo-azure-security-eventhubs-local-auth-disabled
     title: Ensure Event Hubs namespaces disable local authentication
     impact: 80
@@ -34655,6 +36947,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventhubs-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that local authentication using shared access signatures and SAS keys is disabled on Azure Event Hubs namespaces, requiring Microsoft Entra ID authentication instead. By default, Event Hubs namespaces allow SAS key authentication, which creates broad, long-lived credentials that are difficult to scope or rotate safely.
@@ -34755,6 +37051,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_eventhub_namespace").all(
         values['local_auth_enabled'] == false
       )
+  - uid: mondoo-azure-security-eventhubs-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventHub/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventHub/namespaces").all(
+        properties["disableLocalAuth"] == true
+      )
   - uid: mondoo-azure-security-eventhubs-minimum-tls-1-2
     title: Ensure Event Hubs namespaces enforce TLS 1.2 or higher
     impact: 80
@@ -34789,6 +37091,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventhubs-minimum-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Event Hubs namespaces enforce a minimum TLS version of 1.2 for all client connections. TLS 1.0 and 1.1 have known vulnerabilities and are considered deprecated by all major standards bodies. Azure Event Hubs supports TLS 1.2 by default for new namespaces, but older namespaces may still permit TLS 1.0 or 1.1 unless the minimum version is explicitly configured.
@@ -34887,6 +37193,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_eventhub_namespace").all(
         values['minimum_tls_version'] == "1.2"
       )
+  - uid: mondoo-azure-security-eventhubs-minimum-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventHub/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventHub/namespaces").all(
+        properties["minimumTlsVersion"] == "1.2"
+      )
   - uid: mondoo-azure-security-function-app-https-only
     title: Ensure Function Apps enforce HTTPS-only traffic
     impact: 80
@@ -34921,6 +37233,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-https-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function Apps are configured to accept only HTTPS traffic, rejecting any unencrypted HTTP requests. By default, Function Apps can be configured to allow HTTP; explicitly enabling HTTPS-only mode ensures TLS is enforced at the platform level regardless of application logic.
@@ -35019,6 +37335,12 @@ queries:
       terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
         values['https_only'] == true
       )
+  - uid: mondoo-azure-security-function-app-https-only-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["httpsOnly"] == true
+      )
   - uid: mondoo-azure-security-function-app-client-cert-required
     title: Ensure Function Apps require client certificates
     impact: 70
@@ -35053,6 +37375,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-client-cert-required-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function Apps are configured to require client certificates (mutual TLS), adding an authentication layer at the transport level before requests reach application code. By default, Function Apps do not require client certificates; enabling this control ensures that only clients presenting a trusted certificate can invoke the Function App.
@@ -35153,6 +37479,13 @@ queries:
       terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
         values['client_certificate_enabled'] == true && values['client_certificate_mode'] == "Required"
       )
+  - uid: mondoo-azure-security-function-app-client-cert-required-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["clientCertEnabled"] == true &&
+        properties["clientCertMode"] == "Required"
+      )
   - uid: mondoo-azure-security-function-app-managed-identity
     title: Ensure Function Apps use managed identity
     impact: 70
@@ -35187,6 +37520,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-managed-identity-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function Apps have a managed identity assigned, enabling secure, credential-free authentication to other Azure services. By default, Function Apps have no identity assigned and must use stored credentials such as connection strings or API keys to access downstream services; a managed identity replaces those static secrets with automatically rotated, short-lived tokens issued by Azure.
@@ -35289,6 +37626,12 @@ queries:
       terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
         values['identity'] != empty
       )
+  - uid: mondoo-azure-security-function-app-managed-identity-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        body["identity"] != empty
+      )
   - uid: mondoo-azure-security-private-dns-no-auto-registration
     title: Ensure private DNS zones restrict auto-registration
     impact: 50
@@ -35323,6 +37666,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-private-dns-no-auto-registration-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that virtual network links to Azure private DNS zones have auto-registration disabled, preventing virtual machines from automatically registering DNS records in the zone. When auto-registration is enabled, every VM in the linked virtual network creates a DNS entry automatically; disabling it requires DNS records to be created explicitly, maintaining a controlled and auditable internal namespace.
@@ -35423,6 +37770,12 @@ queries:
     mql: |
       terraform.state.resources.where(type == "azurerm_private_dns_zone_virtual_network_link").all(
         values['registration_enabled'] == false || values['registration_enabled'] == null
+      )
+  - uid: mondoo-azure-security-private-dns-no-auto-registration-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/privateDnsZones/virtualNetworkLinks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/privateDnsZones/virtualNetworkLinks").all(
+        properties["registrationEnabled"] != true
       )
   # No Terraform variants: the runtime check enforces httpPort == 0 to confirm HTTP is
   # disabled on the origin, but the azurerm_cdn_frontdoor_origin schema validates http_port
@@ -35557,6 +37910,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-audit-destination-configured-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure SQL Server auditing is enabled and configured to send logs to a retained destination such as an Azure Storage account, or Log Analytics or Event Hub via Azure Monitor. Auditing with no destination produces no useful evidence: events are generated but never persisted for review.
@@ -35662,6 +38019,13 @@ queries:
       terraform.state.resources.where(type == "azurerm_mssql_server_extended_auditing_policy").all(
         values['storage_endpoint'] != null || values['log_monitoring_enabled'] == true
       )
+  - uid: mondoo-azure-security-sql-server-audit-destination-configured-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/auditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/auditingSettings").all(
+        properties["storageEndpoint"] != empty ||
+        properties["isAzureMonitorTargetEnabled"] == true
+      )
   - uid: mondoo-azure-security-sql-database-audit-on
     title: Ensure auditing is enabled for every Azure SQL database
     impact: 60
@@ -35696,6 +38060,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-database-audit-on-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that database-level auditing is enabled on every Azure SQL database. Server-level auditing alone is not sufficient because a database can override the server policy and disable its own auditing, producing a coverage gap that is invisible if you only inspect the server.
@@ -35795,6 +38163,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mssql_database_extended_auditing_policy").all(
         values['enabled'] != false
       )
+  - uid: mondoo-azure-security-sql-database-audit-on-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/databases/auditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/databases/auditingSettings").all(
+        properties["state"] != "Disabled"
+      )
   - uid: mondoo-azure-security-sql-server-devops-auditing-enabled
     title: Ensure DevOps auditing is enabled on Azure SQL Server
     impact: 50
@@ -35829,6 +38203,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-devops-auditing-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that DevOps auditing (also called Microsoft Support operations auditing) is enabled on Azure SQL Server. DevOps auditing logs operations performed by Microsoft support engineers and similar privileged paths that are not captured by the regular database audit policy.
@@ -35925,6 +38303,12 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_mssql_server_microsoft_support_auditing_policy")
     mql: |
       terraform.state.resources.where(type == "azurerm_mssql_server_microsoft_support_auditing_policy").length > 0
+  - uid: mondoo-azure-security-sql-server-devops-auditing-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/devOpsAuditingSettings")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/devOpsAuditingSettings").all(
+        properties["state"] == "Enabled"
+      )
   - uid: mondoo-azure-security-mysql-flexible-geo-backup-cmk
     title: Ensure MySQL Flexible Server geo-redundant backup uses CMK
     impact: 70
@@ -35959,6 +38343,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-flexible-geo-backup-cmk-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Database for MySQL Flexible Server uses a customer-managed key for geo-redundant backups, not just for primary data encryption. The geo-backup key is a separate Key Vault key from the primary CMK; without it, geo-redundant backups fall back to Microsoft-managed encryption even when the primary server is configured with CMK.
@@ -36085,6 +38473,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_mysql_flexible_server").all(
         values['customer_managed_key'] != null && values['customer_managed_key'][0]['geo_backup_key_vault_key_id'] != null
       )
+  - uid: mondoo-azure-security-mysql-flexible-geo-backup-cmk-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/flexibleServers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/flexibleServers").all(
+        properties["dataEncryption"]["geoBackupKeyURI"] != empty
+      )
   - uid: mondoo-azure-security-container-app-https-ingress
     title: Ensure Container Apps enforce HTTPS for ingress traffic
     impact: 80
@@ -36119,6 +38513,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-https-ingress-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Container Apps with ingress enabled redirect all incoming traffic to HTTPS rather than allowing plain HTTP. When the `allowInsecure` flag is set to `true` on the ingress configuration, the platform serves traffic over HTTP, exposing requests, response bodies, and session tokens to network observers without any transport encryption.
@@ -36266,6 +38664,12 @@ queries:
           _['allow_insecure_connections'] == false
         )
       )
+  - uid: mondoo-azure-security-container-app-https-ingress-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        properties["configuration"]["ingress"]["allowInsecure"] != true
+      )
   - uid: mondoo-azure-security-container-app-managed-identity-registries
     title: Ensure Container Apps pull images using managed identity
     impact: 70
@@ -36300,6 +38704,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-managed-identity-registries-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Container Apps that reference one or more private container registries authenticate to those registries using a managed identity rather than embedded credentials stored as Container Apps secrets. When registry credentials are stored as secrets in the Container App configuration, they become long-lived, shareable values that are easy to leak and difficult to rotate across all deployments.
@@ -36460,6 +38868,12 @@ queries:
           _['identity'] != null && _['identity'] != ""
         )
       )
+  - uid: mondoo-azure-security-container-app-managed-identity-registries-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        properties["configuration"]["registries"].all(_["identity"] != empty)
+      )
   - uid: mondoo-azure-security-container-app-image-digest-pinned
     title: Ensure Container Apps pin container images by digest
     impact: 70
@@ -36494,6 +38908,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-image-digest-pinned-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that every container in an Azure Container App references its image by SHA-256 digest, such as `myacr.azurecr.io/app@sha256:abcdef...`, rather than by a mutable tag such as `latest` or `1.0`. Mutable tags can be repointed at a different image at any time, silently changing what code runs in the Container App without any deployment event being recorded.
@@ -36624,6 +39042,12 @@ queries:
           _['container'].all(_['image'].contains("@sha256:"))
         )
       )
+  - uid: mondoo-azure-security-container-app-image-digest-pinned-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        properties["template"]["containers"].all(_["image"] == /@sha256:/)
+      )
   - uid: mondoo-azure-security-container-instance-private-registry
     title: Ensure Container Instances pull images from Azure Container Registry
     impact: 70
@@ -36658,6 +39082,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-instance-private-registry-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that every container in an Azure Container Instance group references an image hosted in a private Azure Container Registry, identified by the `*.azurecr.io/` server prefix, rather than a public registry such as Docker Hub, Quay, or ghcr.io. Pulling from public registries exposes workloads to supply-chain attacks, typo-squatting, and unvetted image updates from external maintainers.
@@ -36832,6 +39260,12 @@ queries:
           _['image'] == /^[A-Za-z0-9.-]+\.azurecr\.io\//
         )
       )
+  - uid: mondoo-azure-security-container-instance-private-registry-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ContainerInstance/containerGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ContainerInstance/containerGroups").all(
+        properties["containers"].all(_["properties"]["image"] == /\.azurecr\.io\//)
+      )
   - uid: mondoo-azure-security-servicebus-namespace-public-network-access-disabled
     title: Ensure Service Bus namespaces disable public network access
     impact: 70
@@ -36866,6 +39300,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-servicebus-namespace-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Service Bus namespaces have public network access disabled, forcing all client traffic through private endpoints or trusted Azure services.
@@ -36971,6 +39409,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_servicebus_namespace").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-servicebus-namespace-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ServiceBus/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ServiceBus/namespaces").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-eventhub-namespace-public-network-access-disabled
     title: Ensure Event Hubs namespaces disable public network access
     impact: 70
@@ -37005,6 +39449,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventhub-namespace-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Event Hubs namespaces have public network access disabled, forcing all producer and consumer traffic through private endpoints or trusted Azure services.
@@ -37110,6 +39558,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_eventhub_namespace").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-eventhub-namespace-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventHub/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventHub/namespaces").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-function-app-public-network-access-disabled
     title: Ensure Function Apps disable public network access
     impact: 70
@@ -37144,6 +39598,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function Apps have public network access disabled, requiring all inbound HTTP traffic to flow through private endpoints or VNet integration.
@@ -37246,6 +39704,12 @@ queries:
       terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-function-app-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   # No runtime variant: cnquery azure provider does not expose Microsoft.Search/searchServices resources. Revisit once the provider adds an azure.subscription.searchService resource.
   - uid: mondoo-azure-security-search-service-public-network-access-disabled
     title: Ensure Azure AI Search services disable public network access
@@ -37277,6 +39741,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-search-service-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure AI Search services have public network access disabled, requiring index and query traffic to flow over private endpoints.
@@ -37372,6 +39840,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_search_service").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-search-service-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Search/searchServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Search/searchServices").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-api-management-internal-vnet-mode
     title: Ensure API Management uses VNet integration
     impact: 70
@@ -37406,6 +39880,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-api-management-internal-vnet-mode-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure API Management services are deployed with virtual network integration in either **Internal** or **External** mode rather than the default **None** mode, which leaves the gateway entirely on the public internet.
@@ -37524,6 +40002,13 @@ queries:
         values['virtual_network_type'] == "Internal" ||
         values['virtual_network_type'] == "External"
       )
+  - uid: mondoo-azure-security-api-management-internal-vnet-mode-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ApiManagement/service")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ApiManagement/service").all(
+        properties["virtualNetworkType"] == "Internal" ||
+        properties["virtualNetworkType"] == "External"
+      )
   # No runtime variant: cnquery azure provider does not expose Microsoft.AppConfiguration/configurationStores resources. Revisit once the provider adds an azure.subscription.appConfiguration resource.
   - uid: mondoo-azure-security-appconfiguration-public-network-access-disabled
     title: Ensure App Configuration stores disable public network access
@@ -37555,6 +40040,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appconfiguration-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Configuration stores have public network access disabled, so configuration keys, feature flags, and Key Vault references can only be read by clients on authorized private networks.
@@ -37650,6 +40139,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_app_configuration").all(
         values['public_network_access'] == "Disabled"
       )
+  - uid: mondoo-azure-security-appconfiguration-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.AppConfiguration/configurationStores")
+    mql: |
+      bicep.resources.where(type == "Microsoft.AppConfiguration/configurationStores").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   # No runtime variant: cnquery azure provider does not expose Microsoft.CognitiveServices/accounts resources. Revisit once the provider adds an azure.subscription.cognitiveServices resource.
   - uid: mondoo-azure-security-cognitive-services-public-network-access-disabled
     title: Ensure Cognitive Services accounts disable public network access
@@ -37681,6 +40176,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Cognitive Services (Azure AI Services) accounts have public network access disabled, so prompt content, model inputs, and embeddings only traverse private endpoints inside an authorized VNet.
@@ -37778,6 +40277,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_cognitive_account").all(
         values['public_network_access_enabled'] == false
       )
+  - uid: mondoo-azure-security-cognitive-services-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.CognitiveServices/accounts").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
   - uid: mondoo-azure-security-application-gateway-no-public-frontend
     title: Ensure Application Gateways have at least one private frontend
     impact: 30
@@ -37812,6 +40317,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-application-gateway-no-public-frontend-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Application Gateways are configured to have at least one private frontend IP configuration attached to a subnet. Gateways with only public frontend configurations expose all listeners to the internet, including those intended to serve only internal or peered-network traffic.
@@ -37969,6 +40478,12 @@ queries:
           _['subnet_id'] != null
         )
       )
+  - uid: mondoo-azure-security-application-gateway-no-public-frontend-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["frontendIPConfigurations"].any(_["properties"]["subnet"] != empty)
+      )
   - uid: mondoo-azure-security-servicebus-namespace-cmk-encryption
     title: Ensure Service Bus namespaces use customer-managed encryption keys
     impact: 60
@@ -38003,6 +40518,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-servicebus-namespace-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Service Bus namespaces encrypt data at rest with customer-managed keys (CMK) stored in Azure Key Vault, rather than relying on platform-managed keys.
@@ -38131,6 +40650,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_servicebus_namespace").all(
         values['customer_managed_key'] != empty
       )
+  - uid: mondoo-azure-security-servicebus-namespace-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ServiceBus/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ServiceBus/namespaces").all(
+        properties["encryption"] != empty
+      )
   - uid: mondoo-azure-security-eventhub-namespace-cmk-encryption
     title: Ensure Event Hubs namespaces use customer-managed encryption keys
     impact: 60
@@ -38165,6 +40690,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventhub-namespace-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Event Hubs namespaces encrypt event payloads at rest with customer-managed keys (CMK) stored in Azure Key Vault, rather than relying on platform-managed keys.
@@ -38293,6 +40822,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_eventhub_namespace_customer_managed_key").all(
         values['key_vault_key_ids'] != empty
       )
+  - uid: mondoo-azure-security-eventhub-namespace-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventHub/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventHub/namespaces").all(
+        properties["encryption"] != empty
+      )
   # No runtime variant: cnquery azure provider does not expose Microsoft.Search/searchServices resources. Revisit once the provider adds an azure.subscription.searchService resource.
   - uid: mondoo-azure-security-search-service-cmk-encryption
     title: Ensure Azure AI Search services enforce customer-managed key encryption
@@ -38324,6 +40859,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-search-service-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure AI Search services enforce customer-managed key (CMK) encryption for indexes and synonym maps, instead of allowing them to fall back to platform-managed keys.
@@ -38424,6 +40963,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_search_service").all(
         values['customer_managed_key_enforcement_enabled'] == true
       )
+  - uid: mondoo-azure-security-search-service-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Search/searchServices")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Search/searchServices").all(
+        properties["encryptionWithCmk"]["enforcement"] == "Enabled"
+      )
   # No runtime variant: cnquery azure provider does not expose Microsoft.AppConfiguration/configurationStores resources. Revisit once the provider adds an azure.subscription.appConfiguration resource.
   - uid: mondoo-azure-security-appconfiguration-cmk-encryption
     title: Ensure App Configuration stores use customer-managed encryption keys
@@ -38455,6 +41000,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appconfiguration-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure App Configuration stores encrypt configuration values at rest with customer-managed keys (CMK) stored in Azure Key Vault, instead of relying on platform-managed keys.
@@ -38574,6 +41123,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_app_configuration").all(
         values['encryption'] != empty
       )
+  - uid: mondoo-azure-security-appconfiguration-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.AppConfiguration/configurationStores")
+    mql: |
+      bicep.resources.where(type == "Microsoft.AppConfiguration/configurationStores").all(
+        properties["encryption"] != empty
+      )
   - uid: mondoo-azure-security-function-app-cmk-encryption
     title: Ensure Function Apps reference a managed identity for Key Vault access
     impact: 30
@@ -38608,6 +41163,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This is a soft check that verifies each Function App declares a `keyVaultReferenceIdentity` so that Key Vault references in app settings resolve through a managed identity rather than the App Service shared identity. Setting this property is a prerequisite for the customer-managed-key pattern used to encrypt application secrets and the storage account backing the function host.
@@ -38726,6 +41285,12 @@ queries:
         values['key_vault_reference_identity'] != null &&
         values['key_vault_reference_identity'] != ""
       )
+  - uid: mondoo-azure-security-function-app-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["keyVaultReferenceIdentity"] != empty
+      )
   - uid: mondoo-azure-security-log-analytics-workspace-cmk-encryption
     title: Ensure Log Analytics workspaces use a CMK-enabled dedicated cluster
     impact: 40
@@ -38760,6 +41325,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-log-analytics-workspace-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Log Analytics workspaces are linked to a dedicated Log Analytics cluster. A cluster link is the prerequisite for customer-managed-key (CMK) encryption of ingested log data: the cluster holds the CMK reference, and every workspace linked to that cluster inherits CMK protection for at-rest log data.
@@ -38895,6 +41464,12 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_log_analytics_workspace")
     mql: |
       terraform.state.resources.contains(type == "azurerm_log_analytics_cluster_customer_managed_key")
+  - uid: mondoo-azure-security-log-analytics-workspace-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.OperationalInsights/clusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.OperationalInsights/clusters").all(
+        properties["keyVaultProperties"] != empty
+      )
   # No runtime variant: cnquery azure provider does not expose `minimumTlsVersion` on azure.subscription.serviceBus.namespaces. Ship Terraform variants only; revisit once the provider adds the field to the Service Bus namespace resource.
   - uid: mondoo-azure-security-servicebus-namespace-min-tls-1-2
     title: Ensure Service Bus namespaces enforce TLS 1.2 or higher
@@ -38926,6 +41501,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-servicebus-namespace-min-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Service Bus namespaces enforce a minimum TLS version of 1.2 for all client connections. TLS 1.0 and 1.1 are deprecated and have known cryptographic weaknesses.
@@ -39023,6 +41602,12 @@ queries:
       terraform.state.resources.where(type == "azurerm_servicebus_namespace").all(
         values['minimum_tls_version'] == "1.2"
       )
+  - uid: mondoo-azure-security-servicebus-namespace-min-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ServiceBus/namespaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ServiceBus/namespaces").all(
+        properties["minimumTlsVersion"] == "1.2"
+      )
   # No runtime variant: cnquery azure provider does not expose `siteConfig.minTlsVersion` on azure.subscription.functions.functionApps. Ship Terraform variants only; revisit once the provider adds site-config TLS fields to the Function App resource.
   - uid: mondoo-azure-security-function-app-min-tls-1-2
     title: Ensure Function Apps enforce minimum TLS 1.2 on the site
@@ -39054,6 +41639,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-min-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure Function Apps enforce a minimum TLS version of 1.2 on the main site, preventing clients from negotiating TLS 1.0 or 1.1 against the function endpoints.
@@ -39160,6 +41749,12 @@ queries:
         values['site_config'] != empty &&
         values['site_config'].all(_['minimum_tls_version'] == "1.2")
       )
+  - uid: mondoo-azure-security-function-app-min-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["minTlsVersion"] == "1.2"
+      )
   - uid: mondoo-azure-security-api-management-gateway-min-tls-1-2
     title: Ensure API Management gateway disables TLS 1.0 and TLS 1.1
     impact: 70
@@ -39194,6 +41789,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-api-management-gateway-min-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure API Management gateways do not accept TLS 1.0 or TLS 1.1 on either the frontend (client-to-gateway) or backend (gateway-to-API) hops. TLS 1.0 and 1.1 are deprecated and carry known cryptographic weaknesses.
@@ -39337,6 +41936,15 @@ queries:
           _['enable_backend_tls11'] != true
         )
       )
+  - uid: mondoo-azure-security-api-management-gateway-min-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.ApiManagement/service")
+    mql: |
+      bicep.resources.where(type == "Microsoft.ApiManagement/service").all(
+        properties["customProperties"]["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"] != "True" &&
+        properties["customProperties"]["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11"] != "True" &&
+        properties["customProperties"]["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10"] != "True" &&
+        properties["customProperties"]["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11"] != "True"
+      )
   # No runtime variant: cnquery azure provider exposes virtual-network-gateway connections but does not surface the typed `ipsecPolicies` array; the strong-IPsec policy check has no runtime analog. Ship Terraform variants only; revisit if the provider adds typed IPsec policy fields to azure.subscription.network.virtualNetworkGateways.connections.
   - uid: mondoo-azure-security-vpn-gateway-ikev2-strong-ipsec-policy
     title: Ensure VPN gateway connections use IKEv2 and strong IPsec ciphers
@@ -39368,6 +41976,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vpn-gateway-ikev2-strong-ipsec-policy-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Azure VPN gateway connections that define a custom IPsec/IKE policy use IKEv2 with strong cipher suites: AES-256 or GCM-AES-256 for both IKE and IPsec encryption.
@@ -39520,6 +42132,13 @@ queries:
         values['ipsec_policy'].all(
           _['ipsec_encryption'] == "AES256" || _['ipsec_encryption'] == "GCMAES256"
         )
+      )
+  - uid: mondoo-azure-security-vpn-gateway-ikev2-strong-ipsec-policy-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/connections")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/connections").all(
+        properties["ipsecPolicies"].all(_["ikeEncryption"] == /^(AES256|GCMAES256)$/) &&
+        properties["ipsecPolicies"].all(_["ipsecEncryption"] == /^(AES256|GCMAES256)$/)
       )
   # No transit-encryption check for Azure AI Search: the data and management endpoints (`*.search.windows.net`) are HTTPS-only by Microsoft platform design, with TLS 1.2+ enforced by the service. `azurerm_search_service` exposes no `tls_min_version` argument and the runtime resource has no TLS-version field. There is no meaningful misconfiguration to detect.
   # No transit-encryption check for Azure App Configuration: the data plane endpoint (`*.azconfig.io`) is HTTPS-only by Microsoft platform design with TLS 1.2+ enforced by the service. `azurerm_app_configuration` exposes no `tls_min_version` argument. There is no meaningful misconfiguration to detect.

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -11,6 +11,7 @@ policies:
     require:
       - provider: ms365
       - provider: terraform
+      - provider: bicep
       - provider: network
     authors:
       - name: Mondoo, Inc.
@@ -36,14 +37,10 @@ policies:
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Identity & Access Protection
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies
           - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies
       - title: Authentication & Access Control
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication
           - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles
@@ -52,19 +49,13 @@ policies:
           - uid: mondoo-m365-security-ensure-that-between-two-and-four-global-admins-are-designated
           - uid: mondoo-m365-security-require-pim-for-privileged-roles
       - title: Password Policies
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-that-ms-365-passwords-are-not-set-to-expire
       - title: Mobile Device Security
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-that-mobile-device-encryption-is-enabled-to-prevent-unauthorized-access-to-mobile-data
           - uid: mondoo-m365-security-ensure-that-mobile-devices-require-a-minimum-password-length-to-prevent-brute-force-attacks
       - title: Email Security
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-that-spf-records-are-published-for-all-exchange-domains
           - uid: mondoo-m365-security-ensure-dkim-signing-enabled-for-all-exchange-domains
@@ -75,19 +66,13 @@ policies:
           - uid: mondoo-m365-security-ensure-anti-phishing-policies-enabled
           - uid: mondoo-m365-security-ensure-transport-rules-enforce-tls
       - title: Application Security
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-third-party-integrated-applications-are-not-allowed
           - uid: mondoo-m365-security-restrict-user-consent-to-applications
       - title: SharePoint Security
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-sharepoint-external-sharing-restricted
       - title: Audit & Logging
-        filters: |
-          asset.platform == "microsoft365"
         checks:
           - uid: mondoo-m365-security-ensure-unified-audit-log-enabled
     scoring_system: highest impact
@@ -126,6 +111,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Entra ID Protection is configured to detect and respond to risky sign-in events in real time and offline. By default, no sign-in risk Conditional Access policy is created, leaving the tenant dependent on after-the-fact log review to spot suspicious authentication activity.
@@ -291,6 +280,14 @@ queries:
         values['conditions'].any(_['sign_in_risk_levels'] != empty) &&
         values['grant_controls'].any(_['built_in_controls'].contains('mfa'))
       )
+  - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Graph/conditionalAccessPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
+          body["state"] == "enabled" &&
+          body["conditions"]["signInRiskLevels"] != empty &&
+          body["grantControls"]["builtInControls"].any(_ == "mfa")
+      )
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies
     title: Enable Azure AD Identity Protection user risk policies
     impact: 100
@@ -325,6 +322,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that Microsoft Entra ID Protection is configured with a Conditional Access policy that acts automatically when user risk reaches a high level. By default, no user-risk policy is created, so accounts flagged as likely compromised continue to operate without interruption unless an administrator manually investigates the alert.
@@ -487,6 +488,14 @@ queries:
         values['conditions'].any(_['user_risk_levels'] != empty) &&
         values['grant_controls'].any(_['built_in_controls'].contains('mfa'))
       )
+  - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Graph/conditionalAccessPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
+          body["state"] == "enabled" &&
+          body["conditions"]["userRiskLevels"] != empty &&
+          body["grantControls"]["builtInControls"].any(_ == "mfa")
+      )
   - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication
     title: Enable Conditional Access policies to block legacy authentication
     impact: 80
@@ -521,6 +530,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that a Conditional Access policy is in place to block legacy authentication client types, including Exchange ActiveSync clients and other legacy protocols such as POP and IMAP. By default, Microsoft 365 tenants permit these older protocols, which cannot enforce multifactor authentication and are routinely targeted in credential-stuffing and password-spray campaigns.
@@ -667,6 +680,14 @@ queries:
         values['conditions'].any(_['client_app_types'] != empty) &&
         values['grant_controls'].any(_['built_in_controls'].contains('block'))
       )
+  - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Graph/conditionalAccessPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
+          body["state"] == "enabled" &&
+          body["conditions"]["clientAppTypes"] != empty &&
+          body["grantControls"]["builtInControls"].any(_ == "block")
+      )
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles
     title: Ensure MFA is enabled for all users in administrative roles
     impact: 100
@@ -701,6 +722,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that a Conditional Access policy is in place requiring multifactor authentication for all users assigned to privileged directory roles in the Microsoft 365 tenant. By default, no such policy is created, leaving administrative accounts protected only by a password and making them prime targets for credential-based attacks.
@@ -909,6 +934,14 @@ queries:
         values['conditions'].any(_['users'].any(_['included_roles'] != empty)) &&
         values['grant_controls'].any(_['built_in_controls'].contains('mfa'))
       )
+  - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Graph/conditionalAccessPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
+          body["state"] == "enabled" &&
+          body["conditions"]["users"]["includeRoles"] != empty &&
+          body["grantControls"]["builtInControls"].any(_ == "mfa")
+      )
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles
     title: Ensure multi-factor authentication (MFA) is enabled for all users
     impact: 100
@@ -943,6 +976,10 @@ queries:
         tags:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
+      - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
     docs:
       desc: |
         This check ensures that a Conditional Access policy is in place requiring multifactor authentication for every user in the Microsoft 365 tenant, not just administrators. By default, no tenant-wide MFA policy exists, so non-privileged user accounts are protected only by a password and are frequently targeted in credential-stuffing and phishing campaigns.
@@ -1084,9 +1121,19 @@ queries:
         values['conditions'].any(_['users'].any(_['included_users'].contains('All'))) &&
         values['grant_controls'].any(_['built_in_controls'].contains('mfa'))
       )
+  - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Graph/conditionalAccessPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Graph/conditionalAccessPolicies").any(
+          body["state"] == "enabled" &&
+          body["conditions"]["users"]["includeUsers"].any(_ == "All") &&
+          body["grantControls"]["builtInControls"].any(_ == "mfa")
+      )
   # No Terraform variants: the security defaults toggle has no azuread Terraform resource and can only be changed through the Graph API or portal.
   - uid: mondoo-m365-security-ensure-security-defaults-is-disabled-on-azure-active-directory
     title: Ensure Security Defaults is disabled on Azure Active Directory
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -1178,6 +1225,8 @@ queries:
   # No Terraform variants: this check counts live Global Administrator assignments, which Terraform source cannot enumerate because portal-created assignments are invisible to it.
   - uid: mondoo-m365-security-ensure-that-between-two-and-four-global-admins-are-designated
     title: Ensure that between two and four global admins are designated
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -1319,6 +1368,8 @@ queries:
   # No Terraform variants: Intune device configuration profiles have no resource in the azuread Terraform provider.
   - uid: mondoo-m365-security-ensure-that-mobile-device-encryption-is-enabled-to-prevent-unauthorized-access-to-mobile-data
     title: Ensure that Android mobile device encryption is enabled
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -1423,6 +1474,8 @@ queries:
   # No Terraform variants: Intune device configuration profiles have no resource in the azuread Terraform provider.
   - uid: mondoo-m365-security-ensure-that-mobile-devices-require-a-minimum-password-length-to-prevent-brute-force-attacks
     title: Ensure minimum password length is set to prevent brute force
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -1550,6 +1603,8 @@ queries:
   # No Terraform variants: per-domain password validity has no azuread Terraform resource and is set only through the Graph API.
   - uid: mondoo-m365-security-ensure-that-ms-365-passwords-are-not-set-to-expire
     title: Ensure password expiration policy is set to never expire
+    filters: |
+      asset.platform == "microsoft365"
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -1649,6 +1704,8 @@ queries:
   # No Terraform variants: this check inspects live published DNS records; the Terraform analog depends on which DNS provider hosts each domain and cannot be expressed as a single M365 resource.
   - uid: mondoo-m365-security-ensure-that-spf-records-are-published-for-all-exchange-domains
     title: Ensure that SPF records are published for all Exchange Domains
+    filters: |
+      asset.platform == "microsoft365"
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -1796,6 +1853,8 @@ queries:
   # No Terraform variants: the tenant authorization policy has no resource in the azuread Terraform provider.
   - uid: mondoo-m365-security-ensure-third-party-integrated-applications-are-not-allowed
     title: Ensure that no third party integrated applications are allowed
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -1889,6 +1948,8 @@ queries:
   # No Terraform variants: Exchange Online configuration has no Terraform provider.
   - uid: mondoo-m365-security-ensure-dkim-signing-enabled-for-all-exchange-domains
     title: Ensure DKIM signing is enabled for all Exchange domains
+    filters: |
+      asset.platform == "microsoft365"
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
@@ -1973,6 +2034,8 @@ queries:
   # No Terraform variants: Exchange Online Safe Links policies have no Terraform provider.
   - uid: mondoo-m365-security-ensure-safe-links-policies-configured
     title: Ensure Safe Links policies are configured
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -2070,6 +2133,8 @@ queries:
   # No Terraform variants: Exchange Online Safe Attachments policies have no Terraform provider.
   - uid: mondoo-m365-security-ensure-safe-attachments-policies-configured
     title: Ensure Safe Attachments policies are configured
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -2165,6 +2230,8 @@ queries:
   # No Terraform variants: Exchange Online anti-phishing policies have no Terraform provider.
   - uid: mondoo-m365-security-ensure-anti-phishing-policies-enabled
     title: Ensure anti-phishing policies are enabled
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -2263,6 +2330,8 @@ queries:
   # No Terraform variants: SharePoint Online tenant settings have no Terraform provider.
   - uid: mondoo-m365-security-ensure-sharepoint-external-sharing-restricted
     title: Ensure SharePoint external sharing is restricted
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -2354,6 +2423,8 @@ queries:
   # No Terraform variants: Exchange Online transport rules have no Terraform provider.
   - uid: mondoo-m365-security-ensure-transport-rules-enforce-tls
     title: Ensure Exchange transport rules enforce TLS for external email
+    filters: |
+      asset.platform == "microsoft365"
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
@@ -2440,6 +2511,8 @@ queries:
   # No Terraform variants: Exchange Online configuration has no Terraform provider.
   - uid: mondoo-m365-security-ensure-unified-audit-log-enabled
     title: Ensure the Microsoft 365 unified audit log is enabled
+    filters: |
+      asset.platform == "microsoft365"
     impact: 95
     tags:
       compliance/bsi-sys-1-5: false
@@ -2523,6 +2596,8 @@ queries:
   # No Terraform variants: Exchange Online configuration has no Terraform provider.
   - uid: mondoo-m365-security-block-external-email-auto-forwarding
     title: Ensure automatic external email forwarding is blocked
+    filters: |
+      asset.platform == "microsoft365"
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
@@ -2612,6 +2687,8 @@ queries:
   # No Terraform variants: the tenant authorization policy has no resource in the azuread Terraform provider.
   - uid: mondoo-m365-security-restrict-user-consent-to-applications
     title: Ensure users cannot consent to applications accessing company data
+    filters: |
+      asset.platform == "microsoft365"
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
@@ -2699,6 +2776,8 @@ queries:
   # No Terraform variants: Microsoft Entra PIM role eligibility has no resource in the azuread Terraform provider.
   - uid: mondoo-m365-security-require-pim-for-privileged-roles
     title: Ensure privileged roles are managed with Privileged Identity Management
+    filters: |
+      asset.platform == "microsoft365"
     impact: 85
     tags:
       compliance/bsi-sys-1-5: false
@@ -2792,6 +2871,8 @@ queries:
   # No Terraform variants: DMARC records are published at an external DNS provider, not in Microsoft 365.
   - uid: mondoo-m365-security-ensure-dmarc-records-published
     title: Ensure DMARC records are published for all Exchange domains
+    filters: |
+      asset.platform == "microsoft365"
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false


### PR DESCRIPTION
## What

Adds a `-bicep` IaC variant to **every Azure and M365 check that ships Terraform variants**, so each control is also enforced against Azure **Bicep** source — the IaC counterpart to the existing `-terraform-hcl` variants.

- **Azure — 249 Bicep variants.** Each filters on `asset.platform == "bicep"` and asserts the same control against `bicep.resources`, keyed by the `Microsoft.*` ARM type and the `properties` path already documented in the check's `id: bicep` remediation.
- **M365 — 5 Bicep variants** for the Conditional Access checks, against the Microsoft Graph extension resource `Microsoft.Graph/conditionalAccessPolicies`.

## Depends on mondoohq/mql#8182 and mondoohq/mql#8183

The variants use Bicep provider accessors added in two provider PRs:
- **#8182** — `bicep.resource.body` (reaches resource-level fields like `identity` and Microsoft Graph resource bodies). *Merged.*
- **#8183** — `bicep.resources` (flattened resource list), unquoted literal `name`, and typed scalars (`== true`, `>= 30`).

**`cnspec policy lint` in CI will fail until those ship in a cnquery release** — this content PR should merge after them.

## Query style

The variants read directly and idiomatically, e.g.:

```yaml
filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Security/pricings" && name == "VirtualMachines")
mql: |
  bicep.resources.where(type == "Microsoft.Security/pricings" && name == "VirtualMachines").all(
    properties["pricingTier"] == "Standard"
  )
```

Booleans/numbers compare as typed values; resource-level fields (`identity`) are read through `body`; literal names match directly.

## M365 gate refactor (also fixes the pre-existing dead Terraform variants)

The M365 policy gated platform at the **group** level (`asset.platform == "microsoft365"` on every group), which blocked **all** IaC variants from ever running — the existing Terraform CA variants were dead too. This refactors the M365 policy to the **same model the Azure (and other cloud) policies already use**: no group-level platform filter; platform selection lives on each check.

- Group-level `filters:` removed from all 8 groups.
- The 18 single-platform checks each get an explicit `asset.platform == "microsoft365"` filter.
- The 5 Conditional Access checks delegate to their variants (`-microsoft365` / `-terraform-*` / `-bicep`), whose own filters now select the platform.

On a Bicep/Terraform asset the Conditional Access variants run and the Microsoft 365-only checks cleanly skip; on an M365 asset behavior is unchanged.

## Documented gap

One Azure check keeps a `# No Bicep variant:` comment — Storage queue logging is classic Storage Analytics with no ARM resource property to assert in Bicep.

## Validation

- `cnspec policy lint` — both bundles valid against the locally-built provider.
- `cnspec scan bicep` against secure/insecure samples — Azure controls and the 5 Microsoft Graph Conditional Access policies all **pass on secure** and **fail on insecure** input; M365-only checks do not run against Bicep assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)