### PR TITLE
🐛 m365: fix lockout-prone MFA guidance and never-fail checks

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.4.1
+    version: 2.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -154,22 +154,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To configure a Sign-In risk policy, use the following steps:**
+            **To configure a sign-in risk policy:**
 
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy.
-              - Under `Users or workload identities` choose `All users`
-              - Under `Cloud apps or actions` choose `All cloud apps`
-              - Under `Conditions` choose `Sign-in risk` then `Yes` and check the risk level boxes `High` and `Medium`
-              - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication`.
-              - Under `Session` select `Sign-in Frequency` and set to `Every time`.
-            5. Select `Select`
-            6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
-            7. Select `Create`.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Protection` > `Conditional Access` > `Policies`.
+            3. Select `New policy`.
+            4. Configure the policy:
+               - Under `Users or workload identities`, choose `All users` and exclude at least one emergency access account.
+               - Under `Cloud apps or actions`, choose `All cloud apps`.
+               - Under `Conditions` > `Sign-in risk`, set `Configure` to `Yes` and select the `High` and `Medium` risk levels.
+               - Under `Access controls` > `Grant`, select `Grant access` and check `Require multifactor authentication`.
+               - Under `Session`, select `Sign-in frequency` and choose `Every time`.
+            5. You may start the policy in `Report-only` mode to assess impact, but it must be set to `On` to be enforced.
+            6. Select `Create`.
 
