### PR TITLE
✨ Use typed docker.file run-command parsing in Dockerfile policies

### DIFF
--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-docker-best-practices
     name: Mondoo Dockerfile Best Practices
-    version: 1.1.0
+    version: 1.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -69,11 +69,7 @@ queries:
     title: Use `apt-get` instead of `apt` for consistent package management
     impact: 40
     mql: |
-      docker.file.stages.all(run.none(script.contains("apt install")))
-      docker.file.stages.all(run.none(script.contains("apt update")))
-      docker.file.stages.all(run.none(script.contains("apt upgrade")))
-      docker.file.stages.all(run.none(script.contains("apt remove")))
-      docker.file.stages.all(run.none(script.contains("apt purge")))
+      docker.file.stages.all(run.all(commands.none(binary == "apt" && subcommand.in(["install", "update", "upgrade", "remove", "purge"]))))
     docs:
       desc: |
         Dockerfile `RUN` instructions should invoke the `apt-get` CLI rather than `apt` for package management operations.
@@ -112,8 +108,8 @@ queries:
     title: Don't use package update instructions alone in a RUN statement
     impact: 60
     mql: |
-      docker.file.stages.all(run.where(script.contains("apt-get update")).all(script.contains("apt-get install")))
-      docker.file.stages.all(run.where(script.contains("apk update")).all(script.contains("apk add")))
+      docker.file.stages.all(run.where(commands.any(binary == "apt-get" && subcommand == "update")).all(commands.any(binary == "apt-get" && subcommand == "install")))
+      docker.file.stages.all(run.where(commands.any(binary == "apk" && subcommand == "update")).all(commands.any(binary == "apk" && subcommand == "add")))
     docs:
       desc: |
         Package manager update commands (`apt-get update`, `apk update`) should run in the same `RUN` instruction as the corresponding install command, never alone in a separate layer.
@@ -160,7 +156,7 @@ queries:
     title: Use --no-cache with apk add
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("apk add")).all(script.contains("--no-cache")))
+      docker.file.stages.all(run.all(commands.where(binary == "apk" && subcommand == "add").all(flags.contains("--no-cache"))))
     docs:
       desc: |
         Alpine's `apk add` command should always include the `--no-cache` flag in Dockerfile `RUN` instructions.
@@ -199,7 +195,7 @@ queries:
     title: Clean apt-get cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("apt-get install")).all(script.contains("/var/lib/apt/lists")))
+      docker.file.stages.all(run.where(commands.any(binary == "apt-get" && subcommand == "install")).all(commands.any(binary == "rm" && args.any(_ == /\/var\/lib\/apt\/lists/))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `apt-get install` should also clean up the apt package lists in the same layer.
@@ -241,7 +237,7 @@ queries:
     title: Clean yum cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("yum install")).all(script.contains("yum clean all")))
+      docker.file.stages.all(run.where(commands.any(binary == "yum" && subcommand == "install")).all(commands.any(binary == "yum" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `yum install` should also run `yum clean all` in the same layer.
@@ -280,7 +276,7 @@ queries:
     title: Clean dnf cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("dnf install")).all(script.contains("dnf clean all")))
+      docker.file.stages.all(run.where(commands.any(binary == "dnf" && subcommand == "install")).all(commands.any(binary == "dnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `dnf install` should also run `dnf clean all` in the same layer.
@@ -319,7 +315,7 @@ queries:
     title: Clean zypper cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("zypper install")).all(script.contains("zypper clean")))
+      docker.file.stages.all(run.where(commands.any(binary == "zypper" && subcommand == "install")).all(commands.any(binary == "zypper" && subcommand == "clean")))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `zypper install` should also run `zypper clean` in the same layer.
@@ -357,7 +353,7 @@ queries:
     title: Use --no-cache-dir with pip install
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("pip install")).all(script.contains("--no-cache-dir")))
+      docker.file.stages.all(run.all(commands.where(binary == "pip" && subcommand == "install").all(flags.contains("--no-cache-dir"))))
     docs:
       desc: |
         `pip install` commands in Dockerfile `RUN` instructions should include the `--no-cache-dir` flag.
@@ -399,7 +395,7 @@ queries:
     title: Clean yarn cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("yarn install")).all(script.contains("yarn cache clean")))
