### PR TITLE
🧹 spelling: allow logouts

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -471,6 +471,7 @@ logingracetime
 logingracetime
 logname
 logons
+logouts
 logprofiles
 logsize
 logstreams


### PR DESCRIPTION
## Summary

The description-accuracy PR #2776 merged while its spell check was still red: the rewritten session-initiation description introduced the word `logouts`, which is not in the spelling allowlist. This adds it so the main branch spell check is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)