### PR TITLE
✨ Use typed azure diagnosticSetting enabledLogCategories

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -5042,10 +5042,10 @@ queries:
       asset.platform == "azure"
     mql: |
       azure.subscription.monitor.diagnosticSettings != empty
-      azure.subscription.monitor.diagnosticSettings.all(properties.logs.where(category == "Administrative").all(enabled == true))
-      azure.subscription.monitor.diagnosticSettings.all(properties.logs.where(category == "Security").all(enabled == true))
-      azure.subscription.monitor.diagnosticSettings.all(properties.logs.where(category == "Alert").all(enabled == true))
-      azure.subscription.monitor.diagnosticSettings.all(properties.logs.where(category == "Policy").all(enabled == true))
+      azure.subscription.monitor.diagnosticSettings.all(enabledLogCategories.contains("Administrative"))
+      azure.subscription.monitor.diagnosticSettings.all(enabledLogCategories.contains("Security"))
+      azure.subscription.monitor.diagnosticSettings.all(enabledLogCategories.contains("Alert"))
+      azure.subscription.monitor.diagnosticSettings.all(enabledLogCategories.contains("Policy"))
   - uid: mondoo-azure-security-diagnostic-settings-essential-categories-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_monitor_diagnostic_setting")
     mql: |


### PR DESCRIPTION
## What

Replaces the raw `properties.logs.where(category == X).all(enabled == true)` dict traversal in the **diagnostic-settings essential-categories** check (`-azure` runtime variant) with the typed `enabledLogCategories` list.

```diff
-      …diagnosticSettings.all(properties.logs.where(category == "Administrative").all(enabled == true))
-      …diagnosticSettings.all(properties.logs.where(category == "Security").all(enabled == true))
-      …diagnosticSettings.all(properties.logs.where(category == "Alert").all(enabled == true))
-      …diagnosticSettings.all(properties.logs.where(category == "Policy").all(enabled == true))
+      …diagnosticSettings.all(enabledLogCategories.contains("Administrative"))
+      …diagnosticSettings.all(enabledLogCategories.contains("Security"))
+      …diagnosticSettings.all(enabledLogCategories.contains("Alert"))
+      …diagnosticSettings.all(enabledLogCategories.contains("Policy"))
```

`enabledLogCategories` is the list of categories whose log entry has `enabled == true` (verified in `monitor.go` `diagnosticCategorySettings`).

## ⚠️ Behavior change — flagged for sign-off

This is a **tightening**, not a pure refactor. The old `.where(category == X).all(enabled == true)` **passes vacuously** when a setting doesn't list category X at all (empty `.all()` is `true`), so it only failed an *explicitly disabled* category. `enabledLogCategories.contains(X)` requires X to be **present and enabled** — which is what the check's title, "Ensure that diagnostic settings collect essential security categories," actually asserts.

Net effect: a diagnostic setting that simply **omits** Administrative / Security / Alert / Policy will now **fail** this check instead of passing. That's the intended semantics, but it can newly fail subscriptions that split categories across multiple diagnostic settings — please confirm that's desired before merging.

Only the runtime `-azure` variant changes; the Terraform/Bicep variants have no `enabledLogCategories` analog and stay as-is.

## Dependency note
Newer than the **mql v13.22.0** the bundle targets; requires the cnquery/mql bump before release. Lints clean against a locally-built azure provider.

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s)
- [x] Provider-source verification of `enabledLogCategories` semantics
- [ ] Runtime verification needs a live Azure subscription (not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)