### PR TITLE
Simplify FreeBSD sudoers use_pty check with sudoers resource

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -4758,8 +4758,7 @@ queries:
     filters: |
       package("sudo").installed
     mql: |
-      sudoersFiles = files.find(from: "/usr/local/etc/sudoers.d/", type: 'file').list.map(path) + ["/usr/local/etc/sudoers"]
-      sudoersFiles.map(file(_).content.lines.where(_ == /^[^#]/)).flat.where(_ == /Defaults/).any(_ == /\s*use_pty/)
+      sudoers.defaults.any(parameter == "use_pty" && negated == false)
     docs:
       refs:
         - url: https://docs.freebsd.org/en/books/handbook/security/


### PR DESCRIPTION
## What

Simplifies the `mondoo-freebsd-security-sudoers-use-pty` check by replacing manual sudoers file globbing and regex parsing with the OS provider's structured `sudoers` resource.

**Before:**
```coffee
sudoersFiles = files.find(from: "/usr/local/etc/sudoers.d/", type: 'file').list.map(path) + ["/usr/local/etc/sudoers"]
sudoersFiles.map(file(_).content.lines.where(_ == /^[^#]/)).flat.where(_ == /Defaults/).any(_ == /\s*use_pty/)
```

**After:**
```coffee
sudoers.defaults.any(parameter == "use_pty" && negated == false)
```

## Why

- The `sudoers` resource already resolves FreeBSD's `/usr/local/etc/sudoers` path (via its per-platform path map) and recursively follows `@include`/`@includedir` directives, so the explicit `sudoers.d/` enumeration and string concatenation are no longer needed.
- It only counts files actually included via sudoers directives, rather than blindly reading every file in `sudoers.d/`.
- The new query adds `negated == false`, so a `Defaults !use_pty` line correctly **fails** the check. The previous regex matched `!use_pty` as a pass, so this is also a correctness fix.

## Testing

- `cnspec policy lint mondoo-freebsd-security.mql.yaml` → valid policy bundle(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)