### PR TITLE
fix: split approve and merge steps to use separate tokens

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -148,14 +148,18 @@ jobs:
         with:
           client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
-      # automerge using bot token
-      - name: Approve and merge a PR
+      # approve using GITHUB_TOKEN (different identity from mondoo-tools, which created the PR)
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr review "${PR_NUMBER}" --approve
+      # merge using the mergebot app token (needs elevated permissions)
+      - name: Merge PR
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: |
-          gh pr review "${PR_NUMBER}" --approve
-          gh pr merge "${PR_NUMBER}" --squash
+        run: gh pr merge "${PR_NUMBER}" --squash
   event_file:
     name: "Store event file"
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Summary:**
The Approve and merge a PR step was using the mondoo-mergebot app token for both the PR review and the merge. Since mondoo-mergebot is the same identity as mondoo-tools (the bot that creates the PR), GitHub rejected the self-review with: `GraphQL: Review Cannot approve your own pull request`

**Fix:**
split into two steps — approve using GITHUB_TOKEN (github-actions[bot], a distinct identity from the PR author) and merge using the mondoo-mergebot app token (which retains the elevated permissions needed for the merge).