### PR TITLE
🧹 openstack: use typed imageSignature for image-signed check

### DIFF
--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -1533,7 +1533,7 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.images.where(status == "active" && owner.id == openstack.projectId).all(
-        properties["img_signature"] != null
+        imageSignature != ""
       )
   - uid: mondoo-openstack-security-image-signed-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_images_image_v2")


### PR DESCRIPTION
## What

Simplifies the runtime variant of the `mondoo-openstack-security-image-signed` check to use the typed `imageSignature` field instead of an untyped dict lookup.

**Before:**

```mql
properties["img_signature"] != null
```

**After:**

```mql
imageSignature != ""
```

`imageSignature` returns an empty string for unsigned images, so `!= ""` is the correct presence test. The field comes from the openstack provider (mql#8309), released in mql#8313. The Terraform HCL/plan/state variants are untouched — they still read the raw `properties` map from the IaC source.

## Verification

`cnspec policy lint content/mondoo-openstack-security.mql.yaml` reports a valid policy bundle against a locally-built openstack provider that includes the typed `imageSignature` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
