### PR TITLE
🧹 gcp: use typed accessors for bucket, DNS, GKE RBAC, and Vertex AI job

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -1694,8 +1694,8 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-gcp
     filters: asset.platform == 'gcp-storage-bucket'
     mql: |
-      gcp.storage.bucket.retentionPolicy['retentionPeriod'] > 0
-      gcp.storage.bucket.retentionPolicy['isLocked'] == true
+      gcp.storage.bucket.retentionPeriod > 0
+      gcp.storage.bucket.retentionPolicyLocked == true
   - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -6649,7 +6649,7 @@ queries:
       asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility == "public"
     mql: |
-      gcp.dns.managedzone.dnssecConfig['state'] == 'on'
+      gcp.dns.managedzone.dnssecEnabled == true
   - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -6807,7 +6807,7 @@ queries:
       asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility != "private"
     mql: |
-      gcp.dns.managedzone.dnssecConfig['state'] == 'on'
+      gcp.dns.managedzone.dnssecEnabled == true
       gcp.dns.managedzone.dnssecConfig.defaultKeySpecs.where(keyType == 'keySigning').all(algorithm != 'rsasha1')
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-terraform-hcl
     filters: |
@@ -6971,7 +6971,7 @@ queries:
       asset.platform == "gcp-dns-zone"
       gcp.project.dnsService.managedzone.visibility != "private"
     mql: |
-      gcp.dns.managedzone.dnssecConfig['state'] == 'on'
+      gcp.dns.managedzone.dnssecEnabled == true
       gcp.dns.managedzone.dnssecConfig.defaultKeySpecs.where(keyType == 'zoneSigning').all(algorithm != 'rsasha1')
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-terraform-hcl
     filters: |
@@ -7305,8 +7305,8 @@ queries:
       asset.platform == "gcp-dns-zone"
       gcp.dns.managedzone.visibility == "public"
     mql: |
-      gcp.dns.managedzone.dnssecConfig['state'] == 'on'
-      gcp.dns.managedzone.dnssecConfig['nonExistence'] == 'nsec3'
+      gcp.dns.managedzone.dnssecEnabled == true
+      gcp.dns.managedzone.dnssecNonExistence == 'nsec3'
   - uid: mondoo-gcp-security-cloud-dns-dnssec-nsec3-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_dns_managed_zone')
@@ -9393,8 +9393,8 @@ queries:
   - uid: mondoo-gcp-security-gke-rbac-no-insecure-system-bindings-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
-      gcp.project.gkeService.cluster.rbacBindingConfig['enableInsecureBindingSystemAuthenticated'] != true &&
-      gcp.project.gkeService.cluster.rbacBindingConfig['enableInsecureBindingSystemUnauthenticated'] != true
+      gcp.project.gkeService.cluster.rbacBindingInsecureSystemAuthenticated != true &&
+      gcp.project.gkeService.cluster.rbacBindingInsecureSystemUnauthenticated != true
   - uid: mondoo-gcp-security-gke-rbac-no-insecure-system-bindings-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_container_cluster')
@@ -25639,9 +25639,7 @@ queries:
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
     filters: asset.platform == 'gcp-storage-bucket'
     mql: |
-      gcp.storage.bucket.softDeletePolicy != null
-      gcp.storage.bucket.softDeletePolicy['retentionDurationSeconds'] != null
-      gcp.storage.bucket.softDeletePolicy['retentionDurationSeconds'].to_int > 0
+      gcp.storage.bucket.softDeleteRetentionDuration > 0
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_storage_bucket')
@@ -27009,7 +27007,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      gcp.project.vertexaiService.customJob.jobSpec['serviceAccount'] != empty
+      gcp.project.vertexaiService.customJob.serviceAccount != empty
     docs:
       desc: |
         This check ensures that every running, pending, or queued Vertex AI custom job has an explicit service account configured in its job specification. Without an explicit service account, custom jobs inherit the project's default Compute Engine service account, which carries broad project-level permissions far beyond what any individual training job actually needs.
@@ -34561,8 +34559,8 @@ queries:
       asset.platform == 'gcp-vertexai-job' &&
       gcp.project.vertexaiService.customJob.state.in(["JOB_STATE_RUNNING", "JOB_STATE_PENDING", "JOB_STATE_QUEUED"])
     mql: |
