### PR TITLE
🧹 m365: use typed Secure Score controls and unified audit log accessor

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -252,7 +252,7 @@ queries:
     filters: |
       asset.platform == "microsoft365"
     mql: |
-      microsoft.security.latestSecureScores.controlScores.where(controlName == 'SigninRiskPolicy').all(_['score'] == 7)
+      microsoft.security.latestSecureScores.controls.where(controlName == 'SigninRiskPolicy').all(score == 7)
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == 'azuread_conditional_access_policy')
@@ -460,7 +460,7 @@ queries:
     filters: |
       asset.platform == "microsoft365"
     mql: |
-      microsoft.security.latestSecureScores.controlScores.where(controlName == 'UserRiskPolicy').all(_['score'] == 7)
+      microsoft.security.latestSecureScores.controls.where(controlName == 'UserRiskPolicy').all(score == 7)
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == 'azuread_conditional_access_policy')
@@ -652,7 +652,7 @@ queries:
     filters: |
       asset.platform == "microsoft365"
     mql: |
-      microsoft.security.latestSecureScores.controlScores.where(controlName == 'BlockLegacyAuthentication').all(_['score'] == 8)
+      microsoft.security.latestSecureScores.controls.where(controlName == 'BlockLegacyAuthentication').all(score == 8)
   - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == 'azuread_conditional_access_policy')
@@ -906,7 +906,7 @@ queries:
     filters: |
       asset.platform == "microsoft365"
     mql: |
-      microsoft.security.latestSecureScores.controlScores.where(controlName == 'AdminMFAV2').all(_['score'] == 10)
+      microsoft.security.latestSecureScores.controls.where(controlName == 'AdminMFAV2').all(score == 10)
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-administrative-roles-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == 'azuread_conditional_access_policy')
@@ -1093,7 +1093,7 @@ queries:
     filters: |
       asset.platform == "microsoft365"
     mql: |
-      microsoft.security.latestSecureScores.controlScores.where(controlName == 'MFARegistrationV2').all(_['score'] == 9)
+      microsoft.security.latestSecureScores.controls.where(controlName == 'MFARegistrationV2').all(score == 9)
   - uid: mondoo-m365-security-ensure-multifactor-authentication-is-enabled-for-all-users-in-all-roles-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == 'azuread_conditional_access_policy')
@@ -2529,7 +2529,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      ms365.exchangeonline.adminAuditLogConfig['unifiedAuditLogIngestionEnabled'] == true
+      ms365.exchangeonline.unifiedAuditLogIngestionEnabled == true
     docs:
       desc: |
         This check ensures that unified audit logging is enabled for the Microsoft 365 tenant. The unified audit log records user and administrator activity across Exchange Online, SharePoint Online, OneDrive, Microsoft Entra ID, Teams, and other workloads in a single searchable log.


### PR DESCRIPTION
## What

Migrate the Microsoft 365 security policy off raw `dict` accessors to the typed MQL fields added in ms365 provider 13.7.0 (mondoohq/mql#8292).

### Secure Score checks (5)

`microsoft.security.securityscore.controlScores []dict` is now marked deprecated in favor of typed `controls []microsoft.security.securityscore.controlScore` (`controlCategory`, `controlName`, `description`, `score`).

Before:
```mql
microsoft.security.latestSecureScores.controlScores.where(controlName == 'AdminMFAV2').all(_['score'] == 10)
```
After:
```mql
microsoft.security.latestSecureScores.controls.where(controlName == 'AdminMFAV2').all(score == 10)
```

Migrated checks: `SigninRiskPolicy`, `UserRiskPolicy`, `BlockLegacyAuthentication`, `AdminMFAV2`, `MFARegistrationV2`. Moving off the deprecated `controlScores` field also clears the deprecation warning.

### Exchange Online unified audit log (1)

`ms365.exchangeonline` gained a typed `unifiedAuditLogIngestionEnabled` bool.

Before:
```mql
ms365.exchangeonline.adminAuditLogConfig['unifiedAuditLogIngestionEnabled'] == true
```
After:
```mql
ms365.exchangeonline.unifiedAuditLogIngestionEnabled == true
```

The typed accessor does a case-insensitive lookup over the admin-audit-log config, so it is robust to the PascalCase property name emitted by `Get-AdminAuditLogConfig`.

## Why

Typed fields are clearer, type-safe, and let us drop fragile dict indexing. Semantics are preserved exactly (same `controlName` filters, same score comparison values).

## Testing

`cnspec policy lint ./content/mondoo-m365-security.mql.yaml` → `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)