### PR TITLE
🐛 http: match remaining header names and values case-insensitively

### DIFF
--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -69,7 +69,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: http.get.header.xContentTypeOptions == "nosniff"
+    mql: http.get.header.xContentTypeOptions.downcase == "nosniff"
     docs:
       desc: |
         This check ensures that the 'X-Content-Type-Options' HTTP header is set to 'nosniff'.
@@ -164,7 +164,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: http.get.header.params.keys.any('Content-Security-Policy')
+    mql: http.get.header.params.keys.any(downcase == "content-security-policy")
     docs:
       desc: |
         This check ensures that the Content Security Policy (CSP) HTTP header is set to mitigate against Cross-Site Scripting (XSS) and data injection attacks.
@@ -287,7 +287,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: http.get.header.params.keys.any('Strict-Transport-Security')
+    mql: http.get.header.params.keys.any(downcase == "strict-transport-security")
     docs:
       desc: |
         This check ensures that the Strict-Transport-Security (HSTS) HTTP header is set to enforce secure connections.
@@ -517,7 +517,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: http.get.header.params.keys.none("X-Powered-By")
+    mql: http.get.header.params.keys.none(downcase == "x-powered-by")
     docs:
       desc: |
         This check ensures that the X-Powered-By header is removed to enhance security.
@@ -813,7 +813,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: http.get.header.params.keys.none("Public-Key-Pins")
+    mql: http.get.header.params.keys.none(downcase == "public-key-pins")
     docs:
       desc: |
         This check ensures that the Public-Key-Pins (HPKP) header is not used, as it is deprecated.


### PR DESCRIPTION
Follow-up to #2834, which downcased the X-Frame-Options and Referrer-Policy key matches. This applies the same case-insensitive treatment to every remaining header check in `mondoo-http-security.mql.yaml`. Policy version bumped to 1.2.3.

## Header-name matches downcased

HTTP header names are case-insensitive per RFC 9110. Four checks still compared `params.keys` entries with exact-match strings:

- **content-security-policy**: `keys.any('Content-Security-Policy')` → `keys.any(downcase == "content-security-policy")`
- **strict-transport-security**: `keys.any('Strict-Transport-Security')` → `keys.any(downcase == "strict-transport-security")`
- **no-x-powered-by**: `keys.none("X-Powered-By")` → `keys.none(downcase == "x-powered-by")`
- **no-public-key-pins**: `keys.none("Public-Key-Pins")` → `keys.none(downcase == "public-key-pins")`

## Header-value match downcased

- **x-content-type-options**: the Fetch standard matches the `nosniff` token case-insensitively, so a server sending `noSniff` satisfies browsers but failed the old exact comparison. Now `xContentTypeOptions.downcase == "nosniff"`. An absent header is null, propagates through `downcase` as null, and still fails the check — verified empirically.

## Checks reviewed and left unchanged

- **obfuscate-server** already downcases the Server value, and the typed accessor looks the header name up in canonical form.
- **x-aspnet-version / x-aspnetmvc-version** already use the downcase pattern.
- **x-frame-options / referrer-policy** were fixed in #2834.
- **The two HSTS directive checks** (`sts.maxAge`, `sts.includeSubDomains`) read typed fields, so the header-name lookup is case-safe. However, the network provider parses STS *directive names* case-sensitively (`case "includeSubDomains"`, `case "max-age"` in `providers/network/resources/http.go`), while RFC 6797 §6.1 makes directives case-insensitive — a server sending `includeSubdomains` is not parsed. That can't be worked around cleanly in MQL and needs a cnquery provider fix, tracked separately.

## Validation

- `cnspec policy lint` passes
- Matching logic verified synthetically against mixed-case inputs, including confirming `Public-Key-Pins-Report-Only` does not false-positive the PKP match
- All five queries exercised live with `cnspec run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)