### PR TITLE
🐛 fortios: fix license checks unlicensed devices pass and a lockout-prone telnet fix

### DIFF
--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-fortios-security
     name: Mondoo Fortinet FortiOS Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -168,7 +168,13 @@ queries:
             get system status
             ```
 
-            Download and install a GA firmware image from [Fortinet Support](https://support.fortinet.com):
+            Back up the configuration before upgrading:
+
+            ```
+            execute backup full-config tftp <filename> <tftp_server_ip>
+            ```
+
+            Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. The device reboots during the upgrade and traffic is interrupted until it comes back up, so run this during a maintenance window:
 
             ```
             execute restore image tftp <filename> <tftp_server_ip>
@@ -236,10 +242,11 @@ queries:
           desc: |
             **Using the FortiGate web interface**
 
-            1. Navigate to **System > Firmware & Registration**
-            2. Review the available firmware versions and their maturity levels
-            3. Select a firmware version with "Mature" maturity status
-            4. Click **Upgrade** and follow the prompts
+            1. Back up the device configuration under **System > Configuration > Backups**
+            2. Navigate to **System > Firmware & Registration**
+            3. Review the available firmware versions and their maturity levels
+            4. Select a firmware version with "Mature" maturity status
+            5. Click **Upgrade** and follow the prompts; the device reboots to complete the upgrade
 
             Consult the [Fortinet firmware maturity documentation](https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware) to identify which releases have reached Mature status for your platform.
         - id: cli
@@ -252,7 +259,13 @@ queries:
             get system status
             ```
 
-            To upgrade, download a Mature release from [Fortinet Support](https://support.fortinet.com) and install:
+            Back up the configuration before upgrading:
+
+            ```
+            execute backup full-config tftp <filename> <tftp_server_ip>
+            ```
+
+            Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. The device reboots during the upgrade and traffic is interrupted until it comes back up, so run this during a maintenance window:
 
             ```
             execute restore image tftp <filename> <tftp_server_ip>
@@ -707,10 +720,13 @@ queries:
           desc: |
             **Using the CLI**
 
+            **Important**: HA configuration requires a second FortiGate unit with matching hardware, firmware, and licenses. Forming a cluster renegotiates interfaces and can briefly interrupt traffic, so apply this change during a maintenance window from the console or a dedicated management interface. Set a cluster password so only authorized units can join.
+
             ```
             config system ha
                 set mode a-p
                 set group-name "fg-cluster"
+                set password <cluster-password>
                 set hbdev "port3" 50
                 set priority 200
             end
@@ -826,7 +842,7 @@ queries:
 
         1. Log in to the FortiGate web interface.
         2. Navigate to **Network > DNS**.
-        3. Check the **DNS over TLS** setting.
+        3. Under **DNS Protocols**, check whether **DNS over TLS** is selected.
 
         A passing result shows DNS over TLS enabled. A failing result shows it disabled.
 
@@ -836,22 +852,34 @@ queries:
         2. Run the following command:
 
            ```
-           get system dns | grep dns-over-tls
+           get system dns
            ```
 
-        A passing result reports `dns-over-tls` set to `enable`. A failing result reports `disable`.
+        On FortiOS 7.0 and later, a passing result reports `protocol` set to `dot`. On FortiOS 6.4 and earlier, a passing result reports `dns-over-tls` set to `enable`. A failing result reports cleartext DNS resolution.
       remediation:
         - id: console
           desc: |
             **Using the FortiGate web interface**
 
             1. Navigate to **Network > DNS**
-            2. Set **DNS over TLS** to **Enable**
-            3. Ensure the configured DNS servers support DNS-over-TLS (e.g., Cloudflare 1.1.1.1, Google 8.8.8.8)
-            4. Click **Apply**
+            2. Set **DNS servers** to **Specify**
+            3. Under **DNS Protocols**, select **DNS over TLS**
+            4. Ensure the configured DNS servers support DNS over TLS, such as Cloudflare 1.1.1.1 or Google 8.8.8.8
+            5. Click **Apply**
         - id: cli
           desc: |
             **Using the CLI**
+
+            FortiOS 7.0 and later select the DNS transport with the `protocol` option:
+
+            ```
+            config system dns
+                set protocol dot
+                set ssl-certificate "Fortinet_Factory"
+            end
+            ```
+
+            FortiOS 6.4 and earlier use the `dns-over-tls` option:
 
             ```
             config system dns
