### PR TITLE
🧹 snowflake: use typed networkPolicy for network-policy check

### DIFF
--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -1556,7 +1556,7 @@ queries:
   - uid: mondoo-snowflake-security-network-policies-configured-snowflake
     filters: asset.platform == 'snowflake'
     mql: |
-      snowflake.account.parameters.where(key == "NETWORK_POLICY").any(value != "")
+      snowflake.account.networkPolicy != ""
   - uid: mondoo-snowflake-security-network-policies-configured-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'snowflake_account_parameter')


### PR DESCRIPTION
## What

Simplifies the runtime check `mondoo-snowflake-security-network-policies-configured-snowflake` to use the typed `networkPolicy` accessor instead of scanning account parameters.

**Before:**
```mql
snowflake.account.parameters.where(key == "NETWORK_POLICY").any(value != "")
```

**After:**
```mql
snowflake.account.networkPolicy != ""
```

The terraform-hcl/plan/state variants are unchanged — they read `terraform.*` resources and have no typed-field equivalent.

## Verification

`cnspec policy lint content/mondoo-snowflake-security.mql.yaml` → **valid policy bundle(s)**, run locally against a snowflake provider built from mql `origin/main` (includes mql#8311). It will fail against the current released provider until mql#8313 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
