### PR TITLE
🐛 guard su-restriction check against null suRestrictedGroups (client panic on k8s node OSes)

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.7.0
+    version: 2.7.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -13925,8 +13925,10 @@ queries:
       suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
 
       suRestrictedPam != empty
-      suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
-      suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
+      if (suRestrictedPam != empty) {
+        suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
+        suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
+      }
     docs:
       desc: |
         This check ensures that access to the `su` command is restricted to authorized users by configuring the `pam_wheel.so` module in the `/etc/pam.d/su` file. This configuration limits the use of the `su` command to members of the `wheel` or `sudo` group, enhancing system security.


### PR DESCRIPTION
## What

Guards the `mondoo-linux-security-su-is-restricted` check so it no longer panics cnspec on hosts without `/etc/pam.d/su`, and bumps the policy to 2.7.1:

```mql
suRestrictedPam != empty
if (suRestrictedPam != empty) {
  suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
  suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
}
```

## Why

The 2.7.0 rewrite of this check (released in cnspec-enterprise-policies v5.26.0 on 2026-06-10T14:57Z) made `suRestrictedGroups` evaluate to **null** (instead of `[]`) on hosts that have no `/etc/pam.d/su`. Passing null as the `containsAll()` argument hits an unguarded type assertion in the MQL engine (`llx.arrayContainsAll`, `builtin_array.go:935` — engine bug tracked in mondoohq/mql#8319) and panics policy evaluation mid-scan.

This caused a ~10x surge in `panic.received` (`panic: interface conversion: interface {} is nil, not []interface {}`) starting ~17 minutes after the v5.26.0 release — 1,050+ panics across 19 spaces in 3 hours, spanning cnspec 13.22.0/13.6.0/13.5.0/11.69.1 simultaneously. Only spaces scanning k8s nodes were hit: container-optimized node OSes (COS, Flatcar, Bottlerocket) don't ship `/etc/pam.d/su`, while standard distros do — which is also why the panic was not reproducible on normal test systems. Incident: INC-2026-06-10-client-panic-k8s (mondoohq/prototype-sre).

## Verification

With released cnspec 13.22.0 (build 261db0c0, the exact build panicking in production) in an `ubuntu:24.04` container:

- `/etc/pam.d/su` removed + 2.7.0 query → panic, byte-identical signature/stack to production
- `/etc/pam.d/su` removed + this guarded query → clean `[failed]` result, no panic
- `/etc/pam.d/su` present (pam_wheel commented, distro default) → clean `[failed]` result in both versions; the guard does not change semantics when pam config exists, since the block only adds the `suRestrictedPam != empty` precondition that statement 1 already asserts

`cnspec bundle lint` failure set is unchanged vs `main` (pre-existing schema-version noise on new chrony/yum/auditd resources); the su check compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
