### PR TITLE
🌟 stackit: add Mondoo STACKIT Security policy

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -206,7 +206,7 @@ queries:
     impact: 85
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin == null).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
+      stackit.securityGroups.all(rules.where(direction == "ingress").where(ipRange == "0.0.0.0/0" || ipRange == "::/0").none(portRangeMin == null || portRangeMin <= 1 && portRangeMax >= 65535))
     docs:
       desc: |
         This check ensures that no security group rule permits inbound traffic on all ports from the entire internet (`0.0.0.0/0` or `::/0`). A rule that opens the full port range to the world exposes every service running on attached servers, including those never intended to be reachable externally.
@@ -294,10 +294,10 @@ queries:
     impact: 85
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.sfs.resourcePools.all(ipAcl.none(_ == "0.0.0.0/0"))
+      stackit.sfs.resourcePools.all(ipAcl.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
       desc: |
-        This check ensures that STACKIT File Storage (SFS) resource pools do not allow mounting from the entire internet (`0.0.0.0/0`) via their IP allow-list (`ipAcl`). NFS shares hosted in a pool that is mountable from anywhere expose file data to any host that can reach the endpoint.
+        This check ensures that STACKIT File Storage (SFS) resource pools do not allow mounting from the entire internet (`0.0.0.0/0` or `::/0`) via their IP allow-list (`ipAcl`). NFS shares hosted in a pool that is mountable from anywhere expose file data to any host that can reach the endpoint.
 
         **Why this matters**
 
@@ -315,10 +315,10 @@ queries:
     impact: 85
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.sfs.exportPolicies.all(rules.all(ipAcl.none(_ == "0.0.0.0/0")))
+      stackit.sfs.exportPolicies.all(rules.all(ipAcl.none(_ == "0.0.0.0/0" || _ == "::/0")))
     docs:
       desc: |
-        This check ensures that no STACKIT File Storage (SFS) export policy rule grants NFS access to the entire internet (`0.0.0.0/0`). Export policies define which clients may mount shares and with what access; a rule open to the world removes the network boundary protecting the data.
+        This check ensures that no STACKIT File Storage (SFS) export policy rule grants NFS access to the entire internet (`0.0.0.0/0` or `::/0`). Export policies define which clients may mount shares and with what access; a rule open to the world removes the network boundary protecting the data.
 
         **Why this matters**
 
@@ -358,7 +358,7 @@ queries:
     impact: 90
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.postgresFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+      stackit.postgresFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
       desc: |
         This check ensures that STACKIT PostgreSQL Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
@@ -400,7 +400,7 @@ queries:
     impact: 90
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.mongoDbFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+      stackit.mongoDbFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
       desc: |
         This check ensures that STACKIT MongoDB Flex instances do not include `0.0.0.0/0` in their access control list (ACL). Internet-reachable databases are a primary target for data theft and extortion.
@@ -442,7 +442,7 @@ queries:
     impact: 90
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.sqlServerFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+      stackit.sqlServerFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
       desc: |
         This check ensures that STACKIT SQLServer Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
@@ -485,7 +485,7 @@ queries:
     impact: 85
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0"))
+      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
       desc: |
         This check ensures that STACKIT Secrets Manager instances do not include `0.0.0.0/0` in their access control list. Secrets Manager stores sensitive credentials; exposing its API to the entire internet broadens the attack surface around your most sensitive data.

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -115,7 +115,7 @@ policies:
           - uid: mondoo-stackit-security-modelserving-token-expiry-set
           - uid: mondoo-stackit-security-modelserving-token-not-expired
 queries:
-  # ----------------------------- Compute -----------------------------
+  # ----------------------------- STACKIT Compute -----------------------------
   - uid: mondoo-stackit-security-compute-server-has-security-group
     title: Ensure STACKIT servers are attached to a security group
     impact: 60
@@ -158,7 +158,7 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/storage/block-storage/
         title: STACKIT Documentation - Block Storage
-  # ----------------------------- Networking -----------------------------
+  # ----------------------------- STACKIT Networking -----------------------------
   - uid: mondoo-stackit-security-network-no-public-ssh
     title: Ensure no security group exposes SSH (port 22) to the internet
     impact: 90
@@ -206,7 +206,7 @@ queries:
     impact: 85
     filters: asset.platform == "stackit-project"
     mql: |
-      stackit.securityGroups.all(rules.where(direction == "ingress").where(ipRange == "0.0.0.0/0" || ipRange == "::/0").none(portRangeMin == null || portRangeMin <= 1 && portRangeMax >= 65535))
+      stackit.securityGroups.all(rules.where(direction == "ingress").where(ipRange == "0.0.0.0/0" || ipRange == "::/0").where(portRangeMin == null || portRangeMin <= 1).none(portRangeMax == null || portRangeMax >= 65535))
     docs:
       desc: |
         This check ensures that no security group rule permits inbound traffic on all ports from the entire internet (`0.0.0.0/0` or `::/0`). A rule that opens the full port range to the world exposes every service running on attached servers, including those never intended to be reachable externally.
@@ -243,7 +243,7 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/network/load-balancing-and-content-delivery/application-load-balancer/
         title: STACKIT Documentation - Application Load Balancer
-  # ----------------------------- Object Storage -----------------------------
+  # ----------------------------- STACKIT Object Storage -----------------------------
   - uid: mondoo-stackit-security-objectstorage-bucket-object-lock
     title: Ensure STACKIT Object Storage buckets have Object Lock enabled
     impact: 70
@@ -288,7 +288,7 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/storage/object-storage/
         title: STACKIT Documentation - Object Storage
-  # ----------------------------- File Storage (SFS) -----------------------------
+  # ----------------------------- STACKIT File Storage -----------------------------
   - uid: mondoo-stackit-security-sfs-resourcepool-restricted-ipacl
     title: Ensure STACKIT SFS resource pools restrict their mount IP allow-list
     impact: 85
@@ -352,7 +352,7 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/storage/file-storage/
         title: STACKIT Documentation - File Storage (SFS)
-  # ----------------------------- Managed Databases -----------------------------
+  # ----------------------------- STACKIT Managed Databases -----------------------------
   - uid: mondoo-stackit-security-db-postgres-acl-restricted
     title: Ensure PostgreSQL Flex instances do not allow access from the internet
     impact: 90
@@ -479,159 +479,6 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/databases/sqlserver-flex/
         title: STACKIT Documentation - SQLServer Flex
-  # ----------------------------- Secrets Manager -----------------------------
-  - uid: mondoo-stackit-security-secretsmanager-acl-restricted
-    title: Ensure Secrets Manager instances do not allow access from the internet
-    impact: 85
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0" || _ == "::/0"))
-    docs:
-      desc: |
-        This check ensures that STACKIT Secrets Manager instances do not include `0.0.0.0/0` in their access control list. Secrets Manager stores sensitive credentials; exposing its API to the entire internet broadens the attack surface around your most sensitive data.
-
-        **Why this matters**
-
-        - **Sensitive data exposure:** Secrets Manager holds credentials whose compromise can cascade across systems.
-        - **Reduced attack surface:** Restricting the ACL limits who can even attempt to reach the secrets API.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, edit the Secrets Manager instance access control list and restrict it to the specific subnets or hosts that require access.
-    refs:
-      - url: https://docs.stackit.cloud/products/security/secrets-manager/
-        title: STACKIT Documentation - Secrets Manager
-  # ----------------------------- Key Management -----------------------------
-  - uid: mondoo-stackit-security-kms-key-not-pending-deletion
-    title: Ensure STACKIT KMS keys are not scheduled for deletion
-    impact: 60
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.kms.keys.all(deletionDate == null)
-    docs:
-      desc: |
-        This check flags STACKIT KMS keys that have a scheduled deletion date. A key pending deletion will become permanently unusable once the date passes, which can render all data encrypted under that key unrecoverable if the deletion was unintended.
-
-        **Why this matters**
-
-        - **Irreversible data loss:** Data encrypted with a deleted KMS key cannot be decrypted.
-        - **Early detection:** Surfacing pending deletions allows the deletion to be cancelled before it is too late.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, review keys with a scheduled deletion. If the deletion is unintended, cancel it; otherwise confirm no active data depends on the key before it is removed.
-    refs:
-      - url: https://docs.stackit.cloud/products/security/kms/
-        title: STACKIT Documentation - Key Management Service (KMS)
-  # ----------------------------- Kubernetes (SKE) -----------------------------
-  - uid: mondoo-stackit-security-ske-cluster-healthy
-    title: Ensure STACKIT SKE clusters are not in an unhealthy state
-    impact: 40
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.ske.clusters.all(status != "STATE_UNHEALTHY")
-    docs:
-      desc: |
-        This check ensures that no STACKIT Kubernetes Engine (SKE) cluster reports an unhealthy state. An unhealthy cluster may not be applying security updates, may have degraded control-plane components, and may not be enforcing intended policy. (Hibernated clusters are a valid operational state and are not flagged.)
-
-        **Why this matters**
-
-        - **Patch and policy enforcement:** An unhealthy cluster may not reliably apply updates or admission controls.
-        - **Operational visibility:** Surfacing unhealthy clusters prompts timely investigation.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, open the SKE cluster's status details, investigate the reported condition, and remediate the underlying issue (for example a failed maintenance or node-pool problem).
-    refs:
-      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
-        title: STACKIT Documentation - Kubernetes Engine (SKE)
-  # ----------------------------- Telemetry -----------------------------
-  - uid: mondoo-stackit-security-telemetry-token-expiry-set
-    title: Ensure STACKIT telemetry router access tokens have an expiry
-    impact: 50
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.telemetry.routers.all(accessTokens.all(expiresAt != null))
-    docs:
-      desc: |
-        This check ensures that every access token issued for a STACKIT telemetry router has an expiry time set. Long-lived or non-expiring credentials increase the window of exposure if a token is leaked.
-
-        **Why this matters**
-
-        - **Bounded exposure:** Expiring tokens limit how long a leaked credential remains valid.
-        - **Credential hygiene:** Enforcing expiry encourages regular rotation.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, reissue telemetry router access tokens with a bounded validity period and remove any non-expiring tokens.
-    refs:
-      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
-        title: STACKIT Documentation - Telemetry Router
-  - uid: mondoo-stackit-security-telemetry-token-not-expired
-    title: Ensure STACKIT telemetry router access tokens are not expired
-    impact: 60
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.telemetry.routers.all(accessTokens.all(expiresAt == null || expiresAt > time.now))
-    docs:
-      desc: |
-        This check flags expired access tokens still present on STACKIT telemetry routers. Expired tokens that are not removed represent stale credentials that should be cleaned up as part of good credential hygiene.
-
-        **Why this matters**
-
-        - **Stale credential cleanup:** Removing expired tokens reduces clutter and the chance of confusion during audits.
-        - **Hygiene:** Lingering expired credentials can mask active ones during review.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, delete expired telemetry router access tokens and reissue new ones where access is still required.
-    refs:
-      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
-        title: STACKIT Documentation - Telemetry Router
-  # ----------------------------- Model Serving -----------------------------
-  - uid: mondoo-stackit-security-modelserving-token-expiry-set
-    title: Ensure STACKIT Model Serving tokens have a bounded validity
-    impact: 50
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.modelServing.tokens.all(validUntil != null)
-    docs:
-      desc: |
-        This check ensures that every STACKIT Model Serving authentication token has a validity end date set. Non-expiring tokens increase the window of exposure if a credential is leaked.
-
-        **Why this matters**
-
-        - **Bounded exposure:** A validity end date limits how long a leaked token remains usable.
-        - **Credential hygiene:** Enforcing expiry encourages regular rotation of inference credentials.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, reissue Model Serving tokens with a bounded validity period and remove any non-expiring tokens.
-    refs:
-      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
-        title: STACKIT Documentation - Model Serving
-  - uid: mondoo-stackit-security-modelserving-token-not-expired
-    title: Ensure STACKIT Model Serving tokens are not expired
-    impact: 60
-    filters: asset.platform == "stackit-project"
-    mql: |
-      stackit.modelServing.tokens.all(validUntil == null || validUntil > time.now)
-    docs:
-      desc: |
-        This check flags expired STACKIT Model Serving tokens that are still present. Expired tokens that are not removed represent stale credentials that should be cleaned up.
-
-        **Why this matters**
-
-        - **Stale credential cleanup:** Removing expired tokens reduces clutter and audit confusion.
-        - **Hygiene:** Lingering expired credentials can obscure active ones during review.
-      remediation:
-        - id: console
-          desc: |
-            In the STACKIT Portal, delete expired Model Serving tokens and reissue new ones where access is still required.
-    refs:
-      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
-        title: STACKIT Documentation - Model Serving
-  # ----------------------------- Managed Databases (HA) -----------------------------
   - uid: mondoo-stackit-security-db-postgres-high-availability
     title: Ensure PostgreSQL Flex instances run with multiple replicas
     impact: 40
@@ -701,7 +548,29 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/databases/sqlserver-flex/
         title: STACKIT Documentation - SQLServer Flex
-  # ----------------------------- Identity & Access -----------------------------
+  # ----------------------------- STACKIT Secrets Manager -----------------------------
+  - uid: mondoo-stackit-security-secretsmanager-acl-restricted
+    title: Ensure Secrets Manager instances do not allow access from the internet
+    impact: 85
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0" || _ == "::/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT Secrets Manager instances do not include `0.0.0.0/0` in their access control list. Secrets Manager stores sensitive credentials; exposing its API to the entire internet broadens the attack surface around your most sensitive data.
+
+        **Why this matters**
+
+        - **Sensitive data exposure:** Secrets Manager holds credentials whose compromise can cascade across systems.
+        - **Reduced attack surface:** Restricting the ACL limits who can even attempt to reach the secrets API.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the Secrets Manager instance access control list and restrict it to the specific subnets or hosts that require access.
+    refs:
+      - url: https://docs.stackit.cloud/products/security/secrets-manager/
+        title: STACKIT Documentation - Secrets Manager
+  # ----------------------------- STACKIT Identity & Access -----------------------------
   - uid: mondoo-stackit-security-serviceaccount-key-bounded-validity
     title: Ensure active service account keys have a bounded validity
     impact: 70
@@ -744,7 +613,28 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/platform/access-and-identity/service-accounts/
         title: STACKIT Documentation - Service Accounts
-  # ----------------------------- Key Management (state) -----------------------------
+  # ----------------------------- STACKIT Key Management -----------------------------
+  - uid: mondoo-stackit-security-kms-key-not-pending-deletion
+    title: Ensure STACKIT KMS keys are not scheduled for deletion
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.kms.keys.all(deletionDate == null)
+    docs:
+      desc: |
+        This check flags STACKIT KMS keys that have a scheduled deletion date. A key pending deletion will become permanently unusable once the date passes, which can render all data encrypted under that key unrecoverable if the deletion was unintended.
+
+        **Why this matters**
+
+        - **Irreversible data loss:** Data encrypted with a deleted KMS key cannot be decrypted.
+        - **Early detection:** Surfacing pending deletions allows the deletion to be cancelled before it is too late.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, review keys with a scheduled deletion. If the deletion is unintended, cancel it; otherwise confirm no active data depends on the key before it is removed.
+    refs:
+      - url: https://docs.stackit.cloud/products/security/kms/
+        title: STACKIT Documentation - Key Management Service (KMS)
   - uid: mondoo-stackit-security-kms-key-healthy-state
     title: Ensure STACKIT KMS keys are in a healthy state
     impact: 50
@@ -766,7 +656,28 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/security/kms/
         title: STACKIT Documentation - Key Management Service (KMS)
-  # ----------------------------- Kubernetes (auto-update) -----------------------------
+  # ----------------------------- STACKIT Kubernetes (SKE) -----------------------------
+  - uid: mondoo-stackit-security-ske-cluster-healthy
+    title: Ensure STACKIT SKE clusters are not in an unhealthy state
+    impact: 40
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.ske.clusters.all(status != "STATE_UNHEALTHY")
+    docs:
+      desc: |
+        This check ensures that no STACKIT Kubernetes Engine (SKE) cluster reports an unhealthy state. An unhealthy cluster may not be applying security updates, may have degraded control-plane components, and may not be enforcing intended policy. (Hibernated clusters are a valid operational state and are not flagged.)
+
+        **Why this matters**
+
+        - **Patch and policy enforcement:** An unhealthy cluster may not reliably apply updates or admission controls.
+        - **Operational visibility:** Surfacing unhealthy clusters prompts timely investigation.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, open the SKE cluster's status details, investigate the reported condition, and remediate the underlying issue (for example a failed maintenance or node-pool problem).
+    refs:
+      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
+        title: STACKIT Documentation - Kubernetes Engine (SKE)
   - uid: mondoo-stackit-security-ske-cluster-auto-update
     title: Ensure STACKIT SKE clusters enable Kubernetes version auto-update
     impact: 50
@@ -788,3 +699,89 @@ queries:
     refs:
       - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
         title: STACKIT Documentation - Kubernetes Engine (SKE)
+  # ----------------------------- STACKIT Telemetry -----------------------------
+  - uid: mondoo-stackit-security-telemetry-token-expiry-set
+    title: Ensure STACKIT telemetry router access tokens have an expiry
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.telemetry.routers.all(accessTokens.all(expiresAt != null))
+    docs:
+      desc: |
+        This check ensures that every access token issued for a STACKIT telemetry router has an expiry time set. Long-lived or non-expiring credentials increase the window of exposure if a token is leaked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** Expiring tokens limit how long a leaked credential remains valid.
+        - **Credential hygiene:** Enforcing expiry encourages regular rotation.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue telemetry router access tokens with a bounded validity period and remove any non-expiring tokens.
+    refs:
+      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
+        title: STACKIT Documentation - Telemetry Router
+  - uid: mondoo-stackit-security-telemetry-token-not-expired
+    title: Ensure STACKIT telemetry router access tokens are not expired
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.telemetry.routers.all(accessTokens.all(expiresAt == null || expiresAt > time.now))
+    docs:
+      desc: |
+        This check flags expired access tokens still present on STACKIT telemetry routers. Expired tokens that are not removed represent stale credentials that should be cleaned up as part of good credential hygiene.
+
+        **Why this matters**
+
+        - **Stale credential cleanup:** Removing expired tokens reduces clutter and the chance of confusion during audits.
+        - **Hygiene:** Lingering expired credentials can mask active ones during review.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, delete expired telemetry router access tokens and reissue new ones where access is still required.
+    refs:
+      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
+        title: STACKIT Documentation - Telemetry Router
+  # ----------------------------- STACKIT Model Serving -----------------------------
+  - uid: mondoo-stackit-security-modelserving-token-expiry-set
+    title: Ensure STACKIT Model Serving tokens have a bounded validity
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.modelServing.tokens.all(validUntil != null)
+    docs:
+      desc: |
+        This check ensures that every STACKIT Model Serving authentication token has a validity end date set. Non-expiring tokens increase the window of exposure if a credential is leaked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** A validity end date limits how long a leaked token remains usable.
+        - **Credential hygiene:** Enforcing expiry encourages regular rotation of inference credentials.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue Model Serving tokens with a bounded validity period and remove any non-expiring tokens.
+    refs:
+      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
+        title: STACKIT Documentation - Model Serving
+  - uid: mondoo-stackit-security-modelserving-token-not-expired
+    title: Ensure STACKIT Model Serving tokens are not expired
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.modelServing.tokens.all(validUntil == null || validUntil > time.now)
+    docs:
+      desc: |
+        This check flags expired STACKIT Model Serving tokens that are still present. Expired tokens that are not removed represent stale credentials that should be cleaned up.
+
+        **Why this matters**
+
+        - **Stale credential cleanup:** Removing expired tokens reduces clutter and audit confusion.
+        - **Hygiene:** Lingering expired credentials can obscure active ones during review.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, delete expired Model Serving tokens and reissue new ones where access is still required.
+    refs:
+      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
+        title: STACKIT Documentation - Model Serving

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -1,0 +1,790 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-stackit-security
+    name: Mondoo STACKIT Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: stackit,cloud
+    require:
+      - provider: stackit
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Secure STACKIT compute, storage, databases, networking, and IAM
+    docs:
+      desc: |
+        The Mondoo STACKIT Security policy identifies critical misconfigurations that could leave your STACKIT projects vulnerable to attackers. It helps organizations detect and remediate security risks before they can be exploited, reducing the likelihood of unauthorized access, data breaches, and operational disruptions.
+
+        The policy runs directly against a STACKIT project and provides security checks across these services:
+
+        - **Compute** — servers attached to security groups, block storage volume encryption
+        - **Networking** — security groups (no public SSH/RDP/all-ports ingress), application load balancers
+        - **Object Storage** — S3-compatible buckets (Object Lock and retention)
+        - **File Storage (SFS)** — resource pool and NFS export-policy access controls, snapshot policy
+        - **Managed Databases** — PostgreSQL Flex, MongoDB Flex, SQLServer Flex (network exposure, backups, high availability)
+        - **Secrets Manager** — network exposure
+        - **Identity & Access** — service account key and access-token expiry
+        - **Key Management (KMS)** — key lifecycle and health
+        - **Kubernetes Engine (SKE)** — cluster health and version auto-update
+        - **Telemetry Router** and **AI Model Serving** — access-token lifecycle
+
+        ## Scope and design
+
+        The checks focus on controls an operator **can misconfigure** — network exposure, access-control lists, credential expiry, backups, and high availability. Where STACKIT enforces a control by default and exposes no setting to weaken it — for example mandatory **TLS 1.3** in transit and always-on **AES-256 encryption at rest** for managed databases and storage — the policy intentionally does not add a check, because there is no insecure state to detect. Per-group notes call out these platform guarantees so a passing scan is not mistaken for missing coverage.
+
+        If you have questions, reach out to Mondoo at hello@mondoo.com.
+    groups:
+      - title: STACKIT Compute
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-compute-server-has-security-group
+          - uid: mondoo-stackit-security-compute-volume-encrypted
+      - title: STACKIT Networking
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-network-no-public-ssh
+          - uid: mondoo-stackit-security-network-no-public-rdp
+          - uid: mondoo-stackit-security-network-no-unrestricted-ingress
+          - uid: mondoo-stackit-security-network-alb-target-security-groups
+      - title: STACKIT Object Storage
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-objectstorage-bucket-object-lock
+          - uid: mondoo-stackit-security-objectstorage-bucket-retention
+      - title: STACKIT File Storage
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-sfs-resourcepool-restricted-ipacl
+          - uid: mondoo-stackit-security-sfs-export-policy-restricted
+          - uid: mondoo-stackit-security-sfs-resourcepool-snapshot-policy
+      - title: STACKIT Managed Databases
+        filters: asset.platform == "stackit-project"
+        docs:
+          desc: |
+            These checks cover the STACKIT managed-database engines (PostgreSQL Flex, MongoDB Flex, and SQLServer Flex).
+
+            **Why encryption and TLS are not checked here**
+
+            Several controls that are configurable (and therefore checkable) on other clouds are *platform guarantees* on STACKIT, not user-tunable settings — so there is no insecure state to detect, and a check would always pass:
+
+            - **Encryption in transit:** Connections are always encrypted with TLS 1.3 and signed certificates; unencrypted access is not possible.
+            - **Encryption at rest:** Instance storage and backup storage are encrypted system-side with AES-256 by default.
+            - **Automated backups:** The full instance is backed up automatically, and deletion is delayed (soft-delete) before permanent removal.
+
+            These checks therefore focus on what an operator *can* misconfigure: network exposure (the access-control list), whether a backup schedule is set, and high availability (replica count).
+        checks:
+          - uid: mondoo-stackit-security-db-postgres-acl-restricted
+          - uid: mondoo-stackit-security-db-postgres-backups
+          - uid: mondoo-stackit-security-db-mongodb-acl-restricted
+          - uid: mondoo-stackit-security-db-mongodb-backups
+          - uid: mondoo-stackit-security-db-sqlserver-acl-restricted
+          - uid: mondoo-stackit-security-db-sqlserver-backups
+          - uid: mondoo-stackit-security-db-postgres-high-availability
+          - uid: mondoo-stackit-security-db-mongodb-high-availability
+          - uid: mondoo-stackit-security-db-sqlserver-high-availability
+      - title: STACKIT Secrets Manager
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-secretsmanager-acl-restricted
+      - title: STACKIT Identity & Access
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-serviceaccount-key-bounded-validity
+          - uid: mondoo-stackit-security-serviceaccount-token-bounded-validity
+      - title: STACKIT Key Management
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-kms-key-not-pending-deletion
+          - uid: mondoo-stackit-security-kms-key-healthy-state
+      - title: STACKIT Kubernetes (SKE)
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-ske-cluster-healthy
+          - uid: mondoo-stackit-security-ske-cluster-auto-update
+      - title: STACKIT Telemetry
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-telemetry-token-expiry-set
+          - uid: mondoo-stackit-security-telemetry-token-not-expired
+      - title: STACKIT Model Serving
+        filters: asset.platform == "stackit-project"
+        checks:
+          - uid: mondoo-stackit-security-modelserving-token-expiry-set
+          - uid: mondoo-stackit-security-modelserving-token-not-expired
+queries:
+  # ----------------------------- Compute -----------------------------
+  - uid: mondoo-stackit-security-compute-server-has-security-group
+    title: Ensure STACKIT servers are attached to a security group
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.servers.all(securityGroups.length > 0)
+    docs:
+      desc: |
+        This check ensures that every STACKIT compute server is associated with at least one security group. Security groups are the primary mechanism for controlling inbound and outbound network traffic to a server; a server with no security group attached has no stateful network filtering applied at the instance level.
+
+        **Why this matters**
+
+        - **No instance-level filtering:** Without a security group, the server relies entirely on network-level controls, increasing the chance of unintended exposure.
+        - **Inconsistent posture:** Servers missing a security group are easy to overlook in audits and drift from the project's intended baseline.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, open **Compute Engine** > **Servers**, select the server, and attach an appropriate security group under its network settings.
+    refs:
+      - url: https://docs.stackit.cloud/products/network/network-security/
+        title: STACKIT Documentation - Security Groups
+  - uid: mondoo-stackit-security-compute-volume-encrypted
+    title: Ensure STACKIT block storage volumes are encrypted
+    impact: 80
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.volumes.all(encrypted == true)
+    docs:
+      desc: |
+        This check ensures that all STACKIT block storage volumes are encrypted at rest. Encryption at rest protects the confidentiality of data stored on a volume if the underlying physical media is accessed outside of the normal service boundary.
+
+        **Why this matters**
+
+        - **Data confidentiality:** Encryption protects sensitive data on the volume from disclosure if storage media is decommissioned or accessed improperly.
+        - **Compliance:** Many frameworks require encryption of data at rest for regulated workloads.
+      remediation:
+        - id: console
+          desc: |
+            Volume encryption is configured at creation time. For an unencrypted volume, create a new encrypted volume and migrate the data, then detach and delete the unencrypted volume.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/block-storage/
+        title: STACKIT Documentation - Block Storage
+  # ----------------------------- Networking -----------------------------
+  - uid: mondoo-stackit-security-network-no-public-ssh
+    title: Ensure no security group exposes SSH (port 22) to the internet
+    impact: 90
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin <= 22 && portRangeMax >= 22).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
+    docs:
+      desc: |
+        This check ensures that no security group rule permits inbound SSH (TCP port 22) from the entire internet (`0.0.0.0/0` or `::/0`). SSH grants interactive shell access; exposing it to the world dramatically increases the risk of brute-force and credential-stuffing attacks.
+
+        **Why this matters**
+
+        - **Direct administrative exposure:** A world-open SSH port is continuously scanned and attacked across the internet.
+        - **Credential risk:** Exposed SSH endpoints are a primary target for password-guessing and key-compromise attacks.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the offending security group rule and restrict the SSH source CIDR to a bastion host, VPN range, or specific administrative network instead of `0.0.0.0/0`.
+    refs:
+      - url: https://docs.stackit.cloud/products/network/network-security/
+        title: STACKIT Documentation - Security Groups
+  - uid: mondoo-stackit-security-network-no-public-rdp
+    title: Ensure no security group exposes RDP (port 3389) to the internet
+    impact: 90
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin <= 3389 && portRangeMax >= 3389).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
+    docs:
+      desc: |
+        This check ensures that no security group rule permits inbound RDP (TCP port 3389) from the entire internet (`0.0.0.0/0` or `::/0`). RDP provides remote desktop access to Windows servers and is a frequent target of automated attacks and ransomware campaigns when exposed publicly.
+
+        **Why this matters**
+
+        - **Remote desktop exposure:** Publicly reachable RDP is aggressively scanned and exploited.
+        - **Ransomware vector:** Internet-facing RDP is one of the most common initial-access vectors for ransomware.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the offending security group rule and restrict the RDP source CIDR to a bastion host or VPN range instead of `0.0.0.0/0`.
+    refs:
+      - url: https://docs.stackit.cloud/products/network/network-security/
+        title: STACKIT Documentation - Security Groups
+  - uid: mondoo-stackit-security-network-no-unrestricted-ingress
+    title: Ensure no security group exposes all ports to the internet
+    impact: 85
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin == null).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
+    docs:
+      desc: |
+        This check ensures that no security group rule permits inbound traffic on all ports from the entire internet (`0.0.0.0/0` or `::/0`). A rule that opens the full port range to the world exposes every service running on attached servers, including those never intended to be reachable externally.
+
+        **Why this matters**
+
+        - **Broad attack surface:** An all-ports world-open rule exposes every listening service, including management and database ports.
+        - **Defeats segmentation:** Such a rule negates the benefit of fine-grained network controls.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, replace the broad rule with specific rules that open only the required ports to the smallest necessary source CIDRs.
+    refs:
+      - url: https://docs.stackit.cloud/products/network/network-security/
+        title: STACKIT Documentation - Security Groups
+  - uid: mondoo-stackit-security-network-alb-target-security-groups
+    title: Ensure STACKIT application load balancers assign target security groups
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.albLoadBalancers.all(disableTargetSecurityGroupAssignment == false)
+    docs:
+      desc: |
+        This check ensures that STACKIT application load balancers (ALBs) do not disable automatic target security group assignment. When this assignment is disabled, the load balancer's targets are not automatically protected by the managed security group, which can leave backend servers reachable from unintended sources.
+
+        **Why this matters**
+
+        - **Backend exposure:** Without the target security group, backend servers may be reachable outside the intended load-balancer path.
+        - **Posture drift:** Disabling managed assignment shifts responsibility to manual rules that are easy to misconfigure.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the application load balancer and re-enable target security group assignment, or manually ensure the targets are protected by an equivalent security group.
+    refs:
+      - url: https://docs.stackit.cloud/products/network/load-balancing-and-content-delivery/application-load-balancer/
+        title: STACKIT Documentation - Application Load Balancer
+  # ----------------------------- Object Storage -----------------------------
+  - uid: mondoo-stackit-security-objectstorage-bucket-object-lock
+    title: Ensure STACKIT Object Storage buckets have Object Lock enabled
+    impact: 70
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.objectStorage.buckets.all(objectLockEnabled == true)
+    docs:
+      desc: |
+        This check ensures that STACKIT Object Storage buckets have Object Lock (write-once-read-many, WORM) enabled. Object Lock protects objects from being overwritten or deleted for a defined retention period, which is important for compliance, ransomware resilience, and audit-log integrity.
+
+        **Why this matters**
+
+        - **Ransomware resilience:** WORM-protected objects cannot be encrypted or deleted by an attacker who gains write access.
+        - **Tamper-evidence:** Retained objects support reliable forensic and compliance evidence.
+
+        Note: Object Lock must be enabled at bucket creation. Apply this check to buckets that store audit logs, backups, or regulated data.
+      remediation:
+        - id: console
+          desc: |
+            Object Lock is set when a bucket is created. For an existing bucket without Object Lock, create a new bucket with Object Lock enabled and migrate the objects.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/object-storage/
+        title: STACKIT Documentation - Object Storage
+  - uid: mondoo-stackit-security-objectstorage-bucket-retention
+    title: Ensure Object-Locked buckets define a default retention period
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.objectStorage.buckets.where(objectLockEnabled == true).all(defaultRetentionDays > 0)
+    docs:
+      desc: |
+        This check ensures that STACKIT Object Storage buckets which have Object Lock enabled also define a default retention period greater than zero. Object Lock without a default retention leaves new objects unprotected unless retention is set per-object, which is easy to miss.
+
+        **Why this matters**
+
+        - **Consistent protection:** A default retention guarantees every new object is WORM-protected without relying on per-object configuration.
+        - **Operational safety:** Reduces the chance of objects being deletable due to a forgotten retention setting.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, configure a default retention period (in days) and mode for the Object-Locked bucket so new objects inherit WORM protection.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/object-storage/
+        title: STACKIT Documentation - Object Storage
+  # ----------------------------- File Storage (SFS) -----------------------------
+  - uid: mondoo-stackit-security-sfs-resourcepool-restricted-ipacl
+    title: Ensure STACKIT SFS resource pools restrict their mount IP allow-list
+    impact: 85
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sfs.resourcePools.all(ipAcl.none(_ == "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT File Storage (SFS) resource pools do not allow mounting from the entire internet (`0.0.0.0/0`) via their IP allow-list (`ipAcl`). NFS shares hosted in a pool that is mountable from anywhere expose file data to any host that can reach the endpoint.
+
+        **Why this matters**
+
+        - **Unauthenticated file access:** NFS typically relies on network reachability for access control; a world-open allow-list exposes the file data broadly.
+        - **Data exfiltration risk:** Any reachable host could mount and read or write share contents.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the SFS resource pool and restrict the IP allow-list to the specific subnets or hosts that must mount its shares.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/file-storage/
+        title: STACKIT Documentation - File Storage (SFS)
+  - uid: mondoo-stackit-security-sfs-export-policy-restricted
+    title: Ensure STACKIT SFS export policies do not allow world-open NFS access
+    impact: 85
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sfs.exportPolicies.all(rules.all(ipAcl.none(_ == "0.0.0.0/0")))
+    docs:
+      desc: |
+        This check ensures that no STACKIT File Storage (SFS) export policy rule grants NFS access to the entire internet (`0.0.0.0/0`). Export policies define which clients may mount shares and with what access; a rule open to the world removes the network boundary protecting the data.
+
+        **Why this matters**
+
+        - **Broad share exposure:** A world-open export rule lets any reachable host mount the share.
+        - **Lateral movement:** Overly broad NFS access can aid an attacker pivoting within the environment.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the export policy and replace any `0.0.0.0/0` rule with specific client CIDRs that require access.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/file-storage/
+        title: STACKIT Documentation - File Storage (SFS)
+  - uid: mondoo-stackit-security-sfs-resourcepool-snapshot-policy
+    title: Ensure STACKIT SFS resource pools have a snapshot policy attached
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sfs.resourcePools.all(snapshotPolicyId != "")
+    docs:
+      desc: |
+        This check ensures that STACKIT File Storage (SFS) resource pools have a snapshot policy attached. Snapshot policies provide point-in-time copies of file data, supporting recovery from accidental deletion, corruption, or ransomware.
+
+        **Why this matters**
+
+        - **Recoverability:** Snapshots enable restoration of file data after destructive events.
+        - **Ransomware resilience:** Regular snapshots provide a recovery path that does not depend on the live data.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, attach a snapshot policy to the SFS resource pool with a schedule and retention appropriate for the data's recovery requirements.
+    refs:
+      - url: https://docs.stackit.cloud/products/storage/file-storage/
+        title: STACKIT Documentation - File Storage (SFS)
+  # ----------------------------- Managed Databases -----------------------------
+  - uid: mondoo-stackit-security-db-postgres-acl-restricted
+    title: Ensure PostgreSQL Flex instances do not allow access from the internet
+    impact: 90
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.postgresFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT PostgreSQL Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
+
+        **Why this matters**
+
+        - **Direct data exposure:** A world-open database ACL puts the data one credential away from the entire internet.
+        - **Attack surface:** Internet-reachable database ports are continuously scanned and attacked.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the PostgreSQL Flex instance ACL and restrict access to the specific application subnets or hosts that require connectivity.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/postgresql-flex/
+        title: STACKIT Documentation - PostgreSQL Flex
+  - uid: mondoo-stackit-security-db-postgres-backups
+    title: Ensure PostgreSQL Flex instances have a backup schedule configured
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.postgresFlex.instances.all(backupSchedule != "")
+    docs:
+      desc: |
+        This check ensures that STACKIT PostgreSQL Flex instances have a backup schedule configured. Regular automated backups are essential for recovery from data loss, corruption, or ransomware.
+
+        **Why this matters**
+
+        - **Recoverability:** A backup schedule provides restore points for the database.
+        - **Business continuity:** Backups limit data loss after a destructive incident.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, configure a backup schedule for the PostgreSQL Flex instance with a frequency and retention that meet your recovery objectives.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/postgresql-flex/
+        title: STACKIT Documentation - PostgreSQL Flex
+  - uid: mondoo-stackit-security-db-mongodb-acl-restricted
+    title: Ensure MongoDB Flex instances do not allow access from the internet
+    impact: 90
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.mongoDbFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT MongoDB Flex instances do not include `0.0.0.0/0` in their access control list (ACL). Internet-reachable databases are a primary target for data theft and extortion.
+
+        **Why this matters**
+
+        - **Direct data exposure:** A world-open ACL exposes the database to the entire internet.
+        - **Attack surface:** Open database ports are continuously scanned and attacked.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the MongoDB Flex instance ACL and restrict access to the specific application subnets or hosts that require connectivity.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/mongodb-flex/
+        title: STACKIT Documentation - MongoDB Flex
+  - uid: mondoo-stackit-security-db-mongodb-backups
+    title: Ensure MongoDB Flex instances have a backup schedule configured
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.mongoDbFlex.instances.all(backupSchedule != "")
+    docs:
+      desc: |
+        This check ensures that STACKIT MongoDB Flex instances have a backup schedule configured. Automated backups provide recovery points after data loss, corruption, or ransomware.
+
+        **Why this matters**
+
+        - **Recoverability:** A backup schedule provides restore points for the database.
+        - **Business continuity:** Backups limit data loss after a destructive incident.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, configure a backup schedule for the MongoDB Flex instance with a frequency and retention that meet your recovery objectives.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/mongodb-flex/
+        title: STACKIT Documentation - MongoDB Flex
+  - uid: mondoo-stackit-security-db-sqlserver-acl-restricted
+    title: Ensure SQLServer Flex instances do not allow access from the internet
+    impact: 90
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sqlServerFlex.instances.all(acl.none(_ == "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT SQLServer Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
+
+        **Why this matters**
+
+        - **Direct data exposure:** A world-open ACL exposes the database to the entire internet.
+        - **Attack surface:** Open database ports are continuously scanned and attacked.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the SQLServer Flex instance ACL and restrict access to the specific application subnets or hosts that require connectivity.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/sqlserver-flex/
+        title: STACKIT Documentation - SQLServer Flex
+  - uid: mondoo-stackit-security-db-sqlserver-backups
+    title: Ensure SQLServer Flex instances have a backup schedule configured
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sqlServerFlex.instances.all(backupSchedule != "")
+    docs:
+      desc: |
+        This check ensures that STACKIT SQLServer Flex instances have a backup schedule configured. Automated backups provide recovery points after data loss, corruption, or ransomware.
+
+        **Why this matters**
+
+        - **Recoverability:** A backup schedule provides restore points for the database.
+        - **Business continuity:** Backups limit data loss after a destructive incident.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, configure a backup schedule for the SQLServer Flex instance with a frequency and retention that meet your recovery objectives.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/sqlserver-flex/
+        title: STACKIT Documentation - SQLServer Flex
+  # ----------------------------- Secrets Manager -----------------------------
+  - uid: mondoo-stackit-security-secretsmanager-acl-restricted
+    title: Ensure Secrets Manager instances do not allow access from the internet
+    impact: 85
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0"))
+    docs:
+      desc: |
+        This check ensures that STACKIT Secrets Manager instances do not include `0.0.0.0/0` in their access control list. Secrets Manager stores sensitive credentials; exposing its API to the entire internet broadens the attack surface around your most sensitive data.
+
+        **Why this matters**
+
+        - **Sensitive data exposure:** Secrets Manager holds credentials whose compromise can cascade across systems.
+        - **Reduced attack surface:** Restricting the ACL limits who can even attempt to reach the secrets API.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the Secrets Manager instance access control list and restrict it to the specific subnets or hosts that require access.
+    refs:
+      - url: https://docs.stackit.cloud/products/security/secrets-manager/
+        title: STACKIT Documentation - Secrets Manager
+  # ----------------------------- Key Management -----------------------------
+  - uid: mondoo-stackit-security-kms-key-not-pending-deletion
+    title: Ensure STACKIT KMS keys are not scheduled for deletion
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.kms.keys.all(deletionDate == null)
+    docs:
+      desc: |
+        This check flags STACKIT KMS keys that have a scheduled deletion date. A key pending deletion will become permanently unusable once the date passes, which can render all data encrypted under that key unrecoverable if the deletion was unintended.
+
+        **Why this matters**
+
+        - **Irreversible data loss:** Data encrypted with a deleted KMS key cannot be decrypted.
+        - **Early detection:** Surfacing pending deletions allows the deletion to be cancelled before it is too late.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, review keys with a scheduled deletion. If the deletion is unintended, cancel it; otherwise confirm no active data depends on the key before it is removed.
+    refs:
+      - url: https://docs.stackit.cloud/products/security/kms/
+        title: STACKIT Documentation - Key Management Service (KMS)
+  # ----------------------------- Kubernetes (SKE) -----------------------------
+  - uid: mondoo-stackit-security-ske-cluster-healthy
+    title: Ensure STACKIT SKE clusters are not in an unhealthy state
+    impact: 40
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.ske.clusters.all(status != "STATE_UNHEALTHY")
+    docs:
+      desc: |
+        This check ensures that no STACKIT Kubernetes Engine (SKE) cluster reports an unhealthy state. An unhealthy cluster may not be applying security updates, may have degraded control-plane components, and may not be enforcing intended policy. (Hibernated clusters are a valid operational state and are not flagged.)
+
+        **Why this matters**
+
+        - **Patch and policy enforcement:** An unhealthy cluster may not reliably apply updates or admission controls.
+        - **Operational visibility:** Surfacing unhealthy clusters prompts timely investigation.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, open the SKE cluster's status details, investigate the reported condition, and remediate the underlying issue (for example a failed maintenance or node-pool problem).
+    refs:
+      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
+        title: STACKIT Documentation - Kubernetes Engine (SKE)
+  # ----------------------------- Telemetry -----------------------------
+  - uid: mondoo-stackit-security-telemetry-token-expiry-set
+    title: Ensure STACKIT telemetry router access tokens have an expiry
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.telemetry.routers.all(accessTokens.all(expiresAt != null))
+    docs:
+      desc: |
+        This check ensures that every access token issued for a STACKIT telemetry router has an expiry time set. Long-lived or non-expiring credentials increase the window of exposure if a token is leaked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** Expiring tokens limit how long a leaked credential remains valid.
+        - **Credential hygiene:** Enforcing expiry encourages regular rotation.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue telemetry router access tokens with a bounded validity period and remove any non-expiring tokens.
+    refs:
+      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
+        title: STACKIT Documentation - Telemetry Router
+  - uid: mondoo-stackit-security-telemetry-token-not-expired
+    title: Ensure STACKIT telemetry router access tokens are not expired
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.telemetry.routers.all(accessTokens.all(expiresAt == null || expiresAt > time.now))
+    docs:
+      desc: |
+        This check flags expired access tokens still present on STACKIT telemetry routers. Expired tokens that are not removed represent stale credentials that should be cleaned up as part of good credential hygiene.
+
+        **Why this matters**
+
+        - **Stale credential cleanup:** Removing expired tokens reduces clutter and the chance of confusion during audits.
+        - **Hygiene:** Lingering expired credentials can mask active ones during review.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, delete expired telemetry router access tokens and reissue new ones where access is still required.
+    refs:
+      - url: https://docs.stackit.cloud/products/logging-and-monitoring/telemetry-router/
+        title: STACKIT Documentation - Telemetry Router
+  # ----------------------------- Model Serving -----------------------------
+  - uid: mondoo-stackit-security-modelserving-token-expiry-set
+    title: Ensure STACKIT Model Serving tokens have a bounded validity
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.modelServing.tokens.all(validUntil != null)
+    docs:
+      desc: |
+        This check ensures that every STACKIT Model Serving authentication token has a validity end date set. Non-expiring tokens increase the window of exposure if a credential is leaked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** A validity end date limits how long a leaked token remains usable.
+        - **Credential hygiene:** Enforcing expiry encourages regular rotation of inference credentials.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue Model Serving tokens with a bounded validity period and remove any non-expiring tokens.
+    refs:
+      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
+        title: STACKIT Documentation - Model Serving
+  - uid: mondoo-stackit-security-modelserving-token-not-expired
+    title: Ensure STACKIT Model Serving tokens are not expired
+    impact: 60
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.modelServing.tokens.all(validUntil == null || validUntil > time.now)
+    docs:
+      desc: |
+        This check flags expired STACKIT Model Serving tokens that are still present. Expired tokens that are not removed represent stale credentials that should be cleaned up.
+
+        **Why this matters**
+
+        - **Stale credential cleanup:** Removing expired tokens reduces clutter and audit confusion.
+        - **Hygiene:** Lingering expired credentials can obscure active ones during review.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, delete expired Model Serving tokens and reissue new ones where access is still required.
+    refs:
+      - url: https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/
+        title: STACKIT Documentation - Model Serving
+  # ----------------------------- Managed Databases (HA) -----------------------------
+  - uid: mondoo-stackit-security-db-postgres-high-availability
+    title: Ensure PostgreSQL Flex instances run with multiple replicas
+    impact: 40
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.postgresFlex.instances.all(replicas >= 2)
+    docs:
+      desc: |
+        This check ensures that STACKIT PostgreSQL Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss. This mirrors the Multi-AZ / high-availability checks applied to managed databases on other clouds.
+
+        **Why this matters**
+
+        - **Failover:** Multiple replicas allow the service to survive the loss of a node without an outage.
+        - **Durability:** Replication reduces the risk of data loss from a single-node failure.
+
+        Note: Single-replica instances may be acceptable for development workloads; tune the expectation to your environment.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, scale the PostgreSQL Flex instance to two or more replicas for production workloads.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/postgresql-flex/
+        title: STACKIT Documentation - PostgreSQL Flex
+  - uid: mondoo-stackit-security-db-mongodb-high-availability
+    title: Ensure MongoDB Flex instances run with multiple replicas
+    impact: 40
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.mongoDbFlex.instances.all(replicas >= 2)
+    docs:
+      desc: |
+        This check ensures that STACKIT MongoDB Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss.
+
+        **Why this matters**
+
+        - **Failover:** Multiple replicas allow the service to survive the loss of a node without an outage.
+        - **Durability:** Replication reduces the risk of data loss from a single-node failure.
+
+        Note: Single-replica instances may be acceptable for development workloads.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, scale the MongoDB Flex instance to two or more replicas for production workloads.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/mongodb-flex/
+        title: STACKIT Documentation - MongoDB Flex
+  - uid: mondoo-stackit-security-db-sqlserver-high-availability
+    title: Ensure SQLServer Flex instances run with multiple replicas
+    impact: 40
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.sqlServerFlex.instances.all(replicas >= 2)
+    docs:
+      desc: |
+        This check ensures that STACKIT SQLServer Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss.
+
+        **Why this matters**
+
+        - **Failover:** Multiple replicas allow the service to survive the loss of a node without an outage.
+        - **Durability:** Replication reduces the risk of data loss from a single-node failure.
+
+        Note: Single-replica instances may be acceptable for development workloads.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, scale the SQLServer Flex instance to two or more replicas for production workloads.
+    refs:
+      - url: https://docs.stackit.cloud/products/databases/sqlserver-flex/
+        title: STACKIT Documentation - SQLServer Flex
+  # ----------------------------- Identity & Access -----------------------------
+  - uid: mondoo-stackit-security-serviceaccount-key-bounded-validity
+    title: Ensure active service account keys have a bounded validity
+    impact: 70
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.serviceAccounts.all(keys.where(_['active'] == true).all(_['validUntil'] != null))
+    docs:
+      desc: |
+        This check ensures that every active service account key has an expiry (`validUntil`) set. Long-lived, non-expiring service account keys are a high-value target: if leaked, they grant programmatic access indefinitely until manually revoked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** An expiry limits how long a leaked key remains usable.
+        - **Forced rotation:** Expiring keys drive regular credential rotation, reducing the blast radius of a compromise.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue service account keys with a bounded validity period and remove any active keys that never expire.
+    refs:
+      - url: https://docs.stackit.cloud/platform/access-and-identity/service-accounts/
+        title: STACKIT Documentation - Service Accounts
+  - uid: mondoo-stackit-security-serviceaccount-token-bounded-validity
+    title: Ensure active service account access tokens have a bounded validity
+    impact: 70
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.serviceAccounts.all(accessTokens.where(_['active'] == true).all(_['validUntil'] != null))
+    docs:
+      desc: |
+        This check ensures that every active service account access token has an expiry (`validUntil`) set. Non-expiring access tokens that are leaked grant programmatic access until they are manually revoked.
+
+        **Why this matters**
+
+        - **Bounded exposure:** An expiry limits how long a leaked token remains usable.
+        - **Credential hygiene:** Enforcing expiry drives regular rotation of access tokens.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, reissue service account access tokens with a bounded validity period and remove any active tokens that never expire.
+    refs:
+      - url: https://docs.stackit.cloud/platform/access-and-identity/service-accounts/
+        title: STACKIT Documentation - Service Accounts
+  # ----------------------------- Key Management (state) -----------------------------
+  - uid: mondoo-stackit-security-kms-key-healthy-state
+    title: Ensure STACKIT KMS keys are in a healthy state
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.kms.keys.none(state == "errors_exist" || state == "not_available")
+    docs:
+      desc: |
+        This check flags STACKIT KMS keys that are in an error or unavailable state (`errors_exist`, `not_available`) rather than the healthy `active` state. A key that is not available cannot perform cryptographic operations, which can break encryption and decryption for any data or service relying on it.
+
+        **Why this matters**
+
+        - **Operational integrity:** A key in an error state may prevent decryption of protected data.
+        - **Early detection:** Surfacing unhealthy keys prompts investigation before dependent workloads fail.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, investigate the key's reported state under Key Management Service and remediate the underlying issue, or rotate to a healthy key.
+    refs:
+      - url: https://docs.stackit.cloud/products/security/kms/
+        title: STACKIT Documentation - Key Management Service (KMS)
+  # ----------------------------- Kubernetes (auto-update) -----------------------------
+  - uid: mondoo-stackit-security-ske-cluster-auto-update
+    title: Ensure STACKIT SKE clusters enable Kubernetes version auto-update
+    impact: 50
+    filters: asset.platform == "stackit-project"
+    mql: |
+      stackit.ske.clusters.all(maintenance['autoUpdate']['kubernetesVersion'] == true)
+    docs:
+      desc: |
+        This check ensures that STACKIT Kubernetes Engine (SKE) clusters have automatic Kubernetes version updates enabled in their maintenance configuration. Clusters that do not auto-update can fall behind on security patches and run unsupported Kubernetes versions.
+
+        **Why this matters**
+
+        - **Timely patching:** Auto-update ensures the cluster receives Kubernetes security fixes during its maintenance window.
+        - **Supported versions:** Staying current avoids running end-of-life Kubernetes releases that no longer receive fixes.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the SKE cluster maintenance settings and enable automatic Kubernetes version updates, choosing an appropriate maintenance time window.
+    refs:
+      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
+        title: STACKIT Documentation - Kubernetes Engine (SKE)


### PR DESCRIPTION
## What

Adds `content/mondoo-stackit-security.mql.yaml` — a security policy for STACKIT projects, modeled on the existing AWS / Azure / GCP cloud policies (same bundle structure, groups-by-service, `docs`/`remediation`/`refs`).

**31 checks across 10 groups**, each scoped with `filters: asset.platform == "stackit-project"`:

| Group | Checks |
|---|---|
| Compute | SG attachment, volume encryption |
| Networking | no public SSH / RDP / all-ports ingress, ALB target SGs |
| Object Storage | Object Lock + default retention |
| File Storage (SFS) | resource-pool & export-policy ACLs, snapshot policy |
| Managed Databases | Postgres/Mongo/SQLServer Flex — ACL, backups, high availability |
| Secrets Manager | network exposure |
| Identity & Access | service-account key + token expiry |
| Key Management | key not pending deletion, healthy state |
| Kubernetes (SKE) | cluster health, version auto-update |
| Telemetry / Model Serving | access-token lifecycle |

## Design notes

- **Secure-by-default scope.** Where STACKIT enforces a control with no setting to weaken it — mandatory **TLS 1.3** in transit, always-on **AES-256 encryption at rest** for databases and storage — the policy intentionally omits a check (there is no insecure state to detect) and documents the platform guarantee in the relevant group's description, so a passing scan isn't mistaken for missing coverage. This is called out explicitly in the Managed Databases group note.
- **DBaaS checks** focus on what an operator can misconfigure: network exposure (ACL), backups, and high availability (replica count). Other cloud DB checks (encryption/TLS/deletion-protection) are not portable — the STACKIT Flex API does not expose those as settings.
- All `refs` point at current `docs.stackit.cloud/products/…` pages (verified HTTP 200).

## Testing

- `cnspec policy lint` ✅ — every MQL query compiles against the live STACKIT provider schema.
- **Live scan against a real STACKIT project** ✅ — 30 pass / 1 real finding / **0 errors**. The finding (an active service-account key with no expiry) is a true positive.

## Requires

- The STACKIT provider with the region/client fixes in mondoohq/mql#8477 (needed for the provider to return data live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)