### PR TITLE
🧹 nutanix: use typed usesLdaps for directory LDAPS check

### DIFF
--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -1428,7 +1428,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      nutanix.directoryServices.all(url == /^ldaps:\/\//i && secondaryUrls.all(_ == /^ldaps:\/\//i))
+      nutanix.directoryServices.all(usesLdaps && secondaryUrls.all(_ == /^ldaps:\/\//i))
     docs:
       desc: |
         This check ensures that every configured directory service (Active Directory or LDAP) uses LDAPS rather than plaintext LDAP. Directory authentication carries credentials and group membership over the network; plaintext LDAP exposes the bind service-account password and every user's credentials to anyone able to observe the traffic.


### PR DESCRIPTION
## What

Check `mondoo-nutanix-security-directory-service-uses-ldaps` previously matched the primary directory URL with a case-insensitive regex. The nutanix provider added a typed `usesLdaps` field on `nutanix.iam.directoryService` (provider change in [mondoohq/mql#8310](https://github.com/mondoohq/mql/pull/8310), released in [mondoohq/mql#8313](https://github.com/mondoohq/mql/pull/8313)), so the primary-URL check can use it directly. The secondary-URL regex is unchanged because the typed field covers the primary URL only.

**Before**

```coffee
nutanix.directoryServices.all(url == /^ldaps:\/\//i && secondaryUrls.all(_ == /^ldaps:\/\//i))
```

**After**

```coffee
nutanix.directoryServices.all(usesLdaps && secondaryUrls.all(_ == /^ldaps:\/\//i))
```

## Verification

Built and installed the nutanix provider from `mondoohq/mql` `origin/main` (which already carries `usesLdaps`) and ran `cnspec policy lint content/mondoo-nutanix-security.mql.yaml` — result: **valid policy bundle(s)**. Against released providers lint will fail until mql#8313 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
