### PR TITLE
🐛 panos: fix CLI commands PAN-OS rejects and version-blind IKE checks

### DIFF
--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 2.0.0
+    version: 2.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -162,7 +162,7 @@ queries:
 
             1. Navigate to **Device → Dynamic Updates**
             2. Click the schedule link next to **Antivirus**
-            3. Set the recurrence (hourly recommended) and enable **Install**
+            3. Set the recurrence to hourly and enable **Install**
             4. Click **OK** and commit the configuration
         - id: cli
           desc: |
@@ -171,8 +171,8 @@ queries:
             Download and install the latest antivirus content:
 
             ```
-            request content upgrade download latest
-            request content upgrade install version latest
+            request anti-virus upgrade download latest
+            request anti-virus upgrade install version latest
             ```
 
     refs:
@@ -314,7 +314,7 @@ queries:
         2. Run the following command:
 
            ```
-           show system license
+           request license info
            ```
 
         If the output lists a DNS Security feature with an expiry date in the future, the check passes. If no DNS Security feature is listed or it is expired, the check fails.
@@ -338,7 +338,7 @@ queries:
 
             ```
             request license fetch
-            show system license
+            request license info
             ```
 
     refs:
@@ -392,7 +392,7 @@ queries:
         2. Run the following command:
 
            ```
-           show system license
+           request license info
            ```
 
         If every feature listed shows an expiry date in the future, the check passes. If any feature is expired, the check fails.
@@ -418,7 +418,7 @@ queries:
 
             ```
             request license fetch
-            show system license
+            request license info
             ```
 
     refs:
@@ -457,14 +457,6 @@ queries:
 
         Devices should operate in normal mode to provide continuous security protection for network traffic.
       audit: |
-        ### Audit via the PAN-OS web interface
-
-        1. Log in to the PAN-OS web interface.
-        2. Navigate to **Dashboard → General Information**.
-        3. Review the **Operational Mode** field.
-
-        If the operational mode is **Normal**, the check passes. If it shows maintenance or any other state, the check fails.
-
         ### Audit via the PAN-OS CLI
 
         1. Open an SSH session to the firewall.
@@ -480,8 +472,7 @@ queries:
           desc: |
             **Using the PAN-OS Web Interface**
 
-            1. Check **Dashboard → General Information** to confirm the current operational mode
-            2. Review **Monitor → System Logs** for errors or warnings that indicate why the device entered a non-normal state
+            1. Review **Monitor → System Logs** for errors or warnings that indicate why the device entered a non-normal state
 
             If the device is in maintenance mode:
 
@@ -499,10 +490,15 @@ queries:
           desc: |
             **Using the CLI**
 
-            Check the current operational mode and restart the system if needed:
+            Check the current operational mode:
 
             ```
             show system info | match oper
+            ```
+
+            If the mode is not normal, investigate the system logs and the maintenance mode console before taking action. A restart is usually required to return to normal mode, but it reboots the entire device and interrupts all traffic, so run it only during an approved maintenance window:
+
+            ```
             request restart system
             ```
 
@@ -645,7 +641,7 @@ queries:
         2. Run the following command:
 
            ```
-           show system license
+           request license info
            ```
 
         If the output lists a Threat Prevention feature with an expiry date in the future, the check passes. If no Threat Prevention feature is listed or it is expired, the check fails.
@@ -659,7 +655,7 @@ queries:
             3. Navigate to **Device → Licenses**
             4. Click **Retrieve license keys from license server** to activate the subscription
             5. Navigate to **Device → Dynamic Updates** and download the latest **Applications and Threats** content
-            6. Configure **Security Profiles** (Anti-Spyware, Vulnerability Protection) and attach them to your security policy rules
+            6. Configure Anti-Spyware and Vulnerability Protection security profiles and attach them to your security policy rules
             7. Commit the configuration
 
             Threat Prevention is considered a core security subscription and should be maintained on all production firewalls.
@@ -671,7 +667,7 @@ queries:
 
             ```
             request license fetch
-            show system license
+            request license info
             request content upgrade download latest
             request content upgrade install version latest
             ```
