### PR TITLE
✨ Add 12 Azure security checks: IoT Hub, Trusted Launch, snapshots, WAF, SQL VA, Databricks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -405,6 +405,7 @@ interoperates
 iommu
 iosxe
 iosxr
+iothub
 ipfw
 isa
 isready
@@ -755,8 +756,7 @@ sqlserver
 srcaddr
 ssbd
 sshusers
-SSID
-SSIDs
+ssid
 ssldir
 ssllabs
 ssls
@@ -794,6 +794,7 @@ TDS
 tensorboard
 textlist
 tfa
+THub
 timeadd
 timeframes
 timestamped
@@ -876,6 +877,7 @@ vulnerablechannelallowlist
 vulns
 vvtd
 vzdump
+wafpolicy
 wafv
 wazuh
 webauthn
@@ -890,7 +892,6 @@ winnuke
 WITHECDSA
 WITHRSA
 wlan
-wlans
 wordlist
 workdir
 workspacesweb

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.1.0
+    version: 9.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -52,6 +52,7 @@ policies:
         - Azure DNS
         - Azure Front Door
         - Azure Functions
+        - Azure IoT Hub
         - Azure Log Analytics
         - Azure Recovery Services
 
@@ -89,6 +90,7 @@ policies:
           - uid: mondoo-azure-security-sql-threat-detection-enabled
           - uid: mondoo-azure-security-sql-ad-admin-configured
           - uid: mondoo-azure-security-sql-server-min-tls-12
+          - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans
           - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled
           - uid: mondoo-azure-security-postgresql-flexible-server-infrastructure-encryption
           - uid: mondoo-azure-security-postgresql-server-min-tls-version
@@ -148,6 +150,10 @@ policies:
           - uid: mondoo-azure-security-compute-disk-encryption-set-cmk
           - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation
           - uid: mondoo-azure-security-compute-disk-access-private-endpoints
+          - uid: mondoo-azure-security-vm-secure-boot-enabled
+          - uid: mondoo-azure-security-vm-vtpm-enabled
+          - uid: mondoo-azure-security-compute-snapshot-public-access-disabled
+          - uid: mondoo-azure-security-compute-snapshot-cmk-encryption
       - title: Azure Network
         checks:
           - uid: mondoo-azure-security-ssh-access-restricted-from-internet
@@ -282,6 +288,7 @@ policies:
           - uid: mondoo-azure-security-appgw-min-tls-version
           - uid: mondoo-azure-security-appgw-no-weak-ciphers
           - uid: mondoo-azure-security-application-gateway-no-public-frontend
+          - uid: mondoo-azure-security-appgw-waf-prevention-mode
       - title: VPN Gateway
         checks:
           - uid: mondoo-azure-security-vpn-gateway-ikev2
@@ -289,6 +296,7 @@ policies:
       - title: Azure Databricks
         checks:
           - uid: mondoo-azure-security-databricks-public-access-disabled
+          - uid: mondoo-azure-security-databricks-no-public-ip
       - title: Azure Data Factory
         checks:
           - uid: mondoo-azure-security-datafactory-public-access-disabled
@@ -371,6 +379,13 @@ policies:
       - title: Azure Front Door
         checks:
           - uid: mondoo-azure-security-frontdoor-origin-https
+          - uid: mondoo-azure-security-frontdoor-waf-policy-attached
+      - title: Azure IoT Hub
+        checks:
+          - uid: mondoo-azure-security-iot-hub-local-auth-disabled
+          - uid: mondoo-azure-security-iot-hub-public-network-access-disabled
+          - uid: mondoo-azure-security-iot-hub-min-tls-1-2
+          - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled
       - title: Azure Container Apps
         checks:
           - uid: mondoo-azure-security-container-app-https-ingress
