### PR TITLE
⭐ Validate kubectl, gh, glab, and hcloud commands via Cobra introspection

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -149,6 +149,7 @@ clickstream
 clientalive
 clientalivecountmax
 clientaliveinterval
+CLIS
 cloudaudit
 cloudflare
 cloudfunctions

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -71,6 +71,50 @@ jobs:
           sudo mv /tmp/doctl /usr/local/bin/doctl
           doctl version
 
+      - name: Verify kubectl and gh
+        # Both ship preinstalled on ubuntu-latest runner images and are
+        # kept current by the image maintainers. The Cobra-tree walkers
+        # only read `__complete` / `--help` output, so any recent version
+        # works; fail fast here if a future image drops them.
+        run: |
+          kubectl version --client
+          gh --version
+
+      - name: Install glab
+        # Pinned release tarball from the gitlab-org/cli generic package
+        # registry. Bump GLAB_VERSION and GLAB_SHA256 in lockstep when
+        # GitLab ships new commands or flags.
+        env:
+          GLAB_VERSION: "1.102.0"
+          GLAB_SHA256: "2e06f278bb1762126e9b695f67baf5e3210df431b2039c76c1991252bf9c0868"
+        run: |
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/${GLAB_VERSION}/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/glab.tar.gz
+          echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/glab-extract
+          tar -xzf /tmp/glab.tar.gz -C /tmp/glab-extract
+          sudo mv /tmp/glab-extract/bin/glab /usr/local/bin/glab
+          glab --version
+
+      - name: Install hcloud
+        # Pinned release tarball from
+        # https://github.com/hetznercloud/cli/releases. Bump HCLOUD_VERSION
+        # and HCLOUD_SHA256 in lockstep when Hetzner ships new commands or
+        # flags — the SHA-256 is published in the per-release checksums.txt.
+        env:
+          HCLOUD_VERSION: "1.65.0"
+          HCLOUD_SHA256: "f78d2db65b7ab58603d343739cb4397e13acef23182e41692a06e147a8d4c011"
+        run: |
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz" \
+            -o /tmp/hcloud.tar.gz
+          echo "${HCLOUD_SHA256}  /tmp/hcloud.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/hcloud-extract
+          tar -xzf /tmp/hcloud.tar.gz -C /tmp/hcloud-extract
+          sudo mv /tmp/hcloud-extract/hcloud /usr/local/bin/hcloud
+          hcloud version
+
       - name: Validate remediation commands
         run: python3 content/validation/validate_remediation_commands.py --github-actions
 

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -257,6 +257,12 @@ python3 content/validation/validate_remediation_commands.py gcp
 python3 content/validation/validate_remediation_commands.py digitalocean
 python3 content/validation/validate_remediation_commands.py nutanix
 
+# Validate a Cobra-based CLI (kubectl / gh / glab / hcloud)
+python3 content/validation/validate_remediation_commands.py kubernetes
+python3 content/validation/validate_remediation_commands.py github
+python3 content/validation/validate_remediation_commands.py gitlab
+python3 content/validation/validate_remediation_commands.py hetzner
+
 # Validate a specific REST API (curl commands against a vendor API)
 python3 content/validation/validate_remediation_commands.py cloudflare
 python3 content/validation/validate_remediation_commands.py tailscale
