### PR TITLE
🧹 Simplify TLS cert-match and reverse-DNS checks with new resource fields

### DIFF
--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -83,13 +83,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      reverseDNSDomain =
-        dns.params.A.rData.first.split(".")[3] + "."
-          + dns.params.A.rData.first.split(".")[2] + "."
-          +  dns.params.A.rData.first.split(".")[1] + "."
-          +  dns.params.A.rData.first.split(".")[0]
-          + ".in-addr.arpa"
-      dns(reverseDNSDomain).params.PTR.rData.any(_.contains(domainName.fqdn))
+      dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
     docs:
       desc: |
         A reverse DNS PTR record maps the sending mail server's IP address back to a fully qualified domain name within your domain. Reverse DNS queries for IPv4 addresses use the special domain `in-addr.arpa`, where the IPv4 address is represented in reverse octet order followed by the `.in-addr.arpa` suffix. When the PTR record resolves to a hostname whose forward A record points back to the original IP address, the domain is in a forward-confirmed reverse DNS state, which receiving mail servers treat as a reliable signal that the sender is legitimate.

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -79,18 +79,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      checkA1 = tls.certificates.first.subject.commonName == asset.fqdn
-
-      if(tls.certificates.first.subject.commonName.contains(/^\*/)) {
-        checkA1 == asset.fqdn.contains(tls.certificates.first.subject.commonName.split("*.")[1])
-      }
-
-      checkA2 = tls.certificates.first.sanExtension.dnsNames.contains(asset.fqdn)
-
-
-      checkA3 = tls.certificates.first.sanExtension.dnsNames.where(_ == /\*/).where(_.split(".")[-2] + "." + _.split(".")[-1]).any(asset.name.contains(_.split("*.")[1]))
-
-      checkA1 || checkA2 || checkA3
+      tls.certificateMatchesDomain
     docs:
       desc: |
         This check ensures that the SSL/TLS certificate presented by the server is configured to match the hostname being secured, through either the Common Name or a Subject Alternative Name entry. A mismatch breaks the identity guarantee that TLS depends on and leaves clients unable to confirm they reached the legitimate server.

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -39,13 +39,7 @@ packs:
         docs:
           desc: Performs reverse DNS lookup on the domain's IP address to verify PTR record configuration.
         mql: |
-          reverseDNSDomain =
-            dns.params.A.rData.first.split(".")[3] + "."
-              + dns.params.A.rData.first.split(".")[2] + "."
-              +  dns.params.A.rData.first.split(".")[1] + "."
-              +  dns.params.A.rData.first.split(".")[0]
-              + ".in-addr.arpa"
-          dns(reverseDNSDomain).params.PTR
+          dns.reverse
       - uid: mondoo-email-inventory-spf-record
         title: Retrieve SPF record
         docs:


### PR DESCRIPTION
## What

Replaces hand-rolled MQL in three content bundles with the new typed resource fields added upstream:

- **`dns.reverse`** — mondoohq/mql#8251 (merged)
- **`tls.certificateMatchesDomain`** — mondoohq/mql#8249 (merged)

## Changes

**`mondoo-tls-security`** — `mondoo-tls-security-cert-domain-name-match`

The certificate/hostname check collapses from a hand-rolled CN + exact-SAN + wildcard-SAN match:

```
checkA1 = tls.certificates.first.subject.commonName == asset.fqdn
if(tls.certificates.first.subject.commonName.contains(/^\*/)) {
  checkA1 == asset.fqdn.contains(tls.certificates.first.subject.commonName.split("*.")[1])
}
checkA2 = tls.certificates.first.sanExtension.dnsNames.contains(asset.fqdn)
checkA3 = tls.certificates.first.sanExtension.dnsNames.where(_ == /\*/).where(_.split(".")[-2] + "." + _.split(".")[-1]).any(asset.name.contains(_.split("*.")[1]))
checkA1 || checkA2 || checkA3
```

to:

```
tls.certificateMatchesDomain
```

The new field is backed by `x509.Certificate.VerifyHostname` (SAN DNS names + RFC 6125 wildcards). This also fixes two latent bugs in the old wildcard arm: a non-boolean `where` body, and matching against `asset.name` instead of `asset.fqdn`.

**`mondoo-email-security`** — `mondoo-email-security-reverse-ip-ptr-record-set`

The forward-confirmed reverse DNS (FCrDNS) check no longer reverses IPv4 octets by hand and runs a second nested `dns()` lookup:

```
reverseDNSDomain =
  dns.params.A.rData.first.split(".")[3] + "." + ... + ".in-addr.arpa"
dns(reverseDNSDomain).params.PTR.rData.any(_.contains(domainName.fqdn))
```

to:

```
dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
```

`dns.reverse` covers **all** A and AAAA addresses (the old form only checked the first A record) and works for IPv6 for free.

**`mondoo-email-inventory`** querypack — `mondoo-email-inventory-mail-records`

The reverse PTR inventory query uses `dns.reverse`, returning typed records (`name`, `rdata`, `ttl`) for every resolved address instead of the raw PTR dict for the first A record.

## Testing

`cnspec policy lint ./content` → **valid policy bundle(s)** (validated against a `network` provider built from current mql main; remaining lint output is pre-existing deprecation warnings in unrelated bundles).

> [!NOTE]
> Linting requires a released `network` provider that includes both fields. `tls.certificateMatchesDomain` merged today, so CI lint will stay red until the next `network` provider release ships.