### PR TITLE
Escape spreadsheet formula triggers in vulnerability CSV output

### DIFF
--- a/cli/reporter/csv_vuln.go
+++ b/cli/reporter/csv_vuln.go
@@ -50,7 +50,7 @@ func VulnReportToCSV(data *mvd.VulnReport, out iox.OutputHelper) error {
 
 	for i := range pkgs {
 		pkg := pkgs[i]
-		err := w.Write(pkg.toSlice())
+		err := w.Write(escapeCSVRow(pkg.toSlice()))
 		if err != nil {
 			return err
 		}
@@ -58,6 +58,28 @@ func VulnReportToCSV(data *mvd.VulnReport, out iox.OutputHelper) error {
 
 	w.Flush()
 	return w.Error()
+}
+
+// escapeCSVRow neutralizes any cell that a spreadsheet application would
+// interpret as a formula. Package fields come from the scanned target, so a
+// value such as "=HYPERLINK(...)" must not execute when the report is opened in
+// Excel, LibreOffice, or Sheets. See OWASP "CSV Injection".
+func escapeCSVRow(row []string) []string {
+	for i := range row {
+		row[i] = escapeCSVCell(row[i])
+	}
+	return row
+}
+
+func escapeCSVCell(value string) string {
+	if value == "" {
+		return value
+	}
+	switch value[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + value
+	}
+	return value
 }
 
 func renderVulnerabilitiesAsCSV(r *mvd.VulnReport) []*csvStruct {

--- a/cli/reporter/csv_vuln_test.go
+++ b/cli/reporter/csv_vuln_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,4 +30,62 @@ func TestCsvConverter(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "libblkid1,5.5,2.34-0.1ubuntu9.1,2.34-0.1ubuntu9.3,2.34-0.1ubuntu9.3,USN-5279-1,CVE-2021-3995 CVE-2021-3996")
+}
+
+func TestCsvConverterNeutralizesFormulas(t *testing.T) {
+	reportRaw, err := os.ReadFile("./testdata/mondoo-debug-vulnReport.json")
+	require.NoError(t, err)
+
+	report := &mvd.VulnReport{}
+	err = json.Unmarshal(reportRaw, report)
+	require.NoError(t, err)
+
+	// A scanned target controls package names; inject a spreadsheet formula
+	// payload into an affected package so it flows through to the CSV output.
+	const payload = `=HYPERLINK("http://evil","click")`
+	found := false
+	for _, pkg := range report.Packages {
+		if pkg.Name == "libblkid1" {
+			pkg.Name = payload
+			found = true
+		}
+	}
+	require.True(t, found, "expected to find a package to mutate")
+
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	err = VulnReportToCSV(report, &writer)
+	require.NoError(t, err)
+
+	out := buf.String()
+	// The payload must survive but be neutralized with a leading single quote,
+	// and no CSV field may begin with the raw formula.
+	assert.Contains(t, out, `'=HYPERLINK`)
+	assert.NotContains(t, out, "\n="+`HYPERLINK`)
+	for _, line := range strings.Split(out, "\n") {
+		assert.False(t, strings.HasPrefix(line, "="), "line begins with a formula: %q", line)
+	}
+}
+
+func TestEscapeCSVCell(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "plain", input: "libblkid1", expected: "libblkid1"},
+		{name: "equals formula", input: "=HYPERLINK(\"http://evil\")", expected: "'=HYPERLINK(\"http://evil\")"},
+		{name: "plus", input: "+1+1", expected: "'+1+1"},
+		{name: "minus", input: "-2+3", expected: "'-2+3"},
+		{name: "at", input: "@SUM(A1)", expected: "'@SUM(A1)"},
+		{name: "tab", input: "\t=1", expected: "'\t=1"},
+		{name: "carriage return", input: "\r=1", expected: "'\r=1"},
+		{name: "formula char not leading", input: "a=b", expected: "a=b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, escapeCSVCell(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Harden the vulnerability CSV reporter (`cnspec vuln -o csv`) against spreadsheet formula interpretation. Package fields in the report (name, installed/fixed/available versions, advisory, CVEs) originate from the scanned target. A value that begins with `=`, `+`, `-`, `@`, tab, or CR is treated as a formula by Excel, LibreOffice, and Google Sheets when the file is opened, so these cells are now prefixed with a single quote and rendered as plain text instead. See OWASP "CSV Injection".

## Changes

- `cli/reporter/csv_vuln.go`: route every data cell through a new `escapeCSVCell` helper before writing.
- `cli/reporter/csv_vuln_test.go`:
  - `TestEscapeCSVCell` — unit coverage for each trigger character, empty/plain values, and a non-leading `=`.
  - `TestCsvConverterNeutralizesFormulas` — end-to-end check that a formula payload injected into a package name is emitted as text and never starts a CSV field.

## Testing

- `go test ./cli/reporter/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)