-      gcp.project.vertexaiService.customJob.jobSpec['serviceAccount'] != empty &&
-      gcp.project.vertexaiService.customJob.jobSpec['serviceAccount'] != /^\d+-compute@developer\.gserviceaccount\.com$/
+      gcp.project.vertexaiService.customJob.serviceAccount != empty &&
+      gcp.project.vertexaiService.customJob.serviceAccount != /^\d+-compute@developer\.gserviceaccount\.com$/
     docs:
       desc: |
         This check ensures that Vertex AI custom training jobs are configured to use a dedicated service account rather than the project's default Compute Engine service account. By default, jobs that omit an explicit service account identity run as the default Compute Engine SA, which carries the Editor role and is shared across all workloads in the project.
@@ -39441,7 +39439,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      gcp.project.vertexaiService.customJob.jobSpec['network'] != empty
+      gcp.project.vertexaiService.customJob.network != empty
     docs:
       desc: |
         This check ensures that active Vertex AI custom jobs specify a VPC network in their job specification so that training workers run on a private network rather than the default public internet path. Without a network configuration, worker-to-worker traffic and access to internal services traverse the public internet, bypassing the organization's network controls.
@@ -39524,7 +39522,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      gcp.project.vertexaiService.customJob.jobSpec['enableWebAccessPortals'] != true
+      gcp.project.vertexaiService.customJob.enableWebAccess != true
     docs:
       desc: |
         This check ensures that active Vertex AI custom jobs do not have interactive web access portals enabled. When `enableWebAccessPortals` is set to `true`, Vertex AI creates a publicly accessible web endpoint that allows anyone with the URL to interact with the training worker, potentially accessing training data, model artifacts, and the container environment directly.


### PR DESCRIPTION
## What

Migrates `mondoo-gcp-security` queries off raw `dict` indexing onto the typed fields added in gcp provider **13.23.0** (mondoohq/mql#8305). Purely a query refactor — no checks added or removed, behavior preserved.

| Resource | Before | After | Source |
|---|---|---|---|
| storage bucket | `retentionPolicy['retentionPeriod']` | `retentionPeriod` | #8301 |
| storage bucket | `retentionPolicy['isLocked']` | `retentionPolicyLocked` | (existing typed field) |
| storage bucket | `softDeletePolicy['retentionDurationSeconds']` | `softDeleteRetentionDuration` | #8301 |
| DNS managed zone | `dnssecConfig['state'] == 'on'` | `dnssecEnabled == true` | (existing typed field) |
| DNS managed zone | `dnssecConfig['nonExistence']` | `dnssecNonExistence` | #8303 |
| GKE cluster | `rbacBindingConfig['enableInsecureBindingSystemAuthenticated']` | `rbacBindingInsecureSystemAuthenticated` | #8299 |
| GKE cluster | `rbacBindingConfig['enableInsecureBindingSystemUnauthenticated']` | `rbacBindingInsecureSystemUnauthenticated` | #8299 |
| Vertex AI custom job | `jobSpec['serviceAccount']` | `serviceAccount` | #8302 |
| Vertex AI custom job | `jobSpec['network']` | `network` | #8302 |
| Vertex AI custom job | `jobSpec['enableWebAccessPortals']` | `enableWebAccess` | #8302 |

## Notes

- These all target the live-resource (`-gcp` platform) variants; the Terraform variants are untouched.
- **Soft-delete check collapse:** `softDeleteRetentionDuration` is a non-nullable int that is `0` when no soft-delete policy is set, so the prior three statements (`softDeletePolicy != null`, `[...] != null`, `[...].to_int > 0`) are equivalent to a single `softDeleteRetentionDuration > 0`.
- `retentionPolicyLocked` and `dnssecEnabled` predate 13.23.0; the upstream PRs flag the dict-indexed checks sitting next to them as policy-side cleanups, included here for consistency.

## Testing

`cnspec policy lint ./content/mondoo-gcp-security.mql.yaml` → `valid policy bundle(s)` (gcp provider 13.23.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)