### PR TITLE
🐛 serve: honor dotted scan_interval/auth config keys

### DIFF
--- a/apps/cnspec/cmd/config/config.go
+++ b/apps/cnspec/cmd/config/config.go
@@ -22,6 +22,31 @@ func ReadConfig() (*CliConfig, error) {
 		return nil, errors.Wrap(err, "unable to decode into config struct")
 	}
 
+	// Backward compatibility: some configs use dotted keys instead of a nested
+	// mapping, e.g.
+	//   scan_interval.timer: 360
+	//   scan_interval.splay: 30
+	// cnquery sets viper's key delimiter to "\\" (see mql cli/config), so viper
+	// does not expand dotted keys into nested maps and the Unmarshal above leaves
+	// these nested fields unset. Detect the dotted form and fold it in.
+	if viper.IsSet("scan_interval.timer") || viper.IsSet("scan_interval.splay") {
+		if opts.ScanInterval == nil {
+			opts.ScanInterval = &ScanInterval{}
+		}
+		if viper.IsSet("scan_interval.timer") {
+			opts.ScanInterval.Timer = viper.GetInt("scan_interval.timer")
+		}
+		if viper.IsSet("scan_interval.splay") {
+			opts.ScanInterval.Splay = viper.GetInt("scan_interval.splay")
+		}
+	}
+	if viper.IsSet("auth.method") {
+		if opts.Authentication == nil {
+			opts.Authentication = &config.CliConfigAuthentication{}
+		}
+		opts.Authentication.Method = viper.GetString("auth.method")
+	}
+
 	return &opts, nil
 }
 

--- a/apps/cnspec/cmd/config/config_test.go
+++ b/apps/cnspec/cmd/config/config_test.go
@@ -49,3 +49,93 @@ scan_interval:
 	assert.Equal(t, 20, cfg.ScanInterval.Splay)
 
 }
+
+// TestConfigParsingDottedKeys verifies that nested config values work both as a
+// nested mapping and as dotted keys. cnquery sets viper's key delimiter to "\\"
+// (see mql cli/config InitViperConfig), so viper does not expand dotted keys
+// into nested maps. ReadConfig folds the dotted form back in for backward
+// compatibility. These tests reproduce production by setting that delimiter.
+func TestConfigParsingDottedKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       string
+		wantTimer  int
+		wantSplay  int
+		wantMethod string
+	}{
+		{
+			name:       "nested",
+			data:       "scan_interval:\n  timer: 360\n  splay: 30\nauth:\n  method: wif\n",
+			wantTimer:  360,
+			wantSplay:  30,
+			wantMethod: "wif",
+		},
+		{
+			name:       "dotted",
+			data:       "scan_interval.timer: 360\nscan_interval.splay: 30\nauth.method: wif\n",
+			wantTimer:  360,
+			wantSplay:  30,
+			wantMethod: "wif",
+		},
+		{
+			name:      "dotted partial timer only",
+			data:      "scan_interval.timer: 360\n",
+			wantTimer: 360,
+			wantSplay: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			// mirror mql's InitViperConfig: disable the "." key delimiter
+			viper.SetOptions(viper.KeyDelimiter("\\"))
+			viper.SetConfigType("yaml")
+			require.NoError(t, viper.ReadConfig(strings.NewReader(tc.data)))
+
+			cfg, err := ReadConfig()
+			require.NoError(t, err)
+
+			require.NotNil(t, cfg.ScanInterval)
+			assert.Equal(t, tc.wantTimer, cfg.ScanInterval.Timer)
+			assert.Equal(t, tc.wantSplay, cfg.ScanInterval.Splay)
+
+			if tc.wantMethod != "" {
+				require.NotNil(t, cfg.Authentication)
+				assert.Equal(t, tc.wantMethod, cfg.Authentication.Method)
+			}
+		})
+	}
+}
+
+// TestConfigParsingDottedMapKeysNotFolded locks in the boundary of the dotted-key
+// compatibility shim: it must NOT fold dotted keys into map fields like
+// annotations/labels. The "\\" key delimiter exists precisely so map keys can
+// contain dots (e.g. "kubernetes.io/role"), so a dotted top-level form such as
+// `annotations.foo: bar` is intentionally treated as a literal key, not a map
+// entry. If someone later extends the shim to maps, this test should fail.
+func TestConfigParsingDottedMapKeysNotFolded(t *testing.T) {
+	viper.Reset()
+	viper.SetOptions(viper.KeyDelimiter("\\"))
+	viper.SetConfigType("yaml")
+	data := "annotations.foo: bar\nlabels.env: prod\n"
+	require.NoError(t, viper.ReadConfig(strings.NewReader(data)))
+
+	cfg, err := ReadConfig()
+	require.NoError(t, err)
+
+	// dotted map keys are not folded into the nested maps
+	assert.Empty(t, cfg.Annotations)
+	assert.Empty(t, cfg.Labels)
+
+	// the nested map form, with a dotted key, works as intended
+	viper.Reset()
+	viper.SetOptions(viper.KeyDelimiter("\\"))
+	viper.SetConfigType("yaml")
+	nested := "annotations:\n  kubernetes.io/role: db\n"
+	require.NoError(t, viper.ReadConfig(strings.NewReader(nested)))
+
+	cfg, err = ReadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"kubernetes.io/role": "db"}, cfg.Annotations)
+}


### PR DESCRIPTION
## Problem

On a Linux box, `cnspec serve` ignored the configured `scan_interval` and fell back to the 60-minute timer / 60-minute splay defaults, e.g.:

```
INF scan interval is 60 minute(s) with a splay of 60 minute(s)
```

even though the config specified other values via dotted keys:

```yaml
scan_interval.timer: 360
scan_interval.splay: 30
```

## Root cause

cnquery sets viper's key delimiter to `\\` in `mql` `cli/config` `InitViperConfig`, specifically so that map keys (`annotations`/`labels`) can contain dots (e.g. `kubernetes.io/role`). A side effect: viper no longer expands dotted keys like `scan_interval.timer` into a nested mapping. They remain literal flat keys, so `viper.Unmarshal` never populates the nested `ScanInterval` (or `Authentication`) struct, and `serve` applies its `nil`→defaults path.

The same failure applies to `auth.method` (the only other nested struct in the config). Map fields (`annotations`/`labels`) are intentionally dotted-incompatible and are left untouched.

## Fix

After `Unmarshal`, fold the dotted form back into the nested structs for `scan_interval.{timer,splay}` and `auth.method`, only when those dotted keys are actually set. Both the nested-mapping and dotted-key config styles now work.

Resolves #2253 

## Tests

- `TestConfigParsingDottedKeys` — nested, dotted, and partial-dotted forms under the production `\\` key delimiter, for both `scan_interval` and `auth`.
- `TestConfigParsingDottedMapKeysNotFolded` — negative test locking in the boundary: dotted keys are **not** folded into `annotations`/`labels` maps, while the nested map form (with dotted keys) still resolves.

## Notes / follow-up

This fixes **cnspec** only. `cnquery` reads `auth`/`scan_interval` through its own `ReadConfig` and still has the gap — the shim's natural home would be mql's config package upstream if we want it fixed everywhere. There's also a separate latent upstream bug in mql's WIF detection (`viper.Set("auth.method", ...)` under the `\\` delimiter sets a literal key), same root cause, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)