### PR TITLE
fix(policy): make framework graph checksum independent of framework-map order

### DIFF
--- a/policy/framework.go
+++ b/policy/framework.go
@@ -303,6 +303,15 @@ func (f *Framework) updateGraphChecksums(
 			AddUint(uint64(dep.Action))
 	}
 
+	// The graph checksum is an order-sensitive rolling hash, so framework maps
+	// must be folded in a deterministic order — exactly like Dependencies are
+	// sorted above. The maps are loaded without an explicit ORDER BY, so their
+	// slice order is not stable across reads; folding them unsorted makes
+	// graph_content_checksum non-deterministic for a framework with >=2 maps.
+	sort.Slice(f.FrameworkMaps, func(i, j int) bool {
+		return f.FrameworkMaps[i].Mrn < f.FrameworkMaps[j].Mrn
+	})
+
 	for _, fm := range f.FrameworkMaps {
 		if fm.LocalContentChecksum == "" || fm.LocalExecutionChecksum == "" {
 			fm.UpdateChecksums()

--- a/policy/frameworks_test.go
+++ b/policy/frameworks_test.go
@@ -81,3 +81,34 @@ func requireComesAfter(t *testing.T, sorted []string, a, b string) {
 		t.Errorf("Expected %s to come after %s", a, b)
 	}
 }
+
+// A framework's graph checksums are an order-sensitive rolling hash over its
+// framework maps. The maps are loaded without a stable ORDER BY, so the
+// checksum must not depend on the order they happen to arrive in — otherwise
+// the same framework yields different graph_content_checksum values across
+// reads, which makes the PolicyBundle rebuild persist CAS never converge.
+func TestFrameworkGraphChecksum_StableAcrossFrameworkMapOrder(t *testing.T) {
+	ctx := context.Background()
+
+	mk := func(maps []*FrameworkMap) *Framework {
+		return &Framework{
+			Mrn:                    "//framework.api.mondoo.app/frameworks/test",
+			LocalContentChecksum:   "local-content",
+			LocalExecutionChecksum: "local-exec",
+			FrameworkMaps:          maps,
+		}
+	}
+	a := &FrameworkMap{Mrn: "//fm/a", LocalContentChecksum: "ca", LocalExecutionChecksum: "ea"}
+	b := &FrameworkMap{Mrn: "//fm/b", LocalContentChecksum: "cb", LocalExecutionChecksum: "eb"}
+
+	f1 := mk([]*FrameworkMap{a, b})
+	f2 := mk([]*FrameworkMap{b, a}) // same maps, reversed load order
+
+	require.NoError(t, f1.UpdateChecksums(ctx, nil, nil, nil))
+	require.NoError(t, f2.UpdateChecksums(ctx, nil, nil, nil))
+
+	assert.Equal(t, f1.GraphContentChecksum, f2.GraphContentChecksum,
+		"graph_content_checksum must not depend on FrameworkMap load order")
+	assert.Equal(t, f1.GraphExecutionChecksum, f2.GraphExecutionChecksum,
+		"graph_execution_checksum must not depend on FrameworkMap load order")
+}


### PR DESCRIPTION
## What

`Framework.updateGraphChecksums` folds each `FrameworkMap`'s local checksums into the graph checksums with an **order-sensitive** rolling hash, but iterates `f.FrameworkMaps` in slice order — while `Dependencies` in the same function are sorted by `Mrn` first. Framework maps are loaded without a stable `ORDER BY`, so a framework with **≥2 maps** computes a different `graph_content_checksum` / `graph_execution_checksum` depending on row order.

This sorts `f.FrameworkMaps` by `Mrn` before folding, mirroring the existing `Dependencies` sort.

## Why

The non-deterministic framework checksum makes the server-side PolicyBundle rebuild persist-CAS (which compares the stored framework `graph_content_checksum` column against a freshly recomputed value) **never converge** for spaces with a compliance framework: each rebuild recomputes a differently-ordered checksum, mismatches → drift, and the workflow exhausts and re-loops indefinitely.

## Test

`TestFrameworkGraphChecksum_StableAcrossFrameworkMapOrder` builds the same framework with its maps in two different input orders and asserts equal graph checksums. Verified it **fails without** the sort and **passes with** it. Existing `Framework`/`Checksum`/`Compliance` tests still pass.

