### PR TITLE
🐛 gitlab: fix calls to a nonexistent approval_settings endpoint and inverted UI steps

### DIFF
--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gitlab-security
     name: Mondoo GitLab Security
-    version: 1.8.1
+    version: 1.8.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -119,7 +119,7 @@ queries:
 
         1. In GitLab, navigate to your group.
         2. Go to **Settings** > **General**.
-        3. Expand the **Visibility, project features, permissions** section.
+        3. Expand the **Naming, description, visibility** section.
         4. Note the selected **Visibility level**.
 
         A passing group has the visibility level set to **Private** or **Internal**. A failing group has the visibility level set to **Public**.
@@ -140,9 +140,11 @@ queries:
 
             1. In GitLab, navigate to your group.
             2. Go to **Settings** > **General**.
-            3. Expand the **Visibility, project features, permissions** section.
+            3. Expand the **Naming, description, visibility** section.
             4. Under **Visibility level**, select **Private**.
             5. Click **Save changes**.
+
+            GitLab rejects the change while any project or subgroup in the group has a higher visibility level. Change those to private or internal first.
 
             For more details, see [Change group visibility](https://docs.gitlab.com/user/public_access.html#change-group-visibility).
         - id: cli
@@ -153,6 +155,8 @@ queries:
             glab api --method PUT groups/GROUP_ID -f visibility=private
             ```
 
+            The request fails while any project or subgroup in the group has a higher visibility level. Change those to private or internal first.
+
             For more details, see the [Groups API](https://docs.gitlab.com/api/groups.html#update-group).
         - id: terraform
           desc: |
@@ -160,9 +164,9 @@ queries:
 
             ```hcl
             resource "gitlab_group" "example" {
-              name        = "example"
-              path        = "example"
-              visibility  = "private"
+              name             = "example"
+              path             = "example"
+              visibility_level = "private"
             }
             ```
 
@@ -242,9 +246,9 @@ queries:
         1. In GitLab, navigate to your group.
         2. Go to **Settings** > **General**.
         3. Expand the **Permissions and group features** section.
-        4. Check whether **Require two-factor authentication** is selected.
+        4. Check whether **All users in this group must set up two-factor authentication** is selected.
 
-        A passing group has **Require two-factor authentication** enabled. A failing group has it disabled.
+        A passing group has **All users in this group must set up two-factor authentication** enabled. A failing group has it disabled.
 
         ### Audit via CLI
 
@@ -263,10 +267,11 @@ queries:
             1. In GitLab, navigate to your group.
             2. Go to **Settings** > **General**.
             3. Expand the **Permissions and group features** section.
-            4. Under **Require two-factor authentication**, check the box.
-            5. Click **Save changes**.
+            4. Check **All users in this group must set up two-factor authentication**.
+            5. Optionally, set **Delay 2FA enforcement (hours)** to give members a grace period.
+            6. Click **Save changes**.
 
-            For more details, see [Enforce two-factor authentication](https://docs.gitlab.com/ee/security/two_factor_authentication.html).
+            For more details, see [Enforce two-factor authentication](https://docs.gitlab.com/security/two_factor_authentication/).
         - id: cli
           desc: |
             To require two-factor authentication for all users in a GitLab group using the `glab` CLI:
@@ -284,8 +289,8 @@ queries:
 
             ```hcl
             resource "gitlab_group" "example" {
-              name        = "example"
-              path        = "example"
+              name                              = "example"
+              path                              = "example"
               require_two_factor_authentication = true
             }
             ```
@@ -395,15 +400,17 @@ queries:
             4. Under **Project visibility**, select **Private**.
             5. Click **Save changes**.
 
-            **Step 2: Set the default visibility for new projects**
+            **Step 2: Prevent future public projects**
 
-            To prevent future projects from being created as public:
+            Setting the group visibility to **Private** prevents any project in the group from being public, because a project cannot be more visible than its group:
 
             1. In GitLab, navigate to your group.
             2. Go to **Settings** > **General**.
-            3. Expand the **Visibility, project features, permissions** section.
-            4. Under **Default project visibility**, select **Private**.
+            3. Expand the **Naming, description, visibility** section.
+            4. Under **Visibility level**, select **Private**.
             5. Click **Save changes**.
+
+            On self-managed instances, administrators can also set **Default project visibility** to **Private** under **Admin area** > **Settings** > **General** > **Visibility and access controls**.
 
             For more details, see [Change project visibility](https://docs.gitlab.com/user/public_access.html#change-project-visibility).
         - id: cli
@@ -427,23 +434,20 @@ queries:
 
             ```hcl
             resource "gitlab_project" "example" {
-              name         = "example"
-              path         = "example"
-              visibility   = "private"
-              namespace_id = gitlab_group.example.id
+              name             = "example"
+              path             = "example"
+              visibility_level = "private"
+              namespace_id     = gitlab_group.example.id
             }
             ```
 
-            To set the default visibility for new projects in a group:
+            To make the group private so that no project inside it can be public:
 
             ```hcl
             resource "gitlab_group" "example" {
-              name                      = "example"
-              path                      = "example"
-              default_branch_protection = 2
-              project_creation_level    = "maintainer"
-              subgroup_creation_level   = "maintainer"
-              visibility_level          = "private"
+              name             = "example"
+              path             = "example"
+              visibility_level = "private"
             }
             ```
 
@@ -563,10 +567,10 @@ queries:
 
             ```hcl
             resource "gitlab_project" "example" {
-              name         = "example"
-              path         = "example"
-              visibility   = "private"
-              namespace_id = gitlab_group.example.id
+              name             = "example"
+              path             = "example"
+              visibility_level = "private"
+              namespace_id     = gitlab_group.example.id
             }
             ```
 
@@ -662,13 +666,23 @@ queries:
 
             1. Navigate to your project.
             2. Go to **Settings** > **Merge requests**.
-            3. Under **Merge request approvals**, set **Approvals required** to at least 1.
-            4. Click **Save changes**.
+            3. Under **Merge request approvals**, edit the **All eligible users** rule, or click **Add approval rule** if no rule exists.
+            4. Set **Approvals required** to at least 1.
+            5. Click **Save changes**.
 
             For more details, see [Merge request approval rules](https://docs.gitlab.com/user/project/merge_requests/approvals/rules.html).
         - id: cli
           desc: |
             To require merge request approvals using the `glab` CLI:
+
+            Set the project-wide approval requirement:
+
+            ```bash
+            glab api --method POST projects/PROJECT_ID/approvals \
+              -f approvals_before_merge=1
+            ```
+
+            To additionally enforce the requirement with a named approval rule:
 
             ```bash
             glab api --method POST projects/PROJECT_ID/approval_rules \
@@ -681,10 +695,6 @@ queries:
             To require merge request approvals using Terraform:
 
             ```hcl
-            resource "gitlab_project_level_mr_approvals" "example" {
-              project = gitlab_project.example.id
-            }
-
             resource "gitlab_project_approval_rule" "example" {
               project            = gitlab_project.example.id
               name               = "default"
@@ -692,7 +702,7 @@ queries:
             }
             ```
 
-            For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_level_mr_approvals).
+            For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_approval_rule).
     refs:
       - url: https://docs.gitlab.com/user/project/merge_requests/approvals/
         title: GitLab Merge Request Approvals
