### PR TITLE
✨ Use typed macos.sharing.printerSharing in printer-sharing check

### DIFF
--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -893,7 +893,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: command('cupsctl | grep _share_printers' ).stdout.contains("_share_printers=0")
+    mql: macos.sharing.printerSharing == false
     docs:
       desc: |
         This check ensures that Printer Sharing is disabled on macOS systems to prevent the computer from being used as a print server. Printer Sharing allows other computers to send print jobs to the Mac, which can pose security risks and increase the attack surface.


### PR DESCRIPTION
## What

Replaces the `command('cupsctl | grep _share_printers').stdout.contains("_share_printers=0")` shell-out in the **Disable Printer Sharing** check with the typed field:

```diff
-    mql: command('cupsctl | grep _share_printers' ).stdout.contains("_share_printers=0")
+    mql: macos.sharing.printerSharing == false
```

`macos.sharing.printerSharing` reads the Printer Sharing toggle from `system_profiler SPSharingDataType` (verified in `macos_sharing.go`) — the same state shown in **System Settings → General → Sharing**. This drops a pipe-and-grep shell-out and reads the authoritative Sharing state an auditor sees in the UI. The Sharing "Printer Sharing" toggle is what drives CUPS's `_share_printers`, so the two track the same setting.

## Scope note — why this is 1 check, not 3

This target was surveyed as "FreeBSD/macOS (~3)". On verification, the **two FreeBSD `sysrc` checks** (core-dump, syslogd-remote) are **better left as `command('sysrc ...')`** and are not changed here:

- `command('sysrc -n …')` reads the **effective** value, including `/etc/defaults/rc.conf`.
- The typed `sysrc.entries` resource parses only the explicit `/etc/rc.conf*` files (verified in `sysrc.go` — no `/etc/defaults`).
- For core-dump, FreeBSD's default `dumpdev="AUTO"` is the insecure case, so a typed `entries.where(name=="dumpdev").all(value=="NO")` would **vacuously pass on an unset (AUTO) host** — a security false-pass. Preserving correct semantics would need a presence guard that's *more* complex than the original command, so the command form is the better tool here.

## Dependency note
`macos.sharing` is newer than the **mql v13.22.0** the bundle targets; requires the cnquery/mql bump before release. Lints clean against a locally-built os provider.

## Test plan
- [x] `cnspec policy lint` → valid policy bundle(s)
- [x] Provider-source verification that `printerSharing` reads the Sharing inventory
- [ ] Runtime verification needs a macOS host (not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)