### PR TITLE
🐛 macos: fix checks unmanaged Macs could never pass and GUI steps for controls that have no GUI

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -13,6 +13,7 @@ ADBs
 adddays
 adduser
 ADH
+XProtect
 adjtimex
 adminuser
 adml
@@ -80,7 +81,6 @@ azconfig
 AZFW
 azuredatabricks
 azurepolicy
-azurewebsites
 backported
 backrefs
 backupdr
@@ -102,6 +102,7 @@ bluetooth
 bmcastecho
 bno
 bootkit
+bootout
 botocore
 bpf
 bqexports
@@ -489,7 +490,6 @@ lpt
 lru
 Lsa
 Lsass
-lsb
 lsetxattr
 lsp
 lsws
@@ -679,7 +679,6 @@ Redir
 rediraccept
 redisenterprise
 redoc
-refreshable
 reissuance
 remoteadministrator
 removexattr
@@ -727,7 +726,6 @@ scrapeable
 screensharing
 sctp
 sdp
-secadmin
 secauth
 secboot
 secgroup
@@ -832,7 +830,6 @@ tmpfiles
 tmsh
 TNS
 toset
-totp
 Tpng
 trae
 trainingjob

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-macos-security
     name: Mondoo macOS Security
-    version: 1.4.1
+    version: 1.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -159,13 +159,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Run the following commands to secure the audit logs and configuration files:
+            Run the following commands to secure the audit configuration file and audit logs:
 
             ```bash
             sudo chown root:wheel /etc/security/audit_control
             sudo chmod 600 /etc/security/audit_control
-            sudo chown -R root:wheel /var/audit/
-            sudo chmod -R 600 /var/audit/
+            sudo chown -R root:wheel /var/audit
+            sudo find /var/audit -type d -exec chmod 700 {} +
+            sudo find /var/audit -type f -exec chmod 600 {} +
             ```
 
             **Note:**
@@ -193,13 +194,12 @@ queries:
                     owner: root
                     group: wheel
                     mode: '0600'
-                - name: Set ownership and permissions for audit logs
-                  ansible.builtin.file:
-                    path: /var/audit/
-                    owner: root
-                    group: wheel
-                    mode: '0700'
-                    recurse: yes
+                - name: Set ownership of audit logs
+                  ansible.builtin.command: find /var/audit -exec chown root:wheel {} +
+                - name: Set audit log directory mode
+                  ansible.builtin.command: find /var/audit -type d -exec chmod 700 {} +
+                - name: Set audit log file mode
+                  ansible.builtin.command: find /var/audit -type f -exec chmod 600 {} +
             ```
 
             **Note:**
@@ -284,11 +284,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            To disable Bluetooth Sharing using the graphical interface, follow these steps:
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Bluetooth Sharing**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Bluetooth Sharing**
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Bluetooth Sharing**.
 
             **Impact:**
 
@@ -341,7 +342,7 @@ queries:
           parse.plist(filePath1).params["com.apple.mDNSResponder"]["NoMulticastAdvertisements"]["value"] == true
         }
         filePath2 = "/Library/Preferences/com.apple.mDNSResponder.plist"
-        b = file(filePath2).exists && parse.plist(filePath2).params["com.apple.mDNSResponder"]["NoMulticastAdvertisements"]["value"] == true
+        b = file(filePath2).exists && parse.plist(filePath2).params["NoMulticastAdvertisements"] == true
         filePath3 = "/Library/Managed Preferences/com.apple.mDNSResponder.plist"
         c = file(filePath3).exists && parse.plist(filePath3).params["NoMulticastAdvertisements"] == true
         a || b || c
@@ -384,24 +385,20 @@ queries:
             sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true
             ```
 
+            Restart the system for the change to take effect, because `mDNSResponder` only reads this preference at startup.
+
             **Impact:**
 
-            Some applications, such as Final Cut Studio and AirPort Base Station management, may not operate properly if the `mDNSResponder` is turned off.
+            Some applications, such as Final Cut Studio and AirPort Base Station management, may not operate properly if multicast advertising is turned off.
         - id: gui
           desc: |
             **Using the GUI**
 
