### PR TITLE
🐛 chef-infra-server: stop add-on removals from uninstalling the whole server

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -118,7 +118,6 @@ Burstable
 bypassable
 callees
 cbc
-cbt
 ccc
 ccmp
 Cdm
@@ -190,7 +189,6 @@ coreutils
 corosync
 cosmosdb
 countmax
-createinstance
 cribl
 crio
 Crowdsourced
@@ -257,6 +255,7 @@ dnl
 DNSKEY
 docdb
 dotfile
+drbdadm
 dpd
 dpi
 dport

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -887,7 +887,15 @@ queries:
 
             **Important**: Before removing Chef HA, migrate to a supported high availability solution such as Chef Backend or an external PostgreSQL cluster. Removing DRBD replication from an active failover pair without a migration plan can cause an outage or data loss.
 
-            1. Remove the package with your platform package manager. The Chef HA add-on has no dedicated ctl command.
+            1. Stop the HA services before removing the package. The Chef HA add-on has no dedicated ctl uninstall command, so unlike the other add-ons nothing stops its services for you; removing the package while keepalived or DRBD replication is active can pull files out from under running processes.
+
+            ```bash
+            chef-server-ctl stop keepalived
+            ```
+
+            Confirm DRBD is not active on the node (for example with `drbdadm status`) before continuing.
+
+            2. Remove the package with your platform package manager.
 
             On Debian and Ubuntu systems:
 
@@ -901,13 +909,13 @@ queries:
             rpm -e chef-ha
             ```
 
-            2. Regenerate the server configuration:
+            3. Regenerate the server configuration:
 
             ```bash
             chef-server-ctl reconfigure
             ```
 
-            3. Verify the package is removed:
+            4. Verify the package is removed:
 
             ```bash
             dpkg -l | grep chef-ha || rpm -qa | grep chef-ha
@@ -980,13 +988,15 @@ queries:
 
             If you cannot upgrade immediately, you can manually configure nginx to disable older TLS versions:
 
-            1. Edit `/etc/opscode/chef-server.rb` and add:
+            1. Edit `/etc/opscode/chef-server.rb` and add one of the following:
 
             ```ruby
+            # On releases that support TLS 1.3:
+            nginx['ssl_protocols'] = 'TLSv1.2 TLSv1.3'
+
+            # On older releases without TLS 1.3 support:
             nginx['ssl_protocols'] = 'TLSv1.2'
             ```
-
-            To also offer TLS 1.3 on releases that support it, use `'TLSv1.2 TLSv1.3'` instead.
 
             2. Reconfigure the server:
 

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-server
     name: Mondoo Chef Infra Server Security
