### PR TITLE
🐛 ai-security: point remediations at the paths and IDs the checks actually read

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -36,6 +36,7 @@ AMQP
 ANSSI
 antispam
 ANVA
+anysphere
 apachectl
 apigatewayv
 apikey
@@ -204,6 +205,7 @@ ctl
 ctx
 CUSTOMERID
 CYAAAAAAAKEY
+cursorpyright
 cyclonedx
 cyserver
 databricks
@@ -413,6 +415,7 @@ initscripts
 inodes
 insertafter
 installable
+intellij
 interoperates
 intransit
 iommu
@@ -795,6 +798,7 @@ STARTTLS
 stdio
 stepfunctions
 stylesheet
+subfolders
 subnetted
 subnetting
 subpaths

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -2635,7 +2635,7 @@ queries:
             ```
 
   - uid: mondoo-ai-security-no-vscode-codex-extension
-    title: No OpenAI Codex extensions in VS Code-compatible editors
+    title: No OpenAI extensions in VS Code-compatible editors
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
@@ -2657,7 +2657,7 @@ queries:
       ).length == 0
     docs:
       desc: |
-        OpenAI Codex extensions installed in VS Code-compatible editors transmit source code to OpenAI's cloud models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        Extensions from the OpenAI publisher installed in VS Code-compatible editors, such as the Codex extension `openai.chatgpt`, transmit source code to OpenAI's cloud models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
 
         **Why this matters**
 
@@ -2666,7 +2666,7 @@ queries:
         - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
         - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
       audit: |-
-        To verify that no OpenAI Codex extension is installed:
+        To verify that no OpenAI extension is installed:
 
         1. Open a terminal on the endpoint.
         2. List installed extensions for each VS Code-compatible editor and search for the OpenAI publisher:
@@ -2681,11 +2681,11 @@ queries:
       remediation:
         - id: gui
           desc: |
-            To remove the OpenAI Codex extension from within the editor:
+            To remove an OpenAI extension from within the editor:
 
             1. Open the Extensions view (`Cmd+Shift+X` on macOS, `Ctrl+Shift+X` on Windows and Linux).
-            2. Search for Codex.
-            3. Select the extension and click **Uninstall**.
+            2. Search for OpenAI.
+            3. Select any extension from the OpenAI publisher and click **Uninstall**.
         - id: cli
           desc: |
             The Codex extension is published under the identifier `openai.chatgpt`. To uninstall it from whichever editor has it installed:

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-ai-security
     name: Mondoo AI Security
-    version: 2.0.0
+    version: 2.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -149,37 +149,37 @@ queries:
             3. On Windows, open **Settings > Apps > Installed apps**, locate the tool, and select **Uninstall**.
         - id: cli
           desc: |
-            To identify, terminate, and uninstall an unapproved AI tool from the command line:
+            To identify, terminate, and uninstall an unapproved AI tool from the command line, search for the same executable names the check matches. The commands below use Ollama as the example; repeat the kill and uninstall steps for each unapproved tool you find.
 
             macOS:
 
             ```bash
-            ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
-            kill <PID>
-            brew uninstall <tool_name>
+            ps aux | grep -iE 'ollama|llama|lmstudio|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|zed|chatgpt'
+            pkill -f ollama
+            brew uninstall ollama
             ```
 
             Linux:
 
             ```bash
-            ps aux | grep -iE 'ollama|lmstudio|cursor|windsurf|codeium'
-            kill <PID>
-            sudo apt remove <package_name>   # Debian/Ubuntu
-            sudo dnf remove <package_name>   # RHEL/Fedora
+            ps aux | grep -iE 'ollama|llama|lmstudio|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|zed|chatgpt'
+            pkill -f ollama
+            sudo apt remove ollama   # Debian/Ubuntu
+            sudo dnf remove ollama   # RHEL/Fedora
             ```
 
             Windows:
 
             ```powershell
-            Get-Process | Where-Object { $_.Name -match 'ollama|lmstudio|cursor|windsurf|codeium' }
-            Stop-Process -Name <process_name>
-            winget uninstall <tool_name>
+            Get-Process | Where-Object { $_.Name -match 'ollama|llama|lmstudio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|zed|chatgpt' }
+            Stop-Process -Name ollama
+            winget uninstall Ollama
             ```
         - id: ansible
           desc: |
             To stop and remove unapproved AI agent processes with Ansible:
 
-            This playbook terminates any running AI processes matching the known tool names and removes the associated packages. The `unapproved_ai_packages` list below holds placeholder values — replace them with the package names flagged on your endpoints.
+            This playbook terminates any running AI processes matching the executable names the check inspects and removes the associated packages. The `unapproved_ai_packages` list holds placeholder values; replace them with the package names flagged on your endpoints.
 
             ```yaml
             ---
