### PR TITLE
🐛 sbom: regenerate cnspec_sbom.pb.go after proto comment fix

### DIFF
--- a/internal/sbom/cnspec_sbom.pb.go
+++ b/internal/sbom/cnspec_sbom.pb.go
@@ -131,7 +131,7 @@ const (
 	// subscription.
 	ExternalIDType_EXTERNAL_ID_TYPE_AZURE_SUB ExternalIDType = 4
 	// EXTERNAL_ID_TYPE_AZURE_ID represents a fully qualified Azure resource
-	// identifier, a standarized format used by Azure to uniquely identify
+	// identifier, a standardized format used by Azure to uniquely identify
 	// resources within the Azure ecosystem.
 	ExternalIDType_EXTERNAL_ID_TYPE_AZURE_ID ExternalIDType = 5
 )


### PR DESCRIPTION
## Problem

The "Check generated files" CI job is **failing on `main`** (and therefore on every branch cut from it, e.g. #2855):

```
-	// identifier, a standarized format used by Azure to uniquely identify
+	// identifier, a standardized format used by Azure to uniquely identify
```

#2854 fixed a typo in `internal/sbom/cnspec_sbom.proto` (`standarized` → `standardized`) but did not regenerate the derived `cnspec_sbom.pb.go`, so the committed generated file drifted from its source.

## Fix

Ran `go generate ./internal/sbom` to regenerate. The only resulting change is the one-line doc comment, matching the proto — no protoc/version drift.

This unblocks the generated-files check on `main`; open PRs (#2855) just need a rebase afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)