### PR TITLE
🐛 Exclude Azure development subscriptions from onboarding Terraform.

### DIFF
--- a/internal/onboarding/azure.go
+++ b/internal/onboarding/azure.go
@@ -227,10 +227,10 @@ func generateAllSubscriptionsBlocks(integration AzureIntegration, resourceADServ
 	resources = append(resources, dataRMAllSubscriptions)
 	dependsOn = append(dependsOn, dataRMAllSubscriptions.TraverseRef())
 
-	// Filter only active subscriptions
+	// Filter only active subscriptions, excluding developer sandbox subscriptions.
 	varActiveSubscriptions := tfgen.NewLocal("active_subscriptions",
 		tfgen.CreateSimpleTraversal(
-			`[for sub in `+dataRMAllSubscriptions.TraverseRefString("subscriptions")+` : sub if sub.state == "Enabled" ]`,
+			`[for sub in `+dataRMAllSubscriptions.TraverseRefString("subscriptions")+` : sub if sub.state == "Enabled" && !startswith(coalesce(sub.quota_id, "none"), "MSDN") && !startswith(coalesce(sub.quota_id, "none"), "MPN") ]`,
 		),
 	)
 	resources = append(resources, varActiveSubscriptions)
@@ -368,6 +368,7 @@ var assetPrintableKeys = []string{"name", "subscription-id"}
 func (a AzAccount) PrintableKeys() []string {
 	return assetPrintableKeys
 }
+
 func (a AzAccount) PrintableValue(index int) string {
 	switch assetPrintableKeys[index] {
 	case "name":
@@ -391,7 +392,7 @@ func (az AzAccount) Display() string {
 }
 
 func generateAzureIntegrationName(subscription string) string {
-	var subsSplit = strings.Split(subscription, "-")
+	subsSplit := strings.Split(subscription, "-")
 	return "subscription-" + subsSplit[len(subsSplit)-1]
 }
 
@@ -405,7 +406,7 @@ func generateAzureIntegrationName(subscription string) string {
 // Azure SDK which will make the binary much bigger, which is unnecessary for the amount
 // of checks we are running today.
 func VerifyUserRoleAssignments() error {
-	var BuiltInRoles = map[string]string{
+	BuiltInRoles := map[string]string{
 		"Privileged Role Administrator": "e8611ab8-c189-46e8-94e1-60213ab1f814",
 		"Global Administrator":          "62e90394-69f5-4237-9190-012177145e10",
 	}

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -88,7 +88,7 @@ data "azurerm_subscriptions" "available" {
 }
 
 locals {
-  active_subscriptions = [for sub in data.azurerm_subscriptions.available.subscriptions : sub if sub.state == "Enabled" ]
+  active_subscriptions = [for sub in data.azurerm_subscriptions.available.subscriptions : sub if sub.state == "Enabled" && !startswith(coalesce(sub.quota_id, "none"), "MSDN") && !startswith(coalesce(sub.quota_id, "none"), "MPN") ]
 }
 
 resource "azurerm_role_assignment" "reader" {
@@ -448,7 +448,7 @@ data "azurerm_subscriptions" "available" {
 }
 
 locals {
-  active_subscriptions = [for sub in data.azurerm_subscriptions.available.subscriptions : sub if sub.state == "Enabled" ]
+  active_subscriptions = [for sub in data.azurerm_subscriptions.available.subscriptions : sub if sub.state == "Enabled" && !startswith(coalesce(sub.quota_id, "none"), "MSDN") && !startswith(coalesce(sub.quota_id, "none"), "MPN") ]
 }
 
 resource "azurerm_role_assignment" "reader" {


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnspec/issues/2711

Using `sub.quota_id` to filter out developer sandbox subscriptions. The display name of a subscription can be edited and also localized which makes it unsuitable for the use case, whereas the `quota_id` is provided by Azure.

`quota_id` values obtained from https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers.

For reference because the Azure CLI returns a trimmed subscription object, here's how you can see your current subscription's quota id:
```bash
az rest --method get \
  --url "https://management.azure.com/subscriptions/$(az account show --query id -o tsv)?api-version=2020-01-01" \
  --query "subscriptionPolicies.quotaId" -o tsv
```