@@ -755,16 +765,17 @@ queries:
 
         1. In GitLab, navigate to your project.
         2. Go to **Settings** > **Merge requests**.
-        3. Under **Merge request approvals**, check the state of **Allow author approval**.
+        3. Under **Merge request approvals**, scroll to **Approval settings**.
+        4. Check the state of **Prevent approval by merge request creator (author)**.
 
-        A passing project has **Allow author approval** unchecked. A failing project has it checked.
+        A passing project has **Prevent approval by merge request creator (author)** checked. A failing project has it unchecked.
 
         ### Audit via CLI
 
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings | jq '.merge_requests_author_approval'
+        glab api projects/PROJECT_ID/approvals | jq '.merge_requests_author_approval'
         ```
 
         A passing project returns `false`. A failing project returns `true`.
@@ -775,8 +786,9 @@ queries:
 
             1. Navigate to your project.
             2. Go to **Settings** > **Merge requests**.
-            3. Under **Merge request approvals**, uncheck **Allow author approval**.
-            4. Click **Save changes**.
+            3. Under **Merge request approvals**, scroll to **Approval settings**.
+            4. Check **Prevent approval by merge request creator (author)**.
+            5. Click **Save changes**.
 
             For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
         - id: cli
@@ -784,7 +796,7 @@ queries:
             To prevent merge request authors from approving their own requests using the `glab` CLI:
 
             ```bash