+      docker.file.stages.all(run.where(commands.any(binary == "yarn" && subcommand == "install")).all(commands.any(binary == "yarn" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `yarn install` should also run `yarn cache clean` in the same layer.
@@ -438,8 +434,8 @@ queries:
     title: Clean npm cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("npm install")).all(script.contains("npm cache clean")))
-      docker.file.stages.all(run.where(script.contains("npm ci")).all(script.contains("npm cache clean")))
+      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "install")).all(commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
+      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "ci")).all(commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `npm install` or `npm ci` should also run `npm cache clean` in the same layer.
@@ -480,7 +476,7 @@ queries:
     title: Use --no-install-recommends with apt-get install
     impact: 60
     mql: |
-      docker.file.stages.all(run.where(script.contains("apt-get install")).all(script.contains("--no-install-recommends")))
+      docker.file.stages.all(run.all(commands.where(binary == "apt-get" && subcommand == "install").all(flags.contains("--no-install-recommends"))))
     docs:
       desc: |
         `apt-get install` commands in Dockerfile `RUN` instructions should include the `--no-install-recommends` flag.
@@ -521,7 +517,7 @@ queries:
     title: Use -y flag with apt-get install
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("apt-get install")).all(script.contains("-y")))
+      docker.file.stages.all(run.all(commands.where(binary == "apt-get" && subcommand == "install").all(flags.any(_ == "--yes" || _ == "--assume-yes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
         `apt-get install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--yes`) flag.
@@ -557,7 +553,7 @@ queries:
     title: Use -y flag with yum install
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("yum install")).all(script.contains("-y")))
+      docker.file.stages.all(run.all(commands.where(binary == "yum" && subcommand == "install").all(flags.any(_ == "--assumeyes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
         `yum install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--assumeyes`) flag.
@@ -593,7 +589,7 @@ queries:
     title: Use -y flag with dnf install
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("dnf install")).all(script.contains("-y")))
+      docker.file.stages.all(run.all(commands.where(binary == "dnf" && subcommand == "install").all(flags.any(_ == "--assumeyes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
         `dnf install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--assumeyes`) flag.
@@ -629,7 +625,7 @@ queries:
     title: Use --non-interactive flag with zypper install
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("zypper install")).all(script.contains("--non-interactive")))
+      docker.file.stages.all(run.all(commands.where(binary == "zypper" && subcommand == "install").all(flags.contains("--non-interactive"))))
     docs:
       desc: |
         `zypper install` commands in Dockerfile `RUN` instructions should include the `--non-interactive` flag.
@@ -790,7 +786,7 @@ queries:
     title: Use WORKDIR instead of `cd` in RUN instructions
     impact: 40
     mql: |
-      docker.file.stages.all(run.none(script == /\bcd\s/))
+      docker.file.stages.all(run.all(commands.none(binary == "cd")))
     docs:
       desc: |
         Dockerfile `RUN` instructions should use the WORKDIR instruction to change directories rather than calling `cd`.
@@ -839,7 +835,7 @@ queries:
     title: Clean microdnf cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(script.contains("microdnf install")).all(script.contains("microdnf clean all")))
+      docker.file.stages.all(run.where(commands.any(binary == "microdnf" && subcommand == "install")).all(commands.any(binary == "microdnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions that use `microdnf install` should also run `microdnf clean all` in the same layer. microdnf is a minimal DNF implementation used in Red Hat UBI micro images, and like other package managers it caches downloaded packages and metadata.

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -154,7 +154,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      docker.file.stages.all(run.none(script.contains("--allow-insecure-repositories")))
+      docker.file.stages.all(run.all(commands.none(flags.contains("--allow-insecure-repositories"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not pass the `--allow-insecure-repositories` option to the APT package manager.
@@ -209,8 +209,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      docker.file.stages.all(run.where(script.contains("curl")).none(script.contains("--insecure")))
-      docker.file.stages.all(run.where(script.contains("curl")).none(script.contains(" -k")))
+      docker.file.stages.all(run.all(commands.where(binary == "curl").none(flags.contains("-k") || flags.contains("--insecure"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not pass the `--insecure` or `-k` options to `curl`.
@@ -264,7 +263,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      docker.file.stages.all(run.none(script.contains("--no-check-certificate")))
+      docker.file.stages.all(run.all(commands.none(flags.contains("--no-check-certificate"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not pass the `--no-check-certificate` option to `wget`.
@@ -318,7 +317,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      docker.file.stages.all(run.none(script.contains("sudo ")))
+      docker.file.stages.all(run.all(commands.none(binary == "sudo")))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not use `sudo` to run commands.
@@ -373,8 +372,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      docker.file.stages.all(run.none(script.contains("--nogpgcheck")))
-      docker.file.stages.all(run.none(script.contains("--no-gpg-check")))
+      docker.file.stages.all(run.all(commands.none(flags.contains("--nogpgcheck") || flags.contains("--no-gpg-check"))))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not pass GPG signature verification bypass options (`--nogpgcheck` for YUM/DNF, `--no-gpg-check` for zypper) to package managers.
@@ -829,7 +827,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      docker.file.stages.all(run.where(script.contains("apt-get")).none(script.contains("dist-upgrade")))
+      docker.file.stages.all(run.all(commands.where(binary == "apt-get").none(subcommand == "dist-upgrade")))
     docs:
       desc: |
         Dockerfile `RUN` instructions should not use `apt-get dist-upgrade`. Unlike `apt-get upgrade`, `dist-upgrade` can remove existing packages, install new dependencies, and make major changes to the package configuration, leading to unpredictable and unreproducible builds.
@@ -884,7 +882,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-1
       compliance/vda-isa-5: false
     mql: |
-      docker.file.finalStage.labels["org.opencontainers.image.source"] != empty
+      docker.file.finalStage.oci.source != empty
     docs:
       desc: |
         The final stage of the Dockerfile should set the `org.opencontainers.image.source` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the URL of the source code repository that produced the image, so any running container can be traced back to the repository it was built from.
@@ -950,7 +948,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-1
       compliance/vda-isa-5: false
     mql: |
-      docker.file.finalStage.labels["org.opencontainers.image.authors"] != empty
+      docker.file.finalStage.oci.authors != empty
     docs:
       desc: |
         The final stage of the Dockerfile should set the `org.opencontainers.image.authors` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the contact information for the people or team responsible for the image, so any running container can be traced back to a clear owner.

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-docker-security
     name: Mondoo Dockerfile Security
-    version: 1.2.0
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## What

Adopts the typed `docker.file.run.commands` parser (mql v13.25.1, mondoohq/mql#8270) and typed `docker.file.stage.oci` labels (mondoohq/mql#8271) so the Dockerfile checks select on the **parsed program, subcommand, and flags** of each command instead of substring-matching the raw `RUN` script. Same approach as the Linux typed-accessor migration (#2742).

Validated end-to-end with `cnspec scan docker file` against a violating fixture (every rewritten check fails) and a compliant fixture (none falsely fail).

## Correctness fixes (not just refactors)

These substring checks were genuinely buggy:

| Check | Old bug | Fix |
|---|---|---|
| `no-sudo-commands` | `script.contains("sudo ")` mis-flagged `apt-get install -y sudo` (installing the **package**) | `commands.none(binary == "sudo")` — proven: the package install no longer trips it |
| `*-assume-yes` (apt-get/yum/dnf) | `script.contains("-y")` matched `-y` **anywhere** — inside `--verify`, filenames, or a different command | require the install command's own `flags` to carry `-y`/`--yes`/`--assumeyes` |
| `no-insecure-certificate-validation-curl` | `-k` matched anywhere in any RUN mentioning curl (e.g. `tar -k`) | scope `-k`/`--insecure` to the `curl` command's flags |
| `apk-no-cache`, `pip-no-cache-dir`, `apt-no-install-recommends` | flag matched anywhere in the RUN, not on the install command | scope the flag to the actual install command |

The `-y` flag regex `/^-[a-z]*y/` also correctly accepts combined short flags like `-yq`.

## Refactors to typed fields

- `no-apt-get-dist-upgrade` → `subcommand == "dist-upgrade"`
- `image-source-label` / `image-authors-label` → `finalStage.oci.source` / `.oci.authors` (typed OCI labels instead of raw `labels["org.opencontainers.image.*"]`)
- `use-apt-get`, `no-update-alone`, the clean-cache family (yum/dnf/zypper/yarn/npm/microdnf), apt-get cache cleanup, `use-workdir-not-cd` → exact `binary`/`subcommand` matching
- apt/wget cert and GPG-skip flag checks → parsed `flags`

## Caveat

`docker.file.run.commands` is **best-effort**: it splits on shell operators (`&&`/`||`/`;`/`|`/newline) but doesn't descend into subshells or `sh -c "..."` strings. This trades the old approach's *over*-matching (comments, heredocs, unrelated args) for *under*-matching of exotic nested invocations — a net correctness improvement for realistic Dockerfiles.

## Dependency note

These accessors are newer than the **mql v13.22.0** the bundle currently targets (`run.commands` and `oci.*` @ 13.25.1). They require the cnquery/mql dependency bump to land before release. Lints clean against a locally-built `os` provider that includes them.

## Test plan
- [x] `cnspec policy lint` on both files → valid policy bundle(s)
- [x] `cnspec scan docker file` on a violating Dockerfile → all rewritten checks fail on the real violations (incl. proving `apt-get install sudo` no longer false-positives the sudo check)
- [x] `cnspec scan docker file` on a compliant Dockerfile → no false failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)