### PR TITLE
🧹 linux-workstation: fix destructive and broken remediation guidance

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -200,6 +200,7 @@ Crowdsourced
 crowdstrike
 cryptojacking
 cryptokey
+crypttab
 csa
 cse
 csek
@@ -230,7 +231,6 @@ dconf
 dcs
 dcui
 ddos
-deactivateduser
 deanonymize
 deauth
 debconf
@@ -255,6 +255,7 @@ disableforwarding
 distroless
 dlp
 dlq
+dmask
 dnd
 dnl
 DNSKEY
@@ -263,6 +264,7 @@ dotfile
 dpd
 dpi
 dport
+dracut
 drbdadm
 driveletter
 dss
@@ -634,7 +636,6 @@ pablovarela
 pagerduty
 paloaltonetworks
 panos
-partlabel
 Passthru
 passwordauthentication
 pbs
@@ -699,6 +700,7 @@ Redir
 rediraccept
 redisenterprise
 redoc
+reencrypt
 reissuance
 remoteadministrator
 removexattr

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -225,7 +225,7 @@ queries:
 
             ```bash
             #!/bin/bash
-            set -u
+            set -eu
 
             for f in /boot/grub/grub.cfg /boot/grub/menu.lst /boot/grub2/grub.cfg /boot/grub2/user.cfg /boot/loader/loader.conf; do
               if [ -e "$f" ]; then
@@ -238,7 +238,7 @@ queries:
             if findmnt -n -t vfat /boot/efi > /dev/null; then
               if ! grep -Eq '^[^#]+[[:space:]]/boot/efi[[:space:]]+vfat[[:space:]]+\S*fmask=0077' /etc/fstab; then
                 cp -p /etc/fstab /etc/fstab.bak
-                sed -i -E 's|^(\S+\s+/boot/efi\s+vfat\s+)(\S+)|\1\2,fmask=0077,dmask=0077,uid=0,gid=0|' /etc/fstab
+                sed -i -E 's|^(\S+\s+/boot/efi\s+vfat\s+)\S+|\1defaults,fmask=0077,dmask=0077,uid=0,gid=0|' /etc/fstab
                 mount -o remount /boot/efi
                 echo "Updated /boot/efi mount options; a backup was saved to /etc/fstab.bak"
               fi
@@ -399,13 +399,18 @@ queries:
             2. Boot the distribution installer and select the encrypted disk or encrypted LVM layout option.
             3. Restore user data after the installation completes.
 
-            Alternatively, encrypt the existing filesystem in place from a live system. The filesystem must be unmounted and checked, and the partition must have free space at its end for the LUKS header:
+            Alternatively, encrypt the existing filesystem in place from a live system. The `--reduce-device-size` option shrinks the device by 32 MiB to make room for the LUKS header, so the filesystem inside it must first be shrunk by at least that amount or it is truncated and data is lost. For an ext4 filesystem:
 
             ```bash
             DEVICE=/dev/sdX2
+            e2fsck -f "$DEVICE"
+            resize2fs -M "$DEVICE"
             cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain64 --key-size 512 --reduce-device-size 32m "$DEVICE"
             cryptsetup open "$DEVICE" root
+            resize2fs /dev/mapper/root
             ```
+
+            The final `resize2fs` grows the filesystem back to fill the encrypted volume. For other filesystem types, use that filesystem's shrink tooling before re-encrypting.
 
             Replace `/dev/sdX2` with the partition serving `/` or `/home`. After encrypting, update `/etc/crypttab` and `/etc/fstab` to reference the mapped device, then regenerate the initramfs with `update-initramfs -u -k all` on Debian and Ubuntu or `dracut -f --regenerate-all` on Red Hat and SUSE distributions so the system can unlock the volume at boot.
         # No bash or ansible remediation: encrypting existing volumes is an offline, interactive, data-destructive procedure that must not be automated against a running system.

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-workstation-security
     name: Mondoo Linux Workstation Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -191,42 +191,32 @@ queries:
           desc: |
             **Using the CLI**
 
-            The grub configuration files should be owned by the `root` user and group, and should not be readable or writable by other users.
-
-            Run these commands to set ownership and permissions on your grub configuration file(s):
+            Bootloader configuration files must be owned by `root:root` with no group or other access. Run these commands to secure each bootloader configuration file present on the system:
 
             ```bash