-            **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
+            **NOTE:** For more information about risk levels, refer to [Microsoft Entra ID Protection risks](https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks).
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -180,7 +179,7 @@ queries:
             Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess", "Policy.Read.All", "Application.Read.All"
             ```
 
-            2. Create a new Conditional Access policy for sign-in risk:
+            2. Create a new Conditional Access policy for sign-in risk. When the sign-in frequency interval is `everyTime`, the `value` and `type` properties must be omitted:
 
             ```powershell
             $params = @{
@@ -189,6 +188,7 @@ queries:
                 conditions = @{
                     users = @{
                         includeUsers = @("All")
+                        excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
                     }
                     applications = @{
                         includeApplications = @("All")
@@ -201,11 +201,9 @@ queries:
                 }
                 sessionControls = @{
                     signInFrequency = @{
-                        value = 1
-                        type = "hours"
                         isEnabled = $true
-                        authenticationType = "primaryAndSecondaryAuthentication"
                         frequencyInterval = "everyTime"
+                        authenticationType = "primaryAndSecondaryAuthentication"
                     }
                 }
             }
@@ -213,7 +211,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform (azuread provider)**
+            **Using Terraform with the azuread provider**
 
             ```hcl
             resource "azuread_conditional_access_policy" "sign_in_risk_policy" {
@@ -223,6 +221,7 @@ queries:
               conditions {
                 users {
                   included_users = ["All"]
+                  excluded_users = [azuread_user.breakglass.object_id]
                 }
                 applications {
                   included_applications = ["All"]
@@ -236,8 +235,8 @@ queries:
               }
 
               session_controls {
-                sign_in_frequency        = 0
-                sign_in_frequency_period = "hours"
+                sign_in_frequency_interval            = "everyTime"
+                sign_in_frequency_authentication_type = "primaryAndSecondaryAuthentication"
               }
             }
             ```
@@ -365,22 +364,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To configure a User risk policy, use the following steps:**
+            **To configure a user risk policy:**
 
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy:
-              - Under `Users or workload identities` choose `All users`
-              - Under `Cloud apps or actions` choose `All cloud apps`
-              - Under `Conditions` choose `User risk` then `Yes` and select the user risk level `High`.
-              - Under `Access Controls` select `Grant` then in the right pane select `Grant access` then select `Require multifactor authentication` and `Require password change`.
-              - Under `Session` ensure `Sign-in frequency` is set to `Every time`.
-            5. Select `Select`.
-            6. You may opt to begin in a state of `Report Only` as you step through implementation however, the policy will need to be set to `On` to be in effect.
-            7. Select `Create`.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Protection` > `Conditional Access` > `Policies`.
+            3. Select `New policy`.
+            4. Configure the policy:
+               - Under `Users or workload identities`, choose `All users` and exclude at least one emergency access account.
+               - Under `Cloud apps or actions`, choose `All cloud apps`.
+               - Under `Conditions` > `User risk`, set `Configure` to `Yes` and select the `High` risk level.
+               - Under `Access controls` > `Grant`, select `Grant access`, then select `Require multifactor authentication` and `Require password change`.
+               - Under `Session`, ensure `Sign-in frequency` is set to `Every time`.
+            5. You may start the policy in `Report-only` mode to assess impact, but it must be set to `On` to be enforced.
+            6. Select `Create`.
 
-            **NOTE:** for more information regarding risk levels refer to [Microsoft's Identity Protection & Risk Doc](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/concept-identity-protection-risks)
+            **NOTE:** For more information about risk levels, refer to [Microsoft Entra ID Protection risks](https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks).
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -400,6 +398,7 @@ queries:
                 conditions = @{
                     users = @{
                         includeUsers = @("All")
+                        excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
                     }
                     applications = @{
                         includeApplications = @("All")
@@ -421,7 +420,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform (azuread provider)**
+            **Using Terraform with the azuread provider**
 
             ```hcl
             resource "azuread_conditional_access_policy" "user_risk_policy" {
@@ -431,6 +430,7 @@ queries:
               conditions {
                 users {
                   included_users = ["All"]
+                  excluded_users = [azuread_user.breakglass.object_id]
                 }
                 applications {
                   included_applications = ["All"]
@@ -444,8 +444,8 @@ queries:
               }
 
               session_controls {
-                sign_in_frequency        = 0
-                sign_in_frequency_period = "hours"
+                sign_in_frequency_interval            = "everyTime"
+                sign_in_frequency_authentication_type = "primaryAndSecondaryAuthentication"
               }
             }
             ```
@@ -572,16 +572,18 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To setup a conditional access policy to block legacy authentication, use the following steps:**
+            **To set up a Conditional Access policy that blocks legacy authentication:**
 
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
-            3. Create a new policy by selecting `New policy`.
-            4. Set the following conditions within the policy.
-              - Select `Conditions` then `Client apps` enable the settings for and `Exchange ActiveSync clients` and `other clients`.
-              - Under `Access controls` set the `Grant` section to `Block access`
-              - Under `Assignments` enable `All users`
-              - Under `Assignments` and `Users and groups` set the `Exclude` to be at least one low risk account or directory role. This is required as a best practice.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Protection` > `Conditional Access` > `Policies`.
+            3. Select `New policy`.
+            4. Configure the policy:
+               - Under `Users`, include `All users`, and under `Exclude`, add at least one emergency access account or directory role. This is required as a best practice so administrators are not locked out.
+               - Under `Target resources`, choose `All cloud apps`.
+               - Under `Conditions` > `Client apps`, set `Configure` to `Yes` and select only `Exchange ActiveSync clients` and `Other clients`.
+               - Under `Access controls` > `Grant`, select `Block access`.
+            5. Set `Enable policy` to `On`.
+            6. Select `Create`.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -764,18 +766,17 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To enable multi-factor authentication (MFA) for administrators:**
+            **To enable multifactor authentication for administrators:**
 
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Protection` > `Conditional Access` > `Policies`.
             3. Select `New policy`.
-            4. Go to `Assignments` > `Users and groups` > `Include` > `Select users and groups` > check `Directory roles`.
-            5. At a minimum, select the `Directory roles listed` below in this section of the document.
-            6. Go to `Cloud apps or actions` > `Cloud apps` > `Include` > select `All cloud apps (and don't exclude any apps)`.
-            7. Under `Access controls` > `Grant` > select `Grant access` > check `Require multi-factor authentication` (and nothing else).
-            8. Leave all other conditions blank.
-            9. Make sure the policy is enabled.
-            10. Create.
+            4. Go to `Users` > `Include` > `Select users and groups` and check `Directory roles`. At a minimum, select the directory roles listed below.
+            5. Under `Users` > `Exclude`, add at least one emergency access account so a failed MFA rollout cannot lock all administrators out of the tenant.
+            6. Go to `Target resources` > `Cloud apps` > `Include` and select `All cloud apps`.
+            7. Under `Access controls` > `Grant`, select `Grant access` and check `Require multifactor authentication`.
+            8. Start the policy in `Report-only` mode, confirm in the sign-in logs that no administrator would be blocked, then set it to `On`.
+            9. Select `Create`.
 
             **At minimum these directory roles should be included for MFA:**
 
@@ -826,7 +827,7 @@ queries:
             )
             ```
 
-            3. Create a Conditional Access policy for admin MFA:
+            3. Create the Conditional Access policy. Exclude at least one emergency access account, and consider creating the policy with `state = "enabledForReportingButNotEnforced"` first to validate impact:
 
             ```powershell
             $params = @{
@@ -835,6 +836,7 @@ queries:
                 conditions = @{
                     users = @{
                         includeRoles = $adminRoles
+                        excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
                     }
                     applications = @{
                         includeApplications = @("All")
@@ -849,11 +851,10 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform (azuread provider)**
+            **Using Terraform with the azuread provider**
 
             ```hcl
             data "azuread_directory_roles" "admin_roles" {
-              # Fetch all directory roles
             }
 
             locals {
@@ -883,6 +884,7 @@ queries:
               conditions {
                 users {
                   included_roles = [for role in data.azuread_directory_roles.admin_roles.roles : role.template_id if contains(local.admin_role_names, role.display_name)]
+                  excluded_users = [azuread_user.breakglass.object_id]
                 }
                 applications {
                   included_applications = ["All"]
@@ -1018,17 +1020,19 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To enable multi-factor authentication (MFA) for all users:**
+            **To enable multifactor authentication for all users:**
 
-            1. Navigate to the `Microsoft Entra admin center` https://entra.microsoft.com.
-            2. Select expand `Protection` > `Conditional Access` select `Policies`.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Protection` > `Conditional Access` > `Policies`.
             3. Select `New policy`.
-            4. Go to `Assignments` > `Users and groups` > `Include` > select `All users` (and do not exclude any user).
-            5. Select `Cloud apps or actions` > `All cloud apps` (and don't exclude any apps).
-            6. `Access Controls` > `Grant` > `Require multi-factor authentication` (and nothing else).
-            7. Leave all other conditions blank.
-            8. Make sure the policy is Enabled/On.
-            9. Create.
+            4. Go to `Users` > `Include` and select `All users`.
+            5. Under `Users` > `Exclude`, add at least one emergency access account so a failed MFA rollout cannot lock administrators out of the tenant.
+            6. Go to `Target resources` > `Cloud apps` > `Include` and select `All cloud apps`.
+            7. Under `Access controls` > `Grant`, select `Grant access` and check `Require multifactor authentication`.
+            8. Start the policy in `Report-only` mode, review the sign-in logs for unintended impact, then set it to `On`.
+            9. Select `Create`.
+
+            **WARNING:** Enforcing MFA tenant wide blocks sign-in for any user who has not registered an authentication method. Communicate the change and confirm registration coverage before enabling the policy.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -1039,7 +1043,7 @@ queries:
             Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess", "Policy.Read.All"
             ```
 
-            2. Create a Conditional Access policy requiring MFA for all users:
+            2. Create a Conditional Access policy requiring MFA for all users. Exclude at least one emergency access account:
 
             ```powershell
             $params = @{
@@ -1048,6 +1052,7 @@ queries:
                 conditions = @{
                     users = @{
                         includeUsers = @("All")
+                        excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
                     }
                     applications = @{
                         includeApplications = @("All")
@@ -1062,7 +1067,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            **Using Terraform (azuread provider)**
+            **Using Terraform with the azuread provider**
 
             ```hcl
             resource "azuread_conditional_access_policy" "require_mfa_all_users" {
@@ -1072,6 +1077,7 @@ queries:
               conditions {
                 users {
                   included_users = ["All"]
+                  excluded_users = [azuread_user.breakglass.object_id]
                 }
                 applications {
                   included_applications = ["All"]
@@ -1243,7 +1249,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(1,4))
+      microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(2,4))
     docs:
       desc: |
         This check ensures that the Global Administrator role is assigned to between two and four accounts. By default Microsoft 365 imposes no upper or lower bound on Global Administrator assignments, so tenants frequently end up either with a single point of failure or with an excessively large group of unrestricted privileged accounts.
@@ -1275,7 +1281,7 @@ queries:
 
         ```powershell
         Connect-MgGraph -Scopes "RoleManagement.Read.Directory"
-        $role = Get-MgDirectoryRole -Filter "displayName eq 'Global Administrator'"
+        $role = Get-MgDirectoryRole -Filter "roleTemplateId eq '62e90394-69f5-4237-9190-012177145e10'"
         Get-MgDirectoryRoleMember -DirectoryRoleId $role.Id
         ```
 
@@ -1310,10 +1316,10 @@ queries:
             Connect-MgGraph -Scopes "RoleManagement.ReadWrite.Directory", "User.Read.All"
             ```
 
-            2. Get the Global Administrator role:
+            2. Get the Global Administrator role. The directory roles endpoint only supports filtering by role template ID, and the Global Administrator template ID is fixed across all tenants:
 
             ```powershell
-            $globalAdminRole = Get-MgDirectoryRole -Filter "displayName eq 'Global Administrator'"
+            $globalAdminRole = Get-MgDirectoryRole -Filter "roleTemplateId eq '62e90394-69f5-4237-9190-012177145e10'"
             ```
 
             3. List current Global Administrators:
@@ -1423,13 +1429,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Microsoft 365 Console**
+            **Using the Microsoft Intune admin center:**
 
-            To update via the Microsoft 365 portal:
-            1. Log in to the Microsoft 365 portal at https://admin.microsoft.com
-            2. Endpoint Manager --> Devices --> Policy --> Configuration profiles
-            3. Ensure that a profile exists for Android with following conditions:
-               * Password section --> Device restrictions --> Encryption is set to require
+            1. Sign in to the Microsoft Intune admin center at https://intune.microsoft.com.
+            2. Go to `Devices` > `Manage devices` > `Configuration`.
+            3. Select `Create` > `New policy`.
+            4. For `Platform`, select `Android device administrator`. For `Profile type`, select `Device restrictions`.
+            5. In the `Password` section, set `Encryption` to `Require`.
+            6. Assign the profile to the appropriate device groups and select `Create`.
+
+            Note that Microsoft has deprecated Android device administrator management. Devices managed through Android Enterprise enforce storage encryption automatically, so this setting applies to remaining device administrator profiles.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -1533,14 +1542,13 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Microsoft 365 Console**
+            **Using the Microsoft Intune admin center:**
 
-            To update via the Microsoft 365 portal:
-
-            1. Log in as to the Microsoft 365 portal at https://admin.microsoft.com
-            2. Endpoint Manager --> Devices --> Policy --> Configuration profiles
-            3. Ensure that a profile exists for each Platform with following conditions:
-               * Password section --> Device restrictions --> Minimum password length is set to 8
+            1. Sign in to the Microsoft Intune admin center at https://intune.microsoft.com.
+            2. Go to `Devices` > `Manage devices` > `Configuration`.
+            3. For each managed platform, Windows 10 and later, macOS, iOS/iPadOS, Android device administrator, and Android Enterprise work profile, create or edit a `Device restrictions` profile.
+            4. In the `Password` section, set `Minimum password length` to `8` or higher. On iOS/iPadOS the setting is named `Minimum passcode length`.
+            5. Assign each profile to the appropriate device groups and save it.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -1591,6 +1599,16 @@ queries:
                 passwordMinimumLength = 8
             }
             New-MgDeviceManagementDeviceConfiguration -BodyParameter $androidParams
+            ```
+
+            **For Android Enterprise work profile:**
+            ```powershell
+            $workProfileParams = @{
+                "@odata.type" = "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration"
+                displayName = "Android Work Profile Password Policy"
+                passwordMinimumLength = 8
+            }
+            New-MgDeviceManagementDeviceConfiguration -BodyParameter $workProfileParams
             ```
 
             3. Assign policies to appropriate device groups.
@@ -1722,8 +1740,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      microsoft.domains.all(serviceConfigurationRecords.any(supportedService == "Email" && recordType == "Txt"))
-      microsoft.domains.all(serviceConfigurationRecords.where(supportedService == "Email" && recordType == "Txt").all(text == "v=spf1 include:spf.protection.outlook.com -all"))
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).params['TXT']['rData'].any(/v=spf1 /))
     docs:
       desc: |
         This check ensures that every Exchange Online domain has a published SPF (Sender Policy Framework) TXT record that explicitly authorizes Microsoft's mail servers. By default no SPF record is created automatically when a domain is added to Microsoft 365; it must be published manually at the DNS provider.
@@ -1773,8 +1790,8 @@ queries:
             **Using Azure DNS CLI:**
             ```bash
             az network dns record-set txt add-record \
-              --resource-group <resource-group> \
-              --zone-name <domain.com> \
+              --resource-group "example-rg" \
+              --zone-name "example.com" \
               --record-set-name "@" \
               --value "v=spf1 include:spf.protection.outlook.com -all"
             ```
@@ -1782,12 +1799,12 @@ queries:
             **Using AWS Route 53 CLI:**
             ```bash
             aws route53 change-resource-record-sets \
-              --hosted-zone-id <zone-id> \
+              --hosted-zone-id "Z0000000EXAMPLE" \
               --change-batch '{
                 "Changes": [{
                   "Action": "UPSERT",
                   "ResourceRecordSet": {
-                    "Name": "domain.com",
+                    "Name": "example.com",
                     "Type": "TXT",
                     "TTL": 3600,
                     "ResourceRecords": [{"Value": "\"v=spf1 include:spf.protection.outlook.com -all\""}]
@@ -1798,11 +1815,11 @@ queries:
 
             **Using Google Cloud DNS:**
             ```bash
-            gcloud dns record-sets create @ \
-              --zone=<zone-name> \
+            gcloud dns record-sets create "example.com." \
+              --zone="example-zone" \
               --type=TXT \
               --ttl=3600 \
-              --rrdatas="v=spf1 include:spf.protection.outlook.com -all"
+              --rrdatas='"v=spf1 include:spf.protection.outlook.com -all"'
             ```
         - id: terraform
           desc: |
@@ -1907,14 +1924,12 @@ queries:
       remediation:
         - id: console
           desc: |
-            **Using Microsoft 365 Console**
+            **Using the Microsoft Entra admin center:**
 
-            To update via the Microsoft 365 portal:
-            1. Log in as Global Administrator to the Microsoft 365 portal at https://admin.microsoft.com.
-            2. Navigate to "Azure Active Directory" in the "Admin Centers."
-            3. Go to "Users" > "User settings."
-            4. Under "App registrations," set "Users can register applications" to "No."
-            5. Save your changes.
+            1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com.
+            2. Go to `Identity` > `Users` > `User settings`.
+            3. Set `Users can register applications` to `No`.
+            4. Select `Save`.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -2020,11 +2035,17 @@ queries:
             Connect-ExchangeOnline
 
             # List DKIM signing configuration for all domains
-            Get-DkimSigningConfig
+            Get-DkimSigningConfig | Format-Table Domain, Enabled, Status
 
-            # Enable DKIM signing for a specific domain
+            # For a domain with no DKIM configuration yet, create one.
+            # The output includes the two selector CNAME records to publish in DNS.
+            New-DkimSigningConfig -DomainName "example.com" -Enabled $true
+
+            # For a domain that already has a configuration, enable signing
             Set-DkimSigningConfig -Identity "example.com" -Enabled $true
             ```
+
+            Enabling DKIM fails until the selector1 and selector2 CNAME records returned by `Get-DkimSigningConfig` are published in the domain's DNS zone. Publish the records, allow them to propagate, then run the enable command again.
         # No Terraform remediation: Exchange Online configuration has no Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure
@@ -2192,15 +2213,15 @@ queries:
           desc: |
             **To configure Safe Attachments policies:**
 
-            1. Navigate to the [Microsoft 365 Defender portal](https://security.microsoft.com).
+            1. Navigate to the [Microsoft Defender portal](https://security.microsoft.com).
             2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies**.
             3. Select **Safe Attachments**.
             4. Click **Create** to create a new policy.
             5. Configure the policy:
                - Name the policy and add a description.
                - Under **Users and domains**, add all users or specific groups.
-               - Under **Settings**, select **Dynamic Delivery** or **Block** as the Safe Attachments unknown malware response.
-               - Enable **Redirect attachment on detection** and specify a security admin email for review.
+               - Under **Settings**, select **Block** as the Safe Attachments unknown malware response. Choose **Dynamic Delivery** instead if you want the message body delivered while attachments are scanned.
+               - Under **Quarantine policy**, keep the default AdminOnlyAccessPolicy unless your review workflow requires otherwise.
             6. Click **Submit** to save the policy.
         - id: powershell
           desc: |
@@ -2212,9 +2233,7 @@ queries:
             # Create a Safe Attachments policy
             New-SafeAttachmentPolicy -Name "Organization Safe Attachments Policy" `
               -Enable $true `
-              -Action Block `
-              -Redirect $true `
-              -RedirectAddress "secadmin@example.com"
+              -Action Block
 
             # Create a Safe Attachments rule to apply the policy
             New-SafeAttachmentRule -Name "Organization Safe Attachments Rule" `
@@ -2248,10 +2267,15 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-4
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      ms365.exchangeonline.antiPhishPolicies.length > 0
+      ms365.exchangeonline.antiPhishPolicies.any(
+        enabled == true &&
+        enableMailboxIntelligence == true &&
+        enableMailboxIntelligenceProtection == true &&
+        enableSpoofIntelligence == true
+      )
     docs:
       desc: |
-        This check ensures that Microsoft Defender for Office 365 is configured with at least one anti-phishing policy. By default, a new tenant has no custom anti-phishing policies; without them, inbound mail receives only basic anti-spoofing checks and lacks impersonation protection for high-value users and trusted domains.
+        This check ensures that Microsoft Defender for Office 365 has an enabled anti-phishing policy with spoof intelligence, mailbox intelligence, and mailbox intelligence protection turned on. Without these protections, inbound mail receives only basic anti-spoofing checks and lacks impersonation protection for high-value users and trusted domains.
 
         **Why this matters**
 
@@ -2485,10 +2509,12 @@ queries:
             1. Navigate to the [Exchange admin center](https://admin.exchange.microsoft.com).
             2. Go to **Mail flow** > **Rules**.
             3. Click **Add a rule** > **Create a new rule**.
-            4. Name the rule (e.g., "Require TLS for outbound email").
+            4. Name the rule, for example `Require TLS for outbound email`.
             5. Under **Apply this rule if**, select **The recipient is external/internal** > **Outside the organization**.
             6. Under **Do the following**, select **Modify the message security** > **Require TLS encryption**.
-            7. Click **Save**.
+            7. Click **Save** and enable the rule.
+
+            **WARNING:** With this rule in place, messages addressed to mail servers that cannot negotiate TLS are not delivered and the sender receives a non-delivery report. Consider scoping the rule to sensitive senders or specific recipient domains first, then monitor non-delivery reports before extending it to all outbound mail.
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
@@ -2502,6 +2528,8 @@ queries:
               -RouteMessageOutboundRequireTls $true `
               -Priority 0
             ```
+
+            **WARNING:** Messages to recipients whose mail servers cannot negotiate TLS will bounce once this rule is active. Scope the rule with conditions such as `-RecipientDomainIs` for a staged rollout if your organization exchanges mail with partners that may not support TLS.
         # No Terraform remediation: Exchange Online transport rules have no Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules
@@ -2656,13 +2684,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            **To block automatic forwarding using the Microsoft Defender portal:**
+            **To block automatic forwarding:**
 
             1. Sign in to the [Microsoft Defender portal](https://security.microsoft.com).
             2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies** > **Anti-spam**.
             3. Open each outbound spam policy and select **Edit automatic forwarding**.
             4. Set the forwarding rule to **Off - Forwarding is disabled**.
             5. Save the policy.
+            6. Then open the [Exchange admin center](https://admin.exchange.microsoft.com), go to **Mail flow** > **Remote domains**, open each remote domain, and clear **Allow automatic forwarding**.
+
+            **NOTE:** Some remote domain entries exist specifically to allow forwarding to trusted partner domains. Disabling the setting stops mailbox rules from relaying mail to those domains, so review each entry with its owners before saving. To keep a narrow exception for specific users, use a dedicated outbound spam policy scoped to those users instead of a forwarding-enabled remote domain.
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
@@ -2675,9 +2706,13 @@ queries:
               Set-HostedOutboundSpamFilterPolicy -Identity $_.Name -AutoForwardingMode Off
             }
 
-            # Disable automatic forwarding on the default remote domain
-            Set-RemoteDomain -Identity Default -AutoForwardEnabled $false
+            # Disable automatic forwarding on every remote domain, not only Default
+            Get-RemoteDomain | ForEach-Object {
+              Set-RemoteDomain -Identity $_.Identity -AutoForwardEnabled $false
+            }
             ```
+
+            **NOTE:** Review the remote domain list before running the loop. Entries other than Default may exist to permit forwarding to specific partner domains, and this change disables that behavior for all of them.
         # No Terraform remediation: Exchange Online configuration has no Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding
@@ -2836,15 +2871,19 @@ queries:
           desc: |
             **To manage privileged roles with PIM using the Microsoft Entra admin center:**
 
+            Privileged Identity Management requires a Microsoft Entra ID P2 or Microsoft Entra ID Governance license. Confirm licensing before you begin.
+
             1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
             2. Go to **Identity governance** > **Privileged Identity Management** > **Microsoft Entra roles** > **Roles**.
             3. Select a privileged role, such as **Global Administrator**.
             4. Select **Add assignments**, choose the user, and set the assignment type to **Eligible**.
             5. For each role, open **Settings** and require MFA, justification, and approval on activation.
-            6. Remove the corresponding permanent (active) assignment once the eligible assignment is in place.
+            6. Remove the corresponding permanent active assignment once the eligible assignment is in place, keeping at least one emergency access account with a standing assignment.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
+
+            Privileged Identity Management requires a Microsoft Entra ID P2 or Microsoft Entra ID Governance license; the request below fails without it.
 
             ```powershell
             Connect-MgGraph -Scopes "RoleManagement.ReadWrite.Directory"


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2793). This PR covers `mondoo-m365-security.mql.yaml`: all 23 checks were reviewed and 16 needed fixes. Policy version bumped to 2.4.2. Check mql was verified against the ms365 provider schema; Graph API behavior was verified against Microsoft's documentation.

## Why these needed checking

The most serious problems were Conditional Access remediations that can lock an entire tenant out, Graph PowerShell calls that error before changing anything, and three checks whose logic could never fail or never pass regardless of what the user did.

## Remediations that can lock administrators out

- **mfa-all-users** explicitly instructed "select All users (and do not exclude any user)" and its PowerShell created an enabled tenant-wide MFA policy with no exclusions. If MFA registration is incomplete, that blocks every user including all administrators in one step. **mfa-admin-roles** had the same gap for every administrative role including Global Administrator. Both now exclude an emergency access account, stage the policy in report-only mode first, and warn about registration coverage, matching Microsoft's own deployment guidance.
- **transport-rules-tls** created a tenant-wide rule requiring TLS for all outbound mail with no warning that messages to non-TLS destinations bounce. The remediation now explains the impact and suggests scoping the rule for a staged rollout.

## Commands and configurations that fail as written

- **two-to-four-global-admins**: `Get-MgDirectoryRole -Filter "displayName eq ..."` returns `Request_UnsupportedQuery`; the directoryRoles endpoint only filters on `roleTemplateId`. Both the audit and remediation now filter on the fixed Global Administrator template ID.
- **sign-in-risk-policies**: the PowerShell set `signInFrequency` `value`/`type` together with `frequencyInterval = "everyTime"`, which Graph rejects; the Terraform used `sign_in_frequency = 0`, which the azuread provider refuses. Both now express "every time" correctly. **user-risk-policies** had the same Terraform defect.
- **spf-records**: the gcloud example used `@` as a record name, which gcloud does not accept; it now uses the FQDN with a trailing dot and properly quoted TXT data.
- **dkim-signing**: `Set-DkimSigningConfig` fails for domains with no existing DKIM configuration and until the selector CNAMEs are published; the remediation now covers `New-DkimSigningConfig` and the DNS prerequisite.
- **safe-attachments** paired `-Action Block` with `-Redirect $true`, but redirect is only honored with Monitor and Microsoft has deprecated the redirect feature; the pairing was removed.

## Checks that could never fail or never pass (mql)

- **spf-records** read `serviceConfigurationRecords` from Graph, which is Microsoft's recommended record set, not live DNS: it always contains the recommended SPF record, so the check always passed and publishing a record changed nothing it read. The check now queries live DNS for `v=spf1` TXT records, using the same idiom as the DMARC check in this policy.
- **anti-phishing-policies** asserted `antiPhishPolicies.length > 0`, but every tenant ships with the built-in default policy, so the check could never fail. It now verifies an enabled policy with spoof intelligence and mailbox intelligence protections turned on, which is what the remediation configures.
- **two-to-four-global-admins** used `inRange(1,4)` while the title, docs, and compliance mappings all require two to four; a tenant with a single global admin wrongly passed. Now `inRange(2,4)`.

## Stale portal navigation

Several console entries pointed at retired admin surfaces: "Endpoint Manager" via admin.microsoft.com for the two Intune device checks (now the Intune admin center with the current Devices > Configuration path, plus the Android device administrator deprecation note), and "Azure Active Directory in the Admin Centers" for third-party apps (now the Entra admin center). **block-legacy-authentication**'s console steps also stopped before targeting cloud apps, enabling the policy, or creating it. **block-external-auto-forwarding** only fixed the Default remote domain while the check requires all remote domains; **mobile-min-password-length** omitted the Android work profile platform the check inspects; **require-pim** never mentioned the Entra ID P2 licensing requirement without which every step fails.

## Left for maintainers

Three platform queries compare Secure Score controls against exact maximum values (`SigninRiskPolicy`/`BlockLegacyAuthentication` score equality, `MFARegistrationV2 == 9`). Secure Score values are proportional floats, so partial coverage, or even the break-glass exclusion these very remediations require, can hold the score fractionally below maximum indefinitely, and `MFARegistrationV2` measures user registration rather than policy existence. Evaluating `microsoft.conditionalAccess.policies` directly would make these checks deterministic; deliberately not changed here since it alters check semantics.

## Validation

- `cnspec policy lint` passes (compiles all modified mql)
- YAML parses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)