-            Perform the following to disable Bonjour advertising services:
-
-            _Graphical Method:_
-
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Bonjour** or any related service that advertises via Bonjour
+            macOS provides no graphical control for Bonjour multicast advertising. Use the CLI command above, or deploy a configuration profile that sets `NoMulticastAdvertisements` to true in the `com.apple.mDNSResponder` preference domain.
 
             **Impact:**
 
-            Some applications, such as Final Cut Studio and AirPort Base Station management, may not operate properly if the `mDNSResponder` is turned off.
+            Some applications, such as Final Cut Studio and AirPort Base Station management, may not operate properly if multicast advertising is turned off.
         - id: ansible
           desc: |
             **Using Ansible**
@@ -497,9 +494,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Content Caching**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Content Caching**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Content Caching**.
 
             **Impact:**
 
@@ -584,11 +584,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Run this command to disable SMB file sharing:
+            Run these commands to disable SMB file sharing:
 
             ```bash
-            sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist
+            sudo launchctl disable system/com.apple.smbd
+            sudo launchctl bootout system/com.apple.smbd
             ```
+
+            The `bootout` command reports an error if the service is not currently running; that error is harmless. On older macOS versions you can use the legacy form `sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist`.
 
             **Impact:**
 
@@ -597,9 +600,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **File Sharing**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **File Sharing**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **File Sharing**.
 
             **Impact:**
 
@@ -695,9 +701,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Internet Sharing**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Internet Sharing**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Internet Sharing**.
 
             **Impact:**
 
@@ -793,9 +802,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Media Sharing**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Media Sharing**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Media Sharing**.
 
             **Impact:**
 
@@ -804,17 +816,20 @@ queries:
           desc: |
             **Using Ansible**
 
-            To disable Media Sharing using Ansible, you can use the following playbook:
+            To disable Media Sharing using Ansible, run the task as the user whose preference you are changing:
 
             ```yaml
             ---
             - name: Disable Media Sharing
               hosts: all
               become: true
+              become_user: firstuser
               tasks:
-                - name: Disable Media Sharing
+                - name: Disable Media Sharing for the user
                   ansible.builtin.command: defaults write com.apple.amp.mediasharingd home-sharing-enabled -int 0
             ```
+
+            Replace `firstuser` with the account that has Media Sharing enabled.
 
             **Impact:**
 
@@ -891,9 +906,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Printer Sharing**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Printer Sharing**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Printer Sharing**.
 
             **Impact:**
 
@@ -982,6 +1000,8 @@ queries:
             sudo systemsetup -setremoteappleevents off
             ```
 
+            On macOS 13 and later, the terminal application running this command must be granted Full Disk Access in System Settings under Privacy & Security. Without it, `systemsetup` cannot change the setting.
+
             **Impact:**
 
             With Remote Apple Events enabled, an AppleScript program running on another Mac can interact with the local computer, potentially leading to unauthorized access or misuse.
@@ -989,9 +1009,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Remote Apple Events**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Remote Apple Events**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Remote Apple Events**.
 
             **Impact:**
 
@@ -1077,8 +1100,14 @@ queries:
             Run this command to disable Remote Login:
 
             ```bash
-            sudo systemsetup -setremotelogin off
+            sudo systemsetup -f -setremotelogin off
             ```
+
+            The `-f` flag suppresses the interactive confirmation prompt. On macOS 13 and later, the terminal application running this command must be granted Full Disk Access in System Settings under Privacy & Security.
+
+            **Warning:**
+
+            Disabling Remote Login immediately ends SSH access to this machine. If you are connected over SSH or manage this system remotely, you will lose access and must use the local console or another remote management channel to get back in. Confirm an alternative access path exists before running this command.
 
             **Impact:**
 
@@ -1087,9 +1116,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Remote Login**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Remote Login**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Remote Login**.
 
             **Impact:**
 
@@ -1098,7 +1130,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            To disable Remote Login using Ansible, you can use the following playbook:
+            To disable Remote Login using Ansible, you can use the following playbook. The `-f` flag is required so the command does not wait for interactive confirmation:
 
             ```yaml
             ---
