### PR TITLE
🐛 linux: guard su-restriction statements for hosts missing /etc/pam.d/su (residual panics after v5.26.1)

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.7.1
+    version: 2.7.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -13926,8 +13926,10 @@ queries:
       suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
 
       suRestrictedPam != empty
-      groups.map(name).containsAll(suRestrictedGroups)
-      suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
+      if (suRestrictedPam != empty) {
+        groups.map(name).containsAll(suRestrictedGroups)
+        suRestrictedGroups != empty || groups.any(name.in(["wheel", "sudo"]))
+      }
     docs:
       desc: |
         This check ensures that access to the `su` command is restricted to authorized users by configuring the `pam_wheel.so` module in the `/etc/pam.d/su` file. This configuration limits the use of the `su` command to members of the `wheel` or `sudo` group, enhancing system security.


### PR DESCRIPTION
## What

Follow-up to #2769 / incident INC-2026-06-10-client-panic-k8s: wraps the su-restriction group statements in `if (suRestrictedPam != empty) { … }` and bumps `mondoo-linux-security` to 2.7.2.

## Why — v5.26.1 closed only part of the hole

The `pam.conf.exists` filter from #2769 excludes hosts with **no PAM config at all** (COS/Flatcar/Bottlerocket k8s nodes) — fleet panics dropped 164→27/15m when v5.26.1 went live at 19:55Z. But hosts that **have `/etc/pam.d/` and lack only the `su` file** still pass the filter, produce a null `suRestrictedGroups`, and panic in `llx.arrayContainsAll` (mondoohq/mql#8319). With the `suRestrictedGroups == empty ||` disjunct removed in #2769, the null flows into `containsAll()` unconditionally.

**Production evidence:** `sva-sap-server` (18 SLES / 2 debian / 1 opensuse-leap assets, no k8s) kept panicking after v5.26.1 rollout — events at 20:54:48Z and 20:56:51Z on cnspec 13.22.0 show `runBoundFunction(…, 0x10000000e)`, the chunk position of `containsAll` in the **v5.26.1-compiled** query (the v5.26.0 text put it at `0x100000010`; removing the two `== empty` chunks shifts it to `0xe`). Residual fleet rate is holding at ~25-29/15m of this signature.

## Verification (released cnspec 13.22.0, build 261db0c0)

| Host state | v5.26.1 text | this PR (2.7.2) |
|---|---|---|
| `/etc/pam.d/su` present (ubuntu 24.04, leap 15.6 stock) | clean fail | clean fail |
| `/etc/pam.d/su` removed, `/etc/pam.d/` present (filter passes) | **panic** at chunk `0x10000000e` | clean fail, no panic |

The `if` block only adds the precondition that statement 1 (`suRestrictedPam != empty`) already asserts, so scoring semantics are unchanged on healthy hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
