### PR TITLE
🔖 Bump policy bundle versions

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.1.0
+    version: 12.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.0
+    version: 1.8.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -56,7 +56,7 @@ policies:
     scoring_system: highest impact
   - uid: mondoo-github-repository-security
     name: Mondoo GitHub Repository Security
-    version: 1.8.0
+    version: 1.8.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gitlab-security
     name: Mondoo GitLab Security
-    version: 1.8.0
+    version: 1.8.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.3.1
+    version: 2.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-macos-security
     name: Mondoo macOS Security
-    version: 1.4.0
+    version: 1.4.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.1
+    version: 2.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.3.0
+    version: 1.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security
-    version: 1.7.1
+    version: 1.7.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-security-baseline
     name: Mondoo VMware vSphere Security Baseline
-    version: 2.0.1
+    version: 2.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Mondoo Microsoft Windows Security
-    version: 2.3.2
+    version: 2.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-email-inventory
     name: Email Inventory Pack
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     require:
       - provider: network


### PR DESCRIPTION
## Summary

Version bumps across security policies and the email inventory query pack. No content changes — version fields only.

| Policy | Old | New | Bump |
|--------|-----|-----|------|
| mondoo-aws-security | 12.1.0 | 12.1.1 | patch |
| mondoo-digitalocean-security | 1.3.0 | 1.4.0 | minor |
| mondoo-email-security | 1.2.0 | 1.2.1 | patch |
| mondoo-github-security (org + repo) | 1.8.0 | 1.8.1 | patch |
| mondoo-gitlab-security | 1.8.0 | 1.8.1 | patch |
| mondoo-hetzner-security | 1.0.1 | 1.0.2 | patch |
| mondoo-http-security | 1.2.0 | 1.2.1 | patch |
| mondoo-m365-security | 2.3.1 | 2.4.0 | minor |
| mondoo-macos-security | 1.4.0 | 1.4.1 | patch |
| mondoo-okta-security | 2.3.1 | 2.3.2 | patch |
| mondoo-openstack-security | 1.1.0 | 1.1.1 | patch |
| mondoo-tailscale-security | 1.3.0 | 1.3.1 | patch |
| mondoo-tls-security | 1.7.1 | 1.7.2 | patch |
| mondoo-vmware-vsphere | 2.0.1 | 2.1.0 | minor |
| mondoo-windows-security | 2.3.2 | 2.4.0 | minor |
| mondoo-email-inventory (querypack) | 1.0.0 | 1.0.1 | patch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)