@@ -191,10 +191,19 @@ queries:
                     cmd: pkill -f "{{ item }}"
                   loop:
                     - ollama
+                    - llama
                     - lmstudio
+                    - lm-studio
+                    - localai
+                    - gpt4all
                     - cursor
                     - windsurf
                     - codeium
+                    - tabby
+                    - codex
+                    - goose
+                    - zed
+                    - chatgpt
                   failed_when: false
 
             - name: Remove unapproved AI packages (system)
@@ -269,34 +278,34 @@ queries:
             To remove an unapproved AI package using the operating system interface:
 
             1. On Windows, open **Settings > Apps > Installed apps**, locate the tool, and select **Uninstall**.
-            2. On macOS, open the app's installer or drag the application from `/Applications` to the Trash.
+            2. On macOS, quit the application and drag it from `/Applications` to the Trash. If the tool shipped with an uninstaller app, run that instead so package receipts are removed.
         - id: cli
           desc: |
-            To remove an unapproved AI package using the system package manager:
+            To remove an unapproved AI package using the system package manager, with Ollama as the example:
 
             macOS:
 
             ```bash
-            brew uninstall <package_name>
+            brew uninstall ollama
             ```
 
             Linux:
 
             ```bash
-            sudo apt remove <package_name>   # Debian/Ubuntu
-            sudo dnf remove <package_name>   # RHEL/Fedora
+            sudo apt remove ollama   # Debian/Ubuntu
+            sudo dnf remove ollama   # RHEL/Fedora
             ```
 
             Windows:
 
             ```powershell
-            winget uninstall <package_name>
+            winget uninstall Ollama
             ```
         - id: ansible
           desc: |
             To remove unapproved AI packages installed via system package managers with Ansible:
 
-            This playbook removes unapproved AI packages from the system package manager on Linux and macOS endpoints. The `unapproved_ai_packages` list below holds placeholder values — replace them with the package names flagged on your endpoints.
+            This playbook removes unapproved AI packages through the system package manager on Linux endpoints. On macOS, packages installed through Homebrew are covered by the Homebrew playbook in the Homebrew check; applications installed outside a package manager must be removed through their own uninstallers. The `unapproved_ai_packages` list holds placeholder values; replace them with the package names flagged on your endpoints.
 
             ```yaml
             ---
@@ -447,6 +456,7 @@ queries:
 
             1. On macOS, quit Cursor and drag the application from `/Applications` to the Trash.
             2. On Windows, open **Settings > Apps > Installed apps**, locate Cursor, and select **Uninstall**.
+            3. Delete the leftover configuration folder, which the uninstaller does not remove and which is what this check inspects. On macOS, open Finder, choose **Go > Go to Folder**, enter `~/.cursor`, and move the folder to the Trash. On Windows, delete the `.cursor` folder in your user profile directory using File Explorer.
         - id: cli
           desc: |
             To uninstall Cursor and remove its configuration from the command line:
@@ -540,6 +550,7 @@ queries:
 
             1. On macOS, quit Windsurf and drag the application from `/Applications` to the Trash.
             2. On Windows, open **Settings > Apps > Installed apps**, locate Windsurf, and select **Uninstall**.
+            3. Delete the leftover configuration folder, which the uninstaller does not remove and which is what this check inspects. On macOS, open Finder, choose **Go > Go to Folder**, enter `~/.codeium/windsurf`, and move the folder to the Trash. On Windows, delete the `.codeium\windsurf` folder in your user profile directory using File Explorer.
         - id: cli
           desc: |
             To uninstall Windsurf and remove its configuration from the command line:
@@ -633,6 +644,7 @@ queries:
 
             1. On macOS, quit Goose and drag the application from `/Applications` to the Trash.
             2. On Windows, open **Settings > Apps > Installed apps**, locate Goose, and select **Uninstall**.
+            3. Delete the leftover configuration folder, which the uninstaller does not remove and which is what this check inspects. On macOS, open Finder, choose **Go > Go to Folder**, enter `~/.config/goose`, and move the folder to the Trash. On Windows, delete the `.config\goose` folder in your user profile directory using File Explorer.
         - id: cli
           desc: |
             To remove the Goose configuration from the command line:
@@ -646,7 +658,7 @@ queries:
             Windows:
 
             ```powershell
