### PR TITLE
🐛 reporter: collapse double blank line for assets with no checks

### DIFF
--- a/cli/reporter/cli_reporter_test.go
+++ b/cli/reporter/cli_reporter_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,8 @@ import (
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/cli/printer"
 	"go.mondoo.com/mql/v13/cli/theme/colors"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/mql/v13/utils/iox"
 )
@@ -45,6 +48,101 @@ func TestCompactReporter(t *testing.T) {
 	assert.Contains(t, strData, "! Error:          Set")
 	assert.Contains(t, strData, "✓ Ensure ")
 	assert.Contains(t, strData, "✕ CRITICAL (100): Ensure")
+}
+
+// TestCompactReporterNoChecksSpacing guards against the regression in
+// https://github.com/mondoohq/mql/issues/6390: an asset with no checks left a
+// double blank line between the asset header and the first printed section.
+// Each non-empty body section must be separated from the header (and from the
+// previous section) by exactly one blank line.
+func TestCompactReporterNoChecksSpacing(t *testing.T) {
+	assetMrn := "//assets.api.mondoo.app/spaces/test/assets/no-checks"
+	riskMrn := "//policy.api.mondoo.app/risks/example"
+
+	data := &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			assetMrn: {
+				Mrn:      assetMrn,
+				Name:     "pdx-fortigate-01",
+				Platform: &inventory.Platform{Name: "fortios", Title: "FortiOS"},
+			},
+		},
+		Reports: map[string]*policy.Report{
+			assetMrn: {
+				ScoringMrn: assetMrn,
+				Score:      &policy.Score{},
+				Scores:     map[string]*policy.Score{},
+				Data:       map[string]*llx.Result{},
+				// A risk factor is present but not detected, so the risks
+				// section prints its "no downgrading risks detected" line.
+				Risks: &policy.ScoredRiskFactors{
+					Items: []*policy.ScoredRiskFactor{{Mrn: riskMrn, IsDetected: false}},
+				},
+			},
+		},
+		// No CHECK reporting jobs => no checks are printed for this asset.
+		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
+			assetMrn: {
+				ExecutionJob: &policy.ExecutionJob{Queries: map[string]*policy.ExecutionQuery{}},
+				CollectorJob: &policy.CollectorJob{
+					ReportingJobs:    map[string]*policy.ReportingJob{},
+					ReportingQueries: map[string]*policy.StringArray{},
+				},
+			},
+		},
+		VulnReports: map[string]*mvd.VulnReport{
+			assetMrn: {Stats: &mvd.ReportStats{Advisories: &mvd.ReportStatsAdvisories{Total: 0}}},
+		},
+		Bundle: &policy.Bundle{
+			Policies: []*policy.Policy{{
+				Mrn:         "//policy.api.mondoo.app/policies/example",
+				RiskFactors: []*policy.RiskFactor{{Mrn: riskMrn, Title: "Example risk"}},
+			}},
+		},
+	}
+
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	rr := &defaultReporter{
+		Reporter: &Reporter{
+			Conf:    defaultPrintConfig(),
+			Printer: &printer.DefaultPrinter,
+			Colors:  &colors.DefaultColorTheme,
+		},
+		output: &writer,
+		data:   data,
+	}
+	rr.print()
+
+	lines := strings.Split(buf.String(), NewLineCharacter)
+
+	// Locate the first section that follows the asset header. With no checks,
+	// the risks section is the first body section.
+	risksIdx := -1
+	for i, l := range lines {
+		if strings.Contains(l, "Risks / Preventive Controls:") {
+			risksIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, risksIdx, 2, "expected a Risks section preceded by the asset header")
+
+	// Exactly one blank line separates the header underline from the section:
+	// the line right before "Risks" is blank, the one before that is not.
+	assert.Equal(t, "", lines[risksIdx-1], "expected a single blank line before the Risks section")
+	assert.NotEqual(t, "", lines[risksIdx-2], "expected exactly one blank line (no double gap) after the asset header")
+
+	// And there should be a single blank line between sections too.
+	vulnsIdx := -1
+	for i, l := range lines {
+		if strings.Contains(l, "Vulnerabilities:") {
+			vulnsIdx = i
+			break
+		}
+	}
+	require.Greater(t, vulnsIdx, risksIdx, "expected a Vulnerabilities section after Risks")
+	assert.Equal(t, "", lines[vulnsIdx-1], "expected a blank line before the Vulnerabilities section")
+	assert.NotEqual(t, "", lines[vulnsIdx-2], "expected exactly one blank line between Risks and Vulnerabilities")
 }
 
 func TestVulnReporter(t *testing.T) {

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -38,12 +38,31 @@ type defaultReporter struct {
 	// indicates if the StoreResourcesData MQL feature is enabled
 	isStoreResourcesEnabled bool
 
+	// tracks whether any section of the current asset's body (controls,
+	// queries, checks, risks, vulnerabilities) has already printed content
+	// since the asset header. It is used to emit exactly one blank line
+	// between consecutive non-empty sections, so an asset with no checks
+	// doesn't leave a double gap after its header.
+	assetBodyPrinted bool
+
 	// vv the items below will be automatically filled
 	bundle *policy.PolicyBundleMap
 }
 
 func (r *defaultReporter) out(s string) {
 	_, _ = r.output.Write([]byte(s))
+}
+
+// beginAssetSection separates a new asset body section from the previous one.
+// The asset header (H2) already emits a trailing blank line, so the first
+// section needs no leading separator; every subsequent non-empty section gets
+// exactly one blank line before it. Call this immediately before a section
+// emits its first content.
+func (r *defaultReporter) beginAssetSection() {
+	if r.assetBodyPrinted {
+		r.out(NewLineCharacter)
+	}
+	r.assetBodyPrinted = true
 }
 
 // hasQueryPacks returns true if the bundle contains any
@@ -307,6 +326,7 @@ func (r *defaultReporter) printAssetSections(orderedAssets []assetMrnName) {
 		}
 
 		r.out(r.Printer.H2("Asset: (" + getPlatformNameForAsset(asset) + ") " + target))
+		r.assetBodyPrinted = false
 
 		errorMsg, ok := r.data.Errors[assetMrn]
 		if ok {
@@ -342,7 +362,6 @@ func (r *defaultReporter) printAssetSections(orderedAssets []assetMrnName) {
 		if r.Conf.printRisks {
 			r.printAssetRisks(resolved, report, assetMrn, asset)
 		}
-		r.out(NewLineCharacter)
 
 		if r.Conf.printVulnerabilities {
 			// TODO: we should re-use the report results
@@ -380,6 +399,7 @@ func (r *defaultReporter) printAssetControls(resolved *policy.ResolvedPolicy, re
 		return scores[i].QrId < scores[j].QrId
 	})
 
+	r.beginAssetSection()
 	r.out("Compliance controls:" + NewLineCharacter)
 
 	for i := range scores {
@@ -393,8 +413,6 @@ func (r *defaultReporter) printAssetControls(resolved *policy.ResolvedPolicy, re
 
 		r.printControl(score, control, resolved, report)
 	}
-
-	r.out(NewLineCharacter)
 }
 
 func (r *defaultReporter) printControl(score *policy.Score, control *policy.Control, resolved *policy.ResolvedPolicy, report *policy.Report) {
@@ -482,9 +500,9 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 		})
 
 		if len(dataQueriesOutput) > 0 {
+			r.beginAssetSection()
 			r.out("Data queries:" + NewLineCharacter)
 			r.out(dataQueriesOutput)
-			r.out(NewLineCharacter)
 		}
 	}
 
@@ -609,25 +627,21 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 			return a > b
 		})
 
