### PR TITLE
🧹 github: use typed accessors for branch protection, webhook SSL, and Dependabot severity

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -914,7 +914,7 @@ queries:
         .all( isProtected == true )
       github.repository.branches
         .where( isDefault == true )
-        .all( protectionRules { allowForcePushes['enabled'] == false } )
+        .all( protectionRules.allowForcePushesEnabled == false )
   - uid: mondoo-github-repository-security-prevent-force-pushes-default-branch-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_branch_protection")
     mql: |
@@ -961,7 +961,7 @@ queries:
         .all( isProtected == true )
       github.repository.branches
         .where( name == props.mondooGithubReleaseBranches )
-        .all( protectionRules { allowForcePushes['enabled'] == false } )
+        .all( protectionRules.allowForcePushesEnabled == false )
     docs:
       desc: |
         This check ensures that the release branch does not allow force pushes. Branch protection enforces certain workflows or requirements that must be met before a collaborator can push changes to a branch in a repository. It is recommended to disable force pushes to any release branches.
@@ -1170,7 +1170,7 @@ queries:
         .all( isProtected == true )
       github.repository.branches
         .where( isDefault == true )
-        .all( protectionRules { requiredConversationResolution['enabled'] == true } )
+        .all( protectionRules.requiredConversationResolutionEnabled == true )
   - uid: mondoo-github-repository-security-require-conversation-resolution-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_branch_protection")
     mql: |
@@ -1566,7 +1566,7 @@ queries:
         .all( isProtected == true )
       github.repository.branches
         .where( isDefault == true )
-        .all( protectionRules.enforceAdmins['enabled'] == true )
+        .all( protectionRules.enforceAdminsEnabled == true )
   - uid: mondoo-github-repository-security-enforce-branch-protection-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_branch_protection")
     mql: |
@@ -2817,7 +2817,7 @@ queries:
         title: Creating webhooks
   - uid: mondoo-github-repository-security-webhooks-use-ssl-github
     filters: asset.platform == "github-repo"
-    mql: github.repository.webhooks.all( config['insecure_ssl'] == "0" )
+    mql: github.repository.webhooks.all( insecureSsl == false )
   - uid: mondoo-github-repository-security-webhooks-use-ssl-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_repository_webhook")
     mql: |
@@ -3087,7 +3087,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      github.repository.dependabotAlerts.none(state == "open" && securityVulnerability['severity'] == "critical")
+      github.repository.dependabotAlerts.none(state == "open" && severity == "critical")
     docs:
       desc: |
         This check ensures that the repository has no open Dependabot alerts with critical severity. Dependabot identifies known vulnerabilities in your project's dependencies.
@@ -3282,7 +3282,7 @@ queries:
         .all( isProtected == true )
       github.repository.branches
         .where( isDefault == true )
-        .all( protectionRules { requiredPullRequestReviews['enabled'] == true } )
+        .all( protectionRules.requiredPullRequestReviewsEnabled == true )
   - uid: mondoo-github-repository-security-require-pull-request-reviews-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_branch_protection")
     mql: |


### PR DESCRIPTION
## What

Updates `content/mondoo-github-security.mql.yaml` to use the typed GitHub resource fields added in mondoohq/mql#8288 (shipped in github provider 13.5.0) instead of indexing into raw `dict` fields.

## Why

The policy had seven checks reaching into dicts purely because the typed field didn't exist yet. Now that mondoohq/mql#8288 has shipped, these queries can use direct, type-safe field access.

For `requiredPullRequestReviews` (and `requiredStatusChecks`), this is also a correctness improvement: the GitHub API omits the protection object entirely when the protection is not configured, so there is no `enabled` sub-key to index. The typed `requiredPullRequestReviewsEnabled` bool is the correct presence signal.

## Before / after

```mql
# before
.all( protectionRules { allowForcePushes['enabled'] == false } )
.all( protectionRules.enforceAdmins['enabled'] == true )
.all( protectionRules { requiredPullRequestReviews['enabled'] == true } )
github.repository.webhooks.all( config['insecure_ssl'] == "0" )
github.repository.dependabotAlerts.none(state == "open" && securityVulnerability['severity'] == "critical")

# after
.all( protectionRules.allowForcePushesEnabled == false )
.all( protectionRules.enforceAdminsEnabled == true )
.all( protectionRules.requiredPullRequestReviewsEnabled == true )
github.repository.webhooks.all( insecureSsl == false )
github.repository.dependabotAlerts.none(state == "open" && severity == "critical")
```

Note the webhook change from a string comparison (`config['insecure_ssl'] == "0"`) to a bool (`insecureSsl == false`).

## Checks changed

- `mondoo-github-repository-security-prevent-force-pushes-default-branch-github` (allowForcePushes)
- `mondoo-github-repository-security-prevent-force-pushes-release-branch-github` (allowForcePushes)
- `mondoo-github-repository-security-require-conversation-resolution-github` (requiredConversationResolution)
- `mondoo-github-repository-security-enforce-branch-protection-github` (enforceAdmins)
- `mondoo-github-repository-security-webhooks-use-ssl-github` (insecureSsl)
- the Dependabot critical-severity check (severity)
- `mondoo-github-repository-security-require-pull-request-reviews-github` (requiredPullRequestReviews)

Remediation docs, shell snippets, and the Terraform/HCL variant queries were left untouched.

## Testing

`cnspec policy lint ./content/mondoo-github-security.mql.yaml` → `valid policy bundle(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)