@@ -731,7 +727,7 @@ queries:
         2. Run the following command:
 
            ```
-           show system license
+           request license info
            ```
 
         If the output lists a URL Filtering feature with an expiry date in the future, the check passes. If no URL Filtering feature is listed or it is expired, the check fails.
@@ -740,7 +736,7 @@ queries:
           desc: |
             **Using the PAN-OS Web Interface**
 
-            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a URL Filtering subscription (Advanced URL Filtering is recommended over the legacy PAN-DB option)
+            1. Contact your Palo Alto Networks sales representative or authorized reseller to purchase a URL Filtering subscription. Advanced URL Filtering is recommended over the legacy PAN-DB option
             2. Log into the [Customer Support Portal](https://support.paloaltonetworks.com) and retrieve the license activation code
             3. Navigate to **Device → Licenses**
             4. Click **Retrieve license keys from license server** to activate the subscription
@@ -757,7 +753,7 @@ queries:
 
             ```
             request license fetch
-            show system license
+            request license info
             ```
 
     refs:
@@ -899,7 +895,7 @@ queries:
         2. Run the following command:
 
            ```
-           show system license
+           request license info
            ```
 
         If the output lists a WildFire feature with an expiry date in the future, the check passes. If no WildFire feature is listed or it is expired, the check fails.
@@ -926,7 +922,7 @@ queries:
 
             ```
             request license fetch
-            show system license
+            request license info
             request wildfire upgrade download latest
             request wildfire upgrade install version latest
             ```
@@ -995,9 +991,9 @@ queries:
             **Using the PAN-OS Web Interface**
 
             1. Navigate to **Network → Network Profiles → Zone Protection**
-            2. Click **Add** to create a new zone protection profile (or select an existing one to review)
-            3. Configure flood protection thresholds (SYN, UDP, ICMP, ICMPv6, Other) under the **Flood Protection** tab
-            4. Enable reconnaissance protection (port scan, host sweep) under the **Reconnaissance Protection** tab
+            2. Click **Add** to create a new zone protection profile or select an existing one to review
+            3. Configure flood protection thresholds for SYN, UDP, ICMP, ICMPv6, and other IP traffic under the **Flood Protection** tab
+            4. Enable reconnaissance protection for port scans and host sweeps under the **Reconnaissance Protection** tab
             5. Configure packet-based attack protection under the **Packet Based Attack Protection** tab
             6. Click **OK** to save the profile
             7. Navigate to **Network → Zones** and select each zone
@@ -1007,11 +1003,15 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create a zone protection profile and apply it to a zone:
+            Create a zone protection profile with flood and reconnaissance protection, then apply it to a zone. Reconnaissance protection entries are keyed by threat ID: 8001 is TCP port scan, 8002 is host sweep, and 8003 is UDP port scan.
 
             ```
             set network profiles zone-protection-profile <profile-name> flood tcp-syn enable yes
-            set network profiles zone-protection-profile <profile-name> scan port-scan action block-ip
+            set network profiles zone-protection-profile <profile-name> flood udp enable yes
+            set network profiles zone-protection-profile <profile-name> flood icmp enable yes
+            set network profiles zone-protection-profile <profile-name> scan 8001 action block-ip duration 3600 track-by source
+            set network profiles zone-protection-profile <profile-name> scan 8002 action alert
+            set network profiles zone-protection-profile <profile-name> scan 8003 action alert
             set zone <zone-name> network zone-protection-profile <profile-name>
             commit
             ```
@@ -1094,9 +1094,11 @@ queries:
             Enable packet buffer protection on a zone:
 
             ```
-            set zone <zone-name> enable-packet-buffer-protection yes
+            set zone <zone-name> network enable-packet-buffer-protection yes
             commit
             ```
+
+            Zone-level packet buffer protection only takes effect when global packet buffer protection is enabled under **Device → Setup → Session**.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/zone-protection-and-dos-protection/configure-packet-buffer-protection
@@ -1169,7 +1171,7 @@ queries:
             Configure log forwarding on a zone:
 
             ```
-            set zone <zone-name> log-setting <log-forwarding-profile>
+            set zone <zone-name> network log-setting <log-forwarding-profile>
             commit
             ```
 
@@ -1251,21 +1253,25 @@ queries:
                - Define specific source and destination zones and addresses
                - Specify the applications that need to be allowed using App-ID
                - Set the service to **application-default** or specific service objects
-               - Attach appropriate security profiles (Antivirus, Anti-Spyware, Vulnerability Protection, URL Filtering, WildFire)
+               - Attach appropriate security profiles such as Antivirus, Anti-Spyware, Vulnerability Protection, URL Filtering, and WildFire
             4. If the rule was a temporary placeholder, replace it with specific rules for each required traffic flow
             5. Commit the configuration
         - id: cli
           desc: |
             **Using the CLI**
 
-            Review and modify overly permissive rules:
+            Review the rulebase, then replace each wildcard member list with specific values. The `set` command appends members to an existing list, so delete each list first to remove the `any` entry:
 
             ```
             show running security-policy
-            set rulebase security rules <rule-name> application <specific-app>
+            delete rulebase security rules <rule-name> application
+            set rulebase security rules <rule-name> application [ <app1> <app2> ]
+            delete rulebase security rules <rule-name> service
             set rulebase security rules <rule-name> service application-default
-            set rulebase security rules <rule-name> source <specific-address>
-            set rulebase security rules <rule-name> destination <specific-address>
+            delete rulebase security rules <rule-name> source
+            set rulebase security rules <rule-name> source [ <source-address> ]
+            delete rulebase security rules <rule-name> destination
+            set rulebase security rules <rule-name> destination [ <destination-address> ]
             commit
             ```
 
@@ -1343,10 +1349,12 @@ queries:
           desc: |
             **Using the CLI**
 
-            Update rules to use specific applications:
+            Replace the application list with specific App-IDs. The `set` command appends members to an existing list, so delete the list first to remove the `any` entry:
 
             ```
-            set rulebase security rules <rule-name> application <app1> <app2>
+            delete rulebase security rules <rule-name> application
+            set rulebase security rules <rule-name> application [ <app1> <app2> ]
+            delete rulebase security rules <rule-name> service
             set rulebase security rules <rule-name> service application-default
             commit
             ```
@@ -1803,12 +1811,12 @@ queries:
 
         **Why this matters**
 
-        Without a management profile, the default behavior for management service access on an interface may expose services unintentionally. If management profiles are not configured:
+        PAN-OS dataplane interfaces allow no management services unless a management profile explicitly enables them, so a missing profile does not expose services on its own. The value of assigning a profile to every active interface is making that deny posture explicit and auditable. If management profiles are not configured:
 
-        - Management services such as HTTP, SSH, or SNMP may be accessible from untrusted networks.
-        - Attackers on connected networks can attempt to access the firewall's management plane.
-        - There is no explicit control over which management protocols are allowed on each interface.
-        - The attack surface of the firewall is unnecessarily expanded.
+        - There is no explicit, reviewable statement of which management protocols are allowed on each interface.
+        - Audits cannot confirm that management access on untrusted interfaces is denied by design rather than by omission.
+        - Administrators may later attach permissive profiles without a baseline that distinguishes trusted from untrusted interfaces.
+        - Profiles that enable services without permitted IP restrictions expand the firewall's management plane attack surface.
 
         Configuring a management profile on every active Layer 3 interface ensures explicit control over which management services are permitted, following the principle of least privilege.
       audit: |
@@ -1836,27 +1844,31 @@ queries:
             **Using the PAN-OS Web Interface**
 
             1. Navigate to **Network → Network Profiles → Interface Mgmt** and create management profiles:
-               - Create a restrictive profile for untrusted interfaces (disable all or allow only ping)
-               - Create appropriate profiles for trusted interfaces (enable only required services)
+               - Create a deny-all profile with no services enabled for untrusted interfaces
+               - Create a restricted profile for trusted interfaces that enables only required services and limits access with **Permitted IP Addresses**
             2. Navigate to **Network → Interfaces → Ethernet**
             3. Select each Layer 3 interface
             4. In the **Advanced** tab, select the appropriate **Management Profile**
             5. Click **OK** and commit the configuration
 
-            Best practice: Create a "deny-all" management profile with no services enabled and apply it to all untrusted interfaces.
+            Never enable HTTP, HTTPS, SSH, or SNMP in a profile assigned to an internet-facing interface. Exposing these services on an untrusted interface gives attackers a direct path to the firewall's management plane.
         - id: cli
           desc: |
             **Using the CLI**
 
-            Create and assign a management profile:
+            Create a deny-all profile for untrusted interfaces and a restricted profile for trusted interfaces, then assign each interface the appropriate profile:
 
             ```
-            set network profiles interface-management-profile <profile-name> permitted-ip <trusted-subnet>
-            set network profiles interface-management-profile <profile-name> https yes
-            set network profiles interface-management-profile <profile-name> ssh yes
-            set network interface ethernet <interface> layer3 interface-management-profile <profile-name>
+            set network profiles interface-management-profile deny-all ping no
+            set network interface ethernet <untrusted-interface> layer3 interface-management-profile deny-all
+            set network profiles interface-management-profile mgmt-trusted https yes
+            set network profiles interface-management-profile mgmt-trusted ssh yes
+            set network profiles interface-management-profile mgmt-trusted permitted-ip <trusted-subnet>
+            set network interface ethernet <trusted-interface> layer3 interface-management-profile mgmt-trusted
             commit
             ```
+
+            Only enable management services on interfaces that face trusted networks, and always restrict access with permitted IP addresses.
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices
@@ -1932,7 +1944,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Replace DHCP with a static address:
+            Replace DHCP with a static address. Perform this change during a maintenance window: the address change interrupts traffic on the interface, and any static routes, NAT rules, or IKE gateways that reference the old address must be updated in the same commit.
 
             ```
             set network interface ethernet <interface> layer3 ip <address/mask>
@@ -2090,7 +2102,7 @@ queries:
             1. Navigate to **Network → Network Profiles → IKE Gateways**
             2. Select each IKE gateway
             3. In the **General** tab, change the **IKE Version** to **IKEv2 only** or **IKEv2 preferred mode**
-            4. Ensure the remote peer also supports IKEv2 (coordinate with the remote administrator)
+            4. Ensure the remote peer also supports IKEv2 and coordinate the change with the remote administrator
             5. Click **OK** and commit the configuration
 
             Note: If the remote peer only supports IKEv1, use **IKEv2 preferred mode** to allow fallback during migration.
@@ -2098,10 +2110,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Update an IKE gateway to use IKEv2:
+            Update an IKE gateway to use IKEv2. Setting the version to IKEv2 only drops the tunnel until the remote peer also negotiates IKEv2, so coordinate the change or use `ikev2-preferred` during migration:
 
             ```
-            set network ike gateway <gateway-name> protocol ikev2
+            set network ike gateway <gateway-name> protocol version ikev2
             commit
             ```
 
@@ -2169,7 +2181,7 @@ queries:
           desc: |
             **Using the PAN-OS Web Interface**
 
-            1. Ensure you have a certificate infrastructure in place (internal CA or third-party CA)
+            1. Ensure you have a certificate infrastructure in place, using either an internal or a third-party certificate authority
             2. Navigate to **Device → Certificate Management → Certificates** and import or generate the required certificates
             3. Navigate to **Device → Certificate Management → Certificate Profile** and create a certificate profile
             4. Navigate to **Network → Network Profiles → IKE Gateways**
@@ -2182,10 +2194,12 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure certificate authentication on an IKE gateway:
+            Switch the gateway from pre-shared key to certificate authentication. The tunnel stays down until the remote peer is also reconfigured for certificate authentication, so coordinate the change:
 
             ```
-            set network ike gateway <gateway-name> authentication certificate local-certificate <cert-name> certificate-profile <profile-name>
+            delete network ike gateway <gateway-name> authentication pre-shared-key
+            set network ike gateway <gateway-name> authentication certificate local-certificate name <cert-name>
+            set network ike gateway <gateway-name> authentication certificate certificate-profile <profile-name>
             commit
             ```
 
@@ -2213,7 +2227,11 @@ queries:
     mql: |
       panos.ikeGateways.
         where(disabled == false).
-        all(enableDeadPeerDetection == true)
+        all(
+          version == "ikev1" && enableDeadPeerDetection == true ||
+          version == "ikev2" && enableLivenessCheck == true ||
+          version == "ikev2-preferred" && enableDeadPeerDetection == true && enableLivenessCheck == true
+        )
     docs:
       desc: |
         This check verifies that all enabled IKE gateways have dead peer detection (DPD) enabled. DPD detects when a VPN peer becomes unreachable and cleans up the associated security associations.
@@ -2233,9 +2251,9 @@ queries:
 
         1. Log in to the PAN-OS web interface.
         2. Navigate to **Network → Network Profiles → IKE Gateways**.
-        3. For each enabled IKE gateway, open **Advanced Options** and review **Enable Dead Peer Detection**.
+        3. For each enabled IKE gateway, open **Advanced Options**. For IKEv1 gateways, review **Dead Peer Detection** on the **IKEv1** tab. For IKEv2 gateways, review **Liveness Check** on the **IKEv2** tab.
 
-        If every enabled IKE gateway has dead peer detection enabled, the check passes. If any enabled gateway has it disabled, the check fails.
+        If every enabled IKEv1 gateway has dead peer detection enabled and every enabled IKEv2 gateway has the liveness check enabled, the check passes. Gateways in IKEv2 preferred mode must have both enabled. If any enabled gateway is missing the required setting, the check fails.
 
         ### Audit via the PAN-OS CLI
 
@@ -2246,27 +2264,30 @@ queries:
            show config running xpath devices/entry/network/ike/gateway
            ```
 
-        If every enabled gateway shows `protocol-common/dpd/enable yes`, the check passes. If any has it set to `no`, the check fails.
+        If every enabled IKEv1 gateway shows `protocol/ikev1/dpd/enable yes` and every enabled IKEv2 gateway shows `protocol/ikev2/dpd/enable yes`, the check passes. Gateways in IKEv2 preferred mode must show both. If any enabled gateway is missing the required setting, the check fails.
       remediation:
         - id: console
           desc: |
             **Using the PAN-OS Web Interface**
 
             1. Navigate to **Network → Network Profiles → IKE Gateways**
-            2. Select each IKE gateway
-            3. In the **Advanced Options** section, check **Enable Dead Peer Detection**
-            4. Configure the **Interval** (default 5 seconds) and **Retry** count (default 5)
+            2. Select each IKE gateway and open **Advanced Options**
+            3. For gateways using IKEv1, open the **IKEv1** tab, check **Dead Peer Detection**, and set the **Interval** and **Retry** values; 5 and 5 are reasonable starting points
+            4. For gateways using IKEv2 or IKEv2 preferred mode, open the **IKEv2** tab, check **Liveness Check**, and set the **Interval**
             5. Click **OK** and commit the configuration
         - id: cli
           desc: |
             **Using the CLI**
 
-            Enable dead peer detection on an IKE gateway:
+            Enable dead peer detection for IKEv1 gateways and the liveness check for IKEv2 gateways:
 
             ```
-            set network ike gateway <gateway-name> protocol-common dpd enable yes interval 5 retry 5
+            set network ike gateway <gateway-name> protocol ikev1 dpd enable yes interval 5 retry 5
+            set network ike gateway <gateway-name> protocol ikev2 dpd enable yes interval 5
             commit
             ```
+
+            Use the first command for gateways negotiating IKEv1 and the second for gateways negotiating IKEv2. Gateways set to IKEv2 preferred mode should have both configured.
 
     refs:
       - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
@@ -2291,7 +2312,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       panos.ikeGateways.
-        where(disabled == false && version == "ikev1").
+        where(disabled == false && version != "ikev2").
         none(ikev1ExchangeMode == "aggressive")
     docs:
       desc: |
@@ -2492,20 +2513,22 @@ queries:
           desc: |
             **Using the PAN-OS Web Interface**
 
-            1. Navigate to **Network → IPsec Tunnels**
-            2. Select each IPsec tunnel
-            3. In the **Tunnel Monitor** section:
+            1. Navigate to **Network → Interfaces → Tunnel** and confirm the tunnel interface has an IP address assigned. Tunnel monitoring sources its probes from this address and the commit fails without one
+            2. Navigate to **Network → IPsec Tunnels**
+            3. Select each IPsec tunnel
+            4. In the **Tunnel Monitor** section:
                - Check **Enable**
                - Set the **Destination IP** to an IP address reachable through the tunnel
-               - Optionally select a **Tunnel Monitor Profile** for custom failover behavior
-            4. Click **OK** and commit the configuration
+               - Select a **Tunnel Monitor Profile** with the fail-over action if traffic should switch to a backup path on failure. The default behavior is wait-recover, which keeps traffic on the tunnel
+            5. Click **OK** and commit the configuration
         - id: cli
           desc: |
             **Using the CLI**
 
-            Enable tunnel monitoring:
+            Assign an IP address to the tunnel interface if it does not already have one, then enable tunnel monitoring:
 
             ```
+            set network interface tunnel units <tunnel-interface> ip <local-address/mask>
             set network tunnel ipsec <tunnel-name> tunnel-monitor enable yes destination-ip <remote-ip>
             commit
             ```
@@ -2827,18 +2850,22 @@ queries:
 
             1. Navigate to **Network → Virtual Routers**
             2. Select the virtual router running OSPF
-            3. Go to the **OSPF** tab and select **Areas**
-            4. Select the area containing the interface
-            5. Select the interface and configure an **Auth Profile** using MD5 or SHA authentication
-            6. Click **OK** and commit the configuration
+            3. Go to the **OSPF** tab and open **Auth Profiles**
+            4. Add an authentication profile that uses MD5 keys. PAN-OS OSPF supports simple password and MD5 authentication, and MD5 is the stronger choice
+            5. Go to **Areas** and select the area containing the interface
+            6. Select the interface and set its **Auth Profile**
+            7. Click **OK** and commit the configuration
+
+            Enabling authentication tears down OSPF adjacencies until every neighbor on the segment uses a matching key, so coordinate the change with the administrators of adjacent routers and schedule a maintenance window.
         - id: cli
           desc: |
             **Using the CLI**
 
-            Configure an authentication profile on an OSPF interface:
+            Create an MD5 authentication profile and reference it from the OSPF interface. Adjacencies drop until neighbors are configured with the same key:
 
             ```
-            set network virtual-router <vr-name> protocol ospf area <area-id> interface <interface-name> authentication auth-profile <profile-name>
+            set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
+            set network virtual-router <vr-name> protocol ospf area <area-id> interface <interface-name> authentication <profile-name>
             commit
             ```
 
@@ -2908,18 +2935,22 @@ queries:
 
             1. Navigate to **Network → Virtual Routers**
             2. Select the virtual router running OSPF
-            3. Go to the **OSPF** tab and select **Areas**
-            4. Select the area containing the virtual link
-            5. Select the virtual link and configure an **Auth Profile** using MD5 or SHA authentication
-            6. Click **OK** and commit the configuration
+            3. Go to the **OSPF** tab and open **Auth Profiles**
+            4. Add an authentication profile that uses MD5 keys. PAN-OS OSPF supports simple password and MD5 authentication, and MD5 is the stronger choice
+            5. Go to **Areas** and select the transit area containing the virtual link
+            6. Select the virtual link and set its **Auth Profile**
+            7. Click **OK** and commit the configuration
+
+            Enabling authentication tears down the virtual link until the router at the other end uses a matching key, so coordinate the change with that router's administrator.
         - id: cli
           desc: |
             **Using the CLI**
 
-            Configure an authentication profile on an OSPF virtual link:
+            Create an MD5 authentication profile and reference it from the OSPF virtual link. The virtual link drops until the remote end is configured with the same key:
 
             ```
-            set network virtual-router <vr-name> protocol ospf area <area-id> virtual-link <link-name> authentication auth-profile <profile-name>
+            set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
+            set network virtual-router <vr-name> protocol ospf area <transit-area-id> virtual-link <link-name> authentication <profile-name>
             commit
             ```
 


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2796). This PR covers `mondoo-panos-security.mql.yaml`: all 36 checks were reviewed and 21 needed fixes. Policy version bumped. Check mql was verified against the panos provider schema; CLI syntax against PAN-OS documentation.

