### PR TITLE
📚 linux: correct check descriptions that misstate what is checked

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -354,16 +354,18 @@ queries:
       systemd.timer('aidecheck').enabled
     docs:
       desc: |
-        This check verifies that AIDE (Advanced Intrusion Detection Environment) is actively used to perform regular integrity scans of the filesystem. It ensures that an AIDE database has been initialized and that periodic checks are scheduled and executed.
+        This check verifies that AIDE (Advanced Intrusion Detection Environment) integrity scans are scheduled to run regularly. It passes when daily runs are enabled through `CRON_DAILY_RUN=yes` in `/etc/default/aide`, when the root crontab contains an `aide --check` entry, or when the `aidecheck` systemd timer is enabled.
 
         **Why this matters**
 
-        Installing AIDE alone is not sufficient to protect a system from unauthorized changes. To be effective, AIDE must be routinely run to compare the current system state against its known-good baseline. Regular execution of these checks helps detect file tampering, unauthorized modifications, and early signs of compromise, especially in sensitive directories like /etc, /bin, and /sbin.
+        Installing AIDE alone is not sufficient to protect a system from unauthorized changes. To be effective, AIDE must run on a schedule so the current system state is routinely compared against its known-good baseline. Regular execution of these checks helps detect file tampering, unauthorized modifications, and early signs of compromise, especially in sensitive directories like /etc, /bin, and /sbin.
 
         If AIDE is not executed on a regular basis:
           - Integrity violations may go undetected, exposing the system to persistent threats such as rootkits or malware.
           - Audit logs and incident response efforts may be incomplete due to a lack of timely data.
           - Organizations may fail to meet compliance requirements that mandate proactive monitoring of system integrity.
+
+        Scheduling recurring AIDE checks turns the integrity baseline into an active detection control that surfaces file tampering shortly after it happens instead of leaving it unnoticed.
       audit: |
         Run these commands to confirm a periodic AIDE check is scheduled:
 
@@ -1475,7 +1477,7 @@ queries:
       kernel.module("atm").installBypass
     docs:
       desc: |
-        This check verifies that the ATM (Asynchronous Transfer Mode) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/atm.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the ATM (Asynchronous Transfer Mode) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -1578,7 +1580,7 @@ queries:
       kernel.module("can").installBypass
     docs:
       desc: |
-        This check verifies that the CAN (Controller Area Network) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/can.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the CAN (Controller Area Network) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -1680,7 +1682,7 @@ queries:
       kernel.module("dccp").installBypass
     docs:
       desc: |
