### PR TITLE
🔒 Mark Chef Infra Client 17 as EOL

### DIFF
--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-client
     name: Mondoo Chef Infra Client Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -569,7 +569,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       command("chef-client -v") {
-        stdout == /^(Chef Infra|Cinc) Client: (17|18|19|20|21).*/m
+        stdout == /^(Chef Infra|Cinc) Client: (18|19|20|21|22).*/m
       }
     docs:
       desc: |


### PR DESCRIPTION
## Summary

Chef Infra Client 17 has reached end of life. Chef supports the current major version plus one previous, so 17 no longer receives security maintenance.

- Update the `non-eol-infra-client` check regex from `(17|18|19|20|21)` to `(18|19|20|21|22)` — drops 17 and extends the supported window forward.
- Bump the `chef-infra-client` policy version `1.3.1` → `1.3.2`.

The audit text and remediation examples already reference version 18, so no changes were needed there.

## Test plan

- `cnspec policy lint content/mondoo-chef-infra-client.mql.yaml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)