## Why these needed checking

The dominant defect is PAN-OS CLI syntax that the firewall rejects outright, including one nonexistent command repeated across five checks, plus two IKE checks whose logic ignored the gateway's IKE version and a pair of rule-hygiene remediations that silently left the `any` member in place.

## Commands PAN-OS rejects or that change the wrong thing

- **`show system license` does not exist.** All five license checks (DNS Security, Threat Prevention, URL Filtering, WildFire, expired licenses) used it in both remediation and audit; the real command is `request license info`.
- **antivirus-content-installed** ran `request content upgrade ...`, which updates the Applications and Threats package. The check reads `av-version`, which only the `request anti-virus upgrade ...` family changes.
- **Zone commands missing the `network` keyword**: `set zone <z> enable-packet-buffer-protection` and `set zone <z> log-setting` fail to parse; both settings live under `zone/<z>/network/`, as each check's own audit already said.
- **IKE commands**: the version selector is `protocol version ikev2`, not `protocol ikev2`; dead peer detection lives at `protocol ikev1 dpd` rather than the invented `protocol-common dpd` (the audit xpath had the same defect); certificate auth needs `local-certificate name <cert>` plus a separate certificate-profile leaf, and the old pre-shared-key branch was never deleted.
- **OSPF authentication** used an `auth-profile` keyword that doesn't exist at the interface/virtual-link position, never created the auth profile, and offered SHA, which PAN-OS OSPFv2 doesn't support (password and MD5 only).
- **zone-protection-profile** keyed reconnaissance entries by name (`scan port-scan`); they're keyed by threat ID (8001 TCP scan, 8002 host sweep, 8003 UDP scan).