-        This check verifies that the DCCP (Datagram Congestion Control Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/dccp.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the DCCP (Datagram Congestion Control Protocol) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -1782,7 +1784,7 @@ queries:
       kernel.module("rds").installBypass
     docs:
       desc: |
-        This check verifies that the RDS (Reliable Datagram Sockets) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/rds.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the RDS (Reliable Datagram Sockets) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -1884,7 +1886,7 @@ queries:
       kernel.module("sctp").installBypass
     docs:
       desc: |
-        This check verifies that the SCTP (Stream Control Transmission Protocol) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/sctp.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the SCTP (Stream Control Transmission Protocol) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -1986,7 +1988,7 @@ queries:
       kernel.module("tipc").installBypass
     docs:
       desc: |
-        This check verifies that the TIPC (Transparent Inter-Process Communication) kernel module is disabled by checking for configuration directives in `/etc/modprobe.d/tipc.conf` that both blacklist the module and redirect its install to `/bin/false`.
+        This check verifies that the TIPC (Transparent Inter-Process Communication) kernel module is disabled by confirming that the modprobe configuration, typically a file in `/etc/modprobe.d/`, both blacklists the module and redirects its install command to `/bin/false`.
 
         **Why this matters**
 
@@ -6114,7 +6116,7 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that the system's GRUB bootloader is configured to pass the audit=1 kernel parameter, which ensures that auditing is enabled from the earliest stages of system initialization, even before the auditd daemon starts.
+        This check verifies that the boot loader passes the audit=1 kernel parameter, which ensures that auditing is enabled from the earliest stages of system initialization, even before the auditd daemon starts. The check inspects the GRUB configuration files under `/boot` and, on systems that use it, the kernel parameters defined in `/etc/secboot/config.json`.
 
         **Why this matters**
 
@@ -6125,7 +6127,7 @@ queries:
           - Attackers or misconfigurations could exploit this window to perform actions undetected.
           - The system's audit trail may be incomplete, undermining trust in audit data and complicating incident response or compliance reviews.
 
-        Adding audit=1 to the GRUB configuration ensures that the Linux kernel begins generating audit records as soon as it starts, capturing all auditable activity regardless of when auditd is fully initialized. This enhances the completeness and integrity of audit logging across the system lifecycle.
+        Adding audit=1 to the kernel command line ensures that the Linux kernel begins generating audit records as soon as it starts, capturing all auditable activity regardless of when auditd is fully initialized. This enhances the completeness and integrity of audit logging across the system lifecycle.
       audit: |
         Run this command to confirm the kernel command line enables auditing of early-boot processes:
 
@@ -6560,18 +6562,18 @@ queries:
         auditd.config.params.admin_space_left_action == /halt|single/
     docs:
       desc: |
-        This check verifies that the system is configured to disable itself when audit logs are full by ensuring the `space_left_action` and `admin_space_left_action` parameters in `/etc/audit/auditd.conf` are set to appropriate values.
+        This check verifies that auditd is configured to respond when audit log disk space runs low by ensuring three parameters in `/etc/audit/auditd.conf` are set: `space_left_action` must be set to `email`, `exec`, `single`, or `halt`; `action_mail_acct` must be set to `root`; and `admin_space_left_action` must be set to `halt` or `single`.
 
         **Why this matters**
 
-        The `space_left_action` setting determines what action auditd takes when disk space for audit logs is low. The `admin_space_left_action` setting specifies the action when space is critically low. Setting these to halt or single ensures that the system does not continue operating with potentially compromised logging capabilities.
+        The `space_left_action` setting determines what auditd does when disk space for audit logs is low, `action_mail_acct` defines which account is notified when the email action triggers, and `admin_space_left_action` specifies the action when space is critically low. Requiring `halt` or `single` at the critical threshold ensures the system stops normal multi-user operation rather than continuing without reliable audit logging.
 
-        If the system does not disable itself when audit logs are full:
-          - Crucial audit data may be lost, leading to gaps in security monitoring.
-          - The system may continue to operate without proper oversight, increasing the risk of undetected malicious activity.
-          - Compliance with regulatory requirements for audit logging may be jeopardized.
+        If these parameters are not configured:
+          - Audit records may be silently dropped once the disk fills, leaving gaps in security monitoring.
+          - Administrators receive no warning that audit capacity is running out, so the condition persists unnoticed.
+          - The system may continue operating without proper oversight, increasing the risk of undetected malicious activity and jeopardizing compliance with regulatory audit requirements.
 
-        Configuring these parameters helps ensure that the system maintains a secure state and that audit logging remains functional, even under adverse conditions.
+        Configuring these parameters ensures administrators are alerted before audit space is exhausted and that the system halts or drops to single-user mode rather than running without a complete audit trail.
       audit: |
         Run this command to inspect the audit disk-space actions:
 
@@ -6890,7 +6892,7 @@ queries:
           mondoo.com/filter-icon: linux
     docs:
       desc: |
-        This check verifies that auditd is configured to monitor login and logout events. The parameters in this section track changes to the files associated with login and logout events. The file `/var/log/lastlog` tracks the last login of each user. The file `/var/log/tallylog` tracks failed login attempts. The file `/var/run/faillock` is used by the `pam_faillock` module to track failed authentication attempts. All audit records will be tagged with the identifier "logins."
+        This check verifies that auditd is configured to monitor the files that record login and logout activity, with all audit records tagged with the identifier "logins". On every system it requires watches on `/var/log/lastlog`, which tracks the last login of each user, and `/var/log/tallylog`, which tracks failed login attempts. On Debian-based systems it additionally requires a watch on `/var/log/faillog`, which records failed login counts. On Red Hat and Amazon Linux systems it additionally requires a watch on `/var/run/faillock`, which is used by the `pam_faillock` module to track failed authentication attempts.
 
         **Why this matters**
 
@@ -6898,10 +6900,10 @@ queries:
 
         If monitoring is not enabled:
           - Unauthorized login attempts may go undetected, allowing attackers to gain access to the system.
-          - Legitimate user activity may be obscured, complicating incident response efforts.
+          - Tampering with login history files to hide an intrusion leaves no audit trail, complicating incident response efforts.
           - The system may fall out of compliance with security policies or regulatory requirements.
 
-        By ensuring that login and logout events are monitored, organizations can maintain a secure environment and quickly respond to potential threats. This is particularly important in environments with sensitive data or critical infrastructure.
+        By ensuring that changes to these login records are audited, organizations can detect both unauthorized access attempts and attempts to cover them up, and can respond quickly to potential threats. This is particularly important in environments with sensitive data or critical infrastructure.
       audit: |
         Run this command to confirm the audit rules for login and logout events are loaded:
 
@@ -7103,18 +7105,18 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that the system is configured to record session start events in the audit logs, ensuring that audit rules are in place to track successful login sessions using the auditd subsystem.
+        This check verifies that auditd watch rules are in place for the session tracking files `/var/run/utmp`, `/var/log/wtmp`, and `/var/log/btmp`, so that session starts, login history, and failed login attempts are all recorded in the audit log.
 
         **Why this matters**
 
-        Capturing session initiation information, such as user logins and terminal access, is essential for establishing a complete record of user activity. These events mark the beginning of user interactions with the system and provide vital context for analyzing subsequent actions.
+        These files form the system's record of who logged in, when, and from where. The `utmp` file tracks active sessions, `wtmp` keeps a history of logins and logouts, and `btmp` records failed login attempts. Together they provide vital context for analyzing user activity.
 
-        If session initiation is not logged:
+        If changes to these files are not audited:
           - User activity cannot be reliably correlated to specific sessions, weakening audit trails.
-          - Security incidents such as unauthorized access or lateral movement may go undetected.
+          - Brute-force attempts recorded in `btmp` and tampering with login history may go undetected.
           - Compliance with security standards and regulatory frameworks that require session logging may be compromised.
 
-        By ensuring session start events are audited, organizations gain visibility into who accessed the system and when, supporting effective monitoring, incident investigation, and user accountability. This forms a foundational element of audit-based security controls.
+        By auditing changes to these session files, organizations gain visibility into who accessed the system and when, and can detect attempts to manipulate the login record. This supports effective monitoring, incident investigation, and user accountability.
       audit: |
         Run this command to confirm the session audit rules are loaded:
 
@@ -7591,18 +7593,18 @@ queries:
           mondoo.com/filter-icon: linux
     docs:
       desc: |
-        This check verifies that the audit system is configured to record changes to key network configuration files and system identity settings by monitoring specific system calls and file paths.
+        This check verifies that the audit system records changes to the system's network identity and core network configuration files. It requires syscall rules for `sethostname` and `setdomainname` on both 32-bit and 64-bit architectures, plus watch rules on `/etc/issue`, `/etc/issue.net`, and `/etc/hosts`. On Debian and Red Hat based systems it also requires a watch rule on the distribution's network configuration location, either `/etc/sysconfig/network` or `/etc/network`.
 
         **Why this matters**
 
         Changes to the system's hostname, domain name, or core network-related files can alter how the system identifies itself and interacts with other hosts. These modifications may indicate reconfiguration, misconfiguration, or unauthorized tampering.
 
         If these events are not audited:
-          - Changes to system identity (via sethostname or setdomainname) may go untracked, affecting asset management and security visibility.
-          - Modifications to files like `/etc/hosts`, `/etc/issue`, or `/etc/sysconfig/network` could enable social engineering, redirect network traffic, or disrupt connectivity.
+          - Changes to system identity through the sethostname or setdomainname system calls may go untracked, affecting asset management and security visibility.
+          - Modifications to files like `/etc/hosts` or `/etc/issue` could enable social engineering, redirect network traffic, or disrupt connectivity.
           - Attackers may exploit these files to mask their activity or persist on the system.
 
-        By auditing the sethostname and setdomainname system calls and monitoring changes to `/etc/issue`, `/etc/issue.net`, `/etc/hosts`, and `/etc/sysconfig/network`, administrators can detect critical network and identity changes. This supports system integrity, operational consistency, and incident investigation efforts.
+        By auditing these system calls and configuration files, administrators can detect critical network and identity changes. This supports system integrity, operational consistency, and incident investigation efforts.
       audit: |
         Run this command to confirm the audit rules for network environment modification events are loaded:
 
@@ -7872,9 +7874,7 @@ queries:
       desiredRules32.containsAll(syscalls_32bit)
     docs:
       desc: |
-        This check verifies that changes to file permissions, attributes, ownership, and group are monitored. It ensures that system calls affecting these properties are audited. Permission syscalls include `chmod`, `fchmod`, and `fchmodat`. Ownership syscalls include `chown`, `fchown`, `fchownat`, and `lchown`. Extended attribute syscalls include `setxattr`, `lsetxattr`, `fsetxattr`, `removexattr`, `lremovexattr`, and `fremovexattr`.
-
-        Note: On ARM architectures, the `chmod` and `chown` system calls may not be available, so only the other system calls are checked.
+        This check verifies that changes to file permissions, attributes, ownership, and group are monitored. It ensures that system calls affecting these properties are audited on both 32-bit and 64-bit architectures for non-privileged users. Permission syscalls include `chmod`, `fchmod`, and `fchmodat`. Ownership syscalls include `chown`, `fchown`, `fchownat`, and `lchown`. Extended attribute syscalls include `setxattr`, `lsetxattr`, `fsetxattr`, `removexattr`, `lremovexattr`, and `fremovexattr`.
 
         **Why this matters**
 
@@ -8121,9 +8121,7 @@ queries:
       desiredRulesEacces32.containsAll(syscalls_32bit)
     docs:
       desc: |
-        This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing system calls such as `creat`, `open`, `openat`, `truncate`, and `ftruncate`. These system calls control the creation, opening, and truncation of files. The audit log will record events where the user is a non-privileged user (auid >= 1000), is not a daemon event (auid=4294967295), and the system call returned EACCES (permission denied) or EPERM (operation not permitted). All audit records will be tagged with the identifier "access."
-
-        Note: On ARM architectures, the `creat` and `open` system calls may not be available, so only the other system calls are checked.
+        This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing the `creat`, `open`, `openat`, `truncate`, and `ftruncate` system calls on both 32-bit and 64-bit architectures. These system calls control the creation, opening, and truncation of files. The audit log records events where the user is a non-privileged user with an auid of 1000 or higher, the event is not a daemon event, and the system call returned EACCES for permission denied or EPERM for operation not permitted. All audit records are tagged with the identifier "access."
 
         **Why this matters**
 
@@ -10267,16 +10265,16 @@ queries:
         }
     docs:
       desc: |
