### PR TITLE
content/querypacks: enrich inventory packs with network context

### DIFF
--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-linux-inventory
     name: Linux Inventory Pack
-    version: 1.8.0
+    version: 1.9.0
     license: BUSL-1.1
     require:
       - provider: os
@@ -150,8 +150,61 @@ packs:
       - uid: mondoo-linux-interface-configuration
         title: Network interface configuration
         docs:
-          desc: Returns detailed network interface configuration for all interfaces.
-        mql: network.interfaces{*}
+          desc: Returns detailed network interface configuration for all interfaces, including MAC address and per-address CIDR and subnet.
+        mql: network.interfaces { name mac vendor mtu flags active virtual ips { ip cidr subnet broadcast gateway } }
+      - uid: mondoo-linux-etc-hosts
+        title: Static host entries
+        docs:
+          desc: Returns the static hostname-to-IP mappings from /etc/hosts.
+        mql: |
+          if (file("/etc/hosts").exists) { file("/etc/hosts").content }
+      - uid: mondoo-linux-resolv-conf
+        title: DNS resolver configuration
+        docs:
+          desc: Returns the contents of /etc/resolv.conf (nameservers and search domains).
+        mql: |
+          if (file("/etc/resolv.conf").exists) { file("/etc/resolv.conf").content }
+      - uid: mondoo-linux-systemd-resolved
+        title: systemd-resolved DNS configuration
+        docs:
+          desc: Returns the systemd-resolved global DNS configuration, including active and fallback servers and search domains.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: systemd.resolved { active dns currentDnsServer fallbackDns domains }
+      - uid: mondoo-linux-cloud-instance
+        title: Cloud instance metadata
+        docs:
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+        mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
+      - uid: mondoo-linux-docker-containers
+        title: Docker containers
+        docs:
+          desc: Lists Docker containers with their image, names, state, labels, and host configuration (including published port bindings).
+        filters: file("/var/run/docker.sock").exists
+        mql: docker.containers { id image imageid command names state status labels hostConfig }
+      - uid: mondoo-linux-iptables-input
+        title: iptables INPUT chain (filter table)
+        docs:
+          desc: Lists the filter-table INPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: iptables.input { lineNumber chain target protocol source destination dport dportRange dports in out packets bytes }
+      - uid: mondoo-linux-iptables-output
+        title: iptables OUTPUT chain (filter table)
+        docs:
+          desc: Lists the filter-table OUTPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: iptables.output { lineNumber chain target protocol source destination dport dportRange dports in out packets bytes }
+      - uid: mondoo-linux-nftables-ruleset
+        title: nftables ruleset
+        docs:
+          desc: Lists nftables chains with their family, table, hook, default policy, and rules. Complements the iptables queries on nftables-native distributions (e.g. RHEL 9+/10, recent Debian/Ubuntu) where the legacy iptables binary is absent. Requires root; returns empty on hosts that do not use nftables or where access is denied.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: nftables.chains { family table name type hook policy isBaseChain rules { handle expr comment } }
+      - uid: mondoo-linux-network-neighbors
+        title: ARP/NDP neighbor cache
+        docs:
+          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with their IP, MAC address, interface, and cache state.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: network.neighbors { ip mac interface state }
       - uid: mondoo-sshd-interface-configuration
         title: sshd configuration
         docs:

--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -173,12 +173,12 @@ packs:
       - uid: mondoo-linux-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-linux-docker-containers
         title: Docker containers
         docs:
-          desc: Lists Docker containers with their image, names, state, labels, and host configuration (including published port bindings).
+          desc: Lists Docker containers with their image, names, state, labels, and host configuration (including published port bindings). Covers the system Docker daemon at the default /var/run/docker.sock; rootless Docker and Podman sockets under $XDG_RUNTIME_DIR are not inspected.
         filters: file("/var/run/docker.sock").exists
         mql: docker.containers { id image imageid command names state status labels hostConfig }
       - uid: mondoo-linux-iptables-input

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -150,7 +150,7 @@ packs:
       - uid: mondoo-macos-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-macos-network-neighbors
         title: ARP/NDP neighbor cache

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-macos-inventory
     name: macOS Inventory Pack
