### PR TITLE
:star: Add Mondoo Nutanix Security policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -3,6 +3,7 @@ aad
 AAWG
 ABIA
 ACCOUNTADMIN
+acli
 acmpca
 acr
 acs
@@ -55,6 +56,7 @@ aspnet
 aspnetmvc
 assumeyes
 atlassian
+authconfig
 authnotrequired
 authsettings
 autobackup
@@ -123,6 +125,7 @@ certbot
 certfile
 certonly
 CFN
+CFT
 chage
 chargen
 chatgpt
@@ -407,6 +410,7 @@ iosxe
 iosxr
 iothub
 ipfw
+ipmitool
 isa
 isready
 ivs
@@ -443,9 +447,11 @@ kubeleta
 kubenet
 KVM
 langen
+lanplus
 lastday
 lastlog
 launchmenu
+ldaps
 ldisc
 letsencrypt
 lexer
@@ -490,6 +496,7 @@ mbr
 mcp
 memorystore
 Mfas
+microarchitectural
 microdnf
 MIGf
 minv
@@ -519,6 +526,7 @@ myservice
 mysqladmin
 nameid
 nameterraform
+ncli
 netname
 netsh
 networkaclchanges
@@ -529,6 +537,7 @@ NEWGROUP
 newkey
 nexthop
 nft
+ngt
 nistp
 nmap
 nocrl
@@ -546,6 +555,7 @@ NTE
 ntpserver
 ntpsync
 nullglob
+nutanix
 nxos
 Nxxxx
 objectstorage
@@ -766,6 +776,7 @@ SSWS
 stalepath
 startswith
 starttime
+STARTTLS
 stdio
 stepfunctions
 stylesheet
@@ -832,6 +843,7 @@ unifi
 uniformbucketlevelaccess
 uninventoried
 unlinkat
+unpatchable
 uploaders
 upnp
 usb
@@ -912,6 +924,7 @@ XXXXXXXXX
 yama
 yescrypt
 yournamespace
+zookeeper
 zrt
 zsk
 zst

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -26,7 +26,7 @@
 #
 
 # s.b. Allow list
