### PR TITLE
🐛 win11-compat: fix the disk check that inverted reality on both sides

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -14,7 +14,6 @@ adddays
 addgroup
 adduser
 ADH
-HMIs
 adjtimex
 adminuser
 adml
@@ -144,6 +143,7 @@ chronyc
 Cim
 CIMSLP
 cimv
+cinc
 claude
 click
 clickstream
@@ -251,6 +251,7 @@ directoryservice
 disa
 disableforwarding
 distroless
+distroless
 dlp
 dlq
 dnd
@@ -258,10 +259,10 @@ dnl
 DNSKEY
 docdb
 dotfile
-drbdadm
 dpd
 dpi
 dport
+drbdadm
 driveletter
 dss
 dsse
@@ -272,7 +273,6 @@ DVersion
 dvfilter
 Eacces
 EBSKMS
-distroless
 ecdsap
 edr
 efi
@@ -395,6 +395,7 @@ healthreporting
 Helpdesk
 hetzner
 hgfs
+HMIs
 Hostbased
 hostbasedauthentication
 hostedzone
@@ -886,6 +887,7 @@ usg
 USLACKBOT
 utm
 uvx
+validatorless
 valkey
 VALUEX
 VAULTNAME
@@ -921,6 +923,7 @@ vzdump
 wafpolicy
 wafv
 wazuh
+wbm
 webauthn
 webfilter
 webui
@@ -951,7 +954,6 @@ xts
 XUtn
 XXXXXX
 XXXXXXXXX
-wbm
 yama
 yescrypt
 yournamespace

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -251,7 +251,6 @@ directoryservice
 disa
 disableforwarding
 distroless
-distroless
 dlp
 dlq
 dnd

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-11-compatibility
     name: Mondoo Microsoft Windows 11 Compatibility for Workstations
-    version: 1.3.0
+    version: 1.3.1
     tags:
       mondoo.com/category: best-practices
       mondoo.com/platform: windows:10
@@ -21,7 +21,7 @@ policies:
         This policy provides checks across the Windows 11 system requirements:
 
         - CPU compatibility with the supported processor list
-        - Minimum RAM of more than 8 GB
+        - Minimum RAM of 8 GB or more
         - Storage capacity of at least 120 GB
         - TPM 2.0 support
         - UEFI firmware
@@ -33,7 +33,7 @@ policies:
     groups:
       - filters: |
           asset.platform.contains("windows")
-          windows.computerInfo['OsProductType'] == 1
+          && windows.computerInfo['OsProductType'] == 1
         checks:
           - uid: mondoo-windows-11-compatibility-cpu-list
           - uid: mondoo-windows-11-compatibility-cpu-cores
@@ -484,7 +484,6 @@ queries:
             "Core 9 270H",
             "i3-N300",
             "i3-N305",
-            "N50",
             "N95",
             "N97",
             "N100",
@@ -833,12 +832,12 @@ queries:
             "W7-3465X",
             "W9-3475X",
             "W9-3495X",
-            "2600",
+            "Ryzen 5 2600",
             "3600",
             "4500",
-            "5500",
-            "5600",
-            "7600",
+            "Ryzen 5 5500",
+            "Ryzen 5 5600",
+            "Ryzen 5 7600",
             "2500X",
             "2600E",
             "2600X",
@@ -888,14 +887,8 @@ queries:
             "7640U",
             "7645HX",
             "7640H",
-            "2600",
-            "3600",
+            "Ryzen 5 PRO 2600",
             "5645",
-            "3350G",
-            "3350GE",
-            "3400G",
-            "3400GE",
-            "3500U",
             "4650G",
             "4650GE",
             "4650U",
@@ -911,15 +904,11 @@ queries:
             "6650H",
             "6650HS",
             "6650U",
-            "7530U",
-            "7540U",
-            "7640U",
             "4655G",
             "4655GE",
-            "2700",
+            "Ryzen 7 2700",
             "5800",