-    version: 1.7.0
+    version: 1.8.0
     license: BUSL-1.1
     require:
       - provider: os
@@ -139,8 +139,25 @@ packs:
       - uid: mondoo-macos-interface-configuration
         title: Network interface configuration
         docs:
-          desc: Returns detailed network interface configuration for all interfaces.
-        mql: network.interfaces{*}
+          desc: Returns detailed network interface configuration for all interfaces, including MAC address and per-address CIDR and subnet.
+        mql: network.interfaces { name mac vendor mtu flags active virtual ips { ip cidr subnet broadcast gateway } }
+      - uid: mondoo-macos-etc-hosts
+        title: Static host entries
+        docs:
+          desc: Returns the static hostname-to-IP mappings from /etc/hosts.
+        mql: |
+          if (file("/etc/hosts").exists) { file("/etc/hosts").content }
+      - uid: mondoo-macos-cloud-instance
+        title: Cloud instance metadata
+        docs:
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+        mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
+      - uid: mondoo-macos-network-neighbors
+        title: ARP/NDP neighbor cache
+        docs:
+          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with their IP, MAC address, interface, and cache state.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: network.neighbors { ip mac interface state }
       - uid: mondoo-macos-sshd-interface-configuration
         title: sshd configuration
         docs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-windows-asset-inventory
     name: Windows Asset Inventory Pack
-    version: 1.8.0
+    version: 1.9.0
     license: BUSL-1.1
     require:
       - provider: os
@@ -144,6 +144,36 @@ packs:
         docs:
           desc: Returns comprehensive Windows computer and OS information.
         mql: windows.computerInfo
+      - uid: mondoo-windows-ad-distinguished-name
+        title: Active Directory distinguished name (OU path)
+        docs:
+          desc: |
+            Returns the computer object's Active Directory distinguished name (DN) as cached by the
+            Group Policy client under
+            HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine. The DN encodes
+            the system's full Organizational Unit path, e.g.
+            "CN=HOST01,OU=Servers,OU=Production,DC=corp,DC=example,DC=com" — so the OU a system lives
+            in can be read straight from it. Returns nothing on workgroup / non-domain-joined hosts.
+            No command execution required (registry read), so it works over WinRM and agent scans.
+        mql: |
+          if (registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine', name: 'Distinguished-Name' ).exists) {
+            registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine', name: 'Distinguished-Name' ).data
+          }
+      - uid: mondoo-windows-organizational-unit
+        title: Active Directory Organizational Unit (OU)
+        docs:
+          desc: |
+            Resolves which Active Directory Organizational Unit the system lives in. It queries the
+            directory for this computer object (via ADSI — no RSAT or AD module required) and parses
+            the OU path out of the returned distinguished name. The result is a record with:
+            DistinguishedName (full DN), OrganizationalUnit (the immediate / most-specific OU the
+            computer sits in), OUPath (the complete OU chain, leaf to root, joined with "/"),
+            Domain, and PartOfDomain. Fields are empty / false on non-domain-joined hosts. This is the
+            authoritative live-directory lookup; the registry-based DN query is the no-command
+            fallback.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: |
+          parse.json(content: powershell("$cn=$env:COMPUTERNAME; $dn=$null; try { $s=[ADSISearcher]('(&(objectCategory=computer)(cn=' + $cn + '))'); $r=$s.FindOne(); if ($r) { $dn=[string]$r.Properties['distinguishedname'][0] } } catch {}; $ous=@(); if ($dn) { $ous=@([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }; $cs=Get-CimInstance Win32_ComputerSystem; [pscustomobject]@{ DistinguishedName=$dn; OrganizationalUnit=$(if ($ous.Count -gt 0) { $ous[0] } else { $null }); OUPath=$(if ($ous.Count -gt 0) { [string]::Join('/', $ous) } else { $null }); Domain=$cs.Domain; PartOfDomain=$cs.PartOfDomain } | ConvertTo-Json -Compress").stdout).params
       - uid: mondoo-windows-security-products
         title: Installed Security Products
         docs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-windows-asset-inventory
     name: Windows Asset Inventory Pack
