### PR TITLE
Use parsed params maps for rsyslog and su PAM checks

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -9396,7 +9396,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      rsyslog.conf.settings.contains("$FileCreateMode 0640")
+      rsyslog.conf.params["FileCreateMode"] == "0640"
     docs:
       desc: |
         This check ensures that `rsyslog` is configured to apply appropriate permissions to newly created log files. This setting controls the default permissions for log files that do not already exist on the system.
@@ -13920,8 +13920,8 @@ queries:
     filters: |
       asset.kind != "container-image"
     mql: |
-      suRestrictedPam = pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth" && module == "pam_wheel.so" && options.contains("use_uid"))
-      suRestrictedGroups = suRestrictedPam.map(options.where(_ == /^group=/).map(_.split("group=")[1])).flat
+      suRestrictedPam = pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
+      suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
 
       suRestrictedPam != empty
       suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)


### PR DESCRIPTION
## What

Modernizes two Linux security checks to use the parsed `params` key/value maps added in cnquery os-provider **13.23.0** ([mondoohq/mql#8054](https://github.com/mondoohq/mql/pull/8054), [#8055](https://github.com/mondoohq/mql/pull/8055)).

### `mondoo-linux-security-rsyslog-default-file-permissions-configured`

```diff
- rsyslog.conf.settings.contains("$FileCreateMode 0640")
+ rsyslog.conf.params["FileCreateMode"] == "0640"
```

The old `settings.contains` required the exact literal string `$FileCreateMode 0640`. A valid config using a tab or extra spaces (`$FileCreateMode  0640`) would **false-fail**, and because `contains` matches *any* line, an overridden earlier directive could **false-pass**. The new `params` map normalizes whitespace, strips the leading `$`, and applies last-occurrence-wins — reflecting rsyslog's effective value.

### `su` access restriction check

```diff
- ... && options.contains("use_uid"))
- suRestrictedGroups = suRestrictedPam.map(options.where(_ == /^group=/).map(_.split("group=")[1])).flat
+ ... && params["use_uid"] != null)
+ suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
```

`params["use_uid"] != null` is the documented existence-check idiom for bare PAM flags, and `params["group"]` reads the value directly instead of regex-filtering and string-splitting `group=<name>`.

## Why

Both checks previously parsed raw config text. The new structured `params` maps make them whitespace-robust, correct under duplicate/overridden directives, and easier to read. Behavior is unchanged for well-formed configs.

## Testing

- `cnspec policy lint ./content/mondoo-linux-security.mql.yaml` passes (compiles both queries against the live os 13.23.0 provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)