@@ -1053,8 +1081,8 @@ queries:
         ### Audit via the FortiGate web interface
 
         1. Log in to the FortiGate web interface.
-        2. Navigate to **Log & Report > Log Settings**.
-        3. Check whether **Log Denied Traffic** or **Implicit Policy Logging** is enabled.
+        2. Navigate to **Policy & Objects > Firewall Policy**.
+        3. Locate the **Implicit Deny** policy at the bottom of the policy table and check whether **Log Violation Traffic** is enabled.
 
         A passing result shows implicit deny logging enabled. A failing result shows it disabled.
 
@@ -1073,9 +1101,10 @@ queries:
           desc: |
             **Using the FortiGate web interface**
 
-            1. Navigate to **Log & Report > Log Settings**
-            2. Enable **Implicit Policy Logging**
-            3. Click **Apply**
+            1. Navigate to **Policy & Objects > Firewall Policy**
+            2. Locate the **Implicit Deny** policy at the bottom of the policy table and click **Edit**
+            3. Enable **Log Violation Traffic**
+            4. Click **OK**
         - id: cli
           desc: |
             **Using the CLI**
@@ -1124,7 +1153,7 @@ queries:
 
         1. Log in to the FortiGate web interface.
         2. Navigate to **Log & Report > Log Settings**.
-        3. Check whether **Local-in Denied Unicast** logging is enabled.
+        3. On the **Global Settings** tab, check whether **Log denied unicast traffic** is enabled. The toggle is visible when **Local traffic logging** is set to **Specify**.
 
         A passing result shows local-in denied unicast logging enabled. A failing result shows it disabled.
 
@@ -1144,8 +1173,9 @@ queries:
             **Using the FortiGate web interface**
 
             1. Navigate to **Log & Report > Log Settings**
-            2. Enable **Local-in Denied Unicast** logging
-            3. Click **Apply**
+            2. On the **Global Settings** tab, set **Local traffic logging** to **Specify**
+            3. Enable **Log denied unicast traffic**
+            4. Click **Apply**
         - id: cli
           desc: |
             **Using the CLI**
@@ -1192,13 +1222,7 @@ queries:
 
         The additional log volume is a worthwhile tradeoff for the improved visibility during investigations.
       audit: |
-        ### Audit via the FortiGate web interface
-
-        1. Log in to the FortiGate web interface.
-        2. Navigate to **Log & Report > Log Settings**.
-        3. Check whether **Extended Logging** (extended UTM log) is enabled.
-
-        A passing result shows extended logging enabled. A failing result shows it disabled.
+        The global extended log format option is not exposed in the FortiGate web interface. Audit it from the CLI.
 
         ### Audit via FortiOS CLI
 
@@ -1211,16 +1235,12 @@ queries:
 
         A passing result reports `extended-log` set to `enable`. A failing result reports `disable`.
       remediation:
-        - id: console
-          desc: |
-            **Using the FortiGate web interface**
-
-            1. Navigate to **Log & Report > Log Settings**
-            2. Enable **Extended Logging**
-            3. Click **Apply**
+        # No console remediation: the global extended-log option in "config log setting" is not exposed in the FortiGate web interface; it is configurable only in the CLI.
         - id: cli
           desc: |
             **Using the CLI**
+
+            The global extended log format option is available only in the CLI:
 
             ```
             config log setting
@@ -1264,13 +1284,7 @@ queries:
 
         If privacy regulations require anonymization in certain contexts, implement it at the SIEM level with role-based access to deanonymize rather than at the source.
       audit: |
-        ### Audit via the FortiGate web interface
-
-        1. Log in to the FortiGate web interface.
-        2. Navigate to **Log & Report > Log Settings**.
-        3. Check the **Anonymize User** setting.
-
-        A passing result shows user anonymization disabled. A failing result shows it enabled.
+        The user-anonymize option is not exposed in the FortiGate web interface. Audit it from the CLI.
 
         ### Audit via FortiOS CLI
 
@@ -1283,16 +1297,12 @@ queries:
 
         A passing result reports `user-anonymize` set to `disable`. A failing result reports `enable`.
       remediation:
-        - id: console
-          desc: |
-            **Using the FortiGate web interface**
-
-            1. Navigate to **Log & Report > Log Settings**
-            2. Disable **Anonymize User**
-            3. Click **Apply**
+        # No console remediation: the user-anonymize option in "config log setting" is not exposed in the FortiGate web interface; it is configurable only in the CLI.
         - id: cli
           desc: |
             **Using the CLI**
+
+            The user anonymization option is available only in the CLI:
 
             ```
             config log setting