-            Remove-Item -Recurse -Force "$env:APPDATA\goose"
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.config\goose"
             ```
         - id: ansible
           desc: |
@@ -713,6 +725,7 @@ queries:
             To remove Zed using the operating system interface:
 
             1. On macOS, quit Zed and drag the application from `/Applications` to the Trash.
+            2. Delete the leftover configuration folder, which is what this check inspects. Open Finder, choose **Go > Go to Folder**, enter `~/.config/zed`, and move the folder to the Trash.
         - id: cli
           desc: |
             To remove the Zed configuration from the command line:
@@ -784,45 +797,48 @@ queries:
         To verify that Cline is not configured on the endpoint:
 
         1. Open a terminal on the endpoint.
-        2. Check for the Cline configuration directory:
+        2. Check for the shared agent skills directory that Cline reads and the Cline configuration directory:
 
            ```bash
-           ls -d ~/.cline 2>/dev/null
+           ls -d ~/.agents/skills ~/.cline 2>/dev/null
            ```
 
-        The endpoint passes when no Cline configuration directory exists. A directory containing configured skills is a failing result.
+        The endpoint passes when the shared skills directory contains no skills. A `~/.agents/skills` directory containing skill definitions is a failing result.
       remediation:
         - id: cli
           desc: |
-            To remove the Cline configuration from the command line:
+            Cline reads agent skills from the shared `~/.agents/skills` directory rather than its own configuration folder. Remove the skill definitions there, and remove the Cline configuration directory as well. The shared directory may also be used by other agents that follow the same skills convention; if an approved tool relies on it, delete only the unapproved skill subfolders instead of the whole directory.
 
             macOS and Linux:
 
             ```bash
+            rm -rf ~/.agents/skills
             rm -rf ~/.cline
             ```
 
             Windows:
 
             ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\skills"
             Remove-Item -Recurse -Force "$env:USERPROFILE\.cline"
             ```
         - id: ansible
           desc: |
-            To remove Cline configuration directories with Ansible:
+            To remove Cline skills and configuration with Ansible:
 
-            This playbook removes the Cline agent configuration directory from the endpoint.
+            This playbook removes the shared agent skills directory that Cline reads and the Cline configuration directory.
 
             ```yaml
             ---
             - name: Remove Cline
               hosts: workstations
               tasks:
-                - name: Remove Cline configuration directories
+                - name: Remove Cline skills and configuration directories
                   ansible.builtin.file:
                     path: "{{ item }}"
                     state: absent
                   loop:
+                    - "{{ ansible_env.HOME }}/.agents/skills"
                     - "{{ ansible_env.HOME }}/.cline"
             ```
 
@@ -1105,7 +1121,7 @@ queries:
             Windows:
 
             ```powershell
-            Remove-Item -Recurse -Force "$env:APPDATA\opencode"
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.config\opencode"
             ```
         - id: ansible
           desc: |
@@ -1834,13 +1850,13 @@ queries:
         To verify that Warp is not configured on the endpoint:
 
         1. Open a terminal on the endpoint.
-        2. Check for the Warp configuration directory:
+        2. Check for the shared agent skills directory that Warp reads and the Warp configuration directory:
 
            ```bash
-           ls -d ~/.warp 2>/dev/null
+           ls -d ~/.agents/skills ~/.warp 2>/dev/null
            ```
 
-        The endpoint passes when no Warp configuration directory exists. A directory containing configured skills is a failing result.
+        The endpoint passes when the shared skills directory contains no skills. A `~/.agents/skills` directory containing skill definitions is a failing result.
       remediation:
         - id: gui
           desc: |
@@ -1848,37 +1864,41 @@ queries:
 
             1. On macOS, quit Warp and drag the application from `/Applications` to the Trash.
             2. On Windows, open **Settings > Apps > Installed apps**, locate Warp, and select **Uninstall**.
+            3. Delete the shared agent skills folder that Warp reads, which is what this check inspects. On macOS, open Finder, choose **Go > Go to Folder**, enter `~/.agents/skills`, and move the folder to the Trash. On Windows, delete the `.agents\skills` folder in your user profile directory using File Explorer.
         - id: cli
           desc: |
