### PR TITLE
🧹 freebsd: use typed inetd.config resource for service checks

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -1046,7 +1046,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      file("/etc/inetd.conf").exists == false || file("/etc/inetd.conf").content.lines.none(_ == /^ftp/)
+      inetd.config.serviceNames.none(_ == "ftp")
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=inetd&sektion=8
@@ -1130,7 +1130,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      file("/etc/inetd.conf").exists == false || file("/etc/inetd.conf").content.lines.none(_ == /^telnet/)
+      inetd.config.serviceNames.none(_ == "telnet")
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=inetd&sektion=8
@@ -1545,7 +1545,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      file("/etc/inetd.conf").exists == false || file("/etc/inetd.conf").content.lines.none(_ == /^tftp/)
+      inetd.config.serviceNames.none(_ == "tftp")
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=inetd&sektion=8


### PR DESCRIPTION
## What

The FreeBSD ftp/telnet/tftp "server is not enabled" checks regexed `/etc/inetd.conf` line by line:

```mql
# before
file("/etc/inetd.conf").exists == false || file("/etc/inetd.conf").content.lines.none(_ == /^ftp/)

# after
inetd.config.serviceNames.none(_ == "ftp")
```

(same for `telnet` and `tftp`)

The `os` provider's `inetd.config` resource already parses `/etc/inetd.conf` plus `/etc/inetd.d` drop-ins, excludes commented-out entries, and exposes the active service names via `serviceNames`.

This also:
- fixes the regex's loose prefix match — `/^ftp/` also matched `ftps` and similar, the typed comparison is exact;
- removes the manual empty-file special case — a missing config yields no entries, so `none(...)` holds trivially.

## Why

Technical-debt cleanup — no new MQL resource needed, `inetd.config` already exists. Follow-up to #2753 (which did the same for the sudoers NOPASSWD check); the inetd commit missed that PR's merge window.

## Testing

- `cnspec policy lint content/mondoo-freebsd-security.mql.yaml` → valid
- Evaluated against test inetd configs: active `ftp` entry → check **fails** (correct); commented/absent → **passes** (correct); commented-out entries correctly excluded from `serviceNames`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)