### PR TITLE
Use windows.tpm and machine.secureboot resources in Windows 11 compatibility policy

### DIFF
--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-11-compatibility
     name: Mondoo Microsoft Windows 11 Compatibility for Workstations
-    version: 1.2.0
+    version: 1.3.0
     tags:
       mondoo.com/category: best-practices
       mondoo.com/platform: windows:10
@@ -1285,8 +1285,8 @@ queries:
     title: Check Windows 11 TPM 2.0 compatibility
     impact: 10
     mql: |
-      powershell("(Get-Tpm).TpmPresent").stdout.trim == "True"
-      powershell("(Get-WmiObject -Namespace 'root\\cimv2\\Security\\MicrosoftTpm' -Class Win32_Tpm).SpecVersion.Split(',')[0].Trim()").stdout.trim == "2.0"
+      windows.tpm.present == true
+      windows.tpm.specVersion == "2.0"
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/hardware-security/tpm/tpm-fundamentals
@@ -1331,7 +1331,7 @@ queries:
     title: Check Windows 11 UEFI firmware compatibility
     impact: 10
     mql: |
-      windows.computerInfo['BiosFirmwareType'] == 2
+      machine.secureboot.efi == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-uefi
@@ -1375,7 +1375,7 @@ queries:
     title: Check Windows 11 Secure Boot compatibility
     impact: 10
     mql: |
-      powershell("try { Confirm-SecureBootUEFI } catch { $false }").stdout.trim == "True"
+      machine.secureboot.enabled == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-secure-boot


### PR DESCRIPTION
## Summary

Improves three checks in `mondoo-windows-11-compatibility.mql.yaml` by replacing brittle PowerShell shell-outs and a magic-number lookup with the native resources shipped in [os-13.23.0](https://github.com/mondoohq/mql/commit/853343ec167ddc9cd500b2532aab08e553a30ded).

| Check | Before | After |
|---|---|---|
| **TPM 2.0** | two `powershell(...)` calls (`Get-Tpm`, `Win32_Tpm` WMI) | `windows.tpm.present` + `windows.tpm.specVersion == "2.0"` |
| **Secure Boot** | `powershell("try { Confirm-SecureBootUEFI } catch { $false }")` | `machine.secureboot.enabled == true` |
| **UEFI firmware** | `windows.computerInfo['BiosFirmwareType'] == 2` (magic number) | `machine.secureboot.efi == true` |

## Why

- No PowerShell process spawning or stdout string-parsing — the provider reads TPM/UEFI state directly, so it's faster and not dependent on PowerShell output formatting.
- The new resources resolve cleanly on non-TPM / legacy-BIOS systems (`present`/`enabled` return `false` instead of erroring), so checks fail gracefully rather than producing parse errors.
- `machine.secureboot.efi` replaces the opaque `BiosFirmwareType == 2` constant with a self-documenting field.

The RAM, HDD, and CPU checks are unchanged — this release added nothing relevant to them.

Bumps the policy version 1.2.0 → 1.3.0.

## Test plan

- [x] `cnspec policy lint content/mondoo-windows-11-compatibility.mql.yaml` reports a valid bundle against the os-13.23.0 provider schema
- [x] Verified `windows.tpm` (`present`, `specVersion`) and `machine.secureboot` (`enabled`, `efi`) fields exist in the installed provider schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)