### PR TITLE
✨ Use typed os accessors in Linux auditd and SNMP checks

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7882,6 +7882,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       syscalls_64bit = ["creat", "open", "openat", "truncate", "ftruncate"]
+      syscalls_32bit = ["creat", "open", "openat", "truncate", "ftruncate"]
 
       // Check for EPERM exit code rules (64-bit)
       desiredRulesEperm64 = auditd.rules.syscalls.where(
@@ -7907,25 +7908,25 @@ queries:
 
       // Check for EPERM exit code rules (32-bit)
       desiredRulesEperm32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.in(syscalls_32bit)
         && arch == "b32"
         && fields.contains(key == "exit" && value == "-EPERM")
         && auidMin == 1000
         && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
-      desiredRulesEperm32.containsAll(syscalls_64bit)
+      desiredRulesEperm32.containsAll(syscalls_32bit)
 
       // Check for EACCES exit code rules (32-bit)
       desiredRulesEacces32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.in(syscalls_32bit)
         && arch == "b32"
         && fields.contains(key == "exit" && value == "-EACCES")
         && auidMin == 1000
         && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
-      desiredRulesEacces32.containsAll(syscalls_64bit)
+      desiredRulesEacces32.containsAll(syscalls_32bit)
     docs:
       desc: |
         This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing system calls such as `creat`, `open`, `openat`, `truncate`, and `ftruncate`. These system calls control the creation, opening, and truncation of files. The audit log will record events where the user is a non-privileged user (auid >= 1000), is not a daemon event (auid=4294967295), and the system call returned EACCES (permission denied) or EPERM (operation not permitted). All audit records will be tagged with the identifier "access."

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7058,7 +7058,7 @@ queries:
       syscalls_64bit = ["adjtimex", "settimeofday", "clock_settime"]
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && keyname == "time-change"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -7067,7 +7067,7 @@ queries:
       syscalls_32bit = ["adjtimex", "settimeofday", "clock_settime", "stime"]
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
+        && arch == "b32"
         && keyname == "time-change"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -7579,7 +7579,7 @@ queries:
       syscalls_64bit = ["sethostname", "setdomainname"]
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && keyname == "system-locale"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -7588,7 +7588,7 @@ queries:
       syscalls_32bit = ["sethostname", "setdomainname"]
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
+        && arch == "b32"
         && keyname == "system-locale"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -7617,7 +7617,7 @@ queries:
       syscalls_64bit = ["sethostname", "setdomainname"]
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && keyname == "system-locale"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -7626,7 +7626,7 @@ queries:
       syscalls_32bit = ["sethostname", "setdomainname"]
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
+        && arch == "b32"
         && keyname == "system-locale"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -7661,9 +7661,9 @@ queries:
       syscalls_64bit = ["chmod", "fchmod", "fchmodat", "chown", "fchown", "fchownat", "lchown", "setxattr", "lsetxattr", "fsetxattr", "removexattr", "lremovexattr", "fremovexattr"]
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && arch == "b64"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
@@ -7672,9 +7672,9 @@ queries:
       syscalls_32bit = ["chmod", "fchmod", "fchmodat", "chown", "fchown", "fchownat", "lchown", "setxattr", "lsetxattr", "fsetxattr", "removexattr", "lremovexattr", "fremovexattr"]
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && arch == "b32"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "perm_mod"
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
@@ -7886,10 +7886,10 @@ queries:
       // Check for EPERM exit code rules (64-bit)
       desiredRulesEperm64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && fields.contains(key == "exit" && value == "-EPERM")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm64.containsAll(syscalls_64bit)
@@ -7897,10 +7897,10 @@ queries:
       // Check for EACCES exit code rules (64-bit)
       desiredRulesEacces64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && fields.contains(key == "exit" && value == "-EACCES")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces64.containsAll(syscalls_64bit)
@@ -7908,10 +7908,10 @@ queries:
       // Check for EPERM exit code rules (32-bit)
       desiredRulesEperm32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
+        && arch == "b32"
         && fields.contains(key == "exit" && value == "-EPERM")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEperm32.containsAll(syscalls_64bit)
@@ -7919,10 +7919,10 @@ queries:
       // Check for EACCES exit code rules (32-bit)
       desiredRulesEacces32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
+        && arch == "b32"
         && fields.contains(key == "exit" && value == "-EACCES")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "access"
       ).map(syscalls).flat
       desiredRulesEacces32.containsAll(syscalls_64bit)
@@ -8270,15 +8270,15 @@ queries:
       // Check for 64-bit or 32-bit mount syscall audit rule
       auditd.rules.syscalls.contains(
         syscalls.contains("mount")
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && arch == "b64"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "mounts"
       ) || auditd.rules.syscalls.contains(
         syscalls.contains("mount")
-        && fields.contains(key == "arch" && op == "=" && value == "b32")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        && arch == "b32"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "mounts"
       )
     docs:
