### PR TITLE
⭐ Validate Cloudflare API request bodies against the OpenAPI spec

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -270,7 +270,7 @@ For `aws`, `oci`, `gcp`, and `digitalocean`, the database is built **in-memory**
 - **oci**: walks the Click command tree from the `oci_cli` Python package
 - **gcp**: reads the Google Cloud SDK's static completion tree
 - **digitalocean**: walks the `doctl --help` Cobra tree breadth-first (parallelized; ~1s for the full ~475-command tree)
-- **cloudflare**: downloads Cloudflare's published OpenAPI spec from [`cloudflare/api-schemas`](https://github.com/cloudflare/api-schemas) at a pinned commit (no Cloudflare CLI required — the validator scans `curl` calls against `api.cloudflare.com/client/v4` and verifies each path + HTTP method against the spec). Bump `CLOUDFLARE_OPENAPI_SHA` in `validate_remediation_commands.py` when refreshing the spec.
+- **cloudflare**: downloads Cloudflare's published OpenAPI spec from [`cloudflare/api-schemas`](https://github.com/cloudflare/api-schemas) at a pinned commit (no Cloudflare CLI required — the validator scans `curl` calls against `api.cloudflare.com/client/v4` and verifies each path + HTTP method, plus the `--data` JSON payload against the operation's `requestBody` schema: field names, types, enums, and required properties; for `/zones/{zone_id}/settings/<setting>` calls it resolves the per-setting value schema from the setting id in the URL, and flags unknown setting ids). Angle-bracket placeholders like `"<account-name>"` act as wildcards. Known spec-vs-docs divergences are listed in `CLOUDFLARE_BODY_EXEMPTIONS`. Bump `CLOUDFLARE_OPENAPI_SHA` in `validate_remediation_commands.py` when refreshing the spec.
 
 If a required CLI is missing, the validator prints actionable install hints and exits non-zero.
 

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -2034,6 +2034,12 @@ def _cf_validate_body(
         props = schema.get("properties")
         if isinstance(props, dict):
             additional = schema.get("additionalProperties")
+            # JSON Schema treats an absent additionalProperties as "allow
+            # anything"; we deliberately flag unknown keys anyway. The spec
+            # documents every accepted field for these endpoints, and a
+            # typo'd field name the API would silently ignore is exactly
+            # the bug this validator exists to catch. Only an explicit
+            # additionalProperties (true or a schema) relaxes the check.
             if not (additional is True or isinstance(additional, dict)):
                 for key in value:
                     if key not in props:
@@ -2097,22 +2103,38 @@ def _cf_request_body_schema(spec: dict, tmpl: str, method: str):
     return schema, bool(request_body.get("required"))
 
 
-def _cf_known_setting(setting_id: str, components: dict) -> bool:
-    """True if the spec has a value/enabled component for a zone setting id.
+def _cf_setting_request_schema(setting_id: str, components: dict) -> dict | None:
+    """Return the narrowed request-body schema for a zone setting id, or
+    None when the spec has no per-setting component (an unknown setting).
 
-    Most settings follow the `zones_<setting_id>_value` convention; a few
-    embed a service prefix (`zones_cache-rules_aegis_value`) or use
-    `_enabled` (`zones_ssl_recommender_enabled`).
+    Most settings follow the `zones_<setting_id>_value` convention with a
+    {"value": ...} body; a few embed a service prefix in the component
+    name (`zones_cache-rules_aegis_value` for `settings/aegis`), and
+    ssl_recommender uses an `_enabled` component with an
+    {"enabled": ...} body instead.
     """
-    if f"zones_{setting_id}_value" in components:
-        return True
-    if f"zones_{setting_id}_enabled" in components:
-        return True
-    suffix = f"_{setting_id}_value"
-    return any(
-        name.startswith("zones_") and name.endswith(suffix)
-        for name in components
-    )
+    prop = "value"
+    name = f"zones_{setting_id}_value"
+    if name not in components:
+        suffix = f"_{setting_id}_value"
+        matches = sorted(
+            n for n in components
+            if n.startswith("zones_") and n.endswith(suffix)
+        )
+        if matches:
+            # Unambiguous in the pinned spec; sorted() keeps the pick
+            # deterministic should a future spec bump introduce a collision.
+            name = matches[0]
+        elif f"zones_{setting_id}_enabled" in components:
+            prop = "enabled"
+            name = f"zones_{setting_id}_enabled"
+        else:
+            return None
+    return {
+        "type": "object",
+        "properties": {prop: {"$ref": f"#/components/schemas/{name}"}},
+        "required": [prop],
+    }
 
 
 def validate_cloudflare_curl(
@@ -2142,14 +2164,14 @@ def validate_cloudflare_curl(
 
     # The settings path template matches any {setting_id}, so a misspelled
     # setting id would otherwise pass path validation.
-    setting_id = None
+    setting_schema = None
     if matched == "/zones/{zone_id}/settings/{setting_id}":
         last_segment = path.rsplit("/", 1)[-1]
         if not _CF_PLACEHOLDER_RE.match(last_segment):
-            if not _cf_known_setting(last_segment, components):
+            setting_schema = _cf_setting_request_schema(last_segment, components)
+            if setting_schema is None:
                 errors.append(f"unknown zone setting '{last_segment}'")
                 return False, errors
-            setting_id = last_segment
 
     exemption = CLOUDFLARE_BODY_EXEMPTIONS.get((method, matched))
     if exemption == "body":
@@ -2182,16 +2204,8 @@ def validate_cloudflare_curl(
     # For the generic settings endpoint, narrow the oneOf-over-everything
     # request schema down to the specific setting named in the URL so enum
     # and field-name mistakes are actually caught.
-    if setting_id is not None and f"zones_{setting_id}_value" in components:
-        schema = {
-            "type": "object",
-            "properties": {
-                "value": {
-                    "$ref": f"#/components/schemas/zones_{setting_id}_value"
-                }
-            },
-            "required": ["value"],
-        }
+    if setting_schema is not None:
+        schema = setting_schema
 
     _cf_validate_body(
         value, schema, spec, "body", errors,

--- a/content/validation/validate_remediation_commands.py
+++ b/content/validation/validate_remediation_commands.py
@@ -1665,8 +1665,19 @@ def validate_digitalocean() -> tuple[int, int]:
 # not cover the surface area this policy targets (SSL/TLS, WAF, security
 # level, 2FA enforcement, etc.). The realistic CLI path is `curl` against
 # the Cloudflare REST API, so the validator scans for those calls and
-# verifies each path + HTTP method against the official OpenAPI spec
-# published at https://github.com/cloudflare/api-schemas.
+# verifies each path + HTTP method — and, where the call sends a JSON
+# payload, the request body — against the official OpenAPI spec published
+# at https://github.com/cloudflare/api-schemas.
+#
+# Body validation covers the subset of JSON Schema the Cloudflare spec
+# actually uses for the endpoints in this policy: $ref, allOf, oneOf/anyOf,
+# type, enum, properties/required, and array items. Angle-bracket
+# placeholders (`"<account-name>"`) act as wildcards that satisfy any
+# schema. For the generic `/zones/{zone_id}/settings/{setting_id}` PATCH —
+# whose spec body is a oneOf over every zone setting — the validator
+# resolves the per-setting component (`zones_<setting_id>_value`) from the
+# literal setting id in the URL, so wrong enum values and misspelled
+# payload fields fail instead of slipping through the union.
 #
 # The spec is large (~9 MB) and the upstream repo doesn't ship releases —
 # `main` is the only branch and it's auto-updated. We pin a known-good
@@ -1807,15 +1818,47 @@ _CF_CURL_URL_RE = re.compile(
 _CF_CURL_METHOD_RE = re.compile(
     r'(?:^|\s)(?:-X|--request)(?:\s+|=)([A-Z]+)'
 )
+# Any curl flag that supplies a request body. split_commands() has already
+# shlex-tokenized and re-joined the command, so the payload appears after
+# the flag with its shell quoting stripped but its JSON quoting intact.
+_CF_CURL_DATA_RE = re.compile(
+    r"(?:^|\s)(?:--data(?:-raw|-binary|-ascii)?|--json|-d)(?:\s+|=)"
+)
+
+# A whole-string placeholder value like "<account-name>". During body
+# validation these act as wildcards that satisfy any schema.
+_CF_PLACEHOLDER_VALUE_RE = re.compile(r"^<[A-Za-z0-9_.-]+>$")
+
+# Quote a bare (unquoted) placeholder so the payload parses as JSON, e.g.
+# {"max_age": <seconds>} -> {"max_age": "<seconds>"}. Placeholders already
+# inside JSON strings are excluded by the quote look-around.
+_CF_BARE_PLACEHOLDER_RE = re.compile(r'(?<![\w"<])<([A-Za-z0-9_.-]+)>(?![\w">])')
+
+# Known divergences between Cloudflare's OpenAPI spec and the documented
+# behavior of the API. Maps (METHOD, path_template) to the validation step
+# to skip:
+#   "body"     — skip request-body validation entirely.
+#   "required" — validate the body but skip required-property checks.
+CLOUDFLARE_BODY_EXEMPTIONS = {
+    # The token-roll endpoint declares its body as `type: object`, but the
+    # Cloudflare API docs (and the live API) require the literal JSON
+    # string "" as the request body.
+    ("PUT", "/user/tokens/{token_id}/value"): "body",
+    # Account update reuses the shared account schema, which marks `id` and
+    # `type` required because responses always carry them; the documented
+    # update payload sends only `name` (plus optional `settings`).
+    ("PUT", "/accounts/{account_id}"): "required",
+}
 
 
-def parse_cloudflare_curl(cmd: str) -> tuple[str, str] | None:
-    """Extract (HTTP_METHOD, URL_PATH) from a curl Cloudflare API call.
+def parse_cloudflare_curl(cmd: str) -> tuple[str, str, str | None] | None:
+    """Extract (HTTP_METHOD, URL_PATH, BODY) from a curl Cloudflare API call.
 
     Returns None if the command is not a Cloudflare API curl. The method
     defaults to GET when -X / --request is absent (matches curl's default
     when no body is supplied; for POST/PATCH/PUT we always require an
-    explicit -X in remediation snippets).
+    explicit -X in remediation snippets). BODY is the raw --data payload,
+    or None when the command sends no body.
     """
     if "api.cloudflare.com/client/v4" not in cmd:
         return None
@@ -1832,12 +1875,251 @@ def parse_cloudflare_curl(cmd: str) -> tuple[str, str] | None:
     method_match = _CF_CURL_METHOD_RE.search(cmd)
     method = method_match.group(1).upper() if method_match else "GET"
 
-    return method, path
+    return method, path, _extract_curl_body(cmd)
+
+
+def _extract_curl_body(cmd: str) -> str | None:
+    """Return the payload passed via --data/-d/--json, or None.
+
+    The command string has been shlex-tokenized and space-joined, so the
+    payload's shell quotes are gone. A JSON object/array payload may
+    therefore contain spaces; scan to its balanced closing brace instead of
+    splitting on whitespace.
+    """
+    m = _CF_CURL_DATA_RE.search(cmd)
+    if not m:
+        return None
+    rest = cmd[m.end():]
+    if not rest:
+        return None
+    if rest[0] in "{[":
+        close = {"{": "}", "[": "]"}[rest[0]]
+        depth = 0
+        in_str = False
+        escaped = False
+        for i, ch in enumerate(rest):
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_str = not in_str
+            elif not in_str:
+                if ch == rest[0]:
+                    depth += 1
+                elif ch == close:
+                    depth -= 1
+                    if depth == 0:
+                        return rest[: i + 1]
+        return rest  # unbalanced; json.loads will report the details
+    return rest.split(None, 1)[0]
+
+
+def _cf_resolve_ref(node, spec: dict):
+    """Follow a chain of $ref JSON pointers within the spec document."""
+    seen: set[str] = set()
+    while isinstance(node, dict) and "$ref" in node:
+        ref = node["$ref"]
+        if ref in seen:
+            return {}
+        seen.add(ref)
+        cur = spec
+        for part in ref.lstrip("#/").split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")
+            cur = cur.get(part, {}) if isinstance(cur, dict) else {}
+        node = cur
+    return node
+
+
+def _cf_type_ok(value, t) -> bool:
+    if isinstance(t, list):
+        return any(_cf_type_ok(value, x) for x in t)
+    if t == "object":
+        return isinstance(value, dict)
+    if t == "array":
+        return isinstance(value, list)
+    if t == "string":
+        return isinstance(value, str)
+    if t == "boolean":
+        return isinstance(value, bool)
+    if t == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if t == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if t == "null":
+        return value is None
+    return True
+
+
+def _cf_json_type_name(value) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    return "object"
+
+
+def _cf_validate_body(
+    value,
+    schema,
+    spec: dict,
+    loc: str,
+    errors: list[str],
+    check_required: bool = True,
+) -> None:
+    """Validate a parsed JSON value against a (subset of) JSON Schema.
+
+    Covers what the Cloudflare spec uses for the request bodies in this
+    policy: $ref, allOf, oneOf/anyOf, type, enum, object properties with
+    required/additionalProperties, and array items. Whole-string
+    placeholders pass any schema. Errors are appended to `errors` with
+    `loc` as the JSON-path-ish location prefix.
+    """
+    schema = _cf_resolve_ref(schema, spec)
+    if not isinstance(schema, dict) or not schema:
+        return
+    if isinstance(value, str) and _CF_PLACEHOLDER_VALUE_RE.match(value):
+        return
+
+    if "allOf" in schema:
+        # Shallow-merge the members into one object view so a property
+        # declared in one member isn't reported unknown by another.
+        merged = {k: v for k, v in schema.items() if k != "allOf"}
+        for member in schema["allOf"]:
+            member = _cf_resolve_ref(member, spec)
+            if not isinstance(member, dict):
+                continue
+            for key in ("type", "enum", "items", "additionalProperties"):
+                if key in member and key not in merged:
+                    merged[key] = member[key]
+            if "properties" in member:
+                merged.setdefault("properties", {}).update(member["properties"])
+            if "required" in member:
+                combined = merged.get("required", []) + member["required"]
+                merged["required"] = list(dict.fromkeys(combined))
+        _cf_validate_body(value, merged, spec, loc, errors, check_required)
+        return
+
+    variants = schema.get("oneOf") or schema.get("anyOf")
+    if variants:
+        for variant in variants:
+            variant_errors: list[str] = []
+            _cf_validate_body(
+                value, variant, spec, loc, variant_errors, check_required
+            )
+            if not variant_errors:
+                return
+        errors.append(f"{loc}: does not match any schema variant accepted here")
+        return
+
+    t = schema.get("type")
+    if t and not _cf_type_ok(value, t):
+        errors.append(f"{loc}: expected {t}, got {_cf_json_type_name(value)}")
+        return
+
+    if "enum" in schema and value not in schema["enum"]:
+        allowed = ", ".join(repr(x) for x in schema["enum"])
+        errors.append(f"{loc}: {value!r} is not one of [{allowed}]")
+        return
+
+    if isinstance(value, dict):
+        props = schema.get("properties")
+        if isinstance(props, dict):
+            additional = schema.get("additionalProperties")
+            if not (additional is True or isinstance(additional, dict)):
+                for key in value:
+                    if key not in props:
+                        errors.append(
+                            f"{loc}: unknown property '{key}' "
+                            f"(documented: {', '.join(sorted(props))})"
+                        )
+            for key, val in value.items():
+                if key in props:
+                    _cf_validate_body(
+                        val, props[key], spec, f"{loc}.{key}", errors, check_required
+                    )
+        if check_required:
+            for req in schema.get("required", []):
+                if req in value:
+                    continue
+                # readOnly properties are response-only; their presence in
+                # `required` does not apply to request bodies.
+                req_schema = {}
+                if isinstance(props, dict) and req in props:
+                    req_schema = _cf_resolve_ref(props[req], spec)
+                if isinstance(req_schema, dict) and req_schema.get("readOnly"):
+                    continue
+                errors.append(f"{loc}: missing required property '{req}'")
+    elif isinstance(value, list):
+        items = schema.get("items")
+        if items:
+            for i, val in enumerate(value):
+                _cf_validate_body(
+                    val, items, spec, f"{loc}[{i}]", errors, check_required
+                )
+
+
+def _cf_parse_body_json(body: str):
+    """Parse a curl payload as JSON. Returns (value, error_message)."""
+    try:
+        return json.loads(body), None
+    except json.JSONDecodeError:
+        pass
+    # Retry with bare placeholders quoted, e.g. {"max_age": <seconds>}.
+    try:
+        return json.loads(_CF_BARE_PLACEHOLDER_RE.sub(r'"<\1>"', body)), None
+    except json.JSONDecodeError as e:
+        return None, f"request body is not valid JSON ({e.msg})"
+
+
+def _cf_request_body_schema(spec: dict, tmpl: str, method: str):
+    """Return (schema, required) for an operation's JSON request body.
+
+    schema is None when the spec defines no request body for the operation.
+    """
+    op = spec.get("paths", {}).get(tmpl, {}).get(method.lower(), {})
+    request_body = _cf_resolve_ref(op.get("requestBody"), spec)
+    if not isinstance(request_body, dict) or not request_body:
+        return None, False
+    schema = (
+        request_body.get("content", {})
+        .get("application/json", {})
+        .get("schema")
+    )
+    return schema, bool(request_body.get("required"))
+
+
+def _cf_known_setting(setting_id: str, components: dict) -> bool:
+    """True if the spec has a value/enabled component for a zone setting id.
+
+    Most settings follow the `zones_<setting_id>_value` convention; a few
+    embed a service prefix (`zones_cache-rules_aegis_value`) or use
+    `_enabled` (`zones_ssl_recommender_enabled`).
+    """
+    if f"zones_{setting_id}_value" in components:
+        return True
+    if f"zones_{setting_id}_enabled" in components:
+        return True
+    suffix = f"_{setting_id}_value"
+    return any(
+        name.startswith("zones_") and name.endswith(suffix)
+        for name in components
+    )
 
 
 def validate_cloudflare_curl(
     method: str,
     path: str,
+    body: str | None,
+    spec: dict,
     openapi_paths: dict[str, set[str]],
 ) -> tuple[bool, list[str]]:
     """Validate a parsed Cloudflare curl call against the OpenAPI spec."""
@@ -1856,7 +2138,66 @@ def validate_cloudflare_curl(
         )
         return False, errors
 
-    return True, errors
+    components = spec.get("components", {}).get("schemas", {})
+
+    # The settings path template matches any {setting_id}, so a misspelled
+    # setting id would otherwise pass path validation.
+    setting_id = None
+    if matched == "/zones/{zone_id}/settings/{setting_id}":
+        last_segment = path.rsplit("/", 1)[-1]
+        if not _CF_PLACEHOLDER_RE.match(last_segment):
+            if not _cf_known_setting(last_segment, components):
+                errors.append(f"unknown zone setting '{last_segment}'")
+                return False, errors
+            setting_id = last_segment
+
+    exemption = CLOUDFLARE_BODY_EXEMPTIONS.get((method, matched))
+    if exemption == "body":
+        return True, errors
+
+    schema, body_required = _cf_request_body_schema(spec, matched, method)
+
+    if body is None:
+        if schema is not None and body_required:
+            errors.append(
+                f"'{method} {matched}' requires a request body, "
+                "but the command sends none"
+            )
+            return False, errors
+        return True, errors
+
+    if body.startswith("@"):
+        # Payload is read from a file the snippet builds; nothing to inspect.
+        return True, errors
+
+    if schema is None:
+        errors.append(f"'{method} {matched}' does not accept a request body")
+        return False, errors
+
+    value, parse_error = _cf_parse_body_json(body)
+    if parse_error:
+        errors.append(parse_error)
+        return False, errors
+
+    # For the generic settings endpoint, narrow the oneOf-over-everything
+    # request schema down to the specific setting named in the URL so enum
+    # and field-name mistakes are actually caught.
+    if setting_id is not None and f"zones_{setting_id}_value" in components:
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$ref": f"#/components/schemas/zones_{setting_id}_value"
+                }
+            },
+            "required": ["value"],
+        }
+
+    _cf_validate_body(
+        value, schema, spec, "body", errors,
+        check_required=(exemption != "required"),
+    )
+    return (not errors), errors
 
 
 def validate_cloudflare() -> tuple[int, int]:
