### PR TITLE
Surface incomplete report generation in local scanner (refs #2857)

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1269,13 +1269,22 @@ func (s *localAssetScanner) getReport(resolvedPolicy *policy.ResolvedPolicy) (*p
 
 	// TODO: we do not needs this anymore since we receive updates already
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("client> send all results")
-	_, err := policy.WaitUntilDone(resolver, s.job.Asset.Mrn, s.job.Asset.Mrn, 1*time.Second)
+	done, err := policy.WaitUntilDone(resolver, s.job.Asset.Mrn, s.job.Asset.Mrn, 1*time.Second)
 	// handle error
 	if err != nil {
 		return &policy.Report{
 			EntityMrn:  s.job.Asset.Mrn,
 			ScoringMrn: s.job.Asset.Mrn,
 		}, err
+	}
+	// If the asset score has not reached full completion, individual check
+	// scores may still be in flight (the buffered collector flushes on an
+	// interval). Generating the report now can silently drop those late
+	// scores from the output, so surface it rather than failing quietly.
+	if !done {
+		log.Warn().
+			Str("asset", s.job.Asset.Mrn).
+			Msg("client> report generated before all scores reported completion; some check scores may be missing from the report")
 	}
 
 	log.Debug().Str("asset", s.job.Asset.Mrn).Msg("generate report")


### PR DESCRIPTION
> Draft: minimal observability step for #2857. The structural fix needs maintainer review (see below).

### Problem

`getReport` (`policy/scan/local_scanner.go`) waits up to **1s** for the asset score to reach full completion via `WaitUntilDone`, but **discarded the returned `done` flag** and generated the report regardless. When the scan has not fully completed within that window — a late-completing check, with the buffered collector (5s flush interval) not yet flushed — `GetReport` is built from partially-collected scores and those checks are **silently dropped** from the output. With `-o json` this is invisible (the JSON reporter only emits scores that exist), so a passing check can simply vanish from the report. Full analysis in #2857.

### This change

Minimal and **zero behavior change** apart from a log line: honor the `done` result and `log.Warn` when the report is generated before scores report completion, so the silent data loss is at least observable.

### What this intentionally does NOT do

It does not change the 1s timeout. Bumping it would slow every scan of an asset that has a legitimately-incomplete datapoint (which never reaches 100% completion), so the proper fix — blocking on a collector/executor completion signal (and flushing the buffered collector) before `GetReport`, rather than a fixed poll on the asset aggregate — is left for maintainer review.

### Verification

`go build ./policy/scan/` and `go vet ./policy/scan/` pass. The race itself is timing-dependent and not reproduced in a unit test here; CI + a maintainer repro are needed for the structural fix.

Refs #2857
