### PR TITLE
🐛 atlassian: point remediations at admin surfaces that exist

### DIFF
--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-atlassian-security
     name: Mondoo Atlassian Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -109,11 +109,13 @@ queries:
           desc: |
             To enable an IP allowlist on your Atlassian organization:
 
-            1. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
-            2. Select your organization.
-            3. Open **Security > IP allowlists**.
-            4. Select **Create allowlist** and add the IP ranges of corporate offices, VPN exit nodes, and approved cloud egress points.
-            5. Apply the allowlist to the products you want to protect and confirm the status is enabled.
+            1. Confirm the products you want to protect are on a plan that supports IP allowlists. Jira, Jira Service Management, Confluence, and Compass require a Premium plan, and Atlassian Analytics requires an Enterprise plan.
+            2. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
+            3. Select your organization.
+            4. Open **Security > IP allowlists**.
+            5. Select **IP allowlist**, name the allowlist, and add the IP ranges of corporate offices, VPN exit nodes, and approved cloud egress points.
+            6. Apply the allowlist to the products you want to protect and select **Create allowlist**.
+            7. Select **Activate IP allowlist** so the policy status changes to enabled. An allowlist that is created but never activated does not restrict access.
     refs:
       - url: https://support.atlassian.com/security-and-access-policies/docs/specify-ip-addresses-for-product-access/
         title: Specify IP addresses for product access
@@ -172,7 +174,7 @@ queries:
           "https://api.atlassian.com/admin/v1/orgs/$ORG_ID/domains"
         ```
 
-        A passing response includes at least one entry whose `type` is `verified`; a failing response shows only domains in `pending` or `failed` verification states.
+        A passing response includes at least one entry whose `attributes.claim.status` is `verified`; a failing response shows no entry whose claim status is `verified`.
       remediation:
         - id: console
           desc: |
@@ -181,9 +183,9 @@ queries:
             1. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
             2. Select your organization.
             3. Open **Directory > Domains** and select **Add domain**.
-            4. Enter the domain name and choose either DNS or HTTP verification.
-            5. Follow the on-screen instructions to publish the verification record, then return to the page and complete verification.
-            6. After the domain is verified, open **Directory > Managed accounts** and claim accounts at the domain to bring them under organization control.
+            4. Enter the domain name and choose a verification method: copy a TXT record to your DNS, upload an HTML file to the root folder of the domain's website, or verify through a connected identity provider such as Google Workspace or Microsoft Entra ID.
+            5. Publish the verification record or file, then return to the page and complete verification.
+            6. After the domain shows as verified, stay on **Directory > Domains** and select **Claim accounts** to bring existing and future accounts at the domain under organization control.
     refs:
       - url: https://support.atlassian.com/user-management/docs/verify-a-domain-to-manage-accounts/
         title: Verify a domain to manage accounts
@@ -240,10 +242,10 @@ queries:
 
         1. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
         2. Select your organization.
-        3. Open **Directory > Managed accounts**.
-        4. Open each active account of type Atlassian, switch to the **API tokens** tab, and review the **Last accessed** column.
+        3. Open **Insights > API token activity** to list every API token created by managed accounts, including when each token was created, when it expires, and when it was last used.
+        4. Review the last-used date for every token.
 
-        A passing result shows every API token with a recent **Last accessed** date inside your configured threshold; a failing result shows a token whose last access falls outside the threshold or has never been recorded.
+        A passing result shows every API token with a last-used date inside your configured threshold; a failing result shows a token whose last activity falls outside the threshold or has never been recorded.
 
         ### Audit via API
 
@@ -262,10 +264,9 @@ queries:
 
             1. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
             2. Select your organization.
-            3. Open **Directory > Managed accounts** and select an account flagged with stale tokens.
-            4. Switch to the **API tokens** tab.
-            5. For each token whose **Last accessed** date is outside your threshold, select the action menu and choose **Revoke**.
-            6. Notify the owner of any token whose purpose is unclear before revocation, and replace the token with a fresh one only if there is a documented active use case.
+            3. Open **Insights > API token activity** to list every API token created by managed accounts, including when each token was created, when it expires, and when it was last used.
+            4. For each token whose last activity falls outside your threshold, select **Revoke**.
+            5. Revocation is permanent and immediately breaks any integration still using the token, so notify the owner of any token whose purpose is unclear before revoking, and issue a replacement token only when there is a documented active use case.
         - id: api
           desc: |
             To revoke a managed-account API token via the Atlassian Admin API:
@@ -330,10 +331,10 @@ queries:
 
         1. Sign in to [admin.atlassian.com](https://admin.atlassian.com) as an organization administrator.
         2. Select your organization.
-        3. Open **Directory > Managed accounts**.
-        4. Filter by **Account type: Atlassian** and **Account status: Active**, then sort by **Last active**.
+        3. Open **Directory > Managed accounts** and export the account list to CSV. The export includes each account's last active date.
+        4. In the export, review every account whose type is Atlassian and whose status is active.
 
-        A passing result shows every active managed account with a **Last active** date inside the configured threshold; a failing result shows an active account whose last activity falls outside the threshold or has never been recorded.
+        A passing result shows every active managed account with a last active date inside the configured threshold; a failing result shows an active account whose last activity falls outside the threshold or has never been recorded.
 
         ### Audit via API
 
@@ -423,10 +424,10 @@ queries:
             To remove anonymous grants from a Jira permission scheme:
 
             1. Sign in to your Jira site as a Jira administrator.
-            2. Open **Settings (cog) > Issues > Permission schemes**.
+            2. Open **Settings > Issues > Permission schemes**.
             3. Open the permission scheme flagged by the audit.
             4. For each permission whose grant is set to anyone, select **Remove** to delete the grant.
-            5. Select **Grant permission** and add the same permission to a named holder such as the project role that should hold it (for example, **Users with an Atlassian account** or a specific group).
+            5. Select **Grant permission** and re-grant the same permission to an authenticated audience such as **Any logged in user**, a specific group, or a project role.
             6. Confirm the change and re-run the audit to verify no anonymous grants remain.
     refs:
       - url: https://support.atlassian.com/jira-cloud-administration/docs/manage-project-permissions/
@@ -487,18 +488,19 @@ queries:
           "https://$ATLASSIAN_HOST/wiki/rest/api/space?expand=permissions"
         ```
 
