### PR TITLE
✨ Use typed digitalocean firewall ingress rules in firewall checks

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -495,14 +495,7 @@ queries:
     filters: asset.platform == "digitalocean"
     mql: |
       digitalocean.firewalls.all(
-        inboundRules.none(
-          _["protocol"] == "tcp" && _["ports"] == "22" && _["sourceAddresses"].contains("0.0.0.0/0")
-        )
-      )
-      digitalocean.firewalls.all(
-        inboundRules.none(
-          _["protocol"] == "tcp" && _["ports"] == "22" && _["sourceAddresses"].contains("::/0")
-        )
+        ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "22")
       )
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-ssh-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
@@ -639,14 +632,7 @@ queries:
     filters: asset.platform == "digitalocean"
     mql: |
       digitalocean.firewalls.all(
-        inboundRules.none(
-          _["protocol"] == "tcp" && _["ports"] == "3389" && _["sourceAddresses"].contains("0.0.0.0/0")
-        )
-      )
-      digitalocean.firewalls.all(
-        inboundRules.none(
-          _["protocol"] == "tcp" && _["ports"] == "3389" && _["sourceAddresses"].contains("::/0")
-        )
+        ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "3389")
       )
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-rdp-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
@@ -785,18 +771,9 @@ queries:
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-db-ports-digitalocean
     filters: asset.platform == "digitalocean"
     mql: |
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "3306" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "3306" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "5432" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "5432" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "27017" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "27017" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "6379" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "6379" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "9092" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "9092" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "9200" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["protocol"] == "tcp" && _["ports"] == "9200" && _["sourceAddresses"].contains("::/0")))
+      digitalocean.firewalls.all(
+        ingressRules.where(openToInternet).none(protocol == "tcp" && ports.in(["3306", "5432", "27017", "6379", "9092", "9200"]))
+      )
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |
@@ -936,14 +913,9 @@ queries:
   - uid: mondoo-digitalocean-security-firewall-no-all-ports-open-digitalocean
     filters: asset.platform == "digitalocean"
     mql: |
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "0" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "0" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "all" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "all" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "1-65535" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "1-65535" && _["sourceAddresses"].contains("::/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "0-65535" && _["sourceAddresses"].contains("0.0.0.0/0")))
-      digitalocean.firewalls.all(inboundRules.none(_["ports"] == "0-65535" && _["sourceAddresses"].contains("::/0")))
+      digitalocean.firewalls.all(
+        ingressRules.where(openToInternet).none(ports.in(["0", "all", "1-65535", "0-65535"]))
+      )
   - uid: mondoo-digitalocean-security-firewall-no-all-ports-open-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |


### PR DESCRIPTION
## What

Adopts the typed `digitalocean.firewall.ingressRules` accessor and its `openToInternet` predicate (mql #8262) so the four firewall checks select on **parsed rule fields** instead of hand-indexing the deprecated `inboundRules` dict and open-coding the public-source test against both `0.0.0.0/0` and `::/0`. Same approach as the other typed-accessor migrations this cycle.

Only the **`-digitalocean` runtime variants** change; the Terraform HCL/plan/state variants read `terraform.resources` and have no typed-rule analog, so they stay as-is.

## Changes

| Check | Before | After |
|---|---|---|
| `no-unrestricted-ssh` | 2 statements (one per IP family) | `ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "22")` |
| `no-unrestricted-rdp` | 2 statements | same shape, `ports == "3389"` |
| `no-unrestricted-db-ports` | **12 statements** | `…none(protocol == "tcp" && ports.in([...6 ports]))` |
| `no-all-ports-open` | **8 statements** | `…none(ports.in(["0","all","1-65535","0-65535"]))` |

Net **−28 lines**.

## Equivalence

`openToInternet` is defined as the rule's source containing `0.0.0.0/0` or `::/0` — exactly the two `sourceAddresses.contains(...)` arms it replaces. Each rewrite is a faithful 1:1 translation; the only behavioral change is **datapoint count**: collapsing the per-IP-family / per-port statements means a failing scan reports one combined finding rather than per-port. The check pass/fail outcome is unchanged.

## Dependency note
`ingressRules`/`openToInternet` are newer than the **mql v13.22.0** the bundle currently targets (#8262). Requires the cnquery/mql bump before release. Lints clean against a locally-built DigitalOcean provider that includes them.

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s) (typed fields compile against the provider schema)
- [ ] Runtime verification requires a live DigitalOcean asset (not available locally); each rewrite is a verified 1:1 translation of the original `inboundRules` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)