@@ -1107,12 +1139,16 @@ queries:
               become: true
               tasks:
                 - name: Disable Remote Login
-                  ansible.builtin.command: systemsetup -setremotelogin off
+                  ansible.builtin.command: systemsetup -f -setremotelogin off
             ```
+
+            **Warning:**
+
+            If Ansible reaches this host over SSH, this task disconnects it and all subsequent tasks fail. Run it last, and confirm console or MDM access exists before applying.
 
             **Impact:**
 
-            Disabling Remote Login prevents the use of the SSH server on macOS. For systems requiring SSH access, ensure proper hardening measures are in place, such as restricting access to trusted IP addresses and using secure authentication methods. Standard user computers should not act as servers, especially in environments where they frequently change locations or IP addresses.
+            Disabling Remote Login prevents the use of the SSH server on macOS. For systems requiring SSH access, ensure proper hardening measures are in place, such as restricting access to trusted IP addresses and using secure authentication methods.
     refs:
       - url: https://support.apple.com/guide/mac-help/allow-a-remote-computer-to-access-your-mac-mchlp1066/mac
         title: Apple - Remote Access Settings
@@ -1185,9 +1221,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Remote Management**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Remote Management**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Remote Management**.
 
             **Impact:**
 
@@ -1283,9 +1322,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Screen Sharing**
+            1. Open **System Settings**
+            2. Select **General**
+            3. Select **Sharing**
+            4. Turn off **Screen Sharing**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Sharing**, and uncheck **Screen Sharing**.
 
             **Impact:**
 
@@ -1305,6 +1347,10 @@ queries:
                 - name: Disable Screen Sharing
                   ansible.builtin.command: launchctl unload -w /System/Library/LaunchDaemons/com.apple.screensharing.plist
             ```
+
+            **Impact:**
+
+            Disabling Screen Sharing prevents remote access to the system's screen. For environments requiring remote support, ensure alternative secure methods are in place, such as using dedicated remote management tools with proper access controls.
     refs:
       - url: https://support.apple.com/guide/mac-help/allow-a-remote-computer-to-access-your-mac-mchlp1066/mac
         title: Apple - Remote Access Settings
@@ -1363,6 +1409,8 @@ queries:
             sudo dsenableroot -d
             ```
 
+            The command prompts for an administrator account password before disabling root.
+
             **Impact:**
 
             Disabling the root account may affect legacy POSIX software that expects an available root account. Ensure alternative administrative methods are in place if required.
@@ -1382,7 +1430,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            To disable the root account using Ansible, you can use the following playbook:
+            The `dsenableroot -d` command prompts interactively for an administrator password, so a plain command task hangs. Use the expect module and supply credentials from Ansible Vault:
 
             ```yaml
             ---
@@ -1391,8 +1439,14 @@ queries:
               become: true
               tasks:
                 - name: Disable root account
-                  ansible.builtin.command: dsenableroot -d
+                  ansible.builtin.expect:
+                    command: dsenableroot -d -u "{{ macos_admin_user }}"
+                    responses:
+                      'password:': "{{ macos_admin_password }}"
+                  no_log: true
             ```
+
+            Store `macos_admin_user` and `macos_admin_password` in Ansible Vault and never in plain text.
 
             **Impact:**
 
@@ -1486,12 +1540,16 @@ queries:
 
             Perform the following to enable FileVault:
 
-            1. Open **System Preferences**
-            2. Select **Security & Privacy**
+            1. Open **System Settings**
+            2. Select **Privacy & Security**
             3. Select **FileVault**
-            4. Select **Turn on FileVault**
+            4. Select **Turn On**
 
-            Note: To pass this check and make sure encryption cannot be turned off by the system, you need to [make sure that the Device Management Profile property `dontAllowFDEDisable` is set to 'true'.](https://developer.apple.com/documentation/devicemanagement/fdefilevaultoptions). To do so you can use an macOS configuration profile [similar to this one.](https://github.com/gregneagle/profiles/blob/master/cant_disable_filevault.mobileconfig)
+            On macOS 12 and earlier, open **System Preferences**, select **Security & Privacy**, select **FileVault**, and select **Turn On FileVault**.
+
+            Record the recovery key shown during setup and store it securely. The recovery key is required to unlock the disk if every enabled account password is forgotten.
+
+            Note: To pass this check and ensure users cannot turn encryption off, the Device Management profile property [`dontAllowFDEDisable` must be set to true](https://developer.apple.com/documentation/devicemanagement/fdefilevaultoptions). You can deploy a macOS configuration profile [similar to this one](https://github.com/gregneagle/profiles/blob/master/cant_disable_filevault.mobileconfig).
 
             **Impact:**
 
@@ -1500,7 +1558,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            To enable FileVault using Ansible, you can use the following playbook:
+            A bare `fdesetup enable` prompts for a password and cannot run unattended. Use deferred enablement, which activates FileVault at the user's next logout and writes the recovery key to a file you must collect and escrow:
 
             ```yaml
             ---