@@ -1893,9 +2234,11 @@ def validate_cloudflare() -> tuple[int, int]:
             parsed = parse_cloudflare_curl(cmd)
             if parsed is None:
                 continue
-            method, path = parsed
+            method, path, body = parsed
 
-            is_valid, errors = validate_cloudflare_curl(method, path, openapi_paths)
+            is_valid, errors = validate_cloudflare_curl(
+                method, path, body, spec, openapi_paths
+            )
 
             if is_valid:
                 print(f"[PASS] {uid}")


### PR DESCRIPTION
## Summary

The `cloudflare` target in `validate_remediation_commands.py` previously checked only the URL path and HTTP method of each `curl` call against `api.cloudflare.com`. A PATCH to a valid endpoint with a misspelled field name, an invalid enum value, or a missing payload still passed.

This PR extends the validator to also check the `--data` JSON payload against the operation's `requestBody` schema from the pinned [`cloudflare/api-schemas`](https://github.com/cloudflare/api-schemas) OpenAPI spec. It runs in CI automatically through the existing **Validate Policy Remediation Content** workflow (the `validate-cli` job already invokes the full validator on `content/**` changes).

## What it catches now

- **Wrong enum values** — `{"value":"fulll"}` on `settings/ssl` fails with `body.value: 'fulll' is not one of ['off', 'flexible', 'full', 'strict']`
- **Misspelled payload fields** — `include_subdomain` instead of `include_subdomains` in an HSTS payload
- **Wrong types** — `"max_age":"31536000"` (string) where the spec wants a number
- **Missing required properties** — `{}` on the R2 managed-domain endpoint, which requires `enabled`
- **Missing bodies** — a PATCH/PUT whose operation requires a request body but sends none
- **Unknown setting ids** — `settings/sssl` previously matched the `{setting_id}` path template and passed