-        This check ensures that SSH private keys are securely stored and handled to prevent unauthorized access and maintain the integrity of SSH public key authentication.
+        This check verifies that the SSH private host key files in `/etc/ssh` are not readable, writable, or executable by group members or other users, and are not executable by their owner.
 
         **Why this matters**
 
-        SSH private keys are critical for authentication in public key cryptography. If private keys are not properly secured:
-          - Unauthorized users could gain access to sensitive systems by using compromised private keys.
-          - The integrity of the authentication process could be undermined, leading to potential security breaches.
-          - Compliance with security policies requiring proper key management may be compromised.
+        Private host keys establish the identity of the SSH server itself. If a non-privileged user can read a private host key:
+          - An attacker could stand up a rogue SSH service that presents the stolen host key, causing clients to trust the impostor as the legitimate server.
+          - Man-in-the-middle attacks become possible, allowing credentials and session data to be intercepted without triggering host key warnings.
+          - Any trust placed in the host's identity, including host-based authentication between systems, is undermined.
 
-        By ensuring that SSH private keys are securely stored and handled, organizations can protect sensitive systems, maintain secure authentication, and comply with security best practices.
+        By restricting access to the private host key files so that only root can read them, organizations protect the server's identity, prevent impersonation and interception attacks, and preserve the trust model that SSH depends on.
       audit: |
         Run this command to inspect the permissions of the SSH private host key files:
 
