### PR TITLE
🧹 linux: use typed exim.localInterfaces for MTA loopback check

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.7.0
+    version: 2.7.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -3607,7 +3607,7 @@ queries:
         postfix.inetInterfaces.containsOnly(["localhost", "loopback-only", "127.0.0.1", "::1"])
       }
       if( package("exim4").installed && service('exim4').running ) {
-        parse.ini("/etc/exim4/update-exim4.conf.conf").params["dc_local_interfaces"] == "'127.0.0.1 ; ::1'"
+        exim.localInterfaces.length > 0 && exim.localInterfaces.containsOnly(["127.0.0.1", "::1"])
       }
       ports.listening.where(address != "127.0.0.1" && address != "[::1]").none(port == 25)
     docs:


### PR DESCRIPTION
## Summary

Improves the Exim portion of the MTA loopback-only check in **Mondoo Linux Security** now that cnquery/mql ships a typed `exim` resource.

```diff
  if( package("exim4").installed && service('exim4').running ) {
-   parse.ini("/etc/exim4/update-exim4.conf.conf").params["dc_local_interfaces"] == "'127.0.0.1 ; ::1'"
+   exim.localInterfaces.length > 0 && exim.localInterfaces.containsOnly(["127.0.0.1", "::1"])
  }
```

## Why

The old `parse.ini(...) == "'127.0.0.1 ; ::1'"` compared against one exact string, which made it brittle:

- **Format-sensitive** — a semantically identical value with reordered addresses or different spacing (`'::1 ; 127.0.0.1'`, `'127.0.0.1;::1'`) would fail the check.
- **Debian-only** — it only understood the `dc_local_interfaces` key form. `exim.localInterfaces` normalizes both the Debian split-config and the monolithic `exim.conf` `local_interfaces` list.
- **No vacuous pass** — `.length > 0` is deliberate: an empty interface list means Exim uses its default of listening on all interfaces, which must fail rather than slip through `containsOnly` (which returns true on an empty list).

The `audit:` and `remediation:` blocks are unchanged — they already use vendor-native tooling and remain correct.

## Version

Bumps `mondoo-linux-security` `2.7.0` → `2.7.1`.

## Note on merge sequencing

The `exim` resource shipped in mql **after** `v13.22.1`, which is what cnspec's `go.mod` currently pins. This PR should not merge until cnspec bumps mql to a release that includes the `exim` resource, or content lint in CI will not resolve the resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)