### PR TITLE
feat: add runtime image cache content

### DIFF
--- a/content/bundles_test.go
+++ b/content/bundles_test.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
 )
 
 func init() {
@@ -138,6 +139,99 @@ func runBundle(policyBundlePath string, policyMrn string, asset *inventory.Asset
 	}
 
 	return nil, errors.New("no report found")
+}
+
+func TestRuntimeImageCacheContent(t *testing.T) {
+	runtime := runtimeImageCacheRuntime(t)
+	loader := policy.DefaultBundleLoader()
+
+	t.Run("policy compiles runtime cache controls", func(t *testing.T) {
+		bundle, err := loader.BundleFromPaths("./mondoo-kubernetes-runtime-image-cache.mql.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, bundle)
+		require.Len(t, bundle.Policies, 1)
+		require.Len(t, bundle.Queries, 5)
+
+		p := bundle.Policies[0]
+		assert.Equal(t, "mondoo-kubernetes-runtime-image-cache", p.Uid)
+		require.Len(t, p.Groups, 1)
+
+		checks := map[string]bool{}
+		for _, check := range p.Groups[0].Checks {
+			checks[check.Uid] = true
+		}
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-delegates-ready"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-delegates-no-pull"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-matched"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"])
+
+		queries := map[string]string{}
+		for _, query := range bundle.Queries {
+			queries[query.Uid] = query.Mql
+		}
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-delegates-ready"], `endpoint != ""`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `initContainerStatuses.all`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `k8s.pods.where(phase == "Running")`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `ephemeralContainerStatuses.all`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `runtimeImage.scanStatus == "scanned"`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `initContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `containerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `ephemeralContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `initContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `k8s.pods.where(phase == "Running")`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `ephemeralContainerStatuses.where`)
+
+		compiled, err := bundle.Compile(context.Background(), runtime.Schema(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, compiled)
+	})
+
+	t.Run("inventory querypack compiles runtime cache queries", func(t *testing.T) {
+		bundle, err := loader.BundleFromPaths("./querypacks/mondoo-kubernetes-inventory.mql.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, bundle)
+		require.Len(t, bundle.Packs, 1)
+
+		queries := map[string]string{}
+		for _, group := range bundle.Packs[0].Groups {
+			for _, query := range group.Queries {
+				queries[query.Uid] = query.Mql
+			}
+		}
+		assert.Contains(t, queries, "k8s-runtime-cache-delegates")
+		assert.Contains(t, queries, "k8s-runtime-cache-images")
+		assert.Contains(t, queries, "k8s-runtime-cache-pod-image-coverage")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "initContainerStatuses")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "containerStatuses")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "ephemeralContainerStatuses")
+
+		bundle.ConvertQuerypacks()
+		compiled, err := bundle.Compile(context.Background(), runtime.Schema(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, compiled)
+	})
+}
+
+func runtimeImageCacheRuntime(t *testing.T) *providers.Runtime {
+	t.Helper()
+
+	runtime := providers.DefaultRuntime()
+	schema, ok := runtime.Schema().(providers.ExtensibleSchema)
+	require.True(t, ok, "provider runtime schema must support adding source schemas")
+	schema.Add("core", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "core", "./testdata/schema/providers/core/resources/core.lr")}))
+	schema.Add("network", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "network", "./testdata/schema/providers/network/resources/network.lr")}))
+	schema.Add("os", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "os", "./testdata/schema/providers/os/resources/os.lr")}))
+	schema.Add("k8s", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "k8s", "./testdata/schema/providers/k8s/resources/k8s.lr")}))
+	return runtime
+}
+
+func runtimeImageCacheSchemaPath(t *testing.T, provider, path string) string {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	require.NoErrorf(t, err, "in-repo schema fixture must point to a readable %s schema file", provider)
+	return path
 }
 
 func TestBundles(t *testing.T) {

--- a/content/mondoo-kubernetes-runtime-image-cache.mql.yaml
+++ b/content/mondoo-kubernetes-runtime-image-cache.mql.yaml
@@ -1,0 +1,334 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+policies:
+  - uid: mondoo-kubernetes-runtime-image-cache
+    name: Mondoo Kubernetes Runtime Image Cache
+    version: 0.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: kubernetes
+    require:
+      - provider: k8s
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Validate node-local Kubernetes image cache scan coverage
+    docs:
+      desc: |
+        The Mondoo Kubernetes Runtime Image Cache policy validates node-local image scan coverage for Kubernetes clusters. It uses runtime image evidence collected from the node runtime cache, so protected registry images can be inspected without reading image pull secrets or pulling images again.
+
+        This policy focuses on visibility and scanner health:
+
+        - Runtime delegates are available on schedulable nodes.
+        - Runtime delegates operate in read-only, no-pull mode.
+        - Running pod container images map to node-local runtime image evidence.
+        - Matched pod images have completed runtime-cache scans.
+        - Matched pod images include immutable image identity for reliable deduplication and reporting.
+
+        Learn more about scanning Kubernetes in the [cnspec Kubernetes documentation](https://mondoo.com/docs/cnspec/cloud/kubernetes).
+    groups:
+      - title: Runtime Image Cache
+        filters: asset.platform == "k8s-cluster"
+        checks:
+          - uid: mondoo-kubernetes-runtime-image-cache-delegates-ready
+          - uid: mondoo-kubernetes-runtime-image-cache-delegates-no-pull
+          - uid: mondoo-kubernetes-runtime-image-cache-pod-images-matched
+          - uid: mondoo-kubernetes-runtime-image-cache-pod-images-scanned
+          - uid: mondoo-kubernetes-runtime-image-cache-pod-images-immutable
+    scoring_system: highest impact
+
+queries:
+  - uid: mondoo-kubernetes-runtime-image-cache-delegates-ready
+    title: Runtime cache scanning should be available on every schedulable node
+    impact: 60
+    mql: |
+      k8s.nodes.where(unschedulable == false).all(runtimeDelegates.any(status == "ready" && endpoint != ""))
+    docs:
+      desc: |
+        This check ensures that every schedulable Kubernetes node reports at least one ready runtime delegate. Runtime delegates provide read-only access to images already present in the node runtime cache, allowing cnspec to scan the images that workloads actually use without requiring registry credentials.
+
+        **Why this matters**
+
+        - **Node coverage:** Schedulable nodes without ready delegates can miss node-local image cache scan coverage.
+        - **Protected registries:** Runtime-cache scanning avoids reading image pull secrets and does not pull images from registries.
+        - **Operational signal:** Missing delegates identify scanner scheduling or runtime socket access gaps before workload images go unscanned.
+      audit: |
+        ### Audit via kubectl
+
+        1. List schedulable nodes:
+
+           ```bash
+           kubectl get nodes --field-selector spec.unschedulable!=true
+           ```
+
+        2. Confirm that the runtime-cache scanner DaemonSet has one ready pod per schedulable node:
+
+           ```bash
+           kubectl get daemonset -n <mondoo-namespace> <auditconfig-name>-runtime-cache-scan
+           kubectl get pods -n <mondoo-namespace> -l scan=runtime-cache -o wide
+           ```
+
+        A passing cluster has a ready runtime-cache scanner pod on every schedulable node. A failing cluster has schedulable nodes without a ready scanner pod or scanner pods that cannot access the configured runtime socket.
+      remediation:
+        - id: kubectl
+          desc: |
+            To enable runtime-cache scanning using kubectl:
+
+            1. Enable `spec.containers.runtimeCache`.
+            2. Configure at least one runtime delegate with the host runtime socket path.
+            3. Verify node selectors and tolerations allow the DaemonSet to run on every schedulable worker node.
+
+            ```bash
+            kubectl patch mondooauditconfig <name> -n <mondoo-namespace> --type merge -p '{"spec":{"containers":{"runtimeCache":{"enable":true,"delegates":[{"name":"containerd-cri","kind":"containerd","hostPath":"/run/containerd/containerd.sock"}]}}}}'
+            ```
+        - id: manifest
+          desc: |
+            To enable runtime-cache scanning in a MondooAuditConfig manifest:
+
+            ```yaml
+            spec:
+              containers:
+                runtimeCache:
+                  enable: true
+                  delegates:
+                    - name: containerd-cri
+                      kind: containerd
+                      hostPath: /run/containerd/containerd.sock
+                      namespaces:
+                        - k8s.io
+            ```
+        - id: helm
+          desc: |
+            To manage runtime-cache scanning through Helm, render the `MondooAuditConfig` runtime-cache fields from chart values and keep node selectors, tolerations, and delegate socket paths aligned with the worker node runtime configuration.
+    refs:
+      - url: https://mondoo.com/docs/cnspec/cloud/kubernetes
+        title: Mondoo Kubernetes scanning
+  - uid: mondoo-kubernetes-runtime-image-cache-delegates-no-pull
+    title: Runtime cache delegates should run read-only and must not pull images
+    impact: 80
+    mql: |
+      k8s.nodes.where(unschedulable == false).all(runtimeDelegates.all(readonly == true && allowPull == false))
+    docs:
+      desc: |
+        This check ensures that runtime-cache delegates are configured for read-only cache inspection and cannot pull images from registries. Runtime-cache scanning should reuse images that already exist on the node, preserving protected-registry boundaries and avoiding duplicate image transfer.
+
+        **Why this matters**
+
+        - **No credential expansion:** No-pull delegates avoid registry credentials and preserve protected-registry boundaries.
+        - **Actual runtime evidence:** Read-only delegates inspect images already present on the node instead of fetching a different copy.
+        - **Lower resource use:** Preventing pulls avoids duplicate network transfer and storage pressure during cluster scans.
+      audit: |
+        ### Audit via kubectl
+
+        1. Inspect the runtime-cache inventory ConfigMap and delegate configuration:
+
+           ```bash
+           kubectl get configmap -n <mondoo-namespace> <auditconfig-name>-runtime-cache-inventory -o yaml
+           ```
+
+        2. Confirm that runtime-cache scanner pods do not mount registry credential volumes or set `DOCKER_CONFIG`:
+
+           ```bash
+           kubectl get daemonset -n <mondoo-namespace> <auditconfig-name>-runtime-cache-scan -o yaml
+           ```
+
+        A passing configuration keeps delegates read-only, does not allow runtime-cache pulls, and does not mount registry credentials into runtime-cache scanner pods. A failing configuration grants write or pull behavior to the node-local scanner.
+      remediation:
+        - id: kubectl
+          desc: |
+            To enforce no-pull runtime-cache scanning using kubectl:
+
+            1. Set `allowPull` to `false` or omit it so the operator applies the no-pull default.
+            2. Remove registry credential mounts from runtime-cache scanner pods.
+            3. Use separate registry scanning only when explicit registry pulls are required.
+
+            ```bash
+            kubectl patch mondooauditconfig <name> -n <mondoo-namespace> --type merge -p '{"spec":{"containers":{"runtimeCache":{"allowPull":false}}}}'
+            ```
+        - id: manifest
+          desc: |
+            To keep runtime-cache delegates no-pull in source control:
+
+            ```yaml
+            spec:
+              containers:
+                runtimeCache:
+                  enable: true
+                  allowPull: false
+                  delegates:
+                    - name: containerd-cri
+                      kind: containerd
+                      hostPath: /run/containerd/containerd.sock
+                      readOnly: true
+            ```
+        - id: helm
+          desc: |
+            To manage no-pull behavior through Helm, render `allowPull: false` and read-only delegate settings into the `MondooAuditConfig` values used for runtime-cache scanning.
+    refs:
+      - url: https://mondoo.com/docs/cnspec/cloud/kubernetes
+        title: Mondoo Kubernetes scanning
+  - uid: mondoo-kubernetes-runtime-image-cache-pod-images-matched
+    title: Running pod images should map to node-local runtime image evidence
+    impact: 70
+    mql: |
+      k8s.pods.where(phase == "Running").all(initContainerStatuses.all(runtimeImageStatus == "matched") && containerStatuses.all(runtimeImageStatus == "matched") && ephemeralContainerStatuses.all(runtimeImageStatus == "matched"))
+    docs:
+      desc: |
+        This check ensures that every observed pod container status can be matched to node-local runtime image evidence. A matched status means cnspec can relate the workload image reference and container runtime ID to the cached image metadata that the runtime-cache scanner uses.
+
+        **Why this matters**
+
+        - **Workload visibility:** Missing runtime image matches create blind spots in workload image reporting.
+        - **Runtime alignment:** Match failures can show that evidence was collected from a different node than the running workload.
+        - **Troubleshooting signal:** Unmatched statuses highlight runtime access, pod lifecycle, or cache-retention gaps.
+      audit: |
+        ### Audit via kubectl
+
+        1. List running pods and the nodes that host them:
+
+           ```bash
+           kubectl get pods -A --field-selector status.phase=Running -o wide
+           ```
+
+        2. Inspect pod container statuses and confirm that each running, init, and ephemeral container has an `imageID` and `containerID`:
+
+           ```bash
+           kubectl get pod -n <namespace> <pod> -o jsonpath='{range .status.initContainerStatuses[*]}{.name}{" imageID="}{.imageID}{" containerID="}{.containerID}{"\n"}{end}{range .status.containerStatuses[*]}{.name}{" imageID="}{.imageID}{" containerID="}{.containerID}{"\n"}{end}{range .status.ephemeralContainerStatuses[*]}{.name}{" imageID="}{.imageID}{" containerID="}{.containerID}{"\n"}{end}'
+           ```
+
+        3. Confirm that the runtime-cache scanner pod is ready on the same node as the workload:
+
+           ```bash
+           kubectl get pods -n <mondoo-namespace> -l scan=runtime-cache -o wide
+           ```
+
+        A passing workload is running on a node with a ready runtime-cache scanner pod and has populated container runtime status fields. A failing workload is missing runtime status fields or runs on a node without scanner coverage.
+      remediation:
+        - id: kubectl
+          desc: |
+            To restore pod image matching using kubectl:
+
+            1. Confirm the workload is scheduled and running.
+            2. Restart or reconcile the runtime-cache scanner DaemonSet on the workload node.
+            3. Review runtime socket path, node selector, and toleration settings if the scanner pod is absent from that node.
+
+            ```bash
+            kubectl rollout restart daemonset -n <mondoo-namespace> <auditconfig-name>-runtime-cache-scan
+            kubectl get pods -n <mondoo-namespace> -l scan=runtime-cache -o wide
+            ```
+        - id: manifest
+          desc: |
+            To keep runtime-cache scanner scheduling aligned in manifests, configure node selectors and tolerations so scanner pods run wherever workloads that need image coverage can be scheduled.
+        - id: helm
+          desc: |
+            To manage runtime-cache coverage through Helm, expose values for runtime-cache node selectors, tolerations, and delegate socket paths and apply them consistently across all worker node pools.
+    refs:
+      - url: https://mondoo.com/docs/cnspec/cloud/kubernetes
+        title: Mondoo Kubernetes scanning
+  - uid: mondoo-kubernetes-runtime-image-cache-pod-images-scanned
+    title: Matched pod images should have completed runtime-cache scans
+    impact: 80
+    mql: |
+      k8s.pods.where(phase == "Running").all(initContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.scanStatus == "scanned") && containerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.scanStatus == "scanned") && ephemeralContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.scanStatus == "scanned"))
+    docs:
+      desc: |
+        This check ensures that every matched runtime-cache image for running pods has a completed scan result. Matching a pod status to node-local runtime evidence is not enough on its own: the cache entry can still be pending, failed, permission denied, or otherwise unavailable for vulnerability and policy evaluation.
+
+        **Why this matters**
+
+        - **Shared evidence:** Runtime-cache scanning deduplicates by immutable image identity, so many pods can share one scan result.
+        - **Complete risk visibility:** A matched cache entry that never reaches `scanned` leaves every workload using that image without completed image assessment.
+        - **Failure isolation:** Pending, failed, or denied scan states point operators to runtime socket, permission, or resource-limit issues.
+      audit: |
+        ### Audit via kubectl
+
+        1. List running pods and runtime-cache scanner pods:
+
+           ```bash
+           kubectl get pods -A --field-selector status.phase=Running -o wide
+           kubectl get pods -n <mondoo-namespace> -l scan=runtime-cache -o wide
+           ```
+
+        2. Inspect scanner pod logs for cache scan failures, permission errors, or pending runtime socket access:
+
+           ```bash
+           kubectl logs -n <mondoo-namespace> -l scan=runtime-cache --tail=200
+           ```
+
+        A passing workload maps to runtime image evidence whose scan status is `scanned`. A failing workload maps to an image whose scan status is pending, failed, denied, or absent.
+      remediation:
+        - id: kubectl
+          desc: |
+            To restore runtime-cache scan coverage using kubectl:
+
+            1. Check runtime-cache scanner logs for the affected image digest or runtime image ID.
+            2. Fix runtime socket permissions, delegate configuration, or scanner resource limits.
+            3. Reconcile or restart the runtime-cache scanner so the image can be scanned again.
+
+            ```bash
+            kubectl rollout restart daemonset -n <mondoo-namespace> <auditconfig-name>-runtime-cache-scan
+            kubectl logs -n <mondoo-namespace> -l scan=runtime-cache --tail=200
+            ```
+        - id: manifest
+          desc: |
+            In source-controlled manifests, keep runtime-cache delegate socket paths, read-only mounts, and resource limits aligned with the node runtime. Use node-targeted scanner sets when smaller control-plane nodes and larger worker nodes need different scanner sizing.
+        - id: helm
+          desc: |
+            In Helm-managed deployments, update runtime-cache scanner values for delegate socket access, tolerations, node selectors, and resource limits, then redeploy the Mondoo operator chart.
+    refs:
+      - url: https://mondoo.com/docs/cnspec/cloud/kubernetes
+        title: Mondoo Kubernetes scanning
+  - uid: mondoo-kubernetes-runtime-image-cache-pod-images-immutable
+    title: Matched pod images should include immutable image identity
+    impact: 60
+    mql: |
+      k8s.pods.where(phase == "Running").all(initContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != "") && containerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != "") && ephemeralContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != ""))
+    docs:
+      desc: |
+        This check ensures that matched runtime images include an immutable digest or runtime image ID. Immutable identity lets Mondoo deduplicate image findings across workloads and verify that the scanned cache entry maps to the image actually running on the node.
+
+        **Why this matters**
+
+        - **Stable identity:** Tags are mutable and can point to different image contents over time.
+        - **Finding deduplication:** Digests and runtime image IDs let Mondoo deduplicate image findings across workloads.
+        - **Private-registry clarity:** Immutable identity prevents ambiguity when the same tag is reused across deployments or protected registries.
+      audit: |
+        ### Audit via kubectl
+
+        1. Inspect container image IDs for running pods:
+
+           ```bash
+           kubectl get pod -n <namespace> <pod> -o jsonpath='{range .status.initContainerStatuses[*]}{.name}{" image="}{.image}{" imageID="}{.imageID}{"\n"}{end}{range .status.containerStatuses[*]}{.name}{" image="}{.image}{" imageID="}{.imageID}{"\n"}{end}{range .status.ephemeralContainerStatuses[*]}{.name}{" image="}{.image}{" imageID="}{.imageID}{"\n"}{end}'
+           ```
+
+        2. Confirm that each running container has an immutable image identity, such as a `sha256:` digest in `imageID`, and prefer workload specs that pin images by digest.
+
+        A passing workload exposes immutable runtime image identity for every matched container. A failing workload only exposes mutable tags or has empty image identity fields.
+      remediation:
+        - id: kubectl
+          desc: |
+            To deploy an image by digest using kubectl:
+
+            ```bash
+            kubectl set image deployment/<deployment> <container>=registry.example.com/team/app@sha256:<digest> -n <namespace>
+            ```
+        - id: manifest
+          desc: |
+            To pin workload images by digest in Kubernetes YAML:
+
+            ```yaml
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: registry.example.com/team/app@sha256:<digest>
+            ```
+        - id: helm
+          desc: |
+            To manage immutable image identity through Helm, split image repository and digest values in the chart and render workload image references with `@sha256:<digest>` for runtime-cache scanned workloads.
+    refs:
+      - url: https://kubernetes.io/docs/concepts/containers/images/#image-names
+        title: Kubernetes image names

--- a/content/mondoo-kubernetes-runtime-image-cache.mql.yaml
+++ b/content/mondoo-kubernetes-runtime-image-cache.mql.yaml
@@ -284,7 +284,7 @@ queries:
     title: Matched pod images should include immutable image identity
     impact: 60
     mql: |
-      k8s.pods.where(phase == "Running").all(initContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != "") && containerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != "") && ephemeralContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != "" || runtimeImage.imageId != ""))
+      k8s.pods.where(phase == "Running").all(initContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != empty || runtimeImage.imageId != empty) && containerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != empty || runtimeImage.imageId != empty) && ephemeralContainerStatuses.where(runtimeImageStatus == "matched").all(runtimeImage.resolvedDigest != empty || runtimeImage.imageId != empty))
     docs:
       desc: |
         This check ensures that matched runtime images include an immutable digest or runtime image ID. Immutable identity lets Mondoo deduplicate image findings across workloads and verify that the scanned cache entry maps to the image actually running on the node.

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -111,6 +111,139 @@ packs:
                   protocols
                 }
               }
+          - uid: k8s-runtime-cache-delegates
+            title: Runtime cache delegates
+            docs:
+              desc: Lists node-local runtime delegates that cnspec can use to inspect cached images without pulling from registries.
+            mql: |
+              k8s.nodes {
+                name
+                runtimeDelegates {
+                  id
+                  kind
+                  endpoint
+                  priority
+                  nodeName
+                  namespaces
+                  snapshotters
+                  readonly
+                  allowPull
+                  status
+                  statusMessage
+                  lastChecked
+                }
+              }
+          - uid: k8s-runtime-cache-images
+            title: Runtime cached images
+            docs:
+              desc: Lists images present in each node runtime cache, including immutable identity, use status, scan status, and layer cache evidence.
+            mql: |
+              k8s.nodes {
+                name
+                runtimeImages {
+                  id
+                  nodeName
+                  delegateId
+                  runtimeKind
+                  imageId
+                  repoTags
+                  repoDigests
+                  resolvedDigest
+                  chainId
+                  targetDigest
+                  mediaType
+                  platform
+                  sizeBytes
+                  created
+                  labels
+                  namespaces
+                  inUse
+                  containers
+                  scanStatus
+                  scanStatusMessage
+                  layers {
+                    digest
+                    diffId
+                    sizeBytes
+                    mediaType
+                    annotations
+                    cachePresent
+                  }
+                }
+              }
+          - uid: k8s-runtime-cache-pod-image-coverage
+            title: Pod runtime image coverage
+            docs:
+              desc: Maps running pod container statuses to their node-local runtime image evidence and skipped or pending scan reasons.
+            mql: |
+              k8s.pods {
+                namespace
+                name
+                nodeName
+                initContainerStatuses {
+                  name
+                  image
+                  imageId
+                  containerId
+                  runtimeImageStatus
+                  runtimeImage {
+                    id
+                    nodeName
+                    delegateId
+                    runtimeKind
+                    imageId
+                    repoTags
+                    repoDigests
+                    resolvedDigest
+                    inUse
+                    containers
+                    scanStatus
+                    scanStatusMessage
+                  }
+                }
+                containerStatuses {
+                  name
+                  image
+                  imageId
+                  containerId
+                  runtimeImageStatus
+                  runtimeImage {
+                    id
+                    nodeName
+                    delegateId
+                    runtimeKind
+                    imageId
+                    repoTags
+                    repoDigests
+                    resolvedDigest
+                    inUse
+                    containers
+                    scanStatus
+                    scanStatusMessage
+                  }
+                }
+                ephemeralContainerStatuses {
+                  name
+                  image
+                  imageId
+                  containerId
+                  runtimeImageStatus
+                  runtimeImage {
+                    id
+                    nodeName
+                    delegateId
+                    runtimeKind
+                    imageId
+                    repoTags
+                    repoDigests
+                    resolvedDigest
+                    inUse
+                    containers
+                    scanStatus
+                    scanStatusMessage
+                  }
+                }
+              }
           - uid: k8s-cluster-clusterroles
             title: Cluster RBAC ClusterRoles
             docs:

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -145,6 +145,40 @@ packs:
                   imageId
                 }
               }
+          - uid: k8s-runtime-cache-delegates
+            title: Runtime cache delegates
+            docs:
+              desc: Lists node-local runtime delegates used to inspect cached images.
+            mql: |
+              k8s.nodes {
+                name
+                runtimeDelegates { id kind endpoint priority nodeName namespaces snapshotters readonly allowPull status statusMessage lastChecked }
+              }
+          - uid: k8s-runtime-cache-images
+            title: Runtime cached images
+            docs:
+              desc: Lists images present in each node runtime cache and their scan evidence.
+            mql: |
+              k8s.nodes {
+                name
+                runtimeImages {
+                  id nodeName delegateId runtimeKind imageId repoTags repoDigests resolvedDigest
+                  chainId targetDigest mediaType platform sizeBytes created labels namespaces inUse containers
+                  scanStatus scanStatusMessage
+                  layers { digest diffId sizeBytes mediaType annotations cachePresent }
+                }
+              }
+          - uid: k8s-runtime-cache-pod-image-coverage
+            title: Pod runtime image coverage
+            docs:
+              desc: Maps pod container statuses to node-local runtime image evidence.
+            mql: |
+              k8s.pods {
+                namespace name nodeName
+                initContainerStatuses { name image imageId containerId runtimeImageStatus runtimeImage { id nodeName delegateId runtimeKind imageId repoTags repoDigests resolvedDigest inUse containers scanStatus scanStatusMessage } }
+                containerStatuses { name image imageId containerId runtimeImageStatus runtimeImage { id nodeName delegateId runtimeKind imageId repoTags repoDigests resolvedDigest inUse containers scanStatus scanStatusMessage } }
+                ephemeralContainerStatuses { name image imageId containerId runtimeImageStatus runtimeImage { id nodeName delegateId runtimeKind imageId repoTags repoDigests resolvedDigest inUse containers scanStatus scanStatusMessage } }
+              }
           - uid: k8s-cluster-serviceaccounts
             title: Service accounts and workload identity bindings
             docs:

--- a/content/testdata/schema/providers/core/resources/core.lr
+++ b/content/testdata/schema/providers/core/resources/core.lr
@@ -1,0 +1,291 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+option provider = "go.mondoo.com/mql/providers/core"
+option go_package = "go.mondoo.com/mql/v13/providers/core/resources"
+
+// MQL runtime and execution environment
+//
+// Examine the client running the current MQL evaluation: the client
+// version and build identifier, the architecture string, the
+// connection capabilities reported for the active connection, and the
+// `jobEnvironment` dict describing the context the agent is running
+// in (scheduled, interactive, CI, etc.).
+mondoo @defaults("version") {
+  // Version of the client running on the asset
+  version() string
+  // Build identifier of the client (e.g., production, development, or commit hash)
+  build() string
+  // Architecture of this client (e.g., linux-amd64)
+  arch() string
+  // Environment context the agent is running in (e.g., scheduled, interactive, CI)
+  jobEnvironment() dict
+  // Connection capabilities
+  capabilities() []string
+}
+
+// Asset identity and platform metadata
+//
+// Examine the basic identity of the asset under evaluation. Surfaces the
+// human-readable name, the full set of asset identifiers, the platform
+// (e.g., redhat, windows, k8s-pod), the platform `kind` (api,
+// baremetal, virtualmachine, container, container-image, network), the
+// specific `runtime` (docker-container, podman-container,
+// aws-ec2-instance, …), the platform version, build, architecture, and
+// pretty `title`, the platform `family` list, the optional FQDN, the
+// per-platform metadata map, and any user-supplied `labels` or
+// `annotations`.
+asset @defaults("name platform version") {
+  // Human readable name of the asset
+  name string
+  // All identifiers for this asset
+  ids []string
+  // Platform for this asset (redhat, windows, k8s-pod)
+  platform string
+  // High-level platform category (e.g., api, baremetal, virtualmachine, container, container-image, network)
+  kind string
+  // Specific runtime the asset is operating in (e.g., docker-container, podman-container, aws-ec2-instance)
+  runtime string
+  // Version of the platform
+  version string
+  // Architecture this OS is running on
+  arch string
+  // Human-readable title of the platform (e.g., "Red Hat 8, Container")
+  title string
+  // List of platform families that this platform belongs to
+  family []string
+  // Fully qualified domain name (optional)
+  fqdn string
+  // Build version of the platform (optional)
+  build string
+  // Platform metadata such as distribution and release details
+  platformMetadata map[string]string
+  // Optional platform information
+  labels map[string]string
+  // Custom annotations (tags) on the asset
+  annotations map[string]string
+}
+
+// Asset platform end-of-life status
+//
+// Examine the End-of-Life metadata for the asset's detected platform:
+// the EoL date itself, a vendor product-page URL, and a documentation
+// URL. Used by audits to flag hosts running platforms whose vendor
+// has stopped issuing security patches.
+asset.eol @defaults("date") {
+  // Documentation URL
+  docsUrl string
+  // Product URL
+  productUrl string
+  // End-of-Life date
+  date time
+}
+
+// Date and time helpers
+//
+// Examine helpers for time-aware MQL expressions. `now` returns the
+// current local time; `today` and `tomorrow` return midnight on those
+// days; `second`, `minute`, `hour`, and `day` are unit constants used
+// when computing durations.
+time {
+  // The current time on the local system
+  now() time
+  // One second, used for durations
+  second() time
+  // One minute, used for durations
+  minute() time
+  // One hour, used for durations
+  hour() time
+  // One day, used for durations
+  day() time
+  // The current day starting at midnight
+  today() time
+  // The next day starting at midnight
+  tomorrow() time
+}
+
+// Built-in regular expressions
+//
+// Examine a library of pre-defined regex patterns for common formats:
+// IPv4 / IPv6 addresses, HTTP/HTTPS URLs, email addresses, MAC
+// addresses, hyphen-delimited UUIDs, emoji code points, semantic
+// version numbers, and credit card numbers.
+regex {
+  // Matches IPv4 addresses
+  ipv4() regex
+  // Matches IPv6 addresses
+  ipv6() regex
+  // Matches URL addresses (HTTP/HTTPS)
+  url() regex
+  // Matches email addresses
+  email() regex
+  // Matches MAC addresses
+  mac() regex
+  // Matches hyphen-deliminated UUIDs
+  uuid() regex
+  // Matches emojis
+  emoji() regex
+  // Matches semantic version numbers
+  semver() regex
+  // Matches credit card numbers
+  creditCard() regex
+}
+
+// Common parsers
+//
+// Namespace for cross-cutting parsing helpers that apply to any
+// connection: `parse.date(value, format)` returns a typed `time`
+// from a string and an optional format, and `parse.duration(value)`
+// converts a duration string into a typed `time` interval.
+parse {
+  // Built-in functions:
+  // date(value, format) time
+  // duration(value) time
+}
+
+// UUID (RFC 4122 / DCE 1.1)
+//
+// Examine a parsed UUID. Initialize with
+// `uuid(value: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")` and inspect
+// the canonical string representation, the URN form
+// (`urn:uuid:...`), the version (1, 4, 5, …), and the variant.
+uuid @defaults("value") {
+  init(value string)
+  // Canonical string representation xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  value string
+  // RFC 2141 URN form of the UUID (e.g., urn:uuid:xxxxxxxx-...)
+  urn() string
+  // Version of UUID
+  version() int
+  // Variant encoded in UUID
+  variant() string
+}
+
+// Common Platform Enumeration (CPE)
+//
+// Examine a parsed CPE identifier (NIST NVD's structured product
+// identifier). Initialize with `cpe(uri: "cpe:2.3:a:vendor:product:1.0:...")`
+// to break the CPE down into its part designation (a / h / o), vendor,
+// product, version, update, edition, language, software edition,
+// target software, target hardware, and miscellaneous fields.
+cpe @defaults("uri") {
+  init(uri string)
+  // URI binding of the CPE
+  uri string
+  // CPE part designation: a (application), h (hardware), or o (operating system)
+  part() string
+  // Vendor of the CPE
+  vendor() string
+  // Product of the CPE
+  product() string
+  // Version of the CPE
+  version() string
+  // Update of the CPE
+  update() string
+  // Edition of the CPE
+  edition() string
+  // Language of the CPE
+  language() string
+  // Software edition of the CPE
+  swEdition() string
+  // Target software of the CPE
+  targetSw() string
+  // Target hardware of the CPE
+  targetHw() string
+  // Miscellaneous CPE attributes not covered by the standard fields
+  other() string
+}
+
+// Product end-of-life lookup
+//
+// Examine the End-of-Life metadata for an arbitrary named product.
+// Each instance carries a product name and version and exposes a
+// typed `releaseCycle` resource with the matching release-cycle
+// information from Mondoo's product catalog.
+product {
+  // Product name
+  name string
+  // Product version
+  version string
+  // Product release information
+  releaseCycle() product.releaseCycleInformation
+}
+
+// End of life information for a product release
+private product.releaseCycleInformation {
+  // Name identifier of the release cycle
+  name string
+  // Release cycle
+  cycle string
+  // Last release version
+  latestVersion string
+  // First release date
+  firstReleaseDate time
+  // Last release date
+  lastReleaseDate time
+  // When active support ends
+  endOfActiveSupport time
+  // End of life date
+  endOfLife time
+  // When extended support ends
+  endOfExtendedSupport time
+  // Release link
+  link string
+}
+
+// Unicode text classification
+//
+// Examine a Unicode-classified view of an input string. Initialize
+// with `unicode(input: "...")` and inspect the per-character
+// classification (each character's code point, category, and
+// description) and the per-category histogram showing how many
+// characters fall into each Unicode general category.
+unicode @maturity("preview") {
+  init(input string)
+  // Input text
+  input string
+  // Classification
+  classification() []unicode.charInfo
+  // Categories
+  categories() []unicode.category
+}
+
+// Unicode Character Information
+private unicode.charInfo @defaults("position category char") {
+  // Position is the zero-based index of the character in the original string
+  position int
+  // Character is the actual Unicode character as a string
+  char string
+  // CodePoint is the Unicode code point in U+XXXX format
+  codePoint string
+  // Major Category is the major Unicode category (single letter)
+  majorCategory string
+  // Category is the Unicode general category code (two-letter code)
+  category string
+  // Description is the human-readable description of the category
+  description string
+}
+
+// Unicode Category Information
+private unicode.category @defaults("category count") {
+  // Category value
+  category string
+  // Major Category
+  majorCategory string
+  // Description
+  description string
+  // Category count
+  count int
+}
+
+// Vulnerability Exchange information (experimental)
+//
+// Examine a single vulnerability identifier as published by an
+// upstream feed: the vulnerability `id` (e.g., CVE-2025-12345) and
+// the `source` registry that published it (NVD, GHSA, …).
+vulnerability.exchange @defaults("id source") @maturity("experimental") {
+  // Vulnerability ID, eg. CVE-2025-12345
+  id string
+  // Source/registry that published the vulnerability record (e.g., NVD, GHSA)
+  source string
+}

--- a/content/testdata/schema/providers/k8s/resources/k8s.lr
+++ b/content/testdata/schema/providers/k8s/resources/k8s.lr
@@ -1,0 +1,2530 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+import "../../os/resources/os.lr"
+import "../../network/resources/network.lr"
+
+option provider = "go.mondoo.com/cnquery/v9/providers/k8s"
+option go_package = "go.mondoo.com/mql/v13/providers/k8s/resources"
+
+// Kubernetes cluster
+//
+// Use the Kubernetes namespace as the cluster-wide handle for every
+// modeled API object. Read `serverVersion` for the control-plane
+// version and `apiResources()` for the list of resource types the
+// API server advertises. Iterate the workload accessors —
+// `namespaces()`, `nodes()`, `pods()`, `deployments()`, `daemonsets()`,
+// `statefulsets()`, `replicasets()`, `jobs()`, `cronjobs()`, and
+// `apps()` — for the running workload, and `services()`, `ingresses()`,
+// `endpointSlices()`, and `networkPolicies()` for the network plane.
+// `secrets()`, `configmaps()`, and `serviceaccounts()` cover identity
+// and configuration data; `clusterroles()`, `clusterrolebindings()`,
+// `roles()`, and `rolebindings()` cover the RBAC graph; `persistentVolumes()`,
+// `persistentVolumeClaims()`, and `storageClasses()` cover storage;
+// `priorityClasses()`, `horizontalPodAutoscalers()`, `resourceQuotas()`,
+// and `limitRanges()` cover scheduling and quota policy. Use
+// `validatingWebhookConfigurations()` for admission control and
+// `customresources()` for custom-resource instances.
+k8s {
+  // Cluster version
+  serverVersion() dict
+  // Available resource types
+  apiResources() []k8s.apiresource
+  // Cluster namespaces
+  namespaces() []k8s.namespace
+  // Cluster nodes
+  nodes() []k8s.node
+  // Cluster Pods
+  pods() []k8s.pod
+  // Cluster deployments
+  deployments() []k8s.deployment
+  // Cluster DaemonSets
+  daemonsets() []k8s.daemonset
+  // Cluster StatefulSets
+  statefulsets() []k8s.statefulset
+  // Cluster ReplicaSets
+  replicasets() []k8s.replicaset
+  // Cluster Jobs
+  jobs() []k8s.job
+  // Cluster CronJobs
+  cronjobs() []k8s.cronjob
+  // Cluster Secrets
+  secrets() []k8s.secret
+  // ConfigMaps
+  configmaps() []k8s.configmap
+  // Kubernetes Services
+  services() []k8s.service
+  // Kubernetes Ingresses
+  ingresses() []k8s.ingress
+  // Kubernetes service accounts
+  serviceaccounts() []k8s.serviceaccount
+  // Kubernetes RBAC ClusterRoles
+  clusterroles() []k8s.rbac.clusterrole
+  // Kubernetes RBAC ClusterRoleBindings
+  clusterrolebindings() []k8s.rbac.clusterrolebinding
+  // Kubernetes RBAC roles
+  roles() []k8s.rbac.role
+  // Kubernetes RBAC RoleBindings
+  rolebindings() []k8s.rbac.rolebinding
+  // Kubernetes network policies
+  networkPolicies() []k8s.networkpolicy
+  // Kubernetes custom resources
+  customresources() []k8s.customresource
+  // Kubernetes admission webhook configurations
+  validatingWebhookConfigurations() []k8s.admission.validatingwebhookconfiguration
+  // Kubernetes applications
+  apps() []k8s.app
+  // Kubernetes PersistentVolumes
+  persistentVolumes() []k8s.persistentvolume
+  // Kubernetes StorageClasses
+  storageClasses() []k8s.storageclass
+  // Kubernetes PriorityClasses
+  priorityClasses() []k8s.priorityclass
+  // Kubernetes HorizontalPodAutoscalers
+  horizontalPodAutoscalers() []k8s.horizontalpodautoscaler
+  // Kubernetes ResourceQuotas
+  resourceQuotas() []k8s.resourcequota
+  // Kubernetes LimitRanges
+  limitRanges() []k8s.limitrange
+  // Kubernetes PersistentVolumeClaims
+  persistentVolumeClaims() []k8s.persistentvolumeclaim
+  // Kubernetes EndpointSlices
+  endpointSlices() []k8s.endpointslice
+  // Kubernetes Gateway API GatewayClasses
+  gatewayClasses() []k8s.gatewayclass
+  // Kubernetes Gateway API Gateways
+  gateways() []k8s.gateway
+  // Kubernetes Gateway API HTTPRoutes
+  httpRoutes() []k8s.httproute
+  // Kubernetes Gateway API GRPCRoutes
+  grpcRoutes() []k8s.grpcroute
+  // Kubernetes Gateway API ReferenceGrants
+  referenceGrants() []k8s.referencegrant
+  // Kubernetes admission mutating webhook configurations
+  mutatingWebhookConfigurations() []k8s.admission.mutatingwebhookconfiguration
+  // Kubernetes PodDisruptionBudgets
+  podDisruptionBudgets() []k8s.poddisruptionbudget
+  // Kubernetes coordination Leases
+  leases() []k8s.lease
+  // Kubernetes CertificateSigningRequests
+  certificateSigningRequests() []k8s.certificatesigningrequest
+  // Kubernetes APIServices (aggregation layer)
+  apiServices() []k8s.apiservice
+  // Kubernetes IngressClasses
+  ingressClasses() []k8s.ingressclass
+}
+
+// Kubernetes API resources
+private k8s.apiresource @defaults("name kind") {
+  // Plural name of the resource
+  name string
+  // Singular name of the resource
+  singularName string
+  // Whether a resource is namespaced
+  namespaced bool
+  // Preferred group of the resource
+  group string
+  // Preferred version of the resource
+  version string
+  // Kubernetes object type
+  kind string
+  // List of suggested short names of the resource
+  shortNames []string
+  // List of the grouped resources
+  categories []string
+}
+
+// Kubernetes namespace
+private k8s.namespace @defaults("name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes object name
+  name string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Kubernetes object type
+  kind string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Pods in this namespace
+  pods() []k8s.pod
+  // Deployments in this namespace
+  deployments() []k8s.deployment
+  // StatefulSets in this namespace
+  statefulsets() []k8s.statefulset
+  // DaemonSets in this namespace
+  daemonsets() []k8s.daemonset
+  // ReplicaSets in this namespace
+  replicasets() []k8s.replicaset
+  // Jobs in this namespace
+  jobs() []k8s.job
+  // CronJobs in this namespace
+  cronjobs() []k8s.cronjob
+  // Services in this namespace
+  services() []k8s.service
+  // Ingresses in this namespace
+  ingresses() []k8s.ingress
+  // EndpointSlices in this namespace
+  endpointSlices() []k8s.endpointslice
+  // NetworkPolicies in this namespace
+  networkPolicies() []k8s.networkpolicy
+  // Secrets in this namespace
+  secrets() []k8s.secret
+  // ConfigMaps in this namespace
+  configmaps() []k8s.configmap
+  // ServiceAccounts in this namespace
+  serviceaccounts() []k8s.serviceaccount
+  // PersistentVolumeClaims in this namespace
+  persistentVolumeClaims() []k8s.persistentvolumeclaim
+  // HorizontalPodAutoscalers in this namespace
+  horizontalPodAutoscalers() []k8s.horizontalpodautoscaler
+  // ResourceQuotas in this namespace
+  resourceQuotas() []k8s.resourcequota
+  // LimitRanges in this namespace
+  limitRanges() []k8s.limitrange
+  // PodDisruptionBudgets in this namespace
+  podDisruptionBudgets() []k8s.poddisruptionbudget
+  // RBAC Roles in this namespace
+  roles() []k8s.rbac.role
+  // RBAC RoleBindings in this namespace
+  rolebindings() []k8s.rbac.rolebinding
+}
+
+// Kubernetes node
+private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes.io/os'] ") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes resource version
+  resourceVersion string
+  // Plural name of the resource
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Node configuration information
+  nodeInfo() dict
+  // Kubelet port
+  kubeletPort int
+  // Node taints for pod scheduling
+  taints() []k8s.nodeTaint
+  // Node health conditions (e.g., Ready, MemoryPressure, DiskPressure)
+  conditions() []k8s.nodeCondition
+  // Node network addresses (e.g., InternalIP, ExternalIP, Hostname)
+  addresses() []k8s.nodeAddress
+  // Total resources available on the node (e.g., cpu, memory, pods)
+  capacity() dict
+  // Resources available for scheduling pods on the node
+  allocatable() dict
+  // Cloud-provider node identifier (e.g., aws:///us-east-1a/i-0123456789abcdef0)
+  providerID() string
+  // Whether the node is marked as unschedulable (cordoned)
+  unschedulable() bool
+  // CIDR range assigned to pods on this node (legacy single-CIDR field)
+  podCIDR() string
+  // CIDR ranges assigned to pods on this node (one per IP family)
+  podCIDRs() []string
+  // OS image reported by the kubelet (e.g., "Ubuntu 22.04.5 LTS")
+  osImage() string
+  // Operating system reported by the kubelet (e.g., linux, windows)
+  operatingSystem() string
+  // CPU architecture reported by the kubelet (e.g., amd64, arm64)
+  architecture() string
+  // Kernel version reported by the kubelet
+  kernelVersion() string
+  // Kubelet version
+  kubeletVersion() string
+  // Container runtime version (e.g., containerd://1.7.20)
+  containerRuntimeVersion() string
+  // Runtime delegates inferred for this node
+  runtimeDelegates() []os.container.runtimeDelegate
+  // Container images present on the node (names + sizeBytes)
+  images() []dict
+  // Normalized runtime-cache images present on the node
+  runtimeImages() []os.container.runtimeImage
+  // Volumes currently attached to the node
+  volumesAttached() []dict
+  // Names of volumes currently in use by pods on the node
+  volumesInUse() []string
+}
+
+// Kubernetes node taint
+private k8s.nodeTaint @defaults("key value effect") {
+  // Taint key that pods must tolerate to be scheduled on the node
+  key string
+  // Taint value (optional) that pods must match alongside the key
+  value string
+  // Taint effect (NoSchedule, PreferNoSchedule, NoExecute)
+  effect string
+  // Time the taint was added
+  timeAdded time
+}
+
+// Kubernetes node condition
+private k8s.nodeCondition @defaults("type status") {
+  // Condition type (Ready, MemoryPressure, DiskPressure, PIDPressure, NetworkUnavailable)
+  type string
+  // Condition status (True, False, Unknown)
+  status string
+  // Last time the condition was updated
+  lastHeartbeatTime time
+  // Last time the condition transitioned between statuses
+  lastTransitionTime time
+  // Brief machine-readable reason for the condition's last transition
+  reason string
+  // Human-readable message with details about the last transition
+  message string
+}
+
+// Kubernetes node address
+private k8s.nodeAddress @defaults("type address") {
+  // Address type (Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS)
+  type string
+  // Node address value
+  address string
+}
+
+// Kubernetes Pod
+private k8s.pod @defaults("namespace name created"){
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object version
+  apiVersion string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Ephemeral containers
+  ephemeralContainers() []k8s.ephemeralContainer
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Container statuses
+  containerStatuses() []k8s.containerStatus
+  // Init container statuses
+  initContainerStatuses() []k8s.containerStatus
+  // Ephemeral container statuses
+  ephemeralContainerStatuses() []k8s.containerStatus
+  // Node the pod runs on
+  node() k8s.node
+  // Name of the node the pod is bound to
+  nodeName() string
+  // Required node labels for scheduling this pod
+  nodeSelector() map[string]string
+  // Node taints this pod tolerates
+  tolerations() []dict
+  // Topology spread constraints
+  topologySpreadConstraints() []dict
+  // Node, pod, and pod anti-affinity rules
+  affinity() dict
+  // Name of the PriorityClass that controls scheduling priority
+  priorityClassName() string
+  // The PriorityClass that controls scheduling priority
+  priorityClass() k8s.priorityclass
+  // Preemption policy (PreemptLowerPriority or Never)
+  preemptionPolicy() string
+  // Name of the scheduler that handles this pod
+  schedulerName() string
+  // Name of the RuntimeClass that selects the container runtime
+  runtimeClassName() string
+  // Name of the ServiceAccount used to run the pod
+  serviceAccountName() string
+  // The ServiceAccount used to run the pod
+  serviceAccount() k8s.serviceaccount
+  // Whether an API token is automatically mounted for the ServiceAccount
+  automountServiceAccountToken() bool
+  // Whether the pod shares the host network namespace
+  hostNetwork() bool
+  // Whether the pod shares the host PID namespace
+  hostPID() bool
+  // Whether the pod shares the host IPC namespace
+  hostIPC() bool
+  // Whether containers in the pod share a single PID namespace
+  shareProcessNamespace() bool
+  // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
+  securityContext() dict
+  // DNS policy (ClusterFirst, ClusterFirstWithHostNet, Default, None)
+  dnsPolicy() string
+  // DNS configuration when dnsPolicy is None (nameservers, searches, options)
+  dnsConfig() dict
+  // Pod hostname (defaults to metadata.name)
+  hostname() string
+  // Subdomain used to construct the pod's FQDN
+  subdomain() string
+  // Host alias entries added to /etc/hosts
+  hostAliases() []dict
+  // Restart policy for all containers (Always, OnFailure, Never)
+  restartPolicy() string
+  // Grace period in seconds before forceful termination
+  terminationGracePeriodSeconds() int
+  // Maximum number of seconds the pod may run before being terminated
+  activeDeadlineSeconds() int
+  // Additional readiness gates the pod must satisfy before being marked ready
+  readinessGates() []dict
+  // Whether environment variables for active services are injected into containers
+  enableServiceLinks() bool
+  // References to image-pull secrets in the same namespace
+  imagePullSecrets() []dict
+  // Resource overhead associated with the runtime (CPU, memory, etc.)
+  overhead() map[string]string
+  // OS the pod runs on (e.g., {name: "linux"})
+  os() dict
+  // Pod phase (Pending, Running, Succeeded, Failed, Unknown)
+  phase() string
+  // Quality-of-Service class assigned to the pod (Guaranteed, Burstable, BestEffort)
+  qosClass() string
+  // IP address allocated to the pod
+  podIP() string
+  // All IP addresses allocated to the pod (one per IP family)
+  podIPs() []string
+  // IP address of the host the pod is running on
+  hostIP() string
+  // Name of the node selected by the scheduler for preemption (when applicable)
+  nominatedNodeName() string
+  // Time at which the pod was acknowledged by the kubelet
+  startTime() time
+  // Pod-level status conditions (PodScheduled, ContainersReady, Initialized, Ready)
+  conditions() []dict
+  // Brief CamelCase reason for the pod's current phase
+  reason() string
+  // Human-readable message about the pod's current phase
+  message() string
+  // ReplicaSet that owns this pod (null if not owned by one)
+  replicaSet() k8s.replicaset
+  // StatefulSet that owns this pod (null if not owned by one)
+  statefulSet() k8s.statefulset
+  // DaemonSet that owns this pod (null if not owned by one)
+  daemonSet() k8s.daemonset
+  // Job that owns this pod (null if not owned by one)
+  job() k8s.job
+  // Deployment that owns this pod via its ReplicaSet (null if not part of a deployment-managed rollout)
+  deployment() k8s.deployment
+}
+
+// Kubernetes Deployment
+private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Pods backing this deployment (label-selector match; technically owned by the deployment's ReplicaSets)
+  pods() []k8s.pod
+  // Number of pods requested by the deployment
+  desiredReplicas() int
+  // Label selector that identifies pods owned by this deployment
+  selector() dict
+  // Rollout strategy (Recreate or RollingUpdate with maxSurge/maxUnavailable)
+  strategy() dict
+  // Number of old ReplicaSets retained to allow rollback
+  revisionHistoryLimit() int
+  // Maximum seconds for the deployment to make progress before being marked failed
+  progressDeadlineSeconds() int
+  // Whether the deployment rollout is paused
+  paused() bool
+  // Minimum seconds a newly created pod must be ready without crashes to be considered available
+  minReadySeconds() int
+  // Total non-terminated pods observed by the controller
+  replicas() int
+  // Number of ready pods
+  readyReplicas() int
+  // Number of pods available for at least minReadySeconds
+  availableReplicas() int
+  // Number of pods updated to the desired pod template
+  updatedReplicas() int
+  // Number of pods that are not available
+  unavailableReplicas() int
+  // Generation of the spec most recently observed by the controller
+  observedGeneration() int
+  // Count of ReplicaSet name hash collisions handled by the controller
+  collisionCount() int
+  // Status conditions (Available, Progressing, ReplicaFailure)
+  conditions() []dict
+}
+
+// Kubernetes DaemonSet
+private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberReady created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Pods backing this DaemonSet (label-selector match)
+  pods() []k8s.pod
+  // Label selector that identifies pods owned by this DaemonSet
+  selector() dict
+  // Update strategy (OnDelete or RollingUpdate with maxUnavailable/maxSurge)
+  updateStrategy() dict
+  // Number of old ControllerRevisions retained to allow rollback
+  revisionHistoryLimit() int
+  // Minimum seconds a newly created pod must be ready without crashes to be considered available
+  minReadySeconds() int
+  // Number of nodes running at least one daemon pod
+  currentNumberScheduled() int
+  // Number of nodes running a daemon pod that shouldn't be running one
+  numberMisscheduled() int
+  // Total number of nodes that should be running a daemon pod
+  desiredNumberScheduled() int
+  // Number of nodes that should be running the daemon pod with the pod in Ready state
+  numberReady() int
+  // Number of nodes running an updated daemon pod
+  updatedNumberScheduled() int
+  // Number of nodes whose daemon pod is available for at least minReadySeconds
+  numberAvailable() int
+  // Number of nodes whose daemon pod is not available
+  numberUnavailable() int
+  // Generation of the spec most recently observed by the controller
+  observedGeneration() int
+  // Count of ControllerRevision name hash collisions handled by the controller
+  collisionCount() int
+  // Status conditions
+  conditions() []dict
+}
+
+// Kubernetes StatefulSet
+private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Pods backing this StatefulSet (label-selector match)
+  pods() []k8s.pod
+  // Number of pods requested by the StatefulSet
+  desiredReplicas() int
+  // Label selector that identifies pods owned by this StatefulSet
+  selector() dict
+  // Name of the governing headless service for the StatefulSet
+  serviceName() string
+  // Pod management policy (OrderedReady or Parallel)
+  podManagementPolicy() string
+  // Update strategy (OnDelete or RollingUpdate with partition/maxUnavailable)
+  updateStrategy() dict
+  // Number of old ControllerRevisions retained to allow rollback
+  revisionHistoryLimit() int
+  // Retention policy for PVCs across StatefulSet scale-down and deletion
+  persistentVolumeClaimRetentionPolicy() dict
+  // Minimum seconds a newly created pod must be ready without crashes to be considered available
+  minReadySeconds() int
+  // Starting ordinal for the StatefulSet's pod indices (defaults to 0)
+  ordinalsStart() int
+  // Total non-terminated pods observed by the controller
+  replicas() int
+  // Number of ready pods
+  readyReplicas() int
+  // Number of pods running the spec's current revision
+  currentReplicas() int
+  // Number of pods updated to the spec's update revision
+  updatedReplicas() int
+  // Number of pods available for at least minReadySeconds
+  availableReplicas() int
+  // Generation of the spec most recently observed by the controller
+  observedGeneration() int
+  // Revision hash of the StatefulSet's current configuration
+  currentRevision() string
+  // Revision hash of the StatefulSet's update configuration
+  updateRevision() string
+  // Count of ControllerRevision name hash collisions handled by the controller
+  collisionCount() int
+  // Status conditions
+  conditions() []dict
+}
+
+// Kubernetes ReplicaSet
+private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Pods backing this ReplicaSet (label-selector match)
+  pods() []k8s.pod
+  // Number of pods requested by the ReplicaSet
+  desiredReplicas() int
+  // Label selector that identifies pods owned by this ReplicaSet
+  selector() dict
+  // Minimum seconds a newly created pod must be ready without crashes to be considered available
+  minReadySeconds() int
+  // Total non-terminated pods observed by the controller
+  replicas() int
+  // Number of pods whose labels match the selector and have been fully labeled
+  fullyLabeledReplicas() int
+  // Number of ready pods
+  readyReplicas() int
+  // Number of pods available for at least minReadySeconds
+  availableReplicas() int
+  // Generation of the spec most recently observed by the controller
+  observedGeneration() int
+  // Status conditions (ReplicaFailure)
+  conditions() []dict
+}
+
+// Kubernetes Job
+private k8s.job @defaults("namespace name succeeded failed created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Pods backing this Job (label-selector match)
+  pods() []k8s.pod
+  // Maximum number of pods the job should run in parallel
+  parallelism() int
+  // Total number of successful completions required to mark the job complete
+  completions() int
+  // Number of retries before marking a pod failed
+  backoffLimit() int
+  // Per-index retry limit when completionMode is Indexed
+  backoffLimitPerIndex() int
+  // Maximum number of failed indexes allowed before the job is marked failed (Indexed completion mode)
+  maxFailedIndexes() int
+  // Completion mode (NonIndexed or Indexed)
+  completionMode() string
+  // Maximum seconds the job may run before being terminated
+  activeDeadlineSeconds() int
+  // Number of seconds after the job finishes before it is automatically deleted
+  ttlSecondsAfterFinished() int
+  // Whether new pod creation is suspended
+  suspend() bool
+  // Policy for replacing pods that are terminating (TerminatingOrFailed or Failed)
+  podReplacementPolicy() string
+  // Label selector that identifies pods owned by this job
+  selector() dict
+  // Number of pods currently running for the job
+  active() int
+  // Number of pods that have successfully completed
+  succeeded() int
+  // Number of pods that have failed
+  failed() int
+  // Number of pods that are ready
+  ready() int
+  // Number of pods that are terminating
+  terminating() int
+  // Comma-separated list or range of indexes that have successfully completed (Indexed completion mode)
+  completedIndexes() string
+  // Comma-separated list of failed indexes (Indexed completion mode)
+  failedIndexes() string
+  // Time the job controller acknowledged the job
+  startTime() time
+  // Time the job entered a terminal state
+  completionTime() time
+  // Status conditions (Complete, Failed, FailureTarget, Suspended)
+  conditions() []dict
+}
+
+// Kubernetes CronJob
+private k8s.cronjob @defaults("namespace name schedule suspend created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Pod description
+  podSpec() dict
+  // Init containers
+  initContainers() []k8s.initContainer
+  // Contained containers
+  containers() []k8s.container
+  // Cron schedule expression that determines when jobs are created
+  schedule() string
+  // IANA time zone the schedule is evaluated in (e.g., "America/New_York")
+  timeZone() string
+  // Concurrency policy (Allow, Forbid, Replace)
+  concurrencyPolicy() string
+  // Seconds within which a missed scheduled job is still allowed to start
+  startingDeadlineSeconds() int
+  // Number of successful finished jobs to retain
+  successfulJobsHistoryLimit() int
+  // Number of failed finished jobs to retain
+  failedJobsHistoryLimit() int
+  // Whether the CronJob is suspended
+  suspend() bool
+  // References to currently running jobs created by this CronJob
+  active() []dict
+  // Time of the last scheduling attempt
+  lastScheduleTime() time
+  // Time of the last successful job completion
+  lastSuccessfulTime() time
+  // Currently active jobs created by this CronJob (resolves status.active ObjectReferences)
+  activeJobs() []k8s.job
+  // All jobs ever owned by this CronJob (filtered from k8s.jobs by ownerReference UID; subject to the CronJob's history limits)
+  jobs() []k8s.job
+}
+
+// Kubernetes workload container
+private k8s.container @defaults("name") {
+  // Kubernetes object UID
+  uid string
+  // Name of the container
+  name string
+  // Container image name
+  imageName string
+  // Container image
+  containerImage() os.container.image
+  // Entry point array
+  command []string
+  // Arguments to the entry point
+  args []string
+  // Compute resources required by this container
+  resources dict
+  // Pod volumes to mount into the container's file system
+  volumeMounts []dict
+  // List of block devices to be used by the container
+  volumeDevices []dict
+  // Periodic probe of container liveness
+  livenessProbe dict
+  // Periodic probe of container service readiness
+  readinessProbe dict
+  // Periodic probe of container startup, gating other probes until it succeeds
+  startupProbe dict
+  // Image pull policy: Always, Never, or IfNotPresent
+  imagePullPolicy string
+  // Security options the pod should run with
+  securityContext dict
+  // Whether the container runs in privileged mode
+  //
+  // Null when not set by the container's security context. Parsed from
+  // `securityContext.privileged`.
+  privileged bool
+  // Whether a process can gain more privileges than its parent process
+  //
+  // Null when not set. Parsed from `securityContext.allowPrivilegeEscalation`.
+  allowPrivilegeEscalation bool
+  // Whether the container must run as a non-root user
+  //
+  // Null when not set on the container; in that case the pod-level setting (if
+  // any) applies. Parsed from `securityContext.runAsNonRoot`.
+  runAsNonRoot bool
+  // UID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsUser`.
+  runAsUser int
+  // GID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsGroup`.
+  runAsGroup int
+  // Whether the container's root filesystem is mounted read-only
+  //
+  // Null when not set. Parsed from `securityContext.readOnlyRootFilesystem`.
+  readOnlyRootFilesystem bool
+  // Linux capabilities added to the container
+  //
+  // From `securityContext.capabilities.add`; empty when none are added.
+  addedCapabilities []string
+  // Linux capabilities dropped from the container
+  //
+  // From `securityContext.capabilities.drop`; empty when none are dropped.
+  droppedCapabilities []string
+  // Seccomp profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no seccomp profile, in which case the pod-level profile (if
+  // any) applies. Parsed from `securityContext.seccompProfile.type`.
+  seccompProfileType string
+  // Container's working directory
+  workingDir string
+  // Whether this container should allocate a TTY for itself
+  tty bool
+  // Whether stdin should be left open after the container starts
+  stdin bool
+  // Whether stdin should be closed after the first attached client disconnects
+  stdinOnce bool
+  // Environment variables
+  env dict
+  // envFrom settings
+  envFrom dict
+  // Network ports exposed by the container (containerPort, protocol, hostPort, hostIP, name)
+  ports []dict
+  // Lifecycle hooks (postStart, preStop)
+  lifecycle dict
+  // Path at which the file to which the container's termination message will be written
+  terminationMessagePath string
+  // Policy for handling the termination message (File or FallbackToLogsOnError)
+  terminationMessagePolicy string
+  // Per-resource resize policy entries (resourceName + restartPolicy)
+  resizePolicy []dict
+  // Container-level restart policy override (currently used to mark a container as a sidecar via Always)
+  restartPolicy string
+}
+
+// Kubernetes container status
+private k8s.containerStatus @defaults("name ready restartCount") {
+  // Name of the container
+  name string
+  // Whether the container is currently passing its readiness check
+  ready bool
+  // Whether the container has passed its startup probe
+  started bool
+  // The amount of times the container has been restarted
+  restartCount int
+  // Name of the container image that the container is running
+  image string
+  // The image ID of the container's image
+  imageId string
+  // The ID of the container in the format '\<type\>://\<container_id\>'
+  containerId string
+  // Current state of the container (waiting, running, or terminated)
+  state dict
+  // State of the container's previous instance, if any
+  lastState dict
+  // Actual compute resources allocated to the container
+  resources dict
+  // Runtime image matched from this container status
+  runtimeImage() os.container.runtimeImage
+  // Runtime image match status: matched, notPresent, ambiguous, or runtimeUnavailable
+  runtimeImageStatus() string
+}
+
+// Kubernetes init container
+private k8s.initContainer @defaults("name") {
+  // Kubernetes object UID
+  uid string
+  // Name of the container
+  name string
+  // Container image name
+  imageName string
+  // Container image
+  containerImage() os.container.image
+  // Entrypoint array
+  command []string
+  // Arguments to the entrypoint
+  args []string
+  // Compute resources required by this container
+  resources dict
+  // Pod volumes to mount into the container's file system
+  volumeMounts []dict
+  // List of block devices to be used by the container
+  volumeDevices []dict
+  // Periodic probe of container liveness (sidecar init containers only)
+  livenessProbe dict
+  // Periodic probe of container service readiness (sidecar init containers only)
+  readinessProbe dict
+  // Periodic probe of container startup (sidecar init containers only)
+  startupProbe dict
+  // Image pull policy: Always, Never, or IfNotPresent
+  imagePullPolicy string
+  // Security options the pod should run with
+  securityContext dict
+  // Whether the container runs in privileged mode
+  //
+  // Null when not set by the container's security context. Parsed from
+  // `securityContext.privileged`.
+  privileged bool
+  // Whether a process can gain more privileges than its parent process
+  //
+  // Null when not set. Parsed from `securityContext.allowPrivilegeEscalation`.
+  allowPrivilegeEscalation bool
+  // Whether the container must run as a non-root user
+  //
+  // Null when not set on the container; in that case the pod-level setting (if
+  // any) applies. Parsed from `securityContext.runAsNonRoot`.
+  runAsNonRoot bool
+  // UID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsUser`.
+  runAsUser int
+  // GID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsGroup`.
+  runAsGroup int
+  // Whether the container's root filesystem is mounted read-only
+  //
+  // Null when not set. Parsed from `securityContext.readOnlyRootFilesystem`.
+  readOnlyRootFilesystem bool
+  // Linux capabilities added to the container
+  //
+  // From `securityContext.capabilities.add`; empty when none are added.
+  addedCapabilities []string
+  // Linux capabilities dropped from the container
+  //
+  // From `securityContext.capabilities.drop`; empty when none are dropped.
+  droppedCapabilities []string
+  // Seccomp profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no seccomp profile, in which case the pod-level profile (if
+  // any) applies. Parsed from `securityContext.seccompProfile.type`.
+  seccompProfileType string
+  // Container's working directory
+  workingDir string
+  // Whether this container should allocate a TTY for itself
+  tty bool
+  // Whether stdin should be left open after the container starts
+  stdin bool
+  // Whether stdin should be closed after the first attached client disconnects
+  stdinOnce bool
+  // Environment variables
+  env dict
+  // envFrom settings
+  envFrom dict
+  // Network ports exposed by the container (containerPort, protocol, hostPort, hostIP, name)
+  ports []dict
+  // Lifecycle hooks (postStart, preStop)
+  lifecycle dict
+  // Path at which the file to which the container's termination message will be written
+  terminationMessagePath string
+  // Policy for handling the termination message (File or FallbackToLogsOnError)
+  terminationMessagePolicy string
+  // Per-resource resize policy entries (resourceName + restartPolicy)
+  resizePolicy []dict
+  // Container-level restart policy; setting this to Always turns the init container into a sidecar
+  restartPolicy string
+}
+
+// Kubernetes ephemeral container
+private k8s.ephemeralContainer @defaults("name") {
+  // Kubernetes object UID
+  uid string
+  // Name of the container
+  name string
+  // Container image name
+  imageName string
+  // Container image
+  containerImage() os.container.image
+  // Entry point array
+  command []string
+  // Arguments to the entry point
+  args []string
+  // Pod volumes to mount into the container's file system
+  volumeMounts []dict
+  // List of block devices to be used by the container
+  volumeDevices []dict
+  // Image pull policy: Always, Never, or IfNotPresent
+  imagePullPolicy string
+  // Security options the Pod should run with
+  securityContext dict
+  // Whether the container runs in privileged mode
+  //
+  // Null when not set by the container's security context. Parsed from
+  // `securityContext.privileged`.
+  privileged bool
+  // Whether a process can gain more privileges than its parent process
+  //
+  // Null when not set. Parsed from `securityContext.allowPrivilegeEscalation`.
+  allowPrivilegeEscalation bool
+  // Whether the container must run as a non-root user
+  //
+  // Null when not set on the container; in that case the pod-level setting (if
+  // any) applies. Parsed from `securityContext.runAsNonRoot`.
+  runAsNonRoot bool
+  // UID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsUser`.
+  runAsUser int
+  // GID the container entry point runs as
+  //
+  // Null when not set. Parsed from `securityContext.runAsGroup`.
+  runAsGroup int
+  // Whether the container's root filesystem is mounted read-only
+  //
+  // Null when not set. Parsed from `securityContext.readOnlyRootFilesystem`.
+  readOnlyRootFilesystem bool
+  // Linux capabilities added to the container
+  //
+  // From `securityContext.capabilities.add`; empty when none are added.
+  addedCapabilities []string
+  // Linux capabilities dropped from the container
+  //
+  // From `securityContext.capabilities.drop`; empty when none are dropped.
+  droppedCapabilities []string
+  // Seccomp profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no seccomp profile, in which case the pod-level profile (if
+  // any) applies. Parsed from `securityContext.seccompProfile.type`.
+  seccompProfileType string
+  // Container's working directory
+  workingDir string
+  // Whether this container should allocate a TTY for itself
+  tty bool
+  // Whether stdin should be left open after the container starts
+  stdin bool
+  // Whether stdin should be closed after the first attached client disconnects
+  stdinOnce bool
+  // Environment variables
+  env dict
+  // envFrom settings
+  envFrom dict
+  // Network ports exposed by the container (typically empty for ephemeral containers)
+  ports []dict
+  // Path at which the file to which the container's termination message will be written
+  terminationMessagePath string
+  // Policy for handling the termination message (File or FallbackToLogsOnError)
+  terminationMessagePolicy string
+}
+
+// Kubernetes Secret
+private k8s.secret @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Secret type
+  type string
+  // Secret certificates
+  certificates() []network.certificate
+  // Pods that reference this Secret through volumes, env, envFrom, or imagePullSecrets
+  usedBy() []k8s.pod
+}
+
+// Kubernetes ConfigMap
+private k8s.configmap @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Key-value pairs containing the configuration data
+  data map[string]string
+  // Pods that reference this ConfigMap through volumes, env, or envFrom
+  usedBy() []k8s.pod
+}
+
+// Kubernetes Service
+private k8s.service @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Service Spec
+  spec() dict
+  // Service type (ClusterIP, NodePort, LoadBalancer, ExternalName)
+  type() string
+  // ClusterIP assigned to the service
+  clusterIP() string
+  // All cluster IPs allocated to the service (one per IP family)
+  clusterIPs() []string
+  // External IPs through which the service is exposed
+  externalIPs() []string
+  // External name the service maps to (for type ExternalName)
+  externalName() string
+  // External traffic policy (Cluster or Local)
+  externalTrafficPolicy() string
+  // Internal traffic policy (Cluster or Local)
+  internalTrafficPolicy() string
+  // Session affinity (ClientIP or None)
+  sessionAffinity() string
+  // Session affinity configuration (clientIP timeout)
+  sessionAffinityConfig() dict
+  // IP families backing the service (IPv4, IPv6)
+  ipFamilies() []string
+  // IP family policy (SingleStack, PreferDualStack, RequireDualStack)
+  ipFamilyPolicy() string
+  // Name of the load-balancer implementation that backs the service
+  loadBalancerClass() string
+  // CIDRs allowed to reach the load balancer
+  loadBalancerSourceRanges() []string
+  // Pre-allocated IP requested for the load balancer (deprecated in newer Kubernetes versions)
+  loadBalancerIP() string
+  // Whether node ports are automatically allocated for type LoadBalancer
+  allocateLoadBalancerNodePorts() bool
+  // Whether DNS records are published for not-yet-ready endpoints
+  publishNotReadyAddresses() bool
+  // Port that the LoadBalancer's health-check uses (type LoadBalancer with Local externalTrafficPolicy)
+  healthCheckNodePort() int
+  // Label selector for pods that back the service
+  selector() map[string]string
+  // Service ports (port, targetPort, protocol, nodePort, name, appProtocol)
+  ports() []dict
+  // Load-balancer ingress entries published in status (ip, hostname, ports)
+  loadBalancerIngress() []dict
+  // EndpointSlices that back this service (filtered by the kubernetes.io/service-name label)
+  endpointSlices() []k8s.endpointslice
+}
+
+// Kubernetes Ingress resource backend
+private k8s.ingressresourceref @defaults("name kind") {
+  // Mondoo ID for object
+  id string
+  // APIGroup specified as part of the resource reference
+  apiGroup string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object name
+  name string
+}
+
+// Kubernetes Ingress service backend
+private k8s.ingressservicebackend @defaults("name") {
+  // Mondoo ID for object
+  id string
+  // Kubernetes service name
+  name string
+  // Kubernetes service port name
+  portName string
+  // Kubernetes service port number
+  portNumber int
+}
+
+// Kubernetes Ingress backend
+private k8s.ingressbackend @defaults("id") {
+  // Mondoo ID for object
+  id string
+  // Kubernetes service for Ingress backend
+  service k8s.ingressservicebackend
+  // Kubernetes resource reference for Ingress backend
+  resourceRef k8s.ingressresourceref
+}
+
+// Kubernetes Ingress HTTP rule
+private k8s.ingresshttprulepath {
+  // Mondoo ID for object
+  id string
+  // HTTP path for Ingress rule
+  path string
+  // PathType for Ingress rule
+  pathType string
+  // Backend to forward matching Ingress traffic
+  backend k8s.ingressbackend
+}
+
+// Kubernetes Ingress rule
+private k8s.ingressrule {
+  // Mondoo ID for object
+  id string
+  // Hostname to match for Ingress rule
+  host string
+  // HTTP paths to manage Ingress for
+  httpPaths []k8s.ingresshttprulepath
+}
+
+// Kubernetes Ingress TLS
+private k8s.ingresstls {
+  // Mondoo ID for object
+  id string
+  // List of hosts associated with TLS certificate
+  hosts []string
+  // Certificates data from the TLS Secret
+  certificates []network.certificate
+}
+
+// Kubernetes Ingress
+private k8s.ingress @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Ingress rules
+  rules []k8s.ingressrule
+  // Ingress TLS data
+  tls() []k8s.ingresstls
+  // Name of the IngressClass that handles this ingress
+  ingressClassName() string
+  // The IngressClass that handles this ingress
+  ingressClass() k8s.ingressclass
+  // Load-balancer ingress entries published in status (ip, hostname, ports)
+  loadBalancerIngress() []dict
+}
+
+// Kubernetes service account
+private k8s.serviceaccount @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // List of secrets that Pods running using this service account are allowed to use
+  secrets []dict
+  // List of references to secrets in the same namespace to use for pulling any images
+  imagePullSecrets []dict
+  // Whether pods running as this service account should have an API token automatically mounted
+  automountServiceAccountToken bool
+}
+
+// Kubernetes ClusterRole
+private k8s.rbac.clusterrole @defaults("name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // ClusterRole rules
+  rules []dict
+  // ClusterRole aggregation rule
+  aggregationRule dict
+  // ClusterRoleBindings that reference this ClusterRole via roleRef
+  boundBy() []k8s.rbac.clusterrolebinding
+}
+
+// Kubernetes ClusterRoleBinding
+private k8s.rbac.clusterrolebinding @defaults("name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // References to the objects the role applies to
+  subjects []dict
+  // ClusterRole in the global namespace
+  roleRef dict
+  // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
+  serviceAccounts() []k8s.serviceaccount
+  // The ClusterRole granted by this binding (roleRef.name)
+  clusterRole() k8s.rbac.clusterrole
+}
+
+// Kubernetes Role
+private k8s.rbac.role @defaults("name namespace") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Role rules defining the permissions granted within this namespace
+  rules []dict
+  // RoleBindings in this namespace that reference this Role via roleRef
+  boundBy() []k8s.rbac.rolebinding
+}
+
+// Kubernetes RoleBinding
+private k8s.rbac.rolebinding @defaults("name namespace created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Subjects holds references to the objects the role applies to
+  subjects []dict
+  // RoleRef can only reference a ClusterRole in the global namespace
+  roleRef dict
+  // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
+  serviceAccounts() []k8s.serviceaccount
+  // The Role granted by this binding (null when roleRef points to a ClusterRole)
+  role() k8s.rbac.role
+  // The ClusterRole granted by this binding (null when roleRef points to a Role)
+  clusterRole() k8s.rbac.clusterrole
+}
+
+// Kubernetes Network Policy
+private k8s.networkpolicy @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Network policy spec
+  spec() dict
+  // Label selector for pods this policy applies to (empty selects all pods in the namespace)
+  podSelector() dict
+  // Policy types in effect (Ingress and/or Egress)
+  policyTypes() []string
+  // Ingress rules; each rule lists `from` peers and `ports`
+  ingress() []dict
+  // Egress rules; each rule lists `to` peers and `ports`
+  egress() []dict
+}
+
+// Kubernetes CustomResource
+private k8s.customresource @defaults("name namespace created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+}
+
+// Kubernetes PersistentVolume
+private k8s.persistentvolume @defaults("name capacity['storage'] phase storageClassName created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // PersistentVolume spec
+  spec() dict
+  // PersistentVolume status
+  status() dict
+  // Total capacity of the volume (resource name -> quantity string, e.g., {storage: "100Gi"})
+  capacity() map[string]string
+  // Access modes the volume supports (ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod)
+  accessModes() []string
+  // Reclaim policy when the bound claim is released (Retain, Delete, Recycle)
+  persistentVolumeReclaimPolicy() string
+  // Name of the StorageClass that backs this volume
+  storageClassName() string
+  // The StorageClass that backs this volume (null if storageClassName is empty)
+  storageClass() k8s.storageclass
+  // Volume mode (Filesystem or Block)
+  volumeMode() string
+  // Mount options propagated to volume mounts
+  mountOptions() []string
+  // Namespace of the PVC bound to this volume (null if unbound)
+  claimNamespace() string
+  // Name of the PVC bound to this volume (null if unbound)
+  claimName() string
+  // The PVC bound to this volume (null if unbound)
+  claim() k8s.persistentvolumeclaim
+  // Node-affinity constraints that gate where this volume can be attached
+  nodeAffinity() dict
+  // Current phase (Pending, Available, Bound, Released, Failed)
+  phase() string
+  // Reason for the current phase (e.g., why Failed)
+  reason() string
+  // Human-readable message about the current phase
+  message() string
+}
+
+// Kubernetes StorageClass
+private k8s.storageclass @defaults("name provisioner") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Provisioner indicates the type of the provisioner
+  provisioner string
+  // Reclaim policy (Delete, Retain, or Recycle)
+  reclaimPolicy string
+  // Volume binding mode (Immediate or WaitForFirstConsumer)
+  volumeBindingMode string
+  // Whether the storage class allows volume expansion
+  allowVolumeExpansion bool
+  // StorageClass parameters for the provisioner
+  parameters() map[string]string
+  // Mount options for PersistentVolumes dynamically created by this storage class
+  mountOptions() []string
+}
+
+// Kubernetes PriorityClass
+private k8s.priorityclass @defaults("name value") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // The value of this priority class (higher is more important)
+  value int
+  // Whether this priority class is the global default
+  globalDefault bool
+  // Preemption policy (PreemptLowerPriority or Never)
+  preemptionPolicy string
+  // Arbitrary text description of this priority class
+  description string
+}
+
+// Kubernetes HorizontalPodAutoscaler
+private k8s.horizontalpodautoscaler @defaults("namespace name minReplicas maxReplicas currentReplicas created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // HorizontalPodAutoscaler spec
+  spec() dict
+  // HorizontalPodAutoscaler status
+  status() dict
+  // API version of the workload the HPA scales
+  scaleTargetApiVersion() string
+  // Kind of the workload the HPA scales (Deployment, StatefulSet, ReplicaSet)
+  scaleTargetKind() string
+  // Name of the workload the HPA scales
+  scaleTargetName() string
+  // The scaled Deployment (null if the target is not a Deployment)
+  scaleTargetDeployment() k8s.deployment
+  // The scaled StatefulSet (null if the target is not a StatefulSet)
+  scaleTargetStatefulSet() k8s.statefulset
+  // The scaled ReplicaSet (null if the target is not a ReplicaSet)
+  scaleTargetReplicaSet() k8s.replicaset
+  // Lower bound on the number of replicas the HPA will allow (defaults to 1)
+  minReplicas() int
+  // Upper bound on the number of replicas the HPA will allow
+  maxReplicas() int
+  // Metrics the HPA evaluates to compute the desired replica count
+  metrics() []dict
+  // Scale-up and scale-down policies (stabilization windows, policies)
+  behavior() dict
+  // Generation of the spec most recently observed by the controller
+  observedGeneration() int
+  // Last time the HPA scaled the target
+  lastScaleTime() time
+  // Current number of replicas observed by the autoscaler
+  currentReplicas() int
+  // Desired number of replicas the autoscaler computed
+  desiredReplicas() int
+  // Most recent metric readings the autoscaler used to compute desiredReplicas
+  currentMetrics() []dict
+  // Status conditions (AbleToScale, ScalingActive, ScalingLimited)
+  conditions() []dict
+}
+
+// Kubernetes ResourceQuota
+private k8s.resourcequota @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // ResourceQuota spec
+  spec() dict
+  // ResourceQuota status
+  status() dict
+  // Hard limits enforced by the quota (resource name -> quantity string)
+  hard() map[string]string
+  // Current usage observed against the quota (resource name -> quantity string)
+  used() map[string]string
+  // Scopes to which the quota applies (e.g., Terminating, NotTerminating, BestEffort, NotBestEffort, PriorityClass, CrossNamespacePodAffinity)
+  scopes() []string
+  // Scope selector for fine-grained scope matching (operators on scope names)
+  scopeSelector() dict
+}
+
+// Kubernetes LimitRange
+private k8s.limitrange @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // LimitRange spec
+  spec() dict
+  // Limit items keyed by resource type (Container, Pod, PersistentVolumeClaim): default, defaultRequest, max, min, maxLimitRequestRatio
+  limits() []dict
+}
+
+// Kubernetes PersistentVolumeClaim
+private k8s.persistentvolumeclaim @defaults("namespace name phase capacity['storage'] storageClassName created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // PersistentVolumeClaim spec
+  spec() dict
+  // PersistentVolumeClaim status
+  status() dict
+  // Access modes the claim requires (ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod)
+  accessModes() []string
+  // Name of the StorageClass requested by the claim
+  storageClassName() string
+  // The StorageClass requested by the claim (null if storageClassName is empty)
+  storageClass() k8s.storageclass
+  // Name of the PV the claim is bound to (empty until bound)
+  volumeName() string
+  // The PV the claim is bound to (null if unbound)
+  volume() k8s.persistentvolume
+  // Volume mode (Filesystem or Block)
+  volumeMode() string
+  // Resource requirements (requests, limits keyed by resource name)
+  resources() dict
+  // Label selector for preexisting PVs eligible to satisfy the claim
+  selector() dict
+  // Data source for populating the volume (snapshot, PVC, custom resource)
+  dataSource() dict
+  // Typed data-source ref (allows cross-namespace refs and arbitrary kinds)
+  dataSourceRef() dict
+  // Current phase (Pending, Bound, Lost)
+  phase() string
+  // Actual capacity of the bound volume (resource name -> quantity string)
+  capacity() map[string]string
+  // Access modes the bound volume actually provides
+  boundAccessModes() []string
+  // Status conditions (Resizing, FileSystemResizePending, etc.)
+  conditions() []dict
+}
+
+// Kubernetes EndpointSlice
+private k8s.endpointslice @defaults("namespace name addressType") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Address type (IPv4, IPv6, or FQDN)
+  addressType string
+  // List of endpoints in this slice
+  endpoints() []dict
+  // List of network ports exposed by each endpoint
+  ports() []dict
+  // The Service this slice backs (resolved from the kubernetes.io/service-name label)
+  service() k8s.service
+}
+
+// Kubernetes AdmissionReview
+//
+// Examine an AdmissionReview that an admission controller is being
+// asked to evaluate. Use `request()` to read the embedded
+// `k8s.admissionrequest` — the operation, requesting user, target
+// namespace, the incoming object, and (for UPDATE/DELETE) the prior
+// object. This resource is populated when MQL is invoked from inside a
+// dynamic admission webhook so policies can decide whether to admit
+// the request.
+k8s.admissionreview {
+  // Requested admission
+  request() k8s.admissionrequest
+}
+
+// Kubernetes AdmissionRequest
+private k8s.admissionrequest @defaults("name namespace")  {
+  // The name of the object presented in the request
+  name string
+  // The namespace associated with the request (if any)
+  namespace string
+  // The operation being performed
+  operation string
+  // Information about the requesting user
+  userInfo() k8s.userinfo
+  // The incoming object from the request
+  object dict
+  // The existing object (only populated for UPDATE and DELETE requests)
+  oldObject dict
+}
+
+// Kubernetes UserInfo
+private k8s.userinfo @defaults("username") {
+  // The username of the user
+  username string
+  // The UID of the user
+  uid string
+}
+
+// Kubernetes Validating Webhook Configuration
+private k8s.admission.validatingwebhookconfiguration @defaults("name") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Webhooks configuration
+  webhooks() []dict
+}
+
+// Kubernetes Application
+private k8s.app {
+  // Application name
+  name string
+  // Application version
+  version string
+  // Application instance
+  instance string
+  // Tool managing the operation of the application (e.g., helm)
+  managedBy string
+  // Name of the higher-level application
+  partOf string
+  // Component names within the architecture (e.g., database, cache, frontend)
+  components []string
+}
+
+// Kubernetes Gateway API GatewayClass
+private k8s.gatewayclass @defaults("name controllerName created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Name of the controller that manages Gateways of this class
+  controllerName string
+  // Human-readable description of the GatewayClass
+  description string
+  // Reference to a controller-specific configuration resource
+  parametersRef dict
+  // Status conditions
+  conditions []dict
+}
+
+// Kubernetes Gateway API Gateway
+private k8s.gateway @defaults("namespace name gatewayClassName created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Name of the GatewayClass that backs this Gateway
+  gatewayClassName string
+  // The GatewayClass that backs this Gateway
+  gatewayClass() k8s.gatewayclass
+  // Listeners associated with the Gateway
+  listeners []dict
+  // Addresses requested for the Gateway
+  addresses []dict
+  // Infrastructure settings (labels, annotations, parametersRef)
+  infrastructure dict
+  // Network addresses assigned to the Gateway by the controller
+  statusAddresses []dict
+  // Per-listener status (attached route count and conditions)
+  listenerStatus []dict
+  // Status conditions
+  conditions []dict
+}
+
+// Kubernetes Gateway API HTTPRoute
+private k8s.httproute @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Parent resources this route is associated with (Gateways, Services, etc.)
+  parentRefs []dict
+  // Hostnames this route should respond to
+  hostnames []string
+  // Rules describing matches, filters, and backend forwarding
+  rules []dict
+  // Status of the route per parent reference
+  parentStatus []dict
+}
+
+// Kubernetes Gateway API GRPCRoute
+private k8s.grpcroute @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Parent resources this route is associated with (Gateways, Services, etc.)
+  parentRefs []dict
+  // Hostnames this route should respond to
+  hostnames []string
+  // Rules describing matches, filters, and backend forwarding
+  rules []dict
+  // Status of the route per parent reference
+  parentStatus []dict
+}
+
+// Kubernetes Gateway API ReferenceGrant
+private k8s.referencegrant @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Resources that are permitted to reference targets in this ReferenceGrant's namespace
+  from []dict
+  // Resources in this namespace that may be referenced
+  to []dict
+}
+
+// Kubernetes MutatingWebhookConfiguration
+private k8s.admission.mutatingwebhookconfiguration @defaults("name") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Webhooks configuration
+  webhooks() []dict
+}
+
+// Kubernetes PodDisruptionBudget
+private k8s.poddisruptionbudget @defaults("namespace name created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Minimum number or percentage of pods that must remain available (IntOrString)
+  minAvailable dict
+  // Maximum number or percentage of pods that may be unavailable (IntOrString)
+  maxUnavailable dict
+  // Label selector for the pods this PDB protects
+  selector dict
+  // Policy for evicting unhealthy pods (IfHealthyBudget or AlwaysAllow)
+  unhealthyPodEvictionPolicy string
+  // Number of currently healthy pods
+  currentHealthy int
+  // Minimum number of healthy pods required
+  desiredHealthy int
+  // Total number of pods counted by this PDB
+  expectedPods int
+  // Number of pod disruptions currently allowed
+  disruptionsAllowed int
+  // Generation of the most recently observed PDB spec
+  observedGeneration int
+  // Status conditions
+  conditions []dict
+}
+
+// Kubernetes Lease (coordination.k8s.io)
+private k8s.lease @defaults("namespace name holderIdentity created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object namespace
+  namespace string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Identity of the lease holder (often "<hostname>_<uuid>")
+  holderIdentity string
+  // Lease duration in seconds
+  leaseDurationSeconds int
+  // Time the current holder acquired the lease
+  acquireTime time
+  // Time the current holder last renewed the lease
+  renewTime time
+  // Number of times this lease has been transferred to a new holder
+  leaseTransitions int
+  // Strategy used to coordinate leadership (e.g., OldestEmulationVersion)
+  strategy string
+  // Preferred future holder for the lease
+  preferredHolder string
+}
+
+// Kubernetes CertificateSigningRequest
+private k8s.certificatesigningrequest @defaults("name signerName username created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // PEM-encoded certificate signing request
+  request string
+  // Name of the signer that should handle this request (e.g., kubernetes.io/kube-apiserver-client)
+  signerName string
+  // Requested duration for the issued certificate, in seconds
+  expirationSeconds int
+  // Requested key usages for the certificate (e.g., client auth, server auth)
+  usages []string
+  // Username of the user that created the request
+  username string
+  // UID of the user that created the request
+  requesterUid string
+  // Groups of the user that created the request
+  groups []string
+  // PEM-encoded issued certificate (empty until the request is approved and signed)
+  certificate string
+  // Status conditions (Approved, Denied, Failed)
+  conditions []dict
+}
+
+// Kubernetes APIService (aggregation layer)
+private k8s.apiservice @defaults("name group version created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // API group this APIService handles (empty for the core group)
+  group string
+  // API version this APIService handles
+  version string
+  // Whether TLS verification of the backend service is skipped
+  insecureSkipTLSVerify bool
+  // PEM-encoded CA bundle used to validate the backend service
+  caBundle string
+  // Minimum priority for this group across versions
+  groupPriorityMinimum int
+  // Ordering priority for this version within the group
+  versionPriority int
+  // Name of the backend service (empty when the APIService is served by kube-apiserver itself)
+  serviceName string
+  // Namespace of the backend service
+  serviceNamespace string
+  // Port the backend service is reachable on
+  servicePort int
+  // The backend Kubernetes service that handles requests for this APIService
+  service() k8s.service
+  // Status conditions (Available)
+  conditions []dict
+}
+
+// Kubernetes IngressClass
+private k8s.ingressclass @defaults("name controller created") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // Name of the controller that handles ingresses of this class (e.g., k8s.io/ingress-nginx)
+  controller string
+  // Reference to a controller-specific configuration resource (apiGroup, kind, name, namespace, scope)
+  parameters dict
+}
+
+// Kubernetes owner reference
+//
+// Examine the controller or parent object that owns this object, as recorded
+// in metadata.ownerReferences: the referent's apiVersion, kind, name, and uid,
+// whether it is the managing controller, and whether it blocks foreground
+// cascading deletion. Correlate uid against the uid of any modeled object to
+// trace provenance and ownership chains across the cluster.
+private k8s.ownerReference @defaults("kind name") {
+  // API version of the referent
+  apiVersion string
+  // Kind of the referent
+  kind string
+  // Name of the referent
+  name string
+  // UID of the referent
+  uid string
+  // Whether the referent is the managing controller
+  controller bool
+  // Whether the referent blocks foreground cascading deletion
+  blockOwnerDeletion bool
+}
+
+// Kubernetes managed field entry
+//
+// Examine one server-side-apply field-management record from
+// metadata.managedFields: the manager that owns a set of fields, the operation
+// it used, the apiVersion those fields are expressed in, the time of the
+// change, the optional subresource, and the fieldsV1 set enumerating exactly
+// which fields the manager owns. Use these records to see which controller or
+// tool last wrote each part of an object.
+private k8s.managedField @defaults("manager operation") {
+  // Workflow or tool managing these fields, for example kubectl, helm, or kube-controller-manager
+  manager string
+  // Operation that led to this entry, either "Apply" or "Update"
+  operation string
+  // API version of the fields set
+  apiVersion string
+  // Time the manager last modified these fields
+  time time
+  // Subresource this entry applies to, for example "status", or empty for the main resource
+  subresource string
+  // Type of the fields set, always "FieldsV1"
+  fieldsType string
+  // Set of fields this manager owns, as a nested map
+  fieldsV1 dict
+}

--- a/content/testdata/schema/providers/network/resources/network.lr
+++ b/content/testdata/schema/providers/network/resources/network.lr
@@ -1,0 +1,677 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+option provider = "go.mondoo.com/cnquery/v13/providers/network"
+option go_package = "go.mondoo.com/mql/v13/providers/network/resources"
+
+// Network socket
+//
+// Examine an addressable network endpoint by `protocol`, `port`, and
+// `address`. Used as a building block for higher-level resources like
+// `tls` that need to know "what to talk to".
+socket @defaults("protocol port address") {
+  // Transport protocol (e.g., tcp, udp)
+  protocol string
+  // Port number
+  port int
+  // Target address (hostname or IP)
+  address string
+}
+
+// HTTP endpoint
+//
+// Empty namespace for HTTP probing. Use `http.get(url: "https://...")`
+// to perform a GET against a URL and inspect the response status,
+// headers (parsed into typed sub-resources for HSTS, CSP, cookies,
+// etc.), and body.
+http {}
+
+// HTTP GET request
+//
+// Examine the result of an HTTP GET against a URL. Initialize with
+// `http.get(rawUrl: "https://example.com", followRedirects: true)`.
+// Surfaces the parsed `url`, the `statusCode`, the HTTP `version`,
+// the response `body`, and a typed `header` sub-resource exposing
+// HSTS, CSP, X-Frame-Options, X-XSS-Protection, X-Content-Type-Options,
+// Referrer-Policy, Content-Type, and Set-Cookie semantics.
+http.get @defaults("url statusCode") {
+  init(rawUrl string, followRedirects bool)
+  // URL for this request
+  url url
+  // Follow redirects
+  followRedirects bool
+  // Header returned from this request
+  header() http.header
+  // Status returned from this request
+  statusCode() int
+  // Version of the HTTP request, (e.g., 1.1)
+  version() string
+  // Body returned from this request
+  body() string
+}
+
+// HTTP header
+private http.header @defaults("length=params.length") {
+  // Raw list of parameters for this header
+  params map[string][]string
+  // HTTP Strict-Transport-Security (HSTS) header
+  sts() http.header.sts
+  // X-Frame-Options header: DENY, SAMEORIGIN, or ALLOW-FROM origin (obsolete)
+  xFrameOptions() string
+  // X-XSS-Protection header
+  xXssProtection() http.header.xssProtection
+  // X-Content-Type-Options header: nosniff
+  xContentTypeOptions() string
+  // Referrer-Policy header
+  referrerPolicy() string
+  // Content-Type header
+  contentType() http.header.contentType
+  // Set-Cookie header
+  setCookie() http.header.setCookie
+  // Content-Security-Policy header
+  csp() map[string]string
+  // Server header value, e.g. "nginx" or "Apache/2.4.62"
+  //
+  // The product token(s) the server discloses about itself. Empty when no
+  // Server header is sent. Frequently flagged by hardening policies because it
+  // leaks the server software and sometimes its version.
+  server() string
+}
+
+// HTTP header Strict-Transport-Security
+private http.header.sts @defaults("maxAge includeSubDomains preload") {
+  // How long to cache HTTPS-only policy in seconds
+  maxAge time
+  // Whether caching applies to subdomains
+  includeSubDomains bool
+  // Non-standard directive for preloading STS
+  preload bool
+}
+
+// HTTP header X-XSS-Protection
+//
+// Now outdated (replaced by Content Security Policy) and may even cause
+// security vulnerabilities. Examine `enabled`, `mode`, and `report` to
+// see how a server is configuring the legacy XSS filter.
+private http.header.xssProtection @defaults("enabled mode report") {
+  // Whether the header is enabled (Enabled when the header value is set to 1; disabled if set to 0)
+  enabled bool
+  // Mode for XSS filtering
+  mode string
+  // Report endpoint for violations (Chromium only)
+  report string
+}
+
+// HTTP header Content-Type
+private http.header.contentType @defaults("type") {
+  // MIME type for the content
+  type string
+  // Additional parameters for this content type
+  params map[string]string
+}
+
+// HTTP header Set-Cookie
+private http.header.setCookie @defaults("name value") {
+  // Name of the cookie to set
+  name string
+  // Value of the cookie to set
+  value string
+  // Additional parameters for setting this cookie
+  params map[string]string
+}
+
+// Parsed URL
+//
+// Examine a parsed URL, generally represented as
+// `[scheme:][//[user[:password]@]host[:port]][/]path[?query][#fragment]`.
+// Initialize with `url(raw: "https://user:pass@host:443/p?q=1#f")` and
+// inspect any of the parsed components individually: scheme, user /
+// password user-info pair, host, port, path, parsed query map, raw
+// query string, and fragment.
+url @defaults("string") {
+  init(raw string)
+  // The full URL as a string
+  string() string
+  // Scheme (e.g., http, https, ssh)
+  scheme string
+  // User component (can contain username or token but no password)
+  user string
+  // Password, an additional optional component of the user info
+  password string
+  // Host, either registered name or IP (e.g., mondoo.com)
+  host string
+  // Port, optional decimal number (e.g., 80)
+  port int
+  // Path, consisting of segments separated by '/'
+  path string
+  // Query, optional, attached to path via '?', parsed via '&' and ';' delimiters
+  query map[string]string
+  // Raw query, optional raw string attached to path after '?'
+  rawQuery string
+  // Fragment, optional raw string attached to path after '#'
+  rawFragment string
+}
+
+// TLS/SSL connection inspection
+//
+// Examine the TLS posture of a network endpoint. Initialize with
+// `tls(target: "host:port")` (an optional `domainName` enables SNI
+// testing). Surfaces every TLS / SSL version the endpoint accepts,
+// the cipher suites and extensions advertised, the version / cipher
+// / key-exchange group a modern client actually negotiates, and the
+// served certificate chain — both the SNI-aware chain and the
+// non-SNI fallback. The resource an audit uses to find weak protocol
+// versions, weak ciphers, expired certs, and missing OCSP / SCT
+// support.
+tls @defaults("socket domainName") {
+  init(target string)
+  // Socket of this connection
+  socket socket
+  // An optional domain name to test
+  domainName string
+  // List of all parameters for this TLS/SSL connection
+  params(socket, domainName) dict
+  // Version of TLS/SSL that is being used
+  versions(params) []string
+  // Ciphers supported by this TLS/SSL connection
+  ciphers(params) []string
+  // Supported cipher suites parsed into components and security properties
+  cipherSuites(params) []tls.cipher
+  // Extensions supported by this TLS/SSL connection
+  extensions(params) []string
+  // Key exchange group negotiated during the TLS handshake (e.g., X25519, X25519MLKEM768)
+  negotiatedGroup(socket, domainName) string
+  // TLS version negotiated by a modern client (e.g., "TLS 1.3")
+  negotiatedVersion(socket, domainName) string
+  // Cipher suite negotiated by a modern client (e.g., "TLS_AES_128_GCM_SHA256")
+  negotiatedCipher(socket, domainName) string
+  // Certificates provided in this TLS/SSL connection
+  certificates(socket, domainName) []certificate
+  // Certificates provided without server name indication (SNI)
+  nonSniCertificates(socket, domainName) []certificate
+  // Whether the served leaf certificate covers the connection hostname
+  //
+  // Matches the connection's domain name against the leaf certificate's
+  // Subject Alternative Name DNS entries using RFC 6125 wildcard rules,
+  // so `*.example.com` covers `api.example.com`. Unlike chain
+  // verification, this isolates hostname coverage — it is true when the
+  // certificate vouches for the host you connected to, independent of
+  // chain trust or expiry. Null when the connection has no domain name
+  // to match, such as when connecting directly to an IP address.
+  certificateMatchesDomain() bool
+}
+
+// TLS/SSL cipher suite
+//
+// Examine a single negotiable cipher suite broken into its key-exchange,
+// authentication, bulk-encryption, and MAC components, plus derived security
+// properties. Components are parsed best-effort from the IANA/OpenSSL suite
+// name, so audits can select suites by property — for example
+// `forwardSecrecy == false` or `cbc` — instead of matching the raw name with
+// regular expressions. Unknown components are empty.
+private tls.cipher @defaults("name") {
+  // Cipher suite name, e.g. "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+  name string
+  // Key-exchange algorithm, e.g. "ECDHE", "DHE", or "RSA"
+  //
+  // Empty for TLS 1.3 suites, where the key exchange is negotiated separately
+  // from the cipher suite.
+  keyExchange string
+  // Authentication algorithm, e.g. "RSA", "ECDSA", or "anon"
+  authentication string
+  // Bulk encryption algorithm, e.g. "AES_128_GCM", "3DES_EDE_CBC", or "RC4_128"
+  encryption string
+  // Message authentication or PRF hash, e.g. "SHA256", "SHA", or "MD5"
+  mac string
+  // Whether the suite provides forward secrecy
+  //
+  // True for ephemeral key exchanges (ECDHE, DHE) and all TLS 1.3 suites.
+  forwardSecrecy bool
+  // Whether the suite uses authenticated encryption (GCM, CCM, or ChaCha20-Poly1305)
+  aead bool
+  // Whether the suite is export-grade (deliberately weakened)
+  export bool
+  // Whether the suite uses null (no) encryption
+  nullCipher bool
+  // Whether the suite is anonymous and performs no server authentication
+  anonymous bool
+  // Whether the suite uses CBC mode, which is exposed to a class of padding attacks
+  cbc bool
+}
+
+// X.509 certificate bundle
+//
+// Examine a list of certificates parsed from PEM content. Use it to
+// iterate over a chain and apply per-certificate checks, or to
+// extract the underlying `pem` source.
+certificates {
+  []certificate
+  // PEM content
+  pem string
+}
+
+// X.509 certificate
+//
+// Examine a single X.509 certificate parsed from PEM. Surfaces the
+// raw PEM, every SHA-1 / SHA-256 fingerprint, the serial number, the
+// subject and authority key identifiers, the parsed PKIX subject and
+// issuer distinguished names, version, validity window
+// (`notBefore`, `notAfter`, `expiresIn`), signature and signing
+// algorithm, the `isCA` flag, key usages and extended key usages, the
+// raw and SAN extensions, policy identifiers, CRL distribution points,
+// OCSP server and issuing-certificate URLs, the revoked / verified /
+// expired flags, public-key algorithm and bit length, the
+// `hasSCTs` flag (Certificate Transparency) and the maximum CA chain
+// path length.
+certificate @defaults("serial subject.commonName subject.dn") {
+  // PEM content
+  pem string
+  // Certificate fingerprints
+  fingerprints() map[string]string
+  // Serial number
+  serial() string
+  // Subject unique identifier
+  subjectKeyID() string
+  // Authority key identifier
+  authorityKeyID() string
+  // Distinguished name of the certificate subject
+  subject() pkix.name
+  // Distinguished name of the certificate issuer
+  issuer() pkix.name
+  // Version number
+  version() int
+  // Validity period validity period
+  notBefore() time
+  // Validity period not after
+  notAfter() time
+  // Expiration duration
+  expiresIn() time
+  // Signature
+  signature() string
+  // Signature algorithm ID
+  signingAlgorithm() string
+  // Whether the certificate is from a certificate authority
+  isCA() bool
+  // Key usage
+  keyUsage() []string
+  // Extended key usage
+  extendedKeyUsage() []string
+  // Extensions
+  extensions() []pkix.extension
+  // Policy identifier
+  policyIdentifier() []string
+  // CRL distribution points
+  crlDistributionPoints() []string
+  // OCSP responder URLs for revocation checking
+  ocspServer() []string
+  // Issuing certificate URL
+  issuingCertificateUrl() []string
+  // Whether this certificate has been revoked
+  isRevoked() bool
+  // The time at which this certificate was revoked
+  revokedAt() time
+  // Whether the certificate is valid (based on its chain)
+  isVerified() bool
+  // SAN extension value params
+  sanExtension() pkix.sanExtension
+  // Public key algorithm (e.g., RSA, ECDSA, Ed25519)
+  publicKeyAlgorithm() string
+  // Public key size in bits (e.g., 2048, 256, 384)
+  publicKeyBits() int
+  // Whether the certificate has expired
+  isExpired() bool
+  // Whether Signed Certificate Timestamps (SCTs) are present (Certificate Transparency)
+  hasSCTs() bool
+  // Maximum CA chain depth (null if unconstrained, 0 = no intermediates allowed)
+  maxPathLen() int
+}
+
+// X.509 PKIX name
+//
+// Examine a parsed RFC 5280 distinguished name (DN) — the structured
+// form of a certificate's subject or issuer. Surfaces the canonical
+// DN string, common name, country, organization and organizational
+// unit, locality, province, street address, postal code, serial
+// number, and any extra named attributes.
+pkix.name @defaults("id dn commonName") {
+  // Cache key derived from the distinguished name
+  id string
+  // Distinguished name qualifier
+  dn string
+  // Serial number
+  serialNumber string
+  // Common name
+  commonName string
+  // Country
+  country []string
+  // Organization
+  organization []string
+  // Organizational unit
+  organizationalUnit []string
+  locality []string
+  // State or province
+  province []string
+  // Street address
+  streetAddress []string
+  // Postal code
+  postalCode []string
+  names      map[string]string
+  extraNames map[string]string
+}
+
+// X.509 PKIX extension
+//
+// Examine a single extension carried by an X.509 certificate: its
+// OID identifier (e.g., 2.5.29.37 for extKeyUsage), the `critical`
+// flag, and the raw extension value.
+pkix.extension @defaults("id") {
+  // Cache key derived from the extension identifier
+  id string
+  // Extension identifier (OID, e.g., 2.5.29.37 for extKeyUsage)
+  identifier string
+  // Whether the extension is critical
+  critical bool
+  // Extension value
+  value string
+}
+
+// X.509 certificate PKIX Subject Alternative Name (SAN) extension
+private pkix.sanExtension @defaults("dnsNames") {
+	// x509 certificate PKIX extension
+	extension pkix.extension
+	// DNS names
+	dnsNames []string
+	// IP addresses
+	ipAddresses []string
+	// Email addresses
+	emailAddresses []string
+	// URIs
+	uris []string
+}
+
+// List of OpenPGP entities parsed from a string
+private openpgp.entities {
+  []openpgp.entity(content)
+  content string
+}
+
+// OpenPGP entity
+private openpgp.entity {
+  // Primary public key, which must be a signing key
+  primaryPublicKey openpgp.publicKey
+  // Entity's identities
+  identities() []openpgp.identity
+}
+
+// OpenPGP public key
+private openpgp.publicKey {
+  // Key ID
+  id string
+  // Key version
+  version int
+  // Key fingerprint
+  fingerprint string
+  // Public key algorithm (e.g., RSA, ECDSA, Ed25519)
+  keyAlgorithm string
+  // Key bit length
+  bitLength int
+  // Key creation time
+  creationTime time
+}
+
+// OpenPGP identity
+private openpgp.identity {
+  // Primary key fingerprint
+  fingerprint string
+  // Full name in form of `Full Name (comment) <email@example.com>`
+  id string
+  // Real name from the OpenPGP user ID
+  name string
+  // Email address from the OpenPGP user ID
+  email string
+  // Free-form comment from the OpenPGP user ID
+  comment string
+  // Identity signatures
+  signatures() []openpgp.signature
+}
+
+// OpenPGP signature
+private openpgp.signature {
+  // Primary key fingerprint
+  fingerprint string
+  // Identity name
+  identityName string
+  // Signature hash
+  hash string
+  // Signature version
+  version int
+  // Signature type
+  signatureType string
+  // Public-key algorithm of the signing key (e.g., RSA, ECDSA, Ed25519)
+  keyAlgorithm string
+  // Creation time
+  creationTime time
+  // Signature lifetime in seconds
+  lifetimeSecs int
+  // Expiration duration
+  expiresIn time
+  // Key lifetime in seconds
+  keyLifetimeSecs int
+  // Key expiration duration
+  keyExpiresIn time
+}
+
+// Domain name
+//
+// Examine a parsed FQDN. Initialize with `domainName(fqdn: "x.example.com")`.
+// Surfaces the FQDN itself, the effective TLD plus one (the
+// registrable domain), the TLD, an `tldIcannManaged` flag indicating
+// whether the TLD is in the ICANN-managed list, and the individual
+// dot-separated labels.
+domainName @defaults("fqdn") {
+  init(fqdn string)
+  // Fully qualified domain name (FQDN)
+  fqdn string
+  // effectiveTLDPlusOne returns the effective top level domain plus one more label
+  effectiveTLDPlusOne string
+  // Top-level domain
+  tld string
+  // Whether the TLD is ICANN managed
+  tldIcannManaged bool
+  // Domain labels
+  labels []string
+}
+
+// DNS resource
+//
+// Examine the DNS records published for a fully-qualified domain
+// name. Initialize with `dns(fqdn: "example.com")`. Surfaces every
+// resolved record, the MX record list, and a parsed view of any DKIM
+// public-key records discovered for the domain.
+dns @defaults("fqdn") {
+  init(fqdn string)
+  // Fully qualified domain name (FQDN)
+  fqdn string
+  // Params is a list of all parameters for DNS FQDN
+  params(fqdn) dict
+  // Successful DNS records
+  records(params) []dns.record
+  // Successful DNS MX records
+  mx(params) []dns.mxRecord
+  // DKIM TXT records
+  dkim(params) []dns.dkimRecord
+  // DNSSEC signing state for the domain
+  dnssec(params) dns.dnssecConfig
+  // Parsed SPF (Sender Policy Framework) records
+  spf(params) []dns.spfRecord
+  // Parsed DMARC record published at the domain's _dmarc subdomain
+  dmarc() dns.dmarcRecord
+  // Reverse DNS (PTR) records for the domain's resolved addresses
+  //
+  // Resolves the domain's A and AAAA addresses, then looks up the PTR
+  // record for each — the forward-confirmed reverse DNS round trip. Use
+  // it to confirm an address resolves back to the expected hostname
+  // without hand-building `in-addr.arpa` names.
+  reverse(params) []dns.record
+}
+
+// DNS record
+//
+// Examine a single resolved DNS record: name, type, class, TTL, and
+// the rdata payload (IP addresses, hostnames, or other values
+// depending on the record type).
+dns.record @defaults("name type") {
+  // DNS name
+  name string
+  // Time-to-live (TTL) in seconds
+  ttl int
+  // DNS class
+  class string
+  // DNS type
+  type string
+  // DNS record response data (IP addresses, hostnames, or other values depending on record type)
+  rdata []string
+}
+
+// DNS MX record
+//
+// Examine a single MX record: the record name, the resolved target
+// `domainName`, and the `preference` value used to choose between
+// multiple MX records.
+dns.mxRecord @defaults("domainName") {
+  // Record name
+  name string
+  // Which mail server used if multiple MX records exist
+  preference int
+  // Domain name
+  domainName string
+}
+
+// DNSSEC configuration for a domain
+//
+// Examine whether a domain is signed with DNSSEC and how. Reports whether
+// the domain publishes DNSKEY records, the parsed signing keys, and the
+// distinct algorithm numbers in use, so audits can require DNSSEC and flag
+// weak or deprecated algorithms without parsing raw DNSKEY rdata. `enabled`
+// reflects the presence of published DNSKEY records and does not, on its own,
+// validate the DS chain of trust at the parent zone.
+dns.dnssecConfig @defaults("enabled") {
+  // Whether the domain publishes DNSKEY records
+  enabled bool
+  // Published DNSKEY signing keys
+  keys []dns.dnssecKey
+  // Distinct DNSSEC algorithm numbers across all published keys
+  //
+  // Algorithm numbers as defined in RFC 8624, e.g. 8 (RSASHA256) or
+  // 13 (ECDSAP256SHA256). Use it to flag deprecated algorithms such as
+  // 5/7 (RSASHA1) or 3 (DSA).
+  algorithms []int
+}
+
+// DNSKEY record (RFC 4034)
+//
+// Examine a single published DNSSEC key: its flags, protocol, algorithm
+// number, and base64-encoded public key. `keySigningKey` is true for a
+// key-signing key — the one whose SEP flag is set (flags value 257) — as
+// opposed to a zone-signing key (flags value 256).
+private dns.dnssecKey @defaults("algorithm keySigningKey") {
+  // DNSKEY flags field, e.g. 256 for a zone-signing key or 257 for a key-signing key
+  flags int
+  // Protocol field, always 3 for DNSSEC
+  protocol int
+  // DNSSEC algorithm number (RFC 8624), e.g. 8 (RSASHA256) or 13 (ECDSAP256SHA256)
+  algorithm int
+  // Base64-encoded public key
+  publicKey string
+  // Whether this is a key-signing key (the SEP flag is set)
+  keySigningKey bool
+}
+
+// SPF policy record (RFC 7208)
+//
+// Examine a parsed Sender Policy Framework record from a domain's TXT records:
+// the version, the ordered list of mechanisms, and the qualifier on the
+// terminating `all` mechanism that decides how unauthorized senders are
+// handled. Select a domain's records with `dns(fqdn: "example.com").spf`.
+private dns.spfRecord @defaults("dnsTxt allQualifier") {
+  // Raw TXT record
+  dnsTxt string
+  // Version tag, e.g. "spf1"
+  version string
+  // Ordered SPF mechanisms and modifiers
+  //
+  // All terms after the version, in order, including the terminating `all`
+  // term — for example `["ip4:192.0.2.0/24", "include:_spf.example.com",
+  // "-all"]`. The `all` qualifier is also surfaced separately as
+  // `allQualifier`.
+  mechanisms []string
+  // Qualifier on the terminating `all` mechanism
+  //
+  // One of `+` (pass), `-` (fail), `~` (softfail), or `?` (neutral). A bare
+  // `all` is reported as `+` (the SPF default). Empty when the record has no
+  // `all` mechanism.
+  allQualifier string
+}
+
+// DMARC policy record (RFC 7489)
+//
+// Examine a parsed DMARC record from a domain's `_dmarc` TXT record: the policy
+// applied to failing mail, the subdomain policy, the aggregate and forensic
+// report destinations, the percentage of mail the policy covers, and the
+// SPF/DKIM identifier alignment modes. Reachable as
+// `dns(fqdn: "example.com").dmarc`, which resolves the `_dmarc` subdomain
+// itself.
+private dns.dmarcRecord @defaults("policy") {
+  // Raw TXT record
+  dnsTxt string
+  // Version tag, e.g. "DMARC1"
+  version string
+  // Policy applied to mail that fails DMARC
+  //
+  // One of `none`, `quarantine`, or `reject` (the `p=` tag).
+  policy string
+  // Policy applied to subdomains (the `sp=` tag); empty when not set
+  subdomainPolicy string
+  // Aggregate report destination URIs (the `rua=` tag)
+  aggregateReportUris []string
+  // Forensic report destination URIs (the `ruf=` tag)
+  forensicReportUris []string
+  // Percentage of failing mail the policy is applied to (the `pct=` tag)
+  //
+  // Defaults to 100 when the tag is absent.
+  percentage int
+  // SPF identifier alignment mode (the `aspf=` tag): `r` relaxed or `s` strict
+  spfAlignment string
+  // DKIM identifier alignment mode (the `adkim=` tag): `r` relaxed or `s` strict
+  dkimAlignment string
+}
+
+// DKIM public-key DNS record (RFC 6376)
+//
+// Examine a parsed DKIM TXT record: the raw DNS text, the selector
+// domain, the version, the acceptable hash algorithms, the key type,
+// the base64-encoded public-key data, the service-type restrictions,
+// the DKIM flags, free-form notes, and a `valid()` predicate that
+// validates the record and its public key.
+dns.dkimRecord @defaults("dnsTxt") {
+  // DNS text representation
+  dnsTxt string
+  // DKIM selector domain
+  domain string
+  // Version
+  version string
+  // Acceptable hash algorithms
+  hashAlgorithms []string
+  // Key type
+  keyType string
+  // Free-form notes about the DKIM record
+  notes string
+  // Public key data base64-encoded
+  publicKeyData string
+  // Service types this DKIM key is restricted to (e.g., email, *)
+  serviceTypes []string
+  // DKIM flags (e.g., y for testing, s to require exact selector match)
+  flags []string
+  // Whether the DKIM entry and public key is valid
+  valid() bool
+}

--- a/content/testdata/schema/providers/os/resources/os.lr
+++ b/content/testdata/schema/providers/os/resources/os.lr
@@ -1,0 +1,8969 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+import "../../core/resources/core.lr"
+import "../../network/resources/network.lr"
+
+option provider = "go.mondoo.com/cnquery/v9/providers/os"
+option go_package = "go.mondoo.com/mql/v13/providers/os/resources"
+
+alias os.base.command = command
+alias os.base.user = user
+alias os.base.group = group
+alias os.base.file = file
+alias os.base.packages = packages
+alias os.base.service = service
+alias os.base.services = services
+alias os.unix.sshd = sshd
+
+extend asset {
+  // Common Platform Enumeration (CPE) for the asset
+  cpes() []core.cpe
+  // Advisory and vulnerability report
+  //
+  // Deprecated in favor of the `vulnmgmt` resource. Will be removed in
+  // version 13.0.
+  vulnerabilityReport() @maturity("deprecated") dict
+  // Platform URL in the package URL format (as opposed to the CPE format)
+  purl() string
+}
+
+// Operating system end-of-life status
+//
+// Examine the End-of-Life metadata Mondoo publishes for the asset's
+// detected operating system or platform: the EoL date itself, a
+// product-page URL, and a documentation URL. Used by audits to flag
+// hosts whose vendor has stopped issuing security patches and to plan
+// migrations before unsupported software accumulates risk.
+asset.eol @defaults("date") {
+  // Documentation URL
+  docsUrl string
+  // Product URL
+  productUrl string
+  // End-of-Life date
+  date time
+}
+
+// Platform end-of-life information
+private mondoo.eol {
+  // Product name
+  product string
+  // Product version
+  version string
+  // End-of-life date for the product
+  date() time
+}
+
+// Asset vulnerability assessment
+//
+// Top-level entry point for vulnerability data Mondoo derives for an
+// asset by joining its installed-package inventory and platform identity
+// against the curated CVE / advisory feed. Exposes every CVE affecting
+// the asset, every vendor advisory that mentions one of those CVEs, the
+// affected packages with their currently-installed and patched-available
+// versions, the timestamp of the last assessment run, and the rolled-up
+// CVSS statistics — the surface used to score asset risk and to drive
+// patch-status policies.
+vulnmgmt {
+  // List of all CVEs affecting the asset
+  cves() []vuln.cve
+  // List of all Advisories affecting the asset
+  advisories() []vuln.advisory
+  // List of all packages affected by vulnerabilities
+  packages() []vuln.package
+  // Last time the vulnerability information was updated
+  lastAssessment() time
+  // Statistics about the vulnerabilities
+  stats() audit.cvss
+}
+
+// CVE information
+private vuln.cve @defaults("id") {
+  // CVE ID
+  id string
+  // CVE state
+  state     string
+  // Summary description
+  summary   string
+  // Whether the CVE has a CVSS score
+  unscored  bool
+  // Publication date
+  published   time
+  // Last modification date
+  modified    time
+  // Worst CVSS score of all assigned CVEs
+  worstScore    audit.cvss
+}
+
+// Advisory information
+private vuln.advisory @defaults("id") {
+  // Advisory ID
+  id string
+  // Title of the advisory
+  title string
+  // Description of the advisory
+  description string
+  // Advisory publication date
+  published   time
+  // Last modification date
+  modified    time
+  // Worst CVSS score of all assigned CVEs
+  worstScore    audit.cvss
+}
+
+// Package information relevant for vulnerability management
+private vuln.package @defaults("name version") {
+  // Package name
+  name string
+  // Package version
+  version string
+  // Available package version
+  available string
+  // Architecture of this package
+  arch string
+}
+
+// Platform and package advisories
+//
+// Examine the consolidated list of vendor advisories that affect the
+// asset, plus a worst-case CVSS roll-up across all of them and a
+// statistical breakdown by severity (total, critical, high, medium, low,
+// none, unknown). Use it to drive policies that require zero outstanding
+// critical-severity advisories or that compare an asset's advisory load
+// against a baseline.
+platform.advisories {
+  []audit.advisory
+  // Worst CVSS score for all advisories
+  cvss() audit.cvss
+  // Statistical information: total, critical, high, medium, low, none, unknown
+  stats() dict
+}
+
+// Platform and package CVEs
+//
+// Examine the full list of CVEs that affect the asset's installed
+// packages or platform, plus a worst-case CVSS roll-up across them and
+// a per-severity statistical breakdown (total, critical, high, medium,
+// low, none, unknown). Used to enforce ceilings on outstanding critical
+// or high-severity CVEs and to surface the most urgent fixes.
+platform.cves {
+  []audit.cve
+  // Worst CVSS score for all CVEs
+  cvss() audit.cvss
+  // Statistical information: total, critical, high, medium, low, none, unknown
+  stats() dict
+}
+
+// Common Vulnerability Scoring System (CVSS) score
+private audit.cvss @defaults("score") {
+  // CVSS score ranging from 0.0 to 10.0
+  score   float
+  // CVSS score represented as a vector string
+  vector  string
+}
+
+// Platform/package advisory
+private audit.advisory {
+  // Advisory ID
+  id          string
+  // Mondoo advisory identifier
+  mrn         string
+  // Advisory title
+  title       string
+  // Advisory description
+  description string
+  // Advisory publication date
+  published   time
+  // Last modification date
+  modified    time
+  // Worst CVSS score of all assigned CVEs
+  worstScore    audit.cvss
+}
+
+// Common Vulnerabilities and Exposures (CVEs)
+private audit.cve {
+  // CVE ID
+  id        string
+  // Mondoo CVE identifier
+  mrn       string
+  // CVE state
+  state     string
+  // Summary description
+  summary   string
+  // Whether the CVE has a CVSS score
+  unscored  bool
+  // Publication date
+  published   time
+  // Last modification date
+  modified    time
+  // Worst CVSS score of all assigned CVEs
+  worstScore    audit.cvss
+}
+
+// Hardware identity from SMBIOS / DMI
+//
+// Top-level namespace for low-level hardware identity exposed by the
+// firmware. The sub-resources below — `machine.bios`, `machine.system`,
+// `machine.baseboard`, `machine.chassis`, `machine.cpu`, and
+// `machine.secureboot` — surface the SMBIOS / DMI tables (vendor /
+// version / release date for the BIOS, manufacturer / product / SKU /
+// UUID / serial for the system, baseboard and chassis identifiers, CPU
+// socket and core counts) plus the EFI Secure Boot posture read from
+// EFI variables on Linux. Used for inventory, warranty / supply-chain
+// reviews, and platform-firmware compliance.
+machine {}
+
+// SMBIOS BIOS information
+//
+// Examine the firmware vendor, version string, and release date as reported
+// by SMBIOS Type 1 tables. Used to inventory BIOS versions across a fleet
+// and to flag hosts that have not applied vendor firmware updates.
+machine.bios {
+  // BIOS vendor
+  vendor string
+  // BIOS version
+  version string
+  // BIOS release date
+  releaseDate string
+}
+
+// SMBIOS system information
+//
+// Examine the manufacturer, product name, version, serial number, UUID,
+// SKU number, and family string as reported in SMBIOS Type 1 tables.
+// Useful for asset inventory, warranty lookups, and supply-chain reviews.
+machine.system {
+  // System manufacturer name (SMBIOS Type 1)
+  manufacturer string
+  // System product name
+  product string
+  // System version string
+  version string
+  // System serial number
+  serial string
+  // System UUID
+  uuid string
+  // SKU number
+  sku string
+  // System family/series
+  family string
+}
+
+// SMBIOS baseboard (or module) information
+//
+// Examine the baseboard manufacturer, product name, version, serial number,
+// and asset tag as reported in SMBIOS Type 2 tables. Used for hardware
+// inventory and to correlate physical boards with asset tracking systems.
+machine.baseboard {
+  // Baseboard manufacturer name (SMBIOS Type 2)
+  manufacturer string
+  // Baseboard product name
+  product string
+  // Baseboard version string
+  version string
+  // Baseboard serial number
+  serial string
+  // Asset tag
+  assetTag string
+}
+
+// SMBIOS system enclosure or chassis
+//
+// Examine the chassis manufacturer, version, serial number, and asset tag
+// as reported in SMBIOS Type 3 tables. Useful for physical-hardware audits
+// and correlating enclosures with asset-tracking records.
+machine.chassis {
+  // Manufacturer
+  manufacturer string
+  // Version
+  version string
+  // Serial number
+  serial string
+  // Asset tag number
+  assetTag string
+}
+
+// CPU information
+//
+// Examine the CPU manufacturer, model name, number of physical processor
+// packages (sockets), and total physical core count as reported by the
+// system. Used for capacity planning, licensing audits, and
+// hardware-baseline policies.
+machine.cpu @defaults("manufacturer model processorCount coreCount") {
+  // CPU manufacturer
+  manufacturer string
+  // CPU model name
+  model string
+  // Number of physical CPU packages (sockets)
+  processorCount int
+  // Total number of physical CPU cores
+  coreCount int
+}
+
+// Secure Boot status
+//
+// Examine whether the system booted in EFI/UEFI mode (`efi`), whether
+// Secure Boot is currently enabled (`enabled`), and whether it is in setup
+// mode (`setupMode`, meaning keys can be modified without authentication).
+// Read from the EFI variables on Linux and from the UEFI firmware on
+// Windows; legacy-BIOS systems resolve to `efi` and `enabled` false rather
+// than erroring. Used to assert that Secure Boot is enforced and that setup
+// mode is not active.
+machine.secureboot @defaults("enabled") {
+  // Whether the system is booted in EFI/UEFI mode
+  efi() bool
+  // Whether Secure Boot is enabled
+  enabled() bool
+  // Whether Secure Boot is in setup mode (keys can be modified without authentication)
+  setupMode() bool
+}
+
+// Operating system information
+//
+// Top-level entry point for operating-system-level facts about the
+// asset. Examine the pretty hostname (or Windows device name), the
+// FQDN-style hostname, the system's machine ID, the hypervisor it's
+// running under (when virtualized), the running environment variables
+// and the resolved PATH list, the current uptime, the list of available
+// OS updates with their categories and severities, whether a reboot is
+// pending after recent installs, and the current system date / timezone.
+// Used as the cross-platform anchor that audits start from when they
+// need OS identity and patch state.
+os {
+  // Pretty hostname on macOS/Linux or device name on Windows
+  name() string
+  // ENV variable contents
+  env() map[string]string
+  // PATH variable contents
+  path(env) []string
+  // Current uptime
+  uptime() time
+  // List of available OS updates
+  updates() []os.update
+  // Whether a reboot is pending
+  rebootpending() bool
+  // Hostname for this OS
+  hostname() string
+  // Hypervisor for this OS
+  hypervisor() string
+  // Machine ID for this OS
+  machineid() string
+  // Current date and timezone of the system
+  date() os.date
+}
+
+// Operating system date and timezone information
+//
+// Examine the current system clock time and the configured timezone string
+// (e.g., "America/New_York", "UTC"). Used to verify that clocks are
+// synchronized and that the correct timezone is set.
+os.date @defaults("time timezone") {
+  // Current system time
+  time() time
+  // System timezone (e.g., "America/New_York", "UTC")
+  timezone() string
+}
+
+// Operating system update information
+//
+// Examine a single pending OS update: its name, category, severity,
+// whether it requires a restart, and the package format it belongs to.
+// Iterated from `os.updates()` to audit patch state and prioritize
+// outstanding updates by severity.
+os.update @defaults("name")  {
+  // Name of the update
+  name string
+  // Category of the update
+  category string
+  // Severity of the update
+  severity string
+  // Whether a restart is required
+  restart bool
+  // Package format for this update
+  format string
+}
+
+// Generic operating system information common to all platforms
+//
+// Cross-platform OS view that embeds `machine` (firmware / SMBIOS
+// hardware identity) and exposes the fields shared by every supported
+// platform: the pretty hostname (or Windows device name), the
+// FQDN-style hostname, environment variables and the resolved PATH
+// list, uptime, the available-OS-update list, the reboot-pending flag,
+// and the typed `users()` and `groups()` collections. `os.unix` and
+// `os.linux` extend this with platform-specific surfaces.
+os.base {
+  embed machine
+
+  // Pretty Hostname on macOS/Linux or device name on Windows
+  name() string
+  // ENV variable contents
+  env() map[string]string
+  // PATH variable contents
+  path(env) []string
+  // Current uptime
+  uptime() time
+  // List of available OS updates
+  updates() []os.update
+  // Whether a reboot is pending
+  rebootpending() bool
+  // Hostname for this OS
+  hostname() string
+  // User groups
+  groups() groups
+  // Users
+  users() users
+}
+
+// Operating system information for Unix-like platforms
+//
+// Extends `os.base` for Unix-family operating systems (macOS, Linux,
+// FreeBSD, and similar). Aliases such as `os.base.user` / `os.base.group`
+// / `os.base.file` / `os.base.command` / `os.base.packages` route to
+// concrete Unix resources, and `os.unix.sshd` aliases to the system-wide
+// `sshd` resource so audits can express "examine sshd on the asset"
+// without knowing the exact platform.
+os.unix {
+  embed os.base as base
+}
+
+// Operating system information for Linux platforms
+//
+// Extends `os.unix` (and through it, `os.base`) with Linux-only
+// surfaces: the four supported packet-filter stacks (`iptables`,
+// `ip6tables`, `nftables`, `ufw`, `firewalld`), the `/etc/fstab` mount
+// table, and the AppArmor mandatory-access-control namespace. Use it
+// to write Linux-specific audits without reaching out to global
+// resource handles.
+os.linux {
+  embed os.unix as unix
+
+  // iptables firewall for IPv4
+  iptables() iptables
+  // iptables firewall for IPv6
+  ip6tables() ip6tables
+  // nftables firewall
+  nftables() nftables
+  // UFW (Uncomplicated Firewall)
+  ufw() ufw
+  // firewalld dynamic firewall manager (RHEL/CentOS/Fedora)
+  firewalld() firewalld
+  // /etc/fstab entries
+  fstab() fstab
+  // AppArmor mandatory access control
+  apparmor() apparmor
+}
+
+// Operating system root certificate trust store
+//
+// Examine the X.509 root certificates that the asset's operating system
+// trusts for TLS validation, derived from the platform-appropriate
+// trust-store files (e.g. `/etc/ssl/certs/ca-certificates.crt` on
+// Debian, `/etc/pki/tls/certs/ca-bundle.crt` on RHEL, the macOS
+// SecTrust store, the Windows Root certificate store). The resource
+// lazily reads each trust-store file and exposes the parsed
+// `network.certificate` list so audits can pin specific issuers,
+// detect untrusted local additions, or count the trust-store size.
+os.rootCertificates {
+  []certificate(content)
+  // List of files that define these certificates
+  files []file
+  content(files) []string
+}
+
+// Result of running a shell command on the system
+//
+// Provides ad-hoc command execution as an MQL resource. Initialize it
+// with a shell command string; the resource lazily executes the command
+// through the connection (local exec, SSH, container exec, etc.) and
+// surfaces the captured `stdout`, `stderr`, and `exitcode`. Used as a
+// fall-back when there isn't a more specific typed resource for a
+// piece of system state, and for assertions on tool versions or
+// command-line probes.
+command {
+  init(command string)
+  // Raw contents of the command
+  command string
+  // Standard output from running the command
+  stdout(command) string
+  // Standard error output from running the command
+  stderr(command) string
+  // Exit code the command returned
+  exitcode(command) int
+}
+
+// Result of running a PowerShell script on the system
+//
+// Provides ad-hoc PowerShell execution as an MQL resource. Initialize
+// it with a script string; the resource lazily executes the script via
+// PowerShell on the asset and surfaces the captured `stdout`, `stderr`,
+// and `exitcode`. Used as the Windows / cross-platform-PowerShell
+// counterpart to `command` for assertions that need PowerShell-only
+// surface area.
+powershell {
+  init(script string)
+  // Raw contents of the script
+  script string
+  // Standard output from running the script
+  stdout() string
+  // Standard error output from running the script
+  stderr() string
+  // Exit code the script returned
+  exitcode() int
+}
+
+// File on the system
+//
+// Examine a single file referenced by absolute path. Surfaces the path
+// itself, the basename and dirname, an `exists` flag, the lazily-loaded
+// `content` string, the file's size in bytes, an `empty` predicate, the
+// owning `user` and `group` as typed references, and a structured
+// `permissions` resource that explodes the POSIX mode into named user /
+// group / other read / write / execute bits, the SUID / SGID / sticky
+// bits, the `isFile` / `isDirectory` / `isSymlink` discriminators, and
+// a printed mode string. The unit of file-level audits and the building
+// block most config-file resources read through.
+file @defaults("path size permissions.string") {
+  init(path string)
+  // Location of the file on the system
+  path string
+  // Filename without path prefix of this file
+  basename(path) string
+  // Path to the folder containing this file
+  dirname(path) string
+  // Contents of this file
+  content(path, exists) string
+  // Whether this file exists on the system
+  exists(path) bool
+  // Permissions for this file
+  permissions(path) file.permissions
+  // Size of this file on disk
+  size(path) int
+  // Ownership information about the user
+  user() user
+  // Ownership information about the group
+  group() group
+  // Whether the path is empty
+  empty(path) bool
+}
+
+// File context is a range of lines/columns in a file
+private file.context @defaults("file.path range content") {
+  // File referenced by this file context
+  file file
+  // Range of content in the file
+  range range
+  // Content for this range in the file, shown as an excerpt
+  content(file, range) string
+}
+
+// Access permissions for a given file
+private file.permissions @defaults("string") {
+  // POSIX file mode as a decimal integer (e.g., 33188 = 0100644)
+  mode int
+  // Whether the file is readable by its owner
+  user_readable bool
+  // Whether the file is writeable by its owner
+  user_writeable bool
+  // Whether the file is executable by its owner
+  user_executable bool
+  // Whether the file is readable by members of the group
+  group_readable bool
+  // Whether the file is writeable by members of the group
+  group_writeable bool
+  // Whether the file is executable by members of the group
+  group_executable bool
+  // Whether the file is readable by others
+  other_readable bool
+  // Whether the file is writeable by others
+  other_writeable bool
+  // Whether the file is executable by others
+  other_executable bool
+  // SUID bit indicator
+  suid bool
+  // SGID bit indicator
+  sgid bool
+  // Sticky bit indicator
+  sticky bool
+  // Whether the file describes a directory
+  isDirectory bool
+  // Whether the file describes a regular file
+  isFile bool
+  // Whether the file is a symlink
+  isSymlink bool
+  // A simple printed string version of the permissions
+  string() string
+}
+
+// File search and discovery namespace
+//
+// Empty top-level namespace whose only purpose is to host
+// `files.find`. Used so audits can write `files.find(...) {...}` to
+// locate files on the asset rather than enumerating known paths.
+files {}
+
+// File search results
+//
+// Examine files discovered by a recursive filesystem walk starting at
+// `from`. Narrow results with `type` (file, directory, device, etc.),
+// `regex` (name pattern), `permissions` (octal mode), `name` (exact name),
+// `depth` (traversal depth), and `xdev` (stay on one device). Returns the
+// matching `[]file` list for content or permission audits.
+files.find {
+  []file
+  // Sets the starting point for the search operation
+  from string
+  // Whether to search across other devices
+  xdev bool
+  // What types of files to list (directories, files, devices, etc)
+  type string
+  // A regular expression for the file search
+  regex string
+  // What permissions the file matches
+  permissions int
+  // Search name
+  name string
+  // The depth of the file search.
+  depth int
+}
+
+// Parse INI configuration files
+//
+// Examine sections and key-value pairs from any INI-formatted file
+parse.ini {
+  init(path string, delimiter string)
+  // Symbol that separates keys and values
+  delimiter string
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // Map of sections and key-value pairs
+  sections(content, delimiter) map[string]map[string]string
+  // Map of parameters that don't belong to sections
+  params(sections) map[string]string
+}
+
+// Parse JSON files
+//
+// Examine the parsed structure of any JSON document on disk
+parse.json {
+  init(path string)
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // The parsed parameters defined in this file
+  params(content) dict
+}
+
+// Parse XML files
+//
+// Examine the parsed structure of any XML document on disk
+parse.xml {
+  init(path string)
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // The parsed parameters defined in this file
+  params(content) dict
+}
+
+// Parse Apple property list (plist) files
+//
+// Examine the parsed structure of XML or binary plist files
+parse.plist {
+  init(path string)
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // The parsed parameters that are defined in this file
+  params(content) dict
+}
+
+// Parse YAML files
+//
+// Examine single- or multi-document YAML structures from disk
+parse.yaml {
+  init(path string)
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // The parsed parameters that are defined in this file
+  params(content) dict
+  // Parsed yaml documents
+  documents(content) []dict
+}
+
+// Parse X.509 certificates from files
+//
+// Examine PEM-encoded certificate chains and bundles
+parse.certificates {
+  []network.certificate(content, path)
+  init(path string)
+  // Certificate file path
+  path string
+  // Certificate file
+  file() file
+  // Certificate file content
+  content(file) string
+}
+
+// Parse OpenPGP keys from files
+//
+// Examine OpenPGP entities (keys, identities, subkeys) from key files
+parse.openpgp {
+  []network.openpgp.entity(content)
+  init(path string)
+  // OpenPGP file
+  file file
+  // OpenPGP file content
+  content(file) string
+}
+
+// User account on the system
+//
+// Examine a single local user account: numeric UID and primary GID
+// (Windows SID where applicable), name, home directory, configured
+// login shell, and an `enabled` flag. Surfaces the typed primary
+// `group` reference, the `authorizedkeys` resource that parses the
+// user's `~/.ssh/authorized_keys`, the SSH private keys discovered in
+// the user's home, and a `loggedIn` predicate that reflects whether
+// the user currently has an active session. Used for identity audits,
+// dormant-account hygiene, and SSH-key inventories.
+user @defaults("name uid gid") {
+  // User ID
+  uid int
+  // User's group ID
+  gid int
+  // User's security identifier (Windows)
+  sid string
+  // Name of the user
+  name string
+  // Home folder
+  home string
+  // Default shell configured
+  shell string
+  // Whether the user is enabled
+  enabled bool
+  // List of authorized keys
+  authorizedkeys(home) authorizedkeys
+  // List of SSH keys
+  sshkeys() []privatekey
+  // Group of which user is a member
+  group(gid) group
+  // Whether the user is currently logged in
+  loggedIn() bool
+}
+
+// Private key on disk
+//
+// Examine a PEM-encoded private key file: the typed `file` reference,
+// the raw PEM `pem` payload, and an `encrypted` flag indicating whether
+// the key uses a passphrase. Used to inventory SSH or service-account
+// keys discovered on the asset and to flag unencrypted private keys
+// stored in user home directories.
+privatekey {
+  // PEM data
+  pem string
+  // Path to the private key file
+  //
+  // Deprecated in favor of the `file` field.
+  path @maturity("deprecated") string
+  // File on disk for this private key
+  file file
+  // Whether the file is encrypted
+  encrypted bool
+}
+
+// All user accounts configured on the system
+//
+// Iterable collection of every local `user` on the asset. Use it as
+// the entry point for fleet-wide identity audits — e.g., asserting
+// that every account with UID < 1000 is enabled, that no account
+// shares another's home directory, or that no human user has the
+// shell set to `/bin/bash` outside an approved list.
+users {
+  []user
+}
+
+// SSH authorized_keys file
+//
+// Examine a single `authorized_keys` file: its path, the typed `file`
+// reference, the raw `content` string, and the parsed `entry` list where
+// each entry surfaces the line number, key type, key material, label, and
+// any `command=` / `from=` / `no-port-forwarding` SSH options. Select the
+// file by absolute path — for example
+// `authorizedkeys(path: "/root/.ssh/authorized_keys")` — or reach it per
+// account through the `user` resource, whose `authorizedkeys` field
+// resolves each user's `~/.ssh/authorized_keys` automatically (for
+// example `users.where(name == "root") { authorizedkeys { list { key } } }`).
+// Used to audit which keys actually grant SSH access to a given user and
+// to detect entries with no source or command restrictions.
+authorizedkeys {
+  []authorizedkeys.entry(file, content)
+  init(path string)
+  // Path to the key file
+  path string
+  // Key file
+  file file
+  // Key file content
+  content(file) string
+}
+
+// SSH authorized key
+//
+// Examine a single entry from an `authorized_keys` file: the source line
+// number, key type, key material, label, and any SSH options such as
+// `command=`, `from=`, or `no-port-forwarding`. Used to audit which keys
+// grant SSH access to a user and to flag entries that lack source or
+// command restrictions.
+authorizedkeys.entry @defaults("key") {
+  // Line of the key
+  line int
+  // Type of key
+  type string
+  // Key
+  key string
+  // Key label
+  label string
+  // SSH key options (e.g., command restrictions, source IP limits)
+  options []string
+  // Key file
+  file file
+}
+
+// Group on the system
+//
+// Examine a single local group: numeric GID (or SID on Windows), group
+// name, and the typed `members()` list of users in the group. Used to
+// audit privileged-group membership (`sudo`, `wheel`, `docker`, `adm`,
+// etc.) and to confirm only expected accounts are present.
+group @defaults("name gid") {
+  init(id string)
+  // Group ID
+  gid int
+  // Group's security identifier (Windows)
+  sid string
+  // Name of this group
+  name string
+  // Users who are members of this group
+  members() []user
+}
+
+// All groups configured on the system
+//
+// Iterable collection of every local `group`. Use it as the entry
+// point for fleet-wide group-membership audits (every member of a
+// privileged group, no two groups sharing a GID, no human user in
+// `wheel` outside an approved list, etc.).
+groups {
+  []group
+}
+
+// Installed package on the platform or OS
+//
+// Examine a single package known to the asset's native package
+// manager (rpm, deb, apk, pkg, msi, nuget, pacman, etc.). Surfaces
+// the package name, description, currently-installed `version`,
+// architecture, epoch, package format, install status, package URL,
+// the CPE list mapping the package to NVD identifiers, the package
+// origin, the latest `available` version known to the package
+// manager, the `installed` and `outdated` flags, the file
+// inventory the package contributed, and the package vendor.
+// The unit of asset-level package audits and the join key for
+// vulnerability correlation.
+package @defaults("name version") {
+  // May be initialized with the name only, in which case it will look up
+  // The package with the given name on the system.
+  init(name string)
+
+  // Name of the package
+  name string
+  // Package description
+  description string
+  // Current version of the package
+  version string
+  // Architecture of this package
+  arch string
+  // Epoch of this package
+  epoch string
+
+  // Format of this package (e.g., rpm, deb)
+  format string
+  // Status of this package (e.g., if it is needed)
+  status() string
+
+  // Package URL
+  purl string
+
+  // Common Platform Enumeration (CPE) for the package
+  cpes []core.cpe
+
+  // Package origin, may include version if available (optional)
+  origin() string
+
+  // Available version
+  available string
+  // Whether the package is installed
+  installed bool
+  // Whether the package is outdated
+  outdated() bool
+
+  // Package files
+  files() []pkgFileInfo
+
+  // Package vendor
+  vendor string
+
+  // Package license
+  //
+  // SPDX license expression (or upstream-reported license string).
+  // Eagerly populated where the package manager has it inline (rpm
+  // %{LICENSE}, apk APKINDEX, pacman desc); fetched on demand for dpkg
+  // (parses /usr/share/doc/<pkg>/copyright). Empty when no source
+  // exists (e.g. Windows registry DisplayName).
+  license() string
+
+  // Package install date
+  //
+  // Time the package was installed on this asset. Populated from
+  // %{INSTALLTIME} (rpm) and the InstallDate column of the Windows
+  // Uninstall registry. Returns the zero time on backends that have
+  // no install-time source (dpkg without log parsing, apk, pacman,
+  // macOS).
+  installDate time
+}
+
+// File installed by a package
+private pkgFileInfo @defaults("path") {
+  // Path to the file
+  path string
+}
+
+// All packages installed on the system
+//
+// Iterable collection of every `package` known to the asset's native
+// package manager(s). Used as the entry point for fleet-wide patch
+// audits, banned-package checks, and inventory exports.
+packages {
+  []package
+}
+
+// PAM (pluggable authentication module) configuration
+//
+// Examine /etc/pam.d service entries with their type, control, and module
+pam.conf {
+  init(path string)
+  // Whether PAM configuration is present on the system
+  //
+  // True when either the `/etc/pam.d` directory or the `/etc/pam.conf` file
+  // exists. Use it to guard PAM audits on hosts that ship no PAM
+  // configuration, such as container-optimized OS images.
+  exists() bool
+  // List of files that make up the PAM configuration
+  files() []file
+  // The raw PAM configuration (across all files)
+  content(files) string
+  // Services configured via PAM
+  //
+  // Deprecated in favor of `entries`, which returns parsed, structured
+  // service entries.
+  services(files) @maturity("deprecated") map[string][]string
+  // List of services with parsed entries that are configured via PAM
+  entries(files) map[string][]pam.conf.serviceEntry
+  // All PAM modules loaded across every service (deduplicated by name)
+  modules(entries) []pam.module
+}
+
+// A single entry within a PAM service configuration
+private pam.conf.serviceEntry @defaults("service module") {
+  // Service the entry belongs to
+  //
+  // The `/etc/pam.d/<service>` file path the line came from, or the service
+  // name in the first column when read from the single-file `/etc/pam.conf`.
+  service string
+  // Line number in service file (used for ID)
+  lineNumber int
+  // Type for PAM entry, (i.e., auth, password, etc)
+  pamType string
+  // Level of control, (i.e., required, requisite, sufficient)
+  control string
+  // PAM module used
+  module string
+  // Configuration options for pam service entry
+  options []string
+  // Options parsed into key/value pairs
+  //
+  // `key=value` options become map entries (key lower-cased); bare flags
+  // such as `use_uid` map to an empty string, so `params["use_uid"] != null`
+  // works as an existence check. When the same key appears more than once
+  // the last occurrence wins, matching how PAM evaluates duplicate options.
+  // The raw `options` list is retained unchanged.
+  params(options) map[string]string
+}
+
+// PAM service configuration
+//
+// Examine the PAM configuration for a single service selected by name — for
+// example `pam.conf.service(name: "su")` or `pam.conf.service(name: "sshd")`.
+// The service is resolved from its `/etc/pam.d/<name>` file, or from the lines
+// naming it in the legacy single-file `/etc/pam.conf`. `entries` are the
+// parsed lines for that service and `modules` aggregates the modules it loads
+// keyed by name, so audits such as
+// `pam.conf.service(name: "su").modules["pam_wheel"].params["use_uid"]` work
+// without filtering `pam.conf.entries` by file path.
+private pam.conf.service {
+  init(name string)
+  // Service name (e.g. `su`, `sshd`, `login`)
+  name string
+  // Path of the configuration file the service is defined in
+  //
+  // `/etc/pam.d/<name>` on systems that use the pam.d directory, or
+  // `/etc/pam.conf` when the service comes from the legacy single file. Empty
+  // when no such service is configured.
+  path string
+  // Parsed entries for this service, in source order
+  entries []pam.conf.serviceEntry
+  // Modules loaded by this service, keyed by canonical module name
+  //
+  // Each value aggregates every entry in this service that loads the module
+  // (last-write-wins per option), so `modules["pam_wheel"].params["use_uid"]`
+  // and `modules["pam_wheel"].enabled` answer module-level questions without
+  // iterating `entries`.
+  modules() map[string]pam.module
+}
+
+// PAM module aggregated view
+//
+// Examine a single PAM module across every service that loads it. The
+// `params` dict merges `key=value` options from every line that uses
+// this module (last-write-wins per key) so audits like
+// `pam.module("pam_faillock").params["deny"]` work without iterating
+// `pam.conf.entries`. `enabled` is true when any service entry loads
+// the module with a non-skip control.
+//
+// Initialize by module name (e.g. `pam.module(name: "pam_faillock")`)
+// or iterate `pam.modules()` for every distinct module name seen
+// across the parsed PAM configuration.
+private pam.module @defaults("name enabled entries.length") {
+  init(name string)
+  // Module name as it appears after `<type> <control>`
+  //
+  // Examples: `pam_unix`, `pam_faillock`, `pam_pwquality`. The `.so`
+  // suffix and any leading path are stripped so lookups by short name
+  // work consistently.
+  name string
+  // All key=value options aggregated across every service entry that loads this module
+  //
+  // The same option key appearing on multiple lines is last-write-wins
+  // in source order (matching how PAM itself evaluates duplicate flags
+  // — the later line wins). Bare options (no `=`) are present in the
+  // map with an empty string value so `params["use_authtok"] != null`
+  // works as an existence check.
+  params map[string]string
+  // Whether the module is loaded by any service with a non-skip control
+  //
+  // True when at least one service entry references this module with a
+  // control of `required`, `requisite`, `sufficient`, `optional`, or a
+  // typed control with `default=ok` / `success=ok`. Always false when
+  // every reference is part of a stub or commented-out line.
+  enabled bool
+  // Every service entry that loads this module
+  //
+  // The full list across all `/etc/pam.d/*` files, in source order.
+  // Each entry carries its originating `service`, `lineNumber`,
+  // `pamType`, `control`, and raw `options` so callers can drill back
+  // into the underlying line if `params` aggregation isn't enough.
+  entries []pam.conf.serviceEntry
+}
+
+// OpenSSH server (sshd) namespace
+//
+// Use sshd.config to examine the effective server settings and match blocks
+sshd {}
+
+// OpenSSH server (sshd) configuration
+//
+// Examine ciphers, MACs, KEX algorithms, host keys, and Match blocks
+sshd.config {
+  init(path? string)
+  // File of this SSH server configuration
+  file() file
+  // A list of lexically sorted files making up the SSH server configuration
+  files(file) []file
+  // Configuration values of this SSH server
+  params(file) map[string]string
+  // Blocks with match conditions in this SSH server config
+  blocks(file) []sshd.config.matchBlock
+  // Ciphers configured for this SSH server
+  ciphers(params) []string
+  // MACs configured for this SSH server
+  macs(params) []string
+  // Key exchange algorithms configured for this SSH server
+  kexs(params) []string
+  // Effective ciphers reported by sshd -T
+  effectiveCiphers() []string
+  // Effective MACs reported by sshd -T
+  effectiveMacs() []string
+  // Effective key exchange algorithms reported by sshd -T
+  effectiveKexs() []string
+  // Host keys configured for this SSH server
+  hostkeys(params) []string
+  // Host key algorithms configured for this SSH server
+  hostkeyalgorithms(params) []string
+  // PermitRootLogin setting in SSH server
+  permitRootLogin(params) []string
+}
+
+// A block of SSH server configuration
+private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
+  // The match criteria for this block
+  criteria string
+  // Configuration values in this block
+  params map[string]string
+  // Ciphers configured for this SSH server
+  ciphers(params) []string
+  // MACs configured for this SSH server
+  macs(params) []string
+  // Key exchange algorithms configured for this SSH server
+  kexs(params) []string
+  // Host keys configured for this SSH server
+  hostkeys(params) []string
+  // Host key algorithms configured for this SSH server
+  hostkeyalgorithms(params) []string
+  // PermitRootLogin setting in SSH server
+  permitRootLogin(params) []string
+}
+
+// inetd super-server namespace
+//
+// Use inetd.config to examine which network services the inetd super-server
+// launches on demand.
+inetd {}
+
+// inetd super-server configuration
+//
+// Examine the services the inetd (or compatible) super-server is configured
+// to launch on demand. Each active entry pairs a service with its socket
+// type, protocol, wait mode, run-as user, and server program. The
+// configuration is assembled from /etc/inetd.conf together with any drop-in
+// files under /etc/inetd.d. A missing configuration yields no entries, so
+// audits such as serviceNames.none("ftp") hold trivially on systems that
+// don't run inetd.
+inetd.config {
+  init(path? string)
+  // Primary inetd configuration file
+  file() file
+  // All files making up the inetd configuration (main file and drop-ins)
+  files(file) []file
+  // Merged contents of all configuration files
+  content(files) string
+  // Active service entries
+  entries(files) []inetd.config.entry
+  // Names of the active services
+  serviceNames(entries) []string
+}
+
+// inetd service entry
+//
+// Examine a single active inetd service line: the service it exposes and how
+// inetd launches it. The name field selects the service as it appears in the
+// first column of inetd.conf — for example
+// inetd.config.entries.where(name == "ftp"). Entries that are commented out
+// with a leading # are disabled and excluded.
+private inetd.config.entry @defaults("name protocol server") @context("file.context") {
+  // Service name or port (first column)
+  name string
+  // Socket type, such as stream, dgram, or raw
+  socketType string
+  // Transport protocol, such as tcp, udp, tcp6, or udp6
+  protocol string
+  // Wait mode, either wait or nowait, with an optional max-connections suffix
+  wait string
+  // User the server runs as, with an optional group suffix
+  user string
+  // Server program path, or "internal" for built-in services
+  server string
+  // Arguments passed to the server program
+  arguments string
+}
+
+// Net-SNMP daemon (snmpd) namespace
+//
+// Use snmpd.config to examine the effective SNMP daemon configuration.
+snmpd {}
+
+// Net-SNMP daemon (snmpd) configuration
+//
+// Examine the snmpd.conf settings that govern SNMP access — community
+// strings, VACM users, and listen addresses. The configuration is assembled
+// from the main snmpd.conf together with any drop-in files under
+// snmpd.conf.d and files pulled in by includeFile and includeDir directives.
+// A missing configuration yields empty accessors, so audits such as
+// rwCommunities == [] hold trivially on hosts that don't run snmpd.
+snmpd.config {
+  init(path? string)
+  // Primary snmpd configuration file
+  file() file
+  // All files making up the SNMP daemon configuration (main file, drop-ins, and includes)
+  files(file) []file
+  // Merged contents of all configuration files
+  content(files) string
+  // Read-only community strings, from rocommunity and rocommunity6 directives
+  roCommunities(content) []string
+  // Read-write community strings, from rwcommunity and rwcommunity6 directives
+  rwCommunities(content) []string
+  // Read-only VACM users, from rouser directives
+  roUsers(content) []string
+  // Read-write VACM users, from rwuser directives
+  rwUsers(content) []string
+  // Addresses snmpd listens on, from agentAddress directives
+  agentAddresses(content) []string
+}
+
+// auditd (Linux Audit Daemon) global configuration
+//
+// Examine /etc/audit/auditd.conf parameters
+auditd.config {
+  init(path? string)
+  // File of this auditd configuration
+  file() file
+  // Configuration values of this config
+  params(file) map[string]string
+}
+
+// auditd (Linux Audit Daemon) ruleset on disk
+//
+// Examine controls, file watches, and syscall rules from /etc/audit/audit.rules
+auditd.rules {
+  // Path to folder to look up rules
+  path() string
+  // All controls for auditd
+  controls(path) []auditd.rule.control
+  // All file rules
+  files(path) []auditd.rule.file
+  // All syscall rules
+  syscalls(path) []auditd.rule.syscall
+}
+
+// auditd (Linux Audit Daemon) rule
+private auditd.rule {}
+
+// auditd (Linux Audit Daemon) rule for a control
+//
+// We translate these into simple key-value pairs consisting of a flag and a value
+// eg: --backlog_wait_time 60000  =>  {flag: "--backlog_wait_time", value: "60000"}
+// eg: -b 8192                    =>  {flag: "-b", value: "8192"}
+// eg: -D                         =>  {flag: "-D", value: nil}
+private auditd.rule.control @defaults("flag value") {
+  // The flag used for this control, i.e. the first part of the control including any leading `-`
+  flag string
+  // The value of the control, which may be specified
+  value string
+}
+
+// auditd (Linux Audit Daemon) rule for a file
+//
+// eg: -w /etc/shadow -p rw -k shadow_access
+//  => {path: "/etc/shadow", permissions: "rw", keyname: "shadow_access"}
+private auditd.rule.file @defaults("path permissions") {
+  // The path this rule matches as specified by -w
+  path string
+  // The permissions specified by this rule via -p
+  permissions string
+  // The key name for related rules as specified by -k
+  keyname string
+}
+
+// auditd (Linux Audit Daemon) rule for a syscall
+//
+// eg: -a always,exit -F arch=b32 -F auid>=1000 -F auid!=unset
+//  => {
+//    action: "always",
+//    list: "exit",
+//    syscalls: [],
+//    field_entries: [
+//      key="arch" op="=" value="b32"
+//      key="auid" op=">=" value="1000"
+//      key="auid" op="!=" value="unset"
+//    ],
+//    keyname: nil,
+// }
+private auditd.rule.syscall @defaults("action list") {
+  // The action specified by -a
+  action string
+  // The list, the second value specified by -a
+  list string
+  // The list of syscalls that this rule matches, specified by -S
+  syscalls []string
+  // All field entries as raw values, as specified by -F
+  fields []dict
+  // All inter-field comparisons as specified by -C
+  comparisons []dict
+  // The key name for related rules as specified by -k
+  keyname string
+  // CPU architecture this rule is restricted to
+  //
+  // The value of the `-F arch=` filter, normally `b64` or `b32`. Empty when
+  // the rule has no architecture filter and therefore applies to all
+  // architectures.
+  arch string
+  // Minimum audit UID this rule is restricted to
+  //
+  // The threshold N from a `-F auid>=N` filter, commonly `1000` to target
+  // interactive users above the system UID range. Null when the rule has no
+  // `auid>=` filter.
+  auidMin int
+  // Whether the rule excludes events with an unset audit UID
+  //
+  // True when the rule carries a `-F auid!=unset` filter (also matching the
+  // raw sentinels `4294967295` and `-1`), which drops events from daemons
+  // and other processes that never had a login UID assigned.
+  excludesUnsetAuid bool
+}
+
+// Apache2 HTTP Server
+//
+// Examine server configuration and daemon version
+apache2 {
+  // Apache2 version (e.g., "2.4.62")
+  version() string
+}
+
+// Apache2 HTTP Server configuration
+//
+// Examine directives, loaded modules, virtual hosts, and directory blocks
+apache2.conf {
+  init(path? string)
+  // Primary configuration file
+  file() file
+  // All configuration files (main + included fragments)
+  files(file) []file
+  // Flat key-value directives from the configuration
+  params(file) map[string]string
+  // Listen addresses/ports
+  listenAddresses(params) []string
+  // Loaded modules (LoadModule directives)
+  modules(file) []apache2.conf.module
+  // VirtualHost blocks
+  virtualHosts(file) []apache2.conf.virtualHost
+  // Directory blocks
+  directories(file) []apache2.conf.directory
+  // <Location> blocks (URL-space access rules)
+  locations(file) []apache2.conf.location
+  // Environment variables sourced by Apache at startup (e.g. Debian's /etc/apache2/envvars)
+  envvars() apache2.conf.envvars
+  // ServerTokens disclosure level (Full, OS, Minimal, Minor, Major, Prod)
+  serverTokens(params) string
+  // ServerSignature footer mode (On, Off, EMail)
+  serverSignature(params) string
+  // TraceEnable directive value (on, off, extended)
+  traceEnable(params) string
+  // Response headers added via `Header always set NAME VALUE` (header name -> values)
+  securityHeaders(file) map[string][]string
+}
+
+// Apache2 environment variables (e.g. Debian's /etc/apache2/envvars)
+private apache2.conf.envvars @defaults("file.path") {
+  init(path? string)
+  // File defining the environment variables
+  file() file
+  // Parsed variable assignments (after shell expansion)
+  params(file) map[string]string
+}
+
+// Apache2 loaded module
+private apache2.conf.module @defaults("name") {
+  // Module name (e.g., "ssl_module")
+  name string
+  // Shared object path (e.g., "modules/mod_ssl.so")
+  path string
+}
+
+// Apache2 VirtualHost block
+private apache2.conf.virtualHost @defaults("address serverName ssl") {
+  // VirtualHost address (e.g., "*:443")
+  address string
+  // ServerName directive
+  serverName string
+  // ServerAlias names (one entry per name across one or more ServerAlias lines)
+  serverAliases []string
+  // DocumentRoot directive
+  documentRoot string
+  // Whether SSL is enabled (SSLEngine on)
+  ssl bool
+  // SSLProtocol directive value (e.g., "all -SSLv3 -TLSv1 -TLSv1.1")
+  sslProtocol string
+  // SSLCipherSuite directive value
+  sslCipherSuite string
+  // SSLHonorCipherOrder directive value (true when "on")
+  sslHonorCipherOrder bool
+  // Path to the server certificate (SSLCertificateFile)
+  sslCertificateFile string
+  // Path to the server private key (SSLCertificateKeyFile)
+  sslCertificateKeyFile string
+  // Path to the certificate chain (SSLCertificateChainFile, deprecated in favor of full chain in SSLCertificateFile)
+  sslCertificateChainFile string
+  // X.509 certificates parsed from sslCertificateFile (empty if the file is unreadable)
+  certificate() []network.certificate
+  // Redirect / RedirectMatch directives within this VirtualHost (target, status, match)
+  redirects []dict
+  // All directives within this VirtualHost
+  params map[string]string
+}
+
+// Apache2 Directory block
+private apache2.conf.directory @defaults("path") {
+  // Directory path
+  path string
+  // Options directive value
+  options string
+  // AllowOverride directive value
+  allowOverride string
+  // Require directive values (one entry per Require line)
+  require []string
+  // All directives within this Directory block
+  params map[string]string
+}
+
+// Apache2 <Location> block — URL-space access rules
+private apache2.conf.location @defaults("path") {
+  // Location path or regex
+  path string
+  // Whether this block was defined with <LocationMatch> (regex form) instead of <Location>
+  isMatch bool
+  // AuthType directive value (None, Basic, Digest, ...)
+  authType string
+  // AuthName directive value (realm)
+  authName string
+  // Require directive values (one entry per Require line)
+  require []string
+  // ProxyPass target, if set
+  proxyPass string
+  // All directives within this Location block
+  params map[string]string
+}
+
+// Nginx HTTP Server
+//
+// Examine server configuration, daemon version, and compiled-in modules
+nginx {
+  // Nginx version (e.g., "1.25.3")
+  version() string
+  // Compiled-in modules from configure arguments
+  modules() []string
+}
+
+// Nginx HTTP Server configuration
+//
+// Examine directives, server blocks, upstream pools, and listen addresses
+nginx.conf {
+  init(path? string)
+  // Primary configuration file
+  file() file
+  // All configuration files (main + included fragments)
+  files(file) []file
+  // Flat key-value directives from main + http context
+  params(file) map[string]string
+  // User directive
+  user(params) string
+  // Worker processes setting
+  workerProcesses(params) string
+  // Error log path
+  errorLog(params) string
+  // Listen addresses/ports across all server blocks
+  listenAddresses(file) []string
+  // HTTP-level directives (inside http block, outside server blocks)
+  httpParams(file) map[string]string
+  // Server blocks
+  servers(file) []nginx.conf.server
+  // Upstream blocks
+  upstreams(file) []nginx.conf.upstream
+}
+
+// Nginx server block
+private nginx.conf.server @defaults("serverName ssl") {
+  // Server name(s)
+  serverName string
+  // Listen directives (comma-separated if multiple)
+  listen string
+  // Listen directives broken out per declaration (port, ssl, http2, defaultServer, proxyProtocol, address, raw)
+  listens []dict
+  // Document root
+  root string
+  // Whether SSL is configured (any listen line carries `ssl`, or ssl_certificate is set)
+  ssl bool
+  // ssl_protocols directive value (e.g., "TLSv1.2 TLSv1.3")
+  sslProtocols string
+  // ssl_ciphers directive value
+  sslCiphers string
+  // Path to the server certificate (ssl_certificate)
+  sslCertificate string
+  // Path to the server private key (ssl_certificate_key)
+  sslCertificateKey string
+  // ssl_prefer_server_ciphers directive value (true when "on")
+  sslPreferServerCiphers bool
+  // ssl_session_tickets directive value ("on"/"off"; empty if unset)
+  sslSessionTickets string
+  // ssl_session_timeout directive value (e.g., "1d")
+  sslSessionTimeout string
+  // X.509 certificates parsed from sslCertificate (empty if the file is unreadable)
+  certificate() []network.certificate
+  // Response headers from `add_header NAME VALUE` directives (header name -> values)
+  addHeaders map[string][]string
+  // Location blocks
+  locations []nginx.conf.location
+  // server_tokens directive value (on/off/build)
+  serverTokens string
+  // All directives within this server block
+  params map[string]string
+}
+
+// Nginx upstream block
+private nginx.conf.upstream @defaults("name loadBalancingMethod") {
+  // Upstream group name
+  name string
+  // Backend server addresses (raw `server` directive arguments)
+  servers []string
+  // Parsed backend entries (address, weight, maxFails, failTimeout, backup, down, slowStart, route)
+  serverDetails []dict
+  // Load-balancing method (round_robin, least_conn, ip_hash, hash, random, least_time)
+  loadBalancingMethod string
+  // keepalive directive value (idle connections per worker; 0 if unset)
+  keepalive int
+  // All directives within this upstream block
+  params map[string]string
+}
+
+// Nginx location block
+private nginx.conf.location @defaults("path") {
+  // Location path or pattern (excluding modifier)
+  path string
+  // Location modifier ("=", "~", "~*", "^~", or "" for prefix-default)
+  modifier string
+  // Proxy pass target
+  proxyPass string
+  // Document root override
+  root string
+  // try_files directive value
+  tryFiles string
+  // return directive value (status + URI/text)
+  return string
+  // fastcgi_pass directive value
+  fastcgiPass string
+  // All directives within this location block
+  params map[string]string
+}
+
+// Squid caching proxy
+//
+// Examine the Squid proxy server version reported by the daemon binary.
+// Use `squid.conf` to inspect the full configuration including ACLs,
+// access rules, listen ports, cache peers, refresh patterns, and any
+// fragments pulled in by `include` directives (for example the contents
+// of `/etc/squid/conf.d/*.conf`).
+squid {
+  // Squid version (e.g., "5.7")
+  version() string
+}
+
+// Squid caching proxy configuration
+//
+// Examine directives, access control lists, listen ports, cache peers,
+// cache directories, refresh patterns, authentication parameters, and
+// access logs from `squid.conf` together with every fragment pulled in
+// by `include` directives. Files matched by glob patterns in include
+// lines (e.g. `include /etc/squid/conf.d/*.conf`) are walked recursively
+// and merged into a single logical configuration, so audits see the
+// flattened directive set the daemon actually runs with.
+squid.conf {
+  init(path? string)
+  // Primary configuration file
+  file() file
+  // All configuration files (main + included fragments)
+  files(file) []file
+  // Flat key-value directives across the merged configuration
+  //
+  // Directives that can repeat (acl, http_access, refresh_pattern, ...)
+  // have their values comma-joined in source order.
+  params(file) map[string]string
+  // http_port listen entries
+  httpPorts(file) []squid.conf.listen
+  // https_port listen entries
+  httpsPorts(file) []squid.conf.listen
+  // Defined ACLs, one entry per unique acl name (values across repeated `acl NAME` lines are merged)
+  acls(file) []squid.conf.acl
+  // Every *_access rule in source order
+  //
+  // Includes http_access, http_reply_access, adapted_http_access,
+  // icp_access, htcp_access, miss_access, cache, always_direct,
+  // never_direct, and the other access directives. Filter by kind to
+  // target one family: `.where(kind == "http_access")`.
+  accessRules(file) []squid.conf.accessRule
+  // cache_peer entries (parents and siblings)
+  cachePeers(file) []squid.conf.cachePeer
+  // cache_dir entries (on-disk cache storage)
+  cacheDirs(file) []squid.conf.cacheDir
+  // refresh_pattern entries (cache freshness rules) in source order
+  refreshPatterns(file) []squid.conf.refreshPattern
+  // auth_param entries grouped by scheme -> param -> value (e.g., authParams["basic"]["program"])
+  authParams(file) map[string]map[string]string
+  // access_log entries (each daemon target / format / acl pair)
+  accessLogs(file) []squid.conf.accessLog
+  // visible_hostname directive value
+  visibleHostname(params) string
+  // unique_hostname directive value
+  uniqueHostname(params) string
+  // cache_log directive value (path to the cache.log file)
+  cacheLog(params) string
+  // cache_store_log directive value (path or "none")
+  cacheStoreLog(params) string
+  // pid_filename directive value
+  pidFilename(params) string
+  // coredump_dir directive value
+  coredumpDir(params) string
+  // via directive value ("on" or "off")
+  via(params) string
+  // forwarded_for directive value (on, off, transparent, delete, truncate)
+  forwardedFor(params) string
+  // httpd_suppress_version_string directive value ("on" or "off")
+  httpdSuppressVersionString(params) string
+  // dns_v4_first directive value ("on" or "off")
+  dnsV4First(params) string
+  // cache_mem directive value (e.g., "256 MB")
+  cacheMem(params) string
+  // maximum_object_size directive value (e.g., "4 MB")
+  maximumObjectSize(params) string
+  // X.509 certificates parsed from cert= / tls-cert= paths declared on http_port and https_port entries
+  certificates() []network.certificate
+}
+
+// Squid listen port (http_port or https_port)
+//
+// Examine a single `http_port` or `https_port` directive: the bind
+// address, port number, parsed mode flags (transparent, intercept,
+// accel, ssl-bump, tproxy), and any `key=value` options including the
+// TLS material (`cert=`, `key=`, `tls-cert=`, `tls-key=`).
+private squid.conf.listen @defaults("port address tls") {
+  // Directive name this entry came from ("http_port" or "https_port")
+  directive string
+  // Bind address ("" when none was given, IPv4/IPv6 literal, or "unix:/path")
+  address string
+  // Numeric port (0 when the target is a unix socket)
+  port int
+  // Whether this entry serves TLS (https_port, or http_port with ssl-bump / tls-cert= / cert=)
+  tls bool
+  // Mode flags present on the directive (e.g., transparent, intercept, accel, ssl-bump, tproxy, ssl)
+  flags []string
+  // Path to the server certificate when set (`cert=` or `tls-cert=`)
+  cert string
+  // Path to the server private key when set (`key=` or `tls-key=`)
+  key string
+  // All `key=value` options on the directive
+  options map[string]string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// Squid Access Control List entry
+//
+// Examine an `acl` definition. ACLs are referenced by name from
+// `http_access`, `icp_access`, and the other *_access rules, so the
+// `values` field together with the rule list tells you which clients,
+// URLs, or methods Squid will allow or deny.
+private squid.conf.acl @defaults("name type") {
+  // ACL name (e.g., "localnet", "Safe_ports", "CONNECT")
+  name string
+  // ACL type (src, dst, port, srcdomain, url_regex, proto, method, proxy_auth, ...)
+  type string
+  // Modifier flags present on any of the acl lines (e.g., "-i" for case-insensitive)
+  flags []string
+  // All match values from every `acl NAME ...` line with this name, in source order
+  values []string
+}
+
+// Squid *_access rule
+//
+// Examine a single allow/deny rule from any of the access directives
+// (`http_access`, `http_reply_access`, `icp_access`, `miss_access`,
+// `cache`, `always_direct`, `never_direct`, etc.). Rules are evaluated
+// top-down by Squid, so the `index` field reflects source order across
+// the merged configuration.
+private squid.conf.accessRule @defaults("kind action acls") {
+  // Directive name (e.g., "http_access", "icp_access", "miss_access", "cache", "always_direct", "never_direct")
+  kind string
+  // 0-based position of this rule within `kind`, in source order across all included files
+  index int
+  // "allow" or "deny"
+  action string
+  // ACL names referenced by this rule, in argument order. An entry starting with "!" is a negated ACL.
+  acls []string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// Squid cache peer
+//
+// Examine a `cache_peer` entry — a parent or sibling cache Squid
+// forwards to. The `host`, `type`, and `httpPort` together identify the
+// peer; the `options` slice carries the remaining flags (`default`,
+// `no-query`, `proxy-only`, `login=...`, `weight=...`, ...).
+private squid.conf.cachePeer @defaults("host type httpPort") {
+  // Peer hostname or IP
+  host string
+  // Peer relationship ("parent", "sibling", or "multicast")
+  type string
+  // HTTP port on the peer
+  httpPort int
+  // ICP/HTCP query port on the peer (0 when disabled)
+  icpPort int
+  // Trailing options on the directive (e.g., default, no-query, proxy-only, login=NAME)
+  options []string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// Squid cache directory
+//
+// Examine a `cache_dir` entry — the on-disk cache storage backing the
+// proxy. Captures the storage `type` (ufs, aufs, diskd, rock), the
+// filesystem `path`, the cache size, the L1/L2 fan-out for hashed
+// stores, and any trailing `key=value` options (e.g., `max-size=`).
+private squid.conf.cacheDir @defaults("type path sizeMb") {
+  // Storage scheme (ufs, aufs, diskd, rock, ...)
+  type string
+  // Filesystem path of the cache
+  path string
+  // Cache size in megabytes
+  sizeMb int
+  // L1 subdirectory count (0 for rock and other single-file stores)
+  l1 int
+  // L2 subdirectory count (0 for rock and other single-file stores)
+  l2 int
+  // Trailing options on the directive (e.g., max-size=4194304, min-size=0)
+  options []string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// Squid refresh_pattern rule
+//
+// Examine a single `refresh_pattern` directive: the regex Squid uses to
+// match URLs, the freshness window (`min` / `percent` / `max`), and any
+// trailing flags. Audit hot spots include `ignore-private`,
+// `ignore-no-store`, `override-expire`, and `override-lastmod`, which
+// weaken cache safety guarantees.
+private squid.conf.refreshPattern @defaults("pattern min max") {
+  // Regex pattern this rule applies to
+  pattern string
+  // Whether the rule was declared case-insensitive (-i)
+  caseInsensitive bool
+  // Minimum freshness in minutes
+  min int
+  // Percent of last-modified age used to compute freshness
+  percent int
+  // Maximum freshness in minutes
+  max int
+  // Trailing flag options
+  //
+  // Common entries: override-expire, override-lastmod,
+  // ignore-no-store, ignore-private, ignore-reload, reload-into-ims,
+  // refresh-ims, store-stale, max-stale=N.
+  options []string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// Squid access_log entry
+//
+// Examine a single `access_log` directive: where requests are written
+// (file path, daemon module target, or "none"), which logformat is in
+// use, and which ACLs gate the log line. Multiple `access_log` lines
+// produce multiple entries in this list.
+private squid.conf.accessLog @defaults("target format") {
+  // Log target ("/var/log/squid/access.log", "daemon:/var/log/...", "stdio:/var/log/...", "syslog:...", or "none" to disable)
+  target string
+  // logformat name selecting the output format ("squid" when unspecified, or the name from a `logformat NAME ...` line)
+  format string
+  // Trailing ACL names that gate this log line, in argument order (an entry starting with "!" is a negated ACL)
+  acls []string
+  // Original directive arguments, joined by spaces
+  raw string
+}
+
+// HAProxy load balancer
+//
+// Examine HAProxy version and configuration. The configuration covers
+// the global section, defaults blocks, frontends, backends, listens, the
+// servers behind each backend, and supporting sections (resolvers,
+// userlists, peers).
+haproxy {
+  // HAProxy version string extracted from the haproxy binary (e.g., "2.8.4-1")
+  version() string
+}
+
+// HAProxy configuration
+//
+// Examine the parsed haproxy.cfg, any `<configdir>/conf.d/*.cfg` fragments
+// next to it, and every file pulled in by `!include` / `!includeglob`
+// directives (HAProxy 2.4+). Pass `init(path: "...")` to point at a
+// non-default config file.
+haproxy.config {
+  init(path? string)
+  // Primary configuration file (defaults to /etc/haproxy/haproxy.cfg)
+  file() file
+  // All configuration files visited (root + conf.d/*.cfg fragments + !included files)
+  files(file) []file
+  // Global section
+  global(file) haproxy.config.global
+  // Defaults sections — one unnamed block in classic configs, possibly several named blocks in HAProxy 2.4+
+  defaults(file) []haproxy.config.defaultsSection
+  // Frontend sections
+  frontends(file) []haproxy.config.frontend
+  // Backend sections
+  backends(file) []haproxy.config.backend
+  // Listen sections (combined frontend + backend)
+  listens(file) []haproxy.config.listen
+  // Resolvers sections (DNS resolver pools)
+  resolvers(file) []haproxy.config.resolversSection
+  // Userlist sections (HTTP auth groups/users)
+  userlists(file) []haproxy.config.userlist
+  // Peers sections (stick-table replication)
+  peers(file) []haproxy.config.peersSection
+  // Every parsed section in source order, including types not exposed as typed resources
+  sections(file) []haproxy.config.section
+}
+
+// HAProxy configuration section (raw view)
+//
+// Examine an arbitrary section by type and name. Useful for sections we
+// don't model as typed resources (mailers, cache, program, ring,
+// http-errors, fcgi-app, crt-store) and for low-level audits that need
+// every directive in source order.
+private haproxy.config.section @defaults("type name") {
+  // Section keyword (global, defaults, frontend, backend, listen, resolvers, userlist, peers, mailers, cache, ...)
+  type string
+  // Section name (empty for global; may be empty for the classic unnamed defaults block)
+  name string
+  // `from <other>` argument when present on the section header (named-defaults inheritance)
+  inherits string
+  // Source file path
+  file string
+  // 1-based source line where the section header appears
+  startLine int
+  // 1-based source line of the last directive in the section
+  endLine int
+  // Flat directive map (name -> joined args; values comma-concatenated when the directive repeats)
+  params map[string]string
+  // Every directive in source order — entries: {name, args, line, file, raw}
+  directives []dict
+  // Raw text of the section including its header line
+  raw string
+}
+
+// HAProxy global section
+//
+// Examine the global section: process settings (daemon, user/group,
+// chroot, pidfile), connection limits, threading, the runtime stats
+// socket, default SSL options applied to every bind and server, and the
+// log destinations.
+private haproxy.config.global @defaults("daemon maxconn nbthread") {
+  // `daemon` directive present
+  daemon bool
+  // `master-worker` directive present
+  masterWorker bool
+  // `user` directive value (UNIX uid)
+  user string
+  // `group` directive value (UNIX gid)
+  group string
+  // `chroot` directory
+  chroot string
+  // `pidfile` path
+  pidfile string
+  // `maxconn` value (global connection limit)
+  maxconn int
+  // `nbthread` value (worker threads per process)
+  nbthread int
+  // `nbproc` value (legacy; replaced by nbthread in HAProxy 2.5+)
+  nbproc int
+  // `hard-stop-after` value (time string, e.g. "30s")
+  hardStopAfter string
+  // `stats socket` path (UNIX path or address)
+  statsSocket string
+  // `mode` arg on the stats socket line (octal as string)
+  statsSocketMode string
+  // `level` arg on the stats socket line (user, operator, admin)
+  statsSocketLevel string
+  // `user`/`group` arg on the stats socket line — UNIX uid/gid the socket is owned by
+  statsSocketUser string
+  // `stats timeout` value (string with time unit)
+  statsTimeout string
+  // `log` directives, one entry per line (e.g. "/dev/log local0")
+  log []string
+  // `ssl-default-bind-ciphers` value
+  sslDefaultBindCiphers string
+  // `ssl-default-bind-ciphersuites` value (TLS 1.3 cipher list)
+  sslDefaultBindCiphersuites string
+  // `ssl-default-bind-options` value (e.g., "ssl-min-ver TLSv1.2 no-tls-tickets")
+  sslDefaultBindOptions string
+  // `ssl-default-bind-curves` value
+  sslDefaultBindCurves string
+  // `ssl-default-server-ciphers` value
+  sslDefaultServerCiphers string
+  // `ssl-default-server-ciphersuites` value
+  sslDefaultServerCiphersuites string
+  // `ssl-default-server-options` value
+  sslDefaultServerOptions string
+  // `ssl-default-server-curves` value
+  sslDefaultServerCurves string
+  // `ca-base` value (base directory for `ca-file` relative paths)
+  caBase string
+  // `crt-base` value (base directory for `crt` relative paths)
+  crtBase string
+  // `tune.ssl.default-dh-param` value
+  tuneSslDefaultDhParam int
+  // Every `option <name> [args]` enabled in this section
+  options []string
+  // Every `no option <name>` disabled in this section
+  disabledOptions []string
+  // All directives within this section (name -> joined args, comma-concatenated when repeated)
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy defaults section
+//
+// Examine the inherited defaults applied to every frontend, backend, and
+// listen that doesn't override a setting locally. HAProxy 2.4+ supports
+// multiple named defaults blocks; `name` selects which one.
+private haproxy.config.defaultsSection @defaults("name mode") {
+  // Defaults section name (empty for the classic unnamed defaults block)
+  name string
+  // `from <other-defaults>` argument when present
+  inherits string
+  // `mode` value (tcp, http)
+  mode string
+  // `balance` algorithm value
+  balance string
+  // `retries` value
+  retries int
+  // `maxconn` value (per-frontend limit when inherited)
+  maxconn int
+  // `option <name> [args]` directives
+  options []string
+  // `no option <name>` directives
+  disabledOptions []string
+  // `timeout <kind> <value>` map keyed by kind (connect, client, server, http-request, queue, tunnel, ...)
+  timeouts map[string]string
+  // `log` directives, one entry per line
+  log []string
+  // All directives within this defaults section
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy frontend section
+//
+// Examine an inbound traffic acceptor: its `bind` listeners (with TLS
+// settings), ACL definitions, request routing rules, the default backend,
+// and the timeout/log/option set applied to client traffic.
+private haproxy.config.frontend @defaults("name mode") {
+  // Frontend name
+  name string
+  // `from <defaults>` argument when present
+  inherits string
+  // `mode` value (tcp, http)
+  mode string
+  // `bind` directives, broken out per address form (a comma-separated address list produces one entry per address)
+  binds []haproxy.config.bind
+  // `default_backend` value
+  defaultBackend string
+  // `acl` definitions — entries: {name, criterion, args, line, raw}
+  acls []dict
+  // `use_backend` rules — entries: {backend, condition, line, raw}
+  useBackends []dict
+  // `http-request <rule>` lines (raw arg strings, in source order)
+  httpRequestRules []string
+  // `http-response <rule>` lines
+  httpResponseRules []string
+  // `tcp-request <rule>` lines
+  tcpRequestRules []string
+  // `tcp-response <rule>` lines
+  tcpResponseRules []string
+  // `capture` lines (raw arg strings)
+  captures []string
+  // `redirect` lines
+  redirects []string
+  // `monitor-uri` value
+  monitorUri string
+  // `monitor fail` condition (everything after `monitor fail`)
+  monitorFail string
+  // `option <name> [args]` directives
+  options []string
+  // `no option <name>` directives
+  disabledOptions []string
+  // `timeout <kind> <value>` map keyed by kind
+  timeouts map[string]string
+  // `log` directives
+  log []string
+  // `maxconn` value (per-frontend limit)
+  maxconn int
+  // All directives within this frontend
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy backend section
+//
+// Examine a backend pool: the load-balancing algorithm, the servers
+// behind it, their TLS posture (ssl/verify/ca-file) and health-check
+// configuration (`option httpchk`/`http-check`), `default-server` defaults,
+// stick-table/cookie persistence, request mutators, and timeouts.
+private haproxy.config.backend @defaults("name mode balance") {
+  // Backend name
+  name string
+  // `from <defaults>` argument when present
+  inherits string
+  // `mode` value (tcp, http)
+  mode string
+  // `balance` algorithm (roundrobin, leastconn, source, uri, url_param, hdr, random, ...)
+  balance string
+  // `hash-type` value
+  hashType string
+  // Servers behind this backend
+  servers []haproxy.config.server
+  // `default-server` directive parsed as a flag bag (same shape as a server, minus name/address)
+  defaultServer dict
+  // `source` directive arguments (e.g., "0.0.0.0 usesrc clientip")
+  source string
+  // Consolidated HTTP health check — keys: {method, uri, version, send[], expect[], disabled}
+  httpCheck dict
+  // `stick-table` arguments (raw string)
+  stickTable string
+  // `stick on` value (raw expression)
+  stickOn string
+  // `cookie` directive arguments (name + flags)
+  cookie string
+  // `acl` definitions
+  acls []dict
+  // `http-request <rule>` lines
+  httpRequestRules []string
+  // `http-response <rule>` lines
+  httpResponseRules []string
+  // `tcp-request <rule>` lines
+  tcpRequestRules []string
+  // `tcp-response <rule>` lines
+  tcpResponseRules []string
+  // `option <name> [args]` directives
+  options []string
+  // `no option <name>` directives
+  disabledOptions []string
+  // `timeout <kind> <value>` map keyed by kind
+  timeouts map[string]string
+  // `log` directives
+  log []string
+  // `retries` value (defaults inherited; 0 means unset locally)
+  retries int
+  // All directives within this backend
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy listen section
+//
+// Examine a combined frontend+backend section. The same audit surface as
+// a backend (servers, balance, health checks) plus the frontend's
+// `bind` listeners and ACL/routing surface.
+private haproxy.config.listen @defaults("name mode") {
+  // Listen section name
+  name string
+  // `from <defaults>` argument when present
+  inherits string
+  // `mode` value (tcp, http)
+  mode string
+  // `bind` directives, broken out per address form
+  binds []haproxy.config.bind
+  // `balance` algorithm
+  balance string
+  // Backend servers
+  servers []haproxy.config.server
+  // `default-server` directive parsed as a flag bag
+  defaultServer dict
+  // `acl` definitions
+  acls []dict
+  // `use_backend` rules
+  useBackends []dict
+  // `http-request <rule>` lines
+  httpRequestRules []string
+  // `http-response <rule>` lines
+  httpResponseRules []string
+  // `tcp-request <rule>` lines
+  tcpRequestRules []string
+  // `tcp-response <rule>` lines
+  tcpResponseRules []string
+  // Consolidated HTTP health check
+  httpCheck dict
+  // `option <name> [args]` directives
+  options []string
+  // `no option <name>` directives
+  disabledOptions []string
+  // `timeout <kind> <value>` map keyed by kind
+  timeouts map[string]string
+  // `log` directives
+  log []string
+  // All directives within this listen
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy bind listener
+//
+// Examine one listener address produced by a `bind` directive. A
+// `bind a:1,b:2 ssl crt foo` directive expands into one of these per
+// address form; the shared parameters (ssl, crt, alpn, verify, etc.)
+// are copied onto each entry.
+private haproxy.config.bind @defaults("address port ssl") {
+  // Raw argument string after the `bind` keyword
+  raw string
+  // Address part: "*" for the wildcard, an IP literal, "[::]" for IPv6, "unix:/path" / "unix@..." / "abns@..." for unix sockets, or a hostname
+  address string
+  // TCP port for a single-port bind; 0 for unix sockets or port ranges
+  port int
+  // Start of a port range (e.g., `bind *:80-89`); 0 if not a range
+  portRangeStart int
+  // End of a port range; 0 if not a range
+  portRangeEnd int
+  // `ssl` flag present
+  ssl bool
+  // `alpn` argument (comma-separated protocols; e.g., "h2,http/1.1")
+  alpn string
+  // `ciphers` argument (TLS 1.0-1.2 cipher list)
+  ciphers string
+  // `ciphersuites` argument (TLS 1.3 cipher suite list)
+  ciphersuites string
+  // `curves` argument (named curve list)
+  curves string
+  // `crt` argument (certificate path or directory)
+  crt string
+  // `crt-list` argument (path to a crt-list file)
+  crtList string
+  // `ca-file` argument (CA bundle for client cert verification)
+  caFile string
+  // `verify` argument (none, optional, required)
+  verify string
+  // `ssl-min-ver` argument (e.g., "TLSv1.2")
+  sslMinVer string
+  // `ssl-max-ver` argument
+  sslMaxVer string
+  // `no-sslv3` flag
+  noSslv3 bool
+  // `no-tlsv10` flag
+  noTlsv10 bool
+  // `no-tlsv11` flag
+  noTlsv11 bool
+  // `no-tlsv12` flag
+  noTlsv12 bool
+  // `no-tlsv13` flag
+  noTlsv13 bool
+  // `accept-proxy` flag (require PROXY protocol header from client)
+  acceptProxy bool
+  // `transparent` flag
+  transparent bool
+  // `v4v6` flag (bind on both IPv4 and IPv6 when the socket supports it)
+  v4v6 bool
+  // `v6only` flag
+  v6only bool
+  // All key=value attributes on this bind line (catch-all including ones not surfaced as typed fields)
+  params map[string]string
+}
+
+// HAProxy backend server
+//
+// Examine one backend pool member. Captures the server identity
+// (name/address/port), TLS posture toward the backend (ssl, verify,
+// ca-file, sni, alpn), the health check tuning (inter/rise/fall/observe),
+// connection limits, and persistence hooks.
+private haproxy.config.server @defaults("name address port check ssl") {
+  // Server name
+  name string
+  // Server address: hostname, IPv4, "[IPv6]", "unix@/path", or "abns@..."
+  address string
+  // Server port (0 for unix sockets or address-only declarations)
+  port int
+  // `check` flag (active health checking enabled)
+  check bool
+  // `ssl` flag (use TLS to reach this server)
+  ssl bool
+  // `verify` argument (none, required)
+  verify string
+  // `ca-file` argument (CA bundle for backend cert verification)
+  caFile string
+  // `crt` argument (client cert presented to the backend)
+  crt string
+  // `sni` argument (SNI value to send)
+  sni string
+  // `alpn` argument
+  alpn string
+  // `weight` value (load-balancing weight; 0 means draining)
+  weight int
+  // `backup` flag (only used when no non-backup server is up)
+  backup bool
+  // `disabled` flag (admin-down)
+  disabled bool
+  // `maxconn` value (per-server concurrent connection cap)
+  maxconn int
+  // `maxqueue` value (queue cap before failing over)
+  maxqueue int
+  // `inter` value (regular health-check interval, e.g. "2s")
+  inter string
+  // `fastinter` value (interval immediately after a state change)
+  fastInter string
+  // `downinter` value (interval while marked down)
+  downInter string
+  // `rise` value (consecutive UP checks required to mark UP)
+  rise int
+  // `fall` value (consecutive failed checks required to mark DOWN)
+  fall int
+  // `slowstart` value
+  slowStart string
+  // `observe` value (passive observation: l4, l7)
+  observe string
+  // `on-error` value (action on observed errors: fastinter, fail-check, sudden-death, mark-down)
+  onError string
+  // `on-marked-up` value
+  onMarkedUp string
+  // `on-marked-down` value
+  onMarkedDown string
+  // `cookie` value (cookie identifier for stickiness)
+  cookie string
+  // `resolvers` name (resolvers section used for hostname resolution)
+  resolvers string
+  // `init-addr` value
+  initAddr string
+  // `send-proxy` flag (send PROXY v1 header to backend)
+  sendProxy bool
+  // `send-proxy-v2` flag (send PROXY v2 header to backend)
+  sendProxyV2 bool
+  // `agent-check` flag (enable external agent health check)
+  agentCheck bool
+  // `agent-port` value
+  agentPort int
+  // `agent-addr` value
+  agentAddr string
+  // `agent-inter` value
+  agentInter string
+  // All key=value flags on the server line (catch-all)
+  params map[string]string
+}
+
+// HAProxy resolvers section
+//
+// Examine a DNS resolver pool used by `server` directives that resolve
+// hostnames at runtime via `resolvers <name>`.
+private haproxy.config.resolversSection @defaults("name") {
+  // Resolvers section name
+  name string
+  // `nameserver <name> <addr>[:<port>]` entries — entries: {name, address, port}
+  nameservers []dict
+  // `resolve_retries` value
+  resolveRetries int
+  // `timeout <kind> <value>` map (resolve, retry)
+  timeouts map[string]string
+  // `accepted_payload_size` value (UDP DNS payload cap)
+  acceptedPayloadSize int
+  // `hold <state> <duration>` map keyed by state (valid, nx, refused, timeout, obsolete, other)
+  holds map[string]string
+  // All directives within this resolvers section
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// HAProxy userlist section
+//
+// Examine an HTTP-auth userlist consumed by `http-request auth` /
+// `http-request deny unless { http_auth(<list>) }`. Captures users
+// (with hashing flag) and groups.
+private haproxy.config.userlist @defaults("name") {
+  // Userlist name
+  name string
+  // `user <name> (password|insecure-password) <secret> [groups <g1,g2>]` entries — entries: {name, password, hashed, groups}
+  users []dict
+  // `group <name> [users <u1,u2>]` entries — entries: {name, users}
+  groups []dict
+  // Source file path
+  file string
+}
+
+// HAProxy peers section
+//
+// Examine a peers section used for stick-table replication between
+// HAProxy instances.
+private haproxy.config.peersSection @defaults("name") {
+  // Peers section name
+  name string
+  // `bind` argument (raw — peers binds are simpler than frontend binds)
+  bind string
+  // `server <name> <addr>:<port>` entries (typed server resources, same shape as backend servers)
+  servers []haproxy.config.server
+  // `table <name> ...` entries — entries: {name, type, size, expire, store, raw}
+  tables []dict
+  // All directives within this peers section
+  params map[string]string
+  // Source file path
+  file string
+}
+
+// systemd journald configuration
+//
+// Examine the [Journal] and other sections of journald.conf
+journald.config {
+  init(path? string)
+  // File of this journald configuration
+  file() file
+  // Flattened journald configuration parameters
+  //
+  // Deprecated in favor of `sections()`.
+  params(file) @maturity("deprecated") map[string]string
+  // All sections in this journald configuration
+  sections(file) []journald.config.section
+}
+
+// journald configuration section
+//
+// Examine a single named section (e.g., "Journal", "Upload") from the
+// journald configuration, including its `params` list of key-value pairs.
+// Used together with `journald.config` to audit individual journald settings
+// within a specific section.
+journald.config.section @defaults("name") {
+  // Name of the section (e.g., "Journal", "Upload")
+  name string
+  // Key-value pairs in this section
+  params []journald.config.section.param
+}
+
+// journald configuration parameter
+//
+// Examine a single key-value directive within a journald configuration
+// section: the parameter `name` (e.g., "Storage", "Compress") and its
+// `value`. Iterated from `journald.config.section.params` to assert
+// specific journald settings.
+journald.config.section.param @defaults("name value") {
+  // Configuration parameter name
+  name string
+  // Configuration parameter value
+  value string
+}
+
+// Service on the system
+//
+// Examine install, enable, run state, type, and unit metadata
+service @defaults("name running enabled type") {
+  init(name string)
+  // Name of the service
+  name string
+  // Service description
+  description string
+  // Whether the service is installed
+  installed bool
+  // Whether the service is running
+  running bool
+  // Whether the service is enabled (start at boot)
+  enabled bool
+  // Service type (e.g., simple, forking, oneshot, notify)
+  type string
+  // Whether the service is masked
+  masked bool
+  // Whether the service is static (unit file has no [Install] section and cannot be enabled/disabled)
+  static bool
+}
+
+// All services configured on the system
+//
+// Iterate every service across the asset's init/service manager
+services {
+  []service
+}
+
+// systemd timer unit
+//
+// Examine schedule, activation target, enable state, and run status
+systemd.timer @defaults("name enabled running") {
+  init(name string)
+  // Name of the timer unit (without .timer suffix)
+  name string
+  // Timer unit description
+  description string
+  // Whether the timer unit file is installed
+  installed bool
+  // Whether the timer is enabled (starts at boot)
+  enabled bool
+  // Whether the timer is masked
+  masked bool
+  // Whether the timer is static (unit file has no [Install] section)
+  static bool
+  // Whether the timer is currently active
+  running bool
+  // The unit that this timer activates (e.g., "apt-daily.service")
+  activates() string
+  // Calendar expression for the timer schedule (empty for monotonic timers)
+  onCalendar() string
+  // Whether missed runs are triggered on next start
+  persistent() bool
+}
+
+// All systemd timer units on the system
+//
+// Iterate every timer for filtering by schedule, target, or status
+systemd.timers {
+  []systemd.timer
+}
+
+// systemd socket unit
+//
+// Examine listen addresses, activation target, and run state
+systemd.socket @defaults("name enabled running") {
+  init(name string)
+  // Name of the socket unit (without .socket suffix)
+  name string
+  // Socket unit description
+  description string
+  // Whether the socket unit file is installed
+  installed bool
+  // Whether the socket is enabled (starts at boot)
+  enabled bool
+  // Whether the socket is masked
+  masked bool
+  // Whether the socket is static (unit file has no [Install] section)
+  static bool
+  // Whether the socket is currently active
+  running bool
+  // The unit that this socket activates (e.g., "dbus.service")
+  activates() string
+  // Addresses, paths, or ports this socket listens on
+  listenAddresses() []string
+  // Whether the socket accepts connections (inetd-style)
+  accept() bool
+}
+
+// All systemd socket units on the system
+//
+// Iterate every socket-activated unit for listen-address and target audits
+systemd.sockets {
+  []systemd.socket
+}
+
+// systemd target unit
+//
+// Examine a single systemd target — load state, active state, the unit
+// file's enabled/disabled state, fragment path on disk, and the
+// dependency lists (`wants`, `requires`, `after`, `before`) that
+// determine which other units the target pulls in or orders around.
+// Iterated from `systemd.targets`.
+private systemd.target @defaults("name loadState activeState") {
+  // Name of the target unit (without .target suffix)
+  name string
+  // Target unit description
+  description string
+  // Load state (e.g., loaded, not-found, masked, error)
+  loadState string
+  // Active state (e.g., active, inactive, failed, activating, deactivating)
+  activeState string
+  // Sub state for the target (e.g., active, dead)
+  subState string
+  // Unit file state (e.g., enabled, disabled, static, masked, alias)
+  unitFileState string
+  // Path to the unit file on disk
+  fragmentPath string
+  // Units listed in Wants= (best-effort dependencies)
+  wants []string
+  // Units listed in Requires= (hard dependencies)
+  requires []string
+  // Units listed in After= (this target starts after them)
+  after []string
+  // Units listed in Before= (this target starts before them)
+  before []string
+}
+
+// All systemd target units on the system
+//
+// Iterate every target unit to audit boot ordering, default target, and
+// dependency wiring
+systemd.targets {
+  []systemd.target
+}
+
+// systemd-resolved DNS resolver state
+//
+// Examine the global DNS resolution configuration provided by
+// systemd-resolved: whether the daemon is `active`, the effective DNS
+// servers (`dns`) and `fallbackDns`, search `domains`, DNSSEC and
+// DNS-over-TLS modes, LLMNR and multicast-DNS settings, the
+// resolv.conf mode, and whether caching is enabled. Backed by
+// `resolvectl status` for the Global scope.
+systemd.resolved @defaults("active dns") {
+  // Whether the systemd-resolved daemon is currently active
+  active() bool
+  // Effective DNS server addresses for the Global scope
+  dns() []string
+  // DNS server currently in use for the Global scope
+  //
+  // resolvectl picks one server from the configured `dns` list at a time;
+  // this is that selection. Empty when no global DNS server is active or
+  // the line is not emitted (e.g., when only per-link DNS is configured).
+  currentDnsServer() string
+  // Fallback DNS servers used when no Link or Global DNS is configured
+  fallbackDns() []string
+  // DNS search domains
+  domains() []string
+  // DNSSEC mode
+  //
+  // One of `yes`, `no`, or `allow-downgrade`. May appear as `no/unsupported`
+  // when the upstream resolver does not support DNSSEC.
+  dnssec() string
+  // DNS-over-TLS mode (e.g., `yes`, `no`, `opportunistic`)
+  dnsOverTls() string
+  // LLMNR mode (e.g., `yes`, `no`, `resolve`)
+  llmnr() string
+  // Multicast DNS mode (e.g., `yes`, `no`, `resolve`)
+  multicastDns() string
+  // /etc/resolv.conf management mode (e.g., `stub`, `static`, `uplink`, `foreign`)
+  resolvConfMode() string
+  // Whether the resolver cache is enabled
+  cache() bool
+}
+
+// systemd-timesyncd NTP client state
+//
+// Examine the SNTP client provided by systemd-timesyncd: whether the
+// daemon is `active`, whether the system clock is currently
+// `synchronized`, the configured `servers` and `fallbackServers`, the
+// currently selected NTP `serverName` and `serverAddress`, the current
+// poll interval, and the leap-second status. Backed by `timedatectl
+// show` and `timedatectl show-timesync`.
+systemd.timesyncd @defaults("active synchronized serverName") {
+  // Whether the systemd-timesyncd daemon is currently active
+  active() bool
+  // Whether the system clock is synchronized to a time source
+  synchronized() bool
+  // NTP servers from configuration (NTP= and DHCP)
+  servers() []string
+  // Fallback NTP servers used when none of `servers` are reachable
+  fallbackServers() []string
+  // Hostname of the currently selected NTP server
+  serverName() string
+  // IP address of the currently selected NTP server
+  serverAddress() string
+  // Current poll interval in microseconds
+  pollIntervalUSec() int
+  // Leap second status (e.g., `normal`, `insert-second`, `delete-second`, `unknown`)
+  leapStatus() string
+}
+
+// Running kernel and its modules
+//
+// Examine kernel info, sysctl parameters, loaded modules, and installed versions
+kernel @defaults("info") {
+  // Active kernel information
+  info() dict
+  // Kernel parameters map
+  parameters() map[string]string
+  // List of kernel modules
+  modules() []kernel.module
+  // Installed versions
+  installed() []dict
+  // Kernel boot command line (Linux only)
+  cmdline() kernel.cmdline
+  // Kernel taint status (Linux only)
+  taint() kernel.taint
+  // Kernel lockdown LSM mode (Linux only)
+  lockdown() kernel.lockdown
+  // Address Space Layout Randomization (ASLR) state (Linux only)
+  aslr() kernel.aslr
+}
+
+// System kernel module information
+//
+// Examine a single kernel module: its `name`, in-memory `size`, and
+// whether it is currently `loaded`. Initialize by name (e.g.,
+// `kernel.module(name: "nf_conntrack")`) to check a specific module,
+// or iterate from `kernel.modules()` to audit the full loaded-module list.
+// Use `blacklisted`, `installBypass`, and `disabled` to express CIS-style
+// "module must not load" controls without falling back to raw modprobe.d
+// file parsing. Use `onDisk` to tell whether a loadable module file is
+// available for the running kernel even when it isn't currently loaded,
+// and `builtIn` to detect functionality compiled directly into the kernel
+// (which is always active and cannot be blacklisted or unloaded).
+kernel.module @defaults("name loaded") {
+  init(name string)
+
+  // Name of the kernel module
+  name string
+  // Size of the kernel module
+  size string
+  // Whether the module is loaded
+  loaded bool
+  // Whether the module is blacklisted in modprobe configuration
+  //
+  // True when any modprobe configuration file declares `blacklist <name>`.
+  // Blacklisted modules will not auto-load (e.g., from udev or hotplug
+  // events) but root can still force-load them with `modprobe --force`
+  // or by writing to `/sys/module/...`. CIS macOS/Linux benchmarks check
+  // for this to ensure unused filesystems/protocols stay off.
+  blacklisted() bool
+  // Whether the module's load is short-circuited to /bin/true or /bin/false
+  //
+  // True when any modprobe configuration file declares
+  // `install <name> /bin/false` (or `/bin/true`). This is stronger than
+  // blacklisting: even an explicit `modprobe <name>` is replaced with
+  // the no-op binary, so the module cannot be loaded without overriding
+  // the install rule.
+  installBypass() bool
+  // Whether the module is effectively disabled
+  //
+  // True when the module is either blacklisted or has an install
+  // short-circuit rule. Use this as the canonical "module will not load
+  // without explicit override" predicate.
+  disabled() bool
+  // Whether a loadable module file is installed on disk for the running kernel
+  //
+  // True when a `.ko` (or compressed `.ko.xz` / `.ko.zst` / `.ko.gz`)
+  // file for this module exists under `/lib/modules/<version>/`, as
+  // listed in that kernel's `modules.dep` index. This reports presence
+  // independently of `loaded`, so it answers "the module is available to
+  // load but isn't loaded right now." Modules compiled into the kernel
+  // have no file on disk and report false here — see `builtIn`.
+  onDisk() bool
+  // Whether the module is compiled into the kernel image
+  //
+  // True when the functionality is built directly into the kernel
+  // (configured `=y`) rather than shipped as a loadable file, as listed
+  // in the running kernel's `modules.builtin` index. Built-in modules
+  // are always active: they never appear in `loaded`, have no file on
+  // disk (`onDisk` is false), and cannot be blacklisted or unloaded.
+  builtIn() bool
+}
+
+// Linux kernel boot command line
+//
+// Examine the kernel command line passed by the bootloader at boot
+// time (the contents of /proc/cmdline). Use `parameters` for
+// `key=value` directives and `flags` for bare tokens such as `ro`,
+// `quiet`, or `nosmt`. The `raw` string is preserved for direct
+// inspection or for callers that need to recover duplicate tokens.
+private kernel.cmdline @defaults("raw") {
+  // Raw contents of /proc/cmdline
+  raw string
+  // Parameters parsed from `key=value` tokens
+  //
+  // When a parameter appears multiple times on the command line
+  // (e.g. `console=tty0 console=ttyS0`), the last occurrence wins.
+  // Use `raw` for full-fidelity inspection.
+  parameters map[string]string
+  // Bare flags on the kernel command line (tokens without `=`)
+  flags []string
+}
+
+// Linux kernel taint status
+//
+// Examine kernel taint flags as reported by /proc/sys/kernel/tainted.
+// A non-zero bitmask indicates that the kernel has loaded
+// proprietary or out-of-tree modules, hit a hardware error, oopsed,
+// or otherwise entered a state that diverges from a clean reference
+// kernel. Use `tainted` for a boolean check and `reasons` for the
+// human-readable list of contributing bits.
+private kernel.taint @defaults("tainted reasons") {
+  // Raw taint bitmask from /proc/sys/kernel/tainted
+  bitmask int
+  // Whether any taint bit is set
+  tainted bool
+  // Human-readable taint reasons in bit order
+  //
+  // See the kernel.org "Tainted kernels" documentation for the full
+  // list of bit meanings (proprietary module, out-of-tree module,
+  // unsigned module, oops, soft lockup, live-patched, etc.).
+  reasons []string
+}
+
+// Linux kernel lockdown mode
+//
+// Examine the kernel lockdown LSM state from
+// /sys/kernel/security/lockdown. Lockdown restricts modifications to
+// a running kernel even from root: `integrity` blocks features that
+// could let userspace modify the kernel (kexec, /dev/mem, etc.) and
+// `confidentiality` additionally blocks features that expose kernel
+// memory contents. `mode` is `unavailable` when the kernel was built
+// without lockdown support.
+private kernel.lockdown @defaults("mode") {
+  // Active lockdown mode
+  //
+  // One of `none`, `integrity`, `confidentiality`, or `unavailable`.
+  mode string
+  // Whether lockdown is enforced (mode is `integrity` or `confidentiality`)
+  enabled bool
+}
+
+// Linux Address Space Layout Randomization (ASLR) state
+//
+// Examine the kernel's userspace ASLR setting from
+// /proc/sys/kernel/randomize_va_space. ASLR randomizes memory layout
+// to make memory-corruption exploits harder; CIS benchmarks require
+// `mode` 2 (full randomization).
+private kernel.aslr @defaults("level enabled") {
+  // Raw ASLR mode value from /proc/sys/kernel/randomize_va_space
+  //
+  // `0` disabled, `1` conservative (stack, libraries, vdso), `2`
+  // full (also heap/brk). `-1` when the file is unavailable.
+  mode int
+  // Human-readable level
+  //
+  // One of `disabled`, `conservative`, `full`, or `unknown`.
+  level string
+  // Whether ASLR is enabled (`mode > 0`)
+  enabled bool
+}
+
+// Linux control groups (cgroup v2)
+//
+// Examine the cgroup hierarchy, available controllers, and the version
+// of cgroups in use. Modern Linux uses cgroup v2 (a single unified
+// hierarchy at /sys/fs/cgroup); v1 hosts and hybrid setups are
+// detected and reported via `version`, but per-controller hierarchies
+// are not modeled. Iterate `list` to query every cgroup on the host,
+// or walk down from `root` to traverse the hierarchy.
+cgroups @defaults("version controllers") {
+  // cgroup version in use: 2 (unified), 1 (legacy v1 only), or 0 if cgroups are not available
+  version() int
+  // Controllers available on the host (e.g., memory, cpu, io, pids)
+  controllers() []string
+  // The root cgroup
+  root() cgroup
+  // Flat list of every cgroup on the host
+  list() []cgroup
+}
+
+// Linux control group
+//
+// Examine a single cgroup v2 entry: its `path` relative to the cgroup
+// root, the kernel `type` (domain, threaded, etc.), the
+// systemd-inferred `unitType` (slice, scope, service, or other), the
+// controllers enabled on it, memory/CPU/PIDs limits and current
+// usage, and the process IDs assigned to the cgroup. Iterated from
+// `cgroups.list` or traversed via `children`. Limit fields use `-1`
+// to mean unlimited (the kernel's `max` literal).
+private cgroup @defaults("path unitType memoryMax") {
+  // Path relative to the cgroup root (e.g., /system.slice/docker-<id>.scope)
+  path string
+  // Kernel cgroup type from `cgroup.type`
+  //
+  // One of `domain`, `domain_threaded`, `domain_invalid`, or
+  // `threaded`. Empty when the file is unreadable (typically the root
+  // cgroup, where `cgroup.type` does not exist).
+  type string
+  // systemd unit kind inferred from the leaf name
+  //
+  // One of `slice`, `scope`, `service`, `root`, or `other`.
+  unitType string
+  // Controllers enabled on this cgroup (from cgroup.controllers)
+  controllers []string
+  // Memory hard limit in bytes; `-1` means unlimited
+  memoryMax int
+  // Memory soft limit / throttling watermark in bytes; `-1` means unlimited
+  memoryHigh int
+  // Current memory usage in bytes
+  memoryCurrent int
+  // Swap hard limit in bytes; `-1` means unlimited
+  memorySwapMax int
+  // CPU quota in microseconds per period; `-1` means unlimited
+  cpuMaxQuotaUSec int
+  // CPU accounting period in microseconds
+  cpuMaxPeriodUSec int
+  // Relative CPU weight (1-10000, default 100)
+  cpuWeight int
+  // PID hard limit; `-1` means unlimited
+  pidsMax int
+  // Current number of processes in this cgroup
+  pidsCurrent int
+  // Process IDs assigned to this cgroup
+  pids []int
+  // Child cgroups directly under this one
+  children() []cgroup
+}
+
+// Docker host
+//
+// Examine images and containers managed by the Docker daemon
+docker {
+  // List all Docker images
+  images() []docker.image
+  // List all Docker containers
+  containers() []docker.container
+}
+
+// Dockerfile parser
+//
+// Examine instructions and per-stage FROM/RUN/COPY/ENV/EXPOSE/USER/HEALTHCHECK
+docker.file @defaults("file.path instructions.length stages.length") {
+  init(path string)
+  // File information about this Dockerfile
+  embed file
+  // List of instructions in the order they appear
+  instructions(file) dict
+  // All stages included in this Dockerfile
+  stages(file) []docker.file.stage
+  // Parser directives declared at the top of the Dockerfile
+  //
+  // Keys include `syntax` (frontend image pin, e.g. `docker/dockerfile:1.7`),
+  // `escape` (line-continuation token, default `\`), and `check` (Buildkit
+  // build-check toggles).
+  directives(file) map[string]string
+  // Whether the Dockerfile defines more than one stage
+  multiStage(file) bool
+  // Whether the Dockerfile pins a frontend via the `syntax` parser directive
+  //
+  // Set when the file begins with `# syntax=<image>` (e.g.
+  // `# syntax=docker/dockerfile:1.7`). The directive selects a specific
+  // BuildKit frontend version. Note that BuildKit-only features such as
+  // `RUN --mount=type=secret` work without this directive too, so `false`
+  // does not mean BuildKit is unused.
+  hasSyntaxDirective(file) bool
+  // Final stage in this Dockerfile
+  //
+  // Shortcut to the last `docker.file.stage`, which is the one that produces
+  // the image when the build runs without `--target`. Null for an empty file.
+  finalStage(file) docker.file.stage
+}
+
+// Dockerfile stages
+private docker.file.stage @defaults("from.name") {
+  // The source of this stage, specified via `FROM` in Dockerfiles
+  from docker.file.from
+  // Contains the reference to the Dockerfile this stage belongs to
+  file docker.file
+  // ENV instructions in this Dockerfile
+  env []docker.file.env
+  // ARG instructions in the Dockerfile
+  arg []docker.file.arg
+  // LABEL instructions in the Dockerfile
+  labels map[string]string
+  // OpenContainer image annotations from this stage's labels
+  oci docker.file.oci
+  // RUN instructions in this Dockerfile
+  run []docker.file.run
+  // CMD instructions in this Dockerfile
+  cmd docker.file.run
+  // USER instruction in this Dockerfile
+  user docker.file.user
+  // ENTRYPOINT instructions in this Dockerfile
+  entrypoint docker.file.run
+  // ADD instructions in this Dockerfile
+  add []docker.file.add
+  // COPY instructions in this Dockerfile
+  copy []docker.file.copy
+  // EXPOSE instructions in this Dockerfile
+  expose []docker.file.expose
+  // HEALTHCHECK instruction in this Dockerfile
+  healthcheck docker.file.healthcheck
+  // VOLUME instructions in this Dockerfile
+  volumes []docker.file.volume
+  // SHELL instruction in this Dockerfile
+  shell docker.file.shell
+  // WORKDIR instructions in this Dockerfile
+  workdir []docker.file.workdir
+  // STOPSIGNAL instruction in this Dockerfile
+  stopsignal docker.file.stopsignal
+  // ONBUILD instructions in this Dockerfile
+  //
+  // ONBUILD instructions are deferred and run when an image built from this
+  // Dockerfile is itself used as the base image of a downstream build.
+  onbuild []docker.file.onbuild
+  // Whether this stage runs as root
+  //
+  // True when no `USER` instruction is present in the stage or when the
+  // declared user resolves to UID 0 (`0` or `root`). Inherited `USER` from
+  // the base image is not considered, because it is not visible from the
+  // Dockerfile alone.
+  runsAsRoot bool
+  // Whether this stage declares a HEALTHCHECK
+  //
+  // True for any `HEALTHCHECK` line, including `HEALTHCHECK NONE` (which
+  // explicitly disables an inherited check).
+  hasHealthcheck bool
+  // Whether this stage is the final stage in the Dockerfile
+  //
+  // Only the final stage produces the image when the Dockerfile is built
+  // without `--target`.
+  final bool
+}
+
+// OpenContainer image annotations declared in a build stage
+//
+// Examine the `org.opencontainers.image.*` labels set via `LABEL`
+// instructions in a single build stage. The standard annotations defined by
+// the OpenContainer image specification are surfaced as named fields so you
+// can read provenance and metadata without remembering the full annotation
+// keys — for example the upstream repository (`source`), the commit it was
+// built from (`revision`), the release (`version`), and the SPDX license
+// expression (`licenses`). The `all` field holds every `org.opencontainers.*`
+// label found on the stage, including vendor-specific annotations that have
+// no named field. A field is empty when its annotation is not declared in the
+// stage. Surrounding quotes are removed from values, so a quoted `LABEL`
+// reads back unquoted; the verbatim form remains available in the stage
+// `labels` map.
+private docker.file.oci @defaults("source version revision") {
+  // Date and time the image was built, as an RFC 3339 string (`org.opencontainers.image.created`)
+  created string
+  // Contact details of the people or organization responsible for the image (`org.opencontainers.image.authors`)
+  authors string
+  // URL to find more information about the image (`org.opencontainers.image.url`)
+  url string
+  // URL to get documentation about the image (`org.opencontainers.image.documentation`)
+  documentation string
+  // URL to the source code that built the image (`org.opencontainers.image.source`)
+  source string
+  // Version of the packaged software (`org.opencontainers.image.version`)
+  version string
+  // Source control revision the image was built from (`org.opencontainers.image.revision`)
+  revision string
+  // Name of the distributing entity, organization, or individual (`org.opencontainers.image.vendor`)
+  vendor string
+  // License(s) under which the contained software is distributed (`org.opencontainers.image.licenses`)
+  //
+  // An SPDX license expression, for example `Apache-2.0` or `MIT OR GPL-2.0-only`.
+  licenses string
+  // Name of the reference for the image's target (`org.opencontainers.image.ref.name`)
+  refName string
+  // Human-readable title of the image (`org.opencontainers.image.title`)
+  title string
+  // Human-readable description of the software packaged in the image (`org.opencontainers.image.description`)
+  description string
+  // Image reference of the base image this image was built on (`org.opencontainers.image.base.name`)
+  baseName string
+  // Digest of the base image this image was built on (`org.opencontainers.image.base.digest`)
+  baseDigest string
+  // Every `org.opencontainers.*` label on the stage, keyed by full annotation name
+  //
+  // Includes the standard annotations surfaced as named fields as well as any
+  // vendor-specific or non-standard annotations under the `org.opencontainers`
+  // namespace.
+  all map[string]string
+}
+
+// Dockerfile ARG instructions
+private docker.file.arg @defaults("name default") {
+  // Name of the variable
+  name string
+  // (optional) Default value of the variable
+  //
+  // Values are preserved as-is, without stripping quotes.
+  default string
+}
+
+// Dockerfile ENV instructions
+private docker.file.env @defaults("name value") {
+  // Name of the variable
+  name string
+  // Value of the variable
+  //
+  // Values are preserved as-is, without stripping quotes.
+  value string
+}
+
+// Dockerfile USER instructions
+private docker.file.user @defaults("user") {
+  // Set the user name or UID
+  user string
+  // Set the user group or GID (optional)
+  group string
+  // Whether the declared user is root
+  //
+  // True when `user` is `0` or `root`. The group is not considered.
+  isRoot bool
+}
+
+// Dockerfile EXPOSE instruction
+private docker.file.expose @defaults("port protocol") {
+  // Port that is exposed
+  port int
+  // Protocol that is exposed (evaluates to `tcp` if not specified)
+  protocol string
+}
+
+// Dockerfile FROM instructions
+private docker.file.from @defaults("name image tag") {
+  platform string
+  image string
+  tag string
+  digest string
+  name string
+}
+
+// Dockerfile RUN instructions
+private docker.file.run @defaults("script") {
+  script string
+  // `--mount=...` flags applied to this RUN
+  //
+  // Each mount exposes a build-time secret, ssh agent socket, cache directory,
+  // tmpfs, or bind-mounted source.
+  mounts []docker.file.run.mount
+  // `--network=...` value
+  //
+  // One of `default`, `none`, or `host`. Empty when the flag is not set
+  // (BuildKit treats that as `default`).
+  network string
+  // `--security=...` value
+  //
+  // One of `sandbox` or `insecure`. Empty when the flag is not set.
+  // `insecure` runs the step with elevated privileges and is commonly
+  // flagged by security policies.
+  security string
+  // Whether the instruction is written in shell form
+  //
+  // Shell form (`RUN echo hi`) wraps the command in the stage `SHELL`
+  // (default `/bin/sh -c`), allowing shell expansion, pipes, and
+  // variable substitution.
+  isShellForm bool
+  // Whether the instruction is written in exec form
+  //
+  // Exec form (`RUN ["echo", "hi"]`) executes the program directly without
+  // a shell, so pipes, redirects, and `${VAR}` expansion are not interpreted.
+  isExecForm bool
+  // Whether the instruction declares a `--mount=type=secret`
+  mountsSecret bool
+  // Whether the instruction declares a `--mount=type=ssh`
+  mountsSsh bool
+  // Individual commands parsed from the instruction
+  //
+  // The script split on the shell operators `&&`, `||`, `;`, and `|` (and
+  // newlines) into separate commands, each tokenized into its executable and
+  // arguments with leading `VAR=value` assignments removed. Exec-form
+  // instructions yield a single command from the argv. Use this to audit the
+  // program invoked and its options instead of substring-matching the raw
+  // `script`. Parsing is best-effort: it does not descend into subshells or
+  // command substitutions, and redirections (`>`, `>>`, `<`, `2>&1`) appear as
+  // ordinary tokens in the following command's `args`.
+  commands []docker.file.run.command
+}
+
+// Single command parsed from a Dockerfile RUN, CMD, or ENTRYPOINT
+//
+// One entry per command in the instruction's shell pipeline. Select the
+// program with `binary` and, for tools with subcommands, `subcommand` — for
+// example `binary == "apt-get"` and `subcommand == "install"` — then inspect
+// `flags` for required options such as `--no-install-recommends`.
+private docker.file.run.command @defaults("binary subcommand") {
+  // Executable invoked, e.g. "apt-get", "curl", or "npm"
+  binary string
+  // First non-flag argument, e.g. "install" or "add"
+  //
+  // Empty when the command takes no subcommand. Resolved independently of flag
+  // position, so `apt-get -y install` and `apt-get install -y` both report
+  // `install`.
+  subcommand string
+  // Dash-prefixed options, e.g. ["--no-install-recommends", "-y"]
+  //
+  // A flag that carries an `=`-joined value is kept as one token, so
+  // `--mount=type=bind` matches `flags.contains("--mount=type=bind")` or
+  // `flags.any(_.contains("--mount"))`, not `flags.contains("--mount")`.
+  flags []string
+  // All arguments after the executable, in the order they appear
+  args []string
+}
+
+// Dockerfile RUN --mount flag
+//
+// One entry per `--mount=...` flag on a `RUN` instruction.
+private docker.file.run.mount @defaults("type target") {
+  // Mount type
+  //
+  // One of `bind`, `cache`, `secret`, `ssh`, or `tmpfs`.
+  type string
+  // Mount destination inside the build container
+  target string
+  // Source path or context for `bind` and `cache` mounts
+  source string
+  // Stage or image to bind-mount from (`--from=<name>`)
+  from string
+  // Identifier
+  //
+  // For `cache` mounts this is the cache id; for `secret` and `ssh` mounts
+  // this is the secret/ssh id supplied via `id=...`.
+  id string
+  // Cache sharing mode
+  //
+  // For `cache` mounts: `shared`, `private`, or `locked`. Empty for other types.
+  sharing string
+  // Whether the mount is read-only
+  readOnly bool
+  // Whether the secret or ssh mount is required to exist at build time
+  required bool
+  // Tmpfs size limit in bytes
+  sizeLimit int
+  // File mode for secret / ssh mounts (octal)
+  mode int
+  // Owner UID for secret / ssh mounts
+  uid int
+  // Owner GID for secret / ssh mounts
+  gid int
+  // Environment variable that exposes the secret to the RUN command
+  env string
+}
+
+// Dockerfile ADD instructions
+private docker.file.add @defaults("src dst") {
+  src []string
+  dst string
+  chown string
+  chmod string
+  // Whether `--link` was set, enabling cache-friendly layered copies
+  link bool
+  // SHA256 digest the remote download must match (`--checksum=sha256:...`)
+  //
+  // Empty when the flag is not set. Frequently required by audit policies
+  // to prevent unverified remote tarballs from entering the image.
+  checksum string
+  // Patterns excluded from the copy (`--exclude=<pattern>`)
+  excludes []string
+}
+
+// Dockerfile COPY instructions
+private docker.file.copy @defaults("src dst") {
+  // Optional source to copy file(s) from when not using the default build context
+  src []string
+  // The destination in the image for the file(s)
+  dst string
+  // Ownership of the file(s)
+  chown string
+  // Octal permissions of the file(s)
+  chmod string
+  // Stage or image to copy from (`--from=<name>`)
+  //
+  // Set when `COPY --from=<stage>` references the output of an earlier
+  // multi-stage build or an external image such as `nginx:1.27`.
+  from string
+  // Whether `--link` was set, enabling cache-friendly layered copies
+  link bool
+  // Patterns excluded from the copy (`--exclude=<pattern>`)
+  excludes []string
+  // Whether `--parents` was set to preserve source directory structure
+  parents bool
+}
+
+// Dockerfile HEALTHCHECK instruction
+private docker.file.healthcheck @defaults("test") {
+  // The health check test command (e.g., ["CMD-SHELL", "curl -f http://localhost/ || exit 1"])
+  test []string
+  // Time between running the check in nanoseconds
+  interval int
+  // Time to wait before considering the check hung in nanoseconds
+  timeout int
+  // Start period for the container to initialize before counting retries in nanoseconds
+  startPeriod int
+  // Interval between checks during start period in nanoseconds
+  startInterval int
+  // Number of consecutive failures needed to report unhealthy
+  retries int
+  // Whether HEALTHCHECK is set to NONE (disables any inherited healthcheck)
+  none bool
+}
+
+// Dockerfile VOLUME instruction
+private docker.file.volume @defaults("path") {
+  // Volume mount path
+  path string
+}
+
+// Dockerfile SHELL instruction
+private docker.file.shell @defaults("command") {
+  // Shell executable and flags (e.g., ["/bin/bash", "-o", "pipefail", "-c"])
+  command []string
+}
+
+// Dockerfile WORKDIR instruction
+private docker.file.workdir @defaults("path") {
+  // Working directory path
+  path string
+}
+
+// Dockerfile STOPSIGNAL instruction
+private docker.file.stopsignal @defaults("signal") {
+  // Signal name or number sent to the container on stop (e.g., `SIGTERM`, `9`)
+  signal string
+}
+
+// Dockerfile ONBUILD instruction
+private docker.file.onbuild @defaults("expression") {
+  // The triggered instruction, exactly as written after `ONBUILD`
+  //
+  // For example `ONBUILD COPY . /app/src` yields `COPY . /app/src`.
+  expression string
+}
+
+// Single Docker image on the host
+//
+// Examine ID, tags, repo digests, size, and labels
+docker.image {
+  // Image ID
+  id string
+  // Image size in kilobytes
+  size int
+  // Repo digests
+  repoDigests []string
+  // Tag key value pairs
+  tags []string
+  // Labels key value pairs
+  labels map[string]string
+}
+
+// Single Docker container on the host
+//
+// Examine state, image, command, labels, and the container's embedded OS
+docker.container @defaults("names.first status"){
+  embed os.linux as os
+  // Container ID
+  id string
+  // Container command
+  command string
+  // Container image
+  image string
+  // Image ID
+  imageid string
+  // Container names
+  names []string
+  // Container state (e.g., created, running, paused, restarting, exited, dead)
+  state string
+  // Status message
+  status string
+  // Label key value pairs
+  labels map[string]string
+  // Container configuration that depends on the host running the container
+  hostConfig() dict
+}
+
+// containerd host
+//
+// Examine containers managed by the containerd runtime
+containerd {
+  // List all containerd containers
+  containers() []containerd.container
+  // Runtime delegate for the local containerd endpoint
+  delegate() container.runtimeDelegate
+  // Container images observed in containerd and referenced by containers
+  images() []container.runtimeImage
+}
+
+// Single containerd container
+//
+// Examine ID, image, status, namespace, and runtime
+containerd.container @defaults("id status") {
+  // Container ID
+  id string
+  // Container image reference
+  image string
+  // Container status (created, running, paused, stopped, unknown)
+  status string
+  // Container labels
+  labels map[string]string
+  // Container PID (0 if not running)
+  pid int
+  // containerd namespace
+  namespace string
+  // Container runtime (e.g., "io.containerd.runc.v2")
+  runtime string
+  // Container snapshotter
+  snapshotter string
+}
+
+// IPv4 packet filter (iptables)
+//
+// Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
+iptables {
+  // All tables (filter, nat, mangle, raw)
+  tables() []iptables.table
+  // IPv4 input chain entries (filter table)
+  input() []iptables.entry
+  // IPv4 output chain entries (filter table)
+  output() []iptables.entry
+  // IPv4 forward chain entries (filter table)
+  forward() []iptables.entry
+  // Default policy for the INPUT chain (e.g., ACCEPT, DROP)
+  inputPolicy() string
+  // Default policy for the FORWARD chain (e.g., ACCEPT, DROP)
+  forwardPolicy() string
+  // Default policy for the OUTPUT chain (e.g., ACCEPT, DROP)
+  outputPolicy() string
+}
+
+// IPv6 packet filter (ip6tables)
+//
+// Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
+ip6tables {
+  // All tables (filter, nat, mangle, raw)
+  tables() []iptables.table
+  // IPv6 input chain entries (filter table)
+  input() []iptables.entry
+  // IPv6 output chain entries (filter table)
+  output() []iptables.entry
+  // IPv6 forward chain entries (filter table)
+  forward() []iptables.entry
+  // Default policy for the INPUT chain (e.g., ACCEPT, DROP)
+  inputPolicy() string
+  // Default policy for the FORWARD chain (e.g., ACCEPT, DROP)
+  forwardPolicy() string
+  // Default policy for the OUTPUT chain (e.g., ACCEPT, DROP)
+  outputPolicy() string
+}
+
+// iptables table (filter, nat, mangle, raw)
+private iptables.table @defaults("name") {
+  // Table name (filter, nat, mangle, raw)
+  name string
+  // Chains in this table
+  chains []iptables.chain
+}
+
+// iptables chain within a table
+private iptables.chain @defaults("table name policy") {
+  // Table this chain belongs to (filter, nat, mangle, raw)
+  table string
+  // Chain name (INPUT, OUTPUT, FORWARD, PREROUTING, POSTROUTING, or user-defined)
+  name string
+  // Default policy (ACCEPT, DROP, REJECT) - empty for user-defined chains
+  policy string
+  // Rules in this chain
+  rules []iptables.entry
+}
+
+// Individual iptables rule entry
+//
+// Examine a single iptables rule: packet and byte counters, target action,
+// protocol, input/output interfaces, source and destination addresses,
+// IP options, and the chain/table identifier used as the resource ID.
+// Iterated from `iptables.input()`, `iptables.output()`, or
+// `iptables.forward()` to audit individual packet-filter rules.
+iptables.entry {
+  // Line number of statistic, which is used to create the ID
+  lineNumber int
+  // Packets from iptable
+  packets int
+  // How large the packet is in octets, including headers and everything.
+  bytes int
+  // What to do with the packet if it matches a rule
+  target string
+  // Protocol of the next level layer (e.g., TCP, UDP, ICMP, etc)
+  protocol string
+  // IP options
+  opt string
+  // Input network interface the rule matches on (empty for any)
+  in string
+  // Output network interface the rule matches on (empty for any)
+  out string
+  // Source address field that tells the receiver where the packet came from
+  source string
+  // The destination IP address of the traffic, subnet of the traffic, or anywhere
+  destination string
+  // Optional settings within the header such as internet timestamps, SACK, or record route options
+  options string
+  // Chain and table identifier used for the resource ID
+  chain string
+  // Destination port
+  //
+  // Single port from `--dport`. Null when the rule does not match by
+  // destination port, or when it matches a range or list — see
+  // `dportRange` for ranges and `dports` for multi-port matches.
+  dport int
+  // Destination port range, e.g. "1024:65535"
+  //
+  // Set when the rule uses `--dport low:high`. Empty otherwise.
+  dportRange string
+  // Destination port list from `-m multiport --dports`
+  //
+  // Empty when no `--dports` match is present. Single ports are integers;
+  // ranges (e.g. "1000:2000") remain as strings unchanged.
+  dports []string
+  // Source port
+  //
+  // Single port from `--sport`. Null when the rule does not match by
+  // source port, or when it matches a range or list.
+  sport int
+  // Source port range, e.g. "1024:65535"
+  sportRange string
+  // Source port list from `-m multiport --sports`
+  sports []string
+  // Conntrack state list from `-m state --state` or `-m conntrack --ctstate`
+  //
+  // Values such as NEW, ESTABLISHED, RELATED, INVALID, UNTRACKED. Empty
+  // when no state/ctstate match is present.
+  ctstate []string
+  // TCP flag match from `-m tcp --tcp-flags`
+  //
+  // Two-element list: [mask, comp] (e.g., ["FIN,SYN,RST,ACK", "SYN"] for
+  // `--tcp-flags FIN,SYN,RST,ACK SYN`). Empty when no `--tcp-flags` match
+  // is present.
+  tcpFlags []string
+  // Rule comment from `-m comment --comment`
+  //
+  // The unquoted comment text. Empty when no comment match is present.
+  comment string
+  // ipset name from `-m set --match-set`
+  //
+  // The set name used in a `--match-set` match. Empty when no `-m set`
+  // match is present.
+  matchSet string
+  // For `-j REJECT`, the `--reject-with` value (e.g., icmp-port-unreachable)
+  //
+  // Empty when target is not REJECT, or when REJECT is used without
+  // `--reject-with`.
+  rejectWith string
+  // Canonical iptables-save line for this rule
+  //
+  // The exact `-A CHAIN ...` line as emitted by `iptables-save -c`. Empty
+  // on systems where `iptables-save` is unavailable and the legacy `-L`
+  // parser is used as a fallback.
+  raw string
+}
+
+// nftables firewall
+//
+// Examine tables, chains, rules, and named sets across all address families
+nftables @defaults("tables") {
+  // nft version string (e.g., "1.0.2")
+  version() string
+  // All nftables tables
+  tables() []nftables.table
+  // All chains across all tables
+  chains() []nftables.chain
+  // All rules across all tables and chains
+  rules() []nftables.rule
+  // All named sets across all tables
+  sets() []nftables.set
+}
+
+// nftables table
+private nftables.table @defaults("family name") {
+  // Address family (ip, ip6, inet, arp, bridge, netdev)
+  family string
+  // Table name
+  name string
+  // Table handle number
+  handle int
+  // Table flags (e.g., dormant, owner, persist)
+  flags []string
+  // Chains in this table
+  chains []nftables.chain
+  // Rules in this table across all chains
+  rules []nftables.rule
+  // Named sets in this table
+  sets []nftables.set
+}
+
+// nftables chain
+private nftables.chain @defaults("family table name") {
+  // Address family
+  family string
+  // Name of the table this chain belongs to
+  table string
+  // Table this chain belongs to
+  tableRef() nftables.table
+  // Chain name
+  name string
+  // Chain handle number
+  handle int
+  // Chain type (filter, route, nat) - only for base chains
+  type string
+  // Hook point (input, output, forward, prerouting, postrouting, ingress, egress) - only for base chains
+  hook string
+  // Chain priority - only for base chains
+  prio int
+  // Default policy (accept, drop) - only for base chains
+  policy string
+  // Whether this is a base chain (has type, hook, and priority)
+  isBaseChain bool
+  // Rules in this chain
+  rules []nftables.rule
+}
+
+// nftables rule
+private nftables.rule @defaults("family table chain handle") {
+  // Address family
+  family string
+  // Name of the table this rule belongs to
+  table string
+  // Table this rule belongs to
+  tableRef() nftables.table
+  // Name of the chain this rule belongs to
+  chain string
+  // Chain this rule belongs to
+  chainRef() nftables.chain
+  // Rule handle number
+  handle int
+  // Rule expressions as structured data
+  expr []dict
+  // Rule comment
+  comment string
+}
+
+// nftables named set (or map)
+private nftables.set @defaults("family table name") {
+  // Address family
+  family string
+  // Name of the table this set belongs to
+  table string
+  // Table this set belongs to
+  tableRef() nftables.table
+  // Set name
+  name string
+  // Set handle number
+  handle int
+  // Element data type (e.g., "ipv4_addr", "inet_service", "ether_addr")
+  keyType string
+  // Value data type for maps (empty for plain sets)
+  valueType string
+  // Set flags (e.g., "constant", "interval", "timeout", "dynamic")
+  flags []string
+  // Set elements (values as strings)
+  elements []string
+  // Whether this is a map (has both key and value types)
+  isMap bool
+  // Set timeout in seconds (0 if not set)
+  timeout int
+}
+
+// UFW (Uncomplicated Firewall) state and rules
+//
+// Examine status, default policies, configured rules, and application profiles
+ufw @defaults("status rules") {
+  // Whether UFW is active ("active", "inactive", "not installed")
+  status() string
+  // Default policy for incoming traffic (e.g., "deny", "allow", "reject")
+  defaultIncoming() string
+  // Default policy for outgoing traffic (e.g., "allow", "deny", "reject")
+  defaultOutgoing() string
+  // Default policy for routed traffic (e.g., "deny", "allow", "reject")
+  defaultRouted() string
+  // Logging level (off, low, medium, high, full)
+  logging() string
+  // All UFW rules
+  rules() []ufw.rule
+  // Application profiles from /etc/ufw/applications.d/
+  applications() []ufw.application
+}
+
+// Individual UFW rule
+private ufw.rule @defaults("action direction port") {
+  // Rule number (sequential across IPv4 and IPv6 rules; may differ from `ufw status numbered`)
+  number int
+  // Action (ALLOW, DENY, REJECT, LIMIT)
+  action string
+  // Direction (IN, OUT, FWD)
+  direction string
+  // Protocol (tcp, udp, any)
+  protocol string
+  // Port or port range (e.g., "22", "6000:6007", "any")
+  port string
+  // Network interface (e.g., "eth0"), empty if not specified
+  interface string
+  // Source address or subnet (e.g., "192.168.1.0/24", "Anywhere")
+  from string
+  // Destination address or subnet
+  to string
+  // Whether this is an IPv6 rule
+  ipv6 bool
+  // Raw rule text as reported by ufw
+  raw string
+}
+
+// UFW application profile from /etc/ufw/applications.d/
+private ufw.application @defaults("name ports") {
+  // Profile name (e.g., "Nginx Full")
+  name string
+  // Short title describing the application
+  title string
+  // Description of the application
+  description string
+  // Port specification (e.g., "80/tcp", "80,443/tcp", "80,443/tcp|443/udp")
+  ports string
+}
+
+// firewalld dynamic firewall manager (RHEL/CentOS/Fedora)
+//
+// Examine state, default zone, and per-zone services, ports, and rich rules
+firewalld @defaults("status defaultZone") {
+  // Whether firewalld is running ("running", "not running", "not installed")
+  status() string
+  // Default zone name (e.g., "public", "home", "dmz")
+  defaultZone() string
+  // All configured zones
+  zones() []firewalld.zone
+}
+
+// firewalld zone configuration
+private firewalld.zone @defaults("name target") {
+  init(name? string)
+  // Zone name (e.g., "public", "internal", "dmz")
+  name string
+  // Default target (default, ACCEPT, REJECT, DROP)
+  target string
+  // Whether ICMP block inversion is enabled
+  icmpBlockInversion bool
+  // Whether this zone is currently active (has bound interfaces or sources)
+  active bool
+  // Network interfaces bound to this zone
+  interfaces []string
+  // Source addresses/subnets bound to this zone
+  sources []string
+  // Allowed service names (e.g., "ssh", "http", "https")
+  services []string
+  // Allowed ports (e.g., "80/tcp", "443/tcp", "8080-8090/udp")
+  ports []string
+  // Whether masquerading is enabled
+  masquerade bool
+  // Port forwarding rules (e.g., "port=80:proto=tcp:toport=8080")
+  forwardPorts []string
+  // Source ports
+  sourcePorts []string
+  // ICMP types that are blocked
+  icmpBlocks []string
+  // Rich rules (expressive firewall rules)
+  richRules []firewalld.richrule
+  // Allowed protocols (e.g., "icmp", "ipv6-icmp")
+  protocols []string
+}
+
+// firewalld rich rule
+private firewalld.richrule @defaults("family rule") {
+  // Address family ("ipv4" or "ipv6"), empty if not specified
+  family string
+  // Full rich rule string
+  rule string
+  // Source address/subnet, empty if not specified
+  source string
+  // True when the source address is negated (e.g., `source NOT address="..."`)
+  sourceInverted bool
+  // Destination address/subnet, empty if not specified
+  destination string
+  // True when the destination address is negated (e.g., `destination NOT address="..."`)
+  destinationInverted bool
+  // Action (accept, reject, drop, mark), empty if not specified
+  action string
+}
+
+// fstab persistent mount table
+//
+// Examine mount entries with device, mount point, fstype, and options
+fstab @defaults("path") {
+  init(path? string)
+  path string
+
+  // fstab entries defined in this fstab file
+  entries() []fstab.entry
+}
+
+// fstab entry for a device and its mount point
+private fstab.entry @defaults("device mountpoint") {
+  // Device referenced in the fstab, e.g., LABEL=rootfs
+  device string
+  // Mount point, e.g., '/'
+  mountpoint string
+  // File system type, e.g., ext4
+  fstype string
+  // Mount options, e.g., defaults (`man fstab` for details)
+  options string
+  // Dump frequency (0 for full backup or an integer above 0, incremental backup, copies all files new or modified since the last dump of a lower level)
+  dump int
+  // File system check order, e.g., 1
+  fsck int
+}
+
+// GRUB bootloader configuration
+//
+// Examine /etc/default/grub parameters, menu entries, and password protection
+grub.config @defaults("defaultsPath grubPath") {
+  init(defaultsPath? string, grubPath? string)
+  // Path to /etc/default/grub (key-value defaults)
+  defaultsPath string
+  // Path to grub.cfg (generated configuration)
+  grubPath string
+  // Configuration parameters from /etc/default/grub (e.g., GRUB_TIMEOUT, GRUB_CMDLINE_LINUX)
+  params() map[string]string
+  // Menu entries defined in grub.cfg
+  entries() []grub.config.entry
+  // Whether GRUB password protection is enabled (superusers + password_pbkdf2)
+  passwordProtected() bool
+}
+
+// GRUB menu entry
+private grub.config.entry @defaults("title") {
+  // Menu entry title
+  title string
+  // Kernel command line (linux/linux16/linuxefi line)
+  cmdline string
+  // Initrd path (initrd/initrd16/initrdefi line)
+  initrd string
+  // Whether this is a submenu
+  isSubmenu bool
+}
+
+// FreeBSD rc.conf system configuration
+//
+// Examine variable assignments across rc.conf and rc.conf.local
+sysrc @defaults("files") {
+  init(path? string)
+  // List of rc.conf files that make up the configuration
+  files() []file
+  // Raw contents of all rc.conf files
+  content(files) string
+  // Parsed key-value entries from all rc.conf files
+  entries(files) []sysrc.entry
+}
+
+// Single rc.conf variable entry
+private sysrc.entry @defaults("name value") {
+  // Variable name
+  name string
+  // Variable value
+  value string
+  // File where this entry is defined
+  file string
+}
+
+// Single process on the system
+//
+// Examine PID, executable, command line, state, and runtime flags
+process @defaults("executable pid state") {
+  init(pid int)
+  // PID (process ID)
+  pid int
+  // State of the process (i.e., sleeping, running, etc)
+  state() string
+  // Executable that is running this process
+  executable() string
+  // Full command used to run this process
+  command() string
+  // Map of additional flags
+  flags() map[string]string
+}
+
+// All processes running on the system
+//
+// Iterate every process for filtering by executable, user, or state
+processes {
+  []process
+}
+
+// Single TCP/UDP port on the system
+//
+// Examine address, state, attached process, and remote peer
+port @defaults("port protocol address process.executable") {
+  // Protocol of this port
+  protocol string
+  // Port number
+  port int
+  // Local address of this port
+  address string
+  // User configured for this port
+  user user
+  // Process that is connected to this port
+  process() process
+  // State of this open port
+  state string
+  // Remote address connected to this port
+  remoteAddress string
+  // Remote port connected to this port
+  remotePort int
+  // TLS on this port, if it is available
+  tls(address, port, protocol) network.tls
+}
+
+// All TCP/UDP ports on the system
+//
+// Iterate every port — including the listening() subset for exposure audits
+ports {
+  []port
+  // All listening ports
+  listening() []port
+}
+
+// Windows audit policies
+//
+// Deprecated in favor of windows.auditPolicy, which reports subcategory
+// names and categories in English regardless of the OS display language
+// and supports looking up a single subcategory by name or GUID.
+auditpol @maturity("deprecated") {
+  []auditpol.entry
+}
+
+// Windows audit policy entry
+//
+// Deprecated in favor of windows.auditPolicy.subcategory, which reports
+// subcategory names and categories in English regardless of the OS display
+// language. This entry carries the subcategory name, GUID, inclusion
+// setting, and exclusion setting as reported by the system, plus the
+// `success` and `failure` booleans derived from the inclusion setting.
+auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") @maturity("deprecated") {
+  // Machine name
+  machinename string
+  // Policy target
+  policytarget string
+  // Subcategory
+  subcategory string
+  // Subcategory GUID
+  subcategoryguid string
+  // Inclusive setting
+  inclusionsetting string
+  // Exclusive settings
+  exclusionsetting string
+  // Whether the inclusion setting audits success events
+  //
+  // True for "Success" and "Success and Failure".
+  success() bool
+  // Whether the inclusion setting audits failure events
+  //
+  // True for "Failure" and "Success and Failure".
+  failure() bool
+}
+
+// Windows local security policy
+//
+// Examine system access, event audit, registry values, and privilege rights
+secpol {
+  // System access
+  systemaccess() map[string]string
+  // Event audit
+  eventaudit() map[string]string
+  // Registry values
+  registryvalues() map[string]string
+  // Privilege rights
+  privilegerights() map[string][]string
+}
+
+// NTP daemon configuration
+//
+// Examine servers, restrict directives, fudge entries, and other settings
+ntp.conf {
+  init(path string)
+  // File of the NTP service configuration
+  file() file
+  // Raw contents of the NTP service configuration
+  content(file) string
+  // List of settings for the NTP service
+  settings(content) []string
+  // List of servers for the NTP service
+  servers(settings) []string
+  // List of access control restrictions for the NTP service
+  restrict(settings) []string
+  // Additional information for clock drivers
+  fudge(settings) []string
+}
+
+// Chrony NTP daemon configuration
+//
+// Examine the configuration of chrony, the default NTP implementation on
+// modern RHEL, Fedora, SUSE, and Debian/Ubuntu systems. The typed
+// accessors parse the configuration into structured form so audits can
+// assert on individual directives without regex over the raw text:
+// `servers`, `pools`, and `peers` enumerate the configured time sources;
+// `allow` and `deny` expose the NTP-server access control lists that
+// decide which clients this host serves time to (an empty `allow` means
+// the daemon does not answer client requests); `bindCmdAddresses` reports
+// where the control socket listens; and `keyFile`, `makeStep`, and
+// `rtcSync` cover the authentication key file, clock-stepping policy, and
+// real-time-clock synchronization. Select an alternate file with
+// `chrony.conf(path: "...")`; the default resolves to `/etc/chrony.conf`
+// (RHEL family) or `/etc/chrony/chrony.conf` (Debian family).
+chrony.conf {
+  init(path string)
+  // File backing the chrony configuration
+  file() file
+  // Raw contents of the chrony configuration
+  content(file) string
+  // Effective settings with comments and blank lines removed
+  settings(content) []string
+  // Time sources from `server` directives (host plus any options)
+  servers(settings) []string
+  // Time-source pools from `pool` directives (host plus any options)
+  pools(settings) []string
+  // Symmetric peers from `peer` directives
+  peers(settings) []string
+  // Hosts permitted to use this system as a time server (`allow` directives)
+  allow(settings) []string
+  // Hosts denied use of this system as a time server (`deny` directives)
+  deny(settings) []string
+  // Addresses the command/monitoring socket binds to (`bindcmdaddress`)
+  bindCmdAddresses(settings) []string
+  // Path to the NTP authentication key file (`keyfile`), empty when unset
+  keyFile(settings) string
+  // Clock-stepping policy from the `makestep` directive, empty when unset
+  makeStep(settings) string
+  // Whether the real-time clock is kept in sync (`rtcsync` directive present)
+  rtcSync(settings) bool
+}
+
+// Postfix mail transfer agent configuration
+//
+// Examine the effective Postfix configuration. `params` reports parameter
+// values from `postconf` when the binary is available — which includes the
+// built-in defaults for parameters not written to the file — and otherwise
+// falls back to parsing main.cf directly (file values only, with `$name`
+// interpolation and continuation lines). `inetInterfaces` is the parsed
+// `inet_interfaces` list and `services` are the daemon definitions from
+// master.cf. By default the per-distribution config locations are used;
+// select an alternate main.cf with `postfix("/path/to/main.cf")`.
+postfix {
+  init(path? string)
+  // Path to the Postfix main.cf configuration file
+  mainCfPath() string
+  // Path to the Postfix master.cf configuration file
+  masterCfPath() string
+  // Effective Postfix parameters
+  //
+  // Reported by `postconf` when available (so parameters left at their
+  // built-in default still appear); otherwise parsed from main.cf, in which
+  // case only values written to the file are present.
+  params() map[string]string
+  // Interfaces Postfix listens on, parsed from the inet_interfaces parameter
+  inetInterfaces() []string
+  // Service definitions from master.cf
+  services() []postfix.service
+}
+
+// Postfix master.cf service definition
+//
+// Examine a single daemon entry from the Postfix master.cf file: its service
+// name and transport type, the chroot and privilege flags, the wake-up and
+// process limits, and the command it runs. The flag columns carry `y`, `n`,
+// or `-` (use the built-in default). Iterated from `postfix.services`.
+private postfix.service @defaults("service type command") {
+  // Service name (first column; a port number, socket name, or path)
+  service string
+  // Transport type (inet, unix, unix-dgram, fifo, or pass)
+  type string
+  // Whether access is restricted to the mail system (private column: y, n, or -)
+  private string
+  // Whether the service runs unprivileged (unpriv column: y, n, or -)
+  unprivileged string
+  // Whether the service runs chrooted (chroot column: y, n, or -)
+  chroot string
+  // Wake-up interval, or - for none (wakeup column)
+  wakeup string
+  // Maximum number of processes, or - for the default (maxproc column)
+  maxProcesses string
+  // Command, with arguments, that the service runs
+  command string
+}
+
+// Exim mail transfer agent configuration
+//
+// Examine the Exim configuration. `params` holds the macros and main-section
+// options parsed from the active config file — both the Debian
+// `update-exim4.conf.conf` key/value form and the monolithic `exim.conf`
+// main section (options before the first `begin` block). `localInterfaces`
+// normalizes the local interface list, handling the Debian
+// `dc_local_interfaces` `' ; '`-separated form and the Exim `local_interfaces`
+// list, so policies can compare it directly. By default the per-distribution
+// config location is used; select an alternate file with
+// `exim("/path/to/exim.conf")`.
+exim {
+  init(path? string)
+  // Path to the active Exim configuration file
+  configPath() string
+  // Parsed macros and main-section options
+  params() map[string]string
+  // Local interfaces parsed and normalized into a list
+  localInterfaces() []string
+}
+
+// rsyslog daemon configuration
+//
+// Examine effective settings across the main file and included fragments.
+// The typed accessors `modules()`, `inputs()`, `actions()`, and `rules()`
+// parse the configuration into structured form so audits can assert on
+// individual statements without regex over raw text. Each typed entry
+// carries `sourceFile` and `sourceLine` so findings can point back at the
+// fragment that introduced the directive.
+rsyslog.conf {
+  init(path string)
+  // Path for the main rsyslog file and search
+  path() string
+  // Files that make up this rsyslog service configuration
+  files(path) []file
+  // Raw contents of this rsyslog service configuration
+  content(files) string
+  // List of settings for this rsyslog service
+  settings(content) []string
+  // Legacy `$Directive value` settings parsed into key/value pairs
+  //
+  // The leading `$` is stripped from each key and the value is trimmed of
+  // surrounding whitespace, so `params["FileCreateMode"] == "0640"` works
+  // regardless of the spacing used in the file. When the same directive
+  // appears more than once the last occurrence wins. The raw `settings`
+  // list is retained unchanged.
+  params(content) map[string]string
+  // Loaded modules (modern module() and legacy $ModLoad)
+  modules(files) []rsyslog.module
+  // Configured inputs (modern input() and legacy $Input* directives)
+  inputs(files) []rsyslog.input
+  // Configured output actions (modern action() and legacy selector-with-target rules)
+  actions(files) []rsyslog.action
+  // Legacy selector-based routing rules (facility.severity → target)
+  rules(files) []rsyslog.rule
+}
+
+// rsyslog loaded module
+//
+// Examine a single module load: modern `module(load="imtcp" KeepAlive="on")`
+// or legacy `$ModLoad imtcp`. Modern declarations carry their full parameter
+// dict; legacy declarations carry only the module name (parameters is empty).
+// The module name follows rsyslog conventions: `im*` for inputs, `om*` for
+// outputs, `mm*` for message modifications, `pm*` for parsers.
+private rsyslog.module @defaults("name sourceFile") {
+  // Module name (e.g. imtcp, imuxsock, omfwd, mmnormalize)
+  name string
+  // Module-load parameters as a dict (empty for legacy $ModLoad)
+  //
+  // Modern `module(load="X" key1="v1" key2="v2")` declarations carry every
+  // key/value pair other than `load` here. Boolean-like values are kept as
+  // strings to preserve the source representation (`"on"` vs `true`).
+  parameters dict
+  // Absolute path of the file this directive was read from
+  sourceFile string
+  // 1-indexed line number within sourceFile
+  sourceLine int
+}
+
+// rsyslog input source
+//
+// Examine a configured input — the module instance that pulls log lines
+// into rsyslog. Surfaces both legacy single-directive forms (e.g.
+// `$InputTCPServerRun 514`) and modern RainerScript blocks
+// (`input(type="imtcp" port="514" ruleset="…")`).
+private rsyslog.input @defaults("type port sourceFile") {
+  // Input module type (e.g. imtcp, imudp, imuxsock, imfile)
+  type string
+  // Listen port for network inputs, 0 when not applicable
+  port int
+  // Listen address for network inputs, empty when not applicable
+  address string
+  // Ruleset this input feeds into, empty for the default ruleset
+  ruleset string
+  // TLS stream-driver mode reported by the input
+  //
+  // `"1"` indicates the input accepts TLS connections (paired with a
+  // `$DefaultNetstreamDriver gtls` global or per-input `StreamDriverMode="1"`).
+  // `"0"` or empty indicates plaintext.
+  streamDriverMode string
+  // All parameters as a dict, in source representation
+  parameters dict
+  // Absolute path of the file this directive was read from
+  sourceFile string
+  // 1-indexed line number within sourceFile
+  sourceLine int
+}
+
+// rsyslog output action
+//
+// Examine where rsyslog ships matched log lines. Surfaces both modern
+// `action(type="omfwd" target="…" …)` statements and the legacy
+// selector-with-target form (e.g. `*.* @@host:514`). When this action came
+// from a legacy selector, the `parameters` dict is empty and `target` /
+// `protocol` / `tlsEnabled` are derived from the target token's syntax.
+private rsyslog.action @defaults("type target sourceFile") {
+  // Action module type (e.g. omfwd, omfile, omusrmsg, omhttp, omkafka)
+  type string
+  // Destination of the action
+  //
+  // For omfile a filesystem path; for omfwd a `host` or `host:port`; for
+  // omusrmsg a comma-separated user list (or `*` for wall); for omhttp /
+  // omkafka the relevant URL or broker list.
+  target string
+  // Transport protocol for network actions: `"tcp"`, `"udp"`, or empty
+  protocol string
+  // Whether TLS is configured for this action
+  //
+  // True when the modern form sets `StreamDriverMode="1"` (or equivalent
+  // per-driver settings). False for legacy selector forms — those rely on
+  // the `$DefaultNetstreamDriver` / `$ActionSendStreamDriverMode` globals.
+  tlsEnabled bool
+  // Template name applied to messages, empty when the default is used
+  template string
+  // Action-level queue configuration, empty when no queue is configured
+  //
+  // Carries the modern `queue.*` parameters as `{type, filename, size,
+  // saveOnShutdown, ...}` — the exact key set depends on the queue type.
+  queue dict
+  // All parameters as a dict
+  //
+  // Modern actions carry every key/value pair other than `type` and
+  // `target` here. Legacy selector-derived actions carry an empty dict.
+  parameters dict
+  // Absolute path of the file this directive was read from
+  sourceFile string
+  // 1-indexed line number within sourceFile
+  sourceLine int
+}
+
+// rsyslog selector rule
+//
+// Examine a legacy `<facility>.<severity> <target>` routing rule — the form
+// that ships in every default rsyslog config. Modern `if … then … {
+// action(…) }` conditionals are not surfaced here; their actions are
+// available via `rsyslog.conf.actions()` only.
+//
+// Selector grammar covered:
+//   - Simple: `auth.info /var/log/auth.log`
+//   - Facility list: `auth,authpriv.* /var/log/auth.log`
+//   - Multi-selector: `*.info;mail.none;authpriv.none /var/log/messages`
+//     (each selector becomes its own rule)
+//   - Negation: `auth,authpriv.none` → `negate = true`
+//   - Wildcards: `*.*` and `auth.*`
+private rsyslog.rule @defaults("facilities severities target sourceFile") {
+  // Facilities matched (e.g. `["auth", "authpriv"]`, or `["*"]`)
+  facilities []string
+  // Severities matched
+  //
+  // For example `["info"]`, `["*"]`, or `["none"]` (negation form).
+  severities []string
+  // Raw target token from the rule
+  //
+  // File path, `@host`, `@@host:port`, `:omusrmsg:user`, `~` (discard),
+  // `|fifo`, etc.
+  target string
+  // Whether the severity is the negation marker (`.none`)
+  negate bool
+  // Resolved typed action for this rule
+  //
+  // Constructed from `target`: file-path → omfile, `@host` → omfwd/udp,
+  // `@@host` → omfwd/tcp, `:omusrmsg:*` → omusrmsg, `~` → discard,
+  // `|name` → ompipe. Legacy rules have no TLS information — the action's
+  // `tlsEnabled` is always false.
+  action() rsyslog.action
+  // Absolute path of the file this directive was read from
+  sourceFile string
+  // 1-indexed line number within sourceFile
+  sourceLine int
+}
+
+// Shadow password suite (login.defs) configuration
+//
+// Examine password aging, UID/GID ranges, and login policy parameters
+logindefs {
+  init(path string)
+  // Current configuration file for resource
+  file() file
+  // Content of the configuration file
+  content(file) string
+  // Parsed logindef parameter
+  params(content) map[string]string
+}
+
+// PAM resource limits configuration (limits.conf)
+//
+// Examine soft/hard caps on processes, files, memory, and other resources
+limits {
+  // List of files that make up the limits configuration
+  files() []file
+  // Parsed limits entries
+  entries(files) []limits.entry
+}
+
+// Resource limit entry
+private limits.entry @defaults("domain item") {
+  // File where this entry is defined
+  file file
+  // Line number in the file
+  lineNumber int
+  // Domain (username, @groupname, *, %)
+  domain string
+  // Limit type (soft, hard, -)
+  type string
+  // Resource item (core, nofile, nproc, etc.)
+  item string
+  // Limit value
+  value string
+}
+
+// Sudo binary and runtime metadata
+//
+// Examine the installed `sudo` binary: where it lives on disk, the
+// version it reports under `sudo -V`, which plugins are loaded
+// (policy, I/O, audit, approval), whether the build supports
+// Python-based plugins, and the result of `visudo -c` against the
+// sudoers configuration. For sudoers configuration parsing, use the
+// `sudoers` resource directly, or access it via this resource's
+// `sudoers` field.
+sudo @defaults("version path") {
+  init(path? string)
+  // Path to the sudo binary
+  //
+  // Filesystem-resolved location of the `sudo` binary on the asset
+  // (e.g., `/usr/bin/sudo`). Empty when sudo is not installed; check
+  // `installed` rather than testing this field for emptiness.
+  path() string
+  // Whether sudo is installed and executable
+  installed() bool
+  // Version string reported by `sudo -V` (e.g., "1.9.5p3")
+  version() string
+  // All sudo plugins reported by `sudo -V`
+  plugins() []sudo.plugin
+  // Policy plugin (typically sudoers_policy). Null when none is loaded.
+  policyPlugin(plugins) sudo.plugin
+  // I/O plugins (e.g., sudoers_io for log_input / log_output)
+  ioPlugins(plugins) []sudo.plugin
+  // Audit plugins (sudo 1.9.3+)
+  auditPlugins(plugins) []sudo.plugin
+  // Approval plugins (sudo 1.9.1+)
+  approvalPlugins(plugins) []sudo.plugin
+  // Whether the build supports Python-based plugins
+  pythonSupport() bool
+  // Result of `visudo -c`. Null when sudoers files cannot be read (e.g., running unprivileged against a mode-0440 /etc/sudoers).
+  validate() sudo.validation
+  // Associated sudoers configuration
+  sudoers() sudoers
+}
+
+// A sudo plugin reported by `sudo -V`
+private sudo.plugin @defaults("name type version") {
+  // Plugin name (e.g., "sudoers_policy", "sudoers_io")
+  name string
+  // Plugin version
+  version string
+  // Full path to the plugin .so file when reported
+  path string
+  // Plugin type: "policy", "io", "audit", or "approval"
+  type string
+}
+
+// Result of validating sudoers configuration with `visudo -c`
+private sudo.validation @defaults("valid") {
+  // True if `visudo -c` exits 0 with no errors
+  valid bool
+  // Parse errors. Empty when valid is true.
+  errors []sudo.validation.error
+}
+
+// A single sudoers parse error reported by `visudo -c`
+private sudo.validation.error @defaults("file line") {
+  // File where the error was found
+  file string
+  // Line number of the error
+  line int
+  // Error message text
+  message string
+}
+
+// sudo authorization configuration
+//
+// Examine user specifications, defaults, and aliases across sudoers files
+sudoers @defaults("files") {
+  init(path? string)
+  // List of files that make up the sudoers configuration
+  files() []file
+  // Raw contents of all sudoers files
+  content(files) string
+  // User permission specifications
+  userSpecs(files) []sudoers.userSpec
+  // Default settings
+  defaults(files) []sudoers.default
+  // Alias definitions (User_Alias, Host_Alias, Cmnd_Alias, Runas_Alias)
+  aliases(files) []sudoers.alias
+}
+
+// Sudoers user specification (permission entry)
+private sudoers.userSpec @defaults("users hosts commands") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Users or user aliases this rule applies to
+  users []string
+  // Hosts or host aliases this rule applies to
+  hosts []string
+  // RunAs users (users the command can be run as)
+  runasUsers []string
+  // RunAs groups (groups the command can be run as)
+  runasGroups []string
+  // Commands or command aliases
+  commands []string
+  // Tags applied to the command (NOPASSWD, SETENV, etc.)
+  tags []string
+}
+
+// Sudoers default setting
+private sudoers.default @defaults("parameter") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Raw Defaults line
+  raw string
+  // Scope: global, user, host, command, or runas
+  scope string
+  // Target (user/host/command/runas this applies to, if not global)
+  target string
+  // Parameter name (e.g., "env_reset", "secure_path")
+  parameter string
+  // Value (if parameter takes a value)
+  value string
+  // Operation: "=", "+=", or "-="
+  operation string
+  // Whether parameter is negated (starts with !)
+  negated bool
+}
+
+// Sudoers alias definition
+private sudoers.alias @defaults("type name") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Type: user, host, cmnd, or runas
+  type string
+  // Alias name (e.g., "ADMINS", "WEBSERVERS")
+  name string
+  // Values assigned to this alias
+  members []string
+}
+
+// Unix block devices (lsblk)
+//
+// Examine device names, filesystem types, labels, UUIDs, and mount points
+lsblk {
+  []lsblk.entry
+}
+
+// Unix block device
+//
+// Examine a single block device reported by `lsblk`: its device `name`,
+// filesystem type (`fstype`), `label`, UUID, and `mountpoints` list. Iterated
+// from `lsblk` to audit disk layout, filesystem labels, and mount
+// configurations.
+lsblk.entry {
+  // Device name
+  name string
+  // File system type
+  fstype string
+  // Label for the file system
+  label string
+  // UUID for the file system
+  uuid string
+  // Mount points for the device
+  mountpoints  []string
+}
+
+// LUKS-encrypted volumes on the host
+//
+// Use this resource to enumerate block devices that carry a LUKS header,
+// inspect each volume's on-disk format version, cipher, and key-derivation
+// parameters, and audit every keyslot. Both LUKS1 and LUKS2 headers are
+// reported through the same schema; the `version` field on each volume
+// distinguishes them and version-specific fields (label, subsystem, and
+// tokens for LUKS2; AF-splitter stripes for LUKS1) are populated only
+// where they apply.
+luks {
+  // LUKS-formatted block devices on the host
+  volumes() []luks.volume
+}
+
+// LUKS-encrypted block device
+//
+// Examine a single LUKS-formatted block device — its header version,
+// label, master-key size and offset, cipher, and keyslots. Select a
+// volume by its `uuid` (e.g.,
+// `luks.volumes.where(uuid == "fd44f17a-...")`) or by the underlying
+// block device's `name`.
+luks.volume @defaults("name uuid version") {
+  // Path of the underlying block device (e.g., /dev/sda3)
+  name string
+  // LUKS header UUID
+  uuid string
+  // LUKS header version (1 or 2)
+  version int
+  // Label assigned in the LUKS2 header (empty on LUKS1)
+  label string
+  // Subsystem string from the LUKS2 header (empty on LUKS1)
+  subsystem string
+  // Master-key size in bits
+  masterKeyBits int
+  // Payload offset in 512-byte sectors
+  payloadOffset int
+  // Underlying lsblk block device
+  blockDevice() lsblk.entry
+  // Cipher protecting the master key
+  cipher() luks.volume.cipher
+  // Keyslots defined in the header
+  keyslots() []luks.keyslot
+  // LUKS2 tokens attached to the header (empty on LUKS1)
+  //
+  // Each entry carries the token id, type (e.g., luks2-keyring,
+  // systemd-tpm2, systemd-fido2, systemd-pkcs11), the keyslot indices
+  // the token unlocks, and any token-type-specific metadata.
+  tokens []dict
+}
+
+// LUKS cipher specification
+//
+// Examine the symmetric cipher protecting a LUKS volume's master key.
+// `name` is the cipher family, `mode` is the chaining mode, and `spec`
+// is the combined cryptsetup string (e.g., `aes-xts-plain64`). On
+// LUKS1, `hash` carries the AF-splitter hash; on LUKS2 it is the
+// integrity hash when sector integrity is configured.
+private luks.volume.cipher @defaults("spec keySize") {
+  // Cipher family (e.g., aes, serpent, twofish)
+  name string
+  // Cipher mode (e.g., xts-plain64, cbc-essiv:sha256)
+  mode string
+  // Combined cipher spec as cryptsetup reports it
+  spec string
+  // Master-key size in bits
+  keySize int
+  // Hash used by the AF splitter (LUKS1) or sector integrity (LUKS2)
+  hash string
+}
+
+// LUKS keyslot
+//
+// Examine one keyslot in a LUKS header — its index, state, and the
+// key-derivation parameters used to wrap the master key. Audit for
+// weak KDFs, low iteration or memory costs, and unexpectedly large
+// numbers of active slots.
+luks.keyslot @defaults("index state kdf") {
+  // Slot index (0–7 on LUKS1, 0–31 on LUKS2)
+  index int
+  // Slot state
+  //
+  // ENABLED or DISABLED on LUKS1; active or inactive on LUKS2.
+  state string
+  // KDF used for this slot
+  //
+  // One of pbkdf2, argon2i, or argon2id.
+  kdf string
+  // PBKDF2 iteration count (pbkdf2 only)
+  iterations int
+  // argon2 time cost (argon2* only)
+  time int
+  // argon2 memory cost in KiB (argon2* only)
+  memory int
+  // argon2 parallelism (argon2* only)
+  parallel int
+  // Hash used by the KDF (pbkdf2 only; e.g., sha256, sha512)
+  hash string
+  // AF-splitter stripe count (LUKS1 only)
+  stripes int
+  // Key-material offset in 512-byte sectors
+  keyMaterialOffset int
+}
+
+// AppArmor mandatory access control
+//
+// Examine status, loaded profiles, and processes under confinement
+apparmor @defaults("profiles") {
+  // AppArmor status output version
+  version() string
+  // Loaded AppArmor profiles
+  profiles() []apparmor.profile
+  // Processes with AppArmor confinement
+  processes() []apparmor.process
+}
+
+// AppArmor profile
+private apparmor.profile @defaults("name mode") {
+  // Profile name
+  name string
+  // Profile mode: enforce, complain, or unconfined
+  mode string
+}
+
+// AppArmor confined process
+private apparmor.process @defaults("pid profile status") {
+  // Process executable path
+  executable string
+  // Profile applied to this process
+  profile string
+  // Process ID
+  pid int
+  // Confinement status (e.g., enforce)
+  status string
+}
+
+// SELinux mandatory access control
+//
+// Examine enforcement mode, policy type, booleans, and loaded modules
+selinux @defaults("mode") {
+  // Whether SELinux is installed on the system
+  installed() bool
+  // Current enforcement mode: enforcing, permissive, or disabled
+  mode() string
+  // Configured mode from /etc/selinux/config (persists across reboot)
+  configMode() string
+  // Active policy type (e.g., targeted, mls, minimum)
+  policyType() string
+  // Loaded SELinux booleans
+  booleans() []selinux.boolean
+  // Installed SELinux policy modules
+  modules() []selinux.module
+}
+
+// SELinux boolean setting
+private selinux.boolean @defaults("name value") {
+  // Boolean name (e.g., httpd_can_network_connect)
+  name string
+  // Current runtime value
+  value bool
+}
+
+// SELinux policy module
+private selinux.module @defaults("name status") {
+  // Module name
+  name string
+  // Module status (e.g., enabled, disabled)
+  status string
+  // Module priority
+  priority int
+}
+
+// Kernel module configuration (modprobe.d)
+//
+// Examine install, remove, blacklist, options, alias, and softdep directives
+modprobe @defaults("blacklists installs") {
+  init(path? string)
+  // List of files that make up the modprobe configuration
+  files() []file
+  // Install directives (custom commands for loading modules)
+  installs(files) []modprobe.install
+  // Remove directives (custom commands for unloading modules)
+  removes(files) []modprobe.remove
+  // Blacklisted modules
+  blacklists(files) []modprobe.blacklist
+  // Module options and parameters
+  options(files) []modprobe.option
+  // Module aliases
+  aliases(files) []modprobe.alias
+  // Soft dependencies
+  softdeps(files) []modprobe.softdep
+}
+
+// Install directive for module loading
+private modprobe.install @defaults("module command") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Module name
+  module string
+  // Command to execute instead of default insmod
+  command string
+}
+
+// Remove directive for module unloading
+private modprobe.remove @defaults("module command") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Module name
+  module string
+  // Command to execute instead of default rmmod
+  command string
+}
+
+// Blacklist directive
+private modprobe.blacklist @defaults("module") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Module name that is blacklisted
+  module string
+}
+
+// Module options and parameters
+private modprobe.option @defaults("module") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Module name
+  module string
+  // Raw parameters string
+  parameters string
+  // Parsed parameters as key-value pairs
+  params() map[string]string
+}
+
+// Module alias
+private modprobe.alias @defaults("alias module") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Alias name (pattern or wildcard)
+  alias string
+  // Target module name
+  module string
+}
+
+// Soft dependency
+private modprobe.softdep @defaults("module") {
+  // File where this entry is defined
+  file string
+  // Line number in the file
+  lineNumber int
+  // Module name
+  module string
+  // Modules to load before (pre: dependencies)
+  pre []string
+  // Modules to load after (post: dependencies)
+  post []string
+}
+
+// Unix mount table
+//
+// Iterate every mount point with device, fstype, options, and capacity
+mount {
+  []mount.point
+}
+
+// NFS service local state
+//
+// Examine the local NFS service from two angles: shares declared on
+// this host (`exports`) and NFS volumes the host has mounted
+// (`mounts`). `exports` is parsed from `/etc/exports` using the
+// platform-specific syntax for Linux, FreeBSD, macOS, and AIX; each
+// row is one `(path, client)` pair so audits like
+// `nfs.exports.where(noRootSquash)` work directly. `mounts` filters
+// the system mount table for NFS file systems and parses
+// NFS-specific options into typed fields (protocol `version`,
+// `security` flavor, `hardMount`, `readOnly`).
+nfs {
+  // NFS exports declared on this host
+  exports() []nfs.export
+  // NFS mounts currently active on this host
+  mounts() []nfs.mount
+}
+
+// NFS export entry for a single path and client
+//
+// Examine one row of the local NFS export table: the directory being
+// shared (`path`), the client specification it is shared with
+// (`client` — a hostname, IP address, CIDR, wildcard, netgroup, or
+// `*` meaning any client) and the effective export `options` as
+// parsed from `/etc/exports`. `readOnly` is true when the share is
+// exported read-only. `noRootSquash` is true when the share grants
+// remote uid 0 on the share — a classic NFS audit finding. Iterate
+// from `nfs.exports`.
+private nfs.export @defaults("path client readOnly noRootSquash") {
+  // Exported directory path on the local host
+  path string
+  // Client specification (hostname, IP, CIDR, wildcard, netgroup, or `*`)
+  client string
+  // Export options as parsed from /etc/exports
+  options []string
+  // Whether the share is exported read-only
+  readOnly bool
+  // Whether the share grants remote uid 0 (`no_root_squash`, `maproot=root`, or `root=`)
+  noRootSquash bool
+}
+
+// NFS client mount
+//
+// Examine a single NFS mount currently active on this host. `device`
+// is the NFS source as the kernel sees it (`server:/remote/path`),
+// split into `server` and `remotePath` for convenience.
+// `mountpoint` is where the share is attached locally. `version` is
+// the negotiated NFS protocol version (for example `3`, `4`, `4.1`,
+// `4.2`); empty when the kernel did not report one. `security` is
+// the authentication flavor — one of `sys`, `krb5`, `krb5i`,
+// `krb5p`, or `none`; empty when unspecified. `hardMount` is true
+// when the mount uses hard semantics (the `soft` option is not
+// set). `readOnly` is true when the mount is `ro`. `options` is the
+// full mount option list as reported by the system. Iterate from
+// `nfs.mounts`.
+private nfs.mount @defaults("server remotePath mountpoint version") {
+  // NFS source as the kernel sees it (server:/remote/path)
+  device string
+  // Local mount point path
+  mountpoint string
+  // NFS server hostname or IP
+  server string
+  // Remote path exported by the server
+  remotePath string
+  // NFS protocol version (for example `3`, `4`, `4.1`, `4.2`); empty when unknown
+  version string
+  // Security flavor: one of `sys`, `krb5`, `krb5i`, `krb5p`, or `none`; empty when unspecified
+  security string
+  // Whether the mount uses hard semantics (the `soft` option is not set)
+  hardMount bool
+  // Whether the mount is read-only
+  readOnly bool
+  // Full mount option list as reported by the system
+  options []string
+}
+
+// Unix mount point
+//
+// Examine a single mounted filesystem: the backing `device`, the `path`
+// where it is attached, the `fstype`, mount `options`, whether it is
+// currently `mounted`, and the total, used, and available bytes. Initialize
+// by path (e.g., `mount.point(path: "/var")`) or iterate from `mount`.
+mount.point @defaults("device path fstype") {
+  init(path string)
+  // Block device or filesystem source backing the mount (e.g., /dev/sda1)
+  device string
+  // Mount point path where the filesystem is attached (e.g., /var)
+  path string
+  // File system type
+  fstype string
+  // Mount options
+  options map[string]string
+  // Whether the mount point is mounted
+  mounted bool
+  // Total size in bytes
+  size() int
+  // Used space in bytes
+  used() int
+  // Available space in bytes
+  available() int
+}
+
+// Shadow password file (/etc/shadow)
+//
+// Examine per-user password aging, expiration, and lock state
+shadow {
+  []shadow.entry
+}
+
+// Shadowed password file entry
+//
+// Examine a single line from `/etc/shadow`: the username, hashed password
+// field, date of last change, minimum and maximum password age in days,
+// warning period, inactivity period, and account expiry date. Used to
+// audit password aging policy compliance and detect accounts with no
+// expiry or with locked passwords.
+shadow.entry {
+  // Username from the /etc/shadow entry
+  user string
+  // Password
+  password string
+  // Date of last password change
+  lastchanged time
+  // Minimum password age in days
+  mindays int
+  // Maximum password age in days
+  maxdays int
+  // Password warning period in days
+  warndays int
+  // Password inactivity period in days
+  inactivedays int
+  // Account expiration date
+  expirydates string
+  // Reserved field
+  reserved string
+}
+
+// Yum/DNF package manager
+//
+// Examine yum variables and configured repositories
+yum {
+  // Variables defined in Yum configuration files (/etc/yum.conf and all .repo files in the /etc/yum.repos.d/)
+  vars() map[string]string
+  // List of all configured Yum repositories
+  repos() []yum.repo
+}
+
+// Yum repository resource
+//
+// Examine a single configured Yum/DNF repository: its `id`, human-readable
+// `name`, `status`, `baseurl` list, expiry indicator, configuration `file`,
+// revision, package count, size, mirrors, and whether it is currently
+// `enabled`. Initialize by ID (e.g., `yum.repo(id: "baseos")`) or iterate
+// from `yum.repos()`.
+yum.repo {
+  init(id string)
+  // Repository ID
+  id string
+  // Human-readable repository name
+  name string
+  // Repository status
+  status string
+  // URL where the repodata directory of a repository is located
+  baseurl []string
+  // Indicator when the repository will expire
+  expire string
+  // Repository configuration file path
+  file file
+  // Repository revision
+  revision string
+  // Packages in repository
+  pkgs string
+  // File size of this repository
+  size string
+  // Mirrors for this repository
+  mirrors string
+  // Whether the repository is used as package source
+  enabled() bool
+}
+
+// Yum/DNF global configuration
+//
+// Examine the system-wide package manager configuration — the `[main]`
+// section of `/etc/yum.conf`, or `/etc/dnf/dnf.conf` on dnf-based
+// systems. Use `gpgcheck` and `localPkgGpgcheck` to assert that package
+// signature verification is enforced for every repository and for
+// locally installed packages, a core CIS supply-chain control;
+// `repoGpgcheck` extends that to repository metadata. The bool accessors
+// reflect the explicit directive and are `false` when the directive is
+// absent. `params` exposes every `[main]` directive as a raw string map
+// for settings without a typed accessor. Select an alternate file with
+// `yum.config(path: "...")`.
+yum.config {
+  init(path string)
+  // File backing the [main] configuration section
+  file() file
+  // Raw contents of the configuration file
+  content(file) string
+  // Every [main] section directive as key/value strings
+  params(content) map[string]string
+  // Whether package signature checking is enforced globally (gpgcheck)
+  gpgcheck(params) bool
+  // Whether signature checking is enforced for local packages (localpkg_gpgcheck)
+  localPkgGpgcheck(params) bool
+  // Whether repository metadata signature checking is enforced (repo_gpgcheck)
+  repoGpgcheck(params) bool
+  // Whether dependencies are removed along with packages (clean_requirements_on_remove)
+  cleanRequirementsOnRemove(params) bool
+}
+
+// Advanced Package Tool (APT) configuration
+//
+// Use this as the entry point to the Debian/Ubuntu package management
+// configuration. `repos` enumerates every configured APT repository
+// across `/etc/apt/sources.list` and the `/etc/apt/sources.list.d/`
+// directory, parsing both the classic one-line format and the deb822
+// `.sources` format. Audit repository trust from there — each `apt.repo`
+// reports whether it is marked `trusted` (signature checks bypassed) and
+// the `signedBy` keyring that pins which key may sign it.
+apt {
+  // All configured APT repositories
+  repos() []apt.repo
+}
+
+// APT software repository
+//
+// Examine a single configured APT repository parsed from a sources list:
+// its package `type` (`deb` for binary or `deb-src` for source), the
+// `url` it fetches from, the `distribution` (suite) and `components` it
+// pulls, and the `file` that declares it. The security-relevant fields
+// are `trusted` — true when the entry carries `[trusted=yes]`, which
+// disables signature verification — and `signedBy`, the keyring path
+// pinning which key may sign the repository. `enabled` is false for
+// entries commented out in a one-line sources file or marked
+// `Enabled: no` in a deb822 file.
+private apt.repo @defaults("type url distribution") {
+  // Package type: `deb` (binary) or `deb-src` (source)
+  type string
+  // Repository URI packages are fetched from
+  url string
+  // Distribution / suite (e.g., `bookworm`, `noble-security`)
+  distribution string
+  // Components enabled for this repository (e.g., `main`, `contrib`)
+  components []string
+  // Whether signature verification is bypassed (`[trusted=yes]`)
+  trusted bool
+  // Keyring path pinning the signing key (`signed-by`), empty when unset
+  signedBy string
+  // Whether the repository entry is active
+  enabled bool
+  // Source list file that declares this repository
+  file file
+}
+
+// Windows registry key
+//
+// Examine items, child keys, and existence at a given registry path
+registrykey @defaults("path") {
+  init(path string)
+  // Registry key path
+  path string
+  // Whether the property exists
+  exists() bool
+  // Properties of the registry key as a name-to-value map
+  //
+  // Deprecated in favor of `items`, which returns structured property
+  // entries.
+  properties() @maturity("deprecated") map[string]string
+  // Registry key items
+  items() []registrykey.property
+  // Registry key children
+  children() []string
+}
+
+// Windows registry key property
+//
+// Examine a single named value within a registry key: the key `path`, value
+// `name`, whether it `exists`, the registry `type` (e.g., REG_SZ, REG_DWORD),
+// and the parsed `data`. Initialize by path and name to look up a specific
+// value, or iterate from `registrykey.items()`.
+registrykey.property @defaults("path name") {
+  init(path string, name string)
+  // Registry key path
+  path string
+  // Registry key name
+  name string
+  // Whether the property exists
+  exists() bool
+  // Registry property value as a string
+  //
+  // Deprecated in favor of `data`, the parsed typed value.
+  value() @maturity("deprecated") string
+  // Registry key type
+  type() string
+  // Registry key data
+  data() dict
+}
+
+// OCI/Docker container image reference
+//
+// Examine fully-qualified name, tag/digest identifier, and source repository
+container.image @defaults("name") {
+  // Image reference
+  reference string
+  // Fully-qualified reference name
+  name string
+  // Identifier of type-specific portion of the image reference
+  identifier string
+  // Identifier type: tag or digest
+  identifierType string
+  // Repository used for the container image
+  repository() container.repository
+}
+
+// Container registry repository
+//
+// Examine registry, scheme, and full repository name for an image source
+container.repository {
+  // Container registry repository name
+  name string
+  // URL scheme
+  scheme string
+  // Container registry repository URL
+  fullName string
+  // Container registry URL
+  registry string
+}
+
+// Local container runtime delegate
+//
+// Examine a configured local runtime endpoint that can provide container image
+// metadata and, when supported by the scanner, image content from the node-local
+// runtime cache without pulling from a registry.
+container.runtimeDelegate @defaults("id status") {
+  // Stable delegate identifier
+  id string
+  // Runtime kind: cri, containerd, crio, docker, or podman
+  kind string
+  // Sanitized runtime endpoint
+  endpoint string
+  // Delegate priority; lower values are tried first
+  priority int
+  // Kubernetes node name where this delegate is valid
+  nodeName string
+  // Runtime namespaces inspected through this delegate
+  namespaces []string
+  // Snapshotters observed through this delegate
+  snapshotters []string
+  // Whether the delegate is used in read-only mode
+  readonly bool
+  // Whether registry pulls are allowed through this delegate
+  allowPull bool
+  // Delegate status: ready, unavailable, permissionDenied, or unsupported
+  status string
+  // Short non-secret diagnostic status message
+  statusMessage string
+  // Last time the delegate was checked
+  lastChecked time
+}
+
+// Local runtime image
+//
+// Examine an image observed in a node-local container runtime cache. Runtime
+// images are keyed by immutable digest where available and can be linked back to
+// Kubernetes workloads or runtime containers that reference them.
+container.runtimeImage @defaults("resolvedDigest imageId repoTags") {
+  // Stable runtime image identifier
+  id string
+  // Kubernetes node name where this image was observed
+  nodeName string
+  // Runtime delegate that reported this image
+  delegateId string
+  // Runtime kind that reported this image
+  runtimeKind string
+  // Runtime image ID
+  imageId string
+  // Repo tags reported by the runtime
+  repoTags []string
+  // Repo digests reported by the runtime
+  repoDigests []string
+  // Preferred immutable digest used for scan deduplication
+  resolvedDigest string
+  // Runtime layer chain ID
+  chainId string
+  // OCI manifest or index digest used for content access
+  targetDigest string
+  // OCI or Docker media type
+  mediaType string
+  // Image platform in os/architecture form
+  platform string
+  // Runtime-reported image size in bytes
+  sizeBytes int
+  // Image creation timestamp
+  created time
+  // Runtime labels
+  labels map[string]string
+  // Runtime namespaces that reference this image
+  namespaces []string
+  // Whether a running or recently observed container references this image
+  inUse bool
+  // Runtime or Kubernetes container identifiers that reference this image
+  containers []string
+  // Scan status: pending, scanned, notPresent, unsupported, permissionDenied, or failed
+  scanStatus string
+  // Short non-secret diagnostic scan message
+  scanStatusMessage string
+  // Image layer metadata
+  layers []container.runtimeImageLayer
+}
+
+// Local runtime image layer
+//
+// Examine layer metadata for an image observed in a node-local runtime cache.
+container.runtimeImageLayer @defaults("digest") {
+  // Compressed layer digest
+  digest string
+  // Uncompressed layer digest
+  diffId string
+  // Layer size in bytes
+  sizeBytes int
+  // OCI or Docker media type
+  mediaType string
+  // OCI annotations
+  annotations map[string]string
+  // Whether the layer content is present in the local cache
+  cachePresent bool
+}
+
+// Kubernetes kubelet on this node
+//
+// Examine config-file parameters merged with the live process's CLI flags
+kubelet {
+  // Kubelet config file
+  configFile file
+  // Kubelet process
+  process process
+  // Combination of config file parameters and CLI parameters
+  configuration() dict
+}
+
+// Python package inventory
+//
+// Examine all installed packages plus the explicitly-installed top level
+python {
+  init(path? string)
+  // Path to a specific site-packages location to exclusively scan (empty means scan default locations)
+  path string
+
+  // List of all discovered packages
+  packages() []python.package
+
+  // List of all packages that were specifically installed (i.e., not auto-installed as a dependency)
+  toplevel() []python.package
+}
+
+// Python package information
+//
+// Examine a single installed Python package: name, version, license, author,
+// summary, required Python version, project URLs, package URL (`purl`), CPEs,
+// and the full transitive `dependencies()` list. Used to inventory Python
+// dependencies and correlate them with vulnerability data.
+python.package @defaults("name version") {
+  init(path? string)
+  // ID is the python.package unique identifier
+  id string
+  // Name of the package
+  name string
+  // File containing the package metadata
+  file file
+  // Version of the package
+  version string
+  // License of the package
+  license string
+  // Author of the package
+  author string
+  // Author email of the package
+  authorEmail string
+  // Short package description
+  summary string
+  // Required Python version (e.g., ">=3.6")
+  requiresPython string
+  // Project URLs by label (e.g., Homepage, Repository, Documentation)
+  projectUrls map[string]string
+  // Package URL
+  purl string
+  // Common Platform Enumeration (CPE) for the package
+  cpes []core.cpe
+  // List of packages depended on
+  dependencies() []python.package
+}
+
+// npm package inventory
+//
+// Examine the project root, direct dependencies, and full transitive tree
+npm.packages {
+  []npm.package
+
+  init(path? string)
+
+  // Path to search for packages
+  //
+  // Deprecated in favor of `paths`, which accepts a list of search paths.
+  path @maturity("deprecated") string
+
+  // Optional: list of paths searched for packages
+  paths() []string
+
+  // Root Package (may not exist)
+  root() npm.package
+
+  // List of direct dependencies
+  directDependencies() []npm.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+
+  // Scripts defined in package.json
+  scripts() map[string]string
+}
+
+// npm package dependency
+//
+// Examine a single npm package: its unique `id`, `name`, `version`,
+// `purl`, CPEs, and the files that contributed it. Iterated from
+// `npm.packages` to audit the full dependency tree or from
+// `npm.packages.directDependencies()` for top-level deps only.
+npm.package @defaults("name version purl") {
+  // ID is the npm.package unique identifier
+  id string
+  // Name of the package
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+  // Package description from package.json
+  description string
+  // Package author
+  //
+  // From package.json `author`. Accepts the SPDX-style string form
+  // ("Name <email>") and the object form ({"name":..., "email":...,
+  // "url":...}); only the name portion is surfaced.
+  author string
+  // Package license
+  //
+  // SPDX expression from package.json `license`. The deprecated
+  // `licenses` array is not yet supported — the field is empty in that
+  // case.
+  license string
+}
+
+// Go module inventory
+//
+// Examine the root module, direct dependencies, and full transitive tree
+go.packages {
+  []go.package
+
+  init(path? string)
+
+  // Path to search for Go module files
+  path string
+
+  // Root module (may not exist)
+  root() go.package
+
+  // List of direct dependencies
+  directDependencies() []go.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Go module dependency
+//
+// Examine a single Go module: its unique `id`, module path as `name`,
+// `version`, `purl`, CPEs, and the files that contributed it. Iterated
+// from `go.packages` or `go.packages.directDependencies()`.
+go.package @defaults("name version purl") {
+  // ID is the go.package unique identifier
+  id string
+  // Name of the module (module path)
+  name() string
+  // Version of the module
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Java package inventory (Maven, Gradle, JAR archives)
+//
+// Examine the root project, direct dependencies, and full transitive tree
+java.packages {
+  []java.package
+
+  init(path? string)
+
+  // Path to search for Java packages (directory, JAR, pom.xml, or gradle.lockfile)
+  path string
+
+  // Root project (may not exist)
+  root() java.package
+
+  // List of direct dependencies
+  directDependencies() []java.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Java package (Maven, Gradle, or JAR archive)
+//
+// Examine a single Java artifact: its unique `id`, `name` in
+// `groupId:artifactId` form, `version`, `purl`, CPEs, and the files that
+// contributed it. Iterated from `java.packages` or
+// `java.packages.directDependencies()`.
+java.package @defaults("name version purl") {
+  // ID is the java.package unique identifier
+  id string
+  // Name of the package (groupId:artifactId)
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Rust/Cargo crate inventory
+//
+// Examine the root crate, direct dependencies, and full transitive tree
+rust.packages {
+  []rust.package
+
+  init(path? string)
+
+  // Path to search for Cargo files
+  path string
+
+  // Root crate (may not exist)
+  root() rust.package
+
+  // List of direct dependencies
+  directDependencies() []rust.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Rust/Cargo crate dependency
+//
+// Examine a single Rust crate: its unique `id`, crate `name`, `version`,
+// `purl`, CPEs, and the files that contributed it. Iterated from
+// `rust.packages` or `rust.packages.directDependencies()`.
+rust.package @defaults("name version purl") {
+  // ID is the rust.package unique identifier
+  id string
+  // Name of the crate
+  name() string
+  // Version of the crate
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// .NET / NuGet package inventory
+//
+// Examine the root project, direct dependencies, and full transitive tree
+dotnet.packages {
+  []dotnet.package
+
+  init(path? string)
+
+  // Path to search for .NET package files
+  path string
+
+  // Root project (may not exist)
+  root() dotnet.package
+
+  // List of direct dependencies
+  directDependencies() []dotnet.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// .NET / NuGet package dependency
+//
+// Examine a single .NET package: its unique `id`, `name`, `version`, `purl`,
+// CPEs, and the files that contributed it. Iterated from `dotnet.packages`
+// or `dotnet.packages.directDependencies()`.
+dotnet.package @defaults("name version purl") {
+  // ID is the dotnet.package unique identifier
+  id string
+  // Name of the package
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// PHP / Composer package inventory
+//
+// Examine the root project, direct dependencies, and full transitive tree
+php.packages {
+  []php.package
+
+  init(path? string)
+
+  // Path to search for Composer files
+  path string
+
+  // Root project (may not exist)
+  root() php.package
+
+  // List of direct dependencies
+  directDependencies() []php.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// PHP / Composer package dependency
+//
+// Examine a single PHP package: its unique `id`, `name` in
+// `vendor/package` form, `version`, `purl`, CPEs, and the files that
+// contributed it. Iterated from `php.packages` or
+// `php.packages.directDependencies()`.
+php.package @defaults("name version purl") {
+  // ID is the php.package unique identifier
+  id string
+  // Name of the package (vendor/package)
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// GitHub Actions workflow dependencies
+//
+// Examine action references (owner/repo@version) used across workflow files
+githubactions.packages {
+  []githubactions.package
+
+  init(path? string)
+
+  // Path to search for workflow files (directory or specific .yml file)
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// GitHub Actions action reference
+//
+// Examine a single GitHub Actions action used in workflow files: its unique
+// `id`, `name` in `owner/repo` or `owner/repo/path` form, `version` (tag,
+// branch, or commit SHA), `purl`, and the workflow files that reference it.
+// Iterated from `githubactions.packages`.
+githubactions.package @defaults("name version purl") {
+  // ID is the githubactions.package unique identifier
+  id string
+  // Name of the action (owner/repo or owner/repo/path)
+  name() string
+  // Version (tag, branch, or commit SHA)
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Swift package inventory (SPM and CocoaPods)
+//
+// Examine all referenced packages with their resolved versions
+swift.packages {
+  []swift.package
+
+  init(path? string)
+
+  // Path to search for Swift package files
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Swift package dependency
+//
+// Examine a single Swift package: its unique `id`, `name`, `version`,
+// `purl`, CPEs, and the files that contributed it. Iterated from
+// `swift.packages`.
+swift.package @defaults("name version purl") {
+  // ID is the swift.package unique identifier
+  id string
+  // Name of the package
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Terraform provider inventory (SBOM cataloger)
+//
+// Examine provider versions pinned in .terraform.lock.hcl
+// Note: the terraform.* namespace is also used by the dedicated Terraform provider
+// for IaC resource scanning. These SBOM resources focus on provider version inventory
+// from .terraform.lock.hcl, not Terraform configuration analysis.
+terraform.packages {
+  []terraform.package
+
+  init(path? string)
+
+  // Path to search for .terraform.lock.hcl
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Terraform provider dependency
+//
+// Examine a single Terraform provider pinned in `.terraform.lock.hcl`:
+// its unique `id`, `name` in `namespace/type` form, `version`, `purl`,
+// CPEs, and the lock files that reference it. Iterated from
+// `terraform.packages`.
+terraform.package @defaults("name version purl") {
+  // ID is the terraform.package unique identifier
+  id string
+  // Name of the provider (namespace/type)
+  name() string
+  // Version of the provider
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the provider
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Homebrew package inventory (macOS and Linux)
+//
+// Examine installed formulae and casks with version, tap, and update status
+homebrew.packages {
+  []homebrew.package
+}
+
+// Homebrew package (formula or cask)
+private homebrew.package @defaults("name version type") {
+  // Package name (formula name or cask token)
+  name string
+  // Currently installed version
+  version string
+  // Latest stable version available (equals version when up-to-date)
+  latestVersion string
+  // Package URL
+  purl string
+  // Package description
+  description string
+  // Homepage URL
+  homepage string
+  // Install path
+  path string
+  // Package type: "formula" or "cask"
+  type string
+  // Application name (casks only)
+  appName string
+  // Whether the cask manages its own updates
+  autoUpdates bool
+  // Whether this package was explicitly installed (not a dependency)
+  installedOnRequest bool
+  // Whether this package was installed as a dependency
+  installedAsDependency bool
+  // Whether a newer version is available
+  outdated bool
+  // Whether the version is pinned
+  pinned bool
+  // Homebrew tap (e.g., "homebrew/core")
+  tap string
+  // Homebrew install prefix (e.g., "/opt/homebrew")
+  prefix string
+}
+
+// Chocolatey package inventory (Windows)
+//
+// Examine installed packages with version, license, dependencies, and pin state
+chocolatey.packages {
+  []chocolatey.package
+}
+
+// Chocolatey package
+private chocolatey.package @defaults("name version") {
+  // Package name
+  name string
+  // Package version
+  version string
+  // Package URL
+  purl string
+  // Short description
+  summary string
+  // Full description
+  description string
+  // Package author(s)
+  author string
+  // License name
+  license string
+  // License URL
+  licenseUrl string
+  // Package install path
+  path string
+  // Whether the package is pinned (won't auto-upgrade)
+  pinned bool
+  // Package dependencies
+  dependencies []string
+  // Package tags
+  tags []string
+  // Upstream project URL
+  projectUrl string
+}
+
+// Jenkins plugin inventory
+//
+// Examine installed plugins with version and inter-plugin dependencies
+jenkins.packages {
+  []jenkins.package
+
+  init(path? string)
+
+  // Path to Jenkins plugins directory
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Jenkins plugin
+private jenkins.package @defaults("name version purl") {
+  // Plugin short name
+  name string
+  // Plugin version
+  version string
+  // Package URL
+  purl string
+  // Plugin long name
+  longName string
+  // Plugin URL
+  url string
+  // Plugin dependencies
+  dependencies []string
+  // Package files
+  files []pkgFileInfo
+}
+
+// WordPress plugin inventory
+//
+// Examine installed plugins with version and WordPress compatibility ranges
+wordpress.packages {
+  []wordpress.package
+
+  init(path? string)
+
+  // Path to WordPress plugins directory (wp-content/plugins/)
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// WordPress plugin
+private wordpress.package @defaults("name version purl") {
+  // Plugin slug (directory name)
+  name string
+  // Plugin version (from Stable tag)
+  version string
+  // Package URL
+  purl string
+  // Plugin display name
+  displayName string
+  // License
+  license string
+  // Minimum required WordPress version
+  requiresWp string
+  // Maximum tested WordPress version
+  testedUpTo string
+  // Package files
+  files []pkgFileInfo
+}
+
+// Ruby gem inventory
+//
+// Examine the root project, direct dependencies, and full transitive tree
+ruby.packages {
+  []ruby.package
+
+  init(path? string)
+
+  // Path to search for Gemfile.lock
+  path string
+
+  // Root project (may not exist)
+  root() ruby.package
+
+  // List of direct dependencies
+  directDependencies() []ruby.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Ruby gem package
+//
+// Examine a single Ruby gem: its unique `id`, gem `name`, `version`,
+// `purl`, CPEs, and the files that contributed it. Iterated from
+// `ruby.packages` or `ruby.packages.directDependencies()`.
+ruby.package @defaults("name version purl") {
+  // ID is the ruby.package unique identifier
+  id string
+  // Gem name
+  name() string
+  // Gem version
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Dart/Flutter package inventory
+//
+// Examine the root project, direct dependencies, and full transitive tree
+dart.packages {
+  []dart.package
+
+  init(path? string)
+
+  // Path to search for pubspec.lock
+  path string
+
+  // Root project (may not exist)
+  root() dart.package
+
+  // List of direct dependencies
+  directDependencies() []dart.package
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Dart/Flutter package dependency
+//
+// Examine a single Dart/Flutter package: its unique `id`, `name`, `version`,
+// `purl`, CPEs, and the files that contributed it. Iterated from
+// `dart.packages` or `dart.packages.directDependencies()`.
+dart.package @defaults("name version purl") {
+  // ID is the dart.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Haskell package inventory (Stack and Cabal)
+//
+// Examine all locked packages with their resolved versions
+haskell.packages {
+  []haskell.package
+
+  init(path? string)
+
+  // Path to search for stack.yaml.lock or cabal.project.freeze
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Haskell package dependency
+//
+// Examine a single Haskell package from a Stack or Cabal lock file: its
+// unique `id`, `name`, `version`, `purl`, and the files that contributed it.
+// Iterated from `haskell.packages`.
+haskell.package @defaults("name version purl") {
+  // ID is the haskell.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Elixir Hex package inventory (mix.lock)
+//
+// Examine all locked Hex packages with their resolved versions
+elixir.packages {
+  []elixir.package
+
+  init(path? string)
+
+  // Path to search for mix.lock
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Elixir Hex package dependency
+//
+// Examine a single Elixir Hex package from a mix.lock file: its unique
+// `id`, `name`, `version`, `purl`, and the files that contributed it.
+// Iterated from `elixir.packages`.
+elixir.package @defaults("name version purl") {
+  // ID is the elixir.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Erlang Hex package inventory (rebar.lock)
+//
+// Examine all locked Hex packages with their resolved versions
+erlang.packages {
+  []erlang.package
+
+  init(path? string)
+
+  // Path to search for rebar.lock
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Erlang Hex package dependency
+//
+// Examine a single Erlang Hex package from a rebar.lock file: its unique
+// `id`, `name`, `version`, `purl`, and the files that contributed it.
+// Iterated from `erlang.packages`.
+erlang.package @defaults("name version purl") {
+  // ID is the erlang.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// SWI-Prolog pack inventory
+//
+// Examine installed packs with their versions
+prolog.packages {
+  []prolog.package
+
+  init(path? string)
+
+  // Path to search for SWI-Prolog packs directory
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// SWI-Prolog pack
+//
+// Examine a single SWI-Prolog pack: its unique `id`, pack `name`,
+// `version`, `purl`, and the files that contributed it. Iterated from
+// `prolog.packages`.
+prolog.package @defaults("name version purl") {
+  // ID is the prolog.package unique identifier
+  id string
+  // Pack name
+  name() string
+  // Pack version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Conda package inventory
+//
+// Examine installed packages from conda-meta or environment.yml
+conda.packages {
+  []conda.package
+
+  init(path? string)
+
+  // Path to search for conda-meta or environment.yml
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Conda package dependency
+private conda.package @defaults("name version purl") {
+  // ID is the conda.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Julia package inventory (Manifest.toml)
+//
+// Examine all locked packages with their resolved versions
+julia.packages {
+  []julia.package
+
+  init(path? string)
+
+  // Path to search for Manifest.toml
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Julia package dependency
+private julia.package @defaults("name version purl") {
+  // ID is the julia.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// R package inventory (renv.lock)
+//
+// Examine all locked packages with their resolved versions
+r.packages {
+  []r.package
+
+  init(path? string)
+
+  // Path to search for renv.lock
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// R package dependency
+private r.package @defaults("name version purl") {
+  // ID is the r.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// Lua/LuaRocks package inventory
+//
+// Examine all installed rocks with their versions
+lua.packages {
+  []lua.package
+
+  init(path? string)
+
+  // Path to search for LuaRocks packages
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Lua package dependency
+private lua.package @defaults("name version purl") {
+  // ID is the lua.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
+// macOS-specific operating system surfaces
+//
+// Examine computer name, user defaults, account policies, and system extensions
+macos {
+  // macOS computer name
+  computerName() string
+  // macOS user defaults
+  userPreferences() map[string]dict
+  // macOS user defaults for current host
+  userHostPreferences() map[string]dict
+  // macOS global account policies
+  globalAccountPolicies() dict
+  // System extensions
+  systemExtensions() []macos.systemExtension
+}
+
+// macOS hardware overview
+//
+// Examine chip type, model, memory, serial, and Activation Lock status
+macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
+  // Activation Lock security feature
+  activationLockStatus string
+  // Boot ROM (firmware) version identifier
+  bootRomVersion string
+  // Processor chip type (e.g., "Apple M1", "Apple M2", "Intel")
+  chipType string
+  // Specific model identifier (e.g., "MacBookPro18,3")
+  machineModel string
+  // User-friendly hardware name (e.g., "MacBook Pro")
+  machineName string
+  // Apple's model number for the device (e.g., "A2442")
+  modelNumber string
+  // Total number of processor cores
+  numberProcessors string
+  // Version of the OS bootloader
+  osLoaderVersion string
+  // Total RAM installed (e.g., "16 GB")
+  physicalMemory string
+  // Universally unique identifier for the hardware platform
+  platformUUID string
+  // Unique Device Identifier for MDM provisioning
+  provisioningUDID string
+  // Apple's unique serial number for the device
+  serialNumber string
+}
+
+// macOS application layer firewall — raw ALF preference values
+//
+// Prefer macos.firewall; this resource exposes the raw integer flags from ALF plist
+macos.alf {
+  // Whether the firewall service allows downloaded software to receive incoming connections
+  allowDownloadSignedEnabled int
+  // Whether the firewall service allows built-in software to receive incoming connections for signed software
+  allowSignedEnabled int
+  // Whether the firewall is unloaded
+  firewallUnload int
+  // Whether the firewall is enabled
+  globalState int
+  // Whether alf.log is used
+  loggingEnabled int
+  // Logging option flags (0=disabled, 1=detail, 2=brief, 3=throttled)
+  loggingOption int
+  // Whether the firewall service is in stealth mode
+  stealthEnabled int
+  // ALF version
+  version string
+  // Service exceptions
+  exceptions []dict
+  // Services explicitly allowed to perform networking
+  explicitAuths []string
+  // Applications with exceptions for network blocking
+  applications []dict
+}
+
+// macOS application layer firewall
+//
+// Examine enable state, stealth mode, signed-app policy, and per-app rules
+macos.firewall @defaults("enabled stealthEnabled") {
+  // Whether the firewall is enabled
+  enabled() bool
+  // Whether block-all-incoming mode is active (globalState == 2)
+  blockAllIncoming() bool
+  // Whether stealth mode is enabled
+  stealthEnabled() bool
+  // Whether logging is enabled
+  loggingEnabled() bool
+  // Logging detail level: disabled (0), detail (1), brief (2), throttled (3)
+  loggingDetail() string
+  // Whether signed applications are automatically allowed
+  allowSignedApps() bool
+  // Whether downloaded signed applications are automatically allowed
+  allowDownloadSignedApps() bool
+  // ALF version
+  version() string
+  // Service exceptions
+  exceptions() []dict
+  // Services explicitly allowed to perform networking
+  explicitAuths() []string
+  // Applications with explicit firewall rules
+  applications() []macos.firewall.app
+  // Whether an installed Configuration Profile manages the firewall
+  //
+  // True when any installed profile carries a payload of type
+  // `com.apple.security.firewall`. Enumerating Configuration Profiles
+  // requires root, so on an unprivileged session the field surfaces
+  // the underlying `profiles list` error rather than silently
+  // returning `false`.
+  managedByMDM() bool
+}
+
+// macOS firewall per-application rule
+private macos.firewall.app @defaults("name state") {
+  // Application path
+  name string
+  // Bundle ID
+  bundleId string
+  // Whether incoming connections are allowed (0=block, 1=allow)
+  state int
+}
+
+// macOS FileVault full-disk encryption
+//
+// Examine enable state, encryption status, and configured recovery keys
+macos.filevault @defaults("enabled status") {
+  // Whether FileVault is enabled
+  enabled() bool
+  // FileVault status (On, Off, Encryption in progress, Decryption in progress)
+  status() string
+  // Whether a personal recovery key exists
+  hasPersonalRecoveryKey() bool
+  // Whether an institutional recovery key exists
+  hasInstitutionalRecoveryKey() bool
+  // Users that can unlock the FileVault encrypted drive
+  users() []string
+}
+
+// macOS Gatekeeper application execution policy
+//
+// Examine whether assessments are enabled and the Gatekeeper status message
+macos.gatekeeper @defaults("enabled status") {
+  // Whether Gatekeeper assessments are enabled
+  enabled() bool
+  // Gatekeeper assessment status (assessments enabled, assessments disabled)
+  status() string
+}
+
+// macOS System Integrity Protection (SIP)
+//
+// Examine whether SIP is enabled and the system status message
+macos.sip @defaults("enabled status") {
+  // Whether System Integrity Protection is enabled
+  enabled() bool
+  // SIP status message
+  status() string
+}
+
+// macOS XProtect anti-malware bundle
+//
+// Examine the version and last-modified timestamp of the XProtect
+// signature bundle (and, when present, the legacy Malware Removal
+// Tool). CIS macOS benchmarks expect XProtect signatures to be
+// current; checking `modified` against the auditor's freshness
+// threshold catches devices that have stopped receiving updates.
+//
+// XProtect.bundle lives at
+// `/Library/Apple/System/Library/CoreServices/XProtect.bundle` on
+// modern macOS (with `/System/Library/CoreServices/XProtect.bundle`
+// as the legacy fallback). `mrtVersion` and `mrtModified` are empty
+// or null on macOS 13+ where MRT has been retired in favor of
+// XProtectRemediator.
+macos.xprotect @defaults("version modified") {
+  // XProtect bundle version (CFBundleShortVersionString)
+  version() string
+  // Last modification time of the XProtect bundle
+  modified() time
+  // MRT (Malware Removal Tool) bundle version
+  //
+  // Empty string when MRT.app is not installed (it was sunset in
+  // macOS 13; its work is now performed by XProtectRemediator).
+  mrtVersion() string
+  // Last modification time of MRT.app, null when MRT is not installed
+  mrtModified() time
+}
+
+// macOS Sharing service state
+//
+// Examine the unified Sharing panel (System Settings > Sharing on
+// macOS Ventura+, System Preferences > Sharing on older versions).
+// Each field corresponds to one toggle in that panel. CIS macOS
+// benchmarks require most of these to be off unless the device
+// explicitly needs the service. Backed by `system_profiler
+// SPSharingDataType`, so the values match exactly what the System
+// Settings UI displays.
+//
+// `system_profiler SPSharingDataType` also reports `Remote Login`
+// and `Remote Apple Events`; those are intentionally not exposed
+// here because `macos.systemsetup.remoteLogin` and
+// `macos.systemsetup.remoteAppleEvents` already cover them via the
+// `systemsetup` CLI. This resource covers the rest of the panel.
+macos.sharing @defaults("screenSharing remoteManagement airplayReceiver") {
+  // Whether Screen Sharing (VNC) is enabled
+  screenSharing() bool
+  // Whether Apple Remote Desktop (Remote Management) is enabled
+  remoteManagement() bool
+  // Whether File Sharing (SMB/AFP) is enabled
+  fileSharing() bool
+  // Whether Printer Sharing is enabled
+  printerSharing() bool
+  // Whether Internet Sharing is enabled
+  internetSharing() bool
+  // Whether Bluetooth Sharing is enabled
+  bluetoothSharing() bool
+  // Whether Media Sharing is enabled
+  mediaSharing() bool
+  // Whether Content Caching is enabled
+  contentCaching() bool
+  // Whether AirPlay Receiver is enabled
+  airplayReceiver() bool
+  // Whether DVD or CD Sharing is enabled
+  dvdSharing() bool
+}
+
+// macOS MDM (Mobile Device Management) enrollment state
+//
+// Examine whether this Mac is enrolled in an MDM solution, the
+// enrollment server, and whether the enrollment was performed via
+// Automated Device Enrollment (formerly DEP) or user-approved. Use
+// `macos.profiles` to enumerate the configuration profiles delivered
+// to the device. Backed by `profiles status -type enrollment`.
+macos.mdm @defaults("enrolled serverUrl") {
+  // Whether the device is enrolled in an MDM solution
+  enrolled() bool
+  // Whether the device is enrolled via Automated Device Enrollment (DEP/ADE)
+  //
+  // DEP-enrolled devices are pre-assigned to the organization through
+  // Apple Business Manager / Apple School Manager and cannot be removed
+  // from MDM by the user.
+  dep() bool
+  // Whether the MDM enrollment is user-approved
+  //
+  // User-approved MDM (UAMDM) is required for managing kernel
+  // extensions, full disk access, and other privileged settings.
+  userApproved() bool
+  // URL of the MDM server (empty when not enrolled)
+  serverUrl() string
+}
+
+// macOS configuration profiles installed on the system
+//
+// Iterate every Configuration Profile delivered to the device — both
+// MDM-delivered and manually installed `.mobileconfig` payloads — to
+// audit what policies are actually in force. Backed by `profiles list
+// -all -output stdout-xml`; requires root to see system-level (`_computerlevel`)
+// profiles, otherwise only the current user's profiles are returned.
+macos.profiles @defaults("list.length") {
+  // All installed Configuration Profiles
+  list() []macos.profile
+}
+
+// macOS Configuration Profile
+//
+// Examine a single Configuration Profile: its `identifier`, `uuid`,
+// human-readable `displayName`, `description`, `organization`,
+// `type`, whether it is install-locked (`removalDisallowed`), the
+// scope it applies to (`scope`: `system` or `user`), and the
+// individual `payloads` that carry the actual policy directives.
+private macos.profile @defaults("identifier displayName type") {
+  // Reverse-DNS profile identifier
+  identifier string
+  // Profile UUID
+  uuid string
+  // Human-readable profile name
+  displayName string
+  // Profile description
+  description string
+  // Distributing organization
+  organization string
+  // Profile type (e.g. "Configuration", "Enrollment Profile")
+  type string
+  // Whether removal of this profile is disallowed by its install settings
+  removalDisallowed bool
+  // Scope this profile applies to
+  //
+  // `system` for `_computerlevel` profiles or `user` for per-user profiles.
+  scope string
+  // Payloads (policy directives) carried by this profile
+  payloads []macos.profile.payload
+}
+
+// macOS Configuration Profile payload
+//
+// Examine a single payload within a Configuration Profile: the
+// `type` (e.g. `com.apple.security.firewall`,
+// `com.apple.MCXFileVault2`), the payload's reverse-DNS
+// `identifier`, its `uuid`, and the raw policy `content` as a dict.
+// Iterated from `macos.profile.payloads` to audit specific policy
+// directives (e.g. firewall payload settings, FileVault policy).
+private macos.profile.payload @defaults("type displayName") {
+  // Payload UUID
+  uuid string
+  // Payload type (reverse-DNS, e.g. `com.apple.security.firewall`)
+  type string
+  // Reverse-DNS payload identifier
+  identifier string
+  // Human-readable payload name
+  displayName string
+  // Raw payload content as parsed from the profile plist
+  //
+  // The schema of `content` is payload-type specific — a firewall
+  // payload differs from a Wi-Fi payload differs from a FileVault
+  // payload. Inspect `type` to know what fields to expect.
+  content dict
+}
+
+// macOS Software Update configuration and pending updates
+//
+// Examine automatic-update policy and the list of updates currently
+// available to install. Policy fields read from
+// `/Library/Preferences/com.apple.SoftwareUpdate.plist` (with
+// `/Library/Managed Preferences/` taking precedence when an MDM
+// configuration profile has been delivered). The `updates` list is
+// produced from `softwareupdate -l --no-scan` so it does not initiate
+// a network check.
+macos.softwareupdate @defaults("autoCheckEnabled autoInstallMacOSUpdates") {
+  // Whether `Software Update` is configured to automatically check for updates
+  autoCheckEnabled() bool
+  // Whether updates are downloaded automatically in the background
+  autoDownloadEnabled() bool
+  // Whether macOS updates (point releases and security updates) install automatically
+  autoInstallMacOSUpdates() bool
+  // Whether system data files (XProtect, MRT definitions) install automatically
+  installSystemDataFiles() bool
+  // Whether Rapid Security Responses install automatically
+  installSecurityResponses() bool
+  // Last successful check timestamp as reported by Software Update
+  //
+  // Null when no successful check has ever been recorded on this
+  // device or when the field is unset by the policy file.
+  lastSuccessfulCheck() time
+  // Available software updates as reported by `softwareupdate -l --no-scan`
+  updates() []macos.softwareupdate.entry
+}
+
+// macOS Software Update entry
+//
+// Examine a single update offered by Software Update: its `label`
+// (the identifier accepted by `softwareupdate --install`), the
+// human-readable `title` and `version`, the estimated download
+// `size`, whether it is `recommended`, and any post-install `action`
+// such as `restart` or `shutdown`. Iterated from
+// `macos.softwareupdate.updates`.
+private macos.softwareupdate.entry @defaults("label title recommended") {
+  // Update label (the argument to `softwareupdate --install`)
+  label string
+  // Human-readable update title
+  title string
+  // Update version
+  version string
+  // Estimated download size in KiB as reported by `softwareupdate`
+  size int
+  // Whether the update is marked recommended
+  recommended bool
+  // Post-install action required (`restart`, `shutdown`, or empty for none)
+  action string
+}
+
+// macOS Time Machine backup configuration
+//
+// Examine destinations, schedule, and exclusion preferences
+macos.timemachine {
+  // macOS Time Machine preferences
+  preferences() dict
+}
+
+// macOS machine settings via the systemsetup CLI
+//
+// Examine date/time, sleep, remote login, power, and network-time configuration
+// Note: this resource requires at least admin privileges to run.
+macos.systemsetup {
+  // Current date
+  date() string
+  // Current time in 24-hour format
+  time() string
+  // Current time zone
+  timeZone() string
+  // Whether network time is on or off
+  usingNetworkTime() string
+  // Configured network time server
+  networkTimeServer() string
+  // Amount of idle time until the machine sleeps
+  sleep() []string
+  // Amount of idle time until the display sleeps
+  displaySleep() string
+  // Amount of idle time until the hard disk sleeps
+  harddiskSleep() string
+  // Whether wake on modem is on or off
+  wakeOnModem() string
+  // Whether wake on network access is on or off
+  wakeOnNetworkAccess() string
+  // Whether restart on power failure is on or off
+  restartPowerFailure() string
+  // Whether restart on freeze is on or off
+  restartFreeze() string
+  // Whether the power button can sleep the computer
+  allowPowerButtonToSleepComputer() string
+  // Whether remote login (SSH) is on or off
+  remoteLogin() string
+  // Whether remote Apple events are on or off
+  remoteAppleEvents() string
+  // Computer name
+  computerName() string
+  // Local subnet name
+  localSubnetName() string
+  // Current startup disk
+  startupDisk() string
+  // Number of seconds after which the computer will start up after a power failure
+  waitForStartupAfterPowerFailure() string
+  // Whether the keyboard is disabled when the X Serve enclosure lock is engaged
+  disableKeyboardWhenEnclosureLockIsEngaged() string
+}
+
+// OpenBSM audit_control configuration (macOS and BSD)
+//
+// Examine audit flags, log retention, and policy parameters
+openBSMAudit @defaults("path") {
+  init(path? string)
+  // Path to the audit_control file
+  path string
+  // File resource for the audit_control file
+  file() file
+  // Content of the audit_control file
+  content(file) string
+  // Parsed parameters from the audit_control file
+  params(content) map[string]string
+  // Directory where audit log files are stored
+  dir(params) string
+  // Audit event flags for attributable (user) events
+  flags(params) []string
+  // Minimum free space threshold (percentage) before audit warnings
+  minfree(params) int
+  // Audit event flags for non-attributable events
+  naflags(params) []string
+  // Audit policy settings
+  policy(params) []string
+  // Maximum size of individual audit log files
+  filesz(params) string
+  // Expiration criteria for audit logs
+  expireAfter(params) string
+  // Flags that superusers can set on their processes
+  superuserSetSflagsMask(params) []string
+  // Flags that superusers can clear on their processes
+  superuserClearSflagsMask(params) []string
+  // Flags that non-superusers can set on their processes
+  memberSetSflagsMask(params) []string
+  // Flags that non-superusers can clear on their processes
+  memberClearSflagsMask(params) []string
+}
+
+// Windows-specific operating system surfaces
+//
+// Examine computer info, hotfixes, and server / optional features
+windows {
+  // A consolidated object of system and operating system properties
+  //
+  // See https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.computerinfo?view=powershellsdk-1.1.0 for more information.
+  computerInfo() dict
+
+  // Hotfixes installed on the computer
+  hotfixes() []windows.hotfix
+
+  // Information about Windows Server roles, role services, and features that are available for installation and installed on a specified server.
+  serverFeatures() []windows.serverFeature
+
+  // Information about optional features in a Windows image.
+  optionalFeatures() []windows.optionalFeature
+
+  // Registered Windows Task Scheduler tasks
+  scheduledTasks() []windows.scheduledTask
+}
+
+// Windows Task Scheduler task
+//
+// Examine a registered task from the Windows Task Scheduler: its identity
+// (`name`, `path`, `uri`), run `state`, whether it is `enabled`, descriptive
+// metadata (`description`, `author`), and the security context it runs under
+// via `principal`. The `actions` it executes, the `triggers` that launch it,
+// and its full `settings` are exposed as nested resources, while `lastRunTime`,
+// `nextRunTime`, `lastTaskResult`, and `missedRuns` report the most recent
+// run-time information. Iterated from `windows.scheduledTasks` to audit
+// which tasks run, as whom, and on what schedule — for example
+// `windows.scheduledTasks.where(enabled).where(principal.runLevel == "Highest")`.
+private windows.scheduledTask @defaults("path name state enabled") {
+  // Task name (the leaf identifier within its folder)
+  name string
+  // Folder path the task is registered under (for example "\Microsoft\Windows\Defrag\")
+  path string
+  // Fully qualified task identifier combining path and name
+  uri string
+  // Run state
+  //
+  // One of "Unknown", "Disabled", "Queued", "Ready", or "Running".
+  state string
+  // Whether the task is enabled to run
+  enabled bool
+  // Human-readable description of the task
+  description string
+  // Author of the task
+  author string
+  // Documentation or notes associated with the task
+  documentation string
+  // Security descriptor (SDDL) controlling who can read or run the task
+  securityDescriptor string
+  // Source the task was registered from
+  source string
+  // Date the task was registered
+  date time
+  // Security context the task runs under
+  principal() windows.scheduledTask.principal
+  // Actions the task executes when it runs
+  actions() []windows.scheduledTask.action
+  // Conditions that launch the task
+  triggers() []windows.scheduledTask.trigger
+  // Conditions and behavior that govern how the task runs
+  settings() windows.scheduledTask.settings
+  // Time the task last ran
+  lastRunTime() time
+  // Time the task is next scheduled to run
+  nextRunTime() time
+  // Exit/result code from the most recent run
+  lastTaskResult() int
+  // Number of times the task was scheduled to run but did not
+  missedRuns() int
+}
+
+// Security context of a Windows scheduled task
+//
+// Examine the account a task runs as: the `userId` or `groupId` it is
+// associated with, the `logonType` used to obtain credentials, and the
+// `runLevel` that determines whether it runs with the highest available
+// privileges.
+private windows.scheduledTask.principal @defaults("userId logonType runLevel") {
+  // User account the task runs as
+  userId string
+  // Group the task is associated with, when run for a group rather than a user
+  groupId string
+  // Friendly name of the principal
+  displayName string
+  // How credentials are obtained
+  //
+  // One of "None", "Password", "S4U", "Interactive", "Group",
+  // "ServiceAccount", or "InteractiveOrPassword".
+  logonType string
+  // Privilege level the task runs with
+  //
+  // One of "Limited" or "Highest".
+  runLevel string
+}
+
+// Action performed by a Windows scheduled task
+//
+// Examine a single executable action a task performs: the program it runs
+// (`execute`), the command-line `arguments` passed to it, and the
+// `workingDirectory` it runs in.
+private windows.scheduledTask.action @defaults("execute arguments") {
+  // Program or command the action runs
+  execute string
+  // Command-line arguments passed to the program
+  arguments string
+  // Working directory the program runs in
+  workingDirectory string
+}
+
+// Trigger that launches a Windows scheduled task
+//
+// Examine a single condition that starts a task. The `type` discriminates
+// the kind of trigger ("daily", "weekly", "monthly", "monthlyDOW", "boot",
+// "logon", "registration", "time", "event", "idle", or "sessionStateChange")
+// and determines which of the schedule fields apply — `daysInterval` and
+// `randomDelay` for daily, `weeksInterval`/`daysOfWeek` for weekly, `delay`
+// for boot/logon/event triggers, and so on. Common fields cover whether the
+// trigger is `enabled`, its active window (`startBoundary`, `endBoundary`),
+// the `executionTimeLimit`, and any repetition pattern.
+private windows.scheduledTask.trigger @defaults("type enabled startBoundary") {
+  // Kind of trigger
+  //
+  // One of "daily", "weekly", "monthly", "monthlyDOW", "boot", "logon",
+  // "registration", "time", "event", "idle", or "sessionStateChange".
+  type string
+  // Whether the trigger is enabled
+  enabled bool
+  // Earliest time the trigger is active
+  startBoundary time
+  // Latest time the trigger is active
+  endBoundary time
+  // Maximum time the task may run when started by this trigger, as an ISO 8601 duration
+  executionTimeLimit string
+  // Interval between repeated runs while the trigger is active, as an ISO 8601 duration
+  repetitionInterval string
+  // How long the task keeps repeating after the trigger fires, as an ISO 8601 duration
+  repetitionDuration string
+  // Whether a running instance is stopped when the repetition duration ends
+  repetitionStopAtDurationEnd bool
+  // Delay after the triggering event before the task starts, as an ISO 8601 duration
+  delay string
+  // Random delay added before starting, as an ISO 8601 duration
+  randomDelay string
+  // Number of days between runs, for daily triggers
+  daysInterval int
+  // Number of weeks between runs, for weekly triggers
+  weeksInterval int
+  // Bitmask of days the task runs, for weekly and monthly-day-of-week triggers
+  daysOfWeek int
+  // User the logon trigger is scoped to, when restricted to a specific user
+  userId string
+}
+
+// Conditions and behavior governing a Windows scheduled task
+//
+// Examine the settings that control how a task runs: whether it is `enabled`
+// or `hidden`, how it behaves on battery power (`disallowStartIfOnBatteries`,
+// `stopIfGoingOnBatteries`), what happens when an instance is already running
+// (`multipleInstances`), restart-on-failure behavior (`restartCount`,
+// `restartInterval`), idle conditions, and execution limits.
+private windows.scheduledTask.settings @defaults("enabled hidden priority") {
+  // Whether the task is enabled
+  enabled bool
+  // Whether the task is hidden from the default Task Scheduler view
+  hidden bool
+  // Whether the task can be started on demand
+  allowDemandStart bool
+  // Whether the task can be terminated with end-task requests
+  allowHardTerminate bool
+  // Whether the task starts as soon as possible after a missed scheduled start
+  startWhenAvailable bool
+  // Whether the task runs only when a network connection is available
+  runOnlyIfNetworkAvailable bool
+  // Whether the task runs only when the computer is idle
+  runOnlyIfIdle bool
+  // Whether the task wakes the computer to run
+  wakeToRun bool
+  // Whether the task is prevented from starting while on battery power
+  disallowStartIfOnBatteries bool
+  // Whether a running task is stopped when the computer switches to battery power
+  stopIfGoingOnBatteries bool
+  // Whether the task is prevented from starting on a remote application session
+  disallowStartOnRemoteAppSession bool
+  // Number of times the task is restarted after a failure
+  restartCount int
+  // Time to wait between restart attempts, as an ISO 8601 duration
+  restartInterval string
+  // Maximum time the task may run, as an ISO 8601 duration
+  executionTimeLimit string
+  // Behavior when an instance of the task is already running
+  //
+  // One of "IgnoreNew", "Parallel", "Queue", or "StopExisting".
+  multipleInstances string
+  // Scheduling priority, from 0 (highest) to 10 (lowest)
+  priority int
+  // Time the task is kept after it expires, as an ISO 8601 duration
+  deleteExpiredTaskAfter string
+  // Lowest Task Scheduler version the task is compatible with
+  compatibility string
+  // How long the computer must be idle before the task runs, as an ISO 8601 duration
+  idleDuration string
+  // How long to wait for an idle condition, as an ISO 8601 duration
+  idleWaitTimeout string
+  // Whether the task stops when the computer is no longer idle
+  idleStopOnIdleEnd bool
+  // Whether the task restarts when the computer becomes idle again
+  idleRestartOnIdle bool
+  // Identifier of the network profile the task is tied to
+  networkId string
+  // Name of the network profile the task is tied to
+  networkName string
+}
+
+// macOS system extension
+private macos.systemExtension @defaults("teamID identifier version state"){
+  // Identifier of the system extension
+  identifier string
+  // System extension unique identifier
+  uuid string
+  // Version of the system extension
+  version string
+  // Categories of the system extension
+  categories []string
+  // State of the system extension
+  state string
+  // Whether the system extension is enabled
+  enabled() bool
+  // Whether the system extension is active
+  active() bool
+  // Team identifier of the system extension
+  teamID string
+  // Path to the system extension
+  bundlePath string
+  // Whether the system extension is MDM managed
+  mdmManaged bool
+}
+
+// Safari browser (macOS only)
+//
+// Examine all installed Safari extensions across users
+safari {
+  // All installed Safari extensions
+  extensions() []safari.extension
+}
+
+// Safari browser extension
+private safari.extension @defaults("name version identifier") {
+  // Extension bundle identifier
+  identifier string
+  // Extension name from Info.plist
+  name string
+  // Extension version
+  version string
+  // Extension description
+  description string
+  // Extension type (e.g., "web-extension", "extension", "content-blocker")
+  extensionType string
+  // Path to the extension bundle
+  path string
+  // Containing application path
+  containerAppPath string
+  // Containing application name
+  containerAppName string
+  // Whether the extension is enabled in Safari preferences
+  enabled bool
+  // UID of the user who owns this extension
+  uid int
+}
+
+// macOS launchd job configurations
+//
+// Examine system, library, and user daemons / agents from their plist files
+launchd {
+  // All launchd jobs from system and user directories
+  jobs() []launchd.job
+}
+
+// Individual launchd job configuration
+private launchd.job @defaults("label type") {
+  // Unique identifier for the job (from Label key)
+  label string
+  // Path to the plist file
+  path string
+  // Type: "daemon" or "agent"
+  type string
+  // Source: "system", "library", or "user"
+  source string
+  // Whether this job runs at load
+  runAtLoad bool
+  // The program to execute
+  program string
+  // Command arguments
+  programArguments []string
+  // Whether the job is disabled
+  disabled bool
+  // Keep alive configuration
+  //
+  // Normalized to: {"enabled": bool} for simple values,
+  // {"enabled": true, "conditions": {...}} for conditional keep-alive,
+  // or null if not specified.
+  keepAlive dict
+  // Working directory
+  workingDirectory string
+  // Environment variables
+  environmentVariables map[string]string
+  // User the job runs as
+  userName string
+  // Group the job runs as
+  groupName string
+  // macOS launchd process type (e.g., Adaptive, Interactive, Background, Standard)
+  processType string
+  // Interval between runs (seconds)
+  startInterval int
+  // Calendar-based schedule
+  startCalendarInterval []dict
+  // Socket configuration
+  sockets dict
+  // Mach services
+  machServices dict
+  // Watch paths that trigger the job
+  watchPaths []string
+  // Path to redirect stdout
+  stdoutPath string
+  // Path to redirect stderr
+  stderrPath string
+  // Directory to chroot to before launch
+  rootDirectory string
+  // The plist file resource
+  file file
+  // Full parsed plist content
+  content dict
+}
+
+// Windows hotfix
+//
+// Examine a single installed Windows hotfix: its `hotfixId` (e.g., "KB5034441"),
+// hotfix `description` type, knowledge-base `caption` URL, installation
+// date, and the user who installed it. Iterated from `windows.hotfixes()`
+// to audit patch compliance.
+windows.hotfix {
+  init(hotfixId string)
+  // Hotfix ID
+  hotfixId string
+  // Type of hotfix (e.g., Update or Security Update)
+  description string
+  // Reference to knowledge base
+  caption string
+  // Date when the hotfix was installed
+  installedOn time
+  // User that installed the hotfix
+  installedBy string
+}
+
+// Windows Update Agent
+//
+// Use to examine how a Windows host receives updates and what it has applied
+// or has pending. The `config` field surfaces Windows Update Agent
+// configuration and freshness — the effective catalog source, WSUS settings,
+// the last successful detection / download / install times, and whether a
+// reboot is pending. `installed` lists the updates the agent has applied
+// (the installed-KB history), and `available` lists updates the agent has
+// found but not yet installed. Configuration is read from the registry and
+// works even on connections that cannot run commands; the installed and
+// available collections fall back to the Windows Update Agent COM API when
+// commands are available.
+windows.update {
+  // Windows Update Agent configuration and freshness
+  config() windows.update.config
+  // Updates that have been installed (Windows Update Agent history)
+  installed() []windows.update.entry
+  // Updates that are available but not yet installed
+  available() []windows.update.entry
+}
+
+// Windows update record
+//
+// Examine a single update reported by the Windows Update Agent — the `kbId`
+// (e.g., "KB5034441"), human-readable `title`, `classification` (such as
+// "Security Updates", "Critical Updates", or "Definition Updates"), the
+// support URL, and the CVEs it addresses. Installed updates carry the install
+// `date` and `operation`; available updates carry the `severity` and whether
+// they require a reboot.
+private windows.update.entry @defaults("kbId title classification") {
+  // Update identity (Windows Update Agent UpdateID GUID, or package name when read from the registry)
+  updateId string
+  // Knowledge base article ID (e.g., "KB5034441"); empty for updates without a KB
+  kbId string
+  // Human-readable update title
+  title string
+  // Update classification
+  //
+  // Microsoft's update category, such as "Security Updates", "Critical
+  // Updates", "Update Rollups", "Definition Updates", "Drivers", or
+  // "Feature Packs". Empty when the agent does not report a category.
+  classification string
+  // Microsoft severity rating for security updates (e.g., "Critical", "Important", "Moderate", "Low")
+  severity string
+  // Vendor support or knowledge base URL
+  supportUrl string
+  // CVE identifiers addressed by this update
+  cveIds []string
+  // Date the update was installed (installed updates only)
+  date time
+  // Operation that produced this history entry (e.g., "Installation", "Uninstallation")
+  operation string
+  // Whether installing the update requires a reboot
+  rebootRequired bool
+  // Update categories reported by the Windows Update Agent
+  categories []string
+}
+
+// Windows Update Agent configuration and freshness
+//
+// Examine where a Windows host gets its updates and whether the Windows
+// Update Agent is healthy. `catalogSource` summarizes the effective source
+// ("windowsUpdate", "wsus", "windowsUpdateForBusiness", "disabled", or
+// "unknown"); `wsusServerUrl` / `useWUServer` reveal WSUS configuration; the
+// `lastDetectionSuccess` / `lastDownloadSuccess` / `lastInstallSuccess` times
+// expose how recently the agent refreshed its view; and `rebootPending` flags
+// hosts waiting on a restart before update state can be trusted. Read from
+// the Windows registry, so it is available even on connections that cannot
+// run commands.
+private windows.update.config @defaults("catalogSource rebootPending") {
+  // Effective update catalog source
+  //
+  // One of "windowsUpdate" (direct Microsoft Update), "wsus" (a configured
+  // WSUS server), "windowsUpdateForBusiness", "disabled" (the agent or
+  // automatic updates are turned off), or "unknown" (the relevant registry
+  // keys could not be read).
+  catalogSource string
+  // Configured WSUS server URL (HKLM\...\WindowsUpdate\WUServer)
+  wsusServerUrl string
+  // Configured WSUS status reporting server URL (HKLM\...\WindowsUpdate\WUStatusServer)
+  wsusStatusServerUrl string
+  // Whether the host is directed to use the WSUS server (HKLM\...\AU\UseWUServer)
+  useWUServer bool
+  // Automatic update behavior
+  //
+  // The HKLM\...\AU\AUOptions value: 1=keep my computer up to date disabled,
+  // 2=notify before download, 3=auto-download and notify of install,
+  // 4=auto-download and schedule install, 5=allow local admin to choose.
+  // 0 when not configured.
+  auOptions int
+  // The Windows Update service (wuauserv)
+  service() service
+  // Time of the last successful update detection
+  lastDetectionSuccess time
+  // Last detection error code (e.g., "0x80244022"); empty when the last detection succeeded
+  lastDetectionError string
+  // Time of the last successful update download
+  lastDownloadSuccess time
+  // Time of the last successful update install
+  lastInstallSuccess time
+  // Whether a reboot is pending from a previous update
+  rebootPending bool
+  // Windows Update for Business policy state (HKLM\SOFTWARE\Microsoft\WindowsUpdate\UpdatePolicy\PolicyState)
+  policyState int
+}
+
+// Windows Server feature resource
+private windows.serverFeature @defaults("name") {
+  init(name string)
+  // Feature full path
+  path string
+  // Command IDs of role, role service, or feature
+  name string
+  // Feature name
+  displayName string
+  // Feature description
+  description string
+  // Whether the feature is installed
+  installed bool
+  // Feature installation state
+  installState int
+}
+
+// Windows optional feature resource (desktop-only)
+private windows.optionalFeature @defaults("name") {
+  init(name string)
+  // Command ID of optional feature
+  name string
+  // Feature name
+  displayName string
+  // Feature description
+  description string
+  // Whether the feature is enabled
+  enabled bool
+  // Feature installation state
+  state int
+}
+
+// Windows Event Log channel configuration
+//
+// Examine the size and retention policy of a single Windows Event Log
+// channel. The `name` field selects the channel as it appears under the
+// EventLog registry tree — for example `windows.eventlog(name: "Security")`
+// or `windows.eventlog(name: "Application")`. `maxSizeKB` reports the
+// maximum log file size in KB and `retention` decodes how the channel
+// behaves when that size is reached. Each field resolves the Group Policy
+// value first, then the effective channel configuration, and finally the
+// documented Windows default when neither is set.
+windows.eventlog @defaults("name") {
+  init(name string)
+  // Event Log channel name (for example Application, Security, Setup, or System)
+  name string
+  // Maximum log file size in KB (MaxSize)
+  maxSizeKB() int
+  // Retention behavior when the log reaches its maximum size
+  //
+  // One of "overwrite_as_needed" (Retention 0), "overwrite_by_days" (a
+  // positive retention period in seconds), or "never_overwrite" (Retention
+  // 4294967295 or -1).
+  retention() string
+  // Whether the channel overwrites events as needed when full (Retention 0)
+  overwriteAsNeeded() bool
+}
+
+// Windows Remote Desktop / Terminal Services configuration
+//
+// Examine the effective Remote Desktop (Terminal Services) policy posture:
+// whether Network Level Authentication is required, the negotiated security
+// layer and minimum client encryption level, device and resource redirection
+// toggles, credential handling, and session idle / disconnection time limits.
+// Each field resolves the Group Policy value (HKLM\SOFTWARE\Policies\Microsoft
+// \Windows NT\Terminal Services) first, then the per-listener configuration
+// (HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp),
+// and finally the documented Windows default when neither is set — so audits
+// can assert the effective state without handling missing registry values.
+windows.rdp {
+  // Whether Network Level Authentication is required (UserAuthentication)
+  networkLevelAuthentication() bool
+  // Whether the user is always prompted for a password on connection (fPromptForPassword)
+  alwaysPromptForPassword() bool
+  // Whether client drive redirection is disabled (fDisableCdm)
+  driveRedirectionDisabled() bool
+  // Whether client COM port redirection is disabled (fDisableCcm)
+  comPortRedirectionDisabled() bool
+  // Whether client LPT port redirection is disabled (fDisableLPT)
+  lptPortRedirectionDisabled() bool
+  // Whether supported Plug and Play device redirection is disabled (fDisablePNPRedir)
+  pnpDeviceRedirectionDisabled() bool
+  // Whether saving of Remote Desktop passwords is disabled (DisablePasswordSaving)
+  passwordSavingDisabled() bool
+  // Whether temporary folders are deleted when the session exits (DeleteTempDirsOnExit)
+  deleteTempDirsOnExit() bool
+  // Whether secure RPC communication is required (fEncryptRPCTraffic)
+  secureRpcRequired() bool
+  // RDP security layer (SecurityLayer)
+  //
+  // One of 0 (native RDP), 1 (Negotiate), or 2 (SSL/TLS).
+  securityLayer() int
+  // Minimum client connection encryption level (MinEncryptionLevel)
+  //
+  // One of 1 (Low), 2 (Client Compatible), 3 (High), or 4 (FIPS Compliant).
+  minEncryptionLevel() int
+  // Time limit in milliseconds for active but idle sessions, 0 for no limit (MaxIdleTime)
+  maxIdleTimeMs() int
+  // Time limit in milliseconds for disconnected sessions, 0 to never end them (MaxDisconnectionTime)
+  maxDisconnectionTimeMs() int
+}
+
+// Windows Trusted Platform Module (TPM)
+//
+// Examine the Trusted Platform Module state: whether a TPM is present,
+// ready for use, enabled, and activated, along with its major specification
+// version and manufacturer version string. Presence and a 2.0 specification
+// version are prerequisites for Windows 11 readiness and several BitLocker
+// and device-health controls. On a system without a TPM the fields resolve
+// cleanly — present is false — rather than erroring.
+windows.tpm {
+  // Whether a TPM is present on the system
+  present() bool
+  // Whether the TPM is ready for use
+  ready() bool
+  // Whether the TPM is enabled
+  enabled() bool
+  // Whether the TPM is activated
+  activated() bool
+  // Major TPM specification version, for example "2.0"
+  specVersion() string
+  // TPM manufacturer version string
+  manufacturerVersion() string
+}
+
+// Windows advanced audit policy
+//
+// Examine the effective Windows advanced audit policy: every audit
+// subcategory together with whether success and failure events are
+// audited. Subcategory names and categories are reported in English
+// regardless of the OS display language, so the same audit works
+// unchanged on localized systems. Iterate the subcategories to assert
+// audit coverage — for example
+// `windows.auditPolicy.where(category == "Account Logon").all(success)` —
+// or select a single subcategory with windows.auditPolicy.subcategory.
+windows.auditPolicy {
+  []windows.auditPolicy.subcategory
+}
+
+// Windows audit policy subcategory
+//
+// Examine the audit settings of a single advanced audit policy
+// subcategory. The `name` field selects the subcategory by its English
+// name — for example `windows.auditPolicy.subcategory(name: "Logon")` —
+// and also accepts a subcategory GUID or the localized name the system
+// reports. `success` and `failure` indicate whether the subcategory
+// audits success and failure events, derived from the reported audit
+// setting independent of the OS display language. A subcategory that is
+// not present on the system audits nothing — `success` and `failure` are
+// false and the reported fields are null — so checks against it fail
+// rather than error.
+windows.auditPolicy.subcategory @defaults("name success failure") {
+  init(name string)
+  // Subcategory name in English (e.g. `Logon`), stable across OS display languages
+  name string
+  // GUID that identifies the subcategory across Windows versions and languages
+  guid string
+  // Audit category the subcategory belongs to (e.g. `Logon/Logoff`)
+  category string
+  // Subcategory name as reported by the system in its display language
+  localizedName string
+  // Whether success events are audited
+  success bool
+  // Whether failure events are audited
+  failure bool
+  // Audit setting as reported by the system in its display language
+  //
+  // One of `Success`, `Failure`, `Success and Failure`, or `No Auditing`,
+  // localized to the OS display language.
+  inclusionSetting string
+  // Per-user audit exclusion setting as reported by the system
+  exclusionSetting string
+}
+
+// Windows Firewall (Advanced Security)
+//
+// Examine global settings, per-profile defaults, and individual firewall rules
+windows.firewall {
+  // Global firewall settings
+  settings() dict
+  // Settings that apply to the per-profile configurations of the Windows Firewall with Advanced Security
+  profiles() []windows.firewall.profile
+  // Firewall rules
+  rules() []windows.firewall.rule
+}
+
+// Windows Firewall profile entry
+//
+// Examine the per-profile firewall settings for one of the three Windows
+// Firewall profiles (Domain, Private, Public): whether the firewall is
+// enabled, default inbound and outbound actions, local rule merge policies,
+// unicast response behavior, stealth mode for IPsec, and log settings
+// including max log size, allowed/blocked packet logging, and log file name.
+windows.firewall.profile {
+  instanceID string
+  // Name of the profile
+  name string
+  // Whether the firewall is enabled on this profile
+  enabled int
+  // Default action for inbound traffic
+  defaultInboundAction int
+  // Default action for outbound traffic
+  defaultOutboundAction int
+  // Whether administrators can create firewall rules that allow unsolicited inbound traffic (if 0, such rules are ignored)
+  allowInboundRules int
+  // Whether local firewall rules should merge into the effective policy along with group policy settings
+  allowLocalFirewallRules int
+  // Whether local IPsec rules should merge into the effective policy along with rules from group policy
+  allowLocalIPsecRules int
+  // Whether to respect user allowed applications created in the legacy firewall
+  allowUserApps int
+  // Whether to respect globally opened ports created in the legacy firewall
+  allowUserPorts int
+  // Whether to allow unicast responses to multicast traffic
+  allowUnicastResponseToMulticast int
+  // Whether to notify users when an application listens on a port that is closed
+  notifyOnListen int
+  // Whether to use stealth mode for IPsec-protected traffic
+  enableStealthModeForIPsec int
+  // Maximum size the log file can reach before being rotated
+  logMaxSizeKilobytes int
+  // Whether to log allowed packets
+  logAllowed int
+  // Whether to log blocked traffic
+  logBlocked int
+  // Whether to log an event when rules are ignored
+  logIgnored int
+  // Filename in which to store the firewall log
+  logFileName string
+}
+
+// Windows Firewall rule entry
+//
+// Examine a single Windows Firewall rule: its unique `instanceID`, display
+// name, description, group, enabled state, traffic direction (inbound/
+// outbound), action (allow/block), edge traversal policy, and enforcement
+// status. Iterated from `windows.firewall.rules()` to audit which rules are
+// active and whether they match expected policy.
+windows.firewall.rule {
+  // A string that uniquely identifies this instance within the policy store
+  instanceID string
+  // Name of the rule
+  name string
+  // Localized name of this rule
+  displayName string
+  // Brief description of the rule
+  description string
+  // The group that this rule belongs to
+  displayGroup string
+  // Whether this rule is administratively enabled or disabled
+  //
+  // Values: enabled (1), disabled (2).
+  enabled int
+  // Specifies which direction of traffic to match with this rule
+  //
+  // Values: inbound (1), outbound (2).
+  direction int
+  // Specifies the action to take on traffic that matches this rule
+  action int
+  // Specifies how this firewall rule will handle edge traversal cases
+  //
+  // Values: block (0), allow (1), defer to user (2), defer to app (3).
+  edgeTraversalPolicy int
+  // Whether to group UDP packets into conversations based on the local address, local port, and remote port
+  looseSourceMapping bool
+  // Whether to group UDP packets into conversations based only on the local address and port
+  localOnlyMapping bool
+  // PrimaryStatus provides a high level status value
+  //
+  // Values: unknown (0), OK (1), degraded (2), error (3).
+  primaryStatus int
+  // Detailed status of the rule
+  status string
+  // Whether this object is retrieved from the ActiveStore
+  enforcementStatus string
+  // Contains the path to the policy store where this rule originally came from
+  policyStoreSource string
+  // Describes the type of policy store where this rule originally came from
+  policyStoreSourceType int
+}
+
+// Windows BitLocker drive encryption
+//
+// Examine encryption, lock, and protection status across BitLocker volumes
+windows.bitlocker {
+  // Windows BitLocker volumes
+  volumes() []windows.bitlocker.volume
+}
+
+// Windows BitLocker volume
+//
+// Examine a single BitLocker-managed volume: the `deviceID`, `driveLetter`,
+// `conversionStatus` (encryption/decryption progress), `encryptionMethod`
+// (algorithm and key size), `lockStatus` (0 = accessible, 1 = locked),
+// `persistentVolumeID`, `protectionStatus` (0 = off, 1 = on, 2 = unknown),
+// and BitLocker `version`. Iterated from `windows.bitlocker.volumes()`.
+windows.bitlocker.volume {
+  // Unique identifier for the volume
+  deviceID string
+  // Drive letter of the volume
+  driveLetter string
+  // Status of the encryption or decryption on the volume
+  conversionStatus dict
+  // Encryption algorithm and key size used on the volume
+  encryptionMethod dict
+  // Whether the contents of the volume are accessible from Windows
+  //
+  // 0 = Full contents of the volume are accessible
+  // 1 = All or a portion of the contents of the volume are not accessible
+  lockStatus int
+  // Persistent identifier for the volume on this system
+  persistentVolumeID string
+  // Status of the volume, whether or not BitLocker is protecting the volume
+  //
+  // 0 = Protection off
+  // 1 = Protection on
+  // 2 = Protection unknown
+  protectionStatus dict
+  // BitLocker Full Volume Encryption metadata version of the volume
+  version dict
+}
+
+// Windows registered security products
+//
+// Examine antivirus, anti-spyware, and firewall providers from Security Center
+windows.security {
+  products() []windows.security.product
+}
+
+// Private Windows security product
+private windows.security.product {
+  // Type of product
+  type string
+  // Product GUID
+  guid string
+  // Product name
+  name string
+  // Product state
+  state int
+  // Product state
+  productState string
+  // Signature state
+  signatureState string
+  // Time stamp
+  timestamp time
+}
+
+// Windows Security Center health
+//
+// Examine firewall, antivirus, anti-spyware, Auto-Update, UAC, and IE settings
+windows.security.health {
+  // Windows Firewall status and configuration
+  firewall dict
+  // Windows Update automatic update settings
+  autoUpdate dict
+  // Installed antivirus software status and details
+  antiVirus dict
+  // Anti-spyware protection status and details
+  antiSpyware dict
+  // Internet settings information
+  internetSettings dict
+  // User Account Control (UAC) configuration
+  uac dict
+  // Windows Security Center service status
+  securityCenterService dict
+}
+
+// Cloud-asset metadata
+//
+// Examine the cloud provider and exposed instance metadata
+cloud @defaults("provider") {
+  // Cloud provider (e.g. aws, azure, gcp)
+  provider() string
+  // Cloud instance metadata
+  instance() cloudInstance
+}
+
+// Cloud instance metadata
+private cloudInstance @defaults("publicHostname privateHostname") {
+  // Cloud instance public hostname
+  publicHostname() string
+  // List of public IPv4 addresses
+  publicIpv4() []ipAddress
+  // Cloud instance private hostname
+  privateHostname() string
+  // List of private IPv4 addresses
+  privateIpv4() []ipAddress
+  // Raw access to the cloud instance metadata
+  metadata() dict
+}
+
+// IP address (v4 or v6) with networking details
+//
+// Examine the address itself plus subnet, CIDR, broadcast, and gateway
+ipAddress @defaults("ip") {
+  // Unique number that identifies a device on a network (e.g. 172.31.24.71 or 2001:0:2851:782c:869:1f7d:a331:f3e1)
+  ip ip
+  // Logical subdivision of a network (e.g. 172.31.16.0/20 or 2001:db8::/64)
+  subnet ip
+  // Classless Inter-Domain Routing notation (e.g. 172.31.24.71/20 or 2001:0:2851:782c:869:1f7d:a331:f3e1/64)
+  cidr ip
+  // Network address used to transmit to all devices connected to a network
+  broadcast ip
+  // IP address that acts as the entry point to another, or external, network
+  gateway ip
+}
+
+// Network configuration of this system
+//
+// Examine interfaces, routes, and detected IPv4 / IPv6 addresses
+network {
+  // Network interfaces
+  interfaces() []networkInterface
+
+  // Routes
+  routes() networkRoutes
+
+  // All IPv4 addresses detected on host interfaces
+  ipv4() []ip
+
+  // All IPv6 addresses detected on host interfaces
+  ipv6() []ip
+
+  // Primary IPv4 address determined by the default route
+  primaryIPv4() ip
+
+  // Primary IPv6 address determined by the default route
+  primaryIPv6() ip
+}
+
+// Detailed information of a network interface
+private networkInterface @defaults("name mac active") {
+  // Name of the network interface
+  name string
+  // Unique 12-digit hexadecimal identifier assigned by the manufacturer
+  mac string
+  // Company that manufactures the network interface
+  vendor string
+  // List of IP addresses assigned to the network interface (v4 and v6)
+  ips []ipAddress
+  // Maximum transmission unit
+  mtu int
+  // Information about an interface's status and capabilities
+  flags []string
+  // Status of the network interface
+  active bool
+  // Whether a network interface is virtual of not
+  virtual bool
+}
+
+// Collection of routing table entries on the system.
+private networkRoutes {
+  []networkRoute
+  // Default routes found on the machine
+  defaults() []networkRoute
+}
+
+// Network route information
+private networkRoute @defaults("destination flags"){
+  // Destination network or destination subnet for this route
+  destination string
+  // Gateway IP address for this route
+  gateway string
+  // Flags that describe route properties (e.g., 'UG' for up/gateway)
+  flags []string
+  // Network interface this route applies to
+  iface() networkInterface
+}
+
+// Chromium-family browsers (Chrome, Brave, Edge variants)
+//
+// Examine installed extensions and their content scripts across users and profiles
+chrome {
+  // All installed Chrome extensions across all profiles and users
+  extensions() []chrome.extension
+  // All content scripts from all Chrome extensions across all profiles and users
+  extensionContentScripts() []chrome.extensionContentScript
+}
+
+// Chrome browser extension
+private chrome.extension @defaults("name version identifier browser") {
+  // Unique extension identifier (32-character string)
+  identifier string
+  // Extension name from manifest
+  name string
+  // Extension version from manifest
+  version string
+  // Extension description from manifest
+  description string
+  // Chrome extension manifest version (2 or 3)
+  manifestVersion int
+  // Permissions requested by the extension (includes host_permissions for Manifest V3)
+  permissions []string
+  // Optional permissions that may be granted at runtime
+  optionalPermissions []string
+  // Path to the extension directory
+  path string
+  // Chrome profile name where extension is installed
+  profile string
+  // Full path to the Chrome profile directory
+  profilePath string
+  // Browser name (e.g., "Google Chrome", "Chromium", "Google Chrome Beta")
+  browser string
+  // Extension author from manifest
+  author string
+  // URL used to check for extension updates
+  updateUrl string
+  // SHA-256 hash of the on-disk manifest.json file
+  manifestHash string
+  // Whether the extension was installed from the Chrome Web Store
+  fromWebstore bool
+  // Extension state (e.g., "enabled", "disabled")
+  state string
+  // Whether the extension is currently enabled
+  enabled bool
+  // Whether the extension runs persistently in the background (Manifest V2 only; V3 is always false)
+  persistent bool
+  // Extension install time
+  installTime time
+  // Default locale for internationalization
+  defaultLocale string
+  // Whether the extension directory exists on disk (referenced in Preferences)
+  referenced bool
+  // UID of the user who owns this extension
+  uid int
+  // Content scripts declared by this extension
+  contentScripts []chrome.extensionContentScript
+}
+
+// Chrome extension content script
+private chrome.extensionContentScript @defaults("script match") {
+  // Parent extension identifier
+  identifier string
+  // Parent extension version
+  version string
+  // Browser name (e.g., "Google Chrome", "Brave")
+  browserType string
+  // UID of the owning user
+  uid int
+  // JavaScript content script filename
+  script string
+  // URL match pattern where the script executes
+  match string
+  // Full path to the Chrome profile directory
+  profilePath string
+  // Path to the extension directory
+  path string
+}
+
+// Firefox-family browsers
+//
+// Examine installed addons across all users and profiles
+firefox {
+  // All installed Firefox addons across all profiles and users
+  addons() []firefox.addon
+}
+
+// Firefox browser addon
+private firefox.addon @defaults("name version active browser") {
+  // Unique addon identifier (e.g., "{uuid}" or "addon@example.com")
+  identifier string
+  // Addon name
+  name string
+  // Addon version
+  version string
+  // Addon description
+  description string
+  // Addon type (extension, theme, locale, dictionary, etc.)
+  type string
+  // Whether the addon is currently active
+  active bool
+  // Whether the addon is disabled by user
+  userDisabled bool
+  // Whether the addon is disabled (user or app disabled)
+  disabled bool
+  // Whether the addon is visible in the addon manager
+  visible bool
+  // Path to the addon (can be XPI file or directory)
+  path string
+  // Firefox profile where addon is installed
+  profile string
+  // Browser name (e.g., "Firefox", "Firefox Developer Edition", "LibreWolf")
+  browser string
+  // Addon creator/author name
+  creator string
+  // Source URI from where addon was installed
+  sourceUri string
+  // Install date as Unix timestamp (milliseconds)
+  installDate int
+  // Last update date as Unix timestamp (milliseconds)
+  updateDate int
+  // Whether auto-updates are enabled for this addon (true when set to "on" or "use global default")
+  autoupdate bool
+  // Whether this is a native WebExtension (no special loader)
+  native bool
+  // Install location (e.g., "app-profile", "app-system-defaults", "app-builtin")
+  location string
+  // Combined API permissions and host origins
+  permissions []string
+  // UID of the user who owns this addon
+  uid int
+}
+
+// USB device inventory (experimental)
+//
+// Examine attached USB devices with vendor, product, class, and serial
+usb @maturity("experimental") {
+  // List of USB devices
+  devices() []usb.device
+}
+
+// Experimental: USB device
+private usb.device @defaults("manufacturer name") @maturity("experimental") {
+  // USB device vendor id
+  vendorId string
+  // USB manufacturer
+  manufacturer string
+  // USB device product id
+  productId string
+  // USB device serial number
+  serial string
+  // USB device name
+  name string
+  // USB device version
+  version string
+  // USB speed
+  speed string
+  // USB device class
+  class string
+  // USB device class name
+  className string
+  // USB device subclass
+  subclass string
+  // USB protocol code within the device class
+  protocol string
+  // Removable device
+  isRemovable bool
+}
+
+// Crontab schedule on the system
+//
+// Examine cron entries from system, user, and /etc/cron.* sources
+crontab {
+  // All cron entries from system and user crontabs
+  entries() []crontab.entry
+  // Files that contain crontab entries
+  files() []file
+}
+
+// Individual crontab entry
+private crontab.entry @defaults("user command") {
+  // Line number in the source file
+  lineNumber int
+  // Minute field (0-59, *, or cron expression)
+  minute string
+  // Hour field (0-23, *, or cron expression)
+  hour string
+  // Day of month field (1-31, *, or cron expression)
+  dayOfMonth string
+  // Month field (1-12, *, or cron expression)
+  month string
+  // Day of week field (0-7, *, or cron expression)
+  dayOfWeek string
+  // User that runs the command
+  user string
+  // Command to execute
+  command string
+  // File containing this entry
+  file file
+}
+
+// Visual Studio Code (and forks)
+//
+// Examine installed extensions across VS Code, Cursor, Windsurf, and similar editors
+vscode {
+  // All installed VS Code extensions across all users
+  extensions() []vscode.extension
+  // Paths searched for VS Code extensions
+  paths() []string
+}
+
+// Visual Studio Code extension
+private vscode.extension @defaults("editor name version") {
+  // Unique extension identifier (publisher.name format)
+  identifier string
+  // Extension name from package.json
+  name string
+  // Extension display name from package.json
+  displayName string
+  // Extension version from package.json
+  version string
+  // Extension description from package.json
+  description string
+  // Extension publisher from package.json
+  publisher string
+  // Editor application (e.g., Visual Studio Code, Cursor, Windsurf)
+  editor string
+  // Path to the extension directory
+  path string
+  // VS Code engine version compatibility
+  vscodeVersion string
+  // Extension categories
+  categories []string
+}
+
+// logrotate configuration
+//
+// Examine global directives and per-log rotation entries across logrotate.d
+logrotate {
+  // List of configuration files (main + logrotate.d fragments)
+  files() []file
+  // Global directives (outside any file block)
+  globalConfig(files) map[string]string
+  // Per-file/glob rotation entries
+  entries(files) []logrotate.entry
+}
+
+// Logrotate configuration entry for a specific log path
+private logrotate.entry @defaults("path") {
+  // Configuration file where this entry is defined
+  file file
+  // Line number in the configuration file
+  lineNumber int
+  // Log file path or glob pattern
+  path string
+  // All directives in this block as key-value pairs
+  config map[string]string
+}
+
+// Linux Logical Volume Manager
+//
+// Examine LVM block-device storage on Linux: physical volumes initialized
+// for LVM, volume groups that aggregate them, and the logical volumes
+// carved out of those groups. Iterate `physicalVolumes`, `volumeGroups`,
+// and `logicalVolumes` to audit LVM layout, free capacity, thin-pool
+// usage, and snapshot relationships.
+lvm @defaults("volumeGroups") {
+  // Physical volumes initialized for LVM
+  physicalVolumes() []lvm.physicalVolume
+  // Volume groups
+  volumeGroups() []lvm.volumeGroup
+  // Logical volumes across all volume groups
+  logicalVolumes() []lvm.logicalVolume
+}
+
+// LVM physical volume
+//
+// Examine a single block device initialized as an LVM physical volume:
+// device path (`name`), `uuid`, the volume group it belongs to
+// (`volumeGroupName`, empty if unassigned), on-disk `format`, attribute
+// flags, and total/free byte counts. Iterated from `lvm.physicalVolumes`.
+private lvm.physicalVolume @defaults("name volumeGroupName sizeBytes") {
+  // Physical volume device path (e.g., /dev/sda1)
+  name string
+  // UUID of the physical volume
+  uuid string
+  // Name of the volume group this PV belongs to (empty if unassigned)
+  volumeGroupName string
+  // PV on-disk format (typically "lvm2")
+  format string
+  // PV attribute flags
+  //
+  // Three-character status string. Common values include `a` (allocatable),
+  // `x` (exported), and `m` (missing). See lvm(8) `pv_attr` for the full set.
+  attributes string
+  // Total size in bytes
+  sizeBytes int
+  // Free space in bytes
+  freeBytes int
+}
+
+// LVM volume group
+//
+// Examine a single LVM volume group: `name`, `uuid`, attribute flags,
+// total and free byte counts, and the counts of physical volumes,
+// logical volumes, and snapshots it contains. Iterated from
+// `lvm.volumeGroups` to audit capacity and group-level policy.
+private lvm.volumeGroup @defaults("name sizeBytes freeBytes") {
+  // Volume group name
+  name string
+  // UUID of the volume group
+  uuid string
+  // VG attribute flags
+  //
+  // Six-character status string covering permissions, resizability,
+  // export state, partial state, allocation policy, and clustering.
+  // See lvm(8) `vg_attr` for the full set.
+  attributes string
+  // Total size in bytes
+  sizeBytes int
+  // Free space in bytes
+  freeBytes int
+  // Number of physical volumes in this group
+  physicalVolumeCount int
+  // Number of logical volumes in this group
+  logicalVolumeCount int
+  // Number of snapshots in this group
+  snapshotCount int
+}
+
+// LVM logical volume
+//
+// Examine a single LVM logical volume: `name`, full device `path`,
+// `uuid`, parent volume group (`volumeGroupName`), attribute flags,
+// size in bytes, snapshot `origin`, and thin-pool data usage. For
+// thin volumes, `poolName` is set; for snapshots, `origin` is the
+// source LV name. Iterated from `lvm.logicalVolumes`.
+private lvm.logicalVolume @defaults("name volumeGroupName sizeBytes") {
+  // Logical volume name
+  name string
+  // Full device path (e.g., /dev/vg0/data)
+  path string
+  // UUID of the logical volume
+  uuid string
+  // Name of the volume group this LV belongs to
+  volumeGroupName string
+  // LV attribute flags
+  //
+  // Ten-character status string covering volume type, permissions,
+  // allocation policy, fixed minor, state, open device, target type,
+  // zeroing, and skipped activation. See lvm(8) `lv_attr` for the full set.
+  attributes string
+  // Size in bytes
+  sizeBytes int
+  // Origin LV name for snapshots, empty if not a snapshot
+  origin string
+  // Data percentage used (for thin pools, thin volumes, snapshots, mirrors); null if not applicable
+  dataPercent() float
+  // Pool name for thin volumes, empty if not a thin volume
+  poolName string
+}
+
+// Linux software RAID arrays (mdadm)
+//
+// Examine arrays with their RAID level, state, member devices, and resync progress
+mdadm @defaults("arrays") {
+  // List of all discovered RAID arrays
+  arrays() []mdadm.array
+}
+
+// Linux software RAID array
+private mdadm.array @defaults("name level state") {
+  // Device name (e.g., /dev/md0)
+  name string
+  // RAID level (e.g., raid0, raid1, raid5, raid6, raid10, linear)
+  level string
+  // Array state (e.g., clean, active, degraded, inactive)
+  state string
+  // Number of active devices in the array
+  activeDevices int
+  // Number of working devices in the array
+  workingDevices int
+  // Number of failed devices in the array
+  failedDevices int
+  // Number of spare devices in the array
+  spareDevices int
+  // Total size of the array in KiB
+  size int
+  // UUID of the array
+  uuid string
+  // Rebuild/resync progress percentage (0-100, -1 if not rebuilding)
+  resyncProgress float
+  // Member devices in the array
+  devices() []mdadm.device
+}
+
+// Member device in a software RAID array
+private mdadm.device @defaults("name state") {
+  // Device path (e.g., /dev/sda1)
+  name string
+  // Role number in the array
+  role int
+  // Device state (e.g., active sync, spare, faulty)
+  state string
+}
+
+// ZFS storage pools and datasets
+//
+// Examine pool health and capacity, vdev topology, and dataset properties
+zfs @defaults("pools") {
+  // ZFS version string
+  version() string
+  // ZFS storage pools
+  pools() []zfs.pool
+  // All ZFS datasets (filesystems, volumes, snapshots, bookmarks)
+  datasets() []zfs.dataset
+}
+
+// ZFS storage pool
+//
+// Examine a single ZFS storage pool: `name`, `guid`, health status,
+// total/allocated/free bytes, fragmentation percentage, space utilization,
+// deduplication ratio, read-only flag, auto-expand/replace/trim settings,
+// the top-level `vdevs()` topology, and the full `properties()` map.
+// Initialize by name (e.g., `zfs.pool(name: "tank")`) or iterate from
+// `zfs.pools()`.
+zfs.pool @defaults("name health sizeBytes") {
+  init(name string)
+  // Pool name
+  name string
+  // Pool GUID
+  guid string
+  // Health status (ONLINE, DEGRADED, FAULTED, OFFLINE, REMOVED, UNAVAIL)
+  health string
+  // Total size in bytes
+  sizeBytes int
+  // Allocated space in bytes
+  allocatedBytes int
+  // Free space in bytes
+  freeBytes int
+  // Fragmentation percentage
+  fragmentation int
+  // Percentage of pool space used (0-100)
+  percentUsed int
+  // Deduplication ratio
+  dedupratio float
+  // Whether the pool is read-only
+  readonly bool
+  // Whether auto-expand is enabled
+  autoexpand bool
+  // Whether auto-replace is enabled
+  autoreplace bool
+  // Whether auto-trim is enabled
+  autotrim bool
+  // Top-level virtual device groups (mirrors, raidz, etc.)
+  vdevs() []zfs.pool.vdev
+  // All pool properties (lazy-loaded via zpool get all)
+  properties() map[string]string
+}
+
+// ZFS virtual device (vdev) in a pool's topology
+//
+// Examine a single vdev within a pool: its `name` (e.g., "raidz2-0",
+// "mirror-0"), `type`, `state`, device `path` (for leaf vdevs),
+// read/write/checksum error counts, slow I/O count, number of child
+// devices, and the nested `devices` list. Iterated from
+// `zfs.pool.vdevs()`.
+zfs.pool.vdev @defaults("name type state numDevices") {
+  // Vdev name (e.g., "raidz2-0", "mirror-0", "sda")
+  name string
+  // Vdev type (mirror, raidz, raidz2, raidz3, disk, file, draid, etc.)
+  type string
+  // Vdev state (ONLINE, DEGRADED, FAULTED, OFFLINE, REMOVED, UNAVAIL)
+  state string
+  // Device path (for leaf vdevs, empty for groups)
+  path string
+  // Read error count
+  readErrors int
+  // Write error count
+  writeErrors int
+  // Checksum error count
+  checksumErrors int
+  // Slow I/O count
+  slowIos int
+  // Number of child devices
+  numDevices int
+  // Child vdevs/devices
+  devices []zfs.pool.vdev
+}
+
+// ZFS dataset (filesystem, volume, snapshot, or bookmark)
+//
+// Examine a single ZFS dataset: full `name`, `type` (filesystem, volume,
+// snapshot, bookmark), used/available/referenced bytes, `mountpoint`,
+// compression algorithm and ratio, `mounted` flag, record size, quota,
+// reservation, `origin` snapshot for clones, creation time, encryption
+// algorithm, full `properties()` map, and `snapshots()` list. Initialize
+// by name or iterate from `zfs.datasets()`.
+zfs.dataset @defaults("name type usedBytes") {
+  init(name string)
+  // Full dataset name (pool/path or pool/path@snap)
+  name string
+  // Dataset type (filesystem, volume, snapshot, bookmark)
+  type string
+  // Used space in bytes
+  usedBytes int
+  // Available space in bytes
+  availableBytes int
+  // Referenced space in bytes
+  referencedBytes int
+  // Mount point (empty for volumes/snapshots)
+  mountpoint string
+  // Compression algorithm (off, lz4, gzip, zstd, etc.)
+  compression string
+  // Compression ratio
+  compressratio float
+  // Whether the dataset is currently mounted
+  mounted bool
+  // Record size in bytes
+  recordsizeBytes int
+  // Quota in bytes (0 = none)
+  quotaBytes int
+  // Reservation in bytes (0 = none)
+  reservationBytes int
+  // Origin snapshot (for clones, empty otherwise)
+  origin string
+  // Creation time
+  creation time
+  // Encryption algorithm (off, aes-256-gcm, etc.)
+  encryption string
+  // All dataset properties (lazy-loaded via zfs get all)
+  properties() map[string]string
+  // Snapshots of this dataset
+  snapshots() []zfs.dataset
+}
+
+// AI Model Cache
+//
+// Examine locally cached AI models from tools such as Ollama, Hugging Face
+// Hub, LM Studio, GPT4All, PyTorch Hub, Keras, TensorFlow Hub, and Jan.
+// Iterate over all discovered models to audit what AI models are present
+// on the system, their sizes, formats, and sources.
+ai @maturity("preview") {
+  // All locally cached AI models across all supported sources
+  models() []ai.model
+}
+
+// AI Model
+//
+// Examine a single locally cached AI model. The `name` field identifies
+// the model and `source` indicates which tool cached it — for example
+// `"ollama"`, `"huggingface"`, `"lmstudio"`, `"gpt4all"`, `"pytorch"`,
+// `"keras"`, `"tfhub"`, or `"jan"`. Use `ai.models.where(source == "ollama")` to filter by
+// source, or inspect `size` and `modifiedAt` to find the largest or most
+// recently used models on the system.
+private ai.model @defaults("name source") @maturity("preview") {
+  // Model name (e.g., "llama3:latest", "meta-llama/Llama-2-7b-hf")
+  name string
+  // Source tool that cached this model (ollama, huggingface, lmstudio, gpt4all, pytorch, keras, tfhub, jan)
+  source string
+  // Publisher or organization that released the model (e.g., "meta-llama", "google", "mistralai")
+  vendor string
+  // Base architecture family (e.g., "llama", "qwen2", "bert", "mixtral")
+  family string
+  // Filesystem path to the model
+  path string
+  // Total size in bytes
+  size int
+  // Last modification time
+  modifiedAt time
+  // Model file format (gguf, safetensors, pytorch, h5, savedmodel, mlx, onnx, keras)
+  format string
+  // Model version identifier (e.g., Ollama tag name, HuggingFace revision hash)
+  version string
+  // Quantization method or level
+  //
+  // For example Q4_K_M, Q8_0, F16, gptq, or awq.
+  quantization string
+  // Human-readable parameter count
+  //
+  // For example 7B, 13B, or 70B.
+  parameterSize string
+  // Model architecture
+  //
+  // For example LlamaForCausalLM, MistralForCausalLM, or llama.
+  architecture string
+  // License identifier if available (e.g., "apache-2.0", "llama3", "MIT")
+  license string
+  // Tags associated with the model
+  tags []string
+  // Short description of the model
+  description string
+}
+
+// Claude Code (Anthropic CLI agent) instance
+//
+// Examine account, plugins, skills, projects, and configured MCP servers
+// URL: https://claude.ai/code
+claude.code @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Claude Code configuration directory
+  configPath string
+  // Account email
+  email() string
+  // Organization name
+  organization() string
+  // Account role within the organization
+  role() string
+  // Subscription type
+  subscription() string
+  // User ID
+  userId() string
+  // Organization ID
+  organizationId() string
+  // Settings dictionary
+  settings() dict
+  // List of enabled plugin names
+  enabledPlugins() []string
+  // Installed plugins
+  plugins() []claude.code.plugin
+  // Configured skills
+  skills() []claude.code.skill
+  // Projects Claude Code has access to
+  projects() []claude.code.project
+  // MCP servers
+  mcpServers() []claude.code.mcpServer
+}
+
+// Claude Code installed plugin
+private claude.code.plugin @defaults("name") @maturity("preview") {
+  // Plugin name (e.g. "gopls-lsp@claude-plugins-official")
+  name string
+  // Plugin version
+  version string
+  // Installation scope (user or project)
+  scope string
+  // Local install path
+  installPath string
+  // Installation timestamp
+  installedAt string
+  // Last updated timestamp
+  lastUpdated string
+  // Git commit SHA of the installed version
+  gitCommitSha string
+  // Whether the plugin is currently enabled
+  enabled bool
+}
+
+// Claude Code skill
+private claude.code.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Claude Code project
+private claude.code.project @defaults("path") @maturity("preview") {
+  // Original filesystem path the project maps to
+  path string
+  // Whether the project has persistent memory configured
+  hasMemory bool
+}
+
+// Claude Code MCP server
+private claude.code.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Whether the server needs authentication
+  needsAuth bool
+  // Timestamp of last authentication check
+  lastChecked string
+}
+
+// OpenAI Codex CLI instance
+//
+// Examine auth mode, plugins, skills, MCP servers, and OAuth connectors
+// URL: https://openai.com/index/introducing-codex/
+openai.codex @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Codex configuration directory
+  configPath string
+  // Authentication mode (e.g. "chatgpt")
+  authMode() string
+  // Account ID
+  accountId() string
+  // Installed version
+  version() string
+  // Last refresh timestamp
+  lastRefresh() string
+  // Installed plugins
+  plugins() []openai.codex.plugin
+  // System and plugin skills
+  skills() []openai.codex.skill
+  // MCP servers configured across plugins
+  mcpServers() []openai.codex.mcpServer
+  // OAuth app connectors
+  connectors() []openai.codex.connector
+}
+
+// OpenAI Codex installed plugin
+private openai.codex.plugin @defaults("name") @maturity("preview") {
+  // Plugin name
+  name string
+  // Plugin version
+  version string
+  // Plugin description
+  description string
+  // Plugin author name
+  author string
+  // Plugin category (e.g. "Coding", "Productivity", "Design")
+  category string
+  // Plugin capabilities (e.g. "Read", "Write", "Interactive")
+  capabilities []string
+  // Plugin skill names
+  skillNames []string
+  // Whether the plugin has MCP servers configured
+  hasMcp bool
+  // Whether the plugin has hooks configured
+  hasHooks bool
+}
+
+// OpenAI Codex skill
+private openai.codex.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Source path of the skill definition
+  source string
+  // Plugin that provides this skill (empty for system skills)
+  plugin string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// OpenAI Codex MCP server
+private openai.codex.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Server type (e.g. "http")
+  type string
+  // Server URL
+  url string
+  // Optional note describing the server
+  note string
+  // Plugin that provides this MCP server
+  plugin string
+}
+
+// OpenAI Codex OAuth app connector
+private openai.codex.connector @defaults("name") @maturity("preview") {
+  // Connector name (matches plugin name)
+  name string
+  // Connector ID (e.g. "connector_..." or "asdk_app_...")
+  id string
+  // Plugin that provides this connector
+  plugin string
+}
+
+// Cursor editor (AI-powered) instance
+//
+// Examine MCP servers, global and project rules, and installed skills
+// URL: https://www.cursor.com/
+cursor @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Cursor configuration directory
+  configPath string
+  // MCP servers
+  mcpServers() []cursor.mcpServer
+  // Cursor rules (global and project-scoped)
+  rules() []cursor.rule
+  // Installed skills
+  skills() []cursor.skill
+}
+
+// Cursor MCP server configuration
+private cursor.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Server command (for stdio type)
+  command string
+  // Server URL (for sse/streamable-http type)
+  url string
+  // Server arguments
+  args []string
+  // Whether environment variables are configured
+  hasEnv bool
+}
+
+// Cursor rule file
+private cursor.rule @defaults("name") @maturity("preview") {
+  // Rule name (derived from filename)
+  name string
+  // Full content of the rule file
+  content string
+  // Source path of the rule file
+  source string
+}
+
+// Cursor skill
+private cursor.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// GitHub Copilot CLI instance
+//
+// Examine authenticated accounts, MCP servers, and installed skills
+// URL: https://github.com/features/copilot
+github.copilot @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the GitHub Copilot configuration directory
+  configPath string
+  // Authenticated GitHub accounts
+  accounts() []github.copilot.account
+  // MCP servers
+  mcpServers() []github.copilot.mcpServer
+  // Installed skills
+  skills() []github.copilot.skill
+}
+
+// GitHub Copilot authenticated account
+private github.copilot.account @defaults("user") @maturity("preview") {
+  // GitHub username
+  user string
+  // GitHub App ID
+  githubAppId string
+}
+
+// GitHub Copilot MCP server configuration
+private github.copilot.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Server type (e.g. "stdio")
+  type string
+  // Server command
+  command string
+  // Server arguments
+  args []string
+}
+
+// GitHub Copilot skill
+private github.copilot.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Goose AI agent (Block) instance
+//
+// Examine the active provider/model, telemetry, extensions, and skills
+// URL: https://block.github.io/goose/
+goose @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Goose configuration directory
+  configPath string
+  // Active AI provider name
+  provider() string
+  // Active model name
+  model() string
+  // Whether telemetry is enabled
+  telemetryEnabled() bool
+  // Configured extensions
+  extensions() []goose.extension
+  // Installed skills
+  skills() []goose.skill
+}
+
+// Goose extension
+private goose.extension @defaults("name") @maturity("preview") {
+  // Extension name
+  name string
+  // Whether the extension is enabled
+  enabled bool
+  // Extension type (platform or builtin)
+  type string
+  // Extension description
+  description string
+  // Whether the extension is bundled with Goose
+  bundled bool
+  // Extension timeout in seconds (0 = no timeout)
+  timeout int
+}
+
+// Goose skill
+private goose.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Gemini CLI (Google) instance
+//
+// Examine auth type, settings, MCP servers, and installed skills
+// URL: https://github.com/google-gemini/gemini-cli
+gemini @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Gemini configuration directory
+  configPath string
+  // Authentication type
+  authType() string
+  // Settings dictionary
+  settings() dict
+  // MCP servers
+  mcpServers() []gemini.mcpServer
+  // Installed skills
+  skills() []gemini.skill
+}
+
+// Gemini MCP server configuration
+private gemini.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Server command
+  command string
+  // Server arguments
+  args []string
+  // Whether environment variables are configured
+  hasEnv bool
+}
+
+// Gemini skill
+private gemini.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Windsurf editor (Codeium) instance
+//
+// Examine global rules / memories, MCP servers, and installed skills
+// URL: https://windsurf.com/
+windsurf @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Windsurf configuration directory
+  configPath string
+  // Global rules / memories
+  rules() []windsurf.rule
+  // MCP servers
+  mcpServers() []windsurf.mcpServer
+  // Installed skills
+  skills() []windsurf.skill
+}
+
+// Windsurf rule / memory file
+private windsurf.rule @defaults("name") @maturity("preview") {
+  // Rule name (derived from filename)
+  name string
+  // Full content of the rule file
+  content string
+  // Source path of the rule file
+  source string
+}
+
+// Windsurf MCP server configuration
+private windsurf.mcpServer @defaults("name") @maturity("preview") {
+  // Server name
+  name string
+  // Server command
+  command string
+  // Server arguments
+  args []string
+  // Whether environment variables are configured
+  hasEnv bool
+}
+
+// Windsurf skill
+private windsurf.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Zed editor instance
+//
+// Examine workspace settings and installed extensions
+// URL: https://zed.dev/
+zed @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Zed configuration directory
+  configPath string
+  // Settings dictionary
+  settings() dict
+  // Extension names installed
+  extensions() []string
+}
+
+// Roo Code editor instance
+//
+// Examine installed skills
+// URL: https://roocode.com/
+roo @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Roo Code configuration directory
+  configPath string
+  // Installed skills
+  skills() []roo.skill
+}
+
+// Roo Code skill
+private roo.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Cline AI agent instance
+//
+// Examine installed skills
+// URL: https://cline.bot/
+cline @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Cline configuration directory
+  configPath string
+  // Installed skills
+  skills() []cline.skill
+}
+
+// Cline skill
+private cline.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Kiro CLI (AWS) instance
+//
+// Examine installed skills
+// URL: https://kiro.dev/
+kiro @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Kiro configuration directory
+  configPath string
+  // Installed skills
+  skills() []kiro.skill
+}
+
+// Kiro skill
+private kiro.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Continue (open-source AI coding assistant) instance
+//
+// Examine installed skills
+// URL: https://continue.dev/
+continuedev @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Continue configuration directory
+  configPath string
+  // Installed skills
+  skills() []continuedev.skill
+}
+
+// Continue skill
+private continuedev.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Trae AI assistant (ByteDance) instance
+//
+// Examine installed skills
+// URL: https://trae.ai/
+trae @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Trae configuration directory
+  configPath string
+  // Installed skills
+  skills() []trae.skill
+}
+
+// Trae skill
+private trae.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// OpenCode AI coding assistant instance
+//
+// Examine installed skills
+// URL: https://opencode.ai/
+opencode @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the OpenCode configuration directory
+  configPath string
+  // Installed skills
+  skills() []opencode.skill
+}
+
+// OpenCode skill
+private opencode.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Pi AI agent instance
+//
+// Examine installed skills
+// URL: https://pi.dev/
+pi @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Pi configuration directory
+  configPath string
+  // Installed skills
+  skills() []pi.skill
+}
+
+// Pi skill
+private pi.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Mistral Vibe (Mistral AI) instance
+//
+// Examine installed skills
+// URL: https://docs.mistral.ai/tools/vibe/
+mistral.vibe @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Mistral Vibe configuration directory
+  configPath string
+  // Installed skills
+  skills() []mistral.vibe.skill
+}
+
+// Mistral Vibe skill
+private mistral.vibe.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Antigravity (Google) instance
+//
+// Examine installed skills
+// URL: https://antigravity.google/
+antigravity @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Antigravity configuration directory
+  configPath string
+  // Installed skills
+  skills() []antigravity.skill
+}
+
+// Antigravity skill
+private antigravity.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// IBM Bob instance
+//
+// Examine installed skills
+// URL: https://www.ibm.com/products/bob
+ibm.bob @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Bob configuration directory
+  configPath string
+  // Installed skills
+  skills() []ibm.bob.skill
+}
+
+// IBM Bob skill
+private ibm.bob.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// OpenClaw AI agent instance
+//
+// Examine installed skills
+// URL: https://openclaw.ai/
+openclaw @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the OpenClaw configuration directory
+  configPath string
+  // Installed skills
+  skills() []openclaw.skill
+}
+
+// OpenClaw skill
+private openclaw.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Snowflake Cortex Code instance
+//
+// Examine installed skills
+// URL: https://www.snowflake.com/en/product/features/cortex-code/
+snowflake.cortex @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Cortex configuration directory
+  configPath string
+  // Installed skills
+  skills() []snowflake.cortex.skill
+}
+
+// Snowflake Cortex Code skill
+private snowflake.cortex.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Junie (JetBrains AI agent) instance
+//
+// Examine installed skills
+// URL: https://www.jetbrains.com/junie/
+junie @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Junie configuration directory
+  configPath string
+  // Installed skills
+  skills() []junie.skill
+}
+
+// Junie skill
+private junie.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Augment Code instance
+//
+// Examine installed skills
+// URL: https://www.augmentcode.com/
+augment @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Augment configuration directory
+  configPath string
+  // Installed skills
+  skills() []augment.skill
+}
+
+// Augment skill
+private augment.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Warp AI terminal instance
+//
+// Examine installed skills
+// URL: https://www.warp.dev/
+warp @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Warp configuration directory
+  configPath string
+  // Installed skills
+  skills() []warp.skill
+}
+
+// Warp skill
+private warp.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Kilo Code AI agent instance
+//
+// Examine installed skills
+// URL: https://kilocode.ai/
+kilocode @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Kilo Code configuration directory
+  configPath string
+  // Installed skills
+  skills() []kilocode.skill
+}
+
+// Kilo Code skill
+private kilocode.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// OpenHands AI agent instance (formerly OpenDevin)
+//
+// Examine installed skills
+// URL: https://www.all-hands.dev/
+openhands @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the OpenHands configuration directory
+  configPath string
+  // Installed skills
+  skills() []openhands.skill
+}
+
+// OpenHands skill
+private openhands.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}
+
+// Qwen Code (Alibaba) instance
+//
+// Examine installed skills
+// URL: https://qwen.ai/qwencode
+qwen.code @defaults("configPath") @maturity("preview") {
+  init(configPath? string)
+  // Path to the Qwen Code configuration directory
+  configPath string
+  // Installed skills
+  skills() []qwen.code.skill
+}
+
+// Qwen Code skill
+private qwen.code.skill @defaults("name") @maturity("preview") {
+  // Skill name
+  name string
+  // Skill description
+  description string
+  // Tools the skill is allowed to use
+  allowedTools []string
+  // Hint for expected arguments
+  argumentHint string
+  // Source path of the skill definition
+  source string
+  // Full content of the skill definition
+  content string
+  // SHA-256 hash of the skill content
+  sha256() string
+}

--- a/content/validation/scans/bundles_test.go
+++ b/content/validation/scans/bundles_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/scan"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 )
 
 // bundleFixtures holds one sample project per expected whole-bundle score: a
@@ -103,6 +104,99 @@ func runBundle(policyBundlePath string, policyMrn string, asset *inventory.Asset
 	}
 
 	return nil, errors.New("no report found")
+}
+
+func TestRuntimeImageCacheContent(t *testing.T) {
+	runtime := runtimeImageCacheRuntime(t)
+	loader := policy.DefaultBundleLoader()
+
+	t.Run("policy compiles runtime cache controls", func(t *testing.T) {
+		bundle, err := loader.BundleFromPaths("./mondoo-kubernetes-runtime-image-cache.mql.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, bundle)
+		require.Len(t, bundle.Policies, 1)
+		require.Len(t, bundle.Queries, 5)
+
+		p := bundle.Policies[0]
+		assert.Equal(t, "mondoo-kubernetes-runtime-image-cache", p.Uid)
+		require.Len(t, p.Groups, 1)
+
+		checks := map[string]bool{}
+		for _, check := range p.Groups[0].Checks {
+			checks[check.Uid] = true
+		}
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-delegates-ready"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-delegates-no-pull"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-matched"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"])
+		assert.True(t, checks["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"])
+
+		queries := map[string]string{}
+		for _, query := range bundle.Queries {
+			queries[query.Uid] = query.Mql
+		}
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-delegates-ready"], `endpoint != ""`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `initContainerStatuses.all`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `k8s.pods.where(phase == "Running")`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-matched"], `ephemeralContainerStatuses.all`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `runtimeImage.scanStatus == "scanned"`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `initContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `containerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-scanned"], `ephemeralContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `initContainerStatuses.where`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `k8s.pods.where(phase == "Running")`)
+		assert.Contains(t, queries["mondoo-kubernetes-runtime-image-cache-pod-images-immutable"], `ephemeralContainerStatuses.where`)
+
+		compiled, err := bundle.Compile(context.Background(), runtime.Schema(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, compiled)
+	})
+
+	t.Run("inventory querypack compiles runtime cache queries", func(t *testing.T) {
+		bundle, err := loader.BundleFromPaths("./querypacks/mondoo-kubernetes-inventory.mql.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, bundle)
+		require.Len(t, bundle.Packs, 1)
+
+		queries := map[string]string{}
+		for _, group := range bundle.Packs[0].Groups {
+			for _, query := range group.Queries {
+				queries[query.Uid] = query.Mql
+			}
+		}
+		assert.Contains(t, queries, "k8s-runtime-cache-delegates")
+		assert.Contains(t, queries, "k8s-runtime-cache-images")
+		assert.Contains(t, queries, "k8s-runtime-cache-pod-image-coverage")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "initContainerStatuses")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "containerStatuses")
+		assert.Contains(t, queries["k8s-runtime-cache-pod-image-coverage"], "ephemeralContainerStatuses")
+
+		bundle.ConvertQuerypacks()
+		compiled, err := bundle.Compile(context.Background(), runtime.Schema(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, compiled)
+	})
+}
+
+func runtimeImageCacheRuntime(t *testing.T) *providers.Runtime {
+	t.Helper()
+
+	runtime := providers.DefaultRuntime()
+	schema, ok := runtime.Schema().(providers.ExtensibleSchema)
+	require.True(t, ok, "provider runtime schema must support adding source schemas")
+	schema.Add("core", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "core", "./testdata/schema/providers/core/resources/core.lr")}))
+	schema.Add("network", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "network", "./testdata/schema/providers/network/resources/network.lr")}))
+	schema.Add("os", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "os", "./testdata/schema/providers/os/resources/os.lr")}))
+	schema.Add("k8s", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "k8s", "./testdata/schema/providers/k8s/resources/k8s.lr")}))
+	return runtime
+}
+
+func runtimeImageCacheSchemaPath(t *testing.T, provider, path string) string {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	require.NoErrorf(t, err, "in-repo schema fixture must point to a readable %s schema file", provider)
+	return path
 }
 
 func TestBundles(t *testing.T) {

--- a/content/validation/scans/bundles_test.go
+++ b/content/validation/scans/bundles_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/cnspec/policy/scan"
+	"go.mondoo.com/mql/providers"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 )
@@ -111,7 +113,7 @@ func TestRuntimeImageCacheContent(t *testing.T) {
 	loader := policy.DefaultBundleLoader()
 
 	t.Run("policy compiles runtime cache controls", func(t *testing.T) {
-		bundle, err := loader.BundleFromPaths("./mondoo-kubernetes-runtime-image-cache.mql.yaml")
+		bundle, err := loader.BundleFromPaths(bundlePath("mondoo-kubernetes-runtime-image-cache.mql.yaml"))
 		require.NoError(t, err)
 		require.NotNil(t, bundle)
 		require.Len(t, bundle.Policies, 1)
@@ -153,7 +155,7 @@ func TestRuntimeImageCacheContent(t *testing.T) {
 	})
 
 	t.Run("inventory querypack compiles runtime cache queries", func(t *testing.T) {
-		bundle, err := loader.BundleFromPaths("./querypacks/mondoo-kubernetes-inventory.mql.yaml")
+		bundle, err := loader.BundleFromPaths(bundlePath("querypacks/mondoo-kubernetes-inventory.mql.yaml"))
 		require.NoError(t, err)
 		require.NotNil(t, bundle)
 		require.Len(t, bundle.Packs, 1)
@@ -184,10 +186,18 @@ func runtimeImageCacheRuntime(t *testing.T) *providers.Runtime {
 	runtime := providers.DefaultRuntime()
 	schema, ok := runtime.Schema().(providers.ExtensibleSchema)
 	require.True(t, ok, "provider runtime schema must support adding source schemas")
-	schema.Add("core", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "core", "./testdata/schema/providers/core/resources/core.lr")}))
-	schema.Add("network", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "network", "./testdata/schema/providers/network/resources/network.lr")}))
-	schema.Add("os", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "os", "./testdata/schema/providers/os/resources/os.lr")}))
-	schema.Add("k8s", testutils.MustLoadSchema(testutils.SchemaProvider{Path: runtimeImageCacheSchemaPath(t, "k8s", "./testdata/schema/providers/k8s/resources/k8s.lr")}))
+	schema.Add("core", testutils.MustLoadSchema(testutils.SchemaProvider{
+		Path: runtimeImageCacheSchemaPath(t, "core", filepath.Join(contentDir, "testdata/schema/providers/core/resources/core.lr")),
+	}))
+	schema.Add("network", testutils.MustLoadSchema(testutils.SchemaProvider{
+		Path: runtimeImageCacheSchemaPath(t, "network", filepath.Join(contentDir, "testdata/schema/providers/network/resources/network.lr")),
+	}))
+	schema.Add("os", testutils.MustLoadSchema(testutils.SchemaProvider{
+		Path: runtimeImageCacheSchemaPath(t, "os", filepath.Join(contentDir, "testdata/schema/providers/os/resources/os.lr")),
+	}))
+	schema.Add("k8s", testutils.MustLoadSchema(testutils.SchemaProvider{
+		Path: runtimeImageCacheSchemaPath(t, "k8s", filepath.Join(contentDir, "testdata/schema/providers/k8s/resources/k8s.lr")),
+	}))
 	return runtime
 }
 

--- a/docs/plans/runtime-cache-image-content.md
+++ b/docs/plans/runtime-cache-image-content.md
@@ -1,0 +1,204 @@
+# Runtime Cache Image Content Plan
+
+## Scope
+
+Add cnspec policy, querypack, docs, and validation coverage for node-local runtime-cache image scanning. MQL provider resources and operator deployment are covered in separate PRs.
+
+## Implementation status
+
+This PR adds the first cnspec content slice:
+
+- Inventory queries in `content/querypacks/mondoo-kubernetes-inventory.mql.yaml` for runtime delegates, runtime cached images, and pod-to-runtime-image coverage.
+- A dedicated preview policy in `content/mondoo-kubernetes-runtime-image-cache.mql.yaml` for runtime delegate readiness, read-only/no-pull delegate posture, pod image match status, and immutable image identity.
+
+The content depends on the runtime-cache MQL schema from the mql provider PR. Until cnspec bumps to a module version containing `container.runtimeDelegate`, `container.runtimeImage`, `container.runtimeImageLayer`, `k8s.node.runtimeDelegates`, `k8s.node.runtimeImages`, `k8s.pod.containerStatuses[].runtimeImage`, and `k8s.pod.containerStatuses[].runtimeImageStatus`, linting this content requires a temporary local module replacement to that MQL branch. The schema fixture in this PR mirrors that provider contract so bundle tests can validate the draft content before the dependency is released; remove the fixture-only coupling once cnspec consumes the released MQL module.
+
+## Goals
+
+- Make node-local cached image scan coverage visible to users.
+- Add inventory content that shows which images are in use, which were scanned, and why any were skipped.
+- Add policies that detect runtime-cache scanner gaps without requiring registry credentials.
+- Keep existing registry and container image policies working unchanged.
+- Provide fixtures and content tests that exercise protected-registry and no-pull semantics.
+
+## Non-goals
+
+- Do not implement runtime access in cnspec content.
+- Do not require the runtime-cache scanner for all Kubernetes users.
+- Do not duplicate existing vulnerability policies when the scanner already reports package and vuln data for the image asset.
+
+## Expected MQL inputs
+
+This plan assumes the MQL PR adds resources equivalent to:
+
+- `container.runtimeDelegate`
+- `container.runtimeImage`
+- `container.runtimeImageLayer`
+- `k8s.node.runtimeDelegates`
+- `k8s.node.runtimeImages`
+- `k8s.pod.containers[].runtimeImage`
+- `k8s.pod.containers[].runtimeImageStatus`
+
+Runtime-cache content also assumes the paired provider resolves configured runtime delegates from the scan connection and matches shared runtime-image resources by immutable identity. That keeps scan results deduplicated by digest instead of workload tag or pod instance.
+
+Policy content should be written defensively so missing resources do not fail older providers.
+
+## Inventory querypack
+
+Add or extend a Kubernetes inventory querypack, likely `content/querypacks/mondoo-kubernetes-inventory.mql.yaml`.
+
+New sections:
+
+- Runtime image cache delegates by node.
+- Runtime images by node.
+- Images in use by workloads.
+- Image scan coverage.
+- Images skipped by reason.
+
+Example query concepts:
+
+```mql
+k8s.nodes {
+  name
+  runtimeDelegates {
+    id
+    kind
+    status
+    statusMessage
+  }
+  runtimeImages {
+    resolvedDigest
+    repoTags
+    repoDigests
+    inUse
+    scanStatus
+    scanStatusMessage
+  }
+}
+```
+
+```mql
+k8s.pods {
+  namespace
+  name
+  containers {
+    name
+    image
+    imageID
+    runtimeImageStatus
+    runtimeImage {
+      resolvedDigest
+      scanStatus
+    }
+  }
+}
+```
+
+## Policy content
+
+Add a dedicated policy file only after MQL resource names are final, for example:
+
+- `content/mondoo-kubernetes-runtime-image-cache.mql.yaml`
+
+Candidate controls:
+
+1. Runtime-cache scanning is enabled on every schedulable node.
+   - Fail when a schedulable node has no ready `container.runtimeDelegate`.
+   - Skip control when runtime-cache resources are unavailable.
+
+2. In-use pod images are matched to a node-local runtime image.
+   - Fail when `runtimeImageStatus` is `notPresent`, `runtimeUnavailable`, or `ambiguous`.
+   - Include workload namespace/name/container in evidence.
+
+3. In-use pod images are scanned from immutable local image identity.
+   - Fail when the runtime image has no `resolvedDigest` or equivalent immutable ID.
+
+4. Runtime-cache scanner does not rely on registry credentials.
+   - Pass when scan evidence comes from `container-runtime-image` or equivalent no-pull source.
+   - Fail only when runtime-cache mode is enabled and image evidence shows a registry pull path.
+
+5. Stale cached images are visible.
+   - Informational control listing cached images with `inUse=false`.
+   - This should not fail by default because runtime garbage collection is cluster-specific.
+
+6. Runtime delegate health is clean.
+   - Fail when delegates report `permissionDenied`.
+   - Warn when delegates are `unavailable` and another delegate covered the node.
+
+## Result UX
+
+Policies should group evidence by:
+
+- Node.
+- Runtime delegate.
+- Workload.
+- Image digest.
+
+Avoid presenting duplicate failures for every pod using the same image. Prefer one image-level failure with workload references when MQL supports it.
+
+## Documentation
+
+Update supply-chain or Kubernetes scanning docs after implementation:
+
+- Explain the difference between registry scanning and node-local runtime-cache scanning.
+- State clearly that runtime-cache scanning does not pull images.
+- State clearly that runtime-cache scanning does not read image pull secrets.
+- Document limitations:
+  - It only scans images present on nodes.
+  - It only sees nodes where the DaemonSet can access the runtime.
+  - Runtime socket access is privileged host access even when the scanner is read-only.
+
+## Implementation phases
+
+### Phase 1: Inventory content
+
+- Add querypack entries guarded by resource availability.
+- Add fixtures with:
+  - ready delegate and scanned image
+  - missing delegate
+  - protected-registry image scanned from cache
+  - image referenced by pod but not present on node
+
+### Phase 2: Policy controls
+
+- Add the dedicated runtime-cache policy.
+- Keep severity modest for preview controls until field data confirms low false positives.
+- Use clear remediation text that points users to the operator runtime-cache scanner config.
+
+### Phase 3: Documentation
+
+- Update `docs/supplychain/docker.mdx` or the Kubernetes scan docs with runtime-cache mode.
+- Add examples for enabling runtime-cache scanning through the operator.
+
+### Phase 4: Bundle and lint integration
+
+- Ensure new policy and querypack are included in content bundle tests.
+- Add testdata for pass and fail outcomes.
+
+## Test plan
+
+Focused tests:
+
+- `make test/lint/content`
+- `go test ./content/...` if content package tests are available.
+- `go test ./policy/...` for bundle loading and policy metadata if touched.
+- Fixture tests for pass/fail runtime-cache controls.
+- Golden tests for policy evidence text when the content framework supports it.
+
+Full verification:
+
+- `make test`
+
+Manual verification after MQL/operator PRs exist:
+
+- Run a k3d cluster with a locally loaded image that is not pullable from the registry.
+- Enable runtime-cache scanner.
+- Confirm cnspec reports the image as scanned and does not require an image pull secret.
+- Confirm a pod image absent from the runtime cache appears as `notPresent`.
+
+## Acceptance criteria
+
+- Users can see runtime delegates, cached images, scan status, and skipped reasons in inventory.
+- Policies distinguish missing local images from registry authentication failures.
+- Content does not fail on older providers where runtime-cache resources do not exist.
+- Content lint and bundle tests cover new controls and querypack entries.


### PR DESCRIPTION
## Summary
- add runtime-cache inventory queries to the Kubernetes inventory querypack
- add a preview `Mondoo Kubernetes Runtime Image Cache` policy for runtime delegate readiness, no-pull/read-only behavior, pod image matching, completed scan status, and immutable image identity
- add focused bundle compile coverage for the new policy and querypack entries
- update the runtime-cache content implementation plan

## Review fixes
- rewrite check audits to use kubectl-native verification steps
- convert Kubernetes remediations to `kubectl`, `manifest`, and `helm` entries per content authoring guidance
- align runtime-cache remediation examples with the current containerd-only operator/MQL implementation
- add a dedicated control for matched running pod images whose runtime-cache scan status is not `scanned`
- remove the local personal-fork MQL `replace` and restore official module checksums
- scope the `delegates-no-pull` query to schedulable nodes, matching `delegates-ready`
- convert `Why this matters` sections to the expected bullet style
- update the generated network provider schema fixture to `cnquery/v13`
- collapse duplicated schema fixture path helpers in bundle tests
- remove the explicit `os` provider requirement after confirming bundle compilation succeeds with the k8s schema dependency

## Dependency
This content depends on the runtime-cache MQL provider schema from https://github.com/mondoohq/mql/pull/8452.

## Validation
- `git diff --check`
- `go test ./content -run TestRuntimeImageCacheContent`
- `go test ./content`