### PR TITLE
🐛 freebsd: fix remediations that lock out, misfire, or use Linux tools

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -27,6 +27,7 @@ allkeys
 allowaccess
 allowedip
 allowgroups
+allowservices
 allowusers
 alpm
 ampl
@@ -324,6 +325,7 @@ firstuser
 FLUSHALL
 fmask
 fnmatch
+FNR
 forti
 fortianalyzer
 fortiguard

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1076,6 +1076,12 @@ queries:
             sed -i '' 's/^ftp/#ftp/' /etc/inetd.conf
             ```
 
+            Reload inetd so the change takes effect:
+
+            ```bash
+            service inetd reload
+            ```
+
             If `inetd` is not needed at all, disable it:
 
             ```bash
@@ -1093,6 +1099,7 @@ queries:
             echo "Disabling FTP server..."
             if [ -f /etc/inetd.conf ]; then
               sed -i '' 's/^ftp/#ftp/' /etc/inetd.conf
+              service inetd reload 2>/dev/null || true
               echo "FTP entries commented out in /etc/inetd.conf."
             fi
 
@@ -1111,6 +1118,12 @@ queries:
                 path: /etc/inetd.conf
                 regexp: '^ftp'
                 replace: '#ftp'
+
+            - name: Reload inetd to apply the change
+              ansible.builtin.service:
+                name: inetd
+                state: reloaded
+              failed_when: false
             ```
   - uid: mondoo-freebsd-security-telnet-server-is-not-enabled
     title: Ensure telnet server is not enabled
@@ -1159,6 +1172,12 @@ queries:
             ```bash
             sed -i '' 's/^telnet/#telnet/' /etc/inetd.conf
             ```
+
+            Reload inetd so the change takes effect:
+
+            ```bash
+            service inetd reload
+            ```
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -1170,6 +1189,7 @@ queries:
             echo "Disabling telnet server..."
             if [ -f /etc/inetd.conf ]; then
               sed -i '' 's/^telnet/#telnet/' /etc/inetd.conf
+              service inetd reload 2>/dev/null || true
               echo "Telnet entries commented out in /etc/inetd.conf."
             fi
 
@@ -1188,6 +1208,12 @@ queries:
                 path: /etc/inetd.conf
                 regexp: '^telnet'
                 replace: '#telnet'
+
+            - name: Reload inetd to apply the change
+              ansible.builtin.service:
+                name: inetd
+                state: reloaded
+              failed_when: false
             ```
   - uid: mondoo-freebsd-security-nis-server-is-not-enabled
     title: Ensure NIS server is not enabled
@@ -1574,6 +1600,12 @@ queries:
             ```bash
             sed -i '' 's/^tftp/#tftp/' /etc/inetd.conf
             ```
+
+            Reload inetd so the change takes effect:
+
+            ```bash
+            service inetd reload
+            ```
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -1585,6 +1617,7 @@ queries:
             echo "Disabling TFTP server..."
             if [ -f /etc/inetd.conf ]; then
               sed -i '' 's/^tftp/#tftp/' /etc/inetd.conf
+              service inetd reload 2>/dev/null || true
               echo "TFTP entries commented out in /etc/inetd.conf."
             fi
 
@@ -1603,6 +1636,12 @@ queries:
                 path: /etc/inetd.conf
                 regexp: '^tftp'
                 replace: '#tftp'
+
+            - name: Reload inetd to apply the change
+              ansible.builtin.service:
+                name: inetd
+                state: reloaded
+              failed_when: false
             ```
   - uid: mondoo-freebsd-security-imap-and-pop3-server-is-not-enabled
     title: Ensure IMAP and POP3 server is not enabled
@@ -1624,8 +1663,8 @@ queries:
     mql: |
       service("dovecot").running == false
       service("dovecot").enabled == false
-      service("cyrus_imapd").running == false
-      service("cyrus_imapd").enabled == false
+      service("imapd").running == false
+      service("imapd").enabled == false
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=rc.conf&sektion=5
@@ -1657,7 +1696,7 @@ queries:
             sysrc dovecot_enable="NO"
             service dovecot stop
             sysrc cyrus_imapd_enable="NO"
-            service cyrus_imapd stop
+            service imapd stop
             ```
         - id: sh
           desc: |
@@ -1671,7 +1710,7 @@ queries:
             sysrc dovecot_enable="NO" 2>/dev/null || true
             service dovecot onestop 2>/dev/null || true
             sysrc cyrus_imapd_enable="NO" 2>/dev/null || true
-            service cyrus_imapd onestop 2>/dev/null || true
+            service imapd onestop 2>/dev/null || true
 
             echo "IMAP and POP3 services disabled."
             ```
@@ -1697,7 +1736,7 @@ queries:
                 state: stopped
               loop:
                 - dovecot
-                - cyrus_imapd
+                - imapd
               failed_when: false
             ```
   - uid: mondoo-freebsd-security-web-proxy-server-is-not-enabled