-            "5800",
-            "7700",
+            "Ryzen 7 7700",
             "2700E",
             "2700X",
             "3700C",
@@ -961,11 +950,8 @@ queries:
             "7840HS",
             "7840S",
             "7840U",
-            "2700",
             "3700",
             "5845",
-            "2700X",
-            "3700U",
             "4750G",
             "4750GE",
             "4750U",
@@ -977,8 +963,6 @@ queries:
             "6850HS",
             "6850U",
             "6860Z",
-            "7730U",
-            "7840U",
             "5900",
             "7900",
             "3900",
@@ -1005,7 +989,6 @@ queries:
             "7945HX",
             "7950X",
             "7950X3D",
-            "3900",
             "5945",
             "6950H",
             "6950HS",
@@ -1068,7 +1051,11 @@ queries:
             "AI Max+ 395",
             "AI Max+ PRO 395",
             "Ryzen Z1",
-            "Snapdragon",
+            "Snapdragon 850",
+            "Snapdragon 7c",
+            "Snapdragon 8c",
+            "Snapdragon 8cx",
+            "Snapdragon X",
             "Microsoft SQ1",
             "Microsoft SQ2",
             "Microsoft SQ3"
@@ -1123,7 +1110,7 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the system has enough installed memory to run Windows 11. Windows 11 requires a minimum of 4 GB of RAM, and this check applies a more comfortable workstation threshold of more than 8 GB.
+        This check confirms that the system has enough installed memory to run Windows 11. Windows 11 requires a minimum of 4 GB of RAM, and this check applies a more comfortable workstation threshold of at least 8 GB. The check allows a small margin below the nominal figure so that devices whose firmware reserves a portion of memory still pass.
 
         **Why this matters**
 
@@ -1137,7 +1124,7 @@ queries:
         1. Open **Settings** and go to **System** > **About**.
         2. Read the **Installed RAM** value under **Device specifications**.
 
-        The workstation passes when installed RAM is greater than 8 GB. It fails if it is 8 GB or less.
+        The workstation passes when installed RAM is 8 GB or more. It fails when it is less than 8 GB.
 
         ### Audit via PowerShell
 
@@ -1148,7 +1135,7 @@ queries:
            [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB, 2)
            ```
 
-        The workstation passes when the reported memory is greater than 8 GB. It fails if it is 8 GB or less.
+        The workstation passes when installed RAM is 8 GB or more. It fails when it is less than 8 GB.
       remediation:
         - id: gui
           desc: |
@@ -1159,7 +1146,7 @@ queries:
     title: Check Windows 11 HDD compatibility
     impact: 10
     mql: |
-      powershell("(get-disk).AllocatedSize/1GB").stdout.trim > "120"
+      powershell("((Get-Disk | Where-Object IsBoot).Size / 1GB) -ge 120").stdout.trim == "True"
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
@@ -1243,13 +1230,13 @@ queries:
     title: Check Windows 11 CPU Clock Speed compatibility
     impact: 5
     mql: |
-      windows.computerInfo.CsProcessors.first.MaxClockSpeed > 1000
+      windows.computerInfo.CsProcessors.first.MaxClockSpeed >= 1000
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the processor runs at a clock speed above 1 GHz, the minimum frequency Windows 11 requires.
+        This check confirms that the processor runs at a clock speed of 1 GHz or faster, the minimum frequency Windows 11 requires.
 
         **Why this matters**
 
@@ -1263,7 +1250,7 @@ queries:
         1. Open **Task Manager** and select the **Performance** tab.
         2. Select **CPU** and read the **Base speed** value.
 
-        The workstation passes when the base speed is above 1 GHz. It fails if it is 1 GHz or lower.
+        The workstation passes when the base speed is 1 GHz or higher. It fails if it is below 1 GHz.
 
         ### Audit via PowerShell
 
@@ -1274,7 +1261,7 @@ queries:
            (Get-CimInstance -ClassName Win32_Processor).MaxClockSpeed
            ```
 
