### PR TITLE
🧹 tailscale: use typed hasExpiration/isRevoked for authkey checks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -471,6 +471,7 @@ logingracetime
 logingracetime
 logname
 logons
+logouts
 logprofiles
 logsize
 logstreams

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -1347,7 +1347,7 @@ queries:
   - uid: mondoo-tailscale-security-authkeys-have-expiration-tailscale
     filters: asset.platform == 'tailscale'
     mql: |
-      tailscale.authKeys.where(invalid == false && revoked.unix == 0).all(expires.unix > 0)
+      tailscale.authKeys.where(invalid == false && isRevoked == false).all(hasExpiration)
   - uid: mondoo-tailscale-security-authkeys-have-expiration-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "tailscale_tailnet_key")
     mql: |
@@ -1472,7 +1472,7 @@ queries:
   - uid: mondoo-tailscale-security-authkeys-not-reusable-tailscale
     filters: asset.platform == 'tailscale'
     mql: |
-      tailscale.authKeys.where(invalid == false && revoked.unix == 0).none(reusable)
+      tailscale.authKeys.where(invalid == false && isRevoked == false).none(reusable)
   - uid: mondoo-tailscale-security-authkeys-not-reusable-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "tailscale_tailnet_key")
     mql: |


### PR DESCRIPTION
## What

Replaces the `.unix == 0` / `.unix > 0` zero-time workarounds in the tailscale auth key checks with the typed boolean fields (`hasExpiration`, `isRevoked`) added to the tailscale provider in mql#8307.

**Auth keys have an expiration** (`mondoo-tailscale-security-authkeys-have-expiration`)

Before:
```mql
tailscale.authKeys.where(invalid == false && revoked.unix == 0).all(expires.unix > 0)
```
After:
```mql
tailscale.authKeys.where(invalid == false && isRevoked == false).all(hasExpiration)
```

**Auth keys are not reusable** (`mondoo-tailscale-security-authkeys-not-reusable`)

Before:
```mql
tailscale.authKeys.where(invalid == false && revoked.unix == 0).none(reusable)
```
After:
```mql
tailscale.authKeys.where(invalid == false && isRevoked == false).none(reusable)
```

## Verification

`cnspec policy lint content/mondoo-tailscale-security.mql.yaml` passes ("valid policy bundle(s)") against a locally built tailscale provider from mql `main` (which already carries the typed fields from mql#8307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