## Remediations that left the check failing

**no-allow-any-rules / rules-use-app-id**: in PAN-OS configure mode, `set` on a member list appends. Running `set ... application <app>` against a rule whose application is `any` yields a list containing both `any` and the new app, so the rule still matches everything and the check still fails. The remediations now delete each member list before setting specific values.

## Check logic fixes (mql)

- **ike-dead-peer-detection** required `enableDeadPeerDetection` on every gateway, but that field maps to the IKEv1 DPD setting; IKEv2 gateways use the separate liveness check field, so every correctly configured IKEv2-only gateway failed with no way to pass. The check is now version-aware (IKEv1 → DPD, IKEv2 → liveness check, IKEv2-preferred → both), with the remediation and audit updated to match.
- **ike-no-aggressive-mode** only inspected `version == "ikev1"` gateways, but ikev2-preferred gateways can fall back to IKEv1 and use the configured aggressive exchange mode. The filter now covers them.

## Safety and accuracy

- **operational-mode-normal** presented `request restart system` as a routine step with no warning that it reboots the firewall; it also pointed at an Operational Mode field on the Dashboard that doesn't exist (the GUI audit section was removed; `show system info` is the reliable source).
- **interface-management-profile**'s description claimed missing profiles "may expose services unintentionally" — backwards: dataplane interfaces expose no management services without a profile. The description now explains the real value (an explicit, auditable deny posture), and the CLI remediation no longer hands out one HTTPS+SSH profile for all interfaces; it splits deny-all for untrusted from permitted-IP-restricted for trusted.
- Traffic-interruption warnings added where missing: DHCP-to-static re-addressing, forcing IKEv2, switching to certificate auth, enabling OSPF authentication (drops adjacencies), and the tunnel-monitoring prerequisite that the tunnel interface needs an IP or the commit fails.

## Validation

- `cnspec policy lint` passes (panos provider installed; compiles both modified mql expressions)
- YAML parses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)