-            glab api --method PUT projects/PROJECT_ID/approval_settings \
+            glab api --method POST projects/PROJECT_ID/approvals \
               -f merge_requests_author_approval=false
             ```
 
@@ -796,7 +808,7 @@ queries:
             ```hcl
             resource "gitlab_project_level_mr_approvals" "example" {
               project                        = gitlab_project.example.id
-              merge_requests_author_approval  = false
+              merge_requests_author_approval = false
             }
             ```
 
@@ -879,16 +891,17 @@ queries:
 
         1. In GitLab, navigate to your project.
         2. Go to **Settings** > **Merge requests**.
-        3. Under **Merge request approvals**, check the state of **Remove all approvals when commits are added to the source branch**.
+        3. Under **Merge request approvals**, scroll to **Approval settings**.
+        4. Check the state of **Remove all approvals**.
 
-        A passing project has this option checked. A failing project has it unchecked.
+        A passing project has **Remove all approvals** checked. A failing project has it unchecked.
 
         ### Audit via CLI
 
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings | jq '.reset_approvals_on_push'
+        glab api projects/PROJECT_ID/approvals | jq '.reset_approvals_on_push'
         ```
 
         A passing project returns `true`. A failing project returns `false`.
@@ -899,16 +912,17 @@ queries:
 
             1. Navigate to your project.
             2. Go to **Settings** > **Merge requests**.
-            3. Under **Merge request approvals**, check **Remove all approvals when commits are added to the source branch**.
-            4. Click **Save changes**.
+            3. Under **Merge request approvals**, scroll to **Approval settings**.
+            4. Check **Remove all approvals**.
+            5. Click **Save changes**.
 
-            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
+            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html#remove-all-approvals-when-commits-are-added-to-the-source-branch).
         - id: cli
           desc: |
             To reset merge request approvals when new commits are pushed using the `glab` CLI:
 
             ```bash
-            glab api --method PUT projects/PROJECT_ID/approval_settings \
+            glab api --method POST projects/PROJECT_ID/approvals \
               -f reset_approvals_on_push=true
             ```
 
@@ -919,8 +933,8 @@ queries:
 
             ```hcl
             resource "gitlab_project_level_mr_approvals" "example" {
-              project                  = gitlab_project.example.id
-              reset_approvals_on_push  = true
+              project                 = gitlab_project.example.id
+              reset_approvals_on_push = true
             }
             ```
 
@@ -1012,7 +1026,7 @@ queries:
         Query the approval settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/approval_settings | jq '.merge_requests_disable_committers_approval'
+        glab api projects/PROJECT_ID/approvals | jq '.merge_requests_disable_committers_approval'
         ```
 
         A passing project returns `true`. A failing project returns `false`.
@@ -1023,8 +1037,9 @@ queries:
 
             1. Navigate to your project.
             2. Go to **Settings** > **Merge requests**.
-            3. Under **Merge request approvals**, check **Prevent approvals by users who add commits**.
-            4. Click **Save changes**.
+            3. Under **Merge request approvals**, scroll to **Approval settings**.
+            4. Check **Prevent approvals by users who add commits**.
+            5. Click **Save changes**.
 
             For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
         - id: cli
@@ -1032,7 +1047,7 @@ queries:
             To prevent committers from approving merge requests they contributed to using the `glab` CLI:
 
             ```bash