@@ -1968,7 +1978,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      fortios.firewall.policies.where(action == "accept").all(sslSshProfile != "")
+      fortios.firewall.policies.where(action == "accept").all(sslSshProfile != "" && sslSshProfile != "no-inspection")
     docs:
       desc: |
         This check verifies that all firewall accept rules have an SSL/SSH inspection profile configured. Without SSL inspection, encrypted traffic bypasses all UTM security profiles.
@@ -1991,7 +2001,7 @@ queries:
         2. Navigate to **Policy & Objects > Firewall Policy**.
         3. For each accept policy, open it and review the **SSL/SSH Inspection** setting.
 
-        A passing result shows every accept policy with an SSL/SSH inspection profile assigned. A failing result shows at least one accept policy with no inspection profile.
+        A passing result shows every accept policy with an SSL/SSH inspection profile assigned other than the built-in **no-inspection** profile. A failing result shows at least one accept policy with no inspection profile or with **no-inspection**.
 
         ### Audit via FortiOS CLI
 
@@ -2002,7 +2012,7 @@ queries:
            show firewall policy
            ```
 
-        A passing result shows every accept policy with a non-empty `set ssl-ssh-profile`. A failing result shows an accept policy with no `ssl-ssh-profile` assigned.
+        A passing result shows every accept policy with `set ssl-ssh-profile` set to a profile other than `no-inspection`. A failing result shows an accept policy with no `ssl-ssh-profile` assigned or with the `no-inspection` profile.
       remediation:
         - id: console
           desc: |
@@ -2088,6 +2098,8 @@ queries:
           desc: |
             **Using the FortiGate web interface**
 
+            **Warning**: Do not make this change while connected through the WAN interface you are editing. Removing management protocols from that interface ends your session immediately and can lock you out. Connect through an internal interface, a dedicated management interface, or the serial console first.
+
             1. Navigate to **Network > Interfaces**
             2. For each WAN interface, click **Edit**
             3. Under **Administrative Access**, remove **HTTPS**, **HTTP**, **SSH**, **Telnet**, and **SNMP**
@@ -2098,6 +2110,10 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            **Warning**: Run these commands from the console or from a session that enters through an internal interface. Replacing the access list on the interface that carries your current session disconnects you immediately. Keep `fgfm` in the list if the device is managed by FortiManager.
+
+            Repeat for every WAN interface:
 
             ```
             config system interface
@@ -2176,17 +2192,23 @@ queries:
           desc: |
             **Using the CLI**
 
-            Remove telnet from each interface that has it enabled:
+            List the interfaces that currently allow telnet:
+
+            ```
+            show system interface
+            ```
+
+            Remove only the telnet option from each affected interface. The `unselect` keyword removes a single option from a multi-option field without touching the others:
 
             ```
             config system interface
                 edit "mgmt"
-                    unset allowaccess telnet
+                    unselect allowaccess telnet
                 next
             end
             ```
 
-            Or set the complete list of allowed protocols without telnet:
+            Alternatively, set the complete list of allowed protocols without telnet:
 
             ```
             config system interface
@@ -2195,6 +2217,8 @@ queries:
                 next
             end
             ```
+
+            Do not run `unset allowaccess`. It clears every management protocol from the interface, including the session you may be using to administer the device.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/552515/interfaces
         title: FortiOS interface configuration
@@ -2325,6 +2349,8 @@ queries:
           desc: |
             **Using the FortiGate web interface**
 
+            **Important**: Graceful restart is negotiated when a BGP session is established, so enabling it resets existing BGP sessions. Apply this change during a maintenance window.
+
             1. Navigate to **Network > BGP**
             2. Enable **Graceful Restart**
             3. Configure appropriate restart and stalepath timers for your environment