-        A passing response shows every space with no permission entry whose `subjects.anonymous` is true; a failing response shows at least one space granting any operation to the anonymous subject.
+        A passing response shows every space with no permission entry whose `anonymousAccess` flag is true; a failing response shows at least one space granting any operation to the anonymous subject.
       remediation:
         - id: console
           desc: |
             To remove anonymous access from a Confluence space:
 
-            1. Sign in to your Confluence site as a Confluence administrator.
-            2. Open the flagged space and select **Space settings > Permissions**.
-            3. Open the **Anonymous Access** section.
-            4. Clear every permission granted to the anonymous principal.
-            5. Save the change and re-run the audit to confirm no permissions remain for the anonymous principal.
-            6. If the space must remain publicly readable, document the business justification and move the content to a dedicated public documentation site instead of leaving it inside an internal Confluence instance.
+            1. Sign in to your Confluence site as an administrator of the flagged space.
+            2. In the sidebar next to the space name, select **More actions**, then **Space settings**.
+            3. Open **Space access > Anonymous access**.
+            4. Select **Edit**, clear every permission granted to anonymous users, and save.
+            5. Re-run the audit to confirm no permissions remain for the anonymous principal. The space-level permissions must be cleared even if site-wide anonymous access is turned off, because the space configuration is what this check inspects.
+            6. To stop space administrators from re-enabling public access, sign in as a Confluence administrator and turn off the global setting that allows spaces to turn on anonymous access.
+            7. If the space must remain publicly readable, document the business justification and move the content to a dedicated public documentation site instead of leaving it inside an internal Confluence instance.
     refs:
       - url: https://support.atlassian.com/confluence-cloud/docs/assign-space-permissions/
         title: Assign space permissions in Confluence
@@ -563,14 +565,14 @@ queries:
           desc: |
             To remove unlicensed-user access from a Confluence space:
 