@@ -42145,3 +42160,1961 @@ queries:
   # No transit-encryption check for Azure Cognitive Services: the data plane endpoints (`*.cognitiveservices.azure.com`) are HTTPS-only by Microsoft platform design with TLS 1.2+ enforced by the service. `azurerm_cognitive_account` exposes no `tls_min_version` argument and the cnquery azure provider does not expose Cognitive Services accounts. There is no meaningful misconfiguration to detect.
   # No transit-encryption check for Azure Log Analytics workspace ingestion: TLS 1.2+ is enforced by Microsoft Azure Monitor platform policy across all ingestion endpoints (since 2022). Neither `azurerm_log_analytics_workspace` nor the cnquery `azure.subscription.monitor.workspaces` resource exposes a per-workspace TLS-version toggle. There is no meaningful misconfiguration to detect at the workspace level.
   # No transit-encryption check for Azure Databricks workspaces: workspace endpoints (`*.azuredatabricks.net`) are HTTPS-only by Microsoft platform design with TLS 1.2+ enforced by the service. `azurerm_databricks_workspace` exposes no `tls_min_version` argument and the runtime resource has no TLS-version field. There is no meaningful misconfiguration to detect.
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled
+    title: Ensure shared access key (local) authentication is disabled for IoT Hub
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-azure-security-iot-hub-local-auth-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure IoT Hub
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that shared access key authentication is disabled for all Azure IoT Hubs so that only Microsoft Entra ID identity-based authentication is accepted for control plane and data plane operations. By default IoT Hub accepts shared access policy keys, which are long-lived symmetric secrets that grant broad access and cannot be tied to an individual identity.
+
+        **Why this matters**
+
+        - **Eliminates static secrets:** Shared access keys are durable symmetric tokens that, once leaked, grant access until they are manually rotated, unlike short-lived Entra ID tokens that expire automatically.
+        - **Centralized identity governance:** Requiring Entra ID brings IoT Hub access under conditional access, role-based access control, and lifecycle policies that already govern the rest of the tenant.
+        - **Stronger accountability:** Entra ID authentication binds every operation to a named user or workload identity, producing attributable audit records instead of anonymous shared-key activity.
+        - **Reduced credential sprawl:** Disabling local auth prevents keys from being copied into device configuration, source code, and connection strings across many systems.
+
+        **Risk mitigation**
+
+        - **Key leak containment:** With local authentication disabled, a stolen shared access key is rejected, removing the most common path to unauthorized hub and device access.
+        - **Consistent policy enforcement:** Access decisions flow through Entra ID, so multi-factor and conditional access requirements apply uniformly and cannot be bypassed with a static key.
+        - **Faster revocation:** Compromised access is revoked centrally by disabling the Entra ID identity rather than racing to rotate keys distributed across fleets of devices and services.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Azure Portal and open your **IoT Hub**.
+        2. Under **Security settings**, select **Shared access policies**.
+        3. Confirm the banner reports that access with shared access policies is **disabled** and that only Microsoft Entra authentication is allowed.
+
+        A hub that still permits shared access keys fails this check.
+
+        ### Audit via CLI
+
+        Query the local authentication state for a single hub:
+
+        ```bash
+        az iot hub show --hub-name <HubName> --query "properties.disableLocalAuth"
+        ```
+
+        A result of `true` passes. A result of `false` or `null` means shared access key authentication is still permitted and the hub fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To disable shared access key authentication for an IoT Hub using the Azure Portal:
+
+            1. Sign in to the Azure Portal and open your **IoT Hub**.
+            2. Under **Security settings**, select **Shared access policies**.
+            3. Set the **Access with shared access policies** option to **Deny**, leaving only **Microsoft Entra (Azure AD)** authentication enabled.
+            4. Select **Save**.
+        - id: cli
+          desc: |
+            To disable shared access key authentication for an IoT Hub using the Azure CLI:
+
+            ```bash
+            az iot hub update --hub-name <HubName> --resource-group-name <ResourceGroupName> --disable-local-auth true
+            ```
+        - id: terraform
+          desc: |
+            To disable shared access key authentication for an IoT Hub in Terraform:
+
+            ```hcl
+            resource "azurerm_iothub" "example" {
+              name                = "example-iothub"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              local_authentication_enabled = false
+
+              sku {
+                name     = "S1"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable shared access key authentication for an IoT Hub in Bicep:
+
+            ```bicep
+            resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+              name: 'example-iothub'
+              location: resourceGroup().location
+              sku: {
+                name: 'S1'
+                capacity: 1
+              }
+              properties: {
+                disableLocalAuth: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/iot-hub/authenticate-authorize-azure-ad
+        title: Control access to IoT Hub by using Microsoft Entra ID
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.iot.iotHubs.all(
+        disableLocalAuth == true
+      )
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
+    mql: |
+      terraform.resources("azurerm_iothub").all(
+        arguments['local_authentication_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_iothub").all(
+        change.after['local_authentication_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_iothub").all(
+        values['local_authentication_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Devices/IotHubs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Devices/IotHubs").all(
+        properties["disableLocalAuth"] == true
+      )
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled
+    title: Ensure public network access is disabled for Azure IoT Hub
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure IoT Hub
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that public network access is disabled for every Azure IoT Hub, so devices and management clients can reach the hub only over private endpoints or explicitly approved networks. By default, an IoT Hub accepts connections from any public IP address on the internet, which exposes its device, messaging, and management endpoints to the entire internet.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** A hub reachable only through private endpoints removes its public IP from internet-wide scanning and brute-force attempts against device and service connection strings.
+        - **Network isolation:** Restricting access to a virtual network keeps device telemetry and cloud-to-device commands on controlled, auditable paths instead of traversing the public internet.
+        - **Defense in depth:** Even if a shared access policy key or device SAS token leaks, disabling public access prevents an attacker outside the approved network from using it to connect to the hub.
+        - **Compliance alignment:** Security frameworks require that ingress to systems handling sensitive data be denied by default and permitted only through controlled boundaries.
+
+        **Risk mitigation**
+
+        - **Credential leak containment:** With public access disabled, a stolen connection string or device key cannot be used from an arbitrary internet host, neutralizing a common remote-exploitation path.
+        - **Lateral movement limitation:** Confining hub connectivity to a private endpoint forces traffic through network controls where anomalous access can be detected and blocked.
+        - **Telemetry exposure reduction:** Private connectivity prevents device messages and twin data from being intercepted or accessed over untrusted public network paths.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **IoT Hub** in the Azure Portal.
+        2. Select an IoT Hub.
+        3. Go to **Networking**.
+        4. On the **Public access** tab, verify that **Public network access** is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az iot hub show --hub-name <HubName> --resource-group <ResourceGroupName> --query "properties.publicNetworkAccess" -o tsv
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access for an Azure IoT Hub using the Azure Portal:
+
+            1. Navigate to **IoT Hub** in the Azure Portal.
+            2. Select the IoT Hub.
+            3. Go to **Networking**.
+            4. On the **Public access** tab, set **Public network access** to **Disabled**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access for an Azure IoT Hub using the Azure CLI:
+
+            ```bash
+            az iot hub update --hub-name <HubName> --resource-group-name <ResourceGroupName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access for an Azure IoT Hub in Terraform:
+
+            ```hcl
+            resource "azurerm_iothub" "example" {
+              name                          = "example-iothub"
+              resource_group_name           = azurerm_resource_group.example.name
+              location                      = azurerm_resource_group.example.location
+              public_network_access_enabled = false
+
+              sku {
+                name     = "S1"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access for an Azure IoT Hub in Bicep:
+
+            ```bicep
+            resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+              name: 'example-iothub'
+              location: resourceGroup().location
+              sku: {
+                name: 'S1'
+                capacity: 1
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-public-network-access
+        title: Manage public network access for your IoT hub
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.iot.iotHubs.all(
+        publicNetworkAccess == "Disabled"
+      )
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
+    mql: |
+      terraform.resources("azurerm_iothub").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_iothub").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_iothub").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Devices/IotHubs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Devices/IotHubs").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2
+    title: Ensure Azure IoT Hub enforces a minimum TLS version of 1.2
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-iot-hub-min-tls-1-2-azure
+        tags:
+          mondoo.com/filter-title: Azure IoT Hub
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-min-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every Azure IoT Hub requires a minimum TLS version of 1.2 for device and service connections. By default an IoT Hub accepts connections that negotiate older TLS 1.0 and TLS 1.1 protocol versions, which contain known weaknesses that expose data in transit to downgrade and interception attacks. The minimum TLS version can only be set when the IoT Hub is created and only in regions that support the setting, so enforcing it requires provisioning a new hub with the value already in place.
+
+        **Why this matters**
+
+        - **Protocol downgrade prevention:** Rejecting TLS 1.0 and TLS 1.1 stops an attacker from forcing a connection onto a weaker protocol that can be decrypted or tampered with.
+        - **Strong cipher enforcement:** TLS 1.2 removes the weak cipher suites and hashing algorithms permitted by earlier protocol versions, raising the cryptographic strength of every device-to-cloud and cloud-to-device message.
+        - **Telemetry confidentiality:** IoT Hubs carry sensitive device telemetry and command payloads, and a strong transport protocol keeps that data confidential as it crosses untrusted networks.
+        - **Compliance alignment:** Security frameworks require that data in transit be protected with strong, current cryptographic protocols, and a TLS 1.2 floor satisfies that expectation for IoT workloads.
+
+        **Risk mitigation**
+
+        - **Eavesdropping containment:** Enforcing TLS 1.2 closes the protocol-level weaknesses that let an on-path attacker recover plaintext from intercepted IoT traffic.
+        - **Legacy client elimination:** A TLS 1.2 floor surfaces and blocks outdated device SDKs and firmware that still negotiate insecure protocol versions, driving them toward secure clients.
+        - **Consistent transport posture:** Setting the floor at the hub guarantees a uniform encryption baseline across every connecting device regardless of individual client configuration.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **IoT Hub** in the Azure Portal.
+        2. Select an IoT hub.
+        3. Go to **Properties** and review the **Minimum TLS Version** value.
+        4. A passing hub shows **1.2**. Any hub showing **1.0** allows legacy protocol versions and fails.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az iot hub list --query "[].{Name:name, MinTlsVersion:properties.minTlsVersion}" --output table
+        ```
+
+        A passing hub reports `1.2` in the `MinTlsVersion` column. A blank value or `1.0` indicates the hub accepts TLS 1.0 and TLS 1.1 connections and fails.
+      remediation:
+        - id: portal
+          desc: |
+            To enforce a minimum TLS version of 1.2 using the Azure Portal:
+
+            1. Navigate to **IoT Hub** in the Azure Portal.
+            2. Select **Create** to provision a new IoT hub in a region that supports the minimum TLS version setting.
+            3. On the creation blade, set **Minimum TLS Version** to **1.2**.
+            4. Complete the wizard and select **Create**.
+            5. Migrate device registrations and routing configuration from the old hub to the new hub, then decommission the old hub.
+        - id: cli
+          desc: |
+            To enforce a minimum TLS version of 1.2 using the Azure CLI, create a new IoT hub with the value set, because the setting cannot be changed on an existing hub:
+
+            ```bash
+            az iot hub create --hub-name <HubName> --resource-group-name <ResourceGroupName> --location <Region> --sku S1 --min-tls-version 1.2
+            ```
+        - id: terraform
+          desc: |
+            To enforce a minimum TLS version of 1.2 in Terraform:
+
+            ```hcl
+            resource "azurerm_iothub" "example" {
+              name                = "example-iothub"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              min_tls_version     = "1.2"
+
+              sku {
+                name     = "S1"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enforce a minimum TLS version of 1.2 in Bicep:
+
+            ```bicep
+            resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+              name: 'example-iothub'
+              location: resourceGroup().location
+              sku: {
+                name: 'S1'
+                capacity: 1
+              }
+              properties: {
+                minTlsVersion: '1.2'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-tls-support
+        title: Transport Layer Security (TLS) support in Azure IoT Hub
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.iot.iotHubs.all(minTlsVersion == "1.2")
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
+    mql: |
+      terraform.resources("azurerm_iothub").all(
+        arguments['min_tls_version'] == "1.2"
+      )
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_iothub").all(
+        change.after['min_tls_version'] == "1.2"
+      )
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_iothub").all(
+        values['min_tls_version'] == "1.2"
+      )
+  - uid: mondoo-azure-security-iot-hub-min-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Devices/IotHubs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Devices/IotHubs").all(
+        properties["minTlsVersion"] == "1.2"
+      )
+  # No Terraform variants: a diagnostic setting is a standalone resource targeting the hub by ID, and static IaC cannot reliably correlate an azurerm_monitor_diagnostic_setting to a specific IoT hub to assert coverage.
+  - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled
+    title: Ensure diagnostic settings are enabled for Azure IoT Hub
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-07
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    variants:
+      - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure IoT Hub
+          mondoo.com/filter-icon: azure
+    docs:
+      desc: |
+        This check ensures that at least one diagnostic setting is configured for every Azure IoT Hub, forwarding hub logs and metrics to a durable destination such as a Log Analytics workspace, Storage account, or Event Hub. By default an IoT Hub emits no diagnostic data to any of these destinations, so connection events, device telemetry routing failures, and control-plane operations are never preserved for investigation.
+
+        **Why this matters**
+
+        - **Device compromise visibility:** IoT Hub mediates authentication and messaging for large fleets of devices; without forwarded logs, a hijacked device or stolen device key leaves no centralized record of its connections and operations.
+        - **Routing and delivery failures:** Message routing errors and dropped telemetry are only observable through diagnostic logs, so a silent loss of device data goes undetected when no setting forwards these events.
+        - **Control-plane auditing:** Creation of shared access policies, consumer groups, and routing endpoints on the hub is recorded only when a diagnostic setting captures operational logs.
+        - **Retention beyond defaults:** Hub logs and metrics that are not forwarded are unavailable to SIEM tooling and cannot be retained for the longer periods that incident response and compliance reviews require.
+
+        **Risk mitigation**
+
+        - **Forensic continuity:** Forwarding hub logs to a controlled destination preserves connection and authentication records past the point where an attacker could rely on default non-collection to hide activity.
+        - **Compliance audit failure:** Frameworks require demonstrable log collection for security-relevant services, and an IoT Hub with no diagnostic setting is an immediately verifiable control gap.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Go to the Azure Portal at https://portal.azure.com.
+        2. Navigate to **IoT Hub** and select the hub to review.
+        3. Under **Monitoring**, select **Diagnostic settings**.
+        4. Verify that at least one diagnostic setting exists and forwards logs and metrics to a Log Analytics workspace, Storage account, or Event Hub.
+
+        **Automated Audit with Azure CLI:**
+
+        To list the diagnostic settings for an IoT Hub, use its resource ID:
+
+        ```bash
+        az monitor diagnostic-settings list --resource <IoTHubResourceId>
+        ```
+
+        An empty result indicates that no diagnostic setting is configured for the hub.
+      remediation:
+        - id: portal
+          desc: |
+            To enable diagnostic settings for an Azure IoT Hub using the Azure Portal:
+
+            1. Log into the Azure Portal at https://portal.azure.com.
+            2. Navigate to **IoT Hub** and select the hub.
+            3. Under **Monitoring**, select **Diagnostic settings** and then **Add diagnostic setting**.
+            4. Provide a name for the diagnostic setting.
+            5. Select the relevant log categories and metrics, such as **Connections**, **DeviceTelemetry**, and **AllMetrics**.
+            6. Choose a destination: a Log Analytics workspace, a Storage account, or an Event Hub.
+            7. Select **Save** to begin forwarding hub logs and metrics.
+        - id: cli
+          desc: |
+            To enable diagnostic settings for an Azure IoT Hub using the Azure CLI:
+
+            ```bash
+            az monitor diagnostic-settings create --name <NameOfSetting> --resource <IoTHubResourceId> --logs '[{"category": "Connections", "enabled": true}, {"category": "DeviceTelemetry", "enabled": true}]' --metrics '[{"category": "AllMetrics", "enabled": true}]' --workspace <LogAnalyticsWorkspaceId>
+            ```
+
+            Replace the placeholders with your hub resource ID, destination, and desired setting name.
+        - id: terraform
+          desc: |
+            To enable diagnostic settings for an Azure IoT Hub in Terraform:
+
+            ```hcl
+            resource "azurerm_monitor_diagnostic_setting" "iothub" {
+              name                       = "iothub-diagnostics"
+              target_resource_id         = azurerm_iothub.example.id
+              log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+              enabled_log {
+                category = "Connections"
+              }
+
+              enabled_log {
+                category = "DeviceTelemetry"
+              }
+
+              metric {
+                category = "AllMetrics"
+                enabled  = true
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable diagnostic settings for an Azure IoT Hub in Bicep:
+
+            ```bicep
+            resource iotHubDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+              name: 'iothub-diagnostics'
+              scope: iotHub
+              properties: {
+                workspaceId: logAnalyticsWorkspace.id
+                logs: [
+                  {
+                    category: 'Connections'
+                    enabled: true
+                  }
+                  {
+                    category: 'DeviceTelemetry'
+                    enabled: true
+                  }
+                ]
+                metrics: [
+                  {
+                    category: 'AllMetrics'
+                    enabled: true
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/iot-hub/monitor-iot-hub
+        title: Monitor Azure IoT Hub
+  - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.iot.iotHubs.all(diagnosticSettings != empty)
+  - uid: mondoo-azure-security-vm-secure-boot-enabled
+    title: Ensure Secure Boot is enabled on Azure virtual machines (Trusted Launch)
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    variants:
+      - uid: mondoo-azure-security-vm-secure-boot-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Virtual Machine
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-secure-boot-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that virtual machines use the Trusted Launch Secure Boot feature so that only signed and trusted boot components are allowed to load during startup. By default, virtual machines can be deployed with a standard security type that performs no firmware-level verification of the boot chain, which lets tampered bootloaders, kernels, and drivers execute before the operating system loads.
+
+        **Why this matters**
+
+        - **Boot integrity:** Secure Boot uses UEFI signature databases to verify each boot component against trusted certificates, blocking unsigned or modified code from running at the earliest stage of startup.
+        - **Rootkit and bootkit defense:** Malware that targets the firmware and bootloader runs before operating system defenses initialize, so blocking it at the firmware level is one of the few effective controls against this class of attack.
+        - **Established trust anchor:** A verified boot chain provides the foundation that later attestation, measured boot, and disk encryption controls depend on to prove the platform has not been compromised.
+        - **Compliance alignment:** Hardening baselines and vendor recommendations call for verified boot on server workloads, especially those handling sensitive or regulated data.
+
+        **Risk mitigation**
+
+        - **Persistence prevention:** Attackers commonly install bootkits to survive reboots and operating system reinstalls, and Secure Boot removes that persistence path by refusing to load unsigned boot code.
+        - **Supply chain protection:** Tampered images or injected drivers fail signature validation, limiting the impact of a compromised build pipeline or malicious third-party component.
+        - **Early detection:** A virtual machine that fails to boot because a component no longer matches a trusted signature surfaces tampering immediately rather than allowing silent compromise.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Virtual machines** in the Azure Portal.
+        2. Select a virtual machine.
+        3. On the **Overview** page, confirm the **Security type** is **Trusted launch**.
+        4. Open **Settings** then **Configuration** and review the **Security type** section.
+        5. A passing result shows **Secure boot** set to **Enabled**. A failing result shows a standard security type or Secure boot disabled.
+
+        ### Audit via CLI
+
+        Inspect the Secure Boot setting on every virtual machine in the subscription:
+
+        ```bash
+        az vm list --query "[].{Name:name, ResourceGroup:resourceGroup, SecureBoot:securityProfile.uefiSettings.secureBootEnabled, SecurityType:securityProfile.securityType}" -o table
+        ```
+
+        A passing result reports `SecureBoot` as `True` for each virtual machine. A `False` or empty value indicates Secure Boot is not enabled.
+      remediation:
+        - id: portal
+          desc: |
+            To enable Secure Boot on an Azure virtual machine using the Azure Portal:
+
+            1. Navigate to **Virtual machines** in the Azure Portal.
+            2. Select the virtual machine.
+            3. Open **Settings** then **Configuration**.
+            4. Under **Security type**, select **Trusted launch**.
+            5. Set **Secure boot** to **Enabled**.
+            6. Select **Save** and restart the virtual machine if prompted.
+
+            Secure Boot requires a Trusted Launch capable virtual machine size and a generation 2 image. Virtual machines created with a standard security type may need to be upgraded to Trusted Launch before Secure Boot can be applied.
+        - id: cli
+          desc: |
+            To enable Secure Boot on an Azure virtual machine using the Azure CLI:
+
+            ```bash
+            az vm update --resource-group-name <ResourceGroupName> --vm-name <VMName> --security-type TrustedLaunch --enable-secure-boot true --enable-vtpm true
+            ```
+
+            Restart the virtual machine after the update so the new boot policy takes effect.
+        - id: terraform
+          desc: |
+            To enable Secure Boot on an Azure virtual machine in Terraform, set `secure_boot_enabled` to `true` on each virtual machine resource:
+
+            ```hcl
+            resource "azurerm_linux_virtual_machine" "example" {
+              name                  = "example-linux-vm"
+              resource_group_name   = azurerm_resource_group.example.name
+              location              = azurerm_resource_group.example.location
+              size                  = "Standard_DC2s_v2"
+              admin_username        = "azureuser"
+              network_interface_ids = [azurerm_network_interface.example.id]
+
+              secure_boot_enabled = true
+              vtpm_enabled        = true
+
+              os_disk {
+                caching              = "ReadWrite"
+                storage_account_type = "Standard_LRS"
+              }
+
+              source_image_reference {
+                publisher = "Canonical"
+                offer     = "0001-com-ubuntu-server-jammy"
+                sku       = "22_04-lts-gen2"
+                version   = "latest"
+              }
+            }
+
+            resource "azurerm_windows_virtual_machine" "example" {
+              name                  = "example-win-vm"
+              resource_group_name   = azurerm_resource_group.example.name
+              location              = azurerm_resource_group.example.location
+              size                  = "Standard_DC2s_v2"
+              admin_username        = "azureuser"
+              admin_password        = var.admin_password
+              network_interface_ids = [azurerm_network_interface.example.id]
+
+              secure_boot_enabled = true
+              vtpm_enabled        = true
+
+              os_disk {
+                caching              = "ReadWrite"
+                storage_account_type = "Standard_LRS"
+              }
+
+              source_image_reference {
+                publisher = "MicrosoftWindowsServer"
+                offer     = "WindowsServer"
+                sku       = "2022-datacenter-g2"
+                version   = "latest"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable Secure Boot on an Azure virtual machine in Bicep, set the security type to `TrustedLaunch` and enable Secure Boot in the `uefiSettings`:
+
+            ```bicep
+            resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
+              name: 'example-vm'
+              location: resourceGroup().location
+              properties: {
+                hardwareProfile: {
+                  vmSize: 'Standard_DC2s_v2'
+                }
+                securityProfile: {
+                  securityType: 'TrustedLaunch'
+                  uefiSettings: {
+                    secureBootEnabled: true
+                    vTpmEnabled: true
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch
+        title: Trusted launch for Azure virtual machines
+  - uid: mondoo-azure-security-vm-secure-boot-enabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.compute.vms.all(secureBootEnabled == true)
+  - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.resources("azurerm_linux_virtual_machine").length > 0) {
+        terraform.resources("azurerm_linux_virtual_machine").all(
+          arguments['secure_boot_enabled'] == true
+        )
+      }
+      if (terraform.resources("azurerm_windows_virtual_machine").length > 0) {
+        terraform.resources("azurerm_windows_virtual_machine").all(
+          arguments['secure_boot_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.plan.resourceChanges.where(type == "azurerm_linux_virtual_machine").length > 0) {
+        terraform.plan.resourceChanges.where(type == "azurerm_linux_virtual_machine").all(
+          change.after['secure_boot_enabled'] == true
+        )
+      }
+      if (terraform.plan.resourceChanges.where(type == "azurerm_windows_virtual_machine").length > 0) {
+        terraform.plan.resourceChanges.where(type == "azurerm_windows_virtual_machine").all(
+          change.after['secure_boot_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-secure-boot-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.state.resources.where(type == "azurerm_linux_virtual_machine").length > 0) {
+        terraform.state.resources.where(type == "azurerm_linux_virtual_machine").all(
+          values['secure_boot_enabled'] == true
+        )
+      }
+      if (terraform.state.resources.where(type == "azurerm_windows_virtual_machine").length > 0) {
+        terraform.state.resources.where(type == "azurerm_windows_virtual_machine").all(
+          values['secure_boot_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-secure-boot-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["securityProfile"]["uefiSettings"]["secureBootEnabled"] == true
+      )
+  - uid: mondoo-azure-security-vm-vtpm-enabled
+    title: Ensure vTPM is enabled on Azure virtual machines (Trusted Launch)
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
+    variants:
+      - uid: mondoo-azure-security-vm-vtpm-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Virtual Machine
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-vm-vtpm-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a virtual Trusted Platform Module (vTPM) is enabled on Azure virtual machines as part of Trusted Launch. A vTPM provides a hardware-rooted, isolated component that performs measured boot and stores boot-integrity measurements and platform secrets. By default, virtual machines can be created without Trusted Launch, leaving the vTPM disabled and the boot chain unattested.
+
+        **Why this matters**
+
+        - **Measured boot:** A vTPM records cryptographic measurements of each boot component, so the integrity of the firmware, bootloader, and operating system kernel can be verified before workloads run.
+        - **Boot integrity attestation:** With a vTPM present, Azure can remotely attest that a virtual machine booted a trusted, unmodified boot chain, giving operators evidence that the platform has not been tampered with.
+        - **Protected platform secrets:** Keys and secrets sealed to the vTPM, such as those used by BitLocker or dm-crypt, are bound to a known-good boot state and cannot be unsealed if the boot chain is altered.
+        - **Rootkit and bootkit resistance:** Measured boot combined with attestation detects firmware-level and pre-boot malware that traditional in-guest defenses cannot see.
+
+        **Risk mitigation**
+
+        - **Tamper evidence:** Any unauthorized modification to early boot components changes the measurements recorded in the vTPM, surfacing tampering that would otherwise go undetected.
+        - **Secret containment:** Because disk-encryption keys can be sealed to the vTPM, a stolen or cloned disk cannot be decrypted on a platform whose boot state does not match, limiting the value of offline disk theft.
+        - **Trusted foundation for later controls:** Boot attestation establishes a verified baseline that downstream controls such as confidential computing and guest attestation policies can build on.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Virtual machines** in the Azure Portal.
+        2. Select a virtual machine.
+        3. Open the **Overview** blade and confirm the **Security type** shows **Trusted launch**.
+        4. Under **Settings**, open **Configuration** and verify that **vTPM** is set to **On**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az vm show --resource-group <ResourceGroupName> --name <VMName> --query "securityProfile.uefiSettings.vTpmEnabled"
+        ```
+
+        A return value of `true` indicates the vTPM is enabled. A value of `false` or `null` indicates Trusted Launch is not configured and the check fails.
+      remediation:
+        - id: portal
+          desc: |
+            To enable vTPM on an Azure virtual machine using the Azure Portal:
+
+            1. Navigate to **Virtual machines** in the Azure Portal.
+            2. Select the virtual machine.
+            3. Under **Settings**, open **Configuration**.
+            4. Ensure **Security type** is set to **Trusted launch virtual machines**.
+            5. Set **vTPM** to **On**.
+            6. Select **Save** and restart the virtual machine if prompted.
+        - id: cli
+          desc: |
+            To enable vTPM on an Azure virtual machine using the Azure CLI:
+
+            ```bash
+            az vm update --resource-group-name <ResourceGroupName> --vm-name <VMName> --security-type TrustedLaunch --enable-vtpm true
+            ```
+        - id: terraform
+          desc: |
+            To enable vTPM on Azure virtual machines in Terraform, set `vtpm_enabled` to `true` on each virtual machine resource:
+
+            ```hcl
+            resource "azurerm_linux_virtual_machine" "example" {
+              name                = "example-linux-vm"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              size                = "Standard_D2s_v5"
+
+              secure_boot_enabled = true
+              vtpm_enabled        = true
+
+              # ... remaining required arguments ...
+            }
+
+            resource "azurerm_windows_virtual_machine" "example" {
+              name                = "example-win-vm"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              size                = "Standard_D2s_v5"
+
+              secure_boot_enabled = true
+              vtpm_enabled        = true
+
+              # ... remaining required arguments ...
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable vTPM on an Azure virtual machine in Bicep, configure the Trusted Launch security profile:
+
+            ```bicep
+            resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-07-01' = {
+              name: 'example-vm'
+              location: resourceGroup().location
+              properties: {
+                securityProfile: {
+                  securityType: 'TrustedLaunch'
+                  uefiSettings: {
+                    vTpmEnabled: true
+                    secureBootEnabled: true
+                  }
+                }
+                // ... remaining required properties ...
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch
+        title: Trusted launch for Azure virtual machines
+  - uid: mondoo-azure-security-vm-vtpm-enabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.compute.vms.all(vtpmEnabled == true)
+  - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.resources("azurerm_linux_virtual_machine").length > 0) {
+        terraform.resources("azurerm_linux_virtual_machine").all(
+          arguments['vtpm_enabled'] == true
+        )
+      }
+      if (terraform.resources("azurerm_windows_virtual_machine").length > 0) {
+        terraform.resources("azurerm_windows_virtual_machine").all(
+          arguments['vtpm_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.plan.resourceChanges.where(type == "azurerm_linux_virtual_machine").length > 0) {
+        terraform.plan.resourceChanges.where(type == "azurerm_linux_virtual_machine").all(
+          change.after['vtpm_enabled'] == true
+        )
+      }
+      if (terraform.plan.resourceChanges.where(type == "azurerm_windows_virtual_machine").length > 0) {
+        terraform.plan.resourceChanges.where(type == "azurerm_windows_virtual_machine").all(
+          change.after['vtpm_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-vtpm-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_virtual_machine/)
+    mql: |
+      if (terraform.state.resources.where(type == "azurerm_linux_virtual_machine").length > 0) {
+        terraform.state.resources.where(type == "azurerm_linux_virtual_machine").all(
+          values['vtpm_enabled'] == true
+        )
+      }
+      if (terraform.state.resources.where(type == "azurerm_windows_virtual_machine").length > 0) {
+        terraform.state.resources.where(type == "azurerm_windows_virtual_machine").all(
+          values['vtpm_enabled'] == true
+        )
+      }
+  - uid: mondoo-azure-security-vm-vtpm-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["securityProfile"]["uefiSettings"]["vTpmEnabled"] == true
+      )
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled
+    title: Ensure public network access is disabled for Azure disk snapshots
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Managed Disk Snapshot
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that public network access is disabled for all Azure managed disk snapshots, preventing snapshot data from being exported or downloaded over the public internet. By default, snapshots allow public network access, meaning anyone holding a valid SAS URI can retrieve the full snapshot contents from any internet-connected location.
+
+        **Why this matters**
+
+        - **Data exfiltration prevention**: A snapshot captures the entire contents of a disk at a point in time, so an exposed snapshot leaks the same data as the disk itself, including secrets, credentials, and regulated records.
+        - **Network isolation**: Disabling public access forces snapshot export and copy operations through private endpoints inside your virtual network, keeping all data movement on controlled paths.
+        - **Defense in depth**: Even if snapshot access credentials are compromised, a disabled public network setting blocks retrieval from outside your network perimeter and reduces the value of stolen SAS tokens.
+        - **Compliance alignment**: Security frameworks require that sensitive data storage and transfer be confined to private network paths rather than reachable from the public internet.
+
+        **Risk mitigation**
+
+        - **SAS token leak containment**: With public access disabled, a leaked or expired snapshot SAS URI cannot be used from the internet, closing one of the most direct paths for bulk data exfiltration.
+        - **Backup vector closure**: Attackers often target snapshots as a quieter alternative to live disks because they are easy to copy and detach from monitoring; restricting them to private endpoints removes that shortcut.
+        - **Audit trail completeness**: Private endpoint access is routed through Azure Private Link infrastructure and generates diagnostic logs tied to the private network path, making it clear who accessed snapshot data and from where.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Snapshots** in the Azure Portal.
+        2. Select a snapshot.
+        3. Go to **Networking**.
+        4. Verify that **Public network access** is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az snapshot show --name <SnapshotName> --resource-group <ResourceGroupName> --query "{Name:name, PublicAccess:publicNetworkAccess, NetworkPolicy:networkAccessPolicy}" -o table
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To ensure public network access is disabled for Azure disk snapshots using the Azure Portal:
+
+            1. Navigate to **Snapshots** in the Azure Portal.
+            2. Select the snapshot.
+            3. Go to **Networking**.
+            4. Set **Public network access** to **Disabled**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To ensure public network access is disabled for Azure disk snapshots using the Azure CLI:
+
+            ```bash
+            az snapshot update --name <SnapshotName> --resource-group <ResourceGroupName> --public-network-access Disabled --network-access-policy DenyAll
+            ```
+        - id: terraform
+          desc: |
+            To ensure public network access is disabled for Azure disk snapshots in Terraform:
+
+            ```hcl
+            resource "azurerm_snapshot" "example" {
+              name                          = "example-snapshot"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              create_option                 = "Copy"
+              source_uri                    = azurerm_managed_disk.example.id
+              public_network_access_enabled = false
+              network_access_policy         = "DenyAll"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To ensure public network access is disabled for Azure disk snapshots in Bicep:
+
+            ```bicep
+            resource snapshot 'Microsoft.Compute/snapshots@2024-03-02' = {
+              name: 'example-snapshot'
+              location: resourceGroup().location
+              properties: {
+                publicNetworkAccess: 'Disabled'
+                networkAccessPolicy: 'DenyAll'
+                creationData: {
+                  createOption: 'Copy'
+                  sourceResourceId: managedDisk.id
+                }
+              }
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-private-links-for-import-export-portal
+        title: Restrict import/export access for managed disks and snapshots using Azure Private Link
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.compute.snapshots.all(
+        publicNetworkAccess == "Disabled"
+      )
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_snapshot")
+    mql: |
+      terraform.resources("azurerm_snapshot").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_snapshot")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_snapshot").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_snapshot")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_snapshot").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-compute-snapshot-public-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/snapshots")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/snapshots").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  # No Terraform variants: azurerm_snapshot exposes no disk_encryption_set_id argument and no server-side encryption block, so the EncryptionAtRestWithCustomerKey posture this check verifies cannot be expressed on the resource. Its only encryption_settings block configures Azure Disk Encryption through a Key Vault secret and key, a different mechanism than server-side encryption with a customer-managed key via a disk encryption set, so it is not a valid analog.
+  - uid: mondoo-azure-security-compute-snapshot-cmk-encryption
+    title: Ensure Azure disk snapshots are encrypted with customer-managed keys
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-compute-snapshot-cmk-encryption-azure
+        tags:
+          mondoo.com/filter-title: Azure Managed Disk Snapshot
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-compute-snapshot-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure managed disk snapshots are encrypted at rest with a customer-managed key through a disk encryption set rather than relying solely on a platform-managed key. By default, Azure encrypts snapshots with platform-managed keys, which leaves key rotation, usage visibility, and revocation entirely under Microsoft's control.
+
+        **Why this matters**
+
+        - **Key ownership:** Customer-managed keys let the organization own the encryption key lifecycle for snapshot data, including rotation cadence and immediate revocation.
+        - **Usage visibility:** Key operations are logged through Azure Key Vault, giving the organization an audit record of when snapshot data is decrypted.
+        - **Snapshot exfiltration path:** A snapshot preserves a full copy of disk contents, so an unprotected snapshot is an alternative route to data that the source disk's controls would otherwise guard.
+        - **Compliance alignment:** Regulated workloads often require demonstrable customer control over the keys protecting stored data, which platform-managed keys cannot satisfy.
+
+        **Risk mitigation**
+
+        - **Revocation containment:** Revoking the key vault key renders the snapshot unreadable, neutralizing a stolen or exported snapshot.
+        - **Centralized control:** A single disk encryption set governs the keys for many snapshots, keeping protection consistent as snapshots proliferate.
+        - **Reduced blast radius:** Customer-managed encryption ensures a copied or leaked snapshot cannot be opened without access to the organization's key vault.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Snapshots** in the Azure Portal.
+        2. Select a snapshot.
+        3. Go to **Encryption**.
+        4. Verify that the encryption type is set to a **customer-managed key** option rather than platform-managed key only.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az snapshot show --name <SnapshotName> --resource-group <ResourceGroupName> --query "encryption" -o json
+        ```
+
+        An `encryption.type` of `EncryptionAtRestWithCustomerKey` or `EncryptionAtRestWithPlatformAndCustomerKeys` indicates a passing result; `EncryptionAtRestWithPlatformKey` indicates a failing result.
+      remediation:
+        - id: portal
+          desc: |
+            To encrypt an Azure disk snapshot with a customer-managed key using the Azure Portal:
+
+            1. Navigate to **Snapshots** in the Azure Portal.
+            2. Select the snapshot.
+            3. Go to **Encryption**.
+            4. Set the encryption type to **Encryption at rest with a customer-managed key** and select a disk encryption set backed by an Azure Key Vault key.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To encrypt an Azure disk snapshot with a customer-managed key using the Azure CLI:
+
+            ```bash
+            az snapshot update --name <SnapshotName> --resource-group <ResourceGroupName> --disk-encryption-set <DiskEncryptionSetId> --encryption-type EncryptionAtRestWithCustomerKey
+            ```
+        - id: bicep
+          desc: |
+            To encrypt an Azure disk snapshot with a customer-managed key in Bicep:
+
+            ```bicep
+            resource snapshot 'Microsoft.Compute/snapshots@2024-03-02' = {
+              name: 'example-snapshot'
+              location: resourceGroup().location
+              properties: {
+                creationData: {
+                  createOption: 'Copy'
+                  sourceResourceId: sourceDisk.id
+                }
+                encryption: {
+                  type: 'EncryptionAtRestWithCustomerKey'
+                  diskEncryptionSetId: diskEncryptionSet.id
+                }
+              }
+            }
+            ```
+        # No Terraform remediation: azurerm_snapshot has no disk_encryption_set_id or server-side encryption argument to set. Its encryption_settings block is Azure Disk Encryption via a Key Vault secret and key, not server-side encryption with a customer-managed key via a disk encryption set.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption
+        title: Server-side encryption of Azure Disk Storage
+  - uid: mondoo-azure-security-compute-snapshot-cmk-encryption-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.compute.snapshots.all(encryptionType == /CustomerKey/)
+  - uid: mondoo-azure-security-compute-snapshot-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/snapshots")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/snapshots").all(
+        properties["encryption"]["type"] == /CustomerKey/
+      )
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans
+    title: Ensure recurring vulnerability assessment scans are enabled on Azure SQL
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-07
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-308-a-8-evaluation
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-8
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ra-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-11-2
+      compliance/pci-dss-4: pcidss-requirement-11-3-1
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    variants:
+      - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-azure
+        tags:
+          mondoo.com/filter-title: Azure SQL Server
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every Azure SQL server has a vulnerability assessment configured with recurring scans enabled, so the database engine and its configuration are evaluated for misconfigurations and known weaknesses on an automatic, periodic basis. By default, Azure SQL does not run vulnerability assessment scans, and even when an assessment is configured the recurring scan schedule can be left off, leaving detection to one-off manual runs.
+
+        **Why this matters**
+
+        - **Continuous detection:** Recurring scans automatically re-evaluate each server on a weekly cadence, catching newly introduced misconfigurations and drift without relying on an administrator to remember to run a manual scan.
+        - **Baseline tracking:** A scheduled assessment maintains a security baseline and flags results that deviate from it, turning vulnerability data into an ongoing signal rather than a single point-in-time snapshot.
+        - **Earlier remediation:** Periodic findings shorten the window between when a weakness is introduced and when it is surfaced for remediation, reducing the time an exploitable condition stays live.
+        - **Compliance alignment:** Many security frameworks require systems that hold sensitive data to be scanned for vulnerabilities on a defined, repeating schedule rather than only on demand.
+
+        **Risk mitigation**
+
+        - **Misconfiguration exposure:** Scheduled scans detect excessive permissions, weak settings, and unsafe defaults on the SQL server before an attacker can take advantage of them.
+        - **Audit readiness:** A recurring scan history provides demonstrable evidence that databases are assessed on a regular interval, which auditors expect for regulated workloads.
+        - **Operational drift:** Automatic re-scanning surfaces changes made outside of change control, so a server that was hardened once does not silently regress over time.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **SQL servers** in the Azure Portal and select a server.
+        2. Under **Security**, select **Microsoft Defender for Cloud**.
+        3. Open **Configure** for the vulnerability assessment settings.
+        4. Confirm a storage account is set and that **Periodic recurring scans** is set to **On**.
+        5. A failing server has no vulnerability assessment configured or has periodic recurring scans turned off.
+
+        ### Audit via CLI
+
+        List the SQL servers in the subscription, then read each server's vulnerability assessment settings through the Azure REST API and confirm `recurringScans.isEnabled` is `true`:
+
+        ```bash
+        az sql server list --query "[].{Name:name, ResourceGroup:resourceGroup}" -o table
+
+        az rest --method get \
+          --url "https://management.azure.com/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroupName>/providers/Microsoft.Sql/servers/<ServerName>/vulnerabilityAssessments/default?api-version=2021-11-01" \
+          --query "properties.recurringScans.isEnabled"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To enable recurring vulnerability assessment scans on an Azure SQL server using the Azure Portal:
+
+            1. Navigate to **SQL servers** in the Azure Portal and select the server.
+            2. Under **Security**, select **Microsoft Defender for Cloud**.
+            3. Select **Configure** for the vulnerability assessment settings.
+            4. Select a **Storage account** to hold scan results.
+            5. Set **Periodic recurring scans** to **On**.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To enable recurring vulnerability assessment scans on an Azure SQL server using the Azure CLI, configure the vulnerability assessment setting through the Azure REST API with `recurringScans.isEnabled` set to `true`:
+
+            ```bash
+            az rest --method put \
+              --url "https://management.azure.com/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroupName>/providers/Microsoft.Sql/servers/<ServerName>/vulnerabilityAssessments/default?api-version=2021-11-01" \
+              --body '{"properties": {"storageContainerPath": "https://<StorageAccount>.blob.core.windows.net/vulnerability-assessment/", "recurringScans": {"isEnabled": true, "emailSubscriptionAdmins": true}}}'
+            ```
+        - id: terraform
+          desc: |
+            To enable recurring vulnerability assessment scans on an Azure SQL server in Terraform, add a `recurring_scans` block to the `azurerm_mssql_server_vulnerability_assessment` resource:
+
+            ```hcl
+            resource "azurerm_mssql_server_security_alert_policy" "example" {
+              resource_group_name = azurerm_resource_group.example.name
+              server_name         = azurerm_mssql_server.example.name
+              state               = "Enabled"
+            }
+
+            resource "azurerm_mssql_server_vulnerability_assessment" "example" {
+              server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.example.id
+              storage_container_path          = "${azurerm_storage_account.example.primary_blob_endpoint}${azurerm_storage_container.example.name}/"
+              storage_account_access_key      = azurerm_storage_account.example.primary_access_key
+
+              recurring_scans {
+                enabled                   = true
+                email_subscription_admins = true
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable recurring vulnerability assessment scans on an Azure SQL server in Bicep, set `recurringScans.isEnabled` to `true` on the server's vulnerability assessment resource:
+
+            ```bicep
+            resource sqlVulnerabilityAssessment 'Microsoft.Sql/servers/vulnerabilityAssessments@2021-11-01' = {
+              name: 'default'
+              parent: sqlServer
+              properties: {
+                storageContainerPath: '${storageAccount.properties.primaryEndpoints.blob}vulnerability-assessment/'
+                recurringScans: {
+                  isEnabled: true
+                  emailSubscriptionAdmins: true
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-sql/database/sql-database-vulnerability-assessment
+        title: SQL Vulnerability Assessment helps you identify database vulnerabilities
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.sql.servers.all(vulnerabilityAssessmentSettings.recurringScanEnabled == true)
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_vulnerability_assessment")
+    mql: |
+      terraform.resources("azurerm_mssql_server_vulnerability_assessment").all(
+        blocks.where(type == "recurring_scans").where(arguments['enabled'] == true) != empty
+      )
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_mssql_server_vulnerability_assessment")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_mssql_server_vulnerability_assessment").all(
+        change.after['recurring_scans'][0]['enabled'] == true
+      )
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_mssql_server_vulnerability_assessment")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_mssql_server_vulnerability_assessment").all(
+        values['recurring_scans'][0]['enabled'] == true
+      )
+  - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Sql/servers/vulnerabilityAssessments")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Sql/servers/vulnerabilityAssessments").all(
+        properties["recurringScans"]["isEnabled"] == true
+      )
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode
+    title: Ensure Application Gateway WAF is attached and set to Prevention mode
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-6-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-3-2
+    variants:
+      - uid: mondoo-azure-security-appgw-waf-prevention-mode-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-prevention-mode-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every Azure Application Gateway has a Web Application Firewall policy attached and that the policy runs in Prevention mode, so the gateway actively blocks malicious requests instead of only logging them. By default an Application Gateway forwards all traffic to its backends without inspection, and even when a WAF policy is attached it often defaults to Detection mode, which records suspicious requests but still lets them reach the application. Prevention mode requires the WAF_v2 SKU on the Application Gateway.
+
+        **Why this matters**
+
+        - **Active attack blocking**: In Prevention mode the WAF terminates requests that match its managed and custom rule sets, stopping SQL injection, cross-site scripting, and other OWASP Top 10 attacks before they reach backend services.
+        - **Detection mode is not protection**: A WAF in Detection mode only writes log entries while still passing malicious traffic through, giving a false sense of coverage to teams who assume an attached WAF means requests are being filtered.
+        - **Centralized application defense**: Attaching the policy at the gateway applies consistent inbound filtering to every listener and backend pool, removing the need to harden each origin application independently.
+        - **Compliance alignment**: Standards for public-facing web applications require an automated technical solution that detects and prevents web-based attacks in real time, which a WAF in Prevention mode satisfies.
+
+        **Risk mitigation**
+
+        - **Reduced exploitation window**: Blocking malicious requests at the edge prevents attackers from probing or exploiting application vulnerabilities, shrinking the exposure of unpatched or poorly coded backends.
+        - **Bot and enumeration control**: Managed rule sets and custom rate-limiting rules running in Prevention mode throttle brute-force and enumeration attempts at the gateway rather than at the application tier.
+        - **Consistent enforcement**: Pinning the policy mode to Prevention removes the drift that occurs when a WAF is left in Detection mode after testing and never switched to active blocking.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Application gateways** in the Azure Portal.
+        2. Select the Application Gateway.
+        3. Under **Settings**, select **Web Application Firewall**.
+        4. Confirm that a WAF policy is associated and that **Mode** is set to **Prevention**.
+
+        A passing gateway has a policy attached with the mode shown as Prevention. A failing gateway has no WAF policy, or a policy whose mode is Detection.
+
+        ### Audit via Azure CLI
+
+        List every WAF policy and its mode:
+
+        ```bash
+        az network application-gateway waf-policy list --query "[].{Name:name, Mode:policySettings.mode, State:policySettings.state}" -o table
+        ```
+
+        Any policy whose `Mode` is not `Prevention` fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To attach a WAF policy and set it to Prevention mode using the Azure Portal:
+
+            1. Navigate to **Application gateways** in the Azure Portal.
+            2. Select the Application Gateway (the gateway must use the **WAF_v2** SKU).
+            3. Under **Settings**, select **Web Application Firewall**.
+            4. Associate an existing WAF policy or create a new one.
+            5. Open the policy, go to **Policy settings**, and set **Mode** to **Prevention**.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To set an existing WAF policy to Prevention mode using the Azure CLI:
+
+            ```bash
+            az network application-gateway waf-policy policy-setting update --policy-name <PolicyName> --resource-group <ResourceGroupName> --mode Prevention --state Enabled
+            ```
+
+            To create a WAF policy in Prevention mode and then associate it with the Application Gateway:
+
+            ```bash
+            az network application-gateway waf-policy create --name <PolicyName> --resource-group <ResourceGroupName> --policy-settings mode=Prevention state=Enabled
+            ```
+        - id: terraform
+          desc: |
+            To enforce Prevention mode on the Web Application Firewall policy in Terraform:
+
+            ```hcl
+            resource "azurerm_web_application_firewall_policy" "example" {
+              name                = "example-wafpolicy"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              policy_settings {
+                enabled = true
+                mode    = "Prevention"
+              }
+
+              managed_rules {
+                managed_rule_set {
+                  type    = "OWASP"
+                  version = "3.2"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enforce Prevention mode on the Web Application Firewall policy in Bicep:
+
+            ```bicep
+            resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-11-01' = {
+              name: 'example-wafpolicy'
+              location: resourceGroup().location
+              properties: {
+                policySettings: {
+                  state: 'Enabled'
+                  mode: 'Prevention'
+                }
+                managedRules: {
+                  managedRuleSets: [
+                    {
+                      ruleSetType: 'OWASP'
+                      ruleSetVersion: '3.2'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/ag-overview
+        title: Azure Web Application Firewall on Azure Application Gateway
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.network.applicationGateways.all(policy != null && policy.mode == "Prevention")
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.resources("azurerm_web_application_firewall_policy").all(
+        blocks.where(type == "policy_settings").where(arguments['mode'] == "Prevention") != empty
+      )
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_web_application_firewall_policy").all(
+        change.after['policy_settings'][0]['mode'] == "Prevention"
+      )
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_web_application_firewall_policy").all(
+        values['policy_settings'][0]['mode'] == "Prevention"
+      )
+  - uid: mondoo-azure-security-appgw-waf-prevention-mode-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies").all(
+        properties["policySettings"]["mode"] == "Prevention"
+      )
+  # Terraform variant limitation: the Terraform checks assert that at least one azurerm_cdn_frontdoor_security_policy is defined, but static IaC cannot bind a security policy to a specific profile. A configuration with multiple profiles where only some have a WAF attached can still pass; the runtime check evaluates each profile individually.
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached
+    title: Ensure a WAF policy is attached to Azure Front Door profiles
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-23
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-6-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-frontdoor-waf-policy-attached-azure
+        tags:
+          mondoo.com/filter-title: Azure Front Door
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-frontdoor-waf-policy-attached-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every Azure Front Door Standard or Premium profile has a security policy that associates a Web Application Firewall policy, so all traffic reaching the edge is inspected and filtered for web-based attacks. By default, a Front Door profile routes traffic without any WAF attached, leaving public-facing applications exposed to common exploits such as SQL injection, cross-site scripting, and automated bot abuse.
+
+        **Why this matters**
+
+        - **Application-layer protection:** A WAF inspects HTTP and HTTPS requests at the edge and blocks malicious payloads before they reach the origin, defending applications that may be improperly coded or unpatched.
+        - **Edge enforcement:** Front Door terminates connections at globally distributed points of presence, so attaching a WAF there stops malicious traffic close to its source rather than at the origin, reducing load and exposure on backend services.
+        - **Coverage of common attacks:** Managed rule sets address the most prevalent web exploits, including injection, scripting, and known vulnerability signatures, without requiring custom rule authoring for every threat.
+        - **Bot and rate abuse mitigation:** WAF rate-limiting and bot-management rules curb credential stuffing, scraping, and volumetric application-layer abuse that ordinary network firewalls cannot distinguish from legitimate traffic.
+
+        **Risk mitigation**
+
+        - **Reduced exploit surface:** Filtering requests at the Front Door edge neutralizes many web attacks before they can reach application code, limiting the impact of an unpatched or vulnerable backend.
+        - **Centralized rule enforcement:** Binding a single WAF policy to a profile applies consistent protection across all domains served by that profile, removing gaps that arise when individual applications are protected inconsistently.
+        - **Auditable blocking:** WAF policies generate logs of matched and blocked requests, giving responders visibility into attempted attacks and evidence that edge filtering is active and effective.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Front Door and CDN profiles** in the Azure Portal.
+        2. Select a Front Door profile.
+        3. Under **Security**, select **Security policies**.
+        4. Verify that at least one security policy exists and that it associates a Web Application Firewall policy with the profile's domains.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az afd security-policy list --resource-group <ResourceGroupName> --profile-name <ProfileName> --query "[].{name:name, waf:parameters.wafPolicy.id}" -o table
+        ```
+
+        A profile with no security policy, or a security policy whose WAF policy reference is empty, fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To attach a WAF policy to a Front Door profile using the Azure Portal:
+
+            1. Navigate to **Front Door and CDN profiles** in the Azure Portal.
+            2. Select the Front Door profile.
+            3. Under **Security**, select **Security policies**.
+            4. Select **Add**, then provide a name and select the domains to protect.
+            5. Under **WAF Policy**, select an existing Web Application Firewall policy or create a new one.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To attach a WAF policy to a Front Door profile using the Azure CLI:
+
+            ```bash
+            az afd security-policy create --resource-group <ResourceGroupName> --profile-name <ProfileName> --security-policy-name <SecurityPolicyName> --domains <DomainResourceId> --waf-policy <WafPolicyResourceId>
+            ```
+        - id: terraform
+          desc: |
+            To attach a WAF policy to a Front Door profile in Terraform, create an `azurerm_cdn_frontdoor_security_policy` that binds a `azurerm_cdn_frontdoor_firewall_policy` to the profile's domains:
+
+            ```hcl
+            resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
+              name                = "exampleWAF"
+              resource_group_name = azurerm_resource_group.example.name
+              sku_name            = azurerm_cdn_frontdoor_profile.example.sku_name
+              enabled             = true
+              mode                = "Prevention"
+
+              managed_rule {
+                type    = "Microsoft_DefaultRuleSet"
+                version = "2.1"
+                action  = "Block"
+              }
+            }
+
+            resource "azurerm_cdn_frontdoor_security_policy" "example" {
+              name                     = "example-security-policy"
+              cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+
+              security_policies {
+                firewall {
+                  cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.example.id
+
+                  association {
+                    domain {
+                      cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.example.id
+                    }
+                    patterns_to_match = ["/*"]
+                  }
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To attach a WAF policy to a Front Door profile in Bicep, deploy a `securityPolicies` child resource that references a Web Application Firewall policy:
+
+            ```bicep
+            resource securityPolicy 'Microsoft.Cdn/profiles/securityPolicies@2024-02-01' = {
+              parent: frontDoorProfile
+              name: 'example-security-policy'
+              properties: {
+                parameters: {
+                  type: 'WebApplicationFirewall'
+                  wafPolicy: {
+                    id: wafPolicy.id
+                  }
+                  associations: [
+                    {
+                      domains: [
+                        {
+                          id: frontDoorEndpoint.id
+                        }
+                      ]
+                      patternsToMatch: [
+                        '/*'
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/web-application-firewall/afds/afds-overview
+        title: Azure Web Application Firewall on Azure Front Door
+      - url: https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview
+        title: What is Azure Front Door?
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.frontDoor.profiles.all(securityPolicies.where(policyType == "WebApplicationFirewall" && wafPolicyId != "").length > 0)
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cdn_frontdoor_profile")
+    mql: |
+      terraform.resources("azurerm_cdn_frontdoor_security_policy").length > 0
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cdn_frontdoor_profile")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_cdn_frontdoor_security_policy").length > 0
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_cdn_frontdoor_profile")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_cdn_frontdoor_security_policy").length > 0
+  - uid: mondoo-azure-security-frontdoor-waf-policy-attached-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Cdn/profiles")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Cdn/profiles/securityPolicies").length > 0 &&
+      bicep.resources.where(type == "Microsoft.Cdn/profiles/securityPolicies").all(properties["parameters"]["wafPolicy"]["id"] != empty)
+  - uid: mondoo-azure-security-databricks-no-public-ip
+    title: Ensure Azure Databricks uses secure cluster connectivity (no public IP)
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-databricks-no-public-ip-azure
+        tags:
+          mondoo.com/filter-title: Azure Databricks
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-databricks-no-public-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-databricks-no-public-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-databricks-no-public-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-databricks-no-public-ip-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Databricks workspaces deploy clusters with secure cluster connectivity so that cluster compute nodes have no public IP address and communicate through VNet injection. By default, Databricks provisions clusters into a managed virtual network where each node receives a public IP, leaving the compute plane directly addressable from the internet.
+
+        **Why this matters**
+
+        - **No public inbound exposure**: Removing public IPs from cluster nodes eliminates the inbound internet surface of the compute plane, so nodes cannot be reached directly by internet-based scanning or exploitation attempts.
+        - **Network isolation through VNet injection**: Secure cluster connectivity routes all node traffic through the customer virtual network, keeping compute communication within controlled network boundaries instead of traversing public IP space.
+        - **Outbound control**: With no public IPs, outbound traffic flows through customer-managed network paths such as NAT gateways or firewalls, allowing egress to be inspected, filtered, and logged.
+        - **Compliance alignment**: Security frameworks require compute resources that process sensitive data to be isolated from public networks and reachable only through controlled internal paths.
+
+        **Risk mitigation**
+
+        - **Compromise containment**: An attacker who obtains valid credentials still cannot reach cluster nodes from the internet, because the nodes have no publicly routable address.
+        - **Lateral movement restriction**: Confining cluster traffic to the injected virtual network prevents an intruder from using public routing to pivot between nodes or into adjacent workloads.
+        - **Egress governance**: Forcing outbound traffic through customer-managed network appliances lets defenders detect and block data exfiltration attempts that would otherwise leave directly from a node's public IP.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Databricks** in the Azure Portal.
+        2. Select a workspace.
+        3. Go to **Networking**.
+        4. Verify that **Deploy Azure Databricks workspace with Secure Cluster Connectivity (No Public IP)** is enabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az databricks workspace show --name <WorkspaceName> --resource-group <ResourceGroupName> --query "parameters.enableNoPublicIp.value"
+        ```
+
+        A value of `true` indicates secure cluster connectivity is enforced.
+      remediation:
+        - id: portal
+          desc: |
+            To enable secure cluster connectivity for an Azure Databricks workspace using the Azure Portal:
+
+            1. Create a new **Azure Databricks** workspace, because secure cluster connectivity cannot be changed on an existing workspace.
+            2. On the **Networking** tab, set **Deploy Azure Databricks workspace with Secure Cluster Connectivity (No Public IP)** to **Yes**.
+            3. Select the virtual network and subnets for VNet injection.
+            4. Complete creation and migrate workloads from the old workspace.
+        - id: cli
+          desc: |
+            To enable secure cluster connectivity for an Azure Databricks workspace using the Azure CLI:
+
+            ```bash
+            az databricks workspace create --name <WorkspaceName> --resource-group <ResourceGroupName> --location <Location> --sku premium --enable-no-public-ip true --vnet <VNetResourceId> --public-subnet <PublicSubnetName> --private-subnet <PrivateSubnetName>
+            ```
+        - id: terraform
+          desc: |
+            To enable secure cluster connectivity for an Azure Databricks workspace in Terraform:
+
+            ```hcl
+            resource "azurerm_databricks_workspace" "example" {
+              name                = "example-workspace"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              sku                 = "premium"
+
+              custom_parameters {
+                no_public_ip                                         = true
+                virtual_network_id                                   = azurerm_virtual_network.example.id
+                public_subnet_name                                   = azurerm_subnet.public.name
+                private_subnet_name                                  = azurerm_subnet.private.name
+                public_subnet_network_security_group_association_id  = azurerm_subnet_network_security_group_association.public.id
+                private_subnet_network_security_group_association_id  = azurerm_subnet_network_security_group_association.private.id
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable secure cluster connectivity for an Azure Databricks workspace in Bicep:
+
+            ```bicep
+            resource databricksWorkspace 'Microsoft.Databricks/workspaces@2024-05-01' = {
+              name: 'example-databricks'
+              location: resourceGroup().location
+              properties: {
+                managedResourceGroupId: managedResourceGroup.id
+                parameters: {
+                  enableNoPublicIp: {
+                    value: true
+                  }
+                }
+              }
+              sku: {
+                name: 'premium'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/secure-cluster-connectivity
+        title: Secure cluster connectivity for Azure Databricks
+  - uid: mondoo-azure-security-databricks-no-public-ip-azure
+    filters: |
+      asset.platform == "azure"
+    mql: |
+      azure.subscription.databricks.workspaces.all(
+        enableNoPublicIp == true
+      )
+  - uid: mondoo-azure-security-databricks-no-public-ip-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_databricks_workspace")
+    mql: |
+      terraform.resources("azurerm_databricks_workspace").all(
+        blocks.where(type == "custom_parameters").where(arguments['no_public_ip'] == true) != empty
+      )
+  - uid: mondoo-azure-security-databricks-no-public-ip-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_databricks_workspace")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_databricks_workspace").all(
+        change.after['custom_parameters'][0]['no_public_ip'] == true
+      )
+  - uid: mondoo-azure-security-databricks-no-public-ip-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_databricks_workspace")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_databricks_workspace").all(
+        values['custom_parameters'][0]['no_public_ip'] == true
+      )
+  - uid: mondoo-azure-security-databricks-no-public-ip-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Databricks/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Databricks/workspaces").all(
+        properties["parameters"]["enableNoPublicIp"]["value"] == true
+      )


### PR DESCRIPTION
## What

Adds 12 new checks to `mondoo-azure-security` (version `9.1.0` → `9.2.0`), grounded in capabilities the Azure MQL provider already exposes (plus two fields added in mondoohq/mql#8208). Each check ships with runtime + Terraform (HCL/plan/state) + Bicep variants, full `docs:` (desc/audit/remediation across portal/cli/terraform/bicep), and verified compliance tags across all 13 frameworks the policy maps.

### New "Azure IoT Hub" group
| Check | Impact |
|---|---|
| `iot-hub-local-auth-disabled` — reject shared access keys, require Entra ID | 80 |
| `iot-hub-public-network-access-disabled` | 80 |
| `iot-hub-min-tls-1-2` | 80 |
| `iot-hub-diagnostic-settings-enabled` (runtime-only — see note) | 70 |

### Azure Compute
| Check | Impact |
|---|---|
| `vm-secure-boot-enabled` (Trusted Launch) | 75 |
| `vm-vtpm-enabled` (Trusted Launch) | 75 |
| `compute-snapshot-public-access-disabled` | 80 |
| `compute-snapshot-cmk-encryption` (runtime + Bicep — see note) | 80 |

### Other services
| Check | Group | Impact |
|---|---|---|
| `sql-server-vulnerability-assessment-recurring-scans` | Azure SQL | 75 |
| `appgw-waf-prevention-mode` | Application Gateway | 80 |
| `frontdoor-waf-policy-attached` | Azure Front Door | 80 |
| `databricks-no-public-ip` (secure cluster connectivity) | Azure Databricks | 80 |

Impacts anchor to siblings in the same policy (most public-access/encryption/WAF checks here sit at 80; Trusted Launch and VA recurring scans are hardening controls at 75/70).

## Dependency

`iot-hub-diagnostic-settings-enabled` and `frontdoor-waf-policy-attached` query two fields added to the Azure provider in **mondoohq/mql#8208** (`iotHub.diagnosticSettings()` and `frontDoorService.profile.securityPolicies()`). This PR lints clean against a locally-built provider with those fields; it should merge after #8208 ships in a provider release.

## Notes on variant coverage

- `iot-hub-diagnostic-settings-enabled` is runtime-only: a diagnostic setting is a standalone resource targeting the hub by ID, and static IaC cannot reliably correlate it to a specific hub. A `# No Terraform variants:` comment documents this; remediation still covers portal/cli/terraform/bicep.
- `compute-snapshot-cmk-encryption` ships runtime + Bicep variants only: `azurerm_snapshot` exposes no customer-managed-key / disk-encryption-set argument. Documented with `# No Terraform variants:` / `# No Terraform remediation:` comments.

## Testing

- `cnspec policy lint content/mondoo-azure-security.mql.yaml` → valid
- `python3 content/validation/validate_remediation_commands.py azure` → 317 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)