### PR TITLE
🐛 linux: gate the su-restriction check on PAM config, simplify it, bump to 2.7.1

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.7.0
+    version: 2.7.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -13926,7 +13926,7 @@ queries:
       suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
 
       suRestrictedPam != empty
-      suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
+      groups.map(name).containsAll(suRestrictedGroups)
       suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
     docs:
       desc: |

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -13920,6 +13920,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-4-1-1
     filters: |
       asset.kind != "container-image"
+      pam.conf.exists
     mql: |
       suRestrictedPam = pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
       suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])


### PR DESCRIPTION
Two changes to the **"access to the su command is restricted"** check in `mondoo-linux-security`, plus a patch version bump.

## 1. Gate on PAM config being present

```diff
     filters: |
       asset.kind != "container-image"
+      pam.conf.exists
```

The check queries `pam.conf.entries["/etc/pam.d/su"]`. On hosts that ship **no** PAM configuration — container-optimized k8s node images (COS, Flatcar, Bottlerocket) have no `/etc/pam.d` — that lookup yields a typed null, which is what surfaced the scan-crashing engine panic in the recent incident (hardened in mql #8320 / #8321). Gating on `pam.conf.exists` makes those hosts correctly **not-applicable** instead of failed/errored.

## 2. Simplify the group-existence assertion

```diff
       suRestrictedPam != empty
-      suRestrictedGroups == empty || groups.map(name).containsAll(suRestrictedGroups)
+      groups.map(name).containsAll(suRestrictedGroups)
       suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
```

The `suRestrictedGroups == empty ||` short-circuit is no longer needed:
- `containsAll([])` is vacuously true (the no-explicit-`group=` case), and
- `containsAll(null)` is now a safe `false` rather than a panic (mql #8320) — and on that path `suRestrictedPam != empty` already fails the check.

Overall pass/fail is unchanged. This is the only check in the bundle using the `pam` resource.

## 3. Version bump

`mondoo-linux-security` `2.7.0` → `2.7.1`.

## Dependency

Both `pam.conf.exists` (os provider, mql #8322) and the safe `containsAll(null)` behavior (mql #8320) ship in mql. This policy should land/release **after** the mql release that includes them; lint against an older provider fails with `cannot find field 'exists' in pam.conf`.

## Testing

- `cnspec policy lint content/mondoo-linux-security.mql.yaml` → valid (against an os provider build with the new field).
- Negative control: a bogus filter field fails lint with `cannot find field …`, confirming filters compile against the provider schema.