### PR TITLE
🧹 Replace deprecated MQL fields in AWS policies

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2346,7 +2346,7 @@ queries:
   - uid: mondoo-aws-security-iam-users-only-one-access-key-aws
     filters: asset.platform == "aws-iam-user"
     mql: |
-      aws.iam.user.accessKeys.flat.where(Status == "Active").length <= 1
+      aws.iam.user.accessKeyDetails.where(status == "Active").length <= 1
   - uid: mondoo-aws-security-iam-users-only-one-access-key-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iam_policy")
     mql: |


### PR DESCRIPTION
## Summary

Addresses `query-deprecated-symbol` lint warnings by migrating AWS security queries off deprecated resource fields to their typed replacements. Check semantics are preserved. This is the AWS-only subset of #2729.

| Query | Deprecated field | Replacement |
|---|---|---|
| iam-users-only-one-access-key | `aws.iam.user.accessKeys` | `accessKeyDetails` |
| s3-bucket-policy-no-public-principal | `aws.s3.bucket.policy.statements` | `aws.s3.bucket.policyStatements` |
| s3-bucket-policy-secure-transport | `aws.s3.bucket.policy.statements` | `aws.s3.bucket.policyStatements` |

## Notes on semantics

- **S3 `policyStatements`** returns `[]` when no bucket policy exists, so the explicit `policy == null` guard is no longer needed. A bare `"*"`, `{"AWS":"*"}`, and `{"AWS":["*"]}` all normalize to `principals['AWS']` containing `"*"`, collapsing the three original principal checks into one.
- **S3 secure-transport** keeps the original flat `&&`/`||` precedence rather than a parenthesized group — a `(` opening a continuation line after `&&` is an MQL parse error.

## Testing

`cnspec policy lint ./content/mondoo-aws-security.mql.yaml`: **0 errors, 0 deprecation warnings** on the migrated queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)