### PR TITLE
✨ Use typed arista.eos resources in Arista EOS security checks

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -373,7 +373,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.one(_ == "aaa authentication policy on-failure log")
+      arista.eos.passwordPolicy.logOnFailure == true
     docs:
       desc: |
         This check verifies that authentication failure events are logged for security monitoring. Logging failed authentication attempts is one of the most important indicators for detecting attacks against the device.
@@ -776,8 +776,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      arista.eos.runningConfig.section(name: "management api http-commands").content.lines.contains("protocol http") == false ||
-      arista.eos.runningConfig.content.contains("management api http-commands") == false
+      arista.eos.eapi.httpServerConfigured == false
     docs:
       desc: |
         This check verifies that the insecure HTTP protocol is disabled for the management API. HTTP transmits all data in clear text, making it unsuitable for device management.
@@ -836,7 +835,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      arista.eos.runningConfig.section(name: "management api http-commands").content.lines.contains("protocol https") == true
+      arista.eos.eapi.httpsServerConfigured == true
     docs:
       desc: |
         This check verifies that HTTPS is enabled for secure API access. HTTPS encrypts all management API traffic using TLS, protecting credentials and data from interception.
@@ -1591,8 +1590,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      arista.eos.runningConfig.content.contains("no password minimum length") == false
-      arista.eos.runningConfig.content.contains("password minimum length") == true
+      arista.eos.passwordPolicy.minimumLength > 0
     docs:
       desc: |
         This check verifies that a minimum password length policy is configured on the switch. Password length is the single most important factor in password strength, as longer passwords exponentially increase the time required for brute-force attacks.
@@ -1830,8 +1828,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      arista.eos.runningConfig.content.contains("management ssh") == true
-      arista.eos.runningConfig.section(name: "management ssh").content.lines.contains("shutdown") == false
+      arista.eos.sshSettings.enabled == true
     docs:
       desc: |
         This check verifies that SSH is enabled for secure remote management access. SSH encrypts all management traffic, including credentials, and is the universally accepted standard for secure remote device administration.
@@ -1893,8 +1890,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      arista.eos.runningConfig.section(name: "management telnet").content.lines.contains("shutdown") == true ||
-      arista.eos.runningConfig.content.contains("management telnet") == false
+      arista.eos.telnetService.enabled == false
     docs:
       desc: |
         This check verifies that the insecure Telnet protocol is disabled on the switch. Telnet transmits all data, including passwords, in clear text and should never be used for network device management.

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-arista-eos-security
     name: Mondoo Arista EOS Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## What

Replaces running-config string/section matching with the typed accessors the arista provider already computes from the same config, so six checks read **parsed service state** instead of grepping `runningConfig`.

| Check | Before | After |
|---|---|---|
| telnet-disabled | `section("management telnet")…contains("shutdown") \|\| …` | `telnetService.enabled == false` |
| http-disabled | `section(…http-commands)…contains("protocol http") == false \|\| …` | `eapi.httpServerConfigured == false` |
| https-enabled | `section(…http-commands)…contains("protocol https") == true` | `eapi.httpsServerConfigured == true` |
| password-minimum-length | `contains("no password minimum length") == false` + `contains("password minimum length") == true` | `passwordPolicy.minimumLength > 0` |
| aaa-authentication-failure-logging | `lines.one(_ == "aaa authentication policy on-failure log")` | `passwordPolicy.logOnFailure == true` |
| ssh-enabled | `contains("management ssh") == true` + `section("management ssh")…contains("shutdown") == false` | `sshSettings.enabled == true` |

## Equivalence — verified against the provider parser

The first five are **behavior-preserving**. I checked the provider source so the typed field is derived from the exact directive the old MQL matched:
- `passwordPolicy.logOnFailure` is set **only** by the literal `aaa authentication policy on-failure log` line (`eos/security.go`).
- `telnetService.enabled` is true only when the block is present and not `shutdown`, with an **absent block treated as disabled** — matching the old `section…contains("shutdown") \|\| content…contains("management telnet") == false`.
- `eapi.httpServerConfigured` / `httpsServerConfigured` are the presence of the `protocol http` / `protocol https` directives; absent eAPI → `false`, matching the old section logic.
- `passwordPolicy.minimumLength` is `0` when unset, so `> 0` matches "a length is configured."

## One deliberate behavior change (a fix)

**ssh-enabled**: EOS enables SSH **by default**, so the provider's `sshSettings.enabled` is `true` when the `management ssh` block is absent (confirmed by `TestParseSshSettings_AbsentDefaultsEnabled`). The old check required the block to be present (`content.contains("management ssh")`), so it **failed a compliant device** that simply relies on the default-on SSH service. `sshSettings.enabled == true` reports that case correctly. Flagging explicitly since it changes the absent-block outcome from fail → pass.

Other running-config checks (logging, banners, ACLs, timezone, NTP servers) have no typed analog and are left as-is.

## Dependency note
These accessors are newer than the **mql v13.22.0** the bundle targets; requires the cnquery/mql bump before release. Lints clean against a locally-built arista provider that includes them.

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s)
- [x] Provider-source verification of each field's derivation (see Equivalence)
- [ ] Runtime verification needs a live Arista EOS device (not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)