### PR TITLE
🧹 azure: use typed accessors for VM/Function App/App Service/AKS/App Gateway/Cosmos DB

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -15917,7 +15917,7 @@ queries:
   - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-azure
     filters: |
       asset.platform == "azure-cosmosdb" &&
-      azure.subscription.cosmosDbService.account.properties["locations"].length > 1
+      azure.subscription.cosmosDbService.account.locations.length > 1
     mql: |
       azure.subscription.cosmosDbService.account.enableAutomaticFailover == true
   - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-terraform-hcl
@@ -16804,8 +16804,7 @@ queries:
     filters: |
       asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDbService.account.properties["cors"] == null ||
-      azure.subscription.cosmosDbService.account.properties["cors"].none(_["allowedOrigins"] == "*")
+      azure.subscription.cosmosDbService.account.corsAllowedOrigins.none(_ == "*")
   - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cosmosdb_account")
     mql: |
@@ -17115,7 +17114,7 @@ queries:
   - uid: mondoo-azure-security-cosmosdb-multi-region-write-azure
     filters: |
       asset.platform == "azure-cosmosdb" &&
-      azure.subscription.cosmosDbService.account.properties["locations"].length > 1
+      azure.subscription.cosmosDbService.account.locations.length > 1
     mql: |
       azure.subscription.cosmosDbService.account.enableMultipleWriteLocations == true
   - uid: mondoo-azure-security-cosmosdb-multi-region-write-terraform-hcl
@@ -28657,7 +28656,7 @@ queries:
       if (azure.subscription.compute.vm.osType != "Linux") {
         return true
       }
-      azure.subscription.compute.vm.properties['osProfile']['linuxConfiguration']['disablePasswordAuthentication'] == true
+      azure.subscription.compute.vm.disablePasswordAuthentication == true
   - uid: mondoo-azure-security-compute-vm-password-auth-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_linux_virtual_machine")
     mql: |


### PR DESCRIPTION
## What

Migrates `mondoo-azure-security` runtime checks off raw ARM `properties[...]` dict indexing and onto the typed fields added in the Azure provider (mql PRs 8293-8298, provider 13.19.0+). Pure accessor swaps — exact semantics preserved, minimal diff. Docs prose, remediation `az`/Bicep snippets, and Terraform variants are untouched.

## Typed fields adopted

**Function App `publicNetworkAccess`** (mondoohq/mql#8294) — `mondoo-azure-security-function-app-public-network-access-disabled-azure`
```mql
# before
azure.subscription.functionsService.functionApp.properties["publicNetworkAccess"] == "Disabled"
# after
azure.subscription.functionsService.functionApp.publicNetworkAccess == "Disabled"
```

**VM `osType` + `disablePasswordAuthentication`** (mondoohq/mql#8295) — `mondoo-azure-security-compute-vm-password-auth-disabled-azure`
```mql
# before
azure.subscription.compute.vm.properties['storageProfile']['osDisk']['osType'] != "Linux"
azure.subscription.compute.vm.properties['osProfile']['linuxConfiguration']['disablePasswordAuthentication'] == true
# after
azure.subscription.compute.vm.osType != "Linux"
azure.subscription.compute.vm.disablePasswordAuthentication == true
```

**App Service `corsAllowedOrigins`** (mondoohq/mql#8296) — `mondoo-azure-security-app-service-cors-no-wildcard-azure`
```mql
# before
configuration.properties["cors"] == null ||
configuration.properties["cors"]["allowedOrigins"] == null ||
configuration.properties["cors"]["allowedOrigins"].none(_ == "*")
# after
configuration.corsAllowedOrigins.none(_ == "*")
```
(`corsAllowedOrigins` is a non-null `[]string`; `.none()` on the empty list covers the old null guards.)

**AKS `diskCsiDriverEnabled`** (mondoohq/mql#8297) — `mondoo-azure-security-aks-disk-encryption-set-azure`
```mql
# before
azure.subscription.aksService.cluster.storageProfile["diskCSIDriver"]["enabled"] == true
# after
azure.subscription.aksService.cluster.diskCsiDriverEnabled == true
```

**Application Gateway `frontendIpConfigs`** (mondoohq/mql#8298) — `mondoo-azure-security-application-gateway-no-public-frontend-azure`
```mql
# before
applicationGateway.properties["frontendIPConfigurations"].any(_["properties"]["subnet"] != null)
# after
applicationGateway.frontendIpConfigs.any(subnetId != empty)
```

**Cosmos DB `defaultConsistencyLevel` / `networkAclBypass` / `corsAllowedOrigins` / `locations`** (mondoohq/mql#8293) — four checks: `cosmosdb-strong-consistency-azure`, `cosmosdb-network-acl-bypass-none-azure`, `cosmosdb-cors-no-wildcard-azure`, plus the `locations.length > 1` selector on `cosmosdb-automatic-failover-enabled-azure` and `cosmosdb-multi-region-write-azure`.
```mql
# before
account.properties["consistencyPolicy"]["defaultConsistencyLevel"].in(["Strong","BoundedStaleness"])
account.properties["networkAclBypass"] == "None"
account.properties["cors"] == null || account.properties["cors"].none(_["allowedOrigins"] == "*")
account.properties["locations"].length > 1
# after
account.defaultConsistencyLevel.in(["Strong","BoundedStaleness"])
account.networkAclBypass == "None"
account.corsAllowedOrigins.none(_ == "*")
account.locations.length > 1
```

## Validation

```
→ lint policy bundle(s) files=["./content/mondoo-azure-security.mql.yaml"]
→ valid policy bundle(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)