### PR TITLE
🐛 junos: fix append-semantics SSH fixes that never removed weak algorithms

### DIFF
--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-junos-security
     name: Mondoo Juniper Junos Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -149,17 +149,25 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable root login via SSH:
+            Before denying root login, verify that at least one named account with the super-user class exists and that you can open an SSH session with it. Denying root login while root is the only usable account cuts off remote management.
+
+            Disable root login via SSH and commit with automatic rollback in case access is lost:
 
             ```
             set system services ssh root-login deny
-            commit
+            commit confirmed 5
             ```
 
             Or allow key-based root login only:
 
             ```
             set system services ssh root-login deny-password
+            commit confirmed 5
+            ```
+
+            Open a new SSH session as a named user to confirm access still works, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -217,14 +225,21 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure only strong ciphers:
+            The `set` command appends to the existing cipher list, so first remove the current list including any weak entries, then configure only strong ciphers. Commit with automatic rollback so a cipher mismatch with your SSH client cannot lock you out:
 
             ```
-            set system services ssh ciphers aes256-ctr
-            set system services ssh ciphers aes128-ctr
+            delete system services ssh ciphers
             set system services ssh ciphers aes256-gcm@openssh.com
             set system services ssh ciphers aes128-gcm@openssh.com
             set system services ssh ciphers chacha20-poly1305@openssh.com
+            set system services ssh ciphers aes256-ctr
+            set system services ssh ciphers aes128-ctr
+            commit confirmed 5
+            ```
+
+            Open a new SSH session to confirm connectivity, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -282,13 +297,20 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure only strong MACs:
+            The `set` command appends to the existing MAC list, so first remove the current list including any weak entries, then configure only strong MACs. Commit with automatic rollback so a MAC mismatch with your SSH client cannot lock you out:
 
             ```
+            delete system services ssh macs
             set system services ssh macs hmac-sha2-256
             set system services ssh macs hmac-sha2-512
             set system services ssh macs hmac-sha2-256-etm@openssh.com
             set system services ssh macs hmac-sha2-512-etm@openssh.com
+            commit confirmed 5
+            ```
+
+            Open a new SSH session to confirm connectivity, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -346,14 +368,21 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure only strong key exchange algorithms:
+            The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
 
             ```
-            set system services ssh key-exchange group-exchange-sha2
+            delete system services ssh key-exchange
+            set system services ssh key-exchange curve25519-sha256
             set system services ssh key-exchange ecdh-sha2-nistp256
             set system services ssh key-exchange ecdh-sha2-nistp384
             set system services ssh key-exchange ecdh-sha2-nistp521
-            set system services ssh key-exchange curve25519-sha256
+            set system services ssh key-exchange group-exchange-sha2
+            commit confirmed 5
+            ```
+
+            Open a new SSH session to confirm connectivity, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -593,7 +622,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set a password for user accounts:
+            Set a password interactively. Junos prompts for the password and stores only the hash:
+
+            ```
+            set system login user <username> authentication plain-text-password
+            commit
+            ```
+
+            Or supply a pre-computed password hash directly:
 
             ```
             set system login user <username> authentication encrypted-password "<hash>"
@@ -603,7 +639,14 @@ queries:
             Or configure SSH key authentication:
 
             ```
-            set system login user <username> authentication ssh-rsa "<public-key>"
+            set system login user <username> authentication ssh-ed25519 "<public-key>"
+            commit
+            ```
+
+            If the account is no longer needed, remove it instead of adding credentials:
+
+            ```
+            delete system login user <username>
             commit
             ```
     refs:
@@ -660,11 +703,13 @@ queries:
           desc: |
             **Using the CLI**
 
-            Reassign users to more restrictive login classes:
+            Do not demote the account you are currently logged in with, and always keep at least one working super-user account. The `operator` class cannot enter configuration mode, so accounts moved to it lose the ability to change the device configuration.
+
+            Reassign users who do not need full access to a more restrictive login class, committing with automatic rollback:
 
             ```
             set system login user <username> class operator
-            commit
+            commit confirmed 5
             ```
 
             Or create a custom login class with targeted permissions:
@@ -673,6 +718,12 @@ queries:
             set system login class limited-admin permissions configure
             set system login class limited-admin permissions view
             set system login user <username> class limited-admin
+            commit confirmed 5
+            ```
+
+            Confirm that affected users retain the access they need and that a super-user session still works, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -732,11 +783,25 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable Telnet:
+            Before removing Telnet, ensure SSH is enabled and verify that you can open an SSH session to the device. If Telnet is your only working management path, removing it without a tested SSH login cuts off remote access.
+
+            Enable SSH if it is not already configured:
+
+            ```
+            set system services ssh
+            commit
+            ```
+
+            Open an SSH session to confirm access, then remove Telnet with automatic rollback:
 
             ```
             delete system services telnet
-            set system services ssh
+            commit confirmed 5
+            ```
+
+            Confirm that your SSH session still works, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -800,10 +865,10 @@ queries:
             commit
             ```
 
-            SCP is automatically available when SSH is enabled. Verify SSH is configured:
+            SCP is automatically available when SSH is enabled. From operational mode, verify SSH is configured:
 
             ```
