### PR TITLE
:star: Add chrony, yum gpgcheck, and APT repo-trust checks to Linux policy

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -128,6 +128,7 @@ cheatsheet
 checkend
 chkconfig
 chokepoints
+chronyc
 Cim
 CIMSLP
 cimv

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -787,6 +787,7 @@ timeframes
 timestamped
 timestreaminflux
 timestreamwrite
+timesync
 tinyssh
 tipc
 tmpfiles

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.6.0
+    version: 2.7.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -194,6 +194,17 @@ policies:
           - uid: mondoo-linux-security-shadow-group-is-empty
           - uid: mondoo-linux-security-system-accounts-are-non-login
           - uid: mondoo-linux-security-uid-min-is-set-to-1000
+      - title: Time Synchronization
+        filters: |
+          asset.family.contains('linux')
+        checks:
+          - uid: mondoo-linux-security-chrony-time-source-is-configured
+      - title: Package Management
+        filters: |
+          asset.family.contains('linux')
+        checks:
+          - uid: mondoo-linux-security-gpgcheck-is-globally-activated
+          - uid: mondoo-linux-security-apt-repositories-enforce-signature-verification
     scoring_system: highest impact
 queries:
   - uid: mondoo-linux-security-aide-is-installed
@@ -14158,3 +14169,309 @@ queries:
     refs:
       - url: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/using_selinux/changing-selinux-states-and-modes_using-selinux
         title: Red Hat - Changing SELinux states and modes