## How

- A small JSON-Schema-subset validator covering `$ref`, `allOf` (shallow-merged), `oneOf`/`anyOf`, `type`, `enum`, object `properties`/`required`/`additionalProperties`, and array `items`. Angle-bracket placeholders (`"<account-name>"`) act as wildcards; bare placeholders (`"max_age": <seconds>`) are quoted before JSON parsing.
- The generic `/zones/{zone_id}/settings/{setting_id}` request schema is a `oneOf` over all ~60 zone settings, which would let a wrong enum value match some *other* setting's schema. The validator narrows it to the per-setting component (`zones_<setting_id>_value`) derived from the literal setting id in the URL.
- `readOnly` properties listed in `required` are treated as response-only, per OpenAPI semantics.
- `CLOUDFLARE_BODY_EXEMPTIONS` documents the two known spec-vs-docs divergences instead of producing false failures:
  - `PUT /user/tokens/{token_id}/value` (token roll) — the spec declares `type: object`, but Cloudflare's API docs require the literal JSON string `""` as the body.
  - `PUT /accounts/{account_id}` — the shared account schema marks `id`/`type` required because responses always carry them; the documented update payload sends only `name` (+ `settings`).

## Testing

- `python3 content/validation/validate_remediation_commands.py cloudflare` — current policy passes 29/29.
- 22 crafted mutation cases (bad enums, misspelled fields at top level and nested, wrong types, missing/extra bodies, unknown setting ids, placeholder handling, exemptions, `@file` payloads) all produce the expected verdicts.
- End-to-end: injecting `{"value":"fulll"}` into the policy produces a `[FAIL]` plus a correctly file/line-anchored `::error` GitHub annotation; reverting restores a clean run.
- Regression: `azure` and `nutanix` targets still exit 0; `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)