-            glab api --method PUT projects/PROJECT_ID/approval_settings \
+            glab api --method POST projects/PROJECT_ID/approvals \
               -f merge_requests_disable_committers_approval=true
             ```
 
@@ -1043,8 +1058,8 @@ queries:
 
             ```hcl
             resource "gitlab_project_level_mr_approvals" "example" {
-              project                                     = gitlab_project.example.id
-              merge_requests_disable_committers_approval   = true
+              project                                    = gitlab_project.example.id
+              merge_requests_disable_committers_approval = true
             }
             ```
 
@@ -1157,9 +1172,18 @@ queries:
           desc: |
             To disable force push on the default branch using the `glab` CLI:
 
+            If the default branch is already protected, update its protection. Replace BRANCH_NAME with the name of the project's default branch:
+
             ```bash
-            glab api --method PATCH projects/PROJECT_ID/protected_branches/main \
+            glab api --method PATCH projects/PROJECT_ID/protected_branches/BRANCH_NAME \
               -f allow_force_push=false
+            ```
+
+            If the default branch is not protected yet, protect it with force push disabled:
+
+            ```bash
+            glab api --method POST projects/PROJECT_ID/protected_branches \
+              -f name=BRANCH_NAME -f allow_force_push=false
             ```
 
             For more details, see the [Protected branches API](https://docs.gitlab.com/api/protected_branches.html#update-a-protected-branch).
@@ -1280,7 +1304,7 @@ queries:
             3. Under **Merge checks**, check **Pipelines must succeed**.
             4. Click **Save changes**.
 
-            For more details, see [Merge request checks](https://docs.gitlab.com/user/project/merge_requests/merge_when_pipeline_succeeds.html).
+            For more details, see [Require a successful pipeline for merge](https://docs.gitlab.com/user/project/merge_requests/auto_merge/#require-a-successful-pipeline-for-merge).
         - id: cli
           desc: |
             To require a successful pipeline before merging using the `glab` CLI:
@@ -1379,9 +1403,9 @@ queries:
         1. In GitLab, navigate to your group.
         2. Go to **Settings** > **General**.
         3. Expand the **Permissions and group features** section.
-        4. Check the state of **Prevent forking outside of the group**.
+        4. Check the state of **Prevent project forking outside current group**.
 
-        A passing group has **Prevent forking outside of the group** checked. A failing group has it unchecked.
+        A passing group has **Prevent project forking outside current group** checked. A failing group has it unchecked.
 
         ### Audit via CLI
 
@@ -1400,10 +1424,10 @@ queries:
             1. Navigate to your group in GitLab.
             2. Go to **Settings** > **General**.
             3. Expand the **Permissions and group features** section.
-            4. Check **Prevent forking outside of the group**.
+            4. Check **Prevent project forking outside current group**.
             5. Click **Save changes**.
 
-            For more details, see [Prevent forking outside the group](https://docs.gitlab.com/user/group/#prevent-forking-outside-the-group).
+            For more details, see [Prevent project forking outside group](https://docs.gitlab.com/user/group/access_and_permissions/#prevent-project-forking-outside-group).
         - id: cli
           desc: |
             To prevent forking projects outside the group using the `glab` CLI:
@@ -1900,24 +1924,32 @@ queries:
 
             1. Navigate to your project in GitLab.
             2. Go to **Secure** > **Security configuration**.
-            3. Under **Continuous Vulnerability Scanning**, toggle the feature to **Enabled**.
-            4. Alternatively, navigate to **Settings** > **Security & Compliance** and enable the feature.
+            3. Under **Continuous Vulnerability Scanning**, turn on the toggle.
 
-            Continuous vulnerability scanning requires GitLab Ultimate.
+            Continuous vulnerability scanning requires GitLab Ultimate. For results to appear, a dependency scanning job must also run at least once on the default branch so GitLab has an SBOM to compare against new security advisories.
 
             For more details, see [Continuous vulnerability scanning](https://docs.gitlab.com/user/application_security/continuous_vulnerability_scanning/).
         - id: cli
           desc: |
             To enable continuous vulnerability scanning using the `glab` CLI:
 
+            The REST API does not support updating this setting, so use the GraphQL API. Replace GROUP/PROJECT with the full path of your project:
+
             ```bash