-		prevPrinted := false
 		if len(sortedPassed) != 0 {
+			r.beginAssetSection()
 			r.out("Passing:" + NewLineCharacter)
 			for _, mrn := range sortedPassed {
 				r.printCheck(foundChecks[mrn], matchedByMrn[mrn], resolved, report, results, false)
 			}
-			prevPrinted = true
 		}
 
 		if len(sortedWarnings) != 0 {
-			if prevPrinted {
-				r.out(NewLineCharacter)
-			}
+			r.beginAssetSection()
 			// FIXME v12: rename to risk threshold
 			r.out("Warnings (below risk threshold):" + NewLineCharacter)
 			for _, mrn := range sortedWarnings {
 				r.printCheck(foundChecks[mrn], matchedByMrn[mrn], resolved, report, results, false)
 			}
-			prevPrinted = true
 		}
 
 		times := []int{}
@@ -638,9 +652,7 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 		}
 		sort.Ints(times)
 		for i := len(times) - 1; i >= 0; i-- {
-			if prevPrinted {
-				r.out(NewLineCharacter)
-			}
+			r.beginAssetSection()
 
 			unixTime := times[i]
 			deadline := time.Unix(int64(unixTime), 0)
@@ -668,14 +680,10 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 				score.Rating = ps.Rating()
 				r.printCheck(score, matchedByMrn[mrn], resolved, report, results, false)
 			}
