### PR TITLE
✨ Use typed gcp org-policy and artifact-registry accessors

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -19416,9 +19416,7 @@ queries:
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
     filters: asset.platform == 'gcp'
     mql: |
-      gcp.project.orgPolicies.where(constraintName == "constraints/compute.disableSerialPortAccess").any(
-        spec['rules'].any(_['enforce'] == true)
-      )
+      gcp.project.orgPolicies.where(constraintName == "constraints/compute.disableSerialPortAccess").any(enforced)
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_org_policy_policy')
@@ -19560,9 +19558,7 @@ queries:
   - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-gcp
     filters: asset.platform == 'gcp'
     mql: |
-      gcp.project.orgPolicies.where(constraintName == "constraints/storage.uniformBucketLevelAccess").any(
-        spec['rules'].any(_['enforce'] == true)
-      )
+      gcp.project.orgPolicies.where(constraintName == "constraints/storage.uniformBucketLevelAccess").any(enforced)
   - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_org_policy_policy')
@@ -33209,9 +33205,7 @@ queries:
   - uid: mondoo-gcp-security-artifact-registry-repository-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-artifactregistry-repository'
     mql: |
-      gcp.project.artifactRegistryService.repository.iamPolicy.all(
-        members.none(_ == "allUsers" || _ == "allAuthenticatedUsers")
-      )
+      gcp.project.artifactRegistryService.repository.public == false
   - uid: mondoo-gcp-security-artifact-registry-repository-iam-no-public-principals-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_artifact_registry_repository_iam_member') ||


### PR DESCRIPTION
## What

Replaces hand-decoded org-policy spec dicts and IAM-member string matching with the typed accessors the gcp provider computes from the same data.

| Check | Before | After |
|---|---|---|
| org-policy serial-port-disabled | `…where(constraintName==…disableSerialPortAccess).any(spec['rules'].any(_['enforce'] == true))` | `…any(enforced)` |
| org-policy uniform-bucket-level-access | same idiom on `storage.uniformBucketLevelAccess` | `…any(enforced)` |
| artifact-registry no-public-principals | `repository.iamPolicy.all(members.none(_ == "allUsers" \|\| _ == "allAuthenticatedUsers"))` | `repository.public == false` |

Only the runtime `-gcp` variants change; the Terraform variants operate on HCL and have no `enforced`/`public` analog, so they stay as-is.

## Equivalence — verified against provider source

- **`enforced`** (`orgpolicy.go` `interpretPolicySpec`): set when an **unconditional** rule has `enforce: true`. For these boolean constraints the outcome matches `spec['rules'].any(_['enforce'] == true)`, and it's the more correct reading — it ignores conditional rules that don't unconditionally enforce, and it handles a `null` spec gracefully where the dict walk would error.
- **`public`** (`artifactregistry.go`): calls `iamPolicyHasPublicMember` over the same IAM bindings, so `repository.public == false` is an exact equivalent of the `allUsers`/`allAuthenticatedUsers` check. The artifact-registry asset is a single repository (per the check's `gcp-artifactregistry-repository` filter), so this is a singular field access.

Other public-principal checks (storage, pubsub, kms, secret-manager, etc.) did **not** receive a `public()` predicate in the provider, so they're left unchanged.

## Dependency note
These accessors are newer than the **mql v13.22.0** the bundle targets; requires the cnquery/mql bump before release. Lints clean against a locally-built gcp provider.

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s)
- [x] Provider-source verification of `enforced` and `public` semantics
- [ ] Runtime verification needs live GCP assets (not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)