@@ -10369,16 +10367,16 @@ queries:
         }
     docs:
       desc: |
-        This check ensures that SSH public keys are properly configured and secured as part of the SSH public key authentication mechanism. Public keys are used to verify digital signatures generated by their corresponding private keys, enabling secure and reliable authentication.
+        This check verifies that the SSH public host key files in `/etc/ssh` are not writable or executable by group members or other users, and are not executable by their owner.
 
         **Why this matters**
 
-        SSH public key authentication provides several benefits:
-          - Enhances security by eliminating the need for password-based authentication, reducing the risk of brute-force attacks.
-          - Ensures that only users with the corresponding private key can authenticate successfully.
-          - Supports compliance with security policies requiring strong authentication mechanisms.
+        Public host keys advertise the server's identity to connecting clients. They are not secret, but their integrity must be protected:
+          - If a non-privileged user can modify a public host key file, the advertised identity of the server can be tampered with, supporting key substitution and undermining trust in the host.
+          - Corrupted or altered host key files cause host key mismatch failures that disrupt client connections and automation relying on a consistent server identity.
+          - Writable key material in `/etc/ssh` signals broken permission hygiene in a directory that also holds the private host keys.
 
-        By properly configuring and securing SSH public keys, organizations can strengthen their authentication processes, protect sensitive systems, and maintain a secure environment.
+        By ensuring the public host key files can be modified only by root, organizations preserve the integrity of the server's advertised identity, prevent tampering, and keep SSH connections and automation reliable.
       audit: |
         Run this command to inspect the permissions of the SSH public host key files:
 
@@ -12510,17 +12508,17 @@ queries:
       sshd.config.params["Banner"] == "/etc/issue.net"
     docs:
       desc: |
-        This check ensures that the `Banner` parameter in the SSH configuration is set to display a warning banner to remote users before authentication. The banner file typically contains legal or security notices to inform users of acceptable use policies.
+        This check ensures that the `Banner` parameter in the SSH configuration is set to `/etc/issue.net` so that a warning banner is displayed to remote users before authentication. The banner file typically contains legal or security notices to inform users of acceptable use policies.
 
         **Why this matters**
 
         Displaying a warning banner before authentication serves several purposes:
 