-\b[Ww]hitelist\b
+# \b[Ww]hitelist\b # Nutanix API/UI uses nfsSubnetWhitelist, nfsWhitelistAddresses, and Filesystem Whitelists
 \b[Ww]hitelisting\b
 # \b[Ww]hitelisted\b # Google Workspace API uses ipWhitelisted field name
 \b[Ww]hite list\b

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -1,0 +1,2024 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-nutanix-security
+    name: Mondoo Nutanix Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: nutanix,nutanix-prism-central
+    authors:
+      - name: Tim Smith
+        email: tim@mondoo.com
+    require:
+      - provider: nutanix
+    summary: Secure Nutanix clusters, hosts, virtual machines, identity, and storage managed through Prism Central
+    docs:
+      desc: |
+        The Mondoo Nutanix Security policy identifies misconfigurations across a Nutanix environment managed through Prism Central that could leave your virtualization platform exposed to attackers, data loss, or compliance gaps. It evaluates the registered clusters, the hypervisor hosts that make up those clusters, the virtual machines running on them, the identity and access configuration of Prism Central, and the storage layer.
+
+        This policy provides security checks across key Nutanix areas:
+
+        - **Cluster hardening**: Data-at-rest and data-in-transit encryption, external key management, password SSH login, remote support tunnel, redundancy factor, fault tolerance, NTP and DNS, SMTP transport security, and the NFS allowlist
+        - **Host security**: UEFI Secure Boot, IPMI/BMC default credentials, and degraded-state monitoring
+        - **Virtual machine security**: Host CPU passthrough, Nutanix Guest Tools presence and currency, and backup/disaster-recovery protection
+        - **Identity and access management**: LDAPS for directory services, directory group allowlists, SAML signed authn requests, inactive account removal, and stale account review
+        - **Storage security**: CHAP authentication on volume groups, storage-container encryption, per-container NFS allowlists, and replication factor
+
+        ## References
+
+        - [Nutanix Security Guide](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:Nutanix-Security-Guide)
+        - [Nutanix Hardening Guide](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:wc-security-hardening-wc-c.html)
+        - [Nutanix v4 API Reference](https://developers.nutanix.com/)
+        - [BSI IT-Grundschutz SYS.1.5 Virtualisation](https://www.bsi.bund.de/)
+
+        Learn more about scanning Nutanix in the [cnspec documentation](https://mondoo.com/docs/cnspec/).
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    scoring_system: highest impact
+
+    groups:
+      - title: "Cluster Security"
+        filters: |
+          asset.platform == "nutanix-prism-central"
+        checks:
+          - uid: mondoo-nutanix-security-cluster-data-at-rest-encryption-enabled
+          - uid: mondoo-nutanix-security-cluster-encryption-in-transit-enabled
+          - uid: mondoo-nutanix-security-cluster-external-key-management
+          - uid: mondoo-nutanix-security-cluster-ssh-password-login-disabled
+          - uid: mondoo-nutanix-security-cluster-remote-support-disabled
+          - uid: mondoo-nutanix-security-cluster-redundancy-factor
+          - uid: mondoo-nutanix-security-cluster-fault-tolerance-ready
+          - uid: mondoo-nutanix-security-cluster-ntp-configured
+          - uid: mondoo-nutanix-security-cluster-dns-configured
+          - uid: mondoo-nutanix-security-cluster-smtp-encrypted
+          - uid: mondoo-nutanix-security-cluster-nfs-allowlist-restricted
+          - uid: mondoo-nutanix-security-cluster-runs-lts-release
+
+      - title: "Host Security"
+        filters: |
+          asset.platform == "nutanix-prism-central"
+        checks:
+          - uid: mondoo-nutanix-security-host-secure-boot-enabled
+          - uid: mondoo-nutanix-security-host-ipmi-not-default-user
+          - uid: mondoo-nutanix-security-host-not-degraded
+
+      - title: "Virtual Machine Security"
+        filters: |
+          asset.platform == "nutanix-prism-central"
+        checks:
+          - uid: mondoo-nutanix-security-vm-cpu-passthrough-disabled
+          - uid: mondoo-nutanix-security-vm-guest-tools-installed
+          - uid: mondoo-nutanix-security-vm-guest-tools-current
+          - uid: mondoo-nutanix-security-vm-protected
+
+      - title: "Identity and Access Management"
+        filters: |
+          asset.platform == "nutanix-prism-central"
+        checks:
+          - uid: mondoo-nutanix-security-directory-service-uses-ldaps
+          - uid: mondoo-nutanix-security-directory-service-group-allowlist
+          - uid: mondoo-nutanix-security-saml-signed-authn-requests
+          - uid: mondoo-nutanix-security-inactive-local-users-removed
+          - uid: mondoo-nutanix-security-no-stale-user-accounts
+
+      - title: "Storage Security"
+        filters: |
+          asset.platform == "nutanix-prism-central"
+        checks:
+          - uid: mondoo-nutanix-security-volume-group-chap-auth
+          - uid: mondoo-nutanix-security-storage-container-encrypted
+          - uid: mondoo-nutanix-security-storage-container-nfs-allowlist
+          - uid: mondoo-nutanix-security-storage-container-replication-factor
+
+queries:
+  # =================================================================
+  # Cluster Security
+  # =================================================================
+
+  - uid: mondoo-nutanix-security-cluster-data-at-rest-encryption-enabled
+    title: Ensure data-at-rest encryption is enabled on clusters
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(encryptionScopes.length > 0)
+    docs:
+      desc: |
+        This check ensures that data-at-rest encryption is enabled on each AOS storage cluster. Without encryption, the data written to physical drives is recoverable by anyone who gains physical access to a disk that is decommissioned, stolen, or returned under warranty.
+
+        **Why this matters**
+
+        - **Physical theft:** Encrypted drives are unreadable when removed from the cluster, defeating drive theft and improper disposal.
+        - **Regulatory data protection:** Many frameworks require sensitive data to be encrypted while stored.
+        - **Defense in depth:** Encryption protects data even when other controls, such as access control on the array, are bypassed.
+
+        **Risk mitigation**
+
+        - **Confidentiality at rest:** Software, self-encrypting drive, or hardware encryption renders stored data unintelligible without the keys.
+        - **Safe decommissioning:** Cryptographic erasure lets you retire drives without physically destroying them.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central or Prism Element.
+        2. Open Settings, then Data-at-Rest Encryption.
+        3. Confirm encryption is enabled for the cluster or for each storage container.
+
+        A passing result shows encryption enabled with a configured scope; a failing result shows encryption disabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli data-at-rest-encryption get-status
+        ```
+
+        A passing result reports encryption as enabled; a failing result reports it as disabled.
+      remediation:
+        - id: console
+          desc: |
+            To enable data-at-rest encryption using Prism:
+
+            1. Open Settings, then Data-at-Rest Encryption.
+            2. Choose the encryption type (software, SED, or hardware) and the key management server.
+            3. Click Enable Encryption and confirm.
+        - id: cli
+          desc: |
+            To enable software data-at-rest encryption using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli data-at-rest-encryption enable
+            ```
+
+            Confirm the new status:
+
+            ```bash
+            ncli data-at-rest-encryption get-status
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-encryption-in-transit-enabled
+    title: Ensure encryption-in-transit is enabled on clusters
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(encryptionInTransitStatus == "ENABLED")
+    docs:
+      desc: |
+        This check ensures that encryption-in-transit is enabled on each AOS cluster so that replication and storage traffic between nodes is protected on the wire. When in-transit encryption is disabled, an attacker positioned on the storage or backplane network can read or tamper with data as it moves between Controller VMs.
+
+        **Why this matters**
+
+        - **Network eavesdropping:** Unencrypted inter-node traffic exposes data to anyone who can sniff the storage network.
+        - **Tampering:** Without integrity protection, replicated data can be altered in flight.
+        - **Lateral movement:** A compromised host on the backplane can harvest data destined for other nodes.
+
+        **Risk mitigation**
+
+        - **Confidentiality in transit:** TLS protects replication and RPC traffic between nodes.
+        - **Integrity:** Authenticated transport detects modification of data in flight.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element for the cluster.
+        2. Open Settings, then Encryption (or Network Configuration).
+        3. Confirm that encryption-in-transit is enabled.
+
+        A passing result shows in-transit encryption enabled; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-params
+        ```
+
+        A passing result reports the encryption-in-transit status as enabled.
+      remediation:
+        - id: console
+          desc: |
+            To enable encryption-in-transit using Prism:
+
+            1. Open Settings, then Encryption.
+            2. Enable encryption-in-transit for the cluster.
+            3. Confirm and allow the cluster to apply the setting to all nodes.
+        - id: cli
+          desc: |
+            To enable encryption-in-transit using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster edit-params enable-encryption-in-transit=true
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-external-key-management
+    title: Ensure clusters use an external key management server
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-08
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/pci-dss-4: pcidss-requirement-3-6-1-2
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(network.keyManagementServerType == "EXTERNAL")
+    docs:
+      desc: |
+        This check ensures that encryption keys are managed by an external key management server (KMS) rather than stored locally on the cluster. When the cluster holds its own keys, an attacker who compromises the cluster can obtain both the ciphertext and the keys, defeating encryption entirely.
+
+        **Why this matters**
+
+        - **Key and data separation:** Keeping keys off the cluster means a single compromise does not yield both data and keys.
+        - **Centralized lifecycle:** An external KMS provides rotation, revocation, and auditing of key usage.
+        - **Compliance:** Several frameworks expect cryptographic keys to be managed in a dedicated, hardened key store.
+
+        **Risk mitigation**
+
+        - **Reduced blast radius:** Revoking keys at the KMS renders cluster data inaccessible after a breach.
+        - **Auditable access:** Key operations are logged centrally and independently of the cluster.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then Key Management Server.
+        3. Confirm an external KMS is configured and used for encryption.
+
+        A passing result shows an external KMS; a failing result shows local key management only.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli key-management-server list
+        ```
+
+        A passing result lists an external key management server in use.
+      remediation:
+        - id: console
+          desc: |
+            To configure an external key management server using Prism:
+
+            1. Open Settings, then Key Management Server.
+            2. Add the external KMS endpoint and upload the client and CA certificates.
+            3. Re-key the cluster to use the external KMS.
+        - id: cli
+          desc: |
+            To add an external key management server using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli key-management-server add name=kms1 address=kms.example.com:5696 server-type=EXTERNAL
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-ssh-password-login-disabled
+    title: Ensure password-based SSH login to clusters is disabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/pci-dss-4: pcidss-requirement-2-2-6
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      nutanix.clusters.all(isPasswordRemoteLoginEnabled == false)
+    docs:
+      desc: |
+        This check ensures that password-based SSH login to the cluster is disabled so that Controller VM and host access requires key-based authentication. Password SSH access to the cluster is a direct target for brute-force and credential-stuffing attacks, and a single guessed password yields administrative control of the storage stack.
+
+        **Why this matters**
+
+        - **Brute-force exposure:** Password authentication can be attacked automatically and at scale.
+        - **Privileged blast radius:** Cluster SSH access exposes the storage controllers that every workload depends on.
+        - **Credential reuse:** Shared or reused passwords compromise the cluster when leaked elsewhere.
+
+        **Risk mitigation**
+
+        - **Key-only authentication:** SSH keys defeat password-guessing campaigns.
+        - **Accountability:** Per-user keys tie cluster access to identifiable operators.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then Cluster Lockdown.
+        3. Confirm that Remote Login With Password is disabled (only key-based access is allowed).
+
+        A passing result shows password remote login disabled; a failing result shows it enabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-params
+        ```
+
+        A passing result reports remote login with password as disabled.
+      remediation:
+        - id: console
+          desc: |
+            To disable password SSH login using Prism:
+
+            1. Open Settings, then Cluster Lockdown.
+            2. Add your SSH public keys for administrative access.
+            3. Disable Remote Login With Password.
+        - id: cli
+          desc: |
+            To disable password SSH login using the CLI, run on a Controller VM after adding your SSH keys:
+
+            ```bash
+            ncli cluster edit-params enable-password-remote-login-to-cluster=false
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-remote-support-disabled
+    title: Ensure the remote support tunnel is disabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ma-2
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ma-4
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      nutanix.clusters.all(isRemoteSupportEnabled == false)
+    docs:
+      desc: |
+        This check ensures that the Nutanix remote support tunnel is disabled. The remote support tunnel opens an outbound connection that lets Nutanix support access the cluster; left on permanently, it is a standing remote access path into the storage controllers that sits outside your normal access controls.
+
+        **Why this matters**
+
+        - **Standing access path:** A persistent support tunnel is an always-available entry point into the cluster.
+        - **Reduced visibility:** Access through the vendor tunnel may bypass your own authentication and logging.
+        - **Least functionality:** Disabling unused remote access reduces the attack surface.
+
+        **Risk mitigation**
+
+        - **On-demand only:** Enable the tunnel only for the duration of an active support case, then disable it.
+        - **Controlled maintenance:** Vendor access becomes a deliberate, time-boxed action rather than a default-on service.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then Remote Support.
+        3. Confirm remote support is disabled.
+
+        A passing result shows remote support disabled; a failing result shows it enabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-params
+        ```
+
+        A passing result reports remote support as disabled.
+      remediation:
+        - id: console
+          desc: |
+            To disable the remote support tunnel using Prism:
+
+            1. Open Settings, then Remote Support.
+            2. Set remote support to disabled.
+            3. Re-enable it only for the duration of an active support case.
+        - id: cli
+          desc: |
+            To disable the remote support tunnel using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster stop-remote-support
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-redundancy-factor
+    title: Ensure clusters use a redundancy factor of at least 2
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a20
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-11
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(redundancyFactor >= 2)
+    docs:
+      desc: |
+        This check ensures that each AOS cluster uses a redundancy factor of at least 2 so that data remains available after the loss of a node or disk. A redundancy factor of 1 keeps only a single copy of data, meaning any single drive or node failure causes permanent data loss and an outage for every workload on the cluster.
+
+        **Why this matters**
+
+        - **Single point of failure:** With one copy of data, a single hardware failure is unrecoverable.
+        - **Availability:** Redundancy lets the cluster keep serving data while a failed component is replaced.
+        - **Ransomware and corruption resilience:** Multiple copies support recovery from localized data damage.
+
+        **Risk mitigation**
+
+        - **Fault tolerance:** A redundancy factor of 2 tolerates the loss of one node or disk without data loss.
+        - **Continuous operation:** Workloads stay online while the cluster self-heals.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element for the cluster.
+        2. Open the cluster details (gear icon, then Cluster Details, or the home dashboard).
+        3. Confirm the redundancy factor is 2 or higher.
+
+        A passing result shows a redundancy factor of 2 or more; a failing result shows 1.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-redundancy-state
+        ```
+
+        A passing result reports a desired redundancy factor of 2 or higher.
+      remediation:
+        - id: console
+          desc: |
+            The redundancy factor is set when the cluster is created and requires sufficient nodes (at least 3 for RF2). To raise it using Prism:
+
+            1. Ensure the cluster has enough nodes to support the target redundancy factor.
+            2. Open the cluster details and edit the redundancy factor.
+            3. Apply the change and allow the cluster to re-protect data.
+        - id: cli
+          desc: |
+            To raise the redundancy factor using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster set-redundancy-state desired-redundancy-factor=2
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-fault-tolerance-ready
+    title: Ensure cluster fault-tolerance ensembles are ready
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a20
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-11
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(
+        faultTolerance.cassandraPreparationDone == true &&
+        faultTolerance.zookeeperPreparationDone == true &&
+        faultTolerance.currentClusterFaultTolerance != "CFT_0N_AND_0D"
+      )
+    docs:
+      desc: |
+        This check ensures that each AOS cluster is actually prepared to meet its desired fault tolerance: the metadata (Cassandra) and configuration (Zookeeper) ensembles are ready and the current fault tolerance is above zero. A cluster can be configured for redundancy yet temporarily unable to deliver it while ensembles rebuild, leaving a window where a failure causes data loss despite the configured policy.
+
+        **Why this matters**
+
+        - **Configured versus actual:** A redundancy policy provides no protection if the ensembles cannot currently satisfy it.
+        - **Metadata loss:** Cassandra and Zookeeper hold cluster-critical state; losing quorum can take the whole cluster offline.
+        - **Hidden risk window:** Operators may believe the cluster is protected when it is not.
+
+        **Risk mitigation**
+
+        - **Verified resilience:** Confirming ensemble readiness ensures the cluster can survive the loss it is configured to tolerate.
+        - **Early warning:** Detecting an unprepared state prompts remediation before a second failure.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element for the cluster.
+        2. Review the cluster resiliency status on the home dashboard (Data Resiliency Status widget).
+        3. Confirm the cluster reports OK resiliency with the desired fault tolerance met.
+
+        A passing result shows resiliency met and ensembles prepared; a failing result shows a degraded or rebuilding state.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-domain-fault-tolerance-status type=node
+        ```
+
+        A passing result reports the current fault tolerance as met with ensembles prepared.
+      remediation:
+        - id: console
+          desc: |
+            To restore fault-tolerance readiness using Prism:
+
+            1. Open the Data Resiliency Status widget on the cluster dashboard.
+            2. Resolve the underlying condition (replace failed disks or nodes, free space, or wait for rebuild to complete).
+            3. Confirm the cluster returns to an OK resiliency state.
+        - id: cli
+          desc: |
+            To investigate and restore fault-tolerance readiness using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster get-domain-fault-tolerance-status type=node
+            ```
+
+            Address any failed components reported, then re-check until the ensembles report prepared.
+
+  - uid: mondoo-nutanix-security-cluster-ntp-configured
+    title: Ensure NTP servers are configured on clusters
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a7
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/pci-dss-4: pcidss-requirement-10-6-2
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.clusters.all(network.ntpServers.length > 0)
+    docs:
+      desc: |
+        This check ensures that NTP servers are configured on each cluster so that system clocks stay synchronized with an authoritative time source. Without reliable time, log timestamps drift, correlation across systems during an investigation becomes unreliable, and time-sensitive operations such as certificate validation and Kerberos authentication fail.
+
+        **Why this matters**
+
+        - **Audit integrity:** Accurate timestamps are essential for correlating events during incident response.
+        - **Authentication:** Kerberos and certificate checks fail when clocks drift too far.
+        - **Cluster operations:** Distributed storage operations depend on consistent time across nodes.
+
+        **Risk mitigation**
+
+        - **Time synchronization:** NTP keeps every node aligned to a trusted source.
+        - **Forensic reliability:** Consistent time enables defensible event reconstruction.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then NTP Servers.
+        3. Confirm one or more reachable NTP servers are configured.
+
+        A passing result shows configured NTP servers; a failing result shows none.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-ntp-servers
+        ```
+
+        A passing result lists one or more NTP servers.
+      remediation:
+        - id: console
+          desc: |
+            To configure NTP servers using Prism:
+
+            1. Open Settings, then NTP Servers.
+            2. Add at least two reachable NTP server addresses.
+            3. Save and confirm the cluster synchronizes.
+        - id: cli
+          desc: |
+            To add NTP servers using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster add-to-ntp-servers servers=time1.example.com,time2.example.com
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-dns-configured
+    title: Ensure name servers are configured on clusters
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.clusters.all(network.nameServers.length > 0)
+    docs:
+      desc: |
+        This check ensures that DNS name servers are configured on each cluster. Name resolution underpins critical cluster functions including directory authentication, NTP, key management server reachability, alerting, and software upgrades. A cluster without name servers may silently fall back to cached or hardcoded behavior and fail these services in ways that are hard to diagnose.
+
+        **Why this matters**
+
+        - **Dependent services:** Directory, KMS, NTP, and alerting endpoints are commonly referenced by name.
+        - **Operational reliability:** Missing resolvers cause intermittent failures that are difficult to trace.
+        - **Security tooling:** Reaching external security and update services depends on working DNS.
+
+        **Risk mitigation**
+
+        - **Consistent resolution:** Configured name servers ensure dependent services resolve reliably.
+        - **Predictable behavior:** Explicit resolvers remove reliance on undocumented fallbacks.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then Name Servers.
+        3. Confirm one or more DNS servers are configured.
+
+        A passing result shows configured name servers; a failing result shows none.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-name-servers
+        ```
+
+        A passing result lists one or more DNS name servers.
+      remediation:
+        - id: console
+          desc: |
+            To configure name servers using Prism:
+
+            1. Open Settings, then Name Servers.
+            2. Add at least two reachable DNS server addresses.
+            3. Save the configuration.
+        - id: cli
+          desc: |
+            To add name servers using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster add-to-name-servers servers=10.0.0.10,10.0.0.11
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-smtp-encrypted
+    title: Ensure cluster SMTP is not configured in plaintext
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      nutanix.clusters.where(network.smtpEmailAddress != "").all(network.smtpType != "PLAIN")
+    docs:
+      desc: |
+        This check ensures that, where a cluster is configured to send email, it uses STARTTLS or SSL rather than a plaintext SMTP connection. Cluster alert emails can disclose host names, IP addresses, software versions, and the nature of failures; sent in plaintext, this operational intelligence is readable by anyone on the network path.
+
+        **Why this matters**
+
+        - **Information disclosure:** Alert emails reveal infrastructure details useful to an attacker.
+        - **Credential exposure:** Plaintext SMTP with authentication can leak the relay credentials.
+        - **Tampering:** Unencrypted mail can be intercepted or altered in transit.
+
+        **Risk mitigation**
+
+        - **Encrypted transport:** STARTTLS or SSL protects alert content and any SMTP credentials.
+        - **Integrity:** TLS prevents interception and modification of cluster notifications.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then SMTP Server.
+        3. Confirm the security mode is STARTTLS or SSL, not None/Plain.
+
+        A passing result shows an encrypted SMTP mode; a failing result shows a plaintext connection.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-smtp-server
+        ```
+
+        A passing result reports the SMTP security mode as STARTTLS or SSL.
+      remediation:
+        - id: console
+          desc: |
+            To secure SMTP using Prism:
+
+            1. Open Settings, then SMTP Server.
+            2. Set the security mode to STARTTLS or SSL and the matching port.
+            3. Save and send a test email to confirm delivery.
+        - id: cli
+          desc: |
+            To configure encrypted SMTP using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster set-smtp-server address=smtp.example.com port=587 security-mode=STARTTLS from-email-address=alerts@example.com
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-nfs-allowlist-restricted
+    title: Ensure the cluster NFS allowlist is not wide-open
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a9
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      nutanix.clusters.all(network.nfsSubnetWhitelist.all(_ != "0.0.0.0/0" && _ != "0.0.0.0"))
+    docs:
+      desc: |
+        This check ensures that the cluster-wide NFS allowlist does not include a wide-open entry such as `0.0.0.0/0`. The global NFS allowlist controls which clients may mount cluster storage; an open entry lets any host on the network mount exported file systems and read or write the data they contain.
+
+        **Why this matters**
+
+        - **Unauthorized access:** An open allowlist exposes stored data to every reachable host.
+        - **Data tampering:** Writable NFS exports can be modified by unauthorized clients.
+        - **Lateral movement:** Open storage is a foothold for spreading across the environment.
+
+        **Risk mitigation**
+
+        - **Least access:** Restricting the allowlist to specific trusted subnets limits who can mount storage.
+        - **Network segmentation:** Explicit allowlist entries enforce a deny-by-default posture on storage exports.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism.
+        2. Open Settings, then Filesystem Whitelists.
+        3. Confirm no entry is `0.0.0.0/0` (or `0.0.0.0/0.0.0.0`).
+
+        A passing result shows only specific trusted subnets; a failing result shows an open allowlist.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster get-params
+        ```
+
+        A passing result shows the filesystem allowlist limited to specific subnets.
+      remediation:
+        - id: console
+          desc: |
+            To restrict the NFS allowlist using Prism:
+
+            1. Open Settings, then Filesystem Whitelists.
+            2. Remove any `0.0.0.0/0` entry.
+            3. Add only the specific subnets that require storage access.
+        - id: cli
+          desc: |
+            To set a restricted filesystem allowlist using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli cluster edit-filesystem-whitelist test-subnet=10.20.0.0/255.255.0.0
+            ```
+
+  - uid: mondoo-nutanix-security-cluster-runs-lts-release
+    title: Ensure clusters run a long-term-support release
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sa-22
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    mql: |
+      nutanix.clusters.where(clusterType == "AOS").all(isLts == true)
+    docs:
+      desc: |
+        This check ensures that each AOS cluster runs a long-term-support (LTS) release. LTS releases receive maintenance and security fixes over an extended window, whereas short-term-support (STS) releases reach end of maintenance quickly and stop receiving security patches, leaving the cluster exposed to known vulnerabilities.
+
+        **Why this matters**
+
+        - **Patch availability:** Only supported releases receive security fixes for newly discovered vulnerabilities.
+        - **Predictable maintenance:** LTS releases provide a defined support lifecycle for planning upgrades.
+        - **Stability:** LTS branches prioritize stability and security over new features.
+
+        **Risk mitigation**
+
+        - **Vulnerability management:** Running a supported release ensures fixes are available when needed.
+        - **Reduced exposure:** Avoiding end-of-life software removes a class of unpatchable risk.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element for the cluster.
+        2. Open the cluster details and note the AOS version.
+        3. Confirm the version is a long-term-support release on the Nutanix support portal.
+
+        A passing result shows an LTS release; a failing result shows an STS or end-of-life release.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli cluster version
+        ```
+
+        Confirm the reported AOS version corresponds to an LTS branch on the Nutanix support portal.
+      remediation:
+        - id: console
+          desc: |
+            To move to a long-term-support release using Prism:
+
+            1. Open Settings, then Upgrade Software (Life Cycle Manager).
+            2. Select a long-term-support AOS target version.
+            3. Run the pre-upgrade checks and apply the upgrade.
+        - id: cli
+          desc: |
+            To upgrade AOS using the CLI, run on a Controller VM after downloading the target LTS release:
+
+            ```bash
+            ncli software upgrade software-type=nos
+            ```
+
+  # =================================================================
+  # Host Security
+  # =================================================================
+
+  - uid: mondoo-nutanix-security-host-secure-boot-enabled
+    title: Ensure Secure Boot is enabled on hosts
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.hosts.all(isSecureBooted == true)
+    docs:
+      desc: |
+        This check ensures that UEFI Secure Boot is enabled on each hypervisor host. Secure Boot verifies the cryptographic signature of the bootloader and kernel before they execute, preventing a tampered or malicious boot chain from loading. Without it, an attacker with low-level access can install a bootkit that survives reinstalls and evades the operating system.
+
+        **Why this matters**
+
+        - **Boot integrity:** Secure Boot blocks unsigned or modified boot components from running.
+        - **Persistence resistance:** It defeats bootkits and rootkits that load before the OS.
+        - **Supply chain assurance:** Only firmware-trusted code is allowed to start the host.
+
+        **Risk mitigation**
+
+        - **Verified boot chain:** Each stage validates the next before handing off control.
+        - **Tamper detection:** A modified bootloader fails signature verification and is refused.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Hardware, then select each host.
+        3. Confirm the host reports Secure Boot as enabled.
+
+        A passing result shows Secure Boot enabled on every host; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        acli host.list
+        ```
+
+        Inspect each host's UEFI/Secure Boot status; a passing result reports Secure Boot enabled.
+      remediation:
+        - id: console
+          desc: |
+            Enabling Secure Boot requires UEFI firmware support and host downtime. Using Prism and the host firmware:
+
+            1. Place the host into maintenance mode and migrate its VMs.
+            2. Enable UEFI and Secure Boot in the host firmware (BIOS) settings.
+            3. Boot the host and confirm Prism reports Secure Boot as enabled.
+        - id: cli
+          desc: |
+            To place a host into maintenance mode for the firmware change using the CLI, run on a Controller VM:
+
+            ```bash
+            acli host.enter_maintenance_mode <host-uuid> wait=true
+            ```
+
+            Enable Secure Boot in the host firmware, then exit maintenance mode:
+
+            ```bash
+            acli host.exit_maintenance_mode <host-uuid>
+            ```
+
+  - uid: mondoo-nutanix-security-host-ipmi-not-default-user
+    title: Ensure host IPMI does not use a default username
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-2-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      nutanix.hosts.all(ipmi.username != "ADMIN" && ipmi.username != "admin" && ipmi.username != "root" && ipmi.username != "")
+    docs:
+      desc: |
+        This check ensures that the IPMI/BMC out-of-band management interface on each host does not use a default vendor username such as `ADMIN`. The IPMI interface provides complete out-of-band control of the physical server, including power, console, and firmware; default credentials on this interface are a well-known target and grant an attacker total control of the host below the hypervisor.
+
+        **Why this matters**
+
+        - **Total host control:** IPMI access allows power control, virtual media, and console regardless of the OS.
+        - **Well-known defaults:** Default BMC usernames and passwords are widely published and scanned for.
+        - **Below the hypervisor:** Compromise here is invisible to OS-level defenses.
+
+        **Risk mitigation**
+
+        - **Unique accounts:** Replacing default usernames removes a trivially guessable entry point.
+        - **Credential hygiene:** Distinct, managed BMC credentials tie access to accountable operators.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Hardware, then select each host and review the IPMI configuration.
+        3. Confirm the IPMI username is not a vendor default such as `ADMIN`.
+
+        A passing result shows a non-default IPMI username on every host; a failing result shows a default.
+
+        ### Audit via CLI
+
+        From a Controller VM, query the BMC of each host:
+
+        ```bash
+        ipmitool -I lanplus -H <ipmi-ip> -U <user> -P <pass> user list 1
+        ```
+
+        A passing result shows no default `ADMIN` account in active use.
+      remediation:
+        - id: console
+          desc: |
+            To replace the default IPMI username using the BMC web interface:
+
+            1. Log in to the host's IPMI/BMC web interface.
+            2. Create a new administrative user with a unique name and a strong password.
+            3. Disable or rename the default `ADMIN` account.
+        - id: cli
+          desc: |
+            To replace the default IPMI account using ipmitool, set a new account and disable the default:
+
+            ```bash
+            ipmitool -I lanplus -H <ipmi-ip> -U ADMIN -P <pass> user set name 3 nutanixadmin
+            ipmitool -I lanplus -H <ipmi-ip> -U ADMIN -P <pass> user set password 3
+            ipmitool -I lanplus -H <ipmi-ip> -U ADMIN -P <pass> user priv 3 4
+            ipmitool -I lanplus -H <ipmi-ip> -U ADMIN -P <pass> user disable 2
+            ```
+
+  - uid: mondoo-nutanix-security-host-not-degraded
+    title: Ensure no host is in a degraded state
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a17
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.hosts.all(isDegraded == false)
+    docs:
+      desc: |
+        This check ensures that no hypervisor host is flagged as degraded. Nutanix marks a node degraded when it detects persistent problems such as intermittent network connectivity, hardware errors, or unresponsive services. A degraded node still participates in the cluster but behaves unreliably, which can slow the whole cluster, corrupt data paths, and erode the redundancy the cluster depends on.
+
+        **Why this matters**
+
+        - **Reduced resilience:** A degraded node consumes a fault-tolerance budget without reliably contributing capacity.
+        - **Performance impact:** Intermittent faults on one node can stall cluster-wide operations.
+        - **Failure precursor:** Degradation often precedes a full node failure.
+
+        **Risk mitigation**
+
+        - **Early detection:** Surfacing degraded nodes lets operators act before a hard failure.
+        - **Maintained redundancy:** Removing or repairing degraded nodes preserves the cluster's protection level.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element for the cluster.
+        2. Review the Hardware view and the alerts dashboard.
+        3. Confirm no host is flagged as degraded.
+
+        A passing result shows all hosts healthy; a failing result shows one or more degraded nodes.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli host list | grep -i degraded
+        ```
+
+        A passing result shows no host reporting a degraded state.
+      remediation:
+        - id: console
+          desc: |
+            To resolve a degraded host using Prism:
+
+            1. Open the alert for the degraded node and review the root cause.
+            2. Address the underlying issue (network link, hardware component, or service).
+            3. Once resolved, clear the degraded status from the node's actions menu.
+        - id: cli
+          desc: |
+            To investigate and clear a degraded node using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli host list
+            ```
+
+            After resolving the root cause, fix the node's degraded marker:
+
+            ```bash
+            ncli host edit id=<host-id> enable-degraded-node-fixer=true
+            ```
+
+  # =================================================================
+  # Virtual Machine Security
+  # =================================================================
+
+  - uid: mondoo-nutanix-security-vm-cpu-passthrough-disabled
+    title: Ensure host CPU passthrough is disabled on VMs
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-39
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.vms.all(isCpuPassthroughEnabled == false)
+    docs:
+      desc: |
+        This check ensures that host CPU passthrough is disabled on virtual machines. CPU passthrough exposes the physical host's exact CPU model and feature flags directly to the guest. This narrows the isolation boundary between guest and host, leaks precise hardware details that aid targeting of CPU-level side-channel attacks, and prevents live migration to dissimilar hosts, weakening both security and resilience.
+
+        **Why this matters**
+
+        - **Isolation boundary:** Passing host CPU features through reduces the abstraction that separates guest from host.
+        - **Side-channel targeting:** Exact CPU details help an attacker select microarchitectural attacks.
+        - **Migration constraints:** Passthrough pins a VM to compatible hardware, undermining live migration and resilience.
+
+        **Risk mitigation**
+
+        - **Hardware abstraction:** A virtualized CPU model keeps host specifics from the guest.
+        - **Portability:** Disabling passthrough preserves live migration across the cluster.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open the VM list and review each VM's CPU configuration.
+        3. Confirm host CPU passthrough is not enabled.
+
+        A passing result shows passthrough disabled on every VM; a failing result shows it enabled.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        acli vm.get <vm-name>
+        ```
+
+        A passing result shows `cpu_passthrough` absent or set to false.
+      remediation:
+        - id: console
+          desc: |
+            CPU passthrough changes require the VM to be powered off. Using Prism:
+
+            1. Power off the affected VM.
+            2. Edit the VM and disable host CPU passthrough.
+            3. Power the VM back on.
+        - id: cli
+          desc: |
+            To disable CPU passthrough using the CLI, run on a Controller VM with the VM powered off:
+
+            ```bash
+            acli vm.update <vm-name> cpu_passthrough=false
+            ```
+
+  - uid: mondoo-nutanix-security-vm-guest-tools-installed
+    title: Ensure Nutanix Guest Tools is installed and reachable
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      nutanix.vms.where(powerState == "ON").all(guestTools.isInstalled == true && guestTools.isReachable == true)
+    docs:
+      desc: |
+        This check ensures that Nutanix Guest Tools (NGT) is installed and reachable on every powered-on virtual machine. NGT provides the in-guest agent that enables application-consistent snapshots, self-service file restore, and accurate guest inventory. Without it, the platform has limited visibility into the guest and cannot take consistent backups, leaving recovery and asset tracking incomplete.
+
+        **Why this matters**
+
+        - **Consistent backups:** NGT enables application-consistent snapshots through VSS and file-system quiescing.
+        - **Asset visibility:** The agent reports guest OS and configuration details for inventory.
+        - **Recovery features:** Self-service restore depends on a working NGT agent.
+
+        **Risk mitigation**
+
+        - **Reliable recovery:** Consistent snapshots reduce the risk of unrecoverable backups.
+        - **Accurate inventory:** Reachable agents keep guest records current.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open the VM list and add the NGT columns, or open each VM's details.
+        3. Confirm NGT is installed and shows as reachable for powered-on VMs.
+
+        A passing result shows NGT installed and reachable; a failing result shows it missing or unreachable.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli ngt list
+        ```
+
+        A passing result shows NGT installed and communicating for each powered-on VM.
+      remediation:
+        - id: console
+          desc: |
+            To install Nutanix Guest Tools using Prism:
+
+            1. Select the VM and choose Manage Guest Tools.
+            2. Enable NGT and mount the NGT ISO.
+            3. Inside the guest, run the NGT installer and confirm the agent connects.
+        - id: cli
+          desc: |
+            To enable and mount NGT using the CLI, run on a Controller VM, then complete installation inside the guest:
+
+            ```bash
+            ncli ngt enable vm-id=<vm-id>
+            ncli ngt mount vm-id=<vm-id>
+            ```
+
+  - uid: mondoo-nutanix-security-vm-guest-tools-current
+    title: Ensure Nutanix Guest Tools is up to date
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    mql: |
+      nutanix.vms.where(guestTools.isInstalled == true).all(guestTools.version == guestTools.availableVersion)
+    docs:
+      desc: |
+        This check ensures that, where Nutanix Guest Tools is installed, it is running the version available on the cluster. An outdated in-guest agent may contain known vulnerabilities and may fail to deliver the consistent-snapshot and inventory features the platform relies on. Keeping the agent current is patch management for a privileged component running inside every guest.
+
+        **Why this matters**
+
+        - **Vulnerability exposure:** Outdated agents may carry unpatched security flaws.
+        - **Feature reliability:** Newer NGT versions fix snapshot and quiescing bugs that affect recoverability.
+        - **Compatibility:** Matching the cluster version avoids agent-to-cluster protocol mismatches.
+
+        **Risk mitigation**
+
+        - **Patch currency:** Updating NGT closes known agent vulnerabilities.
+        - **Dependable backups:** Current agents deliver reliable application-consistent snapshots.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open the VM list and review the NGT version column against the available version.
+        3. Confirm installed NGT matches the version available on the cluster.
+
+        A passing result shows NGT at the available version; a failing result shows an older version.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli ngt list
+        ```
+
+        Compare each VM's installed NGT version against the cluster's available version.
+      remediation:
+        - id: console
+          desc: |
+            To update Nutanix Guest Tools using Prism:
+
+            1. Select the VMs with outdated NGT.
+            2. Choose Upgrade NGT (or Manage Guest Tools, then upgrade).
+            3. Confirm the agent reports the current version after the upgrade.
+        - id: cli
+          desc: |
+            To upgrade NGT using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli ngt upgrade vm-id=<vm-id>
+            ```
+
+  - uid: mondoo-nutanix-security-vm-protected
+    title: Ensure virtual machines are protected
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    mql: |
+      nutanix.vms.all(protectionType != "UNPROTECTED")
+    docs:
+      desc: |
+        This check ensures that virtual machines are covered by a protection policy (a protection domain or a recovery/protection rule) rather than left unprotected. An unprotected VM has no automated snapshots or replication, so a ransomware event, accidental deletion, or storage failure results in permanent loss of that workload with no recovery point.
+
+        **Why this matters**
+
+        - **Ransomware recovery:** Protected VMs can be restored to a clean recovery point after an attack.
+        - **Operational mistakes:** Snapshots recover from accidental deletion or corruption.
+        - **Disaster recovery:** Replication enables failover when a site or cluster is lost.
+
+        **Risk mitigation**
+
+        - **Recovery points:** Scheduled snapshots provide restorable copies of each workload.
+        - **Business continuity:** Replication supports recovery objectives during a disaster.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Data Protection, then review protection policies and the VM list's protection status.
+        3. Confirm every business-critical VM is associated with a protection policy.
+
+        A passing result shows VMs protected by a policy; a failing result shows unprotected VMs.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli protection-domain list-vms
+        ```
+
+        A passing result shows the VMs assigned to protection domains.
+      remediation:
+        - id: console
+          desc: |
+            To protect virtual machines using Prism Central:
+
+            1. Open Data Protection, then Protection Policies.
+            2. Create or edit a policy with a snapshot schedule and, where needed, replication target.
+            3. Assign the VMs (directly or by category) to the policy.
+        - id: cli
+          desc: |
+            To add VMs to a protection domain using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli protection-domain protect name=<pd-name> vm-names=<vm1>,<vm2>
+            ```
+
+  # =================================================================
+  # Identity and Access Management
+  # =================================================================
+
+  - uid: mondoo-nutanix-security-directory-service-uses-ldaps
+    title: Ensure directory services use LDAPS
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a11
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-aa-04
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-6-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      nutanix.directoryServices.all(url == /^ldaps:\/\//i && secondaryUrls.all(_ == /^ldaps:\/\//i))
+    docs:
+      desc: |
+        This check ensures that every configured directory service (Active Directory or LDAP) uses LDAPS rather than plaintext LDAP. Directory authentication carries credentials and group membership over the network; plaintext LDAP exposes the bind service-account password and every user's credentials to anyone able to observe the traffic.
+
+        **Why this matters**
+
+        - **Credential interception:** Plaintext LDAP binds reveal usernames and passwords on the wire.
+        - **Service-account exposure:** The directory bind account is high value and is sent in the clear over LDAP.
+        - **Authorization tampering:** Unencrypted directory responses can be altered to change group membership.
+
+        **Risk mitigation**
+
+        - **Encrypted channel:** LDAPS protects credentials and directory responses in transit.
+        - **Integrity:** TLS prevents manipulation of authentication and group data.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Settings, then Authentication, then Directory List.
+        3. Confirm each directory URL uses `ldaps://` and a secure port (typically 636 or 3269).
+
+        A passing result shows all directory URLs using LDAPS; a failing result shows a plaintext `ldap://` URL.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli authconfig list-directory
+        ```
+
+        A passing result shows directory URLs beginning with `ldaps://`.
+      remediation:
+        - id: console
+          desc: |
+            To switch a directory service to LDAPS using Prism Central:
+
+            1. Open Settings, then Authentication, then Directory List.
+            2. Edit the directory and change the URL to `ldaps://<server>:636` (or `:3269` for the global catalog).
+            3. Upload the directory's CA certificate if required, then save and test login.
+        - id: cli
+          desc: |
+            To update a directory service to LDAPS using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli authconfig edit-directory name=<directory-name> directory-url=ldaps://ad.example.com:636
+            ```
+
+  - uid: mondoo-nutanix-security-directory-service-group-allowlist
+    title: Ensure directory services restrict access with a group allowlist
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a12
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-16
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      nutanix.directoryServices.all(whiteListedGroups.length > 0)
+    docs:
+      desc: |
+        This check ensures that each directory service restricts which directory groups may access Prism by defining a group allowlist. Without an allowlist, the scope of who can attempt to authenticate and be authorized is far broader than intended, and access depends entirely on role mappings being perfectly maintained. An explicit allowlist enforces least privilege at the directory-integration boundary.
+
+        **Why this matters**
+
+        - **Least privilege:** Limiting access to named groups keeps the authorized population small and intentional.
+        - **Reduced attack surface:** Fewer eligible accounts means fewer credentials an attacker can target for access.
+        - **Defense in depth:** The allowlist backstops role-mapping mistakes that would otherwise grant access.
+
+        **Risk mitigation**
+
+        - **Scoped access:** Only members of approved groups can use the directory to reach Prism.
+        - **Clear ownership:** Allowlisted groups make the set of authorized users explicit and reviewable.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Settings, then Role Mapping (and the directory configuration).
+        3. Confirm access is granted to specific allowlisted groups rather than left open.
+
+        A passing result shows one or more allowlisted groups per directory; a failing result shows no group restriction.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli authconfig list-directory
+        ```
+
+        A passing result shows allowlisted groups configured for each directory.
+      remediation:
+        - id: console
+          desc: |
+            To restrict directory access to specific groups using Prism Central:
+
+            1. Open Settings, then Role Mapping.
+            2. Add role mappings that grant access only to named directory groups.
+            3. Remove any broad or default mappings that grant access without a group restriction.
+        - id: cli
+          desc: |
+            To add an allowlisted group mapping using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli authconfig add-role-mapping directory-name=<directory-name> role=ROLE_CLUSTER_VIEWER entity-type=GROUP entity-values="Nutanix-Admins"
+            ```
+
+  - uid: mondoo-nutanix-security-saml-signed-authn-requests
+    title: Ensure SAML identity providers sign authn requests
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-04
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-23
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      nutanix.samlIdentityProviders.all(isSignedAuthnReqEnabled == true)
+    docs:
+      desc: |
+        This check ensures that each SAML identity provider used for single sign-on is configured to sign authn requests. Signing the authentication request lets the identity provider verify that the request genuinely originated from Prism Central, preventing forged or replayed requests from being processed and hardening the federated authentication exchange against tampering.
+
+        **Why this matters**
+
+        - **Request authenticity:** Signing proves the authn request came from the trusted service provider.
+        - **Replay and forgery resistance:** Unsigned requests can be forged or replayed against the IdP.
+        - **Federation integrity:** A signed exchange protects the trust relationship between Prism and the IdP.
+
+        **Risk mitigation**
+
+        - **Verified origin:** The IdP rejects requests that are not signed by the expected service provider.
+        - **Tamper resistance:** Signatures detect modification of the authentication request.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Settings, then Authentication, then the SAML / Identity Providers configuration.
+        3. Confirm signed authn requests are enabled for each identity provider.
+
+        A passing result shows signed authn requests enabled; a failing result shows them disabled.
+
+        ### Audit via CLI
+
+        Query the IAM v4 API from a host with API access:
+
+        ```bash
+        curl -sk -u <user> https://<pc-ip>:9440/api/iam/v4.0/authn/saml-identity-providers
+        ```
+
+        A passing result shows `isSignedAuthnReqEnabled` set to true for each provider.
+      remediation:
+        - id: console
+          desc: |
+            To enable signed authn requests using Prism Central:
+
+            1. Open Settings, then Authentication, then Identity Providers.
+            2. Edit the SAML identity provider.
+            3. Enable signed authn requests and save, updating the IdP metadata if required.
+        - id: api
+          desc: |
+            To enable signed authn requests using the IAM v4 API, update the identity provider with `isSignedAuthnReqEnabled` set to true:
+
+            ```bash
+            curl -sk -u <user> -X PUT \
+              https://<pc-ip>:9440/api/iam/v4.0/authn/saml-identity-providers/<idp-ext-id> \
+              -H 'Content-Type: application/json' \
+              -d '{"isSignedAuthnReqEnabled": true}'
+            ```
+
+  - uid: mondoo-nutanix-security-inactive-local-users-removed
+    title: Ensure inactive local users are removed
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-3-ii-c-workforce-security-establish-termination-procedures
+      compliance/iso-27001-2022: iso-27001-2022-a-5-18
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/pci-dss-4: pcidss-requirement-8-2-6
+      compliance/soc2-2017: soc2-control-cc6-2-2
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      nutanix.users.where(userType == "LOCAL").all(status != "INACTIVE")
+    docs:
+      desc: |
+        This check ensures that local user accounts in an inactive state are removed rather than left in place. An inactive account is no longer used but still exists; if it can be re-enabled or its credentials are recovered, it becomes an unmonitored path back into Prism. Removing accounts that are no longer needed enforces account lifecycle hygiene.
+
+        **Why this matters**
+
+        - **Dormant access:** Inactive accounts are not watched yet can still represent valid identities.
+        - **Re-enablement risk:** A dormant account can be reactivated by an attacker who gains administrative access.
+        - **Credential leakage:** Old accounts may share passwords later exposed in breaches.
+
+        **Risk mitigation**
+
+        - **Account lifecycle:** Removing inactive accounts closes unused entry points.
+        - **Smaller attack surface:** Fewer standing accounts means fewer credentials to compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Settings, then Users (Local User Management).
+        3. Confirm there are no local users in an inactive state.
+
+        A passing result shows no inactive local users; a failing result shows one or more.
+
+        ### Audit via CLI
+
+        Query the IAM v4 API from a host with API access:
+
+        ```bash
+        curl -sk -u <user> "https://<pc-ip>:9440/api/iam/v4.0/authn/users?\$filter=userType eq 'LOCAL'"
+        ```
+
+        A passing result shows no local user with a status of INACTIVE.
+      remediation:
+        - id: console
+          desc: |
+            To remove inactive local users using Prism Central:
+
+            1. Open Settings, then Users.
+            2. Review each local account flagged as inactive and confirm it is no longer required.
+            3. Delete the account.
+        - id: api
+          desc: |
+            To delete an inactive local user using the IAM v4 API:
+
+            ```bash
+            curl -sk -u <user> -X DELETE \
+              https://<pc-ip>:9440/api/iam/v4.0/authn/users/<user-ext-id>
+            ```
+
+  - uid: mondoo-nutanix-security-no-stale-user-accounts
+    title: Ensure active local accounts are not stale
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-08
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-3-ii-c-workforce-security-establish-termination-procedures
+      compliance/iso-27001-2022: iso-27001-2022-a-5-18
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/pci-dss-4: pcidss-requirement-8-2-6
+      compliance/soc2-2017: soc2-control-cc6-2-3
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      nutanix.users.where(userType == "LOCAL" && status == "ACTIVE").where(lastLoginTime != null).all(lastLoginTime > time.now - 90 * time.day)
+    docs:
+      desc: |
+        This check ensures that active local accounts that have logged in have done so within the last 90 days. An account that is still enabled but unused for months is a prime target: nobody is watching it, yet it retains valid access. Reviewing and disabling stale accounts keeps the set of usable credentials aligned with actual need.
+
+        **Why this matters**
+
+        - **Unwatched credentials:** Long-idle accounts attract little scrutiny while remaining fully usable.
+        - **Orphaned access:** Stale accounts often belong to former staff or decommissioned integrations.
+        - **Compliance:** Periodic access review is a baseline expectation across frameworks.
+
+        **Risk mitigation**
+
+        - **Right-sized access:** Disabling unused accounts shrinks the credential attack surface.
+        - **Review cadence:** A 90-day window enforces a regular check on account necessity.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Central.
+        2. Open Settings, then Users (Local User Management).
+        3. Review the last-login time for each active local account.
+
+        A passing result shows all active local accounts used within 90 days; a failing result shows accounts idle longer.
+
+        ### Audit via CLI
+
+        Query the IAM v4 API from a host with API access:
+
+        ```bash
+        curl -sk -u <user> "https://<pc-ip>:9440/api/iam/v4.0/authn/users?\$filter=userType eq 'LOCAL'"
+        ```
+
+        Review `lastLoginTime` for each active account; a passing result shows recent activity within 90 days.
+      remediation:
+        - id: console
+          desc: |
+            To remediate stale local accounts using Prism Central:
+
+            1. Open Settings, then Users.
+            2. Identify active accounts with no login in the last 90 days.
+            3. Confirm whether each is still required; disable or delete those that are not.
+        - id: api
+          desc: |
+            To delete a stale local user using the IAM v4 API after confirming it is unneeded:
+
+            ```bash
+            curl -sk -u <user> -X DELETE \
+              https://<pc-ip>:9440/api/iam/v4.0/authn/users/<user-ext-id>
+            ```
+
+  # =================================================================
+  # Storage Security
+  # =================================================================
+
+  - uid: mondoo-nutanix-security-volume-group-chap-auth
+    title: Ensure volume groups require CHAP authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-3
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      nutanix.volumeGroups.where(usageType == "USER").all(enabledAuthentications == "CHAP")
+    docs:
+      desc: |
+        This check ensures that user-facing volume groups exposed over iSCSI or NVMe-oF require CHAP authentication. Without CHAP, any initiator that can reach the data-services IP can connect to the target and access the block storage it presents. Because volume groups hold raw application data such as database volumes, an unauthenticated target is a direct path to that data.
+
+        **Why this matters**
+
+        - **Unauthenticated access:** Without CHAP, any reachable initiator can attach to the volume group.
+        - **Raw data exposure:** Block targets present application data directly, bypassing file-level controls.
+        - **Data tampering:** An unauthorized initiator can read and write the underlying volumes.
+
+        **Risk mitigation**
+
+        - **Initiator authentication:** CHAP requires a shared secret before a connection is established.
+        - **Access control:** Only initiators that present valid credentials can attach to the target.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element (or Prism Central Storage).
+        2. Open Storage, then Volume Groups, and review each user volume group.
+        3. Confirm CHAP authentication is enabled on each target.
+
+        A passing result shows CHAP required; a failing result shows authentication set to none.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        acli vg.list
+        acli vg.get <volume-group-name>
+        ```
+
+        A passing result shows the volume group's external attachment requiring CHAP.
+      remediation:
+        - id: console
+          desc: |
+            To require CHAP on a volume group using Prism:
+
+            1. Open Storage, then Volume Groups, and edit the volume group.
+            2. Enable CHAP authentication and set a strong secret.
+            3. Update the connecting initiators with the matching CHAP credentials.
+        - id: cli
+          desc: |
+            To enable CHAP on a volume group using the CLI, run on a Controller VM:
+
+            ```bash
+            acli vg.update <volume-group-name> chap_auth=true target_password=<chap-secret>
+            ```
+
+  - uid: mondoo-nutanix-security-storage-container-encrypted
+    title: Ensure storage containers are encrypted
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      nutanix.storageContainers.where(isInternal == false).all(isEncrypted == true)
+    docs:
+      desc: |
+        This check ensures that each user-facing storage container is encrypted. Storage containers hold the virtual disks for every VM placed in them; an unencrypted container leaves that data recoverable from the physical media if a drive is stolen, improperly disposed of, or returned under warranty. Container-level encryption applies protection precisely where workload data lives.
+
+        **Why this matters**
+
+        - **Drive theft and disposal:** Encrypted containers are unreadable from a removed disk.
+        - **Granular protection:** Per-container encryption protects the specific data sets that need it.
+        - **Regulatory alignment:** Encryption at rest is a common requirement for sensitive workloads.
+
+        **Risk mitigation**
+
+        - **Confidentiality at rest:** Container data is unintelligible without the keys.
+        - **Safe media handling:** Cryptographic erasure simplifies secure decommissioning.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element (or Prism Central Storage).
+        2. Open Storage, then Storage Containers.
+        3. Confirm encryption is enabled on each user container.
+
+        A passing result shows encryption enabled per container; a failing result shows an unencrypted container.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli container list
+        ```
+
+        A passing result shows each user container with encryption enabled.
+      remediation:
+        - id: console
+          desc: |
+            To enable encryption on a storage container using Prism:
+
+            1. Ensure cluster data-at-rest encryption and a key management server are configured.
+            2. Open Storage, then Storage Containers, and edit the container.
+            3. Enable encryption and save.
+        - id: cli
+          desc: |
+            To enable encryption on a storage container using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli container edit name=<container-name> enable-software-encryption=true
+            ```
+
+  - uid: mondoo-nutanix-security-storage-container-nfs-allowlist
+    title: Ensure storage container NFS allowlists are restricted
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a9
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      nutanix.storageContainers.where(isInternal == false).all(nfsWhitelistAddresses.all(_ != "0.0.0.0" && _ != "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that a storage container's NFS allowlist does not include a wide-open entry such as `0.0.0.0`. A per-container NFS allowlist controls which clients may mount that container directly; an open entry exposes the container's virtual disks and files to any host that can reach the data-services IP, regardless of the cluster-wide allowlist.
+
+        **Why this matters**
+
+        - **Direct data exposure:** An open container allowlist lets any reachable host mount the container.
+        - **Bypass of higher controls:** A permissive per-container entry can override a stricter global posture.
+        - **Lateral movement:** Mountable storage is a foothold for spreading across the environment.
+
+        **Risk mitigation**
+
+        - **Least access:** Restricting the allowlist to trusted subnets limits who can mount the container.
+        - **Deny by default:** Explicit entries enforce a closed-by-default stance on container exports.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element (or Prism Central Storage).
+        2. Open Storage, then Storage Containers, and review each container's filesystem allowlist.
+        3. Confirm no container allowlist contains `0.0.0.0` (or `0.0.0.0/0`).
+
+        A passing result shows only specific trusted subnets; a failing result shows an open container allowlist.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli container list
+        ```
+
+        A passing result shows each container's NFS allowlist limited to specific subnets.
+      remediation:
+        - id: console
+          desc: |
+            To restrict a container's NFS allowlist using Prism:
+
+            1. Open Storage, then Storage Containers, and edit the container.
+            2. Remove any `0.0.0.0` entry from the filesystem allowlist.
+            3. Add only the specific subnets that require access, or inherit the restricted global allowlist.
+        - id: cli
+          desc: |
+            To set a restricted filesystem allowlist on a container using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli container edit name=<container-name> filesystem-whitelist=10.20.0.0/255.255.0.0
+            ```
+
+  - uid: mondoo-nutanix-security-storage-container-replication-factor
+    title: Ensure storage containers use a replication factor of at least 2
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a20
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-11
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    mql: |
+      nutanix.storageContainers.where(isInternal == false).all(replicationFactor >= 2)
+    docs:
+      desc: |
+        This check ensures that each user-facing storage container keeps at least two copies of its data (a replication factor of 2 or higher). A container with a replication factor of 1 stores a single copy, so any disk or node failure that touches that data results in permanent loss for every virtual disk in the container.
+
+        **Why this matters**
+
+        - **Single point of failure:** One copy means a single hardware failure is unrecoverable.
+        - **Workload impact:** Container data loss affects every VM whose disks live there.
+        - **Recovery resilience:** Multiple copies support recovery from localized data damage.
+
+        **Risk mitigation**
+
+        - **Data redundancy:** A replication factor of 2 tolerates the loss of one copy without data loss.
+        - **Continuous availability:** The container keeps serving data while the cluster restores redundancy.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to Prism Element (or Prism Central Storage).
+        2. Open Storage, then Storage Containers.
+        3. Confirm each user container's replication factor is 2 or higher.
+
+        A passing result shows a replication factor of 2 or more; a failing result shows 1.
+
+        ### Audit via CLI
+
+        Run on a Controller VM:
+
+        ```bash
+        ncli container list
+        ```
+
+        A passing result shows each user container with a replication factor of 2 or higher.
+      remediation:
+        - id: console
+          desc: |
+            To raise a container's replication factor using Prism:
+
+            1. Ensure the cluster has the redundancy factor and node count to support RF2.
+            2. Open Storage, then Storage Containers, and edit the container.
+            3. Set the replication factor to 2 or higher and save.
+        - id: cli
+          desc: |
+            To set a container's replication factor using the CLI, run on a Controller VM:
+
+            ```bash
+            ncli container edit name=<container-name> rf=2
+            ```


### PR DESCRIPTION
## Summary

Adds `content/mondoo-nutanix-security.mql.yaml` — a new security policy for Nutanix infrastructure managed through Prism Central, built against the `nutanix` provider (`asset.platform == "nutanix-prism-central"`).

**28 checks across five domains:**

| Domain | Checks |
|---|---|
| **Cluster** | data-at-rest & in-transit encryption, external KMS, password SSH login disabled, remote support tunnel disabled, redundancy factor ≥ 2, fault-tolerance readiness, NTP, DNS, SMTP transport security, NFS allowlist, LTS release |
| **Host** | UEFI Secure Boot, IPMI/BMC default username, degraded-state monitoring |
| **VM** | host CPU passthrough disabled, Nutanix Guest Tools installed/current, backup/DR protection |
| **IAM** | LDAPS directory services, directory group allowlists, SAML signed authn requests, inactive local users removed, no stale active accounts |
| **Storage** | volume-group CHAP authentication, container encryption, per-container NFS allowlists, replication factor ≥ 2 |

Modeled on `mondoo-proxmox-security` (virtualization platform, no Terraform variants — Nutanix is an API/runtime target with no IaC analog).

## Docs & remediation

Every check ships with `desc` / `audit` / `remediation`. Audit and remediation use vendor-native tooling only — Prism Central/Element UI, `ncli`/`acli`, and the REST v4 API (no Mondoo tools referenced). There is no Nutanix CLI validator harness in `content/validation/`, so commands were hand-verified against Nutanix docs.

## Compliance

All 28 checks carry tags for the same 13 frameworks used by the Proxmox policy: BSI SYS.1.5, CSA CCM 4, DORA, HIPAA, ISO 27001:2022, NIS2, NIST CSF 1, NIST CSF 2, NIST 800-171, NIST 800-53 rev5, PCI DSS 4, SOC 2 2017, VDA ISA 5 (**364 tags total**).

- Each mapping was derived from the framework's **authoritative control text** in `cnspec-enterprise-policies/frameworks/`, not copied from neighboring checks.
- Every control UID was verified to exist in its framework file (no dangling `framework_owner`).
- Where no control strictly fits, the unquoted `false` boolean is used (85 no-fit entries) rather than forcing a loose mapping. There is no published Nutanix CIS *Benchmark*, so mappings target generic control objectives (encrypt-at-rest, manage-access, secure-configuration, time-sync, network-isolation, backup, resiliency).
- The BSI SYS.1.5 Virtualisation module mapped especially cleanly (A28 encryption, A20 high availability, A22 host hardening, A23 VM rights restriction, A5 admin-interface protection, A7 time sync, A9 network planning, A11 management network, A12 roles).

## Edge-case guards

- `vm-guest-tools-installed` filters to powered-on VMs.
- `vm-guest-tools-current` filters to VMs where NGT is installed.
- `no-stale-user-accounts` filters to active local users with a non-null `lastLoginTime`.
- `cluster-smtp-encrypted` only evaluates clusters with SMTP configured.
- storage checks exclude internal Nutanix-managed containers.

## Validation

```
cnspec policy lint content/mondoo-nutanix-security.mql.yaml
→ valid policy bundle(s)
```

MQL for all 28 checks compiles against the installed `nutanix` provider; titles are ≤ 75 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)