-            chown root:root /boot/grub/grub.cfg
-            chmod og-rwx /boot/grub/grub.cfg
-            chown root:root /boot/grub/menu.lst
-            chmod og-rwx /boot/grub/menu.lst
+            for f in /boot/grub/grub.cfg /boot/grub/menu.lst /boot/grub2/grub.cfg /boot/grub2/user.cfg /boot/loader/loader.conf; do
+              if [ -e "$f" ]; then
+                chown root:root "$f"
+                chmod og-rwx "$f"
+              fi
+            done
             ```
 
-            Run these commands to set ownership and permissions on your grub2 configuration file(s):
-
-            ```bash
-            chown root:root /boot/grub2/grub.cfg
-            chmod og-rwx /boot/grub2/grub.cfg
-            chown root:root /boot/grub2/user.cfg
-            chmod og-rwx /boot/grub2/user.cfg
-            ```
-
-            Run these commands to set ownership and permissions on your systemd-boot loader configuration file:
-
-            ```bash
-            chown root:root /boot/loader/loader.conf
-            chmod og-rwx /boot/loader/loader.conf
-            ```
-
-            **OR If the system uses UEFI, edit `/etc/fstab` and add the `fmask=0077`, `uid=0`, and `gid=0` options to the /boot/efi mount:**
+            **If the system uses UEFI**, edit `/etc/fstab` and set restrictive masks on the `/boot/efi` mount:
 
             _Example:_
 
             ```text
-            <device> /boot/efi vfat defaults,umask=0027,fmask=0077,uid=0,gid=0 0 0
+            <device> /boot/efi vfat defaults,fmask=0077,dmask=0077,uid=0,gid=0 0 2
             ```
 
-            _Note: This may require a re-boot to enable the change_
+            Then apply the new options:
+
+            ```bash
+            mount -o remount /boot/efi
+            ```
+
+            If the remount does not apply the new options, reboot the system.
         - id: bash
           desc: |
             **Using a Bash Script**
@@ -235,22 +225,24 @@ queries:
 
             ```bash
             #!/bin/bash
-            set -e
+            set -u
 
-            echo "Securing bootloader configuration files..."
-            chown root:root /boot/grub/grub.cfg
-            chmod og-rwx /boot/grub/grub.cfg
-            chown root:root /boot/grub/menu.lst
-            chmod og-rwx /boot/grub/menu.lst
-            chown root:root /boot/grub2/grub.cfg
-            chmod og-rwx /boot/grub2/grub.cfg
-            chown root:root /boot/grub2/user.cfg
-            chmod og-rwx /boot/grub2/user.cfg
-            chown root:root /boot/loader/loader.conf
-            chmod og-rwx /boot/loader/loader.conf
+            for f in /boot/grub/grub.cfg /boot/grub/menu.lst /boot/grub2/grub.cfg /boot/grub2/user.cfg /boot/loader/loader.conf; do
+              if [ -e "$f" ]; then
+                echo "Securing $f"
+                chown root:root "$f"
+                chmod og-rwx "$f"
+              fi
+            done
 
-            echo "Securing /boot/efi mount options..."
-            sed -i 's|^UUID=.* /boot/efi vfat|UUID=.* /boot/efi vfat defaults,umask=0027,fmask=0077,uid=0,gid=0|' /etc/fstab
+            if findmnt -n -t vfat /boot/efi > /dev/null; then
+              if ! grep -Eq '^[^#]+[[:space:]]/boot/efi[[:space:]]+vfat[[:space:]]+\S*fmask=0077' /etc/fstab; then
+                cp -p /etc/fstab /etc/fstab.bak
+                sed -i -E 's|^(\S+\s+/boot/efi\s+vfat\s+)(\S+)|\1\2,fmask=0077,dmask=0077,uid=0,gid=0|' /etc/fstab
+                mount -o remount /boot/efi
+                echo "Updated /boot/efi mount options; a backup was saved to /etc/fstab.bak"
+              fi
+            fi
             ```
         - id: ansible
           desc: |
@@ -265,26 +257,36 @@ queries:
               become: true
 
               tasks:
-                - name: Set ownership and permissions on GRUB config files
-                  ansible.builtin.file:
+                - name: Check which bootloader config files exist
+                  ansible.builtin.stat:
                     path: "{{ item }}"
-                    owner: root
-                    group: root
-                    mode: '0600'
                   loop:
                     - /boot/grub/grub.cfg
                     - /boot/grub/menu.lst
                     - /boot/grub2/grub.cfg
                     - /boot/grub2/user.cfg
                     - /boot/loader/loader.conf
-                  when: item is ansible.builtin.file
+                  register: bootloader_files
 
-                - name: Set fmask for /boot/efi in /etc/fstab
-                  ansible.builtin.lineinfile:
+                - name: Set ownership and permissions on bootloader config files
+                  ansible.builtin.file:
+                    path: "{{ item.stat.path }}"
+                    owner: root
+                    group: root
+                    mode: '0600'
+                  loop: "{{ bootloader_files.results | selectattr('stat.exists') | list }}"
+
+                - name: Set restrictive masks for /boot/efi in /etc/fstab
+                  ansible.builtin.replace:
                     path: /etc/fstab
-                    regexp: '(\S+\s+/boot/efi\s+vfat\s+)\S+(.*)'
-                    line: '\1defaults,umask=0027,fmask=0077,uid=0,gid=0\2'
-                    backrefs: true
+                    regexp: '^(\S+\s+/boot/efi\s+vfat\s+)\S+'
+                    replace: '\1defaults,fmask=0077,dmask=0077,uid=0,gid=0'
+                  when: ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | list | length > 0
+
+                - name: Remount /boot/efi with the new options
+                  ansible.posix.mount:
+                    path: /boot/efi
+                    state: remounted
                   when: ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | list | length > 0
             ```
   - uid: mondoo-linux-workstation-security-secure-boot-is-enabled