-        - It informs users of the system's acceptable use policy and legal restrictions.
+        - It informs users of the system's acceptable use policy and legal restrictions before they log in.
         - It provides a deterrent to unauthorized access by clearly stating the consequences of misuse.
         - It supports compliance with security standards and regulatory requirements that mandate the use of warning banners.
 
-        By ensuring that the `Banner` parameter is configured, organizations can enhance security awareness, deter unauthorized access, and maintain compliance with security policies.
+        By ensuring that the `Banner` parameter points to `/etc/issue.net`, organizations can enhance security awareness, deter unauthorized access, and maintain compliance with security policies.
       audit: |
         Run this command to inspect the SSH warning banner setting:
 
@@ -12655,7 +12653,7 @@ queries:
         stat -c '%U %G %a' /etc/passwd
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -12742,17 +12740,17 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `/etc/shadow` file, which stores sensitive information about user accounts, is secured with appropriate permissions. Only the root user should have read and write access to this file to prevent unauthorized access to critical account data.
+        This check ensures that the `/etc/shadow` file, which stores hashed user passwords, is secured with appropriate permissions. Write and execute access must be removed for the group, and all access must be removed for other users. Read access for a dedicated `shadow` group, as used on Debian-based systems, is permitted.
 
         **Why this matters**
 
-        The `/etc/shadow` file contains hashed passwords and other security-related information for user accounts. If this file is improperly secured:
+        The `/etc/shadow` file contains hashed passwords and password aging information for user accounts. If this file is readable or writable by unauthorized users:
 
-        - Unauthorized users could access sensitive password data.
-        - Malicious actors could exploit this information to compromise user accounts or escalate privileges.
+        - Attackers could extract password hashes and crack them offline to take over accounts.
+        - Malicious users could alter password entries to lock out administrators or set empty passwords.
         - System integrity and compliance with security policies could be jeopardized.
 
-        By ensuring that only the root user has access to the `/etc/shadow` file, organizations can protect critical account data and maintain a secure system configuration.
+        By restricting access to the `/etc/shadow` file to the root user and, where applicable, the `shadow` group, organizations can protect password hashes from disclosure or tampering and maintain a secure system configuration.
       audit: |
         Run this command to inspect the ownership and permissions of `/etc/shadow`:
 
@@ -12760,7 +12758,7 @@ queries:
         stat -c '%U %G %a' /etc/shadow
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -12861,17 +12859,17 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `/etc/group` file, which contains a list of all valid groups defined in the system, is secured with appropriate permissions. Only the root user should have read and write access to this file to prevent unauthorized modifications to group definitions.
+        This check ensures that the `/etc/group` file, which contains a list of all valid groups defined in the system, is secured with appropriate permissions. The file must remain readable so system utilities can resolve group memberships, but write access must be restricted to the root user to prevent unauthorized modifications to group definitions.
 
         **Why this matters**
 
-        The `/etc/group` file defines group memberships on the system. If this file is improperly secured:
+        The `/etc/group` file defines group memberships on the system. If unauthorized users can modify this file:
 
-        - Unauthorized users could modify group definitions, potentially escalating privileges or disrupting access control.
-        - Malicious actors could exploit this information to compromise system security.
+        - They could add themselves to privileged groups, escalating their privileges.
+        - They could disrupt access control by altering or removing group definitions.
         - System integrity and compliance with security policies could be jeopardized.
 
-        By ensuring that only the root user has access to the `/etc/group` file, organizations can protect critical group membership data and maintain a secure system configuration.
+        By ensuring that only the root user can modify the `/etc/group` file, organizations can protect group membership data from tampering and maintain a secure system configuration.
       audit: |
         Run this command to inspect the ownership and permissions of `/etc/group`:
 
@@ -12879,7 +12877,7 @@ queries:
         stat -c '%U %G %a' /etc/group
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -12959,17 +12957,17 @@ queries:
       }
     docs:
       desc: |-
-        This check ensures that the `/etc/gshadow` file, which stores hashed group passwords, is secured with appropriate permissions. Only the root user should have read and write access to this file to prevent unauthorized access to sensitive group password information.
+        This check ensures that the `/etc/gshadow` file, which stores hashed group passwords and group administrator information, is secured with appropriate permissions. Write and execute access must be removed for the group, and all access must be removed for other users. Read access for a dedicated `shadow` group, as used on Debian-based systems, is permitted.
 
         **Why this matters**
 
-        The `/etc/gshadow` file serves as a companion to `/etc/group`, listing group memberships while storing sensitive password information. If this file is improperly secured:
+        The `/etc/gshadow` file stores group administrators, group members, and encrypted group passwords. If this file is readable or writable by unauthorized users:
 
