### PR TITLE
🧹 Bump patch versions for freebsd, gcp, github, m365, oci, okta, and vsphere policies

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.3.0
+    version: 9.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.1
+    version: 1.8.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -56,7 +56,7 @@ policies:
     scoring_system: highest impact
   - uid: mondoo-github-repository-security
     name: Mondoo GitHub Repository Security
-    version: 1.8.1
+    version: 1.8.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.4.0
+    version: 2.4.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.1.0
+    version: 4.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.2
+    version: 2.3.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline
     name: Mondoo VMware vSphere ESXi Security
-    version: 2.0.1
+    version: 2.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-security-baseline
     name: Mondoo VMware vSphere Security Baseline
-    version: 2.1.0
+    version: 2.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
Bumps the patch version of the following security policies:

| Policy | Version |
| --- | --- |
| `mondoo-freebsd-security` | 1.0.1 → 1.0.2 |
| `mondoo-gcp-security` | 9.3.0 → 9.3.1 |
| `mondoo-github-organization-security` / `mondoo-github-repository-security` | 1.8.1 → 1.8.2 |
| `mondoo-m365-security` | 2.4.0 → 2.4.1 |
| `mondoo-oci-security` | 4.1.0 → 4.1.1 |
| `mondoo-okta-security` | 2.3.2 → 2.3.3 |
| `mondoo-vmware-vsphere-esxi` | 2.0.1 → 2.0.2 |
| `mondoo-vmware-vsphere` | 2.1.0 → 2.1.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)