+  - uid: mondoo-linux-security-chrony-time-source-is-configured
+    title: Ensure a time source is configured in chrony
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    filters: |
+      package('chrony').installed
+    mql: |
+      chrony.conf.servers != [] || chrony.conf.pools != []
+    docs:
+      desc: |
+        This check ensures that chrony, the time synchronization daemon, is configured with at least one upstream time source so the system clock is kept accurate. By default a chrony installation may ship without an active `server` or `pool` directive, leaving the host with an unsynchronized clock.
+
+        **Why this matters**
+
+        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock agrees on the current time.
+        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so drift can break authentication or silently accept expired credentials.
+        - **Forensic integrity:** Accurate timestamps are essential when reconstructing the sequence of an incident.
+
+        **Risk mitigation**
+
+        - **Detect tampering:** A synchronized clock makes it harder for an attacker to disguise the timing of malicious activity.
+        - **Consistent enforcement:** Time-based access controls and scheduled jobs behave predictably when the clock is trustworthy.
+      audit: |
+        Run this command to confirm chrony is tracking at least one time source:
+
+        ```bash
+        chronyc sources
+        ```
+
+        Then inspect the configuration for a configured source:
+
+        ```bash
+        grep -E '^\s*(server|pool)\s' /etc/chrony.conf /etc/chrony/chrony.conf 2>/dev/null
+        ```
+
+        A passing result lists one or more `server` or `pool` entries and shows reachable sources in `chronyc sources`. A failing result returns no `server` or `pool` directives.
+      remediation:
+        - id: cli
+          desc: |
+            **Using CLI**
+
+            Add an authorized time source to the chrony configuration, then restart the daemon:
+
+            ```bash
+            echo "pool 2.pool.ntp.org iburst" >> /etc/chrony.conf
+            systemctl restart chronyd
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to add a pool directive if none is configured and restart chrony:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            CONF=/etc/chrony.conf
+            [ -f "$CONF" ] || CONF=/etc/chrony/chrony.conf
+
+            if ! grep -qE '^\s*(server|pool)\s' "$CONF"; then
+              echo "pool 2.pool.ntp.org iburst" >> "$CONF"
+            fi
+
+            systemctl restart chronyd
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to ensure a time source is configured and chrony is running:
+
+            ```yaml
+            ---
+            - name: Configure a chrony time source
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Ensure a pool directive is present
+                  ansible.builtin.lineinfile:
+                    path: /etc/chrony.conf
+                    line: "pool 2.pool.ntp.org iburst"
+                    regexp: '^\s*pool\s'
+                    state: present
+                  notify: Restart chrony
+
+              handlers:
+                - name: Restart chrony
+                  ansible.builtin.service:
+                    name: chronyd
+                    state: restarted
+            ```
+    refs:
+      - url: https://chrony-project.org/documentation.html
+        title: chrony - Documentation
+  - uid: mondoo-linux-security-gpgcheck-is-globally-activated
+    title: Ensure gpgcheck is globally activated
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-id-ra-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-14
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    filters: |
+      asset.family.contains('redhat') || asset.platform == 'amazonlinux'
+    mql: |
+      yum.config.gpgcheck == true
+    docs:
+      desc: |
+        This check ensures that the system-wide `gpgcheck` option is enabled in the yum or dnf configuration so that the package manager verifies the cryptographic signature of every package before installing it. When `gpgcheck` is disabled the system will install packages whose authenticity and integrity have not been verified.
+
+        **Why this matters**
+
+        - **Authenticity:** Signature verification confirms that a package was produced by the expected vendor and not substituted by an attacker.
+        - **Integrity:** A valid signature guarantees the package was not modified in transit between the repository and the host.
+        - **Supply-chain protection:** A compromised mirror or a manipulated download cannot deliver unsigned malicious software when verification is enforced.
+
+        **Risk mitigation**
+
+        - **Prevent malicious installs:** Tampered or forged packages are rejected before any code runs.
+        - **Consistent enforcement:** Setting the option in the global `[main]` section applies the control to every repository rather than relying on per-repository settings.
+      audit: |
+        Run this command to confirm `gpgcheck` is enabled in the global configuration:
+
+        ```bash
+        grep -E '^gpgcheck' /etc/yum.conf /etc/dnf/dnf.conf 2>/dev/null
+        ```
+
+        A passing result reports `gpgcheck=1`. A failing result reports `gpgcheck=0` or omits the directive entirely.
+      remediation:
+        - id: cli
+          desc: |
+            **Using CLI**
+
+            Enable `gpgcheck` in the global package manager configuration:
+
+            ```bash
+            sed -i 's/^gpgcheck\s*=.*/gpgcheck=1/' /etc/yum.conf
+            grep -q '^gpgcheck' /etc/yum.conf || echo 'gpgcheck=1' >> /etc/yum.conf
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to enforce `gpgcheck` in whichever global configuration file is present:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            CONF=/etc/yum.conf
+            [ -f "$CONF" ] || CONF=/etc/dnf/dnf.conf
+
+            if grep -qE '^gpgcheck' "$CONF"; then
+              sed -i 's/^gpgcheck\s*=.*/gpgcheck=1/' "$CONF"
+            else
+              echo 'gpgcheck=1' >> "$CONF"
+            fi
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to set `gpgcheck` in the global `[main]` section:
+
+            ```yaml
+            ---
+            - name: Enforce global gpgcheck
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Ensure gpgcheck is enabled in yum.conf
+                  ansible.builtin.ini_file:
+                    path: /etc/yum.conf
+                    section: main
+                    option: gpgcheck
+                    value: "1"
+                    no_extra_spaces: true
+            ```
+    refs:
+      - url: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/
+        title: Red Hat - Managing software with the DNF tool
+  - uid: mondoo-linux-security-apt-repositories-enforce-signature-verification
+    title: Ensure APT repositories enforce signature verification
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-id-ra-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-14
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    filters: |
+      asset.family.contains('debian')
+    mql: |
+      apt.repos.where(enabled).all(trusted == false)
+    docs:
+      desc: |
+        This check ensures that no enabled APT repository is marked as trusted, which would bypass cryptographic signature verification. An entry carrying `[trusted=yes]` in a one-line sources file, or `Trusted: yes` in a deb822 `.sources` file, tells APT to install packages from that repository without checking their signatures.
+
+        **Why this matters**
+
+        - **Authenticity:** Signature verification confirms that packages originate from the expected repository owner rather than an impostor.
+        - **Integrity:** A valid signature guarantees that packages were not altered between the repository and the host.
+        - **Supply-chain protection:** A trusted repository accepts packages from a compromised mirror or a manipulated download without objection.
+
+        **Risk mitigation**
+
+        - **Prevent malicious installs:** Removing the trusted flag forces APT to reject unsigned or tampered packages.
+        - **Key pinning:** Replacing `[trusted=yes]` with a `signed-by` keyring restricts the repository to a specific signing key.
+      audit: |
+        Run this command to list any repository that bypasses signature verification:
+
+        ```bash
+        grep -rEi 'trusted\s*=\s*yes|^\s*Trusted:\s*yes' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null
+        ```
+
+        A passing result returns no matches, meaning every enabled repository enforces signature verification. A failing result lists one or more entries marked trusted.
+      remediation:
+        - id: cli
+          desc: |
+            **Using CLI**
+
+            Remove the `[trusted=yes]` option from the offending entry and pin the repository to its signing key instead. For a one-line entry, replace the trusted flag with a `signed-by` keyring:
+
+            ```bash
+            sed -i 's/\[trusted=yes\]/[signed-by=\/usr\/share\/keyrings\/example-archive-keyring.gpg]/' /etc/apt/sources.list.d/example.list
+            apt-get update
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to strip the trusted flag from every one-line sources file so APT enforces signature verification:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+              [ -f "$f" ] || continue
+              sed -i -E 's/\[[^]]*trusted=yes[^]]*\]//I; s/  +/ /g' "$f"
+            done
+
+            apt-get update
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to remove trusted overrides from one-line sources files:
+
+            ```yaml
+            ---
+            - name: Enforce APT signature verification
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Find one-line APT sources files
+                  ansible.builtin.find:
+                    paths: /etc/apt/sources.list.d
+                    patterns: "*.list"
+                  register: apt_sources
+
+                - name: Remove trusted=yes overrides
+                  ansible.builtin.replace:
+                    path: "{{ item.path }}"
+                    regexp: '\[[^]]*trusted=yes[^]]*\]'
+                    replace: ""
+                  loop: "{{ apt_sources.files }}"
+            ```
+    refs:
+      - url: https://manpages.debian.org/stable/apt/sources.list.5.en.html
+        title: Debian - sources.list manual page

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -199,6 +199,8 @@ policies:
           asset.family.contains('linux')
         checks:
           - uid: mondoo-linux-security-chrony-time-source-is-configured
+          - uid: mondoo-linux-security-timesyncd-time-source-is-configured
+          - uid: mondoo-linux-security-timesyncd-clock-is-synchronized
       - title: Package Management
         filters: |
           asset.family.contains('linux')
@@ -14278,6 +14280,212 @@ queries:
     refs:
       - url: https://chrony-project.org/documentation.html
         title: chrony - Documentation
+  - uid: mondoo-linux-security-timesyncd-time-source-is-configured
+    title: Ensure a time source is configured in systemd-timesyncd
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    filters: |
+      systemd.timesyncd.active
+    mql: |
+      systemd.timesyncd.servers != []
+    docs:
+      desc: |
+        This check ensures that systemd-timesyncd, when it is the active time synchronization client, has at least one NTP server explicitly configured rather than relying solely on the compiled-in fallback servers. An explicit `NTP=` setting guarantees the host synchronizes against the time sources the operator intends.
+
+        **Why this matters**
+
+        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock agrees on the current time.
+        - **Operator control:** Defining the NTP servers explicitly ensures the host uses approved, reachable time sources instead of distribution defaults that may be blocked or undesirable.
+        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so drift can break authentication or silently accept expired credentials.
+
+        **Risk mitigation**
+
+        - **Predictable sources:** Pinning the time servers removes any dependency on fallback hosts that the operator does not control.
+        - **Detect tampering:** A synchronized clock makes it harder for an attacker to disguise the timing of malicious activity.
+      audit: |
+        Run this command to display the configured NTP servers and synchronization state:
+
+        ```bash
+        timedatectl show-timesync --all
+        ```
+
+        Also inspect the configuration file directly:
+
+        ```bash
+        grep -E '^\s*NTP=' /etc/systemd/timesyncd.conf
+        ```
+
+        A passing result lists one or more servers in the `SystemNTPServers` field or a non-empty `NTP=` directive. A failing result shows only fallback servers and no configured `NTP=` value.
+      remediation:
+        - id: cli
+          desc: |
+            **Using CLI**
+
+            Set an authorized NTP server in the timesyncd configuration and restart the service:
+
+            ```bash
+            sed -i 's/^#\?NTP=.*/NTP=2.pool.ntp.org/' /etc/systemd/timesyncd.conf
+            systemctl restart systemd-timesyncd
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to ensure an `NTP=` server is configured and restart timesyncd:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            CONF=/etc/systemd/timesyncd.conf
+
+            if grep -qE '^\s*NTP=' "$CONF"; then
+              sed -i 's/^\s*NTP=.*/NTP=2.pool.ntp.org/' "$CONF"
+            else
+              printf '[Time]\nNTP=2.pool.ntp.org\n' >> "$CONF"
+            fi
+
+            systemctl restart systemd-timesyncd
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to set the NTP server in the timesyncd configuration:
+
+            ```yaml
+            ---
+            - name: Configure systemd-timesyncd NTP server
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Ensure an NTP server is configured
+                  ansible.builtin.ini_file:
+                    path: /etc/systemd/timesyncd.conf
+                    section: Time
+                    option: NTP
+                    value: "2.pool.ntp.org"
+                    no_extra_spaces: true
+                  notify: Restart timesyncd
+
+              handlers:
+                - name: Restart timesyncd
+                  ansible.builtin.service:
+                    name: systemd-timesyncd
+                    state: restarted
+            ```
+    refs:
+      - url: https://www.freedesktop.org/software/systemd/man/latest/timesyncd.conf.html
+        title: systemd - timesyncd.conf manual page
+  - uid: mondoo-linux-security-timesyncd-clock-is-synchronized
+    title: Ensure the system clock is synchronized via systemd-timesyncd
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    filters: |
+      service('systemd-timesyncd').enabled
+    mql: |
+      systemd.timesyncd.active == true
+      systemd.timesyncd.synchronized == true
+    docs:
+      desc: |
+        This check ensures that when systemd-timesyncd is enabled it is actually running and has synchronized the system clock to a time source. A daemon that is enabled but inactive, or active but unable to reach a server, leaves the clock drifting without anyone noticing.
+
+        **Why this matters**
+
+        - **Confirmed accuracy:** A configured time source is only useful if the daemon is running and has successfully synchronized against it.
+        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock is actually synchronized.
+        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so an unsynchronized clock can break authentication or silently accept expired credentials.
+
+        **Risk mitigation**
+
+        - **Detect failures early:** Verifying the synchronized state surfaces daemons that started but never reached a time source.
+        - **Forensic integrity:** Accurate timestamps are essential when reconstructing the sequence of an incident.
+      audit: |
+        Run this command to confirm the daemon is active and the clock is synchronized:
+
+        ```bash
+        timedatectl status
+        ```
+
+        A passing result reports `NTP service: active` and `System clock synchronized: yes`. A failing result reports the service as inactive or the clock as not synchronized.
+      remediation:
+        - id: cli
+          desc: |
+            **Using CLI**
+
+            Enable network time synchronization and start the daemon:
+
+            ```bash
+            timedatectl set-ntp true
+            systemctl restart systemd-timesyncd
+            ```
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to enable, start, and verify timesyncd synchronization:
+
+            ```bash
+            #!/bin/bash
+            set -e
+
+            timedatectl set-ntp true
+            systemctl enable --now systemd-timesyncd
+            systemctl restart systemd-timesyncd
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            Use this Ansible playbook to enable and start timesyncd so the clock synchronizes:
+
+            ```yaml
+            ---
+            - name: Ensure systemd-timesyncd synchronizes the clock
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Enable network time synchronization
+                  ansible.builtin.command: timedatectl set-ntp true
+                  changed_when: false
+
+                - name: Ensure timesyncd is enabled and running
+                  ansible.builtin.service:
+                    name: systemd-timesyncd
+                    enabled: true
+                    state: started
+            ```
+    refs:
+      - url: https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html
+        title: systemd - systemd-timesyncd.service manual page
   - uid: mondoo-linux-security-gpgcheck-is-globally-activated
     title: Ensure gpgcheck is globally activated
     impact: 80


### PR DESCRIPTION
## What

Uses the three new OS-provider resources from [mondoohq/mql#8207](https://github.com/mondoohq/mql/pull/8207) (`chrony.conf`, `yum.config`, `apt`/`apt.repo`) plus the existing `systemd.timesyncd` resource to fill several gaps in `mondoo-linux-security`:

| UID | Impact | Platform / gate | Assertion |
|-----|--------|-----------------|-----------|
| `mondoo-linux-security-chrony-time-source-is-configured` | 60 | chrony installed | `chrony.conf.servers != [] \|\| chrony.conf.pools != []` |
| `mondoo-linux-security-timesyncd-time-source-is-configured` | 60 | timesyncd active | `systemd.timesyncd.servers != []` |
| `mondoo-linux-security-timesyncd-clock-is-synchronized` | 60 | timesyncd enabled | `active == true` and `synchronized == true` |
| `mondoo-linux-security-gpgcheck-is-globally-activated` | 80 | RHEL family / amazonlinux | `yum.config.gpgcheck == true` |
| `mondoo-linux-security-apt-repositories-enforce-signature-verification` | 80 | Debian family | `apt.repos.where(enabled).all(trusted == false)` |

Two new groups (`Time Synchronization`, `Package Management`) organize them; platform/daemon gating lives in each check's `filters:` so they don't false-fail on hosts using a different time daemon or package manager. Policy bumped `2.6.0 → 2.7.0`.

## Impact anchoring

- **60** for time sync (supports audit-log integrity / certificate validity — defense in depth); 16 sibling checks sit at 60.
- **80** for the two supply-chain checks (installing unsigned packages is a realistic path to RCE via a compromised repo/mirror); 15 siblings sit at 80.

## Compliance tags

Each check carries verified tags for all 13 frameworks the policy uses. Mappings were read from each framework's control text in `cnspec-enterprise-policies`, best-fit only, `false` where nothing genuinely fits. Highlights:

- **Time sync** (chrony + both timesyncd checks share these) → ISO 27001:2022 A.8.17 (Clock synchronization), NIST 800-53 SC-45 (System Time Synchronization), NIST 800-171 3.3.7, PCI DSS 10.6.1, CSA CCM LOG-06. `false` for SOC2/HIPAA/DORA/NIS2/CSF (no dedicated time-sync control).
- **Package signing** → NIST 800-53 CM-14 (Signed Components), ISO 27001:2022 A.8.19, NIST CSF 1 PR.DS-6, NIST CSF 2 ID.RA-09, NIST 800-171 3.4.8, NIS2 21.2(e), CSA CCM UEM-02, SOC2 CC6.8.1, vda-isa 5.2.3, DORA Art.9. `false` for PCI (nearest is detective FIM, not preventive) and HIPAA.
- `bsi-sys-1-5: false` on all checks, matching every one of the existing 115 checks (the BSI SYS.1.5 virtualization module does not map to OS hardening here).

## Docs & remediation

Every check ships full `desc`/`audit`/`remediation`. Audit steps use vendor-native tooling (`chronyc sources`, `timedatectl`, `grep` on the config files, `apt-get`); remediation covers `cli`, `bash`, and `ansible`. `chronyc` added to the spell-check allowlist.

## Testing

- `cnspec policy lint mondoo-linux-security.mql.yaml` → valid bundle.
- MQL compiled against a locally rebuilt OS provider carrying the mql#8207 resources.

> [!NOTE]
> Depends on the new resources shipping in a released OS provider (mql#8207 lands `chrony.conf`/`yum.config`/`apt` at `13.22.2`). The checks compile against that schema; the chrony/yum/apt checks will no-op on older providers where those resources are absent. `systemd.timesyncd` already ships in the current provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)