-            To remove the Warp configuration from the command line:
+            Warp reads agent skills from the shared `~/.agents/skills` directory rather than its own configuration folder. Remove the skill definitions there, and remove the Warp configuration directory as well. The shared directory may also be used by other agents that follow the same skills convention; if an approved tool relies on it, delete only the unapproved skill subfolders instead of the whole directory.
 
             macOS and Linux:
 
             ```bash
+            rm -rf ~/.agents/skills
             rm -rf ~/.warp
             ```
 
             Windows:
 
             ```powershell
+            Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\skills"
             Remove-Item -Recurse -Force "$env:USERPROFILE\.warp"
             ```
         - id: ansible
           desc: |
-            To remove Warp AI terminal configuration directories with Ansible:
+            To remove Warp skills and configuration with Ansible:
 
-            This playbook removes the Warp terminal configuration directory from the endpoint.
+            This playbook removes the shared agent skills directory that Warp reads and the Warp configuration directory.
 
             ```yaml
             ---
             - name: Remove Warp
               hosts: workstations
               tasks:
-                - name: Remove Warp configuration directories
+                - name: Remove Warp skills and configuration directories
                   ansible.builtin.file:
                     path: "{{ item }}"
                     state: absent
                   loop:
+                    - "{{ ansible_env.HOME }}/.agents/skills"
                     - "{{ ansible_env.HOME }}/.warp"
             ```
 
@@ -2633,7 +2653,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
-        identifier == /(?i)openai\.codex/
+        identifier == /(?i)openai\./
       ).length == 0
     docs:
       desc: |
@@ -2649,15 +2669,15 @@ queries:
         To verify that no OpenAI Codex extension is installed:
 
         1. Open a terminal on the endpoint.
-        2. List installed extensions for each VS Code-compatible editor and search for Codex:
+        2. List installed extensions for each VS Code-compatible editor and search for the OpenAI publisher:
 
            ```bash
-           code --list-extensions | grep -i codex
-           cursor --list-extensions | grep -i codex
-           windsurf --list-extensions | grep -i codex
+           code --list-extensions | grep -i 'openai.'
+           cursor --list-extensions | grep -i 'openai.'
+           windsurf --list-extensions | grep -i 'openai.'
            ```
 
-        The endpoint passes when none of the editors return a Codex extension. Any line beginning with `openai.codex` is a failing result.
+        The endpoint passes when none of the editors return an OpenAI extension. Any line beginning with `openai.`, such as the Codex extension `openai.chatgpt`, is a failing result.
       remediation:
         - id: gui
           desc: |
@@ -2668,18 +2688,18 @@ queries:
             3. Select the extension and click **Uninstall**.
         - id: cli
           desc: |
-            To uninstall the OpenAI Codex extension from whichever editor has it installed:
+            The Codex extension is published under the identifier `openai.chatgpt`. To uninstall it from whichever editor has it installed:
 
             ```bash
-            code --uninstall-extension openai.codex       # VS Code
-            cursor --uninstall-extension openai.codex     # Cursor
-            windsurf --uninstall-extension openai.codex   # Windsurf
+            code --uninstall-extension openai.chatgpt       # VS Code
+            cursor --uninstall-extension openai.chatgpt     # Cursor
+            windsurf --uninstall-extension openai.chatgpt   # Windsurf
             ```
         - id: ansible
           desc: |
             To remove the OpenAI Codex extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the OpenAI Codex extension from VS Code, Cursor, and Windsurf on the endpoint.
+            This playbook uninstalls the Codex extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
@@ -2688,7 +2708,7 @@ queries:
               tasks:
                 - name: Uninstall the OpenAI Codex extension from each editor
                   ansible.builtin.command:
-                    cmd: "{{ item }} --uninstall-extension openai.codex"
+                    cmd: "{{ item }} --uninstall-extension openai.chatgpt"
                   loop:
                     - code
                     - cursor
@@ -2752,18 +2772,18 @@ queries:
             3. Select the extension and click **Uninstall**.
         - id: cli
           desc: |
-            To uninstall the Anthropic Claude extension from whichever editor has it installed:
+            The Claude Code extension is published under the identifier `anthropic.claude-code`. To uninstall it from whichever editor has it installed:
 
             ```bash
-            code --uninstall-extension anthropic.claude       # VS Code
-            cursor --uninstall-extension anthropic.claude     # Cursor
-            windsurf --uninstall-extension anthropic.claude   # Windsurf
+            code --uninstall-extension anthropic.claude-code       # VS Code
+            cursor --uninstall-extension anthropic.claude-code     # Cursor
+            windsurf --uninstall-extension anthropic.claude-code   # Windsurf
             ```
         - id: ansible
           desc: |
             To remove the Anthropic Claude extension from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls the Anthropic Claude extension from VS Code, Cursor, and Windsurf on the endpoint.
