### PR TITLE
🐛 dockerfile-best-practices: stop teaching scanner evasion and broken healthchecks

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -267,6 +267,7 @@ DVersion
 dvfilter
 Eacces
 EBSKMS
+distroless
 ecdsap
 edr
 efi

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-docker-best-practices
     name: Mondoo Dockerfile Best Practices
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
@@ -694,6 +694,14 @@ queries:
             HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
               CMD pg_isready -U postgres || exit 1
             ```
+
+            The health check command must exist inside the final image. Minimal bases such as slim, Alpine, and distroless images often ship without `curl`. If the test command is missing, every probe fails and the container reports unhealthy even when the application works correctly. Either install the tool in the image, use one the base already provides, or build a small health command into the application itself:
+
+            ```dockerfile
+            # Alpine and other BusyBox-based images provide wget:
+            HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+              CMD wget -q --spider http://localhost:8080/health || exit 1
+            ```
     refs:
       - url: https://docs.docker.com/reference/dockerfile/#healthcheck
         title: Dockerfile Reference - HEALTHCHECK
@@ -821,10 +829,12 @@ queries:
             RUN npm install
             ```
 
-            If you need to run a command in a specific directory without changing the persistent working directory, use a subshell:
+            If a build step needs to run in a temporary directory, set WORKDIR for that step and reset it afterward. The size cost is at most an empty directory in the image:
 
             ```dockerfile
-            RUN (cd /tmp/build && make install)
+            WORKDIR /tmp/build
+            RUN make && make install
+            WORKDIR /app
             ```
     refs:
       - url: https://docs.docker.com/reference/dockerfile/#workdir
@@ -882,7 +892,7 @@ queries:
         **Why this matters**
 
         - **Build failures:** With multiple source files, Docker expects the destination to be a directory indicated by a trailing slash. Without it, the build may fail with an ambiguous error.
-        - **Accidental overwrites:** If only two arguments are provided and the destination does not end with `/`, Docker treats it as a file path, overwriting the destination with the last source file rather than copying both files into a directory.
+        - **Required by Docker:** When a COPY instruction lists multiple sources, Docker requires the destination to be a directory ending with `/` and rejects the instruction with a build error otherwise.
         - **Clarity:** A trailing slash explicitly communicates that the destination is a directory, making the Dockerfile easier to understand and maintain.
       audit: |
         Inspect the Dockerfile to confirm multi-source COPY destinations end with `/`:
@@ -898,7 +908,7 @@ queries:
             Add a trailing slash to COPY destinations when copying multiple files:
 
             ```dockerfile
-            # Instead of: ambiguous, may fail or overwrite
+            # Instead of: the build fails because Docker requires a directory destination
             COPY file1.txt file2.txt /app
 
             # Use: clearly copies into the /app/ directory


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2812). This PR covers `mondoo-dockerfile-best-practices.mql.yaml`: all 21 checks were reviewed and 3 needed fixes. Policy version bumped. The review traced every package-manager check through the provider's RUN-command parser; the 18 untouched checks verified clean.

## Why these needed checking

- **use-workdir-not-cd** told users to keep `cd` by wrapping it in a subshell. That contradicts the check's own description, and the only reason `RUN (cd ... && make)` passes the scan is a parser artifact: `(` is treated as word content, so the binary tokenizes as `(cd`. The remediation was teaching scanner evasion that a future provider release could break. It now shows the WORKDIR set-and-reset pattern for temporary build directories.
- **healthcheck-defined**'s example used `curl`, which slim, Alpine, and distroless images do not ship. Pasting the example into such an image yields a permanently unhealthy container that orchestrators restart in a loop — worse than having no healthcheck. The entry now warns that the probe command must exist in the final image and offers the BusyBox `wget --spider` form.
- **copy-dest-trailing-slash** claimed multi-source COPY without a trailing slash "may fail or overwrite"; Docker deterministically rejects it with a build error, and the overwrite scenario only applies to the single-source form the check's `src.length > 1` filter excludes. The comment and the matching desc bullet now describe the real behavior.

## Validation

- `cnspec policy lint` passes
- YAML parses clean; no mql lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)