-            show system services ssh
+            show configuration system services ssh
             ```
 
             To transfer files using SCP from an external host:
@@ -1179,17 +1244,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure syslog with TCP or TLS transport:
-
-            ```
-            set system syslog host <syslog-server> transport tcp
-            commit
-            ```
-
-            Or for encrypted syslog:
+            Configure TLS transport for encrypted and reliable log delivery. The collector must accept syslog over TLS, which conventionally uses port 6514:
 
             ```
             set system syslog host <syslog-server> transport tls
+            set system syslog host <syslog-server> port 6514
+            commit
+            ```
+
+            If the collector does not support TLS, configure TCP transport. TCP provides reliable delivery but does not encrypt log data in transit:
+
+            ```
+            set system syslog host <syslog-server> transport tcp
             commit
             ```
     refs:
@@ -1379,14 +1445,34 @@ queries:
           desc: |
             **Using the CLI**
 
-            Remove unnecessary host-inbound services from the untrust zone:
+            If the device is managed through the untrust zone, removing the `all` keyword also removes SSH and every other inbound service. Explicitly allow the secure services you still need in the same commit, and use automatic rollback in case access is lost.
+
+            Remove the `all` keyword and the insecure host-inbound services from the untrust zone:
 
             ```
+            delete security zones security-zone untrust host-inbound-traffic system-services all
             delete security zones security-zone untrust host-inbound-traffic system-services telnet
             delete security zones security-zone untrust host-inbound-traffic system-services ftp
             delete security zones security-zone untrust host-inbound-traffic system-services finger
             delete security zones security-zone untrust host-inbound-traffic system-services http
             delete security zones security-zone untrust host-inbound-traffic system-services snmp
+            ```
+
+            If management traffic such as SSH or IKE must still reach the device through this zone, allow only those services explicitly:
+
+            ```
+            set security zones security-zone untrust host-inbound-traffic system-services ssh
+            ```
+
+            Commit with automatic rollback:
+
+            ```
+            commit confirmed 5
+            ```
+
+            Verify management access still works, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -1813,16 +1899,30 @@ queries:
           desc: |
             **Using the CLI**
 
-            Check license status:
+            These are operational mode commands and require no commit.
+
+            Check license status and identify expired entries:
 
             ```
             show system license
             ```
 
-            Install renewed licenses:
+            Obtain renewed license keys from the Juniper Agile Licensing portal, then install them by pasting at the terminal:
 
             ```
-            request system license add <license-key>
+            request system license add terminal
+            ```
+
+            Paste the license key text and press Ctrl+D to finish. Alternatively, install from a file or URL:
+
+            ```
+            request system license add <filename-or-url>
+            ```
+
+            Verify the new license state:
+
+            ```
+            show system license
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/system-mgmt/topics/topic-map/license-management.html


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2803). This PR covers `mondoo-junos-security.mql.yaml`: all 27 checks were reviewed and 11 needed fixes. Policy version bumped. Check mql was verified against the junos provider schema and parsing code; no mql defects were found, so every fix is remediation-side.

## Why these needed checking

The headline defect class: Junos `set` commands on list statements append rather than replace, and four remediations relied on replacement semantics, so following them verbatim left the offending configuration in place and the check failing.

## Fixes that never fixed anything

- **ssh-no-weak-ciphers / ssh-no-weak-macs / ssh-no-weak-key-exchanges**: the checks fail when weak algorithms are configured, and `set system services ssh ciphers <strong>` appends to that list without removing the weak entries. All three now `delete` the list first, then set only strong algorithms, with `commit confirmed 5` so an algorithm mismatch with the operator's own SSH client cannot lock them out.
- **untrust-zone-minimal-services**: the check (and its own description) flags the `all` keyword in host-inbound services, yet the remediation never deleted `all` — the most common real-world failure mode. It now removes `all` and the insecure services, explicitly re-allows what management still needs, and commits with rollback since deleting `all` on a device managed through that zone silently drops SSH.
- **no-expired-licenses**: `request system license add <license-key>` is not how the command works; it takes `terminal` for interactive paste or a filename/URL.

## Lockout-prone guidance

`commit confirmed` is the Junos safety idiom for exactly these changes, and none of the affected remediations used it: denying root SSH login (now requires verifying a named super-user account first), removing Telnet (now requires a tested SSH session first), and reassigning login classes (now warns against demoting your own session or the last super-user, and notes the `operator` class cannot enter configuration mode).

## Smaller corrections

- **all-users-have-credentials** only offered `encrypted-password "<hash>"` with no way to produce a hash; the interactive `plain-text-password` form and account deletion are now offered.
- **syslog-secure-transport** led with plain TCP under a "secure transport" title; it now leads with TLS on port 6514 and labels the TCP fallback as unencrypted.
- **ftp-disabled** verified SSH with a configuration-mode command from operational mode; now `show configuration system services ssh`.

## Validation

- `cnspec policy lint` passes
- YAML parses clean; no mql lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)