-        The workstation passes when the reported speed is above 1000 MHz. It fails if it is 1000 MHz or lower.
+        The workstation passes when the reported speed is 1000 MHz or higher. It fails if it is below 1000 MHz.
       remediation:
         - id: gui
           desc: |
@@ -1326,7 +1313,13 @@ queries:
           desc: |
             **Enabling TPM 2.0**
 
-            Many devices include a firmware TPM that is disabled by default. Restart the device, enter the UEFI firmware settings, and enable the TPM (it may be labelled **fTPM**, **PTT**, **Security Device**, or **Trusted Platform Module**). If the device has no TPM 2.0 capability at all, replace it with compatible hardware before Windows 10 reaches end of support.
+            Many devices include a firmware TPM that is disabled by default. If BitLocker is active on the system drive, first suspend it so the firmware change does not trigger a recovery prompt at the next boot:
+
+            ```powershell
+            Suspend-BitLocker -MountPoint "C:" -RebootCount 1
+            ```
+
+            Restart the device and enter the UEFI firmware settings. Enable the TPM option, which vendors label as fTPM, PTT, Security Device, or Trusted Platform Module, then save and exit. Do not select any option that clears the TPM. Clearing the TPM destroys keys stored in the module, including BitLocker key protectors. If the device has no TPM 2.0 capability at all, replace it with compatible hardware before Windows 10 reaches end of support.
   - uid: mondoo-windows-11-compatibility-uefi-firmware
     title: Check Windows 11 UEFI firmware compatibility
     impact: 10
@@ -1339,7 +1332,7 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the system boots with UEFI firmware rather than legacy BIOS. Windows 11 requires UEFI firmware; a firmware type value of 2 indicates UEFI.
+        This check confirms that the system boots with UEFI firmware rather than legacy BIOS, which Windows 11 requires.
 
         **Why this matters**
 
@@ -1370,7 +1363,20 @@ queries:
           desc: |
             **Converting to UEFI**
 
-            On supported Windows 10 devices, the disk can be converted from MBR to GPT and the firmware switched to UEFI without reinstalling the operating system. Run `mbr2gpt /validate` and then `mbr2gpt /convert` from an elevated command prompt, then change the firmware boot mode from Legacy to UEFI in the device firmware settings. If the device firmware does not support UEFI, replace the device with compatible hardware before Windows 10 reaches end of support.
+            On supported Windows 10 devices, the system disk can be converted in place from MBR to GPT and the firmware switched to UEFI without reinstalling the operating system. Back up the device before converting, because a failed conversion can leave the disk unbootable. If BitLocker is active on the system drive, suspend it first:
+
+            ```powershell
+            Suspend-BitLocker -MountPoint "C:" -RebootCount 1
+            ```
+
+            Validate and convert the disk from an elevated PowerShell session. The /allowFullOS switch is required when running from the full operating system rather than the Windows preinstallation environment:
+
+            ```powershell
+            mbr2gpt /validate /allowFullOS
+            mbr2gpt /convert /allowFullOS
+            ```
+
+            Resolve any validation errors before running the conversion. After the conversion completes, restart immediately into the firmware settings and switch the boot mode from Legacy or CSM to UEFI. The system cannot start again until the firmware boot mode matches the new GPT disk layout. If the device firmware does not support UEFI, replace the device with compatible hardware before Windows 10 reaches end of support.
   - uid: mondoo-windows-11-compatibility-secure-boot
     title: Check Windows 11 Secure Boot compatibility
     impact: 10
@@ -1414,4 +1420,10 @@ queries:
           desc: |
             **Enabling Secure Boot**
 