-    version: 1.9.0
+    version: 1.8.0
     license: BUSL-1.1
     require:
       - provider: os

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -163,17 +163,20 @@ packs:
         title: Active Directory Organizational Unit (OU)
         docs:
           desc: |
-            Resolves which Active Directory Organizational Unit the system lives in. It queries the
-            directory for this computer object (via ADSI — no RSAT or AD module required) and parses
-            the OU path out of the returned distinguished name. The result is a record with:
-            DistinguishedName (full DN), OrganizationalUnit (the immediate / most-specific OU the
-            computer sits in), OUPath (the complete OU chain, leaf to root, joined with "/"),
-            Domain, and PartOfDomain. Fields are empty / false on non-domain-joined hosts. This is the
-            authoritative live-directory lookup; the registry-based DN query is the no-command
-            fallback.
+            Resolves which Active Directory Organizational Unit the system lives in. On domain-joined
+            hosts it queries the directory for this computer object (via ADSI — no RSAT or AD module
+            required) and parses the OU path out of the returned distinguished name. The result is a
+            record with: DistinguishedName (full DN), OrganizationalUnit (the immediate / most-specific
+            OU the computer sits in), OUPath (the complete OU chain, leaf to root, joined with "/"),
+            Domain, PartOfDomain, and Error (the directory-lookup failure message, or null on success).
+            The directory lookup is skipped entirely on workgroup / non-domain-joined hosts, so those
+            fields are empty / false and Error is null there. A non-null Error on a domain-joined host
+            flags a genuine lookup failure (e.g., an unreachable domain controller or query timeout)
+            rather than letting it vanish silently. This is the authoritative live-directory lookup;
+            the registry-based DN query is the no-command fallback.
         filters: mondoo.capabilities.contains("run-command")
         mql: |
-          parse.json(content: powershell("$cn=$env:COMPUTERNAME; $dn=$null; try { $s=[ADSISearcher]('(&(objectCategory=computer)(cn=' + $cn + '))'); $r=$s.FindOne(); if ($r) { $dn=[string]$r.Properties['distinguishedname'][0] } } catch {}; $ous=@(); if ($dn) { $ous=@([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }; $cs=Get-CimInstance Win32_ComputerSystem; [pscustomobject]@{ DistinguishedName=$dn; OrganizationalUnit=$(if ($ous.Count -gt 0) { $ous[0] } else { $null }); OUPath=$(if ($ous.Count -gt 0) { [string]::Join('/', $ous) } else { $null }); Domain=$cs.Domain; PartOfDomain=$cs.PartOfDomain } | ConvertTo-Json -Compress").stdout).params
+          parse.json(content: powershell("$cs=Get-CimInstance Win32_ComputerSystem; $dn=$null; $err=$null; if ($cs.PartOfDomain) { try { $s=[ADSISearcher]('(&(objectCategory=computer)(cn=' + $env:COMPUTERNAME + '))'); $r=$s.FindOne(); if ($r) { $dn=[string]$r.Properties['distinguishedname'][0] } } catch { $err=$_.Exception.Message } }; $ous=@(); if ($dn) { $ous=@([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }; [pscustomobject]@{ DistinguishedName=$dn; OrganizationalUnit=$(if ($ous.Count -gt 0) { $ous[0] } else { $null }); OUPath=$(if ($ous.Count -gt 0) { [string]::Join('/', $ous) } else { $null }); Domain=$cs.Domain; PartOfDomain=$cs.PartOfDomain; Error=$err } | ConvertTo-Json -Compress").stdout).params
       - uid: mondoo-windows-security-products
         title: Installed Security Products
         docs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -113,7 +113,7 @@ packs:
       - uid: mondoo-windows-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-windows-network-neighbors
         title: ARP/NDP neighbor cache
@@ -153,7 +153,10 @@ packs:
             HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine. The DN encodes
             the system's full Organizational Unit path, e.g.
             "CN=HOST01,OU=Servers,OU=Production,DC=corp,DC=example,DC=com" — so the OU a system lives