@@ -265,7 +271,7 @@ python3 content/validation/validate_remediation_commands.py atlassian
 python3 content/validation/validate_remediation_commands.py grafana
 ```
 
-The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections. For the REST API targets, ```` ```bash ```` blocks in `audit:` sections are validated too (for API-first products the verification path is also a curl call). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli`/`kubectl`/`gh`/`glab`/`hcloud` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections. For the REST API and Cobra CLI targets, ```` ```bash ```` blocks in `audit:` sections are validated too (these products' verification paths use the same CLI/API surface, and the new validators have no backlog of unvalidated audit blocks). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
 
 The code lives in the `content/validation/validators/` package — one module per validator family (`aws.py`, `azure.py`, …, `openapi.py` for all REST APIs), shared helpers in `common.py` — with `validate_remediation_commands.py` as the entry-point shim.
 
@@ -279,6 +285,8 @@ For `aws`, `oci`, `gcp`, and `digitalocean`, the database is built **in-memory**
 - **oci**: walks the Click command tree from the `oci_cli` Python package
 - **gcp**: reads the Google Cloud SDK's static completion tree
 - **digitalocean**: walks the `doctl --help` Cobra tree breadth-first (parallelized; ~1s for the full ~475-command tree)
+- **kubernetes / github / gitlab / hetzner**: walk the CLI's hidden Cobra `__complete` command (`kubectl`/`gh`/`glab`/`hcloud` must be on PATH), which returns machine-readable subcommand and flag candidates regardless of each CLI's custom help layout. Valid flags are the union of flag completions and flag lines parsed from `--help` (hcloud filters its flag completions to required-only). The walk runs with cloud credentials stripped (`KUBECONFIG=/dev/null`, tokens unset) so positional-value completions stay empty, and only tab-described candidates count as subcommands (kubectl's `rollout restart` statically completes resource types as bare names). Each CLI is an entry in the `COBRA_CLIS` registry in `validators/cobra.py`.
+
 The REST API targets (**cloudflare**, **tailscale**, **slack**, **atlassian**, **grafana**) need no CLI: each provider is an entry in the `API_PROVIDERS` registry in `validators/openapi.py` that maps an API host to the vendor's OpenAPI (or Swagger 2.0) spec. The validator verifies each curl call's path + HTTP method, plus the `--data` JSON payload against the operation's `requestBody` schema: field names, types, enums, and required properties. Angle-bracket (`<account-name>`) and environment-variable (`$ORG_ID`) placeholders act as wildcards. Known spec-vs-docs divergences are listed per provider under `body_exemptions`; Cloudflare additionally narrows the generic `/zones/{zone_id}/settings/{setting_id}` schema to the per-setting component via its `path_hook`.
 
 API specs are sourced two ways:

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -129,7 +129,7 @@ queries:
         Query the group visibility with the `glab` CLI:
 
         ```bash
-        glab api groups/GROUP_ID --jq '.visibility'
+        glab api groups/GROUP_ID | jq '.visibility'
         ```
 
         A passing group returns `private` or `internal`. A failing group returns `public`.
@@ -251,7 +251,7 @@ queries:
         Query the two-factor requirement with the `glab` CLI:
 
         ```bash
-        glab api groups/GROUP_ID --jq '.require_two_factor_authentication'
+        glab api groups/GROUP_ID | jq '.require_two_factor_authentication'
         ```
 
         A passing group returns `true`. A failing group returns `false`.
@@ -374,7 +374,7 @@ queries:
         List the visibility of every project in the group with the `glab` CLI:
 
         ```bash
-        glab api "groups/GROUP_ID/projects?per_page=100" --jq '.[] | {path: .path, visibility: .visibility}'
+        glab api "groups/GROUP_ID/projects?per_page=100" | jq '.[] | {path: .path, visibility: .visibility}'
         ```
 
         A passing group returns `private` or `internal` for every project. A failing group returns `public` for one or more projects.
@@ -532,7 +532,7 @@ queries:
         Query the project visibility with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID --jq '.visibility'
+        glab api projects/PROJECT_ID | jq '.visibility'
         ```
 
         A passing project returns `private` or `internal`. A failing project returns `public`.
@@ -651,7 +651,7 @@ queries:
         Query the project approval configuration with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approvals --jq '.approvals_before_merge'
+        glab api projects/PROJECT_ID/approvals | jq '.approvals_before_merge'
         ```
 
         A passing project returns a value of 1 or greater. A failing project returns 0.
@@ -764,7 +764,7 @@ queries:
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings --jq '.merge_requests_author_approval'
+        glab api projects/PROJECT_ID/approval_settings | jq '.merge_requests_author_approval'
         ```
 
         A passing project returns `false`. A failing project returns `true`.
@@ -888,7 +888,7 @@ queries:
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings --jq '.reset_approvals_on_push'
+        glab api projects/PROJECT_ID/approval_settings | jq '.reset_approvals_on_push'
         ```
 
         A passing project returns `true`. A failing project returns `false`.
@@ -1012,7 +1012,7 @@ queries:
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings --jq '.merge_requests_disable_committers_approval'
+        glab api projects/PROJECT_ID/approval_settings | jq '.merge_requests_disable_committers_approval'
         ```
 
         A passing project returns `true`. A failing project returns `false`.
@@ -1137,7 +1137,7 @@ queries:
         Query the force-push setting for the default protected branch with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/protected_branches/main --jq '.allow_force_push'
+        glab api projects/PROJECT_ID/protected_branches/main | jq '.allow_force_push'
         ```
 
         A passing project returns `false`. A failing project returns `true`.
@@ -1266,7 +1266,7 @@ queries:
         Query the merge-check setting with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID --jq '.only_allow_merge_if_pipeline_succeeds'
+        glab api projects/PROJECT_ID | jq '.only_allow_merge_if_pipeline_succeeds'
         ```
 
         A passing project returns `true`. A failing project returns `false`.
@@ -1388,7 +1388,7 @@ queries:
         Query the forking restriction with the `glab` CLI:
 
         ```bash
-        glab api groups/GROUP_ID --jq '.prevent_forking_outside_group'
+        glab api groups/GROUP_ID | jq '.prevent_forking_outside_group'
         ```
 
         A passing group returns `true`. A failing group returns `false`.
@@ -1511,7 +1511,7 @@ queries:
         List the expiration dates of every active project access token with the `glab` CLI:
 
         ```bash
-        glab api "projects/PROJECT_ID/access_tokens" --jq '.[] | select(.active == true) | {name: .name, expires_at: .expires_at}'
+        glab api "projects/PROJECT_ID/access_tokens" | jq '.[] | select(.active == true) | {name: .name, expires_at: .expires_at}'
         ```
 
         A passing project returns a non-null `expires_at` for every active token. A failing project returns `null` for one or more active tokens.
@@ -1641,7 +1641,7 @@ queries:
         List the expiration dates of every active group access token with the `glab` CLI:
 
         ```bash
-        glab api "groups/GROUP_ID/access_tokens" --jq '.[] | select(.active == true) | {name: .name, expires_at: .expires_at}'
+        glab api "groups/GROUP_ID/access_tokens" | jq '.[] | select(.active == true) | {name: .name, expires_at: .expires_at}'
         ```
 
         A passing group returns a non-null `expires_at` for every active token. A failing group returns `null` for one or more active tokens.
@@ -1772,7 +1772,7 @@ queries:
         List the push access of every deploy key with the `glab` CLI:
 
         ```bash
-        glab api "projects/PROJECT_ID/deploy_keys" --jq '.[] | {title: .title, can_push: .can_push}'
+        glab api "projects/PROJECT_ID/deploy_keys" | jq '.[] | {title: .title, can_push: .can_push}'
         ```
 
         A passing project returns `can_push: false` for every deploy key. A failing project returns `can_push: true` for one or more keys.
@@ -1889,7 +1889,7 @@ queries:
         Query the security settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/security_settings --jq '.continuous_vulnerability_scans_enabled'
+        glab api projects/PROJECT_ID/security_settings | jq '.continuous_vulnerability_scans_enabled'
         ```
 
         A passing project returns `true`. A failing project returns `false`.

--- a/content/validation/validators/cobra.py
+++ b/content/validation/validators/cobra.py
@@ -341,6 +341,14 @@ def parse_cobra_command(
     if not command_path and raw_path_parts:
         command_path = " ".join(raw_path_parts)
 
+    # Collect every --flag in the command, including globals that precede
+    # the subcommand. They are validated against the leaf node's flag
+    # set, which is safe because each leaf's set includes inherited/
+    # persistent flags for all registered CLIs: gh and hcloud list them
+    # in --help ("INHERITED FLAGS" / "Global Flags:"), kubectl and glab
+    # include them in flag completion — and the leaf set is the union of
+    # both sources. Scoping collection to parts after the command path
+    # would silently skip typo'd global flags instead.
     flags = []
     for token in parts:
         if token.startswith("--"):
@@ -368,6 +376,14 @@ def validate_cobra_command(
     # A node with subcommands needs one; the next positional token (if
     # any) was already rejected by the longest-path match, so it's a
     # misspelled subcommand rather than a positional argument.
+    #
+    # This assumes a node with subcommands is a pure command group.
+    # Cobra technically allows a command to be runnable AND have
+    # children (Run set alongside subcommands); none of the registered
+    # CLIs' policy commands use that shape today, but if a future policy
+    # legitimately invokes such a command bare, this will false-positive
+    # with "missing subcommand" — relax this check rather than chase a
+    # phantom parse bug.
     if node["subcommands"]:
         if raw_next_token is not None:
             errors.append(

--- a/content/validation/validators/cobra.py
+++ b/content/validation/validators/cobra.py
@@ -1,0 +1,442 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+# Generic validation for Cobra-based CLIs (kubectl, gh, glab, hcloud).
+#
+# Like doctl, these are Go binaries with no Python introspection surface.
+# Unlike doctl, their --help layouts differ wildly (gh and glab render
+# custom uppercase-header templates, kubectl uses "Options:" with
+# `--flag=default:` lines), so instead of parsing help text per CLI we
+# walk the hidden `__complete` command that Cobra builds into every CLI
+# for shell completion:
+#
+#   <cli> __complete <path...> ""    -> subcommand candidates (name\tdesc)
+#   <cli> __complete <path...> "--"  -> flag candidates (--name\tdesc)
+#
+# The output is machine-readable and identical across all Cobra CLIs.
+# Two caveats shape the implementation:
+#
+#   - Flag completion can be filtered by custom completion logic (hcloud
+#     only suggests required flags that haven't been given yet), so the
+#     valid flag set is the UNION of flag completions and flag-shaped
+#     lines parsed from `<cli> <path> --help`.
+#   - Leaf commands may complete positional VALUES (pod names, server
+#     names) instead of subcommands when the CLI can reach a live
+#     API. The walk subprocesses run with cloud credentials stripped
+#     (KUBECONFIG=/dev/null, tokens unset) so value completions come
+#     back empty and the walk is deterministic.
+
+import concurrent.futures
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+from .common import (
+    FAILURES,
+    SCRIPT_DIR,
+    extract_bash_blocks,
+    policy_relpath,
+    split_commands,
+    truncate_cmd,
+)
+
+# ---------------------------------------------------------------------------
+# CLI registry
+# ---------------------------------------------------------------------------
+#
+# Each entry:
+#   cli           — binary name (must be on PATH)
+#   policies      — policy files (relative to content/) to scan
+#   include_audit — validate ```bash blocks in audit: sections too. On for
+#                   all of these: they are new validators with no backlog
+#                   of unvalidated audit blocks (kubectl in particular
+#                   appears almost exclusively in audit sections — the
+#                   kubernetes policies remediate via manifests).
+#   install       — install hint printed when the binary is missing
+
+COBRA_CLIS = {
+    "kubernetes": {
+        "cli": "kubectl",
+        "policies": [
+            "mondoo-kubernetes-security.mql.yaml",
+            "mondoo-kubernetes-best-practices.mql.yaml",
+        ],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew install kubectl\n"
+            "  Linux:            https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+        ),
+    },
+    "github": {
+        "cli": "gh",
+        "policies": [
+            "mondoo-github-security.mql.yaml",
+            "mondoo-github-best-practices.mql.yaml",
+        ],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew install gh\n"
+            "  Linux:            https://github.com/cli/cli#installation"
+        ),
+    },
+    "gitlab": {
+        "cli": "glab",
+        "policies": ["mondoo-gitlab-security.mql.yaml"],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew install glab\n"
+            "  Linux:            https://gitlab.com/gitlab-org/cli#installation"
+        ),
+    },
+    "hetzner": {
+        "cli": "hcloud",
+        "policies": ["mondoo-hetzner-security.mql.yaml"],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew install hcloud\n"
+            "  Linux:            https://github.com/hetznercloud/cli/releases"
+        ),
+    },
+}
+
+
+def _walk_env() -> dict:
+    """Subprocess environment with cloud/API credentials stripped, so
+    completion callbacks can't reach a live backend and positional-value
+    completions (pod names, server names) come back empty."""
+    env = dict(os.environ)
+    env["KUBECONFIG"] = "/dev/null"
+    for var in (
+        "GH_TOKEN", "GITHUB_TOKEN",
+        "GITLAB_TOKEN", "GLAB_TOKEN",
+        "HCLOUD_TOKEN",
+    ):
+        env.pop(var, None)
+    return env
+
+
+# A completion candidate that is a plausible subcommand name. Cobra
+# candidates are "name\tdescription"; real subcommands are short
+# lowercase identifiers, which also filters out any stray value
+# completions a CLI might produce without credentials.
+_SUBCOMMAND_CANDIDATE_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+# A flag-definition line in --help output:
+#   "      --description string        Description of the rule"
+#   "  -A, --all-namespaces=false:"    (kubectl)
+_HELP_FLAG_LINE_RE = re.compile(r"^\s+(?:-\w,\s+)?(--[a-z][a-z0-9-]*)")
+
+
+def _run_cli(args: list[str], env: dict) -> str:
+    r = subprocess.run(args, capture_output=True, text=True, timeout=20, env=env)
+    return r.stdout
+
+
+def _complete(
+    cli: str, path: str, to_complete: str, env: dict, described_only: bool = False
+) -> list[str]:
+    """Return completion candidate names for `<cli> __complete <path...>
+    <to_complete>`. The trailing `:<n>` directive line is dropped, as is
+    each candidate's tab-separated description.
+
+    With described_only=True, candidates without a tab-separated
+    description are dropped: real subcommands always carry their Short
+    description, while static positional-value completions (kubectl's
+    `rollout restart` completes resource types like `deployment`) are
+    bare names. This is what keeps value completions from masquerading
+    as subcommands and turning a leaf into a phantom command group.
+    """
+    args = [cli, "__complete"] + (path.split() if path else []) + [to_complete]
+    out = _run_cli(args, env)
+    names = []
+    for line in out.split("\n"):
+        if not line or line.startswith(":"):
+            continue
+        if described_only and ("\t" not in line or not line.split("\t", 1)[1].strip()):
+            continue
+        names.append(line.split("\t", 1)[0])
+    return names
+
+
+def _node_info(cli: str, path: str, env: dict) -> dict:
+    """Discover one command node: its subcommands and valid flags."""
+    subcommands = [
+        c for c in _complete(cli, path, "", env, described_only=True)
+        if _SUBCOMMAND_CANDIDATE_RE.match(c)
+    ]
+    flags = {f for f in _complete(cli, path, "--", env) if f.startswith("--")}
+    help_text = _run_cli([cli] + (path.split() if path else []) + ["--help"], env)
+    for line in help_text.split("\n"):
+        m = _HELP_FLAG_LINE_RE.match(line)
+        if m:
+            flags.add(m.group(1))
+    return {"subcommands": sorted(set(subcommands)), "flags": sorted(flags)}
+
+
+def detect_cli_services(cli: str, policy_files: list, include_audit: bool) -> list[str]:
+    """Top-level <cli> subcommands used across the given policies.
+
+    Global flags may precede the subcommand (`kubectl -n kube-system get
+    pod`), and whether a leading flag consumes the next token as its
+    value isn't knowable without the CLI's flag table — so collect every
+    plausible candidate. Bogus candidates (flag values like
+    `kube-system`) introspect to empty nodes, which the walk drops.
+    """
+    services = set()
+    for policy_file in policy_files:
+        if not policy_file.exists():
+            continue
+        content = policy_file.read_text()
+        for block, line, _ in extract_bash_blocks(content, include_audit=include_audit):
+            for cmd, _ in split_commands(block, cli, line):
+                parts = cmd.split()[1:]
+                for token in parts[:4]:
+                    if token.startswith("-"):
+                        continue
+                    if _SUBCOMMAND_CANDIDATE_RE.match(token):
+                        services.add(token)
+                    break
+                # Also take the token after a possible `-f value` pair.
+                if (
+                    len(parts) >= 3
+                    and parts[0].startswith("-")
+                    and "=" not in parts[0]
+                    and not parts[1].startswith("-")
+                    and _SUBCOMMAND_CANDIDATE_RE.match(parts[2] or "-")
+                ):
+                    services.add(parts[2])
+    return sorted(services)
+
+
+def build_cobra_commands_db(key: str, extra_services: list[str] | None = None) -> dict[str, dict]:
+    """Walk a Cobra CLI's command tree breadth-first via __complete,
+    scoped to the top-level subcommands the policies actually use
+    (plus extra_services, used by tests to widen the walk).
+
+    Returns {} when the policies contain no commands for this CLI. Exits
+    with an install hint when the binary is missing.
+    """
+    entry = COBRA_CLIS[key]
+    cli = entry["cli"]
+    policy_files = [SCRIPT_DIR / ".." / p for p in entry["policies"]]
+
+    services = detect_cli_services(cli, policy_files, entry["include_audit"])
+    services = sorted(set(services) | set(extra_services or []))
+    if not services:
+        return {}
+
+    cli_path = subprocess.run(
+        ["which", cli], capture_output=True, text=True
+    ).stdout.strip()
+    if not cli_path:
+        print(
+            f"Error: {cli} CLI not found in PATH.\n"
+            "\n"
+            f"Validating {cli} commands requires the {cli} CLI to be installed\n"
+            "locally — its Cobra completion tree is the source of truth for\n"
+            "valid commands and flags.\n"
+            "\n"
+            "Install options:\n"
+            f"{entry['install']}\n"
+            "\n"
+            f"After installing, ensure `{cli}` is on your PATH and re-run:\n"
+            f"  python3 {sys.argv[0]} {key}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    env = _walk_env()
+
+    # Breadth-first walk, parallelizing the subprocess calls in each
+    # round (same scheme as the doctl walker).
+    visited: set[str] = set()
+    db: dict[str, dict] = {}
+    queue = list(services)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        while queue:
+            future_to_path = {}
+            for path in queue:
+                if path in visited:
+                    continue
+                visited.add(path)
+                future_to_path[pool.submit(_node_info, cli, path, env)] = path
+            next_queue: list[str] = []
+            for fut, path in future_to_path.items():
+                try:
+                    node = fut.result()
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"Warning: timed out introspecting `{cli} {path}`",
+                        file=sys.stderr,
+                    )
+                    continue
+                # A path that introspects to nothing — no subcommands and
+                # no flags (a real leaf always has at least --help) — is
+                # not a command. This drops bogus service candidates from
+                # detect_cli_services (e.g. a leading flag's value) and
+                # keeps misspelled commands out of the db so validation
+                # reports them.
+                if not node["subcommands"] and not node["flags"]:
+                    continue
+                db[path] = node
+                for s in node["subcommands"]:
+                    sub_path = f"{path} {s}".strip()
+                    if sub_path not in visited:
+                        next_queue.append(sub_path)
+            queue = next_queue
+
+    return db
+
+
+def parse_cobra_command(
+    cli: str, cmd: str, db: dict[str, dict]
+) -> tuple[str, str | None, list[str]]:
+    """Parse a CLI command into (command_path, next_token, flags).
+
+    Matches the longest known command path from the database; tokens
+    after it (resource types, names, file args) are positionals and not
+    validated. next_token is the first positional after the matched
+    path, which the caller reports as a misspelled subcommand when the
+    path lands on a command group. Returns the raw pre-flag tokens as
+    the path when nothing matches, so the caller reports it as unknown.
+    """
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        tokens = cmd.split()
+
+    if len(tokens) < 2 or tokens[0] != cli:
+        return "", None, []
+
+    parts = tokens[1:]
+
+    # Global flags may precede the subcommand (`kubectl -n kube-system
+    # get pod`). Start path matching at the first token that is a known
+    # top-level command; flag values like `kube-system` won't match.
+    start = 0
+    for i, token in enumerate(parts):
+        if not token.startswith("-") and token in db:
+            start = i
+            break
+
+    command_path = ""
+    next_token = None
+    raw_path_parts = []
+    for i in range(start, len(parts)):
+        if parts[i].startswith("-"):
+            break
+        raw_path_parts.append(parts[i])
+        candidate = " ".join(parts[start: i + 1])
+        if candidate in db:
+            command_path = candidate
+            depth = i + 1
+            next_token = (
+                parts[depth]
+                if depth < len(parts) and not parts[depth].startswith("-")
+                else None
+            )
+
+    if not command_path and raw_path_parts:
+        command_path = " ".join(raw_path_parts)
+
+    flags = []
+    for token in parts:
+        if token.startswith("--"):
+            flags.append(token.split("=")[0])
+
+    return command_path, next_token, flags
+
+
+def validate_cobra_command(
+    cli: str,
+    command_path: str,
+    raw_next_token: str | None,
+    flags: list[str],
+    db: dict[str, dict],
+) -> tuple[bool, list[str]]:
+    """Validate a parsed command against the walked command tree."""
+    errors = []
+
+    if command_path not in db:
+        errors.append(f"unknown command '{cli} {command_path}'")
+        return False, errors
+
+    node = db[command_path]
+
+    # A node with subcommands needs one; the next positional token (if
+    # any) was already rejected by the longest-path match, so it's a
+    # misspelled subcommand rather than a positional argument.
+    if node["subcommands"]:
+        if raw_next_token is not None:
+            errors.append(
+                f"unknown subcommand '{raw_next_token}' for '{cli} {command_path}'"
+            )
+        else:
+            errors.append(
+                f"'{cli} {command_path}' is a command group; missing subcommand"
+            )
+        return False, errors
+
+    valid_flags = set(node["flags"])
+    for flag in flags:
+        if flag not in valid_flags:
+            errors.append(f"unknown flag '{flag}' for '{cli} {command_path}'")
+
+    return len(errors) == 0, errors
+
+
+def validate_cobra_cli(key: str) -> tuple[int, int]:
+    """Validate one registered Cobra CLI. Returns (pass, fail)."""
+    entry = COBRA_CLIS[key]
+    cli = entry["cli"]
+
+    db = build_cobra_commands_db(key)
+    if not db:
+        return 0, 0
+
+    pass_count = 0
+    fail_count = 0
+
+    for policy_name in entry["policies"]:
+        policy_file = SCRIPT_DIR / ".." / policy_name
+        if not policy_file.exists():
+            print(f"Error: Policy file not found: {policy_file}", file=sys.stderr)
+            sys.exit(1)
+
+        content = policy_file.read_text()
+        blocks = extract_bash_blocks(content, include_audit=entry["include_audit"])
+        relpath = policy_relpath(policy_file)
+
+        for block_text, block_line, uid in blocks:
+            commands = split_commands(block_text, cli, block_line)
+            for cmd, line_num in commands:
+                command_path, next_token, flags = parse_cobra_command(cli, cmd, db)
+                if not command_path:
+                    continue
+
+                is_valid, errors = validate_cobra_command(
+                    cli, command_path, next_token, flags, db
+                )
+
+                if is_valid:
+                    print(f"[PASS] {uid}")
+                    print(f"       {truncate_cmd(cmd)}")
+                    pass_count += 1
+                else:
+                    print(f"[FAIL] {uid}")
+                    print(f"       {truncate_cmd(cmd)}")
+                    for error in errors:
+                        print(f"       {error}")
+                    fail_count += 1
+                    FAILURES.append({
+                        "file": relpath,
+                        "line": line_num,
+                        "uid": uid,
+                        "command": truncate_cmd(cmd),
+                        "errors": errors,
+                        "cloud": key,
+                    })
+
+    return pass_count, fail_count

--- a/content/validation/validators/main.py
+++ b/content/validation/validators/main.py
@@ -6,6 +6,7 @@ import sys
 
 from .aws import validate_aws
 from .azure import validate_azure
+from .cobra import COBRA_CLIS, validate_cobra_cli
 from .common import emit_github_annotations
 from .digitalocean import validate_digitalocean
 from .gcloud import validate_gcloud
@@ -13,8 +14,8 @@ from .nutanix import validate_nutanix
 from .oci import validate_oci
 from .openapi import API_PROVIDERS, validate_api_provider
 
-# CLI validators, dispatched by name. The REST API validators come from
-# the openapi provider registry and are appended below.
+# CLI validators, dispatched by name. The Cobra CLI and REST API
+# validators come from their registries and are appended below.
 CLI_VALIDATORS = {
     "aws": validate_aws,
     "azure": validate_azure,
@@ -24,7 +25,7 @@ CLI_VALIDATORS = {
     "nutanix": validate_nutanix,
 }
 
-VALIDATORS = list(CLI_VALIDATORS) + list(API_PROVIDERS)
+VALIDATORS = list(CLI_VALIDATORS) + list(COBRA_CLIS) + list(API_PROVIDERS)
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +62,12 @@ def main():
     for name, validator in CLI_VALIDATORS.items():
         if target in ("all", name):
             p, f = validator()
+            total_pass += p
+            total_fail += f
+
+    for name in COBRA_CLIS:
+        if target in ("all", name):
+            p, f = validate_cobra_cli(name)
             total_pass += p
             total_fail += f
 


### PR DESCRIPTION
## Summary

Follow-up to #2815, extending remediation command validation to four more CLIs: `kubectl`, `gh`, `glab`, and `hcloud` (228 commands across the kubernetes, github, gitlab, and hetzner policies). The full suite now validates **2,032 commands**.

## Approach: Cobra `__complete` instead of help-text parsing

The doctl validator parses `--help` output, which works because doctl renders standard Cobra help. These four CLIs don't: gh and glab use custom uppercase-header templates, kubectl uses `Options:` with `--flag=default:` lines. Instead of four bespoke parsers, the new `validators/cobra.py` walks the hidden `__complete` command Cobra builds into every Go CLI for shell completion — machine-readable `name\tdescription` candidates, identical across all of them. Each CLI is a `COBRA_CLIS` registry entry; adding the next Cobra CLI is a few lines.

Three discoveries shaped the implementation (each empirically verified):

- **Flag completion can be filtered.** hcloud only suggests required flags not yet given (2 of 7 for `firewall add-rule`), while kubectl's `--help` omits the global flags its completion includes. Valid flags are therefore the **union** of completions and flag-shaped `--help` lines.
- **Value completions can masquerade as subcommands.** kubectl's `rollout restart` statically completes resource types (`deployment`, `daemonset`, …) as bare names, which would turn the leaf into a phantom command group. Real subcommands always carry a tab-separated description; bare candidates are dropped.
- **Live backends would break determinism.** Completion callbacks can query the cluster/API for pod or server names, so the walk runs with credentials stripped (`KUBECONFIG=/dev/null`, GH/GITLAB/HCLOUD tokens unset).

The command-path matcher also tolerates global flags before the subcommand (`kubectl -n kube-system get pod` — a third of the kubernetes policy's commands).

## Audit-section coverage

All four validators scan `audit:` bash blocks as well as `id: cli` remediation blocks, the same scope #2815 established for REST APIs. These are new validators with no unvalidated-block backlog, and kubectl appears almost exclusively in audit sections (the kubernetes policies remediate via manifests — without audit blocks there'd be nothing to validate).

## Real bug found and fixed

All **15** `glab api` audit commands in the gitlab policy used `--jq '<filter>'` — a `gh api` flag that **glab does not have** (glab's own docs pipe to external `jq`). Every gitlab audit command was broken as written; users following the docs verbatim would get `unknown flag: --jq`. Fixed by rewriting to `glab api ... | jq '<filter>'` (second commit; same filters, unchanged semantics).

## CI

`glab` and `hcloud` install from pinned, checksum-verified release tarballs (the doctl pattern — bump version + SHA in lockstep). `kubectl` and `gh` ship preinstalled on ubuntu-latest and get a fail-fast version check instead.

## Testing

- All four validators pass on the live policies: kubernetes 81, github 83, hetzner 34, gitlab 30 (after the fix).
- 21 mutation cases — typo'd commands, subcommands, group-as-leaf, flags per CLI, the `--jq` bug class, leading global flags, `gh api --jq` (valid!) vs `glab api --jq` (invalid) — all produce the expected verdicts.
- Full suite: 2,032 passed, 0 failed; pre-existing validators unchanged.
- `cnspec policy lint` passes on the modified gitlab policy; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)