### PR TITLE
🐛 linux: make su-restriction check crash-safe via pam.conf.service

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.7.1
+    version: 2.7.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -13922,7 +13922,11 @@ queries:
       asset.kind != "container-image"
       pam.conf.exists
     mql: |
-      suRestrictedPam = pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
+      // `su` should be limited to a trusted group by pam_wheel, which keys on the
+      // caller's real uid. Selecting the service by name returns an empty list when
+      // `/etc/pam.d/su` is absent, so a host missing the file fails this check
+      // rather than feeding a null into the group comparison.
+      suRestrictedPam = pam.conf.service(name: "su").entries.where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
       suRestrictedGroups = suRestrictedPam.where(params["group"] != null).map(params["group"])
 
       suRestrictedPam != empty


### PR DESCRIPTION
## What

Rewrites `mondoo-linux-security-access-to-the-su-command-is-restricted` to source its PAM data from `pam.conf.service(name: "su").entries` instead of `pam.conf.entries["/etc/pam.d/su"]`, and bumps the policy to `2.7.2`.

```diff
-suRestrictedPam = pam.conf.entries["/etc/pam.d/su"].where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
+// `su` should be limited to a trusted group by pam_wheel, which keys on the
+// caller's real uid. Selecting the service by name returns an empty list when
+// `/etc/pam.d/su` is absent, so a host missing the file fails this check
+// rather than feeding a null into the group comparison.
+suRestrictedPam = pam.conf.service(name: "su").entries.where(pamType == "auth" && module == "pam_wheel.so" && params["use_uid"] != null)
```

## Why

On a host that has `/etc/pam.d/` but lacks the `su` file, the old query indexed a map key that doesn't exist, so `pam.conf.entries["/etc/pam.d/su"]` resolved to **null**. That null propagated through `.where(...).map(...)` into:

```mql
groups.map(name).containsAll(suRestrictedGroups)
```

The llx `arrayContainsAll` builtin guards its *bind* but not its *argument* — `arg.Value.([]any)` on a nil — so it **panics and takes down the entire scan**:

```
panic: interface conversion: interface {} is nil, not []interface {}
go.mondoo.com/mql/v13/llx.arrayContainsAll(...) llx/builtin_array.go:935
```

(These hosts pass the `pam.conf.exists` filter because PAM config *is* present — they're just missing the one `su` service file.)

`pam.conf.service(name:)` (added in mql [#8324](https://github.com/mondoohq/mql/pull/8324)) returns an **empty list**, not null, when the service file is absent. Keeping the whole expression in array-space means `suRestrictedPam != empty` is `false` and `suRestrictedGroups == empty` short-circuits the `containsAll`, so a missing `su` file makes the check **cleanly fail** (the correct finding) instead of crashing. The named-service form also reads better than a hardcoded `/etc/pam.d/su` path.

> Note: this is the content half of the fix. The underlying llx `arrayContainsAll` argument should also nil-guard so a single missing map key can never crash a scan again — tracked separately on the mql side.

## Testing

- `cnspec policy lint` → valid bundle.
- Live Debian 13 host (`su` configured with `pam_wheel.so` / `use_uid` / `group=sugroup`): check **passes** end-to-end via `cnspec scan`.
- Simulated missing service (`pam.conf.service(name: "doesnotexist")`): assertions resolve to `[false, true, true]` — the check **fails with no panic and no error**.