@@ -2332,6 +2358,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            **Important**: Enabling graceful restart resets established BGP sessions while the new capability is negotiated. Apply this change during a maintenance window.
 
             ```
             config router bgp
@@ -2431,7 +2459,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: fortios.system.fortiGuard.antispamExpiration > time.now.unix
+    mql: fortios.system.fortiGuard.antispamLicense != 0 && fortios.system.fortiGuard.antispamExpiration > time.now.unix
     docs:
       desc: |
         This check verifies that the FortiGuard antispam subscription has not expired. An expired subscription stops receiving spam signature updates, degrading email security.
@@ -2511,7 +2539,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: fortios.system.fortiGuard.webfilterExpiration > time.now.unix
+    mql: fortios.system.fortiGuard.webfilterLicense != 0 && fortios.system.fortiGuard.webfilterExpiration > time.now.unix
     docs:
       desc: |
         This check verifies that the FortiGuard web filter subscription has not expired. An expired subscription stops receiving URL category updates, rendering web filtering policies ineffective against newly categorized threats.
@@ -2591,7 +2619,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: fortios.system.fortiGuard.outbreakPreventionExpiration > time.now.unix
+    mql: fortios.system.fortiGuard.outbreakPreventionLicense != 0 && fortios.system.fortiGuard.outbreakPreventionExpiration > time.now.unix
     docs:
       desc: |
         This check verifies that the FortiGuard outbreak prevention subscription has not expired. Outbreak prevention provides rapid response signatures for zero-day malware and emerging threats before traditional AV signatures are available.

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -2218,7 +2218,7 @@ queries:
             end
             ```
 
-            Do not run `unset allowaccess`. It clears every management protocol from the interface, including the session you may be using to administer the device.
+            Do not use `unset` to remove telnet. The `unset` keyword takes no protocol argument: `unset allowaccess` resets the whole field, removing every management protocol from the interface, including the session you may be using to administer the device.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/552515/interfaces
         title: FortiOS interface configuration


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2800). This PR covers `mondoo-fortios-security.mql.yaml`: all 33 checks were reviewed and 15 needed fixes. Policy version bumped. Verified against the fortios provider schema, its parsers, and real-device API captures in the provider's testdata, plus Fortinet documentation for CLI and GUI claims.

## Why these needed checking

The provider's own testdata, captured from a real FortiOS device, proves two classes of defect: license checks that pass on unlicensed devices, and a check that cannot pass at all on FortiOS 7.x. On the remediation side, one CLI example strips every management protocol from the interface carrying the administrator's session.

## Checks that pass when they should fail (mql)

**FortiGuard antispam / webfilter / outbreak-prevention**: the checks compared only `*Expiration > time.now`. Unlicensed devices report `*-license: 0` together with a placeholder expiration in 2038, so devices with no subscription at all — exactly the population these checks exist to catch — passed. All three now also require a nonzero license value.

**policy-ssl-inspection** accepted any non-empty profile name, including the built-in read-only `no-inspection` profile, which performs zero SSL/SSH inspection. The check now excludes it.

## A check that can never pass on supported firmware (left for maintainers)

**dns-over-tls**: FortiOS 7.0 replaced the `dns-over-tls` option with `set protocol {cleartext dot doh}`; the provider testdata from a 7.6.4 device contains `"protocol": "dot"` and no `dns-over-tls` key. The provider parser only reads the old key, so `dnsOverTls` is empty on every 7.x device and the check can never pass there, even though the sibling check in this policy requires major version 7+. Fixing this needs a `protocol` field on `fortios.system.dns` in the provider; the check mql is deliberately untouched. The remediation and audit are now version-aware so users on either firmware line get working commands.

## Lockout-prone and destructive guidance

- **no-telnet-access**: the example `unset allowaccess telnet` is invalid FortiOS syntax, and the `unset` form it degrades to clears every management protocol from the interface, including the HTTPS or SSH session running the command. The correct single-option removal keyword is `unselect`; an explicit warning against `unset allowaccess` is included.
- **wan-no-management-access**: replacing the access list disconnects any administrator entering through that WAN interface and stripped `fgfm` on FortiManager-managed devices. Both entries now warn and preserve the management path. The check itself only evaluates interfaces with `role == "wan"`, and the testdata shows internet-facing ports with `role: "undefined"` escaping it — documented here for maintainers.
- **firmware upgrades**: `execute restore image` reboots the device; both firmware checks now include a configuration backup step and maintenance-window warning. **ha-enabled** gains a cluster password (the heartbeat was unauthenticated) and an interface-renegotiation warning. **bgp-graceful-restart** now notes that enabling it resets established BGP sessions.

## Console steps for controls that are CLI-only or live elsewhere

`extended-log` and `user-anonymize` have no GUI controls; their console entries are replaced with explanatory comments. Implicit-deny logging is configured on the Implicit Deny policy itself via Log Violation Traffic, not a Log Settings toggle, and denied-unicast logging only appears after setting Local traffic logging to Specify. Audits updated to match.

## Validation

- `cnspec policy lint` passes (compiles all four modified mql expressions; field names verified in the provider schema)
- YAML parses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)