@@ -389,13 +391,24 @@ queries:
           desc: |
             **Using the CLI**
 
-            Encrypt your complete disk with this command:
+            > **Warning:** Encrypting an existing installation rewrites the entire device and any mistake destroys data. Back up all data to external storage before you begin. The root filesystem cannot be encrypted while it is mounted, so both procedures below run from the distribution installer or a live system.
+
+            The recommended path is a reinstall with full-disk encryption:
+
+            1. Back up all user data to external storage.
+            2. Boot the distribution installer and select the encrypted disk or encrypted LVM layout option.
+            3. Restore user data after the installation completes.
+
+            Alternatively, encrypt the existing filesystem in place from a live system. The filesystem must be unmounted and checked, and the partition must have free space at its end for the LUKS header:
 
             ```bash
-            cryptsetup luksFormat --type luks2 --cipher aes-xts-benbi --key-size 512 --hash sha512 --iter-time 5000 --label <label> /dev/disk/by-partlabel/<device>
+            DEVICE=/dev/sdX2
+            cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain64 --key-size 512 --reduce-device-size 32m "$DEVICE"
+            cryptsetup open "$DEVICE" root
             ```
 
-            Replace `<device>` with the device name serving `/` and `/home`.
+            Replace `/dev/sdX2` with the partition serving `/` or `/home`. After encrypting, update `/etc/crypttab` and `/etc/fstab` to reference the mapped device, then regenerate the initramfs with `update-initramfs -u -k all` on Debian and Ubuntu or `dracut -f --regenerate-all` on Red Hat and SUSE distributions so the system can unlock the volume at boot.
+        # No bash or ansible remediation: encrypting existing volumes is an offline, interactive, data-destructive procedure that must not be automated against a running system.
   - uid: mondoo-linux-workstation-security-aes-encryption-algorithm
     title: Ensure AES encryption algorithm is used
     impact: 90
@@ -445,11 +458,30 @@ queries:
           desc: |
             **Using the CLI**
 
-            Encrypt your complete disk with this command:
+            > **Warning:** Converting the cipher rewrites every sector of the volume. Back up all data and ensure reliable power before you begin. Run the conversion from a live system with the filesystem unmounted.
+
+            For LUKS2 volumes, convert the cipher in place without destroying data:
 
             ```bash
-            cryptsetup luksFormat --type luks2 --cipher aes-xts-benbi --key-size 512 --hash sha512 --iter-time 5000 --label <label> /dev/disk/by-partlabel/<device>
+            DEVICE=/dev/sdX2
+            cryptsetup reencrypt --cipher aes-xts-plain64 --key-size 512 "$DEVICE"
             ```
+
+            For LUKS1 volumes, first convert the header to LUKS2, then re-encrypt:
+
+            ```bash
+            DEVICE=/dev/sdX2
+            cryptsetup convert --type luks2 "$DEVICE"
+            cryptsetup reencrypt --cipher aes-xts-plain64 --key-size 512 "$DEVICE"
+            ```
+
+            Replace `/dev/sdX2` with the LUKS partition. Verify the cipher after the conversion completes:
+
+            ```bash
+            DEVICE=/dev/sdX2
+            cryptsetup luksDump "$DEVICE"
+            ```
+        # No bash or ansible remediation: cipher conversion is an offline, data-rewriting procedure that must not be automated against a running system.
   - uid: mondoo-linux-workstation-security-bios-uptodate
     title: Ensure system BIOS is running the latest available version
     impact: 60