-            glab api --method PUT projects/PROJECT_ID \
-              -f continuous_vulnerability_scans_enabled=true
+            glab api graphql -f query='
+              mutation {
+                projectSetContinuousVulnerabilityScanning(
+                  input: { projectPath: "GROUP/PROJECT", enable: true }
+                ) {
+                  continuousVulnerabilityScanningEnabled
+                  errors
+                }
+              }'
             ```
 
             This setting requires a GitLab Ultimate subscription.
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [GraphQL API reference](https://docs.gitlab.com/api/graphql/reference/#mutationprojectsetcontinuousvulnerabilityscanning).
         # No Terraform remediation: the GitLab Terraform provider exposes no resource for the project security setting that toggles continuous vulnerability scanning.
     refs:
       - url: https://docs.gitlab.com/user/application_security/continuous_vulnerability_scanning/


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2816). This PR covers `mondoo-gitlab-security.mql.yaml`: all 15 checks were reviewed and 12 needed fixes. Policy version bumped. Verified against the gitlab provider schema, GitLab's REST/GraphQL docs and source, and the terraform provider registry docs.

## Endpoints that do not exist

Three approval checks (author approval, committer approval, reset-on-push) sent `PUT /projects/:id/approval_settings` — not a GitLab REST endpoint; the request 404s. Their audit sections queried the same path. The real interface is `POST /projects/:id/approvals` with the corresponding field, which is precisely what the provider reads back, so the corrected commands flip the checks directly.

## UI steps for controls that do not exist or are inverted

- **no-author-approval** told users to uncheck "Allow author approval"; the actual control is the inverted checkbox **Prevent approval by merge request creator (author)**, which must be checked.
- **private-projects** step 2 sent users to a group-level "Default project visibility" setting that does not exist (it is instance-level admin only); the real group-level lever — group visibility capping member projects — is now explained.
- **continuous-vulnerability-scanning** pointed at Settings > Security & Compliance; the toggle lives on Secure > Security configuration, and the SBOM prerequisite is now stated.
- Wrong group-settings section names, checkbox labels, and two dead doc links corrected; audits updated to match.

## Terraform that fails validation

`gitlab_group` and `gitlab_project` have no `visibility` argument — the attribute is `visibility_level`, which the policy's own terraform variants assert, so the published HCL both failed `terraform validate` and could never satisfy the check. Fixed in three checks; an empty no-op `gitlab_project_level_mr_approvals` block was dropped.

## Remediations that never changed the checked state

- **approvals-required**: the CLI created a named approval rule, but the check reads the legacy `approvals_before_merge` field, which rules never touch — following the remediation left the check failing forever. The field-setting call now leads, with the rule as reinforcement.
- **continuous-vulnerability-scanning**: the Projects edit API silently ignores `continuous_vulnerability_scans_enabled`; the GraphQL `projectSetContinuousVulnerabilityScanning` mutation is the only programmatic path and is now what the CLI entry uses.
- **no-force-push-default-branch** hardcoded `main` and PATCHed, which 404s on unprotected or differently named default branches; both cases are now covered.

## Left for maintainers

Modern GitLab manages approvals exclusively through approval rules and never writes the legacy `approvals_before_merge` column the approvals-required check reads, so a project genuinely requiring approvals via an \"All eligible users\" rule still fails. Re-basing the check on `gitlab.project.approvalRules` (e.g. any rule with `approvalsRequired >= 1`) would modernize it; deferred here as a semantic change.

## Validation

- `cnspec policy lint` passes
- `validate_terraform_remediation.py gitlab` with tflint: 14 passed, 0 failed
- YAML parses clean; no mql changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)