### PR TITLE
🐛 google-workspace: drop guidance for removed and nonexistent console settings

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-google-workspace-security
     name: Mondoo Google Workspace Security
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -110,23 +110,26 @@ queries:
       remediation:
         - id: console
           desc: |
-            To enforce 2-Step Verification (2FA) for Google Workspace users:
+            To enforce 2-step verification for Google Workspace users:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
-            2. From the Admin console Home page, go to **Security** > **Authentication** > **2-step verification**.
-            3. Click **Allow users to turn on 2-step verification** and select **On**.
-            4. Under **Enforcement**, select **Turn on enforcement now** or **Turn on enforcement from** and choose a date.
-            5. Click **Save**.
-            6. Inform your users to set up 2-step verification before the enforcement date.
+            2. Go to **Security** > **Authentication** > **2-step verification**.
+            3. Check **Allow users to turn on 2-step verification** and click **Save**.
+            4. Notify all users to enroll in 2-step verification, and track enrollment progress under **Reporting** > **Reports** > **User Reports** > **Security**.
+            5. Once users have enrolled, return to **Security** > **Authentication** > **2-step verification** and under **Enforcement** select **Turn on enforcement from** with a date that gives remaining users time to enroll.
+            6. Set a **New user enrollment period** such as one week so new accounts can sign in once and enroll before enforcement applies to them.
+            7. Click **Save**.
 
