### PR TITLE
🐛 http-security: fix X-AspNet(Mvc)-Version checks never firing

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -50,6 +50,8 @@ artifactregistry
 ashburn
 asl
 aslr
+aspnet
+aspnetmvc
 assumeyes
 atlassian
 authnotrequired

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -537,7 +537,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: http.get.header.params.keys.none("X-AspNet-Version")
+    mql: http.get.header.params.keys.none(downcase == "x-aspnet-version")
     docs:
       desc: |
         This check ensures that the X-AspNet-Version header is removed to enhance security.
@@ -629,7 +629,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: http.get.header.params.keys.none("X-AspNetMvc-Version")
+    mql: http.get.header.params.keys.none(downcase == "x-aspnetmvc-version")
     docs:
       desc: |
         This check ensures that the X-AspNetMvc-Version header is removed to enhance security.


### PR DESCRIPTION
## Problem

The two information-disclosure checks for ASP.NET version headers compared literal strings against `http.get.header.params.keys`:

```mql
http.get.header.params.keys.none("X-AspNet-Version")
http.get.header.params.keys.none("X-AspNetMvc-Version")
```

But response header keys are canonicalized by Go's `textproto.CanonicalMIMEHeaderKey`, which capitalizes only the first letter after each hyphen and lowercases the rest. The actual keys are `X-Aspnet-Version` and `X-Aspnetmvc-Version`, so the comparisons **never matched** — both checks always passed, even when the server disclosed the header.

Verified:
```
X-AspNet-Version    -> X-Aspnet-Version
X-AspNetMvc-Version -> X-Aspnetmvc-Version
```

## Fix

Compare case-insensitively with `downcase`, so the checks fire regardless of how the key is cased:

```mql
http.get.header.params.keys.none(downcase == "x-aspnet-version")
http.get.header.params.keys.none(downcase == "x-aspnetmvc-version")
```

Verified the new queries compile and evaluate against a live host.