### PR TITLE
🧹 spelling: add logouts to expect list

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -471,6 +471,7 @@ logingracetime
 logingracetime
 logname
 logons
+logouts
 logprofiles
 logsize
 logstreams


### PR DESCRIPTION
PR #2776 introduced the word `logouts` in the Linux policy check descriptions (`content/mondoo-linux-security.mql.yaml:7112`) without adding it to the spelling expect list. The spell-check workflow now fails on every branch containing that commit. This adds `logouts` to `.github/actions/spelling/expect.txt` in sorted position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)