-
-			prevPrinted = true
 		}
 
 		if len(sortedExceptions) > 0 {
-			if prevPrinted {
-				r.out(NewLineCharacter)
-			}
+			r.beginAssetSection()
 
 			sort.Slice(sortedExceptions, func(i, j int) bool {
 				return matchedByMrn[sortedExceptions[i]].Title < matchedByMrn[sortedExceptions[j]].Title
@@ -685,13 +693,10 @@ func (r *defaultReporter) printAssetQueries(resolved *policy.ResolvedPolicy, rep
 			for _, mrn := range sortedExceptions {
 				r.printCheck(foundChecks[mrn], matchedByMrn[mrn], resolved, report, results, true)
 			}
-			prevPrinted = true
 		}
 
 		if len(sortedFailed) != 0 {
-			if prevPrinted {
-				r.out(NewLineCharacter)
-			}
+			r.beginAssetSection()
 			if r.RiskThreshold != DEFAULT_RISK_THRESHOLD {
 				r.out("Failures (above risk threshold):" + NewLineCharacter)
 			} else {
@@ -753,7 +758,8 @@ func (r *defaultReporter) printAssetRisks(resolved *policy.ResolvedPolicy, repor
 	}
 	out := res.String()
 
-	r.out(NewLineCharacter + "Risks / Preventive Controls:" + NewLineCharacter)
+	r.beginAssetSection()
+	r.out("Risks / Preventive Controls:" + NewLineCharacter)
 	if out != "" {
 		r.out(out)
 	} else {
@@ -894,6 +900,7 @@ func (r *defaultReporter) printVulns(report *policy.Report, assetMrn string) {
 	if vulnReport == nil {
 		return
 	}
+	r.beginAssetSection()
 	r.out(print.Primary("Vulnerabilities:" + NewLineCharacter))
 
 	score := report.Scores[advisoryPolicyMrn]


### PR DESCRIPTION
## What

When scanning an asset that has **no checks**, the compact reporter left a double blank line between the asset header and the first printed section, producing a large empty gap:

**Before**
```
Asset: (FortiOS) pdx-fortigate-01
---------------------------------


Risks / Preventive Controls:
✓ no downgrading risks detected
```

**After**
```
Asset: (FortiOS) pdx-fortigate-01
---------------------------------

Risks / Preventive Controls:
✓ no downgrading risks detected
```

## Why

The asset header (`H2`) already emits a trailing blank line, and each body section managed its own separators inconsistently — the risks section prepended a newline, an unconditional newline sat before vulnerabilities, and the checks block used a local `prevPrinted` flag. When no checks/data/controls printed, the header's trailing blank and the next section's leading newline stacked into a double gap.

## How

Centralized inter-section spacing into a single `beginAssetSection()` helper. After the header, `assetBodyPrinted` resets to `false`; each section calls `beginAssetSection()` immediately before its first output, which emits one blank line **only if** a previous section already printed. The header's own trailing blank serves as the separator for the first section, so there is always exactly one blank line between the header and the first section, and between any two consecutive sections.

This also removes the ad-hoc `prevPrinted` mechanism in the checks block, unifying all section spacing through the same helper.

## Tests

Added `TestCompactReporterNoChecksSpacing`, which renders a no-checks asset (risks + vulnerabilities, no checks) and asserts a single blank line both after the asset header and between sections. Confirmed it fails on the unpatched reporter and passes with the fix. Full `cli/reporter` test suite passes.

Resolves mondoohq/mql#6390

> Note: the reporter rendering lives in cnspec, so although the issue was filed in `mondoohq/mql`, the fix belongs here.