+            This playbook uninstalls the Claude Code extension from VS Code, Cursor, and Windsurf on the endpoint.
 
             ```yaml
             ---
@@ -2772,7 +2792,7 @@ queries:
               tasks:
                 - name: Uninstall the Anthropic Claude extension from each editor
                   ansible.builtin.command:
-                    cmd: "{{ item }} --uninstall-extension anthropic.claude"
+                    cmd: "{{ item }} --uninstall-extension anthropic.claude-code"
                   loop:
                     - code
                     - cursor
@@ -2801,7 +2821,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       vscode.extensions.where(
-        identifier == /(?i)cursor\./
+        identifier == /(?i)(cursor|anysphere)\./
       ).length == 0
     docs:
       desc: |
@@ -2820,43 +2840,44 @@ queries:
         2. List installed extensions for each VS Code-compatible editor and search for Cursor publishers:
 
            ```bash
-           code --list-extensions | grep -i 'cursor.'
-           cursor --list-extensions | grep -i 'cursor.'
-           windsurf --list-extensions | grep -i 'cursor.'
+           code --list-extensions | grep -iE 'cursor\.|anysphere\.'
+           cursor --list-extensions | grep -iE 'cursor\.|anysphere\.'
+           windsurf --list-extensions | grep -iE 'cursor\.|anysphere\.'
            ```
 
-        The endpoint passes when none of the editors return a Cursor-specific extension. Any line beginning with `cursor.` is a failing result.
+        The endpoint passes when none of the editors return a Cursor-specific extension. Any line beginning with `cursor.` or `anysphere.`, the publisher namespace Cursor uses, is a failing result.
       remediation:
         - id: gui
           desc: |
-            To remove a Cursor-specific extension from within the editor:
+            To remove a Cursor extension from within the editor:
 
             1. Open the Extensions view (`Cmd+Shift+X` on macOS, `Ctrl+Shift+X` on Windows and Linux).
-            2. Search for the extension.
+            2. Search for the flagged extension.
             3. Select the extension and click **Uninstall**.
         - id: cli
           desc: |
-            To uninstall a Cursor-specific extension from whichever editor has it installed:
+            Cursor publishes its extensions under the `anysphere` namespace. Set the variable to the `publisher.extension` identifier flagged on the endpoint, then uninstall it from whichever editor has it installed:
 
             ```bash
-            code --uninstall-extension <cursor.extension-name>       # VS Code
-            cursor --uninstall-extension <cursor.extension-name>     # Cursor
-            windsurf --uninstall-extension <cursor.extension-name>   # Windsurf
+            extension_id="anysphere.cursorpyright"
+            code --uninstall-extension "$extension_id"       # VS Code
+            cursor --uninstall-extension "$extension_id"     # Cursor
+            windsurf --uninstall-extension "$extension_id"   # Windsurf
             ```
         - id: ansible
           desc: |
-            To remove Cursor-specific extensions from VS Code-compatible editors with Ansible:
+            To remove Cursor extensions from VS Code-compatible editors with Ansible:
 
-            This playbook uninstalls a Cursor-specific extension from VS Code, Cursor, and Windsurf on the endpoint. The `cursor_extension_name` value is a placeholder — replace it with the `publisher.extension` identifier flagged on your endpoints.
+            This playbook uninstalls a Cursor extension from VS Code, Cursor, and Windsurf on the endpoint. The `cursor_extension_name` value is a placeholder; replace it with the `publisher.extension` identifier flagged on your endpoints.
 
             ```yaml
             ---
-            - name: Remove the Cursor-specific extension from VS Code-compatible editors
+            - name: Remove the Cursor extension from VS Code-compatible editors
               hosts: workstations
               vars:
-                cursor_extension_name: cursor.example-extension
+                cursor_extension_name: anysphere.cursorpyright
               tasks:
-                - name: Uninstall the Cursor-specific extension from each editor
+                - name: Uninstall the Cursor extension from each editor
                   ansible.builtin.command:
                     cmd: "{{ item }} --uninstall-extension {{ cursor_extension_name }}"
                   loop:
@@ -2998,31 +3019,34 @@ queries:
         To verify that only approved MCP servers are configured:
 
         1. Open a terminal on the endpoint.