@@ -8423,16 +8423,16 @@ queries:
 
       // Get rules with delete key and proper auid filtering
       deleteRules64 = auditd.rules.syscalls.where(
-        fields.contains(key == "arch" && op == "=" && value == "b64")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        arch == "b64"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "delete"
       ).map(syscalls).flat
 
       deleteRules32 = auditd.rules.syscalls.where(
-        fields.contains(key == "arch" && op == "=" && value == "b32")
-        && fields.contains(key == "auid" && op == ">=" && value == "1000")
-        && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+        arch == "b32"
+        && auidMin == 1000
+        && excludesUnsetAuid
         && keyname == "delete"
       ).map(syscalls).flat
 
@@ -8641,7 +8641,7 @@ queries:
       // Syscall rules for module loading
       auditd.rules.syscalls.contains(
         syscalls.containsAll(["init_module", "delete_module"])
-        && fields.contains(key == "arch" && op == "=" && value == "b64")
+        && arch == "b64"
         && keyname == "modules"
       )
     docs:

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: linux-snmp-policy
     name: Linux Server SNMP Policy
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
@@ -123,16 +123,7 @@ queries:
     title: Ensure SNMP config does not contain read-write community strings
     impact: 100
     mql: |
-      files.find(from: '/etc/snmp/snmpd.conf.d', type: "file").list
-        {files = _
-          path
-          if(path.length > 0) {
-            file(path).content.lines.none(/^(\s+)?(rwcommunity|rwcommunity6)(\s+)/)
-          }
-        }
-      file("/etc/snmp/snmpd.conf") {
-        _.content.lines.none(/^(\s+)?(rwcommunity|rwcommunity6)(\s+)/)
-      }
+      snmpd.config.rwCommunities.length == 0
     docs:
       desc: |
         This check verifies that `/etc/snmp/snmpd.conf` and any files under `/etc/snmp/snmpd.conf.d` contain no `rwcommunity` or `rwcommunity6` directives.
@@ -207,17 +198,8 @@ queries:
   - uid: linux-snmp-no-unauthenticated-access
     title: Ensure unauthenticated access to SNMP is not allowed
     impact: 100
-    mql: |-
-      files.find(from: '/etc/snmp/snmpd.conf.d', type: "file").list
-        {files = _
-          path
-          if(path.length > 0) {
-            file(path).content.lines.none(/^(\s+)?rwuser\s+noauth(\s+)?/)
-          }
-        }
-      file("/etc/snmp/snmpd.conf") {
-        _.content.lines.none(/^(\s+)?rwuser\s+noauth(\s+)?/)
-      }
+    mql: |
+      snmpd.config.content.lines.none(/^\s*rwuser\s+\S+\s+noauth/)
     docs:
       desc: |
         This check verifies that `/etc/snmp/snmpd.conf` and any files under `/etc/snmp/snmpd.conf.d` contain no `rwuser` directives that specify the `noauth` security level. This check applies to Debian-based distributions.


### PR DESCRIPTION
## What

Adopts typed resources from the `os` provider so the Linux auditd and SNMP checks select on **parsed configuration** instead of hand-digging raw `auditd` fields and regex-matching SNMP config files. Same pattern as #2739 (network typed accessors), applied to the OS provider.

## Changes

### `mondoo-linux-security` — auditd syscall checks
Replace raw `-F` field matching on `auditd.rule.syscall.fields` with the typed `arch`, `auidMin`, and `excludesUnsetAuid` accessors (mql v13.25.1, mondoohq/mql#8269):

```diff
- && fields.contains(key == "arch" && op == "=" && value == "b64")
- && fields.contains(key == "auid" && op == ">=" && value == "1000")
- && fields.where(key == "auid" && op == "!=").any(value.in(["unset", "4294967295", "-1"]))
+ && arch == "b64"
+ && auidMin == 1000
+ && excludesUnsetAuid
```

`excludesUnsetAuid` is computed by the provider's parser, so the `auid!=unset` test no longer depends on a brittle literal allowlist (`unset`/`4294967295`/`-1`). Touched checks: date/time, MAC-policy network-environment (×2), DAC permission modification, unauthorized file access, file-system mounts, file deletion, user/group modification, kernel module load/unload.

The `exit=-EPERM`/`-EACCES` predicate in the unauthorized-access check keeps its raw `.fields` match — there's no typed accessor for it.

### `mondoo-linux-snmp-policy` — SNMP config checks
Replace the manual `/etc/snmp/snmpd.conf` + `snmpd.conf.d` glob/regex with the `snmpd.config` resource (mql v13.24.1, mondoohq/mql#8256), which assembles the main file, drop-ins, **and** `includeFile`/`includeDir` includes the old version missed:

- read-write community check → `snmpd.config.rwCommunities.length == 0`
- unauthenticated-access check → regex over `snmpd.config.content`

The unauthenticated-access change also **fixes a latent bug**: the old `rwuser\s+noauth` pattern omitted the username and never matched a real `rwuser <name> noauth` directive. It now uses `rwuser\s+\S+\s+noauth`, matching the check's own audit text.

Bumps the SNMP policy to **1.1.1**.

## Dependency note

These accessors are newer than the **mql v13.22.0** the bundle currently targets (snmpd.config @ 13.24.1, auditd accessors @ 13.25.1). They require the cnquery/mql dependency bump to land before release. Lints clean against a locally-built `os` provider that includes them.

## Test plan
- [x] `cnspec policy lint mondoo-linux-snmp-policy.mql.yaml mondoo-linux-security.mql.yaml` → valid policy bundle(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)