### PR TITLE
🧹 okta: use typed security notification email flags on organization

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -1071,7 +1071,7 @@ queries:
         title: Okta Security Administration
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['reportSuspiciousActivityEnabled'] == true
+    mql: okta.organization.reportSuspiciousActivityEnabled == true
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources("okta_security_notification_emails").all( arguments['report_suspicious_activity_enabled'] == /var/ || arguments['report_suspicious_activity_enabled'] == true )
@@ -1172,7 +1172,7 @@ queries:
         title: Okta Security Administration
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForNewDeviceEnabled'] == true
+    mql: okta.organization.sendEmailForNewDeviceEnabled == true
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources("okta_security_notification_emails").all( arguments['send_email_for_new_device_enabled'] == /var/ || arguments['send_email_for_new_device_enabled'] == true )
@@ -1273,7 +1273,7 @@ queries:
         title: Okta Security Administration
   - uid: mondoo-okta-security-factor-enrollment-notifications-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForFactorEnrollmentEnabled'] == true
+    mql: okta.organization.sendEmailForFactorEnrollmentEnabled == true
   - uid: mondoo-okta-security-factor-enrollment-notifications-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources("okta_security_notification_emails").all( arguments['send_email_for_factor_enrollment_enabled'] == /var/ || arguments['send_email_for_factor_enrollment_enabled'] == true )
@@ -1374,7 +1374,7 @@ queries:
         title: Okta Security Administration
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForFactorResetEnabled'] == true
+    mql: okta.organization.sendEmailForFactorResetEnabled == true
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources("okta_security_notification_emails").all( arguments['send_email_for_factor_reset_enabled'] == /var/ || arguments['send_email_for_factor_reset_enabled'] == true )
@@ -1475,7 +1475,7 @@ queries:
         title: Okta Security Administration
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
-    mql: okta.organization.securityNotificationEmails['sendEmailForPasswordChangedEnabled'] == true
+    mql: okta.organization.sendEmailForPasswordChangedEnabled == true
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.providers.any( nameLabel == "okta" )
     mql: terraform.resources("okta_security_notification_emails").all( arguments['send_email_for_password_changed_enabled'] == /var/ || arguments['send_email_for_password_changed_enabled'] == true )


### PR DESCRIPTION
## What

Replaces the five string-key `securityNotificationEmails[...]` dict lookups with the typed bool fields on `okta.organization`:

| Check | Before | After |
|-------|--------|-------|
| enable-suspicious-activity-reporting-api | `securityNotificationEmails['reportSuspiciousActivityEnabled']` | `reportSuspiciousActivityEnabled` |
| sign-on-notifications-for-end-users-api | `securityNotificationEmails['sendEmailForNewDeviceEnabled']` | `sendEmailForNewDeviceEnabled` |
| factor-enrollment-notifications-api | `securityNotificationEmails['sendEmailForFactorEnrollmentEnabled']` | `sendEmailForFactorEnrollmentEnabled` |
| factor-reset-notifications-for-end-users-api | `securityNotificationEmails['sendEmailForFactorResetEnabled']` | `sendEmailForFactorResetEnabled` |
| password-changed-notifications-for-end-users-api | `securityNotificationEmails['sendEmailForPasswordChangedEnabled']` | `sendEmailForPasswordChangedEnabled` |

## Verification

Will lint clean once the provider in mondoohq/mql#8308 is released (the typed fields are sourced from the same backing data as the retained dict). Today lint fails solely because the released provider predates those fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