-        2. Inspect each agent's configuration for an `mcpServers` section:
+        2. Inspect the locations each agent reads MCP servers from:
 
            ```bash
-           cat ~/.claude/settings.json
+           cat ~/.claude.json ~/.claude/mcp-needs-auth-cache.json
            cat ~/.cursor/mcp.json
-           ls ~/.codex/ ~/.config/github-copilot/ ~/.codeium/windsurf/ ~/.gemini/
+           cat ~/.config/github-copilot/mcp.json ~/.config/github-copilot/intellij/mcp.json
+           cat ~/.codeium/windsurf/mcp_config.json
+           cat ~/.gemini/settings.json
+           ls ~/.codex/.tmp/plugins/
            ```
 
         The endpoint passes when every configured MCP server name appears in the approved allow-list. Any server name outside the allow-list is a failing result.
       remediation:
         - id: cli
           desc: |
-            To remove unapproved MCP servers, open each agent's configuration file, locate the `mcpServers` section, and delete any server entry not in the approved list:
+            To remove unapproved MCP servers, delete the server entry from the location each agent actually reads:
 
-            - Claude Code: `~/.claude/settings.json` (`%USERPROFILE%\.claude\settings.json` on Windows)
-            - OpenAI Codex: `~/.codex/` (`%USERPROFILE%\.codex\` on Windows)
-            - Cursor: `~/.cursor/mcp.json` (`%USERPROFILE%\.cursor\mcp.json` on Windows)
-            - GitHub Copilot: `~/.config/github-copilot/` (`%APPDATA%\github-copilot\` on Windows)
-            - Windsurf: `~/.codeium/windsurf/` (`%USERPROFILE%\.codeium\windsurf\` on Windows)
-            - Gemini CLI: `~/.gemini/` (`%USERPROFILE%\.gemini\` on Windows)
+            - Claude Code: run `claude mcp remove example-server` to delete the server from the user configuration in `~/.claude.json`, and remove any project-scoped entry from the repository's `.mcp.json`. Then delete the stale cache file `~/.claude/mcp-needs-auth-cache.json` so the removed server no longer appears in the inventory; Claude Code rebuilds it on next start.
+            - OpenAI Codex: MCP servers can be defined in `~/.codex/config.toml` under `[mcp_servers.<name>]` tables and bundled by installed plugins under `~/.codex/.tmp/plugins/`. Remove the TOML table for a directly configured server, and uninstall the plugin that ships an unapproved server.
+            - Cursor: edit `~/.cursor/mcp.json` (`%USERPROFILE%\.cursor\mcp.json` on Windows) and delete the entry under `mcpServers`.
+            - GitHub Copilot: edit `~/.config/github-copilot/mcp.json` and, if present, `~/.config/github-copilot/intellij/mcp.json`, and delete the entry under `mcpServers`.
+            - Windsurf: edit `~/.codeium/windsurf/mcp_config.json` (`%USERPROFILE%\.codeium\windsurf\` on Windows) and delete the entry under `mcpServers`.
+            - Gemini CLI: edit `~/.gemini/settings.json` (`%USERPROFILE%\.gemini\settings.json` on Windows) and delete the entry under `mcpServers`.
         - id: ansible
           desc: |
             To surgically remove an unapproved MCP server entry from AI agent configuration files with Ansible:
 
-            This playbook deletes a single named MCP server from each agent's `mcpServers` object using a JSON patch, leaving the rest of the configuration file intact. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. For agents whose configuration nests `mcpServers` under another key, adjust the JSON pointer in the `path` accordingly. Each file is backed up before modification.
+            This playbook deletes a single named MCP server from each agent's `mcpServers` object using a JSON patch, leaving the rest of the configuration file intact, and removes the Claude Code MCP cache file so the deleted server no longer appears in its inventory. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. Each patched file is backed up before modification.
 
             ```yaml
             ---
@@ -3031,8 +3055,9 @@ queries:
               vars:
                 unapproved_mcp_server: example-server
                 mcp_config_files:
-                  - "{{ ansible_env.HOME }}/.claude/settings.json"
+                  - "{{ ansible_env.HOME }}/.claude.json"
                   - "{{ ansible_env.HOME }}/.cursor/mcp.json"
+                  - "{{ ansible_env.HOME }}/.config/github-copilot/mcp.json"
                   - "{{ ansible_env.HOME }}/.gemini/settings.json"
               tasks:
                 - name: Remove the unapproved server from each agent's mcpServers object
@@ -3044,6 +3069,11 @@ queries:
                     backup: true
                   loop: "{{ mcp_config_files }}"
                   failed_when: false
+
+                - name: Remove the stale Claude Code MCP cache
+                  ansible.builtin.file:
+                    path: "{{ ansible_env.HOME }}/.claude/mcp-needs-auth-cache.json"
+                    state: absent
             ```
 
   # ---------------------------------------------------------------------------
@@ -3105,6 +3135,7 @@ queries:
             macOS:
 
             ```bash
+            pkill -f ollama
             brew uninstall ollama
             ```
 
@@ -3180,12 +3211,12 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      ports.listening.where(address.notIn(["127.0.0.1", "[::1]"])).none(
+      ports.listening.where(address.notIn(["127.0.0.1", "::1", "[::1]"])).none(
         port == 11434 || port == 1234 || port == 1337
       )
     docs:
       desc: |
-        Local LLM inference servers expose an HTTP API on well-known ports — 11434 for Ollama, 1234 for LM Studio, and 1337 for LocalAI. Listening on `127.0.0.1` or `::1` is acceptable because it limits the server to the local machine. The check fails when one of these ports is bound to `0.0.0.0`, a LAN address, or any other non-loopback interface, because that exposes the model to other hosts on the network.
+        Local LLM inference servers expose an HTTP API on well-known ports: 11434 for Ollama, 1234 for LM Studio, and 1337 for Jan. Listening on `127.0.0.1` or `::1` is acceptable because it limits the server to the local machine. The check fails when one of these ports is bound to `0.0.0.0`, a LAN address, or any other non-loopback interface, because that exposes the model to other hosts on the network.
 
         **Why this matters**
 
@@ -3206,49 +3237,67 @@ queries:
       remediation:
         - id: cli
           desc: |
-            Identify the process bound to the flagged port and reconfigure it to bind to `127.0.0.1` only:
+            Identify the process bound to the flagged port and reconfigure it to bind to the loopback address only:
 
-            macOS and Linux:
+            macOS:
 
             ```bash
-            lsof -i :<port>
-            # Ollama: restart with the loopback bind address
+            lsof -nP -iTCP:11434 -iTCP:1234 -iTCP:1337 -sTCP:LISTEN
             launchctl setenv OLLAMA_HOST 127.0.0.1:11434
-            # then restart the Ollama service / app
             ```
 
-            For LM Studio and LocalAI, change the "Server host" / `address` setting in the app or config file from `0.0.0.0` to `127.0.0.1` and restart the server.
+            Then quit and reopen the Ollama app so it picks up the new bind address.
+
+            Linux:
+
+            ```bash
+            sudo mkdir -p /etc/systemd/system/ollama.service.d
+            printf '[Service]\nEnvironment="OLLAMA_HOST=127.0.0.1:11434"\n' | sudo tee /etc/systemd/system/ollama.service.d/override.conf
+            sudo systemctl daemon-reload
+            sudo systemctl restart ollama
+            ```
 
             Windows:
 
             ```powershell
             Get-NetTCPConnection -LocalPort 11434,1234,1337 | Select-Object LocalAddress,LocalPort,OwningProcess
-            # Ollama: set the loopback bind address and restart
             [Environment]::SetEnvironmentVariable("OLLAMA_HOST", "127.0.0.1:11434", "User")
             ```
 
-            For LM Studio and LocalAI, change the server host from `0.0.0.0` to `127.0.0.1` in the application settings and restart the server.
+            Then restart Ollama so it picks up the new bind address.
+
+            For LM Studio, change the server settings in the app so the listen address is `127.0.0.1` instead of `0.0.0.0` and restart the server. For Jan, which serves its local API on port 1337, set the API server host to `127.0.0.1` in **Settings > Local API Server** and restart the server.
         - id: ansible
           desc: |
             Reconfigure local LLM inference servers to bind to localhost with Ansible:
 
-            This playbook configures Ollama to bind to `127.0.0.1` on known LLM inference ports. It uses `lsof`, which is available on both Linux and macOS.
+            This playbook creates a systemd override that binds Ollama to the loopback address and restarts the service. The override approach is required because the unit file installed by Ollama does not read `/etc/default/ollama`. LM Studio and Jan are desktop applications; change their server host settings in the app.
 
             ```yaml
             ---
-            - name: Rebind local LLM inference servers to localhost
+            - name: Rebind Ollama to localhost
               hosts: workstations
+              become: true
               tasks:
-                - name: Configure Ollama to bind to localhost
-                  ansible.builtin.lineinfile:
-                    path: /etc/default/ollama
-                    regexp: '^OLLAMA_HOST='
-                    line: 'OLLAMA_HOST=127.0.0.1:11434'
-                    create: true
-                  notify: restart ollama
+                - name: Create the systemd override directory for Ollama
+                  ansible.builtin.file:
+                    path: /etc/systemd/system/ollama.service.d
+                    state: directory
+                    mode: "0755"
+
+                - name: Bind Ollama to the loopback address
+                  ansible.builtin.copy:
+                    dest: /etc/systemd/system/ollama.service.d/override.conf
+                    content: |
+                      [Service]
+                      Environment="OLLAMA_HOST=127.0.0.1:11434"
+                    mode: "0644"
+                  notify: Restart Ollama
+
               handlers:
-                - name: restart ollama
-                  ansible.builtin.systemd:
+                - name: Restart Ollama
+                  ansible.builtin.systemd_service:
                     name: ollama
                     state: restarted
+                    daemon_reload: true
             ```


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2794). This PR covers `mondoo-ai-security.mql.yaml`: all 38 checks were reviewed and 15 needed fixes. Policy version bumped to 2.0.1. Every claim was verified against the os provider implementation (`ai_agents.go`, `claude_code.go`, `openai_codex.go`, `port.go`, and friends), which is the source of truth for what each check reads.

## Why these needed checking

The dominant failure class here is remediations that delete a directory the check never reads. A user can follow the steps exactly, see the tool disappear, and still fail the check on the next scan.

## Remediations that never changed the inspected state

- **no-cline / no-warp**: both checks count skills, and the provider reads those from the shared `~/.agents/skills` directory, not from `~/.cline` or `~/.warp`. The old remediations removed only the tool's own config directory, which the checks ignore. Both now clear the shared skills directory, with a caution about other agents using the same convention.
- **no-unapproved-mcp-servers**: the remediation edited `~/.claude/settings.json`, but the provider inventories Claude Code MCP servers from `~/.claude.json` and the `mcp-needs-auth-cache.json` cache file; Codex servers come from TOML config and plugin manifests, not a JSON `mcpServers` section; Copilot reads specific `mcp.json` paths. The remediation and audit now name the real locations per agent, including clearing the Claude Code cache so removed servers leave the inventory.
- **no-goose / no-opencode (Windows)**: the provider resolves `.config/goose` and `.config/opencode` under the user profile on every platform, but the Windows commands removed `$env:APPDATA` paths the checks never read.
- **GUI uninstalls (cursor, windsurf, goose, zed)**: dragging the app to the Trash leaves the config directory the check inspects; each gui entry now includes deleting it.
- **no-local-llm-runtimes (macOS)**: `brew uninstall ollama` removes the package but not the running process the check matches; a kill step was added.

## Checks that could never fail (mql)

- **no-vscode-codex-extension** matched identifier `openai.codex`, which does not exist on the marketplace; the real Codex extension is `openai.chatgpt`. The check now matches the `openai.` publisher namespace and the uninstall commands use the real ID.
- **no-vscode-cursor-extension** matched a `cursor.` publisher namespace, but Cursor publishes its extensions under `anysphere`. The check now matches both.
- **no-local-llm-listening-ports** excluded IPv6 loopback only in the bracketed form `[::1]`, but the macOS lsof path strips brackets, so a server correctly bound to IPv6 loopback was flagged with no way to pass. Bare `::1` is now excluded too.

## Commands that fail or do nothing as written

- The unapproved-process remediation's grep/pkill patterns covered five of the sixteen executable names the check matches; they now mirror the check's full pattern. Its bash blocks also contained literal `kill <PID>` angle-bracket placeholders that are shell syntax errors.
- The Ollama rebind playbook wrote `OLLAMA_HOST` to `/etc/default/ollama`, a file the official systemd unit never reads; it now uses a systemd drop-in override, and the manual steps use `launchctl setenv` on macOS.
- The packages playbook claimed to handle macOS, but `ansible.builtin.package` has no Homebrew backend there; scope corrected to Linux with a pointer to the Homebrew check.
- Port 1337 was attributed to LocalAI; it is Jan's local API default (LocalAI uses 8080). Docs and remediation corrected.

## Left for maintainers (provider limitations)

- The Claude Code MCP inventory only includes servers present in the needs-auth cache, so servers that never required auth are invisible to the check.
- On macOS the provider rewrites wildcard binds to loopback addresses, so an Ollama bound to `0.0.0.0` is reported as `127.0.0.1` and the listening-ports check cannot fail for IPv4 wildcard binds there.

Both need provider changes; the checks were left as-is.

## Validation

- `cnspec policy lint` passes
- YAML parses clean
- All modified bash blocks shellcheck-clean at warning level; all 38 ansible playbooks pass ansible-lint with the repo validator settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)