### PR TITLE
🐛 k8s: fix two NET_RAW capability checks to match their siblings

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -9082,7 +9082,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.job.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.job.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
         This check ensures that Jobs are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
@@ -9165,8 +9166,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      k8s.deployment.containers.all( addedCapabilities.none( _ == "NET_RAW" ))
-      k8s.deployment.containers.all( addedCapabilities.none( _ == "ALL" ))
+      k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.deployment.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
         This check ensures that Deployments are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.


### PR DESCRIPTION
## Background

This started as the Kubernetes typed-field modernization from the policy survey. On inspection, **that migration is already complete** — every security-context check already uses the typed `privileged` / `allowPrivilegeEscalation` / `runAsNonRoot` / `readOnlyRootFilesystem` / `addedCapabilities` / `droppedCapabilities` fields, and the remaining `securityContext.capabilities` references are all inside `kubectl … | jq` **audit** instructions (vendor-native, correct to keep). So there's no dict-lookup MQL left to modernize.

The audit did, however, surface **two real bugs** in the NET_RAW checks, where `job` and `deployment` diverged from the five working siblings (`pod`, `daemonset`, `replicaset`, `statefulset`, `cronjob`).

## Bug 1 — `job-capability-net-raw` queried the wrong resource

```diff
-      k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.job.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.job.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
```

The "Jobs should not run with NET_RAW" check was actually scanning **Deployments** (copy-paste error), so Jobs were never evaluated. It also omitted the `droppedCapabilities.any(...)` requirement every sibling enforces.

## Bug 2 — `deployment-capability-net-raw` used weaker matching

```diff
-      k8s.deployment.containers.all( addedCapabilities.none( _ == "NET_RAW" ))
-      k8s.deployment.containers.all( addedCapabilities.none( _ == "ALL" ))
+      k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
+      k8s.deployment.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
```

Case-sensitive exact matching (would miss e.g. lowercase) instead of the siblings' `_.upcase == /…/`, and again omitted the `droppedCapabilities.any(...)` requirement. Both checks are now identical in shape to their five siblings, differing only in the workload kind.

This is a behavior change for these two checks: a Job or Deployment that neither adds nor drops NET_RAW previously passed and now fails, exactly as Pods, DaemonSets, ReplicaSets, StatefulSets, and CronJobs already behave on main. The check docs for every workload kind already describe both the no-add and the must-drop requirement.

I also ran a full sweep for workload/UID cross-wiring across the policy — **no other mismatches** were found (this was the only one).

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s)
- [x] Static equivalence: both checks now match the 5 already-shipping sibling checks verbatim except for the workload resource
- [ ] Runtime verification requires a live k8s cluster — the workload checks run under an `asset.platform == "k8s-cluster"` group filter, so a manifest-file scan can't exercise them

## Note (out of scope)
All non-pod NET_RAW / SYS_ADMIN checks evaluate only `.containers`, while the `pod` variants also cover `initContainers`/`ephemeralContainers`. That's a pre-existing consistency gap shared by all non-pod workloads; widening it would change pass/fail behavior, so it's left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