@@ -1508,12 +1566,21 @@ queries:
               hosts: all
               become: true
               tasks:
-                - name: Enable FileVault
-                  ansible.builtin.command: fdesetup enable
+                - name: Enable FileVault at next logout
+                  ansible.builtin.command: fdesetup enable -defer /var/db/filevault-recovery.plist
+                - name: Fetch the recovery key for escrow
+                  ansible.builtin.fetch:
+                    src: /var/db/filevault-recovery.plist
+                    dest: filevault-keys/
+                - name: Remove the local recovery key copy
+                  ansible.builtin.file:
+                    path: /var/db/filevault-recovery.plist
+                    state: absent
             ```
 
-            Note: To pass this check and make sure encryption cannot be turned off by the system, you need to [make sure that the Device Management Profile property `dontAllowFDEDisable` is set to 'true'.](https://developer.apple.com/documentation/devicemanagement/fdefilevaultoptions). To do so you can use an macOS configuration profile [similar to this one.](https://github.com/gregneagle/profiles/blob/master/cant_disable_filevault.mobileconfig)
+            Store the fetched recovery keys in a secure escrow location. If the recovery key is lost and a user forgets their password, the encrypted data cannot be recovered. In MDM-managed fleets, prefer enabling FileVault through an MDM profile with institutional key escrow instead.
 
+            Note: To pass this check and ensure users cannot turn encryption off, the Device Management profile property [`dontAllowFDEDisable` must be set to true](https://developer.apple.com/documentation/devicemanagement/fdefilevaultoptions).
 
             **Impact:**
 
@@ -1588,10 +1655,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Security & Privacy**
+            1. Open **System Settings**
+            2. Select **Network**
             3. Select **Firewall**
-            4. Select **Turn On Firewall**
+            4. Turn on the **Firewall** toggle
+
+            On macOS 12 and earlier, open **System Preferences**, select **Security & Privacy**, select **Firewall**, and select **Turn On Firewall**.
 
             **Impact:**
 
@@ -1687,10 +1756,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Security & Privacy**
-            3. Select **Firewall Options**
-            4. Turn on **Enable stealth mode**
+            1. Open **System Settings**
+            2. Select **Network**
+            3. Select **Firewall**
+            4. Select **Options**
+            5. Turn on **Enable stealth mode**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Security & Privacy**, select **Firewall Options**, and turn on **Enable stealth mode**.
 
             **Impact:**
 
@@ -1786,11 +1858,15 @@ queries:
           desc: |
             **Using the CLI**
 
-            Run this command to enable Gatekeeper:
+            Run this command to enable Gatekeeper assessments:
 
             ```bash