-            1. Sign in to your Confluence site as a Confluence administrator.
-            2. Open the flagged space and select **Space settings > Permissions**.
-            3. Locate the unlicensed-user permission row (such as the JSM customer subject).
-            4. Clear every permission granted to that subject.
-            5. Save the change and re-run the audit.
-            6. If unlicensed users genuinely need documentation access, build that documentation in a dedicated customer-facing space rather than relaxing permissions on internal spaces.
+            1. Identify each Jira Service Management project whose knowledge base links to the flagged space.
+            2. Sign in to Jira as a project administrator and open **Project settings > Knowledge base** in each of those service projects.
+            3. Next to the linked space, change **Who can view** so that viewing requires access to the linked Confluence space rather than allowing all logged-in users without a Confluence license.
+            4. Repeat for every service project linked to the flagged space, then re-run the audit to confirm the space no longer reports unlicensed access.
+            5. If no service project on the site should expose Confluence content to unlicensed users, a Confluence administrator can additionally open **Confluence settings**, select the **JSM Access** tab, and clear **Use Confluence**. This disables the knowledge base integration for the whole site, so confirm no team depends on it first.
+            6. If portal customers genuinely need documentation, link a dedicated customer-facing space whose content is reviewed and published as external collateral rather than relaxing access on internal spaces.
     refs:
       - url: https://support.atlassian.com/confluence-cloud/docs/assign-space-permissions/
         title: Assign space permissions in Confluence
-      - url: https://support.atlassian.com/jira-service-management-cloud/docs/give-portal-only-customers-access-to-confluence/
-        title: Give portal-only customers access to Confluence
+      - url: https://support.atlassian.com/confluence-cloud/docs/give-access-to-unlicensed-users-from-jira-service-management/
+        title: Give access to unlicensed users from Jira Service Management


### PR DESCRIPTION
Part of the series reviewing every remediation in `content/` for correctness (#2775, #2780–#2835). This PR covers `mondoo-atlassian-security.mql.yaml`: all 7 checks were reviewed and all 7 needed fixes. Policy version bumped. Verified against the atlassian provider schema and implementation, the checked-in Atlassian OpenAPI specs, and current Atlassian support documentation.

## Remediation surfaces that do not exist

- **admin-no-stale-api-tokens** sent admins to a per-account \"API tokens\" tab under Managed accounts; no such tab exists. Managed-account tokens are reviewed and revoked centrally at **Insights > API token activity**, now in both remediation and audit, with the permanence of revocation stated.
- **confluence-no-unlicensed-space-access** looked for an \"unlicensed-user permission row\" in space permissions; none exists. That access is granted through the Jira Service Management knowledge-base integration, so the fix now goes through **Project settings > Knowledge base > Who can view** per linked service project, with the site-wide **JSM Access** gate as the structural control. The refs URL for portal customers 404s and is replaced with the live doc.
- **confluence-no-anonymous-space-access** used the outdated Space settings path; now **More actions > Space settings > Space access > Anonymous access**, plus the site-level setting that stops space admins reintroducing public access — with the drift note that the space-level entries the check reads must still be cleared.
- **jira-no-anonymous-permission-grants** offered a holder label that doesn't exist in the grant dialog; the authenticated catch-all is **Any logged in user**.

## Flows that stopped one step short

The IP-allowlist remediation never mentioned the separate **Activate IP allowlist** action — an allowlist created but not activated keeps `status` at disabled and the check failing — nor the Premium/Enterprise plan prerequisite without which the steps can't be followed. Domain verification now includes identity-provider verification and the real **Claim accounts** location (Directory > Domains, not Managed accounts).

## Audit corrections

The verified-domains audit claimed passing = `type == \"verified\"` — the API's `type` is the JSON:API discriminator, always `\"domains\"`; verification lives in `attributes.claim.status`. The dormant-users audit referenced list filters that couldn't be verified to exist and now uses the documented CSV export. The Confluence anonymous-grant field is the `anonymousAccess` boolean, not `subjects.anonymous`.

## Left for maintainers (never-pass check)

**admin-verified-domains-configured** can never pass: the provider populates `domain.type` from the JSON:API resource discriminator, whose only enum value is `\"domains\"`, so `any(type == \"verified\")` matches nothing on any organization. The go-atlassian model carries `attributes.claim.status` but the provider never reads it. Fixing requires a provider field (e.g. `claimStatus`) plus an mql change; the `.lr` doc comment \"Domain type (e.g., verified)\" likely seeded the error.

## Validation

- `cnspec policy lint` passes
- YAML parses clean; no mql changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)