-            in can be read straight from it. Returns nothing on workgroup / non-domain-joined hosts.
+            in can be read straight from it. Returns nothing on workgroup / non-domain-joined hosts, and
+            also on domain-joined hosts that have not yet completed a machine Group Policy refresh (the
+            Group Policy client populates this value), e.g. right after a domain join — use the
+            mondoo-windows-organizational-unit live lookup as the authoritative source.
             No command execution required (registry read), so it works over WinRM and agent scans.
         mql: |
           if (registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine', name: 'Distinguished-Name' ).exists) {
@@ -169,32 +172,53 @@ packs:
             record with: DistinguishedName (full DN), OrganizationalUnit (the immediate / most-specific
             OU the computer sits in), OUPath (the complete OU chain, leaf to root, joined with "/"),
             Domain, PartOfDomain, and Error (the directory-lookup failure message, or null on success).
-            The directory lookup is skipped entirely on workgroup / non-domain-joined hosts, so those
-            fields are empty / false and Error is null there. A non-null Error on a domain-joined host
-            flags a genuine lookup failure (e.g., an unreachable domain controller or query timeout)
+            The directory lookup is skipped entirely on workgroup / non-domain-joined hosts: there
+            DistinguishedName, OrganizationalUnit, and OUPath are null, PartOfDomain is false, and Error
+            is null, while Domain still reports the host's workgroup name (e.g. "WORKGROUP") — so use
+            PartOfDomain, not a non-empty Domain, to tell domain members from standalone hosts. A non-null
+            Error on a domain-joined host flags a genuine lookup failure — an unreachable domain controller,
+            a query timeout, a WMI/CIM error, or the computer object simply not being found in the directory —
             rather than letting it vanish silently. This is the authoritative live-directory lookup;
             the registry-based DN query is the no-command fallback.
         filters: mondoo.capabilities.contains("run-command")
         mql: |
           parse.json(content: powershell("
-            $cs = Get-CimInstance Win32_ComputerSystem
             $dn = $null
             $err = $null
-            if ($cs.PartOfDomain) {
-              try {
-                # Escape LDAP filter metacharacters (RFC 4515) in the host name; $bs is a literal backslash.
-                $bs = [char]92
+            $cs = $null
+            $bs = [string][char]92
+            try {
+              # -ErrorAction Stop routes a WMI/CIM failure into the catch (and thus into Error) instead
+              # of leaving $cs null, which would make a domain-joined host look like a healthy workgroup
+              # host (PartOfDomain false, Error null).
+              $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop
+              if ($cs.PartOfDomain) {
+                # $env:COMPUTERNAME is spliced into single-quoted PowerShell string literals below, so
+                # PowerShell never re-interprets a '$' (or any other char) in its value; only the LDAP
+                # filter syntax needs sanitizing. A domain-joined host always has this variable set, but
+                # guard the empty case so it surfaces a clear error instead of a meaningless '(cn=)' filter.
                 $name = $env:COMPUTERNAME
-                $name = $name.Replace($bs, $bs + '5c').Replace('(', $bs + '28').Replace(')', $bs + '29').Replace('*', $bs + '2a')
+                if ([string]::IsNullOrEmpty($name)) { throw 'COMPUTERNAME is empty; cannot resolve the AD computer object' }
+                # Escape the RFC 4515 filter metacharacters (backslash, open/close paren, asterisk, NUL).
+                # $bs (above) is a single-character backslash STRING (built from [char]92 so no literal
+                # backslash appears in this double-quoted MQL string); using string operands keeps every
+                # .Replace() bound to the (string, string) overload. Backslash is replaced first so the
+                # escapes introduced below are not themselves re-escaped.
+                $name = $name.Replace($bs, $bs + '5c').Replace('(', $bs + '28').Replace(')', $bs + '29').Replace('*', $bs + '2a').Replace([string][char]0, $bs + '00')
                 $s = [ADSISearcher]('(&(objectCategory=computer)(|(cn=' + $name + ')(sAMAccountName=' + $name + '$)))')
                 $r = $s.FindOne()
-                if ($r) { $dn = [string]$r.Properties['distinguishedname'][0] }
-              } catch {
-                $err = $_.Exception.Message
+                # FindOne() returns $null (not an exception) when the directory has no matching object;
+                # record that as an error so the documented 'non-null Error == genuine failure' contract holds.
+                if ($r) { $dn = [string]$r.Properties['distinguishedname'][0] } else { $err = 'computer object not found in directory' }
               }
+            } catch {
+              $err = $_.Exception.Message
             }
             $ous = @()
-            if ($dn) { $ous = @([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }
+            # AD returns the DN in RFC 4514 form, where a comma inside an OU name is escaped with a leading
+            # backslash. Match OU values honoring that escaping (the regex is built from $bs so no literal
+            # backslash appears in this MQL string), then strip the escaping backslash for a readable name.
+            if ($dn) { $ous = @([regex]::Matches($dn, 'OU=((?:[^,' + $bs + $bs + ']|' + $bs + $bs + '.)+)') | ForEach-Object { $_.Groups[1].Value -replace ($bs + $bs + '(.)'), '$1' }) }
             [pscustomobject]@{
               DistinguishedName = $dn
               OrganizationalUnit = $(if ($ous.Count -gt 0) { $ous[0] } else { $null })

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -176,7 +176,30 @@ packs:
             the registry-based DN query is the no-command fallback.
         filters: mondoo.capabilities.contains("run-command")
         mql: |
-          parse.json(content: powershell("$cs=Get-CimInstance Win32_ComputerSystem; $dn=$null; $err=$null; if ($cs.PartOfDomain) { try { $s=[ADSISearcher]('(&(objectCategory=computer)(cn=' + $env:COMPUTERNAME + '))'); $r=$s.FindOne(); if ($r) { $dn=[string]$r.Properties['distinguishedname'][0] } } catch { $err=$_.Exception.Message } }; $ous=@(); if ($dn) { $ous=@([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }; [pscustomobject]@{ DistinguishedName=$dn; OrganizationalUnit=$(if ($ous.Count -gt 0) { $ous[0] } else { $null }); OUPath=$(if ($ous.Count -gt 0) { [string]::Join('/', $ous) } else { $null }); Domain=$cs.Domain; PartOfDomain=$cs.PartOfDomain; Error=$err } | ConvertTo-Json -Compress").stdout).params
+          parse.json(content: powershell("
+            $cs = Get-CimInstance Win32_ComputerSystem
+            $dn = $null
+            $err = $null
+            if ($cs.PartOfDomain) {
+              try {
+                $s = [ADSISearcher]('(&(objectCategory=computer)(cn=' + $env:COMPUTERNAME + '))')
+                $r = $s.FindOne()
+                if ($r) { $dn = [string]$r.Properties['distinguishedname'][0] }
+              } catch {
+                $err = $_.Exception.Message
+              }
+            }
+            $ous = @()
+            if ($dn) { $ous = @([regex]::Matches($dn, 'OU=([^,]+)') | ForEach-Object { $_.Groups[1].Value }) }
+            [pscustomobject]@{
+              DistinguishedName = $dn
+              OrganizationalUnit = $(if ($ous.Count -gt 0) { $ous[0] } else { $null })
+              OUPath = $(if ($ous.Count -gt 0) { [string]::Join('/', $ous) } else { $null })
+              Domain = $cs.Domain
+              PartOfDomain = $cs.PartOfDomain
+              Error = $err
+            } | ConvertTo-Json -Compress
+          ").stdout).params
       - uid: mondoo-windows-security-products
         title: Installed Security Products
         docs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -182,7 +182,11 @@ packs:
             $err = $null
             if ($cs.PartOfDomain) {
               try {
-                $s = [ADSISearcher]('(&(objectCategory=computer)(|(cn=' + $env:COMPUTERNAME + ')(sAMAccountName=' + $env:COMPUTERNAME + '$)))')
+                # Escape LDAP filter metacharacters (RFC 4515) in the host name; $bs is a literal backslash.
+                $bs = [char]92
+                $name = $env:COMPUTERNAME
+                $name = $name.Replace($bs, $bs + '5c').Replace('(', $bs + '28').Replace(')', $bs + '29').Replace('*', $bs + '2a')
+                $s = [ADSISearcher]('(&(objectCategory=computer)(|(cn=' + $name + ')(sAMAccountName=' + $name + '$)))')
                 $r = $s.FindOne()
                 if ($r) { $dn = [string]$r.Properties['distinguishedname'][0] }
               } catch {

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-windows-asset-inventory
     name: Windows Asset Inventory Pack
-    version: 1.7.0
+    version: 1.8.0
     license: BUSL-1.1
     require:
       - provider: os
@@ -102,8 +102,43 @@ packs:
       - uid: mondoo-windows-interface-configuration
         title: Network interfaces
         docs:
-          desc: Returns detailed network interface configuration for all interfaces.
-        mql: network.interfaces{*}
+          desc: Returns detailed network interface configuration for all interfaces, including MAC address and per-address CIDR and subnet.
+        mql: network.interfaces { name mac vendor mtu flags active virtual ips { ip cidr subnet broadcast gateway } }
+      - uid: mondoo-windows-etc-hosts
+        title: Static host entries
+        docs:
+          desc: Returns the static hostname-to-IP mappings from the Windows hosts file.
+        mql: |
+          if (file("C:\\Windows\\System32\\drivers\\etc\\hosts").exists) { file("C:\\Windows\\System32\\drivers\\etc\\hosts").content }
+      - uid: mondoo-windows-cloud-instance
+        title: Cloud instance metadata
+        docs:
+          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. Returns an unknown provider on non-cloud hosts.
+        mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
+      - uid: mondoo-windows-network-neighbors
+        title: ARP/NDP neighbor cache
+        docs:
+          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with their IP, MAC address, interface, and cache state.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: network.neighbors { ip mac interface state }
+      - uid: mondoo-windows-smb-shares
+        title: SMB shares
+        docs:
+          desc: Lists SMB shares published by the host with their local path, scope, and share type.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: windows.smb.shares { name path description scopeName shareType }
+      - uid: mondoo-windows-smb-sessions
+        title: SMB sessions
+        docs:
+          desc: Lists active inbound SMB sessions with the client computer, user, negotiated dialect, and open-file count. Requires administrative privileges; returns data only on hosts serving SMB.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: windows.smb.sessions { clientComputerName clientUserName dialect numOpens }
+      - uid: mondoo-windows-smb-connections
+        title: SMB connections
+        docs:
+          desc: Lists outbound SMB connections from this host with the server name, share, user, and negotiated dialect.
+        filters: mondoo.capabilities.contains("run-command")
+        mql: windows.smb.connections { serverName shareName userName dialect }
       - uid: mondoo-windows-computer-info
         title: Windows Computer/ System information
         docs:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -182,7 +182,7 @@ packs:
             $err = $null
             if ($cs.PartOfDomain) {
               try {
-                $s = [ADSISearcher]('(&(objectCategory=computer)(cn=' + $env:COMPUTERNAME + '))')
+                $s = [ADSISearcher]('(&(objectCategory=computer)(|(cn=' + $env:COMPUTERNAME + ')(sAMAccountName=' + $env:COMPUTERNAME + '$)))')
                 $r = $s.FindOne()
                 if ($r) { $dn = [string]$r.Properties['distinguishedname'][0] }
               } catch {


### PR DESCRIPTION
Add network-context data queries to the default Linux/Windows/macOS inventory packs to improve asset fidelity and grouping signals:

- Interface configuration now emits per-address cidr/subnet/broadcast/ gateway and the interface MAC (replacing network.interfaces{*}, which rendered only the bare ip).
- New queries: /etc/hosts, /etc/resolv.conf, systemd-resolved DNS config, cloud instance metadata (IMDS, incl. the account/region metadata dict), docker containers (socket-gated), iptables INPUT/OUTPUT (filter table), and an nftables ruleset query for nft-native distros where the legacy iptables binary is absent.
- network.neighbors (ARP/NDP cache) on all three packs and windows.smb.{shares,sessions,connections} on Windows.

Version bumps: linux 1.8.0 -> 1.9.0, windows 1.7.0 -> 1.8.0, macos 1.7.0 -> 1.8.0.

NOTE: the network.neighbors and windows.smb.* queries depend on new os-provider resources and will not lint/run until that mql change is released and the go.mondoo.com/mql/v13 dependency is bumped; the remaining queries use existing resources. Verified live on EC2 RHEL 10 (SSH) and Windows Server 2022 (SSH/PowerShell).


**DONT MERGE THIS UNTIL** https://github.com/mondoohq/mql/pull/8444 is released!