### PR TITLE
⭐ executor: attach the running query to panic reports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260610003616-faefada3536e
-	go.mondoo.com/mql/v13 v13.22.1
+	go.mondoo.com/mql/v13 v13.22.2-0.20260610222949-17d6d58f1814
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260610003616-faefada3536e h1:+n6VOzpgedcm5icWvvn73vu/RBQnUDYRePXAwSilaZ4=
 go.mondoo.com/mondoo-go v0.0.0-20260610003616-faefada3536e/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.22.1 h1:hRevKpBDOdgevJFkzfBq/y5uyG6JWr90EjqsZq7rOKY=
-go.mondoo.com/mql/v13 v13.22.1/go.mod h1:SghhtabMZH0oVd93Ik0K8pDWGGD3Yf30dvIrdj6qsqM=
+go.mondoo.com/mql/v13 v13.22.2-0.20260610222949-17d6d58f1814 h1:MEzm8buKCyPRSEQIteWyLhyCf9YMPQqeEjpL2TRCSWA=
+go.mondoo.com/mql/v13 v13.22.2-0.20260610222949-17d6d58f1814/go.mod h1:SghhtabMZH0oVd93Ik0K8pDWGGD3Yf30dvIrdj6qsqM=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -70,9 +70,8 @@ func (em *executionManager) Start() {
 		defer em.wg.Done()
 		// current is the code bundle being executed; the deferred panic
 		// reporter snapshots it at crash time so the report carries WHICH
-		// query was running, not just where the engine died (the gap that
-		// slowed down INC-2026-06-10-client-panic-k8s). The recover stays
-		// at the goroutine top — recovering closer to the query and
+		// query was running, not just where the engine died. The recover
+		// stays at the goroutine top — recovering closer to the query and
 		// re-panicking would truncate the stacktrace.
 		var current *llx.CodeBundle
 		defer health.ReportPanicWithTags("cnspec", cnspec.Version, cnspec.Build, func() map[string]string {

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -111,7 +111,9 @@ func (em *executionManager) Start() {
 				}
 
 				current = item.codeBundle
-				if err := em.executeCodeBundle(item.codeBundle, props, errMsg); err != nil {
+				err := em.executeCodeBundle(item.codeBundle, props, errMsg)
+				current = nil
+				if err != nil {
 					// an error is returned if we cannot execute a query. This happens
 					// if the lumi runtime doesn't report back expected data, there is
 					// a problem with the lumi runtime, or the query is somehow invalid.

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -68,7 +68,19 @@ func (em *executionManager) Start() {
 	em.wg.Add(1)
 	go func() {
 		defer em.wg.Done()
-		defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
+		// current is the code bundle being executed; the deferred panic
+		// reporter snapshots it at crash time so the report carries WHICH
+		// query was running, not just where the engine died (the gap that
+		// slowed down INC-2026-06-10-client-panic-k8s). The recover stays
+		// at the goroutine top — recovering closer to the query and
+		// re-panicking would truncate the stacktrace.
+		var current *llx.CodeBundle
+		defer health.ReportPanicWithTags("cnspec", cnspec.Version, cnspec.Build, func() map[string]string {
+			if current == nil {
+				return nil
+			}
+			return health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
+		})
 		for {
 			// Prioritize stopChan
 			select {
@@ -98,6 +110,7 @@ func (em *executionManager) Start() {
 					props[k] = r.Data
 				}
 
+				current = item.codeBundle
 				if err := em.executeCodeBundle(item.codeBundle, props, errMsg); err != nil {
 					// an error is returned if we cannot execute a query. This happens
 					// if the lumi runtime doesn't report back expected data, there is


### PR DESCRIPTION
## What

The policy executor's run goroutine now tracks the in-flight `*llx.CodeBundle` and, when a query panics the engine, attaches `queryCodeID` + `querySource` tags to the panic report via `health.ReportPanicWithTags`.

## Why

During INC-2026-06-10-client-panic-k8s (mondoohq/mql#8319), the panic report identified *where* the engine died (`llx.arrayContainsAll`, `builtin_array.go:935`) but not *which query* it was evaluating. Root-causing it to the su-restriction check took a policy-release diff plus compiled-chunk-ref forensics; with these tags the report itself names the query. Slow-query reports already carry code ID + query text — this brings panic reports to parity.

The recover stays at the goroutine top so the stacktrace is preserved intact; the deferred reporter just snapshots the tracked bundle at crash time.

## Dependencies

- ⚠️ **Depends on mondoohq/mql#8330** (`ReportPanicWithTags` / `QueryPanicTags`) — needs a `go.mondoo.com/mql/v13` bump here once that merges and releases. Verified compiling against the mql branch via a local go.work.
- Companion server PR maps the tags to the existing `mondoo.query.text` / `mondoo.query.code_id` obslog fields on `panic.received` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