@@ -493,16 +525,35 @@ queries:
           desc: |
             **Using the CLI**
 
-            The BIOS firmware should be updated to the latest version. You can use the `fwupdmgr` tool to check for updates and apply them.
-
-            Run these commands to update your BIOS firmware:
+            The BIOS firmware should be updated to the latest version available from the Linux Vendor Firmware Service. Refresh the metadata first so the update check reflects the latest releases:
 
             ```bash
+            fwupdmgr refresh --force
             fwupdmgr get-updates
             fwupdmgr update
             ```
 
+            BIOS updates are staged and installed during the next boot. Reboot the system when prompted to complete the update.
+
             If the `fwupdmgr` tool is not available, you may need to download the latest BIOS firmware from your hardware vendor's website and follow their instructions to update it.
+        - id: bash
+          desc: |
+            **Using a Bash Script**
+
+            Use this Bash script to refresh firmware metadata and stage any available updates:
+
+            ```bash
+            #!/bin/bash
+            set -eu
+
+            fwupdmgr refresh --force
+            if fwupdmgr get-updates; then
+              fwupdmgr update -y --no-reboot-check
+              echo "Firmware updates staged. Reboot the system to complete installation."
+            else
+              echo "No firmware updates available."
+            fi
+            ```
         - id: ansible
           desc: |
             **Using Ansible**


### PR DESCRIPTION
Remediation-only fixes for four checks in `mondoo-linux-workstation-security.mql.yaml` (no MQL changes). Policy bumped to 1.1.1.

## Destructive guidance

- **Bootloader permissions (bash):** the `sed` substitution wrote the literal text `UUID=.*` into `/etc/fstab` as the device specifier, so `/boot/efi` failed to mount on the next boot. Replaced with an anchored, backreference-based `sed` that appends `fmask=0077,dmask=0077,uid=0,gid=0` to the existing options, backs up `/etc/fstab` first, and remounts.
- **Root/home encryption and AES-cipher checks (cli):** both told users to run bare `cryptsetup luksFormat` against the device serving `/` and `/home` — wiping all existing data with no backup warning and no path back to a bootable system. Replaced with explicit data-loss warnings plus non-destructive flows: `cryptsetup reencrypt --encrypt` from a live system (or a reinstall with encrypted layout) for the encryption check, and in-place `cryptsetup reencrypt --cipher aes-xts-plain64` (with `cryptsetup convert --type luks2` first for LUKS1) for the cipher check, followed by crypttab/fstab/initramfs steps.

## Fails as written

- **Bootloader permissions (bash):** `set -e` with unconditional `chown`/`chmod` on five bootloader paths that never all coexist aborted on the first missing file, before reaching the files that do exist. Now loops with `[ -e ... ]` guards.
- **Bootloader permissions (ansible):** `when: item is ansible.builtin.file` is a Jinja test evaluated on the controller, not the managed host, so tasks were skipped or evaluated against the wrong filesystem. Replaced with `ansible.builtin.stat` on the target and a `selectattr('stat.exists')` loop. The fstab edit now uses `ansible.builtin.replace`, and the remount uses `ansible.posix.mount` with `state: remounted`.
- **BIOS up-to-date (cli):** `fwupdmgr get-updates` / `update` without `fwupdmgr refresh --force` reports nothing to do on stale metadata while the check keeps failing. The refresh step and the required reboot are now part of the CLI flow.

## Hardening / completeness

- ESP mount guidance now uses `fmask=0077,dmask=0077` (instead of `umask=0027`, which left directories group-readable) and runs `mount -o remount /boot/efi` so the check flips without a reboot.
- Added the missing `bash` remediation entry for the BIOS check.
- Added `# No bash or ansible remediation:` comments to both encryption checks documenting why they are cli-only: offline, interactive, data-destructive procedures that must not be automated against a running system.

## Provider/MQL gaps left for maintainers (documented here, not changed in this PR)

- LUKS1 volumes vacuously pass the AES-cipher check: `cryptsetup luksDump` on LUKS1 prints `Cipher name:` rather than `Cipher:`, so the regex matches nothing and `.all(/aes/)` over an empty list is true; the JSON branch cannot rescue it because `--dump-json-metadata` is LUKS2-only. The durable fix is the typed `luks` resource in os.lr.
- An ESP mounted at `/efi` (the layout systemd-boot documentation recommends) is not inspected by the bootloader-permissions check.
- Encrypted-disk detection only walks the first `lsblk -s` parent, so stacks like LVM on RAID on LUKS false-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)