### PR TITLE
🧹 oci: use typed legacyImdsEndpointsDisabled for IMDSv2 check

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3555,7 +3555,7 @@ queries:
     filters: asset.platform == 'oci'
     mql: |
       oci.compute.instances.all(
-        instanceOptions['areLegacyImdsEndpointsDisabled'] == true
+        legacyImdsEndpointsDisabled == true
       )
   - uid: mondoo-oci-security-compute-imds-v2-only-terraform-hcl
     filters: |


### PR DESCRIPTION
## What

The `mondoo-oci-security-compute-imds-v2-only-oci` runtime check reached into the untyped `instanceOptions` dict with a string key:

```mql
oci.compute.instances.all(instanceOptions['areLegacyImdsEndpointsDisabled'] == true)
```

The `oci` provider now exposes a typed `legacyImdsEndpointsDisabled` field on `oci.compute.instance` (sourced from the same backing data, available since provider 13.10.1), so the check becomes:

```mql
oci.compute.instances.all(legacyImdsEndpointsDisabled == true)
```

## Scope

Only the `-oci` runtime variant changes. The Terraform HCL/plan/state variants already use `terraform.*` resources and are untouched, as is the OCI CLI remediation example (`--instance-options '{"areLegacyImdsEndpointsDisabled": true}'`), which is a real OCI CLI flag.

## Verification

`cnspec policy lint content/mondoo-oci-security.mql.yaml` → valid policy bundle(s) (installed provider 13.22.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)