### PR TITLE
🧹 shodan: fix unverifiable membership audit and add re-scan latency guidance

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -230,7 +230,6 @@ dconf
 dcs
 dcui
 ddos
-deactivateduser
 deanonymize
 deauth
 debconf
@@ -848,6 +847,7 @@ timestreamwrite
 timesync
 tinyssh
 tipc
+tlnp
 tmm
 tmpfiles
 tmsh

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-shodan
     name: Mondoo Shodan Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -78,12 +78,17 @@ queries:
 
         A passing account shows an active membership tier; a failing account shows a free or expired plan.
 
-        ### Audit via the Shodan CLI
+        ### Audit via the Shodan API
 
-        1. Run `shodan info`.
-        2. Review the output for `Membership: True` and the remaining query and scan credits.
+        1. Run the following command with your API key:
 
-        A passing account reports `Membership: True`; a failing account reports `Membership: False`.
+        ```bash
+        curl -s "https://api.shodan.io/account/profile?key=$SHODAN_API_KEY"
+        ```
+
+        2. Review the `member` field in the JSON response.
+
+        A passing account returns `"member": true`; a failing account returns `"member": false`.
       remediation:
         - id: console
           desc: |
@@ -142,7 +147,7 @@ queries:
         1. Browse to `https://www.shodan.io/host/<ip-address>`, replacing `<ip-address>` with the host's public IP address.
         2. Review the **Ports** panel for any reachable services.
 
-        A passing host shows no ports in the panel; a failing host lists one or more reachable services.
+        A passing host shows no record or no listed ports; a failing host lists one or more reachable services.
 
         ### Audit via the Shodan CLI
 
@@ -155,12 +160,19 @@ queries:
           desc: |
             **On the affected host**
 
-            Review the open ports identified by Shodan and close any that are not required for the system's operation:
+            Review the open ports identified by Shodan and close any exposure that is not required:
 
-            1. Identify the services running on each open port.
-            2. Disable unnecessary services and close their corresponding ports using firewall rules.
-            3. For required services, ensure they are properly secured with authentication, encryption, and access controls.
-            4. Re-scan the host to verify that the ports have been closed.
+            1. Identify the service listening on each open port, for example with `ss -tlnp` on Linux.
+            2. Stop and disable services that are not required, and block their ports at the host or network firewall so they are no longer reachable from the internet.
+            3. For required services, restrict access to trusted source networks using firewall rules or a VPN, and enforce authentication and encryption.
+            4. Verify from an external network that the ports no longer accept connections.
+            5. Request an on-demand Shodan re-scan, which consumes a scan credit, or wait for Shodan's next crawl:
+
+            ```bash
+            shodan scan submit 198.51.100.7
+            ```
+
+            This check reads Shodan's cached view of the host, so it continues to fail until Shodan re-scans the host and its records reflect the closed ports.
     refs:
       - url: https://www.shodan.io/
         title: Shodan
@@ -220,12 +232,19 @@ queries:
           desc: |
             **On the affected host**
 
-            Review the vulnerabilities identified by Shodan and remediate them:
+            Review the vulnerabilities identified by Shodan and remediate them at the source:
 
             1. Cross-reference the detected CVEs with vendor advisories and the National Vulnerability Database (NVD).
-            2. Apply available patches and updates to affected services.
-            3. If patches are not available, implement compensating controls such as network segmentation or Web Application Firewalls (WAFs).
-            4. Re-scan the host to verify that the vulnerabilities have been addressed.
+            2. Apply available patches or upgrade the affected services to a fixed release. Shodan derives most findings from the version string in the service banner, so the fix must change the version the service reports. Backported fixes that keep the old version string can leave Shodan reporting the CVE even after the host is patched.
+            3. If patches are not available, implement compensating controls such as restricting the service to trusted networks or placing it behind a web application firewall.
+            4. If the vulnerable service is not required, stop and disable it and block its port at the firewall.
+            5. Request an on-demand Shodan re-scan, which consumes a scan credit, or wait for Shodan's next crawl:
+
+            ```bash
+            shodan scan submit 198.51.100.7
+            ```
+
+            This check reads Shodan's cached view of the host, so it continues to fail until Shodan re-scans the host and its records reflect the remediated services.
     refs:
       - url: https://www.shodan.io/
         title: Shodan


### PR DESCRIPTION
Applies reviewed remediation fixes to `content/mondoo-shodan.mql.yaml`, grouped by failure class. Bumps the policy to 1.1.1.

## Audit cannot reproduce the check

- **mondoo-shodan-membership**: the audit told users to run `shodan info` and look for `Membership: True`, but `shodan info` prints only query and scan credits — membership status is not exposed by any shodan CLI subcommand. The check reads `shodan.profile.member`, which comes from the `/account/profile` REST endpoint; the audit now curls that endpoint and reads the `member` field. The website audit section is unchanged, and the remediation needed no changes.

## Remediation cannot flip the check promptly

- **mondoo-shodan-no-port** and **mondoo-shodan-vulnerabilities**: both checks read Shodan's cached view of the host, so closing ports or patching locally does not change the result until Shodan re-crawls the IP. Both remediations now explain this and offer `shodan scan submit` (which consumes a scan credit) as the on-demand re-scan path, with waiting for Shodan's next crawl as the alternative. The no-port remediation also gains a concrete service-identification step (`ss -tlnp`) and external verification before re-scanning.

## Misleading guidance

- **mondoo-shodan-vulnerabilities**: findings are banner-version derived — backported distro patches that keep the old version string leave the CVE showing even after a re-scan. The remediation now warns that the fix must change the version the service reports, and offers removing the exposure entirely (stop, disable, and firewall the service) as the strongest fix.
- **mondoo-shodan-no-port**: the audit's passing condition now reads "no record or no listed ports" since Shodan typically has no host page at all for unexposed IPs.

## MQL

All three queries were verified field-by-field against the shodan provider schema (`member`, `ports`, and `vulns` — the non-deprecated field) — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)