-            sudo spctl --master-enable
+            sudo spctl --global-enable
             ```
+
+            On older macOS versions the equivalent command is `sudo spctl --master-enable`. Starting with macOS Sequoia, Apple restricts command-line changes to Gatekeeper policy; if the command reports the operation is not permitted, enforce the setting with a configuration profile instead.
+
+            Note: To pass this check, you must also deploy a Device Management configuration profile with the [`com.apple.systempolicy.control`](https://developer.apple.com/documentation/devicemanagement/systempolicycontrol) payload that sets `EnableAssessment` to true and `AllowIdentifiedDevelopers` to true. Without that managed preference the check fails even when `spctl --status` reports assessments enabled.
 
             **Impact:**
 
@@ -1799,10 +1875,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Security & Privacy**
-            3. Select **General**
-            4. Set **Allow apps downloaded from** to **App Store and identified developers**
+            1. Open **System Settings**
+            2. Select **Privacy & Security**
+            3. Under **Security**, set **Allow applications downloaded from** to **App Store and identified developers**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Security & Privacy**, select **General**, and set **Allow apps downloaded from** to **App Store and identified developers**.
+
+            Note: To pass this check, you must also deploy a Device Management configuration profile with the [`com.apple.systempolicy.control`](https://developer.apple.com/documentation/devicemanagement/systempolicycontrol) payload that sets `EnableAssessment` to true and `AllowIdentifiedDevelopers` to true.
 
             **Impact:**
 
@@ -1819,9 +1898,11 @@ queries:
               hosts: all
               become: true
               tasks:
-                - name: Enable Gatekeeper
-                  ansible.builtin.command: spctl --master-enable
+                - name: Enable Gatekeeper assessments
+                  ansible.builtin.command: spctl --global-enable
             ```
+
+            On macOS versions that restrict `spctl` policy changes, deploy a Device Management configuration profile with the `com.apple.systempolicy.control` payload instead. That profile is also required for this check to pass.
 
             **Impact:**
 
@@ -2005,10 +2086,11 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Network**
-            3. Select **Wi-Fi**
-            4. Enable **Show Wi-Fi status in menu bar**
+            1. Open **System Settings**
+            2. Select **Control Center**
+            3. Set **Wi-Fi** to **Show in Menu Bar**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Network**, select **Wi-Fi**, and enable **Show Wi-Fi status in menu bar**.
 
             **Impact:**
 
@@ -2017,32 +2099,20 @@ queries:
           desc: |
             **Using Ansible**
 
-            To enable the Wi-Fi status in the menu bar using Ansible, you can use the following playbook:
+            To enable the Wi-Fi status in the menu bar using Ansible, run the task as the user whose preference you are changing:
 
             ```yaml
             ---
             - name: Enable Wi-Fi status in menu bar
               hosts: all
               become: true
+              become_user: firstuser
               tasks:
                 - name: Enable Wi-Fi status in menu bar
                   ansible.builtin.command: defaults -currentHost write com.apple.controlcenter.plist WiFi -int 18
             ```
 
-            _Example:_
-
-            ```yaml
-            ---
-            - name: Enable Wi-Fi status in menu bar for firstuser
-              hosts: all
-              become: true
-              become_user: firstuser
-              tasks:
-                - name: Enable Wi-Fi status in menu bar for firstuser
-                  ansible.builtin.command: defaults -currentHost write com.apple.controlcenter.plist WiFi -int 18
-            ```
-
-            _Note: Both `18` and `2` are valid values for this parameter._
+            Replace `firstuser` with the account being configured. Both `18` and `2` are valid values for this parameter.
 
             **Impact:**
 
