### PR TITLE
Replace deprecated MQL fields in Azure and GCP policies

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -30806,7 +30806,7 @@ queries:
     filters: |
       asset.platform == "azure-datafactory"
     mql: |
-      azure.subscription.dataFactory.factory.encryption != empty
+      azure.subscription.dataFactory.factory.cmkKeyName != empty
   - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -22044,7 +22044,7 @@ queries:
     filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.vertexai.pipelineJobs.all(
-        network != ""
+        networkRef != null
       )
   # No Terraform variants: Vertex AI pipeline jobs are imperative API executions with no
   # Terraform resource analog (no google_vertex_ai_pipeline_job), so the service-account
@@ -22177,9 +22177,9 @@ queries:
     filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.vertexai.pipelineJobs.all(
-        serviceAccount != "" &&
-        serviceAccount != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
-        serviceAccount != /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
+        serviceAccountRef != null &&
+        serviceAccountRef.email != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
+        serviceAccountRef.email != /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
       )
   - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption
     title: Ensure Vertex AI feature online stores use CMEK
@@ -33704,7 +33704,7 @@ queries:
     mql: |
       gcp.project.cloudBuildService.workerPools.all(
         networkConfig != null &&
-        networkConfig.peeredNetwork != "" &&
+        networkConfig.peeredNetworkRef != null &&
         networkConfig.egressOption == "NO_PUBLIC_EGRESS"
       )
   - uid: mondoo-gcp-security-cloud-build-worker-pool-private-terraform-hcl
@@ -33859,8 +33859,8 @@ queries:
     filters: asset.platform == 'gcp'
     mql: |
       gcp.project.cloudBuildService.triggers.all(
-        serviceAccount != "" &&
-        serviceAccount != /\/\d+-compute@developer\.gserviceaccount\.com$/
+        iamServiceAccount != null &&
+        iamServiceAccount.email != /^\d+-compute@developer\.gserviceaccount\.com$/
       )
   - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-terraform-hcl
     filters: |


### PR DESCRIPTION
## Summary

Addresses `query-deprecated-symbol` lint warnings by migrating queries off deprecated resource fields to their typed replacements. Check semantics are preserved.

| Policy | Query | Deprecated field | Replacement |
|---|---|---|---|
| Azure | datafactory-cmk-encryption | `…factory.encryption` | `cmkKeyName` |
| GCP | vertexai-pipeline-job-vpc-network | `…pipelineJob.network` | `networkRef` |
| GCP | vertexai-pipeline-job-no-default-service-account | `…pipelineJob.serviceAccount` | `serviceAccountRef` |
| GCP | cloud-build-worker-pool-private | `…workerPool.networkConfig.peeredNetwork` | `peeredNetworkRef` |
| GCP | cloud-build-trigger-no-default-service-account | `…trigger.serviceAccount` | `iamServiceAccount` |

## Notes on semantics

- **Azure `cmkKeyName`** is non-empty exactly when a customer-managed key is configured (empty for platform-managed), matching the deprecated dict's signal.
- **GCP `networkRef`/`peeredNetworkRef`** are null iff the deprecated raw string was empty. `serviceAccountRef.email`/`iamServiceAccount.email` carry the same email the regexes matched; the cloud-build trigger regex anchor changes from `/…` (leading slash from the resource name) to `^` since `.email` strips the path.

## Testing

`cnspec policy lint` on both bundles: **0 errors, 0 deprecation warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)