-    version: 1.3.0
+    version: 1.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -527,7 +527,7 @@ queries:
             1. Check your current Chef Infra Server version:
 
             ```bash
-            cat /opt/opscode/version-manifest.txt | head -1
+            head -1 /opt/opscode/version-manifest.txt
             ```
 
             2. Review the [Chef Infra Server upgrade documentation](https://docs.chef.io/server/upgrades/) for your upgrade path.
@@ -600,18 +600,39 @@ queries:
           desc: |
             **Using CLI**
 
-            Run these commands to uninstall the Reporting package:
+            1. Shut down the Reporting add-on services:
 
             ```bash
-            chef-server-ctl uninstall opscode-reporting
+            opscode-reporting-ctl uninstall
+            ```
+
+            2. Remove the package with your platform package manager.
+
+            On Debian and Ubuntu systems:
+
+            ```bash
+            dpkg -P opscode-reporting
+            ```
+
+            On Red Hat family systems:
+
+            ```bash
+            rpm -e opscode-reporting
+            ```
+
+            3. Regenerate the server configuration so the add-on endpoints are removed:
+
+            ```bash
             chef-server-ctl reconfigure
             ```
 
-            After uninstallation, verify the package is removed:
+            4. Verify the package is removed:
 
             ```bash
             dpkg -l | grep opscode-reporting || rpm -qa | grep opscode-reporting
             ```
+
+            **Note**: Running `chef-server-ctl reconfigure` restarts server services and briefly interrupts client requests. Do not run `chef-server-ctl uninstall`; that command removes the entire Chef Infra Server application.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -674,20 +695,39 @@ queries:
           desc: |
             **Using CLI**
 
-            Run these commands to uninstall the Push Jobs Server package:
+            1. Shut down the Push Jobs Server services:
 
             ```bash
-            chef-server-ctl uninstall opscode-push-jobs-server
+            opscode-push-jobs-server-ctl uninstall
+            ```
+
+            2. Remove the package with your platform package manager.
+
+            On Debian and Ubuntu systems:
+
+            ```bash
+            dpkg -P opscode-push-jobs-server
+            ```
+
+            On Red Hat family systems:
+
+            ```bash
+            rpm -e opscode-push-jobs-server
+            ```
+
+            3. Regenerate the server configuration so the add-on endpoints are removed:
+
+            ```bash
             chef-server-ctl reconfigure
             ```
 
-            After uninstallation, verify the package is removed:
+            4. Verify the package is removed:
 
             ```bash
             dpkg -l | grep opscode-push-jobs-server || rpm -qa | grep opscode-push-jobs-server
             ```
 
-            **Note**: You will also need to remove the `push-jobs-client` package from managed nodes to complete the migration.
+            **Note**: You will also need to remove the `push-jobs-client` package from managed nodes to complete the migration. Running `chef-server-ctl reconfigure` restarts server services and briefly interrupts client requests. Do not run `chef-server-ctl uninstall`; that command removes the entire Chef Infra Server application.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -750,18 +790,39 @@ queries:
           desc: |
             **Using CLI**
 
-            Run these commands to uninstall the Opscode Analytics package:
+            1. Shut down the Analytics services:
 
             ```bash
-            chef-server-ctl uninstall opscode-analytics
+            opscode-analytics-ctl uninstall
+            ```
+
+            2. Remove the package with your platform package manager.
+
+            On Debian and Ubuntu systems:
+
+            ```bash
+            dpkg -P opscode-analytics
+            ```
+
+            On Red Hat family systems:
+
+            ```bash
+            rpm -e opscode-analytics
+            ```
+
+            3. Regenerate the server configuration:
+
+            ```bash
             chef-server-ctl reconfigure
             ```
 
-            After uninstallation, verify the package is removed:
+            4. Verify the package is removed:
 
             ```bash
             dpkg -l | grep opscode-analytics || rpm -qa | grep opscode-analytics
             ```
+
+            **Note**: Running `chef-server-ctl reconfigure` restarts server services and briefly interrupts client requests. Do not run `chef-server-ctl uninstall`; that command removes the entire Chef Infra Server application.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -824,20 +885,35 @@ queries:
           desc: |
             **Using CLI**
 
-            Run these commands to uninstall the Chef HA package:
+            **Important**: Before removing Chef HA, migrate to a supported high availability solution such as Chef Backend or an external PostgreSQL cluster. Removing DRBD replication from an active failover pair without a migration plan can cause an outage or data loss.
+
+            1. Remove the package with your platform package manager. The Chef HA add-on has no dedicated ctl command.
+
+            On Debian and Ubuntu systems:
 
             ```bash
-            chef-server-ctl uninstall chef-ha
+            dpkg -P chef-ha
+            ```
+
+            On Red Hat family systems:
+
+            ```bash
+            rpm -e chef-ha
+            ```
+
+            2. Regenerate the server configuration:
+
+            ```bash
             chef-server-ctl reconfigure
             ```
 
-            After uninstallation, verify the package is removed:
+            3. Verify the package is removed:
 
             ```bash
             dpkg -l | grep chef-ha || rpm -qa | grep chef-ha
             ```
 
-            **Important**: Before removing Chef HA, ensure you have planned your migration to a supported high-availability solution to avoid service disruption.
+            **Note**: Running `chef-server-ctl reconfigure` restarts server services and briefly interrupts client requests. Do not run `chef-server-ctl uninstall`; that command removes the entire Chef Infra Server application.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -876,10 +952,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      file("/var/opt/opscode/nginx/etc/chef_https_lb.conf").content.contains("ssl_protocols TLSv1.2;")
+      file("/var/opt/opscode/nginx/etc/chef_https_lb.conf").content.contains(/ssl_protocols TLSv1\.2( TLSv1\.3)?;/)
     docs:
       desc: |
-        This check verifies that the nginx front-end configuration restricts `ssl_protocols` to `TLSv1.2`, so that the legacy TLS 1.0 and 1.1 protocols are not offered. nginx terminates all HTTPS connections from Chef clients, knife, and the management console.
+        This check verifies that the nginx front-end configuration restricts `ssl_protocols` to TLS 1.2 and optionally TLS 1.3, so that the legacy TLS 1.0 and 1.1 protocols are not offered. nginx terminates all HTTPS connections from Chef clients, knife, and the management console.
 
         **Why this matters**
 
@@ -894,7 +970,7 @@ queries:
         grep ssl_protocols /var/opt/opscode/nginx/etc/chef_https_lb.conf
         ```
 
-        If the output shows `ssl_protocols TLSv1.2;` (and no TLS 1.0 or 1.1), only modern TLS is offered and the check passes. If TLS 1.0 or 1.1 is listed, or the directive is missing, the check fails.
+        If the output shows `ssl_protocols TLSv1.2;` or `ssl_protocols TLSv1.2 TLSv1.3;`, only modern TLS is offered and the check passes. If TLS 1.0 or 1.1 is listed, or the directive is missing, the check fails.
       remediation:
         - id: cli
           desc: |
@@ -910,6 +986,8 @@ queries:
             nginx['ssl_protocols'] = 'TLSv1.2'
             ```
 
+            To also offer TLS 1.3 on releases that support it, use `'TLSv1.2 TLSv1.3'` instead.
+
             2. Reconfigure the server:
 
             ```bash
@@ -922,7 +1000,7 @@ queries:
             grep ssl_protocols /var/opt/opscode/nginx/etc/chef_https_lb.conf
             ```
 
-            **Note**: Ensure all Chef Infra Clients support TLS 1.2. Clients older than version 12.0 may need to be upgraded.
+            **Note**: Reconfiguring restarts the nginx front end and briefly interrupts client connections, so schedule this during a maintenance window. Ensure all Chef Infra Clients support TLS 1.2. Clients older than version 12.0 may need to be upgraded.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -1054,7 +1132,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      file("/etc/opscode/chef-server.rb").content.contains(/postgresql\['vip'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
+      file("/etc/opscode/chef-server.rb") {
+        content.contains(/postgresql\['listen_address'\]\s*=\s*['"](0\.0\.0\.0|\*)['"]/) == false
+        content.contains(/postgresql\['vip'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
+      }
     docs:
       desc: |
         This check verifies that `chef-server.rb` does not bind the embedded PostgreSQL database to `0.0.0.0`. The embedded database holds all Chef Infra Server data and binds to `127.0.0.1` by default; binding it to all interfaces exposes it to the network.
@@ -1068,35 +1149,38 @@ queries:
 
         Note: External PostgreSQL configurations for multi-server deployments are a valid exception to this check.
       audit: |
-        Run the following command to check whether the embedded PostgreSQL VIP is bound to all interfaces:
+        Run the following command to check whether the embedded PostgreSQL service is bound to all interfaces:
 
         ```bash
-        grep "postgresql\['vip'\]" /etc/opscode/chef-server.rb
+        grep -E "postgresql\['(listen_address|vip)'\]" /etc/opscode/chef-server.rb
         ```
 
-        If the command returns no output, or the configured VIP is `127.0.0.1`, the database is not exposed and the check passes. If a `postgresql['vip']` line is set to `0.0.0.0`, the check fails. A `postgresql['vip']` pointing at a dedicated external PostgreSQL host in a multi-server deployment is a valid exception.
+        If the command returns no output, or the configured address is `127.0.0.1` or `localhost`, the database is not exposed and the check passes. If a `postgresql['listen_address']` line is set to `0.0.0.0` or `*`, or a `postgresql['vip']` line is set to `0.0.0.0`, the check fails. A `postgresql['vip']` pointing at a dedicated external PostgreSQL host in a multi-server deployment is a valid exception.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            If using embedded PostgreSQL, remove any `postgresql['vip']` line binding to `0.0.0.0` from `/etc/opscode/chef-server.rb`, then reconfigure:
+            If using embedded PostgreSQL, edit `/etc/opscode/chef-server.rb` and remove any `postgresql['listen_address']` or `postgresql['vip']` line that binds the database to `0.0.0.0` or `*`. The default of `localhost` keeps the database on the loopback interface. Then reconfigure:
 
             ```bash
             chef-server-ctl reconfigure
             ```
+
+            **Note**: Reconfiguring restarts server services and briefly interrupts client requests.
 
             If using external PostgreSQL in a multi-server deployment, ensure your PostgreSQL server has appropriate firewall rules and authentication configured.
         - id: chef
           desc: |
             **Using Chef Infra**
 
-            If you manage your Chef Infra Server configuration with Chef, use a `ruby_block` to remove the insecure binding without overwriting the rest of the file:
+            If you manage your Chef Infra Server configuration with Chef, use a `ruby_block` to remove the insecure bindings without overwriting the rest of the file:
 
             ```ruby
-            ruby_block 'remove external postgresql vip' do
+            ruby_block 'remove external postgresql bindings' do
               block do
                 file = Chef::Util::FileEdit.new('/etc/opscode/chef-server.rb')
+                file.search_file_delete_line(/postgresql\['listen_address'\]\s*=\s*['"](0\.0\.0\.0|\*)['"]/)
                 file.search_file_delete_line(/postgresql\['vip'\]\s*=\s*['"]0\.0\.0\.0['"]/)
                 file.write_file
               end
@@ -1131,11 +1215,12 @@ queries:
     mql: |
       file("/etc/opscode/chef-server.rb") {
         content.contains(/opscode_solr4\['ip_address'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
-        content.contains(/opensearch\['ip_address'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
+        content.contains(/elasticsearch\['listen'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
+        content.contains(/opensearch\['listen'\]\s*=\s*['"]0\.0\.0\.0['"]/) == false
       }
     docs:
       desc: |
-        This check verifies that `chef-server.rb` does not bind the embedded search service to `0.0.0.0`. The embedded Elasticsearch (Chef Infra Server before version 14) or OpenSearch (version 14 and later) binds to `127.0.0.1` by default; binding it to all interfaces exposes its index to the network.
+        This check verifies that `chef-server.rb` does not bind the embedded search service to `0.0.0.0`. Chef Infra Server used Solr through version 12, Elasticsearch in versions 13 and 14, and OpenSearch from version 15. The embedded search service binds to `127.0.0.1` by default; binding it to all interfaces exposes its index to the network.
 
         **Why this matters**
 
@@ -1147,20 +1232,22 @@ queries:
         Run the following command to check whether the embedded search service is bound to all interfaces:
 
         ```bash
-        grep -E "opscode_solr4\['ip_address'\]|opensearch\['ip_address'\]" /etc/opscode/chef-server.rb
+        grep -E "opscode_solr4\['ip_address'\]|elasticsearch\['listen'\]|opensearch\['listen'\]" /etc/opscode/chef-server.rb
         ```
 
-        If the command returns no output, or the configured address is `127.0.0.1`, the search service is not exposed and the check passes. If an `ip_address` line is set to `0.0.0.0`, the check fails.
+        If the command returns no output, or the configured address is `127.0.0.1`, the search service is not exposed and the check passes. If any of these lines is set to `0.0.0.0`, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Remove any `opscode_solr4['ip_address']` or `opensearch['ip_address']` lines from `/etc/opscode/chef-server.rb` that bind to `0.0.0.0`, then reconfigure:
+            Edit `/etc/opscode/chef-server.rb` and remove any `opscode_solr4['ip_address']`, `elasticsearch['listen']`, or `opensearch['listen']` line that binds the search service to `0.0.0.0`. The default of `127.0.0.1` keeps search on the loopback interface. Then reconfigure:
 
             ```bash
             chef-server-ctl reconfigure
             ```
+
+            **Note**: Reconfiguring restarts server services and briefly interrupts client requests.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -1168,11 +1255,12 @@ queries:
             If you manage your Chef Infra Server configuration with Chef, use a `ruby_block` to remove the insecure bindings without overwriting the rest of the file:
 
             ```ruby
-            ruby_block 'remove external search ip_address' do
+            ruby_block 'remove external search bindings' do
               block do
                 file = Chef::Util::FileEdit.new('/etc/opscode/chef-server.rb')
                 file.search_file_delete_line(/opscode_solr4\['ip_address'\]\s*=\s*['"]0\.0\.0\.0['"]/)
-                file.search_file_delete_line(/opensearch\['ip_address'\]\s*=\s*['"]0\.0\.0\.0['"]/)
+                file.search_file_delete_line(/elasticsearch\['listen'\]\s*=\s*['"]0\.0\.0\.0['"]/)
+                file.search_file_delete_line(/opensearch\['listen'\]\s*=\s*['"]0\.0\.0\.0['"]/)
                 file.write_file
               end
               notifies :run, 'execute[reconfigure chef server]', :immediately
@@ -1237,14 +1325,22 @@ queries:
           desc: |
             **Using CLI**
 
-            Run these commands to set proper permissions on your /var/opt/opscode/local-mode-cache/backup directory:
+            The permanent fix is to upgrade to Chef Infra Server 15.7 or later, which restricts the configuration backup path automatically on each `chef-server-ctl` execution.
+
+            Until you can upgrade, run these commands to set proper permissions on your /var/opt/opscode/local-mode-cache/backup directory:
 
             ```bash
             chown root:root /var/opt/opscode/local-mode-cache/backup
             chmod 700 /var/opt/opscode/local-mode-cache/backup
             ```
 
-            Note: Chef Infra Server 15.7 and later automatically set the configuration backup path to `600` permissions on each `chef-server-ctl` execution.
+            To verify the permissions were applied correctly:
+
+            ```bash
+            stat -c '%a %U:%G %n' /var/opt/opscode/local-mode-cache/backup
+            ```
+
+            Expected output: `700 root:root /var/opt/opscode/local-mode-cache/backup`
         - id: chef
           desc: |
             **Using Chef Infra**


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2818). This PR covers `mondoo-chef-infra-server.mql.yaml`: all 14 checks were reviewed and 9 needed fixes. Policy version bumped. Verified against Chef's chef-server-ctl reference, the chef-server.rb settings reference, and the os provider schema.

## The worst finding in this policy

All four EOL add-on checks (Reporting, Push Jobs, Analytics, HA) instructed `chef-server-ctl uninstall <addon-name>`. Per Chef's own reference, `uninstall` takes no arguments and "will shut down all services" — omnibus-ctl ignores the trailing add-on name, so the documented command unconfigures the entire production Chef Infra Server while leaving the add-on package installed, meaning the check still fails afterward. Each check now uses the add-on's dedicated ctl command where one exists (`opscode-reporting-ctl`, `opscode-push-jobs-server-ctl`, `opscode-analytics-ctl`; Chef HA has none), removes the package via dpkg/rpm, reconfigures, verifies, and carries an explicit warning never to run `chef-server-ctl uninstall`. The HA check's DRBD migration warning is strengthened since removing replication from an active pair risks data loss.

## Checks whose logic missed the real exposure (mql)

- **secure-tls-only** required the literal substring `ssl_protocols TLSv1.2;`, so configuring `'TLSv1.2 TLSv1.3'` per Chef's documented setting — a strictly stronger posture — failed a check titled \"disable TLS before 1.2\". The regex now accepts optional TLS 1.3, with desc/audit/remediation aligned.
- **search-not-externally-accessible** tested `opensearch['ip_address']`, a setting that does not exist; the real bind settings are `elasticsearch['listen']` and `opensearch['listen']` (and the EOL `opscode_solr4['ip_address']`), so a modern server exposed via the documented setting passed. The check, audit, remediation, and the desc's engine version history are corrected.
- **postgresql-not-externally-accessible** only matched `postgresql['vip']`, the service-discovery address; the setting that controls what embedded PostgreSQL binds is `postgresql['listen_address']`, the documented exposure vector, which the check now also rejects (including the `*` form).

## Smaller fixes

- **remediate-cve-2023-28864** now leads with the permanent fix (upgrade to 15.7+) instead of burying it in a note, and gains the verify step every other permission check here has.
- **non-eol-infra-server** drops a useless-cat pipeline that fails shellcheck.
- Every `chef-server-ctl reconfigure` invocation now notes the service restart impact on a production server.

## Validation

- `cnspec policy lint` passes (compiles all three modified mql expressions)
- YAML parses clean; all 52 bash blocks in the file shellcheck-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)