@@ -2071,9 +2141,7 @@ queries:
       users.where(name != /^_/ && shell != "/usr/bin/false" && name != "root") {
         name
         filePath1 = home + "/Library/Preferences/com.apple.NetworkBrowser.plist"
-        a = file(filePath1).exists == true && [filePath1].where(file(_).exists) {
-            parse.plist(filePath1).params["allowAirDrop"]["value"] == false
-          }
+        a = file(filePath1).exists && parse.plist(filePath1).params["DisableAirDrop"] == true
         filePath2 = "/Library/Managed Preferences/" + name + "/complete.plist"
         b = file(filePath2).exists == true && [filePath2].where(file(_).exists) {
             parse.plist(filePath2).params["com.apple.applicationaccess"]["allowAirDrop"]["value"] == false
@@ -2151,30 +2219,24 @@ queries:
           desc: |
             **Using Ansible**
 
-            To disable AirDrop using Ansible, you can use the following playbook:
+            To disable AirDrop using Ansible, run the task as the user whose preference you are changing:
 
             ```yaml
             ---
             - name: Disable AirDrop
               hosts: all
               become: true
-              tasks:
-                - name: Disable AirDrop
-                  ansible.builtin.command: defaults write com.apple.NetworkBrowser DisableAirDrop -bool true
-            ```
-
-            _Example:_
-
-            ```yaml
-            ---
-            - name: Disable AirDrop for firstuser
-              hosts: all
-              become: true
               become_user: firstuser
               tasks:
-                - name: Disable AirDrop for firstuser
+                - name: Disable AirDrop for the user
                   ansible.builtin.command: defaults write com.apple.NetworkBrowser DisableAirDrop -bool true
             ```
+
+            Replace `firstuser` with the account being configured.
+
+            **Impact:**
+
+            Disabling AirDrop can limit the ability to move files quickly over the network without using file shares.
     refs:
       - url: https://support.apple.com/guide/security/welcome/web
         title: Apple Platform Security Guide
@@ -2247,11 +2309,11 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Security & Privacy**
-            3. Select **Firewall**
-            4. Select **Firewall Options**
-            5. Enable **Enable logging**
+            macOS provides no graphical control for application firewall logging. Use the CLI command to enable it:
+
+            ```bash
+            sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setloggingmode on
+            ```
 
             **Impact:**
 
@@ -2343,9 +2405,11 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **Web Sharing**
+            macOS no longer provides a graphical control for the built-in Apache web server. Apple removed the Web Sharing option from the Sharing pane. Use the CLI command to disable the service:
+
+            ```bash
+            sudo launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
+            ```
 
             **Impact:**
 
@@ -2437,10 +2501,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Sharing**
-            3. Uncheck **File Sharing**
-            4. Uncheck **NFS Sharing**
+            macOS provides no graphical control for the NFS server. The Sharing pane does not manage `nfsd`. Use the CLI command to disable it:
+
+            ```bash
+            sudo nfsd disable
+            ```
+
+            Also remove or empty `/etc/exports` so the service does not restart with active exports.
 
             **Impact:**
 
@@ -2488,7 +2555,7 @@ queries:
       file("/etc/security/audit_control").exists;
       ["/etc/security/audit_control"].where(file(_).exists) {
         file(_).content.lines.where( _ == /^expire-after/) {
-          _.split(":")[1] == /[6-9]\dd|\d{3,}d/ || _.split(":")[1] == /\d+0G|[1-9G]/
+          _.split(":")[1] == /^([6-9]\d|[1-9]\d{2,})d$/ || _.split(":")[1] == /^[1-9]\d*G$/
         }
       }
     docs:
@@ -2533,10 +2600,16 @@ queries:
             expire-after:60d
             ```
 
-            Alternatively, use `sed` to update the value:
+            If an `expire-after` line already exists, you can update it with `sed` instead:
 
             ```bash
             sudo sed -i '' 's/^expire-after:.*/expire-after:60d/' /etc/security/audit_control
+            ```
+
+            The `sed` command only changes an existing line. If the file has no `expire-after` line, add one with the editor. Then apply the new configuration:
+
+            ```bash
+            sudo audit -s
             ```
 
             **Note:** The `/etc/security/audit_control` file is a plain text configuration file, not a plist. Use a text editor or `sed` to modify it.
@@ -2653,10 +2726,7 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Users & Groups**
-            3. Select **Login Options**
-            4. Set **Password expiration** to **365 days**
+            macOS provides no graphical setting for password expiration on local accounts. Use the CLI command, or deploy an MDM passcode configuration profile that sets `maxPINAgeInDays` to 365 or less.
 
             **Impact:**
 
@@ -2765,10 +2835,7 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
-            2. Select **Users & Groups**
-            3. Select **Login Options**
-            4. Set **Password history** to **15 passwords**
+            macOS provides no graphical setting for password history on local accounts. Use the CLI command, or deploy an MDM passcode configuration profile that sets `pinHistory` to 15 or more.
 
             **Impact:**
 
@@ -2906,7 +2973,7 @@ queries:
     mql: |
       file('/etc/asl/com.apple.install') {
         content != /all_max/
-        content == /ttl/
+        content == /ttl=(36[5-9]|3[7-9]\d|[4-9]\d{2}|[1-9]\d{3,})/
       }
     docs:
       desc: |
@@ -3142,11 +3209,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
+            1. Open **System Settings**
             2. Select **General**
             3. Select **Software Update**
-            4. Select **Advanced**
-            5. Enable **Check for updates**
+            4. Select the info button next to **Automatic updates**
+            5. Turn on **Check for updates**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Software Update**, select **Advanced**, and enable **Check for updates**.
 
             **Impact:**
 
@@ -3242,11 +3311,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
+            1. Open **System Settings**
             2. Select **General**
             3. Select **Software Update**
-            4. Select **Advanced**
-            5. Enable **Download new updates when available**
+            4. Select the info button next to **Automatic updates**
+            5. Turn on **Download new updates when available**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Software Update**, select **Advanced**, and enable **Download new updates when available**.
 
             **Impact:**
 
@@ -3266,6 +3337,10 @@ queries:
                 - name: Enable automatic downloads of software updates
                   ansible.builtin.command: /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true
             ```
+
+            **Impact:**
+
+            Enabling automatic downloads ensures that updates are readily available for installation. However, users must still manually approve or install updates unless additional automatic update settings are enabled.
     refs:
       - url: https://support.apple.com/guide/mac-help/keep-your-mac-up-to-date-mchlpx1065/mac
         title: Apple - Keep Your Mac Up to Date
@@ -3328,11 +3403,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Run this command to enable automatic installation of critical updates:
+            Run these commands to enable automatic installation of system data files and critical security updates:
 
             ```bash
+            sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true
             sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
             ```
+
+            Both keys are required: `ConfigDataInstall` controls system data files such as XProtect definitions, and `CriticalUpdateInstall` controls security responses.
 
             **Impact:**
 
@@ -3341,11 +3419,13 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
+            1. Open **System Settings**
             2. Select **General**
             3. Select **Software Update**
-            4. Select **Advanced**
-            5. Enable **Install system data files and security updates**
+            4. Select the info button next to **Automatic updates**
+            5. Turn on **Install Security Responses and system files**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Software Update**, select **Advanced**, and enable **Install system data files and security updates**.
 
             **Impact:**
 
@@ -3357,11 +3437,14 @@ queries:
             To enable automatic installation of critical updates using Ansible, you can use the following playbook:
 
             ```yaml
+            ---
             - name: Enable automatic installation of critical updates
               hosts: all
               become: true
               tasks:
-                - name: Enable automatic installation of critical updates
+                - name: Enable automatic installation of system data files
+                  ansible.builtin.command: /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true
+                - name: Enable automatic installation of security responses
                   ansible.builtin.command: /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
             ```
 
@@ -3437,8 +3520,10 @@ queries:
             To install all available updates, run:
 
             ```bash
-            softwareupdate -i -a
+            sudo softwareupdate -i -a
             ```
+
+            Updates that require a restart will prompt for one; add `-R` to restart automatically after installation.
 
             **Impact:**
 
@@ -3447,10 +3532,12 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **System Preferences**
+            1. Open **System Settings**
             2. Select **General**
             3. Select **Software Update**
             4. Select **Update Now**
+
+            On macOS 12 and earlier, open **System Preferences**, select **Software Update**, and select **Update Now**.
 
             **Impact:**
 
@@ -3585,11 +3672,14 @@ queries:
             - name: Block all incoming firewall connections
               hosts: all
               become: true
-
               tasks:
                 - name: Block all incoming connections
                   ansible.builtin.command: /usr/libexec/ApplicationFirewall/socketfilterfw --setblockall on
             ```
+
+            **Impact:**
+
+            Blocking all incoming connections will prevent any application from receiving inbound network traffic, except for essential system services like DHCP and Bonjour. This may disrupt services that rely on incoming connections, such as file sharing, screen sharing, or remote management. Ensure this setting is appropriate for the device's role before enabling, especially when applying it to many machines at once.
     refs:
       - url: https://support.apple.com/guide/mac-help/block-connections-to-your-mac-with-a-firewall-mh34041/mac
         title: Apple - Block Connections with Firewall


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2799). This PR covers `mondoo-macos-security.mql.yaml`: all 34 checks were reviewed and 32 needed fixes. Policy version bumped. Verified against the os provider schema and parsing code (`macos.go`, `macos_sharing.go`, `macos_softwareupdate.go`) and against a live macOS host for command behavior.

## Why these needed checking

Four checks could never pass or never fail regardless of what the user did, five GUI entries described controls that do not exist in any current macOS, and three remediations hang forever when run unattended because the underlying commands prompt interactively.

## Checks that could never pass or never fail (mql)

- **disable-bonjour-advertising-service / ensure-airdrop-is-disabled**: one branch of each check read the managed-preferences nesting (`domain → key → value`) from a plain plist, a structure that only exists under `/Library/Managed Preferences`. The documented `defaults write` commands write flat keys, so on an unmanaged Mac the remediation could never make the check pass. Both branches now read the flat keys the commands write, with the MDM branches untouched.
- **ensure-security-auditing-retention**: the regex alternative `[1-9G]` matched any digit anywhere, so `expire-after:1d` passed a check whose title demands 60 days. The expression now requires at least 60 days or a gigabyte value.
- **retain-install-log-for-365-or-more-days**: the check matched the bare substring `ttl`, which the default configuration line already contains, so systems retaining far less than 365 days passed. It now requires `ttl=365` or greater.

## GUI steps for controls that have no GUI

Bonjour multicast advertising, application firewall logging, password age, and password history have never had graphical settings; Web Sharing left the Sharing pane in OS X 10.8 and NFS has never been there. Each entry now points at the real mechanism (CLI or MDM profile keys) instead of sending users hunting for checkboxes that do not exist.

## Commands that hang, lock out, or lose data unattended

- **disable-remote-login**: `systemsetup -setremotelogin off` prompts for confirmation, so the Ansible task hung forever; it needs `-f`. The remediation also gains the warning that it severs the very SSH session running it.
- **do-not-enable-the-root-account**: `dsenableroot -d` prompts for admin credentials; the Ansible entry now uses the expect module with Vault-stored credentials.
- **enable-filevault**: bare `fdesetup enable` prompts for a password and prints the recovery key to the terminal; unattended it hangs, or the key lands in logs or is lost, which means permanent data loss if the login password is forgotten. The playbook now uses deferred enablement with explicit key escrow steps.

## Remediations that changed the wrong state

- Three Ansible playbooks ran `defaults write` as root without `become_user`, writing root's preference domain while the checks read the console user's (media sharing, Wi-Fi status, AirDrop). The Wi-Fi check even shipped two playbooks, one broken and one correct; the broken one is removed.
- **software-updates-install-critical-updates** set only `CriticalUpdateInstall` while the check requires `ConfigDataInstall` too; both keys are now set.
- **control-access-to-audit-records**: `chmod -R 600 /var/audit` strips the execute bit from directories, breaking traversal, and the Ansible entry disagreed with the CLI (0700 recursive marks log files executable). Both now converge: directories 700, files 600.
- **ensure-macos-is-up-to-date** ran `softwareupdate -i -a` without root.
- **enable-gatekeeper** used `spctl --master-enable`, no longer documented; now `--global-enable` with the Sequoia MDM restriction noted, plus the managed-preference payload the check requires.

## Stale navigation

Nearly every gui entry said System Preferences with pre-Ventura pane names while the audits already said System Settings. All gui entries now lead with current System Settings paths and keep a one-line macOS 12 fallback.

## Left for maintainers

The password-age, password-history, and minimum-length checks read `pwpolicy -getaccountpolicies` parameter names while the remediations set legacy global policy keys; macOS translates between them, but the exact translated parameter names could not be verified on a live system. The Gatekeeper check additionally requires a managed preference on every regular user, now documented in the remediation, which unmanaged machines cannot satisfy.

## Validation

- `cnspec policy lint` passes (compiles all four modified mql expressions)
- `validate_ansible_remediation.py macos`: 35 passed, 0 failed
- YAML parses clean; all modified bash blocks shellcheck-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)