-            For more details, see [Enforce 2-Step Verification](https://support.google.com/a/answer/175197?hl=en).
+            Users who have not enrolled when enforcement begins are locked out of their accounts, so confirm enrollment status before the enforcement date.
+
+            For more details, see [Deploy 2-Step Verification](https://support.google.com/a/answer/175197).
     refs:
       - url: https://support.google.com/a/answer/175197
         title: Google Workspace - Deploy 2-Step Verification
       - url: https://support.google.com/a/answer/9011373
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-limit-super-admins
-    title: Ensure fewer than four users have super admin permissions
+    title: Ensure no more than four users have super admin permissions
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -179,8 +182,18 @@ queries:
         ```
 
         A passing response shows four or fewer users with `accounts:is_super_admin` set to `true`; a failing response shows five or more.
-      remediation: |
-        Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Admin roles for businesses](https://support.google.com/a/topic/9832445?hl=en&ref_topic=2785005) in the Google Workspace documentation.
+      remediation:
+        - id: console
+          desc: |
+            To reduce the number of super admin accounts:
+
+            1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
+            2. Go to **Directory** > **Users** and filter by the **Super Admin** role to list all current super admins.
+            3. Decide which two to four users genuinely require full administrative control.
+            4. For each super admin beyond that set, open the user, click **Admin roles and privileges**, and remove the **Super Admin** role assignment.
+            5. Assign a delegated role such as **User Management Admin** or **Help Desk Admin** that covers the tasks the user actually performs, or [create a custom role](https://support.google.com/a/answer/2406043) with only the required privileges.
+
+            For more details, see [Pre-built administrator roles](https://support.google.com/a/answer/2405986).
     refs:
       - url: https://support.google.com/a/answer/9011373
         title: Google Workspace Security Best Practices
@@ -238,8 +251,18 @@ queries:
         ```
 
         A passing response shows two or more users with `accounts:is_super_admin` set to `true`; a failing response shows one or zero.
-      remediation: |
-        Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Admin roles for businesses](https://support.google.com/a/topic/9832445?hl=en&ref_topic=2785005) in the Google Workspace documentation.
+      remediation:
+        - id: console
+          desc: |
+            To add a backup super admin account:
+
+            1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
+            2. Go to **Directory** > **Users** and select a trusted user who should serve as a backup administrator.
+            3. Click **Admin roles and privileges**.
+            4. Next to the **Super Admin** role, turn on the assignment slider and click **Save**.
+            5. Require the new super admin to enroll in 2-step verification with a hardware security key before relying on the account.
+
+            For more details, see [Assign specific admin roles](https://support.google.com/a/answer/33310).
     refs:
       - url: https://support.google.com/a/answer/9011373
         title: Google Workspace Security Best Practices
@@ -279,11 +302,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
-        2. Go to **Security** > **Access and data control** > **Less secure apps**.
-        3. Confirm that **Disable access to less secure apps (Recommended)** is selected for all users.
-
-        A passing result shows less secure app access disabled for the whole organization; a failing result shows it allowed for some or all users.
+        Google removed less secure app support from Google Workspace in 2024, and the **Less secure apps** page no longer appears in the Admin console. Sign-ins that use only a username and password are rejected, so there is no console setting left to review. This check reads report data, which can still flag accounts with stale report values or a legacy configuration set through the API.
 
         ### Audit via API
 
@@ -296,8 +315,19 @@ queries:
         ```
 
         A passing response shows `accounts:is_less_secure_apps_access_allowed` set to `false` for every user; a failing response shows one or more users with the value set to `true`.
-      remediation: |
-        Make sure to block the usage of less secure apps in Google Workspace. To learn how, read [Control access to less secure apps](https://support.google.com/a/answer/6260879?hl=en) in the Google Workspace documentation.
+      remediation:
+        - id: console
+          desc: |
+            Google removed support for less secure apps from Google Workspace in 2024, and the **Less secure apps** setting no longer appears in the Admin console. Sign-ins that use only a username and password are rejected for Gmail, Google Calendar, and Google Contacts, so any account still reporting less secure app access reflects stale report data or a legacy configuration set through the API.
+
+            To clear remaining legacy access:
+
+            1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
+            2. Go to **Security** > **Access and data control** > **API controls** and review which apps are granted access to Google Workspace data.
+            3. Identify users or devices still connecting through IMAP, POP, or SMTP with passwords and migrate them to clients that support OAuth.
+            4. Remove app passwords that are no longer needed by having each user visit [App passwords](https://myaccount.google.com/apppasswords) and delete unused entries.
+
+            For more details, see [Transition from less secure apps to OAuth](https://support.google.com/a/answer/14114704).
     refs:
       - url: https://support.google.com/a/answer/7281227
         title: Google Workspace - Control Third-Party App Access
@@ -357,8 +387,21 @@ queries:
         ```
 
         A passing response shows every user with `accounts:is_super_admin` set to `true` also reporting `accounts:num_security_keys` of one or more; a failing response shows a super admin with `accounts:num_security_keys` of zero.
-      remediation: |
-        Make sure that all high-value targets such as Super Admins have some form of two-factor authentication enabled. Also make sure that they are using security keys for the 2-Step verification process. To learn about setting up security keys for the 2-Step verification process, read [Use a security key for 2-Step Verification](https://support.google.com/accounts/answer/6103523?hl=En).
+      remediation:
+        - id: console
+          desc: |
+            To require hardware security keys for super admin accounts:
+
+            1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
+            2. Place all super admin accounts in a dedicated organizational unit or group so the stricter policy applies only to them.
+            3. Distribute FIDO2 hardware security keys such as YubiKey or Google Titan to each super admin.
+            4. Have each super admin register a key at [2-Step Verification settings](https://myaccount.google.com/signinoptions/twosv) by selecting **Add security key** and following the prompts. Register at least two keys per admin so a lost key does not lock the account.
+            5. In the Admin console, go to **Security** > **Authentication** > **2-step verification**, select the organizational unit or group containing the super admins, and under the allowed methods select **Only security key**.
+            6. Click **Save**.
+
+            Confirm every super admin has registered a key before restricting methods, because admins without a registered key are locked out once the restriction takes effect.
+
+            For more details, see [Use a security key for 2-Step Verification](https://support.google.com/accounts/answer/6103523).
     refs:
       - url: https://support.google.com/a/answer/175197
         title: Google Workspace - Deploy 2-Step Verification
@@ -423,15 +466,23 @@ queries:
       remediation:
         - id: console
           desc: |
-            To review and restrict third-party app access:
+            To remove full Gmail and Drive access from connected apps:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/).
-            2. Go to **Security** > **Access and data control** > **API controls**.
-            3. Under **Third-Party App access**, review connected apps and their scopes.
-            4. Block or restrict apps that have full Gmail (`https://mail.google.com/`) or Drive (`https://www.googleapis.com/auth/drive`) access.
-            5. Configure app access control to require admin approval for apps requesting sensitive scopes.
+            2. Go to **Security** > **Access and data control** > **API controls** and click **Manage Third-Party App Access**.
+            3. Review each connected app and its granted scopes. Identify apps holding the full Gmail scope `https://mail.google.com/` or the full Drive scope `https://www.googleapis.com/auth/drive`.
+            4. Coordinate with the owners of each affected integration before making changes, because removing access stops the app from working until it is reauthorized with narrower scopes.
+            5. Set each affected app to **Blocked**, or to **Limited** if it should keep access to non-sensitive data.
+            6. Revoke the tokens users have already issued to the app. Go to **Directory** > **Users**, select each affected user, click **Security** > **Connected applications**, select the app, and click **Remove access**. To revoke at scale, use the Directory API:
 
-            For more details, see [Control which third-party & internal apps access Google Workspace data](https://support.google.com/a/answer/7281227).
+               ```bash
+               curl -s -X DELETE -H "Authorization: Bearer $ACCESS_TOKEN" \
+                 "https://admin.googleapis.com/admin/directory/v1/users/jane@example.com/tokens/$CLIENT_ID"
+               ```
+
+            7. Where the integration is still needed, work with the vendor to reauthorize it using narrower scopes such as `gmail.send` or `drive.file`.
+
+            For more details, see [Control which third-party and internal apps access Google Workspace data](https://support.google.com/a/answer/7281227).
     refs:
       - url: https://support.google.com/a/answer/7281227
         title: Google Workspace - Control Third-Party App Access
@@ -568,18 +619,25 @@ queries:
       remediation:
         - id: console
           desc: |
-            To restrict calendar sharing:
+            To remove public calendar sharing:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/).
             2. Go to **Apps** > **Google Workspace** > **Calendar**.
-            3. Under **Sharing settings**, set **External sharing options for primary calendars** to **Only free/busy information** or a more restrictive option.
+            3. Under **Sharing settings**, set **External sharing options for primary calendars** to **No sharing** to prevent users from publishing calendars, or to **Only free/busy information** if external scheduling visibility is required.
             4. Click **Save**.
 
-            For individual users who have already shared their calendars publicly:
+            The organization-wide setting limits future sharing, but calendars that users already made public keep their public access rule, and even free/busy public access leaves a calendar publicly visible. Remove the existing public access rule on each affected calendar:
 
             1. Have the user open [Google Calendar](https://calendar.google.com/).
-            2. Click the three dots next to the calendar name > **Settings and sharing**.
+            2. Click the three dots next to the calendar name and select **Settings and sharing**.
             3. Under **Access permissions for events**, uncheck **Make available to public**.
+
+            To remove the public access rule directly through the Calendar API:
+
+            ```bash
+            curl -s -X DELETE -H "Authorization: Bearer $ACCESS_TOKEN" \
+              "https://www.googleapis.com/calendar/v3/calendars/jane@example.com/acl/default"
+            ```
 
             For more details, see [Set Calendar sharing options](https://support.google.com/a/answer/60765).
     refs:
@@ -623,11 +681,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. Sign in to the Google Admin console at admin.google.com using an administrator account.
-        2. Go to **Directory** > **Users**.
-        3. Open each user and review the **Security** section for the IP whitelisting setting.
-
-        A passing result shows no user with IP whitelisting enabled; a failing result shows one or more users with the legacy setting turned on.
+        The deprecated IP whitelisting flag is not displayed anywhere in the Admin console, so affected users cannot be identified there. Audit the setting through the Directory API query below.
 
         ### Audit via API
 
@@ -640,15 +694,29 @@ queries:
 
         A passing response shows `ipWhitelisted` set to `false` for every user; a failing response shows one or more users with `ipWhitelisted` set to `true`.
       remediation:
-        - id: console
+        - id: cli
           desc: |
-            To remove IP whitelisting from user accounts:
+            The IP whitelisting flag is a deprecated user property that the Admin console does not display, so it must be cleared through the Directory API.
 
-            1. Sign in to the [Google Admin console](https://admin.google.com/).
-            2. Go to **Directory** > **Users**.
-            3. Select the user with IP whitelisting enabled.
-            4. Under **Security**, review and disable the IP whitelisting setting.
-            5. Configure [context-aware access policies](https://support.google.com/a/answer/9275380) as a replacement for IP-based controls.
+            1. Identify affected users by listing accounts and checking the `ipWhitelisted` property:
+
+               ```bash
+               curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+                 "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer" \
+                 | jq -r '.users[] | select(.ipWhitelisted == true) | .primaryEmail'
+               ```
+
+            2. Clear the flag on each affected user:
+
+               ```bash
+               curl -s -X PATCH \
+                 -H "Authorization: Bearer $ACCESS_TOKEN" \
+                 -H "Content-Type: application/json" \
+                 -d '{"ipWhitelisted": false}' \
+                 "https://admin.googleapis.com/admin/directory/v1/users/jane@example.com"
+               ```
+
+            3. If the users relied on the exemption for network-based access, configure [context-aware access policies](https://support.google.com/a/answer/9275380) as the supported replacement for IP-based controls.
 
             For more details, see [Context-Aware Access overview](https://support.google.com/a/answer/9275380).
     refs:
@@ -855,14 +923,17 @@ queries:
           desc: |
             To resolve pending admin password resets:
 
-            1. Sign in to the [Google Admin console](https://admin.google.com/).
-            2. Go to **Directory** > **Users**.
-            3. Filter for admin users and check for accounts with pending password changes.
-            4. Contact the admin and require them to complete the password change immediately.
-            5. If the admin account is inactive or no longer needed, consider:
-               - Removing admin privileges from the account.
-               - Suspending the account until the owner can complete the password change.
-            6. Review the reason the password reset was triggered and investigate if there are signs of compromise.
+            1. Identify admin accounts with a pending forced password change. The Admin console does not display this state, so query the Directory API:
+
+               ```bash
+               curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+                 "https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer&query=isAdmin=true" \
+                 | jq -r '.users[] | select(.changePasswordAtNextLogin == true) | .primaryEmail'
+               ```
+
+            2. Contact each affected admin and require them to sign in and complete the password change immediately.
+            3. If the admin account is inactive or no longer needed, remove its admin privileges or suspend it in the [Google Admin console](https://admin.google.com/) under **Directory** > **Users**.
+            4. Review why the password reset was triggered and investigate signs of compromise, such as suspicious sign-in events under **Reporting** > **Audit and investigation**.
 
             For more details, see [Reset a user's password](https://support.google.com/a/answer/33319).
     refs:


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2824). This PR covers `mondoo-google-workspace-security.mql.yaml`: all 12 checks were reviewed and 9 needed fixes. Policy version bumped. Verified against the google-workspace provider schema and current Google Workspace documentation; no mql defects were found.

## Guidance for settings that no longer exist

- **less-secure-app-access**: Google removed less secure app support from Workspace in 2024; the Admin console page the remediation and audit pointed at is gone, and password-only IMAP/POP/SMTP sign-ins are rejected outright. Both sections now explain this and direct admins to the remaining legacy cleanup: API controls review, OAuth migration, and unused app passwords.
- **no-ip-whitelisted-users**: the console has no per-user IP-whitelist toggle — `ipWhitelisted` is a deprecated Directory API property — so the documented console steps dead-ended. The remediation is now a CLI entry with the API list/PATCH calls and points at context-aware access as the supported replacement. **admins-no-pending-password-reset** had the same problem in its identification step (the console doesn't surface the flag) and gains the API query.

## Lockout-prone enforcement ordering

- **two-step-verification-enforced** offered "Turn on enforcement now" first and notified users after saving — locking out everyone not yet enrolled. Now: allow, notify, track enrollment, then enforce from a date, with the new-user enrollment period so new hires can sign in once to enroll.
- **super-admins-hardware-2fa** never explained org-level enforcement; now a dedicated OU/group, key registration with backups, then \"Only security key\", with the register-before-restrict warning.

## Remediations that didn't flip the check

- **connected-apps-no-full-access**: blocking an app prevents future authorizations but the check inspects already-issued tokens, which blocking never revokes; an explicit per-user and API revocation step is added, plus a warning that blocking breaks the integration immediately.
- **calendar-no-public-sharing**: the org-wide sharing setting doesn't remove public ACL rules from calendars users already published, and the suggested free/busy level itself produces the default-scope rule the check flags; per-calendar ACL removal is now the load-bearing step with a Calendar API bulk option.

## Copy-paste and title drift

Both super-admin checks shared one vague \"between 2 and 4\" one-liner even though one check requires adding an admin and the other removing; each now has direction-appropriate steps. The limit check's title said \"fewer than four\" while its logic and docs say no more than four; retitled to match.

## Validation

- `cnspec policy lint` passes
- YAML parses clean; no mql changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)