### PR TITLE
🐛 slack: fix a never-fail conjunction and a domain check that swept DMs and bots

### DIFF
--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.6.0
+    version: 1.6.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -87,7 +87,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage members**.
+        2. Open **Tools & settings > Manage members**.
         3. Filter the member list by **Account type** and select **Workspace Admins** and **Workspace Owners**.
         4. Count the members shown.
 
@@ -104,7 +104,15 @@ queries:
 
         A passing response lists between 2 and 4 members where `is_admin` or `is_owner` is `true`; a failing response shows fewer than 2 or more than 4 such members.
       remediation: |
-        Adjust the number of users who have admin privileges to be between 2 and 4. To learn how, read [Change a member's role](https://slack.com/help/articles/218124397-Change-a-members-role) in the Slack documentation.
+        Adjust the number of members holding the admin or owner role so that between 2 and 4 accounts are privileged:
+
+        1. Sign in to your Slack workspace as a workspace owner.
+        2. Click your workspace name and open **Tools & settings > Manage members**.
+        3. Filter the member list by account type to show workspace admins and owners.
+        4. For each admin who no longer needs privileged access, click the three dots icon next to their name, select **Change account type**, and choose **Member**.
+        5. If only one account holds the admin or owner role, promote a trusted second member to admin using the same menu.
+
+        To learn more, read [Change a member's role](https://slack.com/help/articles/218124397-Change-a-members-role) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
@@ -153,7 +161,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage members**.
+        2. Open **Tools & settings > Manage members**.
         3. Filter the list to show **Workspace Admins** and **Workspace Owners**.
         4. Review the **2FA** column for each administrator and confirm the method shown is an authentication app rather than SMS.
 
@@ -170,7 +178,14 @@ queries:
 
         A passing response shows every member with `is_admin` or `is_owner` set to `true` also having `has_2fa` set to `true` and `two_factor_type` set to `app`; a failing response shows an administrator with `has_2fa` false or `two_factor_type` set to `sms`.
       remediation: |
-        Make sure that all admin accounts use authentication applications for two-factor authentication rather than SMS. To learn about setting up two-factor authentication to use an application, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
+        Slack does not provide a workspace setting that forces a specific two-factor method, so each administrator must switch their own account from SMS to an authentication app:
+
+        1. Sign in to your Slack workspace as an owner or admin and open **Tools & settings > Manage members**.
+        2. Review the 2FA column to identify administrators using SMS or no second factor.
+        3. Ask each affected administrator to open their [account settings](https://slack.com/account/settings), expand **Two-Factor Authentication**, and select the option to use an authentication app such as Google Authenticator or 1Password.
+        4. Confirm in **Manage members** that every admin and owner now shows an authentication app as their 2FA method.
+
+        To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/204509068
         title: Slack Two-Factor Authentication
@@ -198,7 +213,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      slack.users.members.where(name != /deactivateduser/).all( has2FA == true || enterpriseUser != empty || id=="USLACKBOT" )
+      slack.users.members.where(deleted == false).all( has2FA == true || enterpriseUser != empty || id == "USLACKBOT" )
     docs:
       desc: |
         This check ensures that every active Slack user is configured with two-factor authentication enabled on their account. Slack leaves two-factor authentication optional for individual members unless an owner enforces it at the workspace or organization level.
@@ -219,8 +234,8 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage members** and review the **2FA** column for each active member.
-        3. To confirm enforcement, open **Settings & administration > Workspace settings** and select the **Authentication** tab, then verify that two-factor authentication is required for all members.
+        2. Open **Tools & settings > Manage members** and review the **2FA** column for each active member.
+        3. To confirm enforcement, open **Tools & settings > Workspace settings** and select the **Authentication** tab, then verify that two-factor authentication is required for all members.
 
         A passing result shows two-factor authentication required for the workspace and enabled for every active member; a failing result shows an active member without two-factor authentication or workspace enforcement turned off.
 
@@ -235,7 +250,17 @@ queries:
 
         A passing response shows every active member, where `deleted` is `false` and `is_bot` is `false`, with `has_2fa` set to `true`; a failing response shows an active human member with `has_2fa` set to `false`.
       remediation: |
-        Make sure that all users have some form of two-factor authentication enabled. To learn about setting up two-factor authentication, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
+        Require two-factor authentication for the whole workspace so every member must enroll:
+
+        1. Sign in to your Slack workspace as a workspace owner.
+        2. Click your workspace name and open **Tools & settings > Workspace settings**.
+        3. Select the **Authentication** tab.
+        4. Next to **Workspace-wide two-factor authentication**, click **Expand**, then activate two-factor authentication for the workspace.
+        5. Members who have not yet enrolled are signed out and prompted to set up two-factor authentication the next time they sign in.
+
+        If your workspace signs in through single sign-on, enforce multi-factor authentication in your identity provider instead, because Slack two-factor authentication is unavailable when SSO is enabled.
+
+        To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/204509068
         title: Slack Two-Factor Authentication
@@ -269,7 +294,7 @@ queries:
       - uid: mondooSlackSecurityExternalChannelName
         title: Enter your naming pattern for externally shared Slack channels in the mql below
         mql: |
-          return /ext|extern|ex_/
+          return /^(ext|extern|ex)[-_]/
     mql: |
       slack.conversations.where(isExtShared && isChannel ).all(name == props.mondooSlackSecurityExternalChannelName )
     docs:
@@ -292,7 +317,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage channels**.
+        2. Open **Tools & settings > Manage channels**.
         3. Filter the channel list by **Channel type** and select externally shared channels, including Slack Connect channels.
         4. Review the name of each external channel against your documented naming pattern.
 
@@ -309,7 +334,14 @@ queries:
 
         A passing response shows every channel with `is_ext_shared` set to `true` having a `name` that matches your external naming pattern; a failing response shows an externally shared channel with a non-conforming `name`.
       remediation: |
-        Make sure to use a fixed pattern for all externally shared channels. To learn more, read [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
+        Rename every externally shared channel so its name matches your documented naming pattern for external channels:
+
+        1. Document a naming standard for externally shared channels, such as an `ext-` prefix, and set the policy's external channel name property to match it.
+        2. In Slack, open each externally shared channel and click the channel name in the conversation header.
+        3. Select the **Settings** tab, click **Edit** next to the channel name, and rename the channel to match the pattern.
+        4. Share the naming guideline with channel creators so new external channels follow it from the start.
+
+        To learn more, read [Rename a channel](https://slack.com/help/articles/201654214-Rename-a-channel) and [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
@@ -366,7 +398,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage channels**.
+        2. Open **Tools & settings > Manage channels**.
         3. Review the channel list and identify channels that are not shared with external users, other organizations, or other workspaces.
 
         A passing result shows at least one channel that is fully internal with no external or cross-workspace sharing; a failing result shows that every channel is shared in some form.
@@ -382,7 +414,14 @@ queries:
 
         A passing response includes at least one channel where `is_shared`, `is_ext_shared`, `is_org_shared`, and `is_pending_ext_shared` are all `false`; a failing response shows no such channel.
       remediation: |
-        Create at least one channel that is for internal workspace use only. To learn more, read [Slack Connect: Manage channel invitation settings and permissions](https://slack.com/help/articles/1500012572621-Slack-Connect--Manage-channel-invitation-settings-and-permissions-) in the Slack documentation.
+        Create at least one channel that is reserved for internal use and is never shared outside the workspace:
+
+        1. In Slack, click the plus icon next to **Channels** in the sidebar and select **Create channel**.
+        2. Name the channel, choose its visibility, and finish the setup.
+        3. Do not share the channel with another organization through Slack Connect and do not invite guest accounts, so the channel remains fully internal.
+        4. Communicate the channel's internal-only purpose to your team so confidential discussions happen there.
+
+        To learn more, read [Create a channel](https://slack.com/help/articles/201402297-Create-a-channel) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
@@ -418,10 +457,10 @@ queries:
           _.isExtShared == false &&
           _.isPendingExtShared == false
         )
-        .all(
+        .any(
           members.none(
-            isStranger == true &&
-            isRestricted == true &&
+            isStranger == true ||
+            isRestricted == true ||
             isUltraRestricted == true
           )
         )
@@ -445,7 +484,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage channels** and select a channel that should be internal only.
+        2. Open **Tools & settings > Manage channels** and select a channel that should be internal only.
         3. Open the channel's member list and review each member's account type.
         4. Confirm that no member is a guest, single-channel guest, or external user.
 
@@ -462,7 +501,14 @@ queries:
 
         Cross-reference each returned member ID against `users.list`. A passing response shows an internal channel where no member has `is_restricted`, `is_ultra_restricted`, or `is_stranger` set to `true`; a failing response shows such a member present.
       remediation: |
-        Create at least one channel which is for internal workspace use only. Make sure that no user who does not belong to your organization is in the channel(s).
+        Keep internal channels free of guest and external accounts:
+
+        1. Open each channel that is meant for internal use and click the channel name in the conversation header.
+        2. Select the **Members** tab and review each member's account type.
+        3. Remove any guest, single-channel guest, or external member from the channel.
+        4. If no fully internal channel exists, create one and invite only full members of your workspace.
+
+        To learn more, read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
@@ -494,8 +540,8 @@ queries:
       - uid: mondooSlackSecurityAllowListedDomains
         title: Enter your domains in the mql below
         mql: |
-          return /mondoo.com|example.com/
-    mql: slack.conversations.where(isExtShared == false ).all( members.all( profile['email'] == props.mondooSlackSecurityAllowListedDomains ) )
+          return /@(mondoo\.com|example\.com)$/
+    mql: slack.conversations.where(isChannel == true && isExtShared == false).all( members.where(isBot == false && id != "USLACKBOT").all(profile['email'] == props.mondooSlackSecurityAllowListedDomains) )
     docs:
       desc: |
         This check ensures that every member of an internal, non-externally-shared Slack channel has an email address from one of your organization's approved domains. Slack channel membership can include accounts with unexpected email domains unless membership is verified against an allowlist.
@@ -516,7 +562,7 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage channels** and select an internal channel.
+        2. Open **Tools & settings > Manage channels** and select an internal channel.
         3. Open the channel's member list and review the email address associated with each member.
         4. Confirm that every email domain appears on your organization's approved domain list.
 
@@ -533,7 +579,12 @@ queries:
 
         Resolve each member ID with `users.list` and read the `profile.email` field. A passing response shows every member of an internal channel with an email domain on your allowlist; a failing response shows a member with an email domain that is not approved.
       remediation: |
-        Review all internal channels for members with email domains not on your allowlist. Remove unauthorized users and investigate how they gained access. To manage workspace membership, read [Manage members in your Slack workspace](https://slack.com/help/articles/201314026-Manage-members-in-a-workspace) in the Slack documentation.
+        Remove members whose email domain is not on your allowlist from internal channels:
+
+        1. Open each internal channel and click the channel name in the conversation header.
+        2. Select the **Members** tab and review the email address associated with each member.
+        3. Remove any member whose email domain is not on your approved list. Read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
+        4. Investigate how each unauthorized account gained access. Deactivate accounts that do not belong to your organization from **Tools & settings > Manage members**. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551
         title: Slack Workspace Administration Guide
@@ -591,9 +642,9 @@ queries:
         ### Audit via Admin Settings
 
         1. Sign in to your Slack workspace as an owner or admin.
-        2. Open **Settings & administration > Manage members**.
+        2. Open **Tools & settings > Manage members**.
         3. Review the member list for accounts flagged as having an unconfirmed or pending email address.
-        4. Open **Settings & administration > Workspace settings** to confirm that sign-in options require SSO or a verified corporate domain.
+        4. Open **Tools & settings > Workspace settings** to confirm that sign-in options require SSO or a verified corporate domain.
 
         A passing result shows every active human member with a confirmed email address; a failing result shows an active member whose email address is still unconfirmed.
 
@@ -611,7 +662,7 @@ queries:
         Investigate each flagged user:
 
         1. Confirm whether the account belongs to a real, current member of your organization.
-        2. For legitimate users, have them complete the email confirmation flow. Slack sends a confirmation link when the email is added or changed — users can request a new link from their [account settings](https://slack.com/account/settings).
+        2. For legitimate users, have them complete the email confirmation flow. Slack sends a confirmation link when the email is added or changed, and users can request a new link from their [account settings](https://slack.com/account/settings).
         3. For accounts you cannot attribute to a known person, deactivate them immediately. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
         4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/115005206006) in the Slack documentation.
     refs:


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2831). This PR covers `mondoo-slack-security.mql.yaml`: all 8 checks were reviewed and all 8 needed fixes. Policy version bumped. Verified against the slack provider schema and implementation, and current Slack documentation.

## A check that could never fail (mql)

The internal-channel guest check required a member to be **simultaneously** a stranger from another workspace, a guest, and a single-channel guest (`&&` conjunction) — states that never co-occur, so `members.none(...)` always passed. The check's own audit text describes OR semantics. Fixed to `||`, and the outer `.all()` became `.any()` to match the title's \"at least one internal channel\" claim (and to stop passing vacuously on workspaces with zero internal channels).

## A check that could never pass (mql)

The domain-allowlist check filtered conversations only on `isExtShared == false`, sweeping every DM, group DM, and archived conversation — whose members include Slackbot and app bots with no profile email, failing the email-domain assertion on any real workspace regardless of remediation. Now scoped to channels with bot members excluded. The default domain prop was also unanchored with unescaped dots (`/mondoo.com|example.com/`), matching `attacker@mondoo-com.evil.example`; now anchored. The external-channel naming prop got the same anchoring (`/ext|extern|ex_/` matched \"next-steps\").

## A fragile exclusion

The workspace 2FA check excluded deactivated accounts by matching the literal username `deactivateduser`, which Slack does not reliably set — any deactivated account keeping its name produced an unfixable finding. Now `deleted == false`, the idiom the sibling email-confirmed check already uses.

## Remediations that pointed elsewhere or said nothing

The internal-channel check linked Slack Connect invitation settings — unrelated to creating an unshared channel — and now walks through channel creation. The external-naming fix never included the rename procedure, so findings could never clear. The admin-2FA fix now states the operational reality that Slack has no setting forcing the app method, so each admin must act. Workspace 2FA enforcement leads with the workspace-wide toggle and notes SSO workspaces must enforce MFA at the IdP since Slack 2FA is unavailable there. All menu paths updated from the 2023-renamed **Settings & administration** to **Tools & settings**, audits included.

## Validation

- `cnspec policy lint` passes (compiles all three modified mql expressions and both prop defaults; field names verified in the provider schema)
- YAML parses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)