### PR TITLE
🧹 vault: link all backends via registry blank-import

### DIFF
--- a/apps/cnspec/cnspec.go
+++ b/apps/cnspec/cnspec.go
@@ -18,6 +18,11 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/health"
 
 	_ "github.com/glebarez/go-sqlite"
+
+	// Link in all vault backends (AWS, GCP, HashiCorp, keyring) so they
+	// self-register with the vault registry. The in-memory backend is always
+	// available via the SDK.
+	_ "go.mondoo.com/mql/v13/vault/register"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260608064248-5890e657cd12
-	go.mondoo.com/mql/v13 v13.22.0
+	go.mondoo.com/mql/v13 v13.22.1-0.20260609195634-cc68cbcf1514
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260608064248-5890e657cd12 h1:YIowpXatTZ8LEZ+Kfr6Hg0B7Q9G38V7zBVYpm/jkzBo=
 go.mondoo.com/mondoo-go v0.0.0-20260608064248-5890e657cd12/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.22.0 h1:RxGkfU3TVzxjRIbd0c0a85pulCUIjNo7zkJboQb/NsQ=
-go.mondoo.com/mql/v13 v13.22.0/go.mod h1:c+WsB3hhuVODyKEAgmuEqbJNXY3EWLR2VZK5hl73jiU=
+go.mondoo.com/mql/v13 v13.22.1-0.20260609195634-cc68cbcf1514 h1:LcDwZIhUP1DfDTTV5P7aMGaQO2lVDyIxrreDRr6lZEs=
+go.mondoo.com/mql/v13 v13.22.1-0.20260609195634-cc68cbcf1514/go.mod h1:c+WsB3hhuVODyKEAgmuEqbJNXY3EWLR2VZK5hl73jiU=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
## What

mql PR mondoohq/mql#8273 moved the vault backends out of the provider SDK and behind a **runtime registry**. `inventory.GetVault` now calls `vault.New(cfg)`, which dispatches through a registry that backends populate by self-registering in their `init()` — instead of the old static `switch` in `vaultconfigstore.go`.

The trade-off of that design (a deliberate one): a backend is only available if its package is linked into the binary. The in-memory backend is always registered by the SDK; every other backend (AWS Secrets Manager, AWS Parameter Store, GCP Secret Manager, GCP Berglas, HashiCorp Vault, OS keyring / encrypted-file) must be opted into.

This PR opts the cnspec binary into **all** backends via a single blank-import, so cnspec keeps exactly the vault support it had before the refactor.

## Changes

- `apps/cnspec/cnspec.go`: blank-import `go.mondoo.com/mql/v13/vault/register` (links all heavy backends).
- `go.mod` / `go.sum`: bump `go.mondoo.com/mql/v13` to the vault-registry commit.

## Why it matters

Without the blank-import, cnspec would **compile fine but fail at runtime** for any non-memory vault type — `vault.New` would return `could not connect to vault: <name> (<type>)` because no backend registered for that type. This is the exact footgun the mql PR review flagged, so cnspec must add the import in lockstep with the dependency bump.

> Note: the mql dep is pinned to a pseudo-version on the vault-registry commit. Once a tagged mql release contains it, this can be re-pointed at the tag.

## Test

- `go build ./apps/cnspec/` ✅
- `go mod tidy` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)