-        - Unauthorized users could access sensitive group password data.
-        - Malicious actors could exploit this information to escalate privileges or compromise system security.
+        - Attackers could extract group password hashes and crack them offline to join privileged groups.
+        - Malicious users could alter group administrator entries to grant themselves control over groups.
         - System integrity and compliance with security policies could be jeopardized.
 
-        By ensuring that only the root user has access to the `/etc/gshadow` file, organizations can protect critical group password data and maintain a secure system configuration.
+        By restricting access to the `/etc/gshadow` file to the root user and, where applicable, the `shadow` group, organizations can protect group password data from disclosure or tampering and maintain a secure system configuration.
       audit: |
         Run this command to inspect the ownership and permissions of `/etc/gshadow`:
 
@@ -12977,7 +12975,7 @@ queries:
         stat -c '%U %G %a' /etc/gshadow
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -13093,7 +13091,7 @@ queries:
         stat -c '%U %G %a' /etc/passwd-
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -13184,17 +13182,17 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `/etc/shadow-` file, which contains a backup of the `/etc/shadow` file, is secured with appropriate permissions. Only the root user should have read and write access to this file to prevent unauthorized access to sensitive user account information.
+        This check ensures that the `/etc/shadow-` file, which contains a backup of the `/etc/shadow` file, is secured with appropriate permissions. Write and execute access must be removed for the group, and all access must be removed for other users. Read access for a dedicated `shadow` group, as used on Debian-based systems, is permitted.
 
         **Why this matters**
 
-        The `/etc/shadow-` file serves as a backup for the `/etc/shadow` file, which stores hashed passwords and other critical security information about user accounts. If this file is improperly secured:
+        The `/etc/shadow-` file is a backup copy of `/etc/shadow` and contains the same hashed passwords and password aging information. If this backup is readable or writable by unauthorized users:
 
-        - Unauthorized users could access sensitive password data.
-        - Malicious actors could exploit this information to compromise user accounts or escalate privileges.
+        - Attackers could extract password hashes from the backup and crack them offline, even when the live file is locked down.
+        - Malicious users could tamper with the backup to reintroduce weakened entries if it is ever restored.
         - System integrity and compliance with security policies could be jeopardized.
 
-        By ensuring that only the root user has access to the `/etc/shadow-` file, organizations can protect critical user account data and maintain a secure system configuration.
+        By restricting access to the `/etc/shadow-` file to the root user and, where applicable, the `shadow` group, organizations can protect password hashes in backups just as strictly as in the live file.
       audit: |
         Run this command to inspect the ownership and permissions of `/etc/shadow-`:
 
@@ -13202,7 +13200,7 @@ queries:
         stat -c '%U %G %a' /etc/shadow-
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -13336,7 +13334,7 @@ queries:
         stat -c '%U %G %a' /etc/group-
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -13434,17 +13432,17 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `/etc/gshadow-` file, which contains a backup of the `/etc/gshadow` file, is secured with appropriate permissions. Only the root user should have read and write access to this file to prevent unauthorized access to sensitive group password information.
+        This check ensures that the `/etc/gshadow-` file, which contains a backup of the `/etc/gshadow` file, is secured with appropriate permissions. Write and execute access must be removed for the group, and all access must be removed for other users. Read access for a dedicated `shadow` group, as used on Debian-based systems, is permitted.
 
         **Why this matters**
 
-        The `/etc/gshadow-` file serves as a backup for the `/etc/gshadow` file, which stores information about group administrators, group members, and encrypted group passwords. If this file is improperly secured:
+        The `/etc/gshadow-` file is a backup copy of `/etc/gshadow` and contains the same group administrators, group members, and encrypted group passwords. If this backup is readable or writable by unauthorized users:
 
-        - Unauthorized users could access sensitive group password information.
-        - Malicious actors could exploit this information to escalate privileges or compromise system security.
+        - Attackers could extract group password hashes from the backup and crack them offline to join privileged groups.
+        - Malicious users could tamper with the backup to reintroduce weakened entries if it is ever restored.
         - System integrity and compliance with security policies could be jeopardized.
 
-        By ensuring that only the root user has access to the `/etc/gshadow-` file, organizations can protect critical group password data and maintain a secure system configuration.
+        By restricting access to the `/etc/gshadow-` file to the root user and, where applicable, the `shadow` group, organizations can protect group password data in backups just as strictly as in the live file.
       audit: |
         Run this command to inspect the ownership and permissions of `/etc/gshadow-`:
 
