### PR TITLE
Use windows.rdp resource for RDP/Terminal Services checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -465,6 +465,7 @@ logstreams
 logtraffic
 lookalike
 LPE
+lpt
 lru
 Lsa
 Lsass
@@ -618,6 +619,7 @@ pkr
 pmd
 pmf
 PMTU
+pnp
 poap
 portgroup
 posix

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -399,7 +399,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fPromptForPassword' ).data == 1
+      windows.rdp.alwaysPromptForPassword
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -4554,7 +4554,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fDisableCcm' ).data == 1
+      windows.rdp.comPortRedirectionDisabled
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -4651,7 +4651,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fDisableCdm' ).data == 1
+      windows.rdp.driveRedirectionDisabled
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -4752,7 +4752,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fDisableLPT' ).data == 1
+      windows.rdp.lptPortRedirectionDisabled
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -4849,7 +4849,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'DisablePasswordSaving' ).data == 1
+      windows.rdp.passwordSavingDisabled
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -4949,7 +4949,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'fDisablePNPRedir' ).data == 1
+      windows.rdp.pnpDeviceRedirectionDisabled
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -5046,7 +5046,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'DeleteTempDirsOnExit' ).data == 1
+      windows.rdp.deleteTempDirsOnExit
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -7910,7 +7910,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services', name: 'fEncryptRPCTraffic' ).data == 1
+      windows.rdp.secureRpcRequired
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -8009,7 +8009,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'SecurityLayer' ).data == 2
+      windows.rdp.securityLayer == 2
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -8115,7 +8115,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'UserAuthentication' ).data == 1
+      windows.rdp.networkLevelAuthentication
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -8438,7 +8438,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MinEncryptionLevel' ).data == 3
+      windows.rdp.minEncryptionLevel == 3
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -8553,8 +8553,8 @@ queries:
         mql: |
           900000
     mql: |
-      registrykey.property(path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MaxIdleTime').data <= props.mondooWindowsSecurityMaxIdleTime
-      registrykey.property(path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MaxIdleTime').data != 0
+      windows.rdp.maxIdleTimeMs <= props.mondooWindowsSecurityMaxIdleTime
+      windows.rdp.maxIdleTimeMs != 0
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
@@ -8666,7 +8666,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services', name: 'MaxDisconnectionTime' ).data == 60000
+      windows.rdp.maxDisconnectionTimeMs == 60000
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure


### PR DESCRIPTION
## Summary

Rewrites 13 Remote Desktop / Terminal Services checks in `mondoo-windows-security.mql.yaml` to read the new typed [`windows.rdp` resource](https://github.com/mondoohq/cnquery/pull/8060) instead of raw `registrykey.property(...)` lookups against `HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services`.

The `windows.rdp` resource resolves each setting in precedence order (Group Policy → per-listener effective settings → Windows defaults), so the checks now reflect the *effective* RDP configuration rather than only the Group Policy registry key. Boolean fields use inverted "true = secure" semantics, so the `== 1` comparisons collapse to bare field references.

## Field mapping

| Old registry value | New `windows.rdp` field |
|---|---|
| `fPromptForPassword == 1` | `alwaysPromptForPassword` |
| `fDisableCcm == 1` | `comPortRedirectionDisabled` |
| `fDisableCdm == 1` | `driveRedirectionDisabled` |
| `fDisableLPT == 1` | `lptPortRedirectionDisabled` |
| `DisablePasswordSaving == 1` | `passwordSavingDisabled` |
| `fDisablePNPRedir == 1` | `pnpDeviceRedirectionDisabled` |
| `DeleteTempDirsOnExit == 1` | `deleteTempDirsOnExit` |
| `fEncryptRPCTraffic == 1` | `secureRpcRequired` |
| `SecurityLayer == 2` | `securityLayer == 2` |
| `UserAuthentication == 1` | `networkLevelAuthentication` |
| `MinEncryptionLevel == 3` | `minEncryptionLevel == 3` |
| `MaxIdleTime <= prop && != 0` | `maxIdleTimeMs <= prop` / `!= 0` |
| `MaxDisconnectionTime == 60000` | `maxDisconnectionTimeMs == 60000` |

Each new field's secure-state semantics match the original registry comparison exactly. `audit:`/`remediation:` prose is intentionally unchanged — it still describes the underlying registry keys, which is the correct vendor-native verification path and what the resource reads under the hood.

## Notes

- Requires the `os` provider that ships the `windows.rdp` resource; should land together with or after that provider release.
- `cnspec policy lint content/mondoo-windows-security.mql.yaml` → **valid policy bundle** (validated against a locally-built provider from the resource branch).
- No compliance-tag changes; control objectives are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)