@@ -4018,7 +4057,13 @@ queries:
             awk -F: '$3 == 0 { print $1 }' /etc/passwd
             ```
 
-            Remove or change the UID of any account other than `root` that has UID 0.
+            FreeBSD ships a `toor` account that shares UID 0 with `root`. If it is not needed, remove it:
+
+            ```bash
+            pw userdel toor
+            ```
+
+            Remove any other UID 0 account with `pw userdel`, or assign it a unique UID with `pw usermod -u`.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -4102,7 +4147,7 @@ queries:
             Identify duplicate UIDs and assign unique UIDs to each user:
 
             ```bash
-            awk -F: '{print $3}' /etc/passwd | sort -n | uniq -d
+            awk -F: '$3 != 0 { print $3 }' /etc/passwd | sort -n | uniq -d
             ```
         - id: sh
           desc: |
@@ -4113,7 +4158,7 @@ queries:
             set -e
 
             echo "Checking for duplicate UIDs..."
-            DUPES=$(awk -F: '{print $3}' /etc/passwd | sort -n | uniq -d)
+            DUPES=$(awk -F: '$3 != 0 { print $3 }' /etc/passwd | sort -n | uniq -d)
 
             if [ -n "$DUPES" ]; then
               echo "WARNING: Duplicate UIDs found:"
@@ -4135,7 +4180,7 @@ queries:
 
             ```yaml
             - name: Find duplicate UIDs
-              ansible.builtin.shell: "awk -F: '{print $3}' /etc/passwd | sort -n | uniq -d"
+              ansible.builtin.shell: "awk -F: '$3 != 0 { print $3 }' /etc/passwd | sort -n | uniq -d"
               register: dup_uids
               changed_when: false
 
@@ -4436,20 +4481,22 @@ queries:
         To verify that every user's primary group exists in `/etc/group`, run the following command:
 
         ```bash
-        pwck -r
+        awk -F: 'NR==FNR { gids[$3]; next } !($4 in gids) { print $1 " GID " $4 }' /etc/group /etc/passwd
         ```
 
-        If `pwck` reports no missing groups, the check passes. If it reports a primary group that does not exist in `/etc/group`, the check fails.
+        If the command returns no output, the check passes. If it lists a user whose primary group does not exist in `/etc/group`, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using the CLI**
 
-            Identify users with missing groups and create the missing groups or reassign users:
+            Identify users whose primary group is missing from `/etc/group`:
 
             ```bash
-            pwck -r
+            awk -F: 'NR==FNR { gids[$3]; next } !($4 in gids) { print $1 " GID " $4 }' /etc/group /etc/passwd
             ```
+
+            Create each missing group with `pw groupadd -g <gid> <name>` or reassign the user's primary group with `pw usermod`.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -4483,16 +4530,15 @@ queries:
             2. Run the playbook, then create the missing groups or reassign the reported users.
 
             ```yaml
-            - name: Check passwd consistency
-              ansible.builtin.command: pwck -r
-              register: pwck_result
+            - name: Find users whose primary group is missing
+              ansible.builtin.shell: "awk -F: 'NR==FNR { gids[$3]; next } !($4 in gids) { print $1 }' /etc/group /etc/passwd"
+              register: missing_groups
               changed_when: false
-              failed_when: false
 
             - name: Fail when a primary group is missing
               ansible.builtin.fail:
-                msg: "pwck reported missing primary groups: {{ pwck_result.stdout }}"
-              when: "'no group' in pwck_result.stdout"
+                msg: "Users with missing primary groups: {{ missing_groups.stdout }}"
+              when: missing_groups.stdout | length > 0
             ```
   - uid: mondoo-freebsd-security-syslogd-is-enabled-and-running
     title: Ensure syslogd is enabled and running
@@ -4621,7 +4667,7 @@ queries:
             Enable secure mode for syslogd:
 
             ```bash
-            sysrc syslogd_flags="-s"
+            sysrc syslogd_flags+="-s"
             service syslogd restart
             ```
         - id: sh
@@ -4637,7 +4683,7 @@ queries:
             if echo "$CURRENT_FLAGS" | grep -q -- '-s'; then
               echo "syslogd_flags already contains -s."
             else
-              sysrc syslogd_flags="-s"
+              sysrc syslogd_flags+="-s"
             fi
 
             service syslogd restart
@@ -4656,6 +4702,7 @@ queries:
               community.general.sysrc:
                 name: syslogd_flags
                 value: '-s'
+                state: value_present
 
             - name: Restart the syslogd service
               ansible.builtin.service:
@@ -4801,12 +4848,12 @@ queries:
             echo "Configuring sudo to use pty..."
             # Check if use_pty is already configured
             HAS_USE_PTY=false