@@ -13452,7 +13450,7 @@ queries:
         stat -c '%U %G %a' /etc/gshadow-
         ```
 
-        A passing result shows the file owned by `root:root` with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any group or other read access.
+        A passing result shows the file owned by root with the expected hardened mode. A failing result shows group or other write or execute access, or for shadow files any read access for other users.
       remediation:
         - id: cli
           desc: |
@@ -13541,17 +13539,17 @@ queries:
       users.list.duplicates(uid).none()
     docs:
       desc: |
-        This check ensures that each user ID (UID), login name, and group ID (GID) is unique across the system. Duplicate UIDs, user names, or GIDs can lead to security and operational issues, making it critical to maintain uniqueness.
+        This check ensures that each user ID (UID) defined in the `/etc/passwd` file is unique. Duplicate UIDs allow multiple accounts to share the same identity, which undermines access control and accountability.
 
         **Why this matters**
 
-        Unique UIDs, user names, and GIDs are essential for proper system management and security. If duplicates exist:
+        The kernel and system utilities identify users by UID, not by name. If two accounts share a UID:
 
-        - It becomes difficult to track user activity and file ownership, leading to potential security gaps.
-        - System utilities and applications may behave unpredictably due to conflicts in user or group identification.
-        - Networked systems may experience inconsistencies, especially when sharing resources or accessing files across systems.
+        - Both accounts gain identical access to each other's files and processes, so compromising one account compromises both.
+        - Audit logs and file ownership cannot distinguish which account performed an action, breaking accountability.
+        - System utilities and applications may behave unpredictably when resolving the shared UID to a name.
 
-        By ensuring that UIDs, user names, and GIDs are unique, organizations can maintain a secure and well-functioning system configuration.
+        By ensuring that every UID is unique, organizations can preserve reliable access control, maintain accurate audit trails, and keep a well-functioning system configuration.
       audit: |
         Run this command to list any UIDs assigned to more than one account:
 
@@ -13718,17 +13716,17 @@ queries:
       groups.list.duplicates(name).none()
     docs:
       desc: |
-        This check ensures that each login name, user ID (UID), and group ID (GID) is unique across the system. It also ensures that every user is a member of at least one group, and that every GID mentioned in the `/etc/passwd` file is defined in the `/etc/group` file.
+        This check ensures that each group name defined in the `/etc/group` file is unique. Unique group names are critical for maintaining proper group identification and predictable access control.
 
         **Why this matters**
 
-        Unique UIDs, user names, and GIDs are essential for proper system management and security. If duplicates or inconsistencies exist:
+        Administrators and tools reference groups by name when assigning permissions. If two group entries share a name:
 
-        - It becomes difficult to track user activity and file ownership, leading to potential security gaps.
-        - System utilities and applications may behave unpredictably due to conflicts in user or group identification.
-        - Networked systems may experience inconsistencies, especially when sharing resources or accessing files across systems.
+        - Permissions granted by group name may resolve to a different GID than intended, silently giving access to the wrong set of users.
+        - It becomes difficult to track group ownership and audit who holds which access rights.
+        - System utilities and applications may behave unpredictably when resolving the duplicated name.
 
-        By ensuring that UIDs, user names, and GIDs are unique, and that group memberships are properly defined, organizations can maintain a secure and well-functioning system configuration.
+        By ensuring that group names are unique, organizations can keep group-based access control predictable and maintain a secure and well-functioning system configuration.
       audit: |
         Run this command to list any group names defined more than once:
 
@@ -13861,17 +13859,17 @@ queries:
       users.list.all(gid != empty)
     docs:
       desc: |
-        This check ensures that each user is a member of at least one group, as defined in the `/etc/group` file. Group memberships are essential for managing access control and permissions on Linux systems.
+        This check ensures that every user account has a primary group ID assigned in the user database. A user account without a primary group breaks the basic ownership model that Linux relies on for access control.
 
         **Why this matters**
 
-        Group memberships provide a mechanism for assigning permissions and access rights to multiple users. If a user is not a member of any group:
+        The primary group determines the group ownership of files a user creates and is required during login and permission handling. If a user account has no primary group assigned:
 
-        - The user may lack necessary permissions to access files or resources.
-        - System administrators may face challenges in managing access control effectively.
-        - Compliance with security policies that require group-based access control may be compromised.
+        - Logins and session setup can fail or behave unpredictably because the group identity cannot be established.
+        - Files created by the user may receive incorrect or undefined group ownership, weakening access control.
+        - Administrators lose the ability to manage the user's access consistently through group-based permissions.
 
-        By ensuring that each user is a member of at least one group, organizations can maintain proper access control, streamline user management, and enhance system security.
+        By ensuring that each user has a primary group assigned, organizations can maintain proper access control, streamline user management, and enhance system security.
       audit: |
         Run this command to find accounts whose primary group does not exist in `/etc/group`:
 
@@ -14638,7 +14636,7 @@ queries:
           - A system update or configuration management drift may have changed the persistent setting.
           - An attacker with root access may have modified the config to disable SELinux on next reboot.
 
-        Verifying both the runtime mode and the persistent configuration ensures that SELinux protection survives reboots and is not silently weakened.
+        Setting `SELINUX=enforcing` in the persistent configuration ensures that SELinux protection survives reboots and is not silently weakened over time.
       audit: |
         Run this command to inspect the persistent SELinux mode:
 


### PR DESCRIPTION
## Summary

A full review of every check's `docs.desc` in the Linux Security policy, comparing each description against the check's MQL to verify that it accurately states what is checked, explains the concrete risk of leaving it unresolved, and motivates the fix. 26 descriptions were corrected; the rest were accurate and adequately motivated. No check logic changed.

Follows up on #2775, which fixed the remediations.

## Descriptions that claimed a different scope than the check tests

- **Shadow-family permission checks** (`/etc/shadow`, `/etc/gshadow`, `/etc/shadow-`, `/etc/gshadow-`): every description claimed "Only the root user should have read and write access", but none of these checks test group readability, by design, because the Debian convention is `root:shadow` with mode 640. The descriptions now state exactly which access bits must be removed and note that read access for a dedicated `shadow` group is permitted. The shared audit sentence claiming any group read access fails was corrected in the same way across all eight file-permission checks.
- **`/etc/group` permissions**: claimed only root should have read access, but the file is world-readable by design (mode 644) and the check only restricts write and execute. The description now explains why the file must stay readable and what the actual restriction is.
- **No-duplicate-UIDs / no-duplicate-group-names**: both descriptions claimed the checks validate uniqueness of login names, UIDs, and GIDs together, plus group membership consistency. Each check tests exactly one thing (duplicate UIDs, duplicate group names); the descriptions now describe that one thing and its specific consequences, such as shared-UID accounts being indistinguishable in audit logs.
- **Each-user-member-of-a-group**: claimed membership in `/etc/group` is verified, but the MQL only verifies each account has a primary GID assigned and never consults `/etc/group`. Cross-file GID consistency is a separate check.
- **AIDE filesystem-integrity**: claimed the check ensures the AIDE database is initialized and checks are "executed", but the MQL only verifies a schedule exists. The description now lists the three accepted scheduling mechanisms.
- **Kernel module checks** (atm, can, dccp, rds, sctp, tipc): each claimed the directives must live in a specific file such as `/etc/modprobe.d/dccp.conf`, but the checks accept the blacklist and install-bypass directives in any modprobe configuration file.
- **Early-boot auditing**: claimed the check verifies GRUB configuration, but it also accepts `audit=1` from `/etc/secboot/config.json` on systems without GRUB.
- **SSH warning banner**: claimed any configured banner passes, but the MQL requires `Banner /etc/issue.net` exactly.
- **SELinux config**: the closing sentence claimed both runtime and persistent modes are verified; this check only inspects `/etc/selinux/config`. The runtime mode has its own check.

## Descriptions whose risk explanation was about the wrong thing

- **SSH private host key permissions**: described user authentication keys and the risk of attackers logging in with compromised keys. The check tests the server's host keys in `/etc/ssh`; the real risks are server impersonation with a stolen host key and man-in-the-middle interception that triggers no host key warning. Rewritten accordingly.
- **SSH public host key permissions**: the entire "Why this matters" section explained the benefits of public key authentication over passwords, which has nothing to do with file permissions on host keys. Rewritten around integrity of the server's advertised identity and key substitution.
- **Session initiation**: said the rules "track successful login sessions", but the check also requires a watch on `/var/log/btmp`, which records failed attempts. The description now covers all three session files and what each records.

## Descriptions that contradicted the per-distro check logic

- **Login and logout events**: listed `lastlog`, `tallylog`, and `faillock` as universally monitored, but the per-distro logic requires `faillog` instead of `faillock` on Debian, `faillock` only on Red Hat and Amazon Linux, and just `lastlog` plus `tallylog` elsewhere. The description now states the per-distro requirements.
- **Network environment events**: stated `/etc/sysconfig/network` is monitored, but Debian and Red Hat systems may satisfy the check with `/etc/network`, and other distributions are not required to have a network directory watch at all.
- **DAC permission modification and unsuccessful file access**: both descriptions contained a note claiming that on ARM the `chmod`/`chown` or `creat`/`open` syscalls are not checked. The MQL has no such exception, so the notes promised a carve-out that does not exist and were removed. The underlying ARM gap in the MQL remains the known follow-up flagged in #2775.
- **System disabled when audit logs full**: omitted the `action_mail_acct = root` requirement the check enforces, and claimed both space actions must be `halt` or `single` when the low-space threshold accepts `email`, `exec`, `single`, or `halt`. The description now states all three required parameters and their accepted values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
