### PR TITLE
🧹 Simplify AWS Batch/Lightsail/SQS/SNS checks with new provider fields

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -63903,16 +63903,9 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.batch.jobDefinitions.where(status == "ACTIVE").none(
-        container.image == /^public\.ecr\.aws\// ||
-        container.image == /^docker\.io\// ||
-        container.image == /^registry\.hub\.docker\.com\// ||
-        container.image == /^[^\/]+$/ ||
-        container.image == /^[^.:\/]+\// ||
-        nodeRangeProperties.any(container.image == /^public\.ecr\.aws\//) ||
-        nodeRangeProperties.any(container.image == /^docker\.io\//) ||
-        nodeRangeProperties.any(container.image == /^registry\.hub\.docker\.com\//) ||
-        nodeRangeProperties.any(container.image == /^[^\/]+$/) ||
-        nodeRangeProperties.any(container.image == /^[^.:\/]+\//)
+        images.any(_['registry'] == "docker.io" ||
+                   _['registry'] == "registry.hub.docker.com" ||
+                   _['registry'] == "public.ecr.aws")
       )
   - uid: mondoo-aws-security-batch-approved-image-registry-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Batch::JobDefinition")
@@ -64866,15 +64859,15 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.lightsail.instances.all(
-        firewallRules.where(_['cidrs'].contains("0.0.0.0/0")).none(
-          _['fromPort'] <= 22 && _['toPort'] >= 22 ||
-          _['fromPort'] <= 3389 && _['toPort'] >= 3389 ||
-          _['fromPort'] <= 3306 && _['toPort'] >= 3306 ||
-          _['fromPort'] <= 5432 && _['toPort'] >= 5432 ||
-          _['fromPort'] <= 1433 && _['toPort'] >= 1433 ||
-          _['fromPort'] <= 27017 && _['toPort'] >= 27017 ||
-          _['fromPort'] <= 6379 && _['toPort'] >= 6379 ||
-          _['fromPort'] <= 9200 && _['toPort'] >= 9200
+        inboundRules.where(publicAccess).none(
+          fromPort <= 22 && toPort >= 22 ||
+          fromPort <= 3389 && toPort >= 3389 ||
+          fromPort <= 3306 && toPort >= 3306 ||
+          fromPort <= 5432 && toPort >= 5432 ||
+          fromPort <= 1433 && toPort >= 1433 ||
+          fromPort <= 27017 && toPort >= 27017 ||
+          fromPort <= 6379 && toPort >= 6379 ||
+          fromPort <= 9200 && toPort >= 9200
         )
       )
   - uid: mondoo-aws-security-lightsail-instance-no-public-sensitive-ports-terraform-hcl
@@ -68473,17 +68466,9 @@ queries:
   - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-aws
     filters: asset.platform == "aws-sqs-queue"
     mql: |
-      aws.sqs.queue.policy != null &&
-      aws.sqs.queue.policy['Statement'] != null &&
-      aws.sqs.queue.policy['Statement'].any(
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == false
+      aws.sqs.queue.policyStatements.any(
+        effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == "false" ||
+        effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == false
       )
   - uid: mondoo-aws-security-sqs-queue-policy-secure-transport-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue_policy")
@@ -68695,17 +68680,9 @@ queries:
   - uid: mondoo-aws-security-sns-topic-policy-secure-transport-aws
     filters: asset.platform == "aws-sns-topic"
     mql: |
-      aws.sns.topic.policy != null &&
-      aws.sns.topic.policy['Statement'] != null &&
-      aws.sns.topic.policy['Statement'].any(
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == false
+      aws.sns.topic.policyStatements.any(
+        effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == "false" ||
+        effect == "Deny" && conditions['Bool']['aws:SecureTransport'] == false
       )
   - uid: mondoo-aws-security-sns-topic-policy-secure-transport-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")


### PR DESCRIPTION
## Why

[mondoohq/mql#8261](https://github.com/mondoohq/mql/pull/8261) pushed navigation, null-guarding, and type-coercion down into the aws provider. This PR adopts those provider-side fields so the corresponding cnspec checks collapse to readable one-liners.

## Changes

All in `content/mondoo-aws-security.mql.yaml` (the `-aws` variants only — the Terraform/CloudFormation variants operate on raw config dicts and are unchanged):

- **`batch-approved-image-registry`** — replace 10 image regexes (which only inspected `container`/`nodeRangeProperties` and missed ECS/EKS containers entirely) with `aws.batch.jobDefinition.images` + a `registry` check.
- **`lightsail-instance-no-public-sensitive-ports`** — use the typed `inboundRules` sub-resource and its derived `publicAccess` bool instead of raw `firewallRules` dict access and a manual `0.0.0.0/0` filter.
- **`sqs-queue-policy-secure-transport`** / **`sns-topic-policy-secure-transport`** — query the typed `policyStatements` field, dropping the `policy` / `Statement` / `Condition` null guards. Behavior is unchanged: a resource with no policy yields an empty `policyStatements` list, so `.any(...)` is `false` and the check fails as before.

## Verification

- All four fields already ship in the installed aws provider (v13.21.x).
- `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` → valid bundle, no new warnings (the 3 remaining `query-deprecated-symbol` warnings predate this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)