-            if grep -q 'use_pty' "$SUDOERS" 2>/dev/null; then
+            if grep -Eq '^[^#!]*Defaults[^#]*[[:space:],]use_pty' "$SUDOERS" 2>/dev/null; then
               HAS_USE_PTY=true
             fi
             if [ -d "$SUDOERS_D" ]; then
               for f in "$SUDOERS_D"/*; do
-                if [ -f "$f" ] && grep -q 'use_pty' "$f" 2>/dev/null; then
+                if [ -f "$f" ] && grep -Eq '^[^#!]*Defaults[^#]*[[:space:],]use_pty' "$f" 2>/dev/null; then
                   HAS_USE_PTY=true
                 fi
               done
@@ -4983,15 +5030,19 @@ queries:
           desc: |
             **Using the CLI**
 
+            Warning: Starting a firewall on a remote system can terminate your SSH session and lock you out. Run these commands from the system console, and confirm the rule set allows SSH before starting the firewall.
+
             Enable `ipfw`:
 
             ```bash
             sysrc firewall_enable="YES"
             sysrc firewall_type="workstation"
+            sysrc firewall_myservices="22/tcp"
+            sysrc firewall_allowservices="any"
             service ipfw start
             ```
 
-            Or enable `pf`:
+            Or enable `pf` after creating an `/etc/pf.conf` rule set that allows SSH:
 
             ```bash
             sysrc pf_enable="YES"
@@ -5000,6 +5051,8 @@ queries:
         - id: sh
           desc: |
             **Using a Shell Script**
+
+            Warning: Starting a firewall on a remote system can terminate your SSH session and lock you out. Run this script from the system console, and confirm the rule set allows SSH before starting the firewall.
 
             ```sh
             #!/bin/sh
@@ -5015,6 +5068,8 @@ queries:
               echo "No firewall enabled. Enabling ipfw in workstation mode..."
               sysrc firewall_enable="YES"
               sysrc firewall_type="workstation"
+              sysrc firewall_myservices="22/tcp"
+              sysrc firewall_allowservices="any"
               service ipfw start
 
               echo "ipfw firewall enabled in workstation mode."
@@ -5035,6 +5090,8 @@ queries:
               loop:
                 - { name: firewall_enable, value: 'YES' }
                 - { name: firewall_type, value: 'workstation' }
+                - { name: firewall_myservices, value: '22/tcp' }
+                - { name: firewall_allowservices, value: 'any' }
 
             - name: Start the ipfw service
               ansible.builtin.service:

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -1698,6 +1698,8 @@ queries:
             sysrc cyrus_imapd_enable="NO"
             service imapd stop
             ```
+
+            The cyrus-imapd port installs its rc script as `imapd` while keeping `cyrus_imapd_enable` as the rc.conf variable, so the two names differ by design.
         - id: sh
           desc: |
             **Using a Shell Script**

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -4669,7 +4669,7 @@ queries:
             Enable secure mode for syslogd:
 
             ```bash
-            sysrc syslogd_flags+="-s"
+            sysrc syslogd_flags+=" -s"
             service syslogd restart
             ```
         - id: sh
@@ -4685,7 +4685,7 @@ queries:
             if echo "$CURRENT_FLAGS" | grep -q -- '-s'; then
               echo "syslogd_flags already contains -s."
             else
-              sysrc syslogd_flags+="-s"
+              sysrc syslogd_flags+=" -s"
             fi
 
             service syslogd restart


### PR DESCRIPTION
## Summary

A full review of every remediation entry in the FreeBSD Security policy: 54 checks, each with cli, sh, and ansible entries, compared against the check logic with the cnquery BSD service manager and FreeBSD base tooling verified at the source. 10 checks needed fixes. Bumps the policy patch version.

Continues the per-policy review series: Linux (#2775), AWS (#2780), GCP (#2781), Azure (#2782), Kubernetes (#2783), OCI (#2784), Windows (#2785), UniFi (#2786), vSphere (#2787).

## A lockout hazard

The firewall remediation enabled ipfw with `firewall_type="workstation"` and started it, which blocks inbound connections not listed in `firewall_myservices` — running it over SSH drops the session and locks the administrator out. All three entries now set the SSH allowance first and carry an explicit warning to work from the console; the pf path now requires an SSH-allowing rule set before starting.

## A check half that could never fail

cnquery's BSD service manager keys services by rc script name, and the cyrus-imapd port installs its script as `imapd`, so `service("cyrus_imapd")` always resolved to a missing service that trivially passed even with cyrus running. The query now targets `imapd`, and all three remediation entries stop the right service (the `cyrus_imapd_enable` rc knob was already correct and stays).

## Fixes that left the exposure live

The FTP, telnet, and TFTP entries commented the service out of `/etc/inetd.conf` but never reloaded inetd, so the listener stayed active until something else restarted it; each entry now reloads inetd in all three forms.

## Linux tooling in a BSD policy

`pwck -r` is a Linux shadow-utils command absent from the FreeBSD base system, so the group-consistency cli command failed outright and the ansible play silently passed with `failed_when: false` hiding the error. The audit, cli, and ansible entries now use a portable awk lookup with `pw groupadd`/`pw usermod` guidance.

## False positives and silent skips

- The duplicate-UID scripts scanned every UID while the check and audit deliberately ignore UID 0, so stock installs with `root` and `toor` failed the script; all three now exclude UID 0, and the UID 0 check itself gained concrete `pw userdel toor` guidance instead of a vague instruction.
- `sysrc syslogd_flags="-s"` overwrote any other configured flags; the entries now append with `+=` and the ansible task uses `state: value_present`.
- The sudo `use_pty` idempotence guard matched a negated `Defaults !use_pty` line and skipped remediation while the check kept failing; the pattern now excludes negated entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)