-            Restart the device and enter the UEFI firmware settings. Locate the **Secure Boot** option, usually under the **Boot** or **Security** tab, set it to **Enabled**, then save and exit. The system disk must be using GPT partitioning and the firmware must be in UEFI mode for Secure Boot to be available. If the device firmware is not Secure Boot capable, replace the device with compatible hardware before Windows 10 reaches end of support.
+            The system disk must use GPT partitioning and the firmware must boot in UEFI mode before Secure Boot can be enabled. If BitLocker is active on the system drive, first suspend it so the firmware change does not trigger a recovery prompt at the next boot:
+
+            ```powershell
+            Suspend-BitLocker -MountPoint "C:" -RebootCount 1
+            ```
+
+            Restart the device and enter the UEFI firmware settings. Locate the **Secure Boot** option, usually under the **Boot** or **Security** tab, set it to **Enabled**, then save and exit. If the option is unavailable or reports missing keys, choose the firmware option to install or restore the factory default Secure Boot keys, then enable Secure Boot. Confirm afterward that Windows starts normally. A system that loads unsigned or third party boot software will not start with Secure Boot enabled until that software is removed or replaced with a signed version. If the device firmware is not Secure Boot capable, replace the device with compatible hardware before Windows 10 reaches end of support.


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2828). This PR covers `mondoo-windows-11-compatibility.mql.yaml`: all 8 checks were reviewed and 7 needed fixes. Policy version bumped. Verified against the os provider schema and Microsoft's Windows 11 requirements documentation.

## A check that inverted reality

**hdd** compared PowerShell output as strings: `\"99\" > \"120\"` is lexicographically true, so a 99 GB disk passed, while `\"1024\" < \"120\"` made a 1 TB disk fail. On multi-disk machines `(get-disk).AllocatedSize / 1GB` throws on the array, stdout comes back empty, and every such machine failed regardless of capacity. The comparison now runs numerically inside PowerShell against the boot disk and returns a stable True/False token.

## An allowlist that approved 2011 hardware

The CPU props list contains bare model numbers stripped of brand, and the check does substring matching against the full processor name. `\"2600\"` (meant: Ryzen 5 2600) matched the unsupported 2011 i7-2600; `\"5600\"` matched the Broadwell i7-5600U; `\"7600\"` matched a 2009 Core 2 Duo E7600; the bare `\"Snapdragon\"` entry matched Windows-10-only models like the 835. Devices failing Microsoft's requirement passed, so the hardware-replacement remediation never fired for exactly the machines it exists for. Six ambiguous entries are brand-qualified (including a Ryzen PRO disambiguation and three more found during application: 2700, 5500, 7700 vs i7-2700K, i7-5500U, i7-7700), sixteen exact duplicates removed, and the Snapdragon entry replaced with the specific supported models.

## Boundary and prose drift

- **cpu-speed**: Microsoft requires \"1 GHz or faster\"; `> 1000` failed a processor at exactly 1000 MHz. Now `>= 1000`, with desc/audit aligned.
- **ram**: the docs said \"passes when greater than 8 GB, fails at 8 GB or less\", but the 7500 MiB threshold passes nominal 8 GB machines (whose firmware reserves some memory). Docs now say 8 GB or more, with the margin explained.
- **uefi-firmware**'s desc referenced a \"firmware type value of 2\" from an implementation the check no longer uses.

## Commands that fail and missing safety rails

`mbr2gpt /convert` requires `/allowFullOS` when run outside WinPE — the documented elevated-prompt flow errored as written. The conversion now validates with the switch, and the three firmware flows (UEFI conversion, TPM enable, Secure Boot enable) gain the warnings they lacked: suspend BitLocker first or trigger recovery prompts, never select Clear TPM (destroys BitLocker protectors), back up before a one-way disk conversion, the machine cannot boot after conversion until firmware switches to UEFI, and unsigned boot software blocks startup under Secure Boot. The group filter's two statements are now joined with explicit `&&` per repo convention.

## Validation

- `cnspec policy lint` passes (compiles both modified mql expressions)
- YAML parses clean; props list dedup verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)