### PR TITLE
✨ ci: add xgrep security scanning

### DIFF
--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -22,8 +22,7 @@ jobs:
         with:
           fetch-depth: 0 # required for diff-aware scanning on pull requests
       - name: Run xgrep
-        # pinned to actions main; bump to a release tag once one includes xgrep
-        uses: mondoohq/actions/xgrep@6ae6dcf2dfbb346a033c35dcff9c140dff668852 # main
+        uses: mondoohq/actions/xgrep@b41754752763419780430abef5e35842ba2bec66 # v13.2.0
         with:
           path: .
           output-file: results.sarif

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -22,8 +22,8 @@ jobs:
         with:
           fetch-depth: 0 # required for diff-aware scanning on pull requests
       - name: Run xgrep
-        # TODO: bump to a released tag once mondoohq/actions#143 is merged and tagged
-        uses: mondoohq/actions/xgrep@66c4a1fec802d77ec4fd6516ab2ec2161314ec3d # add-xgrep-action
+        # pinned to actions main; bump to a release tag once one includes xgrep
+        uses: mondoohq/actions/xgrep@6ae6dcf2dfbb346a033c35dcff9c140dff668852 # main
         with:
           path: .
           output-file: results.sarif

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -1,0 +1,36 @@
+name: xgrep
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: xgrep security scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload SARIF to code scanning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # required for diff-aware scanning on pull requests
+      - name: Run xgrep
+        # TODO: bump to a released tag once mondoohq/actions#143 is merged and tagged
+        uses: mondoohq/actions/xgrep@66c4a1fec802d77ec4fd6516ab2ec2161314ec3d # add-xgrep-action
+        with:
+          path: .
+          output-file: results.sarif
+          fail-on: "off" # report-only for now; surface findings without blocking PRs
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: xgrep


### PR DESCRIPTION
## What

Adds an `xgrep` workflow that runs the shared **`mondoohq/actions/xgrep`** action (released in [actions v13.2.0](https://github.com/mondoohq/actions/releases/tag/v13.2.0)) and uploads results to GitHub code scanning.

- Triggers on push/PR to `main`; `security-events: write` to upload SARIF.
- `fetch-depth: 0` so `xgrep ci` can scan diff-aware against the PR base.
- **Report-only** (`fail-on: off`) initially — findings appear in the Security tab without blocking merges. Can flip to `error` once findings are triaged.
- SARIF uploaded with `category: xgrep` (matches the action's default `--sarif-category`).

The action is pinned to the released tag:

```yaml
uses: mondoohq/actions/xgrep@b41754752763419780430abef5e35842ba2bec66 # v13.2.0
```

## Status

The shared action (mondoohq/actions#143) is **merged and released as v13.2.0**, so this is ready to merge — it no longer tracks the actions feature branch or `main`.

## Verification

The xgrep workflow runs on this PR and uploads SARIF to code scanning. Validated locally with `xgrep v0.9.0` that the action produces well-formed SARIF (category `xgrep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
