### PR TITLE
🧹 vsphere: use typed ESXi host hardening settings in esxi policy

### DIFF
--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -101,7 +101,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vsphere.host.advancedSettings['Security.AccountUnlockTime'] == 900
+      vsphere.host.accountUnlockTime == 900
     docs:
       desc: |-
         This check ensures that a locked account is automatically released after 15 minutes. ESXi locks an account once it reaches the maximum number of failed consecutive login attempts, and a defined unlock window restores access for legitimate users without leaving the account locked indefinitely.
@@ -418,7 +418,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      vsphere.host.advancedSettings['Net.DVFilterBindIpAddress'] == empty
+      vsphere.host.dvFilterBindIpAddress == empty
     docs:
       desc: |-
         This check ensures that the dvfilter network API is left unconfigured when no security appliance uses it. The dvfilter API allows certain network security products to inspect virtual machine traffic, and an unused binding address needlessly exposes VM network data.
@@ -496,7 +496,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] <= 300
+      vsphere.host.esxiShellInteractiveTimeOut <= 300
       vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] != 0
     docs:
       desc: |-
@@ -573,7 +573,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      vsphere.host.advancedSettings['Config.HostAgent.plugins.solo.enableMob'] == false
+      vsphere.host.mobEnabled == false
     docs:
       desc: |-
         This check ensures that the Managed Object Browser, or MOB, is disabled on the ESXi host. The MOB is a web-based interface that exposes the host's internal object model and allows configuration changes, and it serves no purpose in normal operations.
@@ -793,7 +793,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      vsphere.host.advancedSettings['Syslog.global.logDir'] != ""
+      vsphere.host.syslogLogDir != ""
       vsphere.host.advancedSettings['Syslog.global.logDir'] != /scratch/
     docs:
       desc: |-
@@ -1058,7 +1058,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      vsphere.host.advancedSettings['Syslog.global.logHost'] != ""
+      vsphere.host.syslogLogHost != ""
     docs:
       desc: |-
         This check ensures that the ESXi host forwards its logs to a central syslog server. By default ESXi stores logs only on a local scratch volume or ramdisk, so a remote log host is needed to preserve a copy off the host.
@@ -1281,7 +1281,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] <= 600
+      vsphere.host.dcuiTimeOut <= 600
       vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] != 0
     docs:
       desc: |-
@@ -1349,7 +1349,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-6
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-3-1
-    mql: vsphere.host.advancedSettings['Mem.ShareForceSalting'] == 2
+    mql: vsphere.host.memShareForceSalting == 2
     docs:
       desc: |-
         This check ensures that per-virtual-machine salting for Transparent Page Sharing is set to its default of 2. With this setting each virtual machine receives a distinct salt, so memory pages are shared only within a single virtual machine and never across virtual machines.
@@ -1707,7 +1707,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5
+      vsphere.host.accountLockFailures == 5
     docs:
       desc: |-
         This check ensures that an account is locked after 5 consecutive failed login attempts. A bounded failure count locks an account that is under attack before an attacker can work through a large set of password guesses.
@@ -1780,7 +1780,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] <= 3600
+      vsphere.host.esxiShellTimeOut <= 3600
       vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] != 0
     docs:
       desc: |-

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -497,7 +497,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.esxiShellInteractiveTimeOut <= 300
-      vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] != 0
+      vsphere.host.esxiShellInteractiveTimeOut != 0
     docs:
       desc: |-
         This check ensures that idle ESXi shell and SSH sessions are automatically terminated after no more than 300 seconds. An interactive timeout closes sessions that an operator opened but left unattended, so an open prompt does not remain available indefinitely.
@@ -794,7 +794,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       vsphere.host.syslogLogDir != ""
-      vsphere.host.advancedSettings['Syslog.global.logDir'] != /scratch/
+      vsphere.host.syslogLogDir != /scratch/
     docs:
       desc: |-
         This check ensures that the ESXi host writes its log files to a persistent datastore location rather than an in-memory file system. When the log directory points at a non-persistent location such as `/scratch`, only a single day of logs is retained and all log files are reinitialized on every reboot.
@@ -1282,7 +1282,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.dcuiTimeOut <= 600
-      vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] != 0
+      vsphere.host.dcuiTimeOut != 0
     docs:
       desc: |-
         This check ensures that an idle Direct Console User Interface session is terminated after no more than 600 seconds. The Direct Console User Interface allows local login and host management, and an idle timeout closes sessions an operator opened but left unattended.
@@ -1781,7 +1781,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       vsphere.host.esxiShellTimeOut <= 3600
-      vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] != 0
+      vsphere.host.esxiShellTimeOut != 0
     docs:
       desc: |-
         This check ensures that the ESXi shell and SSH services automatically stop after no more than 1 hour. Without this timeout the services run indefinitely once enabled, leaving remote access available long after the work that required it is finished.


### PR DESCRIPTION
## What

Replaces ten `vsphere.host.advancedSettings['<KEY>']` dict lookups in `mondoo-vmware-vsphere-esxi.mql.yaml` with the new typed host fields added in [mondoohq/mql#8306](https://github.com/mondoohq/mql/pull/8306). Comparison operators and values are preserved exactly; only the MQL accessor changes. No `desc`/`audit`/`remediation` prose was touched.

| Before | After |
|---|---|
| `vsphere.host.advancedSettings['Security.AccountUnlockTime'] == 900` | `vsphere.host.accountUnlockTime == 900` |
| `vsphere.host.advancedSettings['Net.DVFilterBindIpAddress'] == empty` | `vsphere.host.dvFilterBindIpAddress == empty` |
| `vsphere.host.advancedSettings['UserVars.ESXiShellInteractiveTimeOut'] <= 300` | `vsphere.host.esxiShellInteractiveTimeOut <= 300` |
| `vsphere.host.advancedSettings['Config.HostAgent.plugins.solo.enableMob'] == false` | `vsphere.host.mobEnabled == false` |
| `vsphere.host.advancedSettings['Syslog.global.logDir'] != ""` | `vsphere.host.syslogLogDir != ""` |
| `vsphere.host.advancedSettings['Syslog.global.logHost'] != ""` | `vsphere.host.syslogLogHost != ""` |
| `vsphere.host.advancedSettings['UserVars.DcuiTimeOut'] <= 600` | `vsphere.host.dcuiTimeOut <= 600` |
| `vsphere.host.advancedSettings['Mem.ShareForceSalting'] == 2` | `vsphere.host.memShareForceSalting == 2` |
| `vsphere.host.advancedSettings['Security.AccountLockFailures'] == 5` | `vsphere.host.accountLockFailures == 5` |
| `vsphere.host.advancedSettings['UserVars.ESXiShellTimeOut'] <= 3600` | `vsphere.host.esxiShellTimeOut <= 3600` |

## Verification

Built and installed the vsphere provider from `mondoohq/mql` `main` (which already carries the #8306 typed fields), then ran `cnspec policy lint content/mondoo-vmware-vsphere-esxi.mql.yaml` → **valid policy bundle(s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
