### PR TITLE
🐛 unifi: fix incorrect and incomplete remediations across the security policy

### DIFF
--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -160,6 +160,8 @@ queries:
             To declare a wireless network with WPA encryption in Terraform using the `ubiquiti-community/unifi` provider, set `security` to a non-open value (`wpapsk` for personal, `wpaeap` for enterprise) on every `unifi_wlan` resource:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -266,6 +268,8 @@ queries:
             To declare a wireless network with WPA2/WPA3 encryption in Terraform, set `security` to `wpapsk` (Personal) or `wpaeap` (Enterprise) on every `unifi_wlan` resource:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -367,6 +371,8 @@ queries:
             To enable WPA3 support on a wireless network in Terraform, set `wpa3_support = true` (and optionally `wpa3_transition = true` for backward-compatible mode) on every secured `unifi_wlan` resource:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -473,6 +479,8 @@ queries:
             To enable Protected Management Frames on a wireless network in Terraform, set `pmf_mode` to `"required"` or `"optional"` on every secured `unifi_wlan` resource:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -689,6 +697,8 @@ queries:
             To enable Layer 2 isolation on a guest wireless network in Terraform, set `l2_isolation = true` on every `unifi_wlan` resource that uses `is_guest = true`:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -795,6 +805,8 @@ queries:
             To mark a wireless network with a `guest`-style name as a guest network in Terraform, set `is_guest = true` on the `unifi_wlan` resource so guest network policy applies:
 
             ```hcl
+            # The provider exposes UniFi user groups as client QOS rates; this
+            # looks up the default user group for the required user_group_id.
             data "unifi_client_qos_rate" "default" {
             }
 
@@ -2365,6 +2377,7 @@ queries:
             ```hcl
             resource "unifi_network" "lan" {
               name          = "Default"
+              # The provider expects the gateway address in CIDR notation, not the network address.
               subnet        = "10.0.0.1/24"
               vlan          = 1
               igmp_snooping = true

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-unifi-security
     name: Mondoo Ubiquiti UniFi Security
-    version: 1.3.0
+    version: 1.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -160,12 +160,15 @@ queries:
             To declare a wireless network with WPA encryption in Terraform using the `ubiquiti-community/unifi` provider, set `security` to a non-open value (`wpapsk` for personal, `wpaeap` for enterprise) on every `unifi_wlan` resource:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "secure" {
-              name       = "internal"
-              security   = "wpapsk"
-              passphrase = var.wifi_passphrase
-              network_id = unifi_network.lan.id
-              user_group_id = data.unifi_user_group.default.id
+              name          = "internal"
+              security      = "wpapsk"
+              passphrase    = var.wifi_passphrase
+              network_id    = unifi_network.lan.id
+              user_group_id = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -263,12 +266,15 @@ queries:
             To declare a wireless network with WPA2/WPA3 encryption in Terraform, set `security` to `wpapsk` (Personal) or `wpaeap` (Enterprise) on every `unifi_wlan` resource:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "personal" {
-              name       = "internal"
-              security   = "wpapsk"
-              passphrase = var.wifi_passphrase
-              network_id = unifi_network.lan.id
-              user_group_id = data.unifi_user_group.default.id
+              name          = "internal"
+              security      = "wpapsk"
+              passphrase    = var.wifi_passphrase
+              network_id    = unifi_network.lan.id
+              user_group_id = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -361,6 +367,9 @@ queries:
             To enable WPA3 support on a wireless network in Terraform, set `wpa3_support = true` (and optionally `wpa3_transition = true` for backward-compatible mode) on every secured `unifi_wlan` resource:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "modern" {
               name            = "internal"
               security        = "wpapsk"
@@ -368,7 +377,7 @@ queries:
               wpa3_support    = true
               wpa3_transition = true
               network_id      = unifi_network.lan.id
-              user_group_id   = data.unifi_user_group.default.id
+              user_group_id   = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -464,13 +473,16 @@ queries:
             To enable Protected Management Frames on a wireless network in Terraform, set `pmf_mode` to `"required"` or `"optional"` on every secured `unifi_wlan` resource:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "with_pmf" {
               name          = "internal"
               security      = "wpapsk"
               passphrase    = var.wifi_passphrase
               pmf_mode      = "optional"
               network_id    = unifi_network.lan.id
-              user_group_id = data.unifi_user_group.default.id
+              user_group_id = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -516,7 +528,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      unifi.wlans.where(enabled == true && security != "open").all(wpaEnc == "ccmp" || wpaEnc == "gcmp256")
+      unifi.wlans.where(enabled == true && security != "open").all(wpaEnc == "ccmp" || wpaEnc == "gcmp-256")
     docs:
       desc: |
         This check ensures that all secured wireless networks use strong WPA encryption ciphers such as AES-CCMP or GCMP-256.
@@ -599,7 +611,7 @@ queries:
 
             1. Go to **Settings > WiFi**.
             2. Select each wireless network.
-            3. Under advanced settings, set the **Group Rekey Interval** to **3600** seconds or less.
+            3. Under advanced settings, set the **Group Rekey Interval** to a value between 1 and 3600 seconds, such as 3600. Do not set it to 0, which disables rekeying.
         # No cli remediation: wireless network security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/205231710
@@ -677,6 +689,9 @@ queries:
             To enable Layer 2 isolation on a guest wireless network in Terraform, set `l2_isolation = true` on every `unifi_wlan` resource that uses `is_guest = true`:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "guest" {
               name          = "guest"
               security      = "wpapsk"
@@ -684,7 +699,7 @@ queries:
               is_guest      = true
               l2_isolation  = true
               network_id    = unifi_network.guest.id
-              user_group_id = data.unifi_user_group.default.id
+              user_group_id = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -780,13 +795,16 @@ queries:
             To mark a wireless network with a `guest`-style name as a guest network in Terraform, set `is_guest = true` on the `unifi_wlan` resource so guest network policy applies:
 
             ```hcl
+            data "unifi_client_qos_rate" "default" {
+            }
+
             resource "unifi_wlan" "guest" {
               name          = "guest-wifi"
               security      = "wpapsk"
               passphrase    = var.guest_passphrase
               is_guest      = true
               network_id    = unifi_network.guest.id
-              user_group_id = data.unifi_user_group.default.id
+              user_group_id = data.unifi_client_qos_rate.default.id
             }
             ```
     refs:
@@ -813,9 +831,9 @@ queries:
   # ─── Threat Management ───────────────────────────────────────────────────────
   # No Terraform variants: the IPS/IDS toggle and `ipsMode` field live under UniFi's
   # Threat Management settings (`siteSettings.threatManagement.enabled` / `.ipsMode`).
-  # The ubiquiti-community/unifi provider exposes no threat-management settings —
-  # unifi_setting carries only `mgmt`, `radius`, and `usg` nested attributes. IPS can
-  # only be enabled in the controller UI under Settings > Security > Threat Management.
+  # The ubiquiti-community/unifi provider exposes the setting via the `ips` nested
+  # attribute on unifi_setting (`ips_mode`), so a Terraform remediation entry is
+  # provided below.
   - uid: mondoo-unifi-security-ips-enabled
     title: Ensure Intrusion Prevention System is enabled
     impact: 80
@@ -869,6 +887,19 @@ queries:
             3. Set the mode to **IPS** (Intrusion Prevention System).
             4. Review and enable appropriate threat categories for your environment.
         # No cli remediation: Threat Management is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable Threat Management in IPS mode in Terraform, set `ips_mode` to `ips` inside the `ips` attribute on the `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "ips" {
+              site = "default"
+
+              ips = {
+                ips_mode = "ips"
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
         title: UniFi Threat Management
@@ -979,6 +1010,7 @@ queries:
 
             1. Go to **Settings > Security > Threat Management**.
             2. Enable **Internal Honeypot**.
+            3. Select the network and the IP address to use for the honeypot.
         # No cli remediation: the internal honeypot is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
@@ -1500,7 +1532,7 @@ queries:
         # No cli remediation: global switch settings are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
         - id: terraform
           desc: |
-            To set the STP version to RSTP in Terraform, set `stp_version = "rstp"` on each `unifi_device` resource managing a switch. Note that the runtime check inspects the site-wide global switch STP version via `unifi.siteSettings.globalSwitch.stpVersion`; the ubiquiti-community/unifi provider only exposes STP per-device, so the variant scope is each declared switch device rather than the site default:
+            To set the STP version to RSTP in Terraform, set `stp_version = "rstp"` on each `unifi_device` resource that manages a switch. The check run against a live controller inspects the site-wide global switch STP version, while the ubiquiti-community/unifi provider only exposes STP per device, so this setting must be applied to every declared switch:
 
             ```hcl
             resource "unifi_device" "switch" {
@@ -1682,8 +1714,8 @@ queries:
             To disable device SSH password authentication using the UniFi Network web application:
 
             1. Go to **Settings > System > Advanced**.
-            2. If SSH must remain enabled, disable **SSH Password Authentication**.
-            3. Configure SSH key-based authentication instead.
+            2. Add an SSH public key for each administrator and verify key-based SSH access works.
+            3. Disable **SSH Password Authentication**.
         # No cli remediation: the device SSH authentication setting is a controller-managed site setting; the device SSH CLI cannot durably change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
@@ -1861,8 +1893,8 @@ queries:
           desc: |
             To enable automatic firmware upgrades using the UniFi Network web application:
 
-            1. Go to **Settings > System > Firmware**.
-            2. Enable **Auto Update**.
+            1. Go to **Settings > System > Updates**.
+            2. Enable automatic updates for device firmware.
             3. Configure the update window to a low-traffic period.
         # No cli remediation: the auto-update setting is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
         - id: terraform
@@ -2080,7 +2112,8 @@ queries:
             1. Go to **Settings > Routing > Port Forwarding**.
             2. Review all enabled port forwarding rules.
             3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
-            4. Use a VPN to access management interfaces remotely instead of port forwarding.
+            4. Remove or disable any rule whose destination IP belongs to an adopted UniFi device such as an access point, switch, or gateway.
+            5. Use a VPN to access management interfaces remotely instead of port forwarding.
         # No cli remediation: port forwarding rules are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
         - id: terraform
           desc: |
@@ -2125,9 +2158,9 @@ queries:
       )
 
   # No Terraform variants: DNS-over-HTTPS is configured under a `doh` site setting in the
-  # UniFi controller, but the ubiquiti-community/unifi unifi_setting resource only exposes
-  # `mgmt`, `radius`, and `usg` nested attributes — there is no `doh` block. The setting
-  # can only be toggled through the controller UI or the network-application API.
+  # UniFi controller. The ubiquiti-community/unifi provider exposes the setting via the
+  # `doh` nested attribute on unifi_setting (`state` accepts `off`, `auto`, `manual`, or
+  # `custom`), so a Terraform remediation entry is provided below.
   - uid: mondoo-unifi-security-dns-over-https-enabled
     title: Ensure DNS over HTTPS is enabled
     impact: 40
@@ -2146,10 +2179,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      unifi.siteSettings.doh.state != "disabled"
+      unifi.siteSettings.doh.state != "off"
     docs:
       desc: |
-        This check ensures that DNS over HTTPS (DoH) is not disabled on the UniFi controller. Any active state (such as "auto" or "enabled") is considered compliant.
+        This check ensures that DNS over HTTPS (DoH) is not turned off on the UniFi controller. The check fails when the DoH state is "off"; any other state, such as "auto", "manual", or "custom", is considered compliant.
 
         **Why this matters**
 
@@ -2178,6 +2211,20 @@ queries:
             1. Go to **Settings > Security > DNS Shield** or **Settings > Internet**.
             2. Enable **DNS over HTTPS**.
         # No cli remediation: DNS over HTTPS is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable DNS over HTTPS in Terraform, set `state` to a value other than `off` inside the `doh` attribute on the `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "doh" {
+              site = "default"
+
+              doh = {
+                state        = "auto"
+                server_names = ["cloudflare"]
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360052224054
         title: UniFi DNS settings
@@ -2313,15 +2360,14 @@ queries:
         # No cli remediation: network configuration is controller-managed; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
         - id: terraform
           desc: |
-            To enable IGMP snooping in Terraform, set `igmp_snooping = true` on each `unifi_network` resource. Note that the runtime check filters by `networkGroup == "LAN"`; the ubiquiti-community/unifi provider has no `network_group` argument, so the variant applies the assertion to every declared network — keep that in mind for non-LAN networks where snooping may not be desired:
+            To enable IGMP snooping in Terraform, set `igmp_snooping = true` on each `unifi_network` resource. The check run against a live controller filters networks by the LAN interface group; the ubiquiti-community/unifi provider has no equivalent argument, so the assertion applies to every declared network. Keep that in mind for non-LAN networks where snooping may not be desired:
 
             ```hcl
             resource "unifi_network" "lan" {
-              name           = "Default"
-              purpose        = "corporate"
-              subnet         = "10.0.0.0/24"
-              vlan_id        = 1
-              igmp_snooping  = true
+              name          = "Default"
+              subnet        = "10.0.0.1/24"
+              vlan          = 1
+              igmp_snooping = true
             }
             ```
     refs:
@@ -2394,12 +2440,12 @@ queries:
       remediation:
         - id: console
           desc: |
-            To set a modern protocol on a VPN server using the UniFi Network web application:
+            To replace a legacy VPN server using the UniFi Network web application:
 
             1. Go to **Settings > VPN > VPN Server**.
-            2. Select each VPN server configuration.
-            3. Set the protocol to **WireGuard** or **IPsec**.
-            4. Migrate any existing OpenVPN tunnels to a modern protocol.
+            2. Create a new VPN server that uses **WireGuard**, or create an IPsec tunnel under **Settings > VPN > Site-to-Site VPN**.
+            3. Migrate remote users to the new server configuration.
+            4. Remove the legacy OpenVPN server.
         # No cli remediation: VPN configuration is controller-managed; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
@@ -2510,12 +2556,11 @@ queries:
       remediation:
         - id: console
           desc: |
-            To set a modern protocol on a VPN client using the UniFi Network web application:
+            To replace a legacy VPN client using the UniFi Network web application:
 
             1. Go to **Settings > VPN > VPN Client**.
-            2. Select each VPN client configuration.
-            3. Set the protocol to **WireGuard** or **IPsec**.
-            4. Coordinate with the remote site to ensure protocol compatibility.
+            2. Create a new VPN client connection that uses **WireGuard** or **IPsec**, coordinating with the remote site for protocol compatibility.
+            3. Verify the new tunnel is connected, then remove the legacy OpenVPN client.
         # No cli remediation: VPN configuration is controller-managed; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115005445768
@@ -2580,7 +2625,7 @@ queries:
             1. Go to **Devices** and review devices showing available updates.
             2. Click **Update** on each device with a pending firmware upgrade.
             3. If devices fail to update, verify they are properly adopted and can reach the update servers.
-            4. Enable **Auto Update** under **Settings > System > Firmware** to prevent future drift.
+            4. Enable automatic updates under **Settings > System > Updates** to prevent future drift.
         # No cli remediation: firmware updates are orchestrated by the controller; the device SSH CLI has no supported firmware-update path that the controller will not revert.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204911424
@@ -2735,7 +2780,7 @@ queries:
           desc: |
             To enable Deep Packet Inspection using the UniFi Network web application:
 
-            1. Go to the security/system settings.
+            1. Go to **Settings > Security**. On older versions, go to **Settings > System**.
             2. Enable **Deep Packet Inspection**.
         # No cli remediation: DPI is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
@@ -2786,10 +2831,26 @@ queries:
           desc: |
             To enable geo-IP filtering using the UniFi Network web application:
 
-            1. Go to the gateway/internet security settings.
+            1. Go to **Settings > Security > Geo IP Filtering**. On older versions, go to **Settings > Internet Security**.
             2. Enable **Geo IP Filtering**.
             3. Choose **Block** (or **Allow**) mode, select the countries, and set the traffic direction (both, ingress, or egress) appropriate for your environment.
         # No cli remediation: gateway security is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
+        - id: terraform
+          desc: |
+            To enable geo-IP filtering in Terraform, set the `geo_ip_filtering_*` attributes inside the `usg` attribute on the `unifi_setting` resource:
+
+            ```hcl
+            resource "unifi_setting" "gateway" {
+              site = "default"
+
+              usg = {
+                geo_ip_filtering_enabled           = true
+                geo_ip_filtering_block             = "block"
+                geo_ip_filtering_countries         = "KP,IR"
+                geo_ip_filtering_traffic_direction = "both"
+              }
+            }
+            ```
     refs:
       - url: https://help.ui.com/hc/en-us/articles/115003173168
         title: UniFi gateway settings


### PR DESCRIPTION
## Summary

A full review of every remediation entry in the UniFi Security policy: 37 checks with console and terraform guidance compared against the check logic, with every claim verified against the cnquery unifi provider schema and fixtures and the ubiquiti-community/unifi Terraform provider v0.46.0 documentation. 20 checks needed fixes. Bumps the policy patch version.

Continues the per-policy review series: Linux (#2775), AWS (#2780), GCP (#2781), Azure (#2782), Kubernetes (#2783), OCI (#2784), Windows (#2785).

## Terraform snippets that fail validation

Six WLAN snippets referenced `data.unifi_user_group`, a data source the provider does not define; the documented lookup for the required `user_group_id` is the `unifi_client_qos_rate` data source, now used in all six. The IGMP snooping snippet used `purpose` and `vlan_id`, neither of which exists on `unifi_network`; it now uses the real `vlan` attribute.

## Checks comparing against values the controller never reports

- The strong-cipher check required `wpaEnc == "gcmp256"`, but the controller API reports the hyphenated `gcmp-256` (the provider passes the raw value through, and the Terraform provider enumerates the accepted set), so a GCMP-256 network could never pass; the query now accepts `ccmp` or `gcmp-256`.
- The DNS-over-HTTPS check failed when the state equaled `"disabled"`, a value the API never produces; the disabled state is `"off"`, so the check could never fail. Query and description corrected.

## Safety and lockout ordering

The SSH hardening steps disabled password authentication before any key was configured; they now add and verify administrator keys first. The group-rekey console step said "3600 seconds or less", which a value of 0 satisfies while disabling rekeying entirely and failing the check; it now requires a value between 1 and 3600.

## UI paths and incomplete steps

The VPN server and client entries told users to change the protocol on an existing connection, which the UniFi UI does not offer since protocol is fixed at creation; both now describe the create-migrate-remove flow. Firmware settings moved to **Settings > System > Updates**; the honeypot steps gained the required network and IP selection; the port-forwarding steps now also cover rules targeting adopted UniFi devices, which the check fails on; the DPI and Geo IP entries gained concrete navigation paths.

## New terraform entries

The provider now exposes the IPS mode, DNS-over-HTTPS state, and Geo IP filtering settings on `unifi_setting`; those three checks gained terraform entries with verified attributes. Three header comments noting possible Terraform check coverage for the cipher, group-rekey, and honeypot checks were left for a maintainer decision, since adding check variants changes scoring scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)