### PR TITLE
🐛 cisco-iosxe: persist config in remediations + harden auth guidance

### DIFF
--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-iosxe-security
     name: Mondoo Cisco IOS-XE Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -164,9 +164,15 @@ queries:
             ip domain name <domain.com>
             crypto key generate rsa modulus 2048
             ip ssh version 2
+            end
+            write memory
             ```
 
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
+
             If an RSA key pair already exists, the key generation command asks for confirmation before replacing it. Replacing the key pair changes the SSH host identity, so clients that stored the old host key must accept the new one.
+
+            Generating the host key alone does not let anyone log in over SSH. The VTY lines must accept SSH and use a login method. Configure `transport input ssh` and a login method such as `login local` or AAA on the VTY lines, which the SSH transport check and the AAA authentication check cover, or remote access still fails.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_ssh/configuration/xe-16/sec-usr-ssh-xe-16-book/sec-secure-shell-v2.html
         title: Cisco IOS-XE SSH Configuration Guide
@@ -223,7 +229,11 @@ queries:
             ```
             configure terminal
             ip ssh version 2
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_ssh/configuration/xe-16/sec-usr-ssh-xe-16-book/sec-secure-shell-v2.html
         title: Cisco IOS-XE SSH Configuration Guide
@@ -280,7 +290,11 @@ queries:
             ```
             configure terminal
             ip ssh time-out 60
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_ssh/configuration/xe-16/sec-usr-ssh-xe-16-book/sec-secure-shell-v2.html
         title: Cisco IOS-XE SSH Configuration Guide
@@ -336,7 +350,11 @@ queries:
             ```
             configure terminal
             crypto key generate rsa modulus 2048
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             The device asks for confirmation before replacing an existing key pair. Replacing the key pair changes the SSH host identity, so SSH clients that stored the old host key receive a host key change warning and must accept the new key. Existing sessions stay connected. Notify administrators and update any automation that verifies the host key.
     refs:
@@ -398,7 +416,11 @@ queries:
             username <admin-user> privilege 15 algorithm-type scrypt secret <strong-password>
             aaa new-model
             aaa authentication login default local
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Open a second session and confirm that you can still log in before closing your current session.
     refs:
@@ -463,7 +485,11 @@ queries:
              key <shared-secret>
             exit
             aaa authentication login default group tacacs+ local
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             The `local` fallback ensures access is maintained if AAA servers are unreachable.
     refs:
@@ -523,7 +549,11 @@ queries:
             configure terminal
             aaa accounting exec default start-stop group tacacs+
             aaa accounting commands 15 default start-stop group tacacs+
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Verify that records arrive on the TACACS+ server after the next login.
     refs:
@@ -585,7 +615,11 @@ queries:
             configure terminal
             no username <user>
             username <user> privilege <level> algorithm-type scrypt secret <password>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             The `algorithm-type scrypt` keyword stores the credential as a type 9 hash, which is the strongest option. Repeat for every account that still uses `password`.
     refs:
@@ -639,15 +673,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure the enable secret first, then remove the legacy enable password so the device is never left without a privileged EXEC credential:
+            Configure the enable secret with the strongest available hash first, then remove the legacy enable password so the device is never left without a privileged EXEC credential. Use `algorithm-type scrypt`, which stores the credential as a Type 9 hash that resists offline cracking far better than the older Type 5 MD5 hash:
 
             ```
             configure terminal
-            enable secret 0 <strong-password>
+            enable algorithm-type scrypt secret <strong-password>
             no enable password
+            end
+            write memory
             ```
 
-            To store the credential as a type 9 hash, use `enable algorithm-type scrypt secret <strong-password>` instead of the `enable secret 0` form.
+            On releases that do not support `algorithm-type scrypt`, the legacy `enable secret 0 <strong-password>` form is acceptable as a fallback, but it stores the credential as the weaker Type 5 hash.
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_aaa/configuration/xe-16/sec-usr-aaa-xe-16-book/sec-cfg-authentification.html
         title: Cisco IOS-XE Password Configuration Guide
@@ -704,7 +742,11 @@ queries:
             ```
             configure terminal
             service password-encryption
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_aaa/configuration/xe-16/sec-usr-aaa-xe-16-book/sec-cfg-authentification.html
         title: Cisco IOS-XE Password Configuration Guide
@@ -761,7 +803,11 @@ queries:
             ```
             configure terminal
             no ip http server
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/https/configuration/xe-16/https-xe-16-book/nm-https.html
         title: Cisco IOS-XE HTTP Configuration Guide
@@ -817,7 +863,11 @@ queries:
             ```
             configure terminal
             ip http secure-server
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/https/configuration/xe-16/https-xe-16-book/nm-https.html
         title: Cisco IOS-XE HTTPS Configuration Guide
@@ -874,7 +924,11 @@ queries:
             ```
             configure terminal
             no cdp run
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Before disabling CDP, confirm that nothing depends on it. Cisco IP phones use CDP for voice VLAN assignment and power negotiation, and some monitoring and topology tools rely on CDP data. Plan the change with the teams that operate those systems.
     refs:
@@ -932,7 +986,11 @@ queries:
             ```
             configure terminal
             no ip bootp server
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipaddr_dhcp/configuration/xe-16/dhcp-xe-16-book.html
         title: Cisco IOS-XE DHCP/BOOTP Configuration Guide
@@ -989,7 +1047,11 @@ queries:
             ```
             configure terminal
             no ip source-route
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipaddr_nat/configuration/xe-16/nat-xe-16-book.html
         title: Cisco IOS-XE IP Configuration Guide
@@ -1045,7 +1107,11 @@ queries:
             ```
             configure terminal
             no service pad
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Service Configuration Guide
@@ -1105,7 +1171,13 @@ queries:
             ntp authentication-key 1 md5 <key-value>
             ntp trusted-key 1
             ntp server <server-ip> key 1
+            end
+            write memory
             ```
+
+            MD5 is a weak hash and should be treated as the minimum. On releases that support a stronger keyed hash such as HMAC-SHA2, configure the authentication key with that algorithm instead of `md5`. The key number, the key value, and the trusted-key setting must match exactly on the NTP server, or authentication fails and the device rejects time updates.
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/bsm/configuration/xe-16/bsm-xe-16-book/bsm-time-calendar-set.html
         title: Cisco IOS-XE NTP Configuration Guide
@@ -1163,7 +1235,11 @@ queries:
             configure terminal
             ntp server <ntp-server-ip-1>
             ntp server <ntp-server-ip-2>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/bsm/configuration/xe-16/bsm-xe-16-book/bsm-time-calendar-set.html
         title: Cisco IOS-XE NTP Configuration Guide
@@ -1222,7 +1298,11 @@ queries:
             archive
             log config
             logging enable
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/config-mgmt/configuration/xe-16/config-mgmt-xe-16-book/cm-config-logger.html
         title: Cisco IOS-XE Configuration Change Logging Guide
@@ -1281,7 +1361,11 @@ queries:
             logging host <syslog-server-ip>
             logging trap informational
             logging source-interface <interface>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/config-mgmt/configuration/xe-16/config-mgmt-xe-16-book/cm-config-logger.html
         title: Cisco IOS-XE Logging Configuration Guide
@@ -1338,7 +1422,11 @@ queries:
             ```
             configure terminal
             login on-failure log
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_aaa/configuration/xe-16/sec-usr-aaa-xe-16-book/sec-login-enhance.html
         title: Cisco IOS-XE Login Enhancement Guide
@@ -1393,6 +1481,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            The secure path is SNMPv3 with both authentication and privacy, because v3 encrypts traffic and authenticates each request, while SNMPv1 and v2c send the community string in clear text. Where SNMPv3 cannot be used yet, removing the default community strings and restricting a unique community string with an ACL is a v2c stopgap that reduces but does not eliminate the exposure.
+
             Remove the default community strings, create an ACL that permits only your management stations, and configure a unique community string restricted by that ACL:
 
             ```
@@ -1401,7 +1491,11 @@ queries:
             no snmp-server community private
             access-list 10 permit <nms-ip>
             snmp-server community <unique-string> RO 10
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Any monitoring system still polling with the removed community strings loses access immediately. Update all pollers to the new community string as part of the same change.
     refs:
@@ -1463,7 +1557,11 @@ queries:
             access-list 10 permit <nms-ip-1>
             access-list 10 permit <nms-ip-2>
             snmp-server community <community-string> RO 10
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Make sure the ACL permits every monitoring server before applying it. Servers not matched by the ACL lose SNMP access immediately.
     refs:
@@ -1530,9 +1628,13 @@ queries:
             transport input ssh
             line vty 16 31
             transport input ssh
+            end
+            write memory
             ```
 
             Adjust the second range to match the highest VTY line your platform provides.
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_ssh/configuration/xe-16/sec-usr-ssh-xe-16-book/sec-secure-shell-v2.html
         title: Cisco IOS-XE SSH Configuration Guide
@@ -1592,7 +1694,11 @@ queries:
             configure terminal
             line vty 0 15
             exec-timeout 10 0
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Line Configuration Guide
@@ -1654,7 +1760,11 @@ queries:
             access-class 11 in
             line vty 16 31
             access-class 11 in
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Display all VTY lines with `show line` and apply the access class to every range your platform provides.
     refs:
@@ -1714,7 +1824,11 @@ queries:
             configure terminal
             line aux 0
             no exec
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Line Configuration Guide
@@ -1771,7 +1885,11 @@ queries:
             configure terminal
             line con 0
             exec-timeout 10 0
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Line Configuration Guide
@@ -1828,7 +1946,11 @@ queries:
             ```
             configure terminal
             banner login ^Authorized access only. All activity is monitored and logged.^
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Banner Configuration Guide
@@ -1884,7 +2006,11 @@ queries:
             ```
             configure terminal
             banner motd ^Unauthorized access is prohibited. All activity is subject to monitoring.^
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Banner Configuration Guide
@@ -1943,7 +2069,11 @@ queries:
             ```
             configure terminal
             hostname <unique-descriptive-name>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE System Configuration Guide
@@ -2000,7 +2130,11 @@ queries:
             ```
             configure terminal
             ip domain name <your-domain.com>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE System Configuration Guide
@@ -2056,7 +2190,11 @@ queries:
             ```
             configure terminal
             service tcp-keepalives-in
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Service Configuration Guide
@@ -2112,7 +2250,11 @@ queries:
             ```
             configure terminal
             service tcp-keepalives-out
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/xe-16/fundamentals-xe-16-book.html
         title: Cisco IOS-XE Service Configuration Guide
@@ -2171,7 +2313,11 @@ queries:
             configure terminal
             router bgp <as-number>
             neighbor <neighbor-ip> password <password>
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             When neighbors belong to a peer group, set the password on the peer group so every member inherits it.
     refs:
@@ -2238,7 +2384,11 @@ queries:
             exit
             router ospf <process-id>
             area <area-id> authentication message-digest
+            end
+            write memory
             ```
+
+            Exit configuration mode with `end` and save the configuration with `write memory`. Changes are written to the running configuration first, which is volatile, so saving copies them to the startup configuration and ensures they survive a reload.
 
             Repeat the interface step for each OSPF interface in the area, then verify adjacencies with `show ip ospf neighbor`.
     refs:


### PR DESCRIPTION
## Summary

Quality fixes to the remediation guidance in `content/mondoo-cisco-iosxe-security.mql.yaml`, driven by a remediation-quality audit of the network-device policies. Focus is on `remediation:`/`desc:` prose and CLI examples only. No changes to `mql:`, `filters:`, `uid:`, `title:`, `impact:`, or `tags:`.

## Fixes by theme

### Systemic: persist the configuration (all 36 CLI remediations)
Previously every CLI remediation left the change in the running configuration and never saved it, so the fix was silently lost on the next reload. Each CLI block now ends with `end` followed by `write memory`, and each remediation includes one sentence explaining that the running configuration is volatile and saving copies it to the startup configuration so it survives a reload. Every block already entered config mode with `configure terminal`.

### Hardened authentication / management guidance
- **ssh-enabled**: notes that generating the host key alone does not enable login; the VTY lines need `transport input ssh` and a login method (`login local` or AAA), with a cross-reference to the SSH transport and AAA authentication checks.
- **ntp-authentication-enabled**: notes MD5 is the weak minimum and recommends a stronger keyed hash such as HMAC-SHA2 on releases that support it; adds the "why" that the key number, key value, and trusted-key must match the NTP server or time updates are rejected.
- **enable-secret-configured**: now leads with `enable algorithm-type scrypt secret <password>` (Type 9) and presents `enable secret 0` (Type 5) as the legacy fallback.
- **snmp-no-public-community**: notes SNMPv3 with auth+priv is the secure path and that community-string-plus-ACL is a v2c stopgap that reduces but does not eliminate the cleartext exposure.

## Validation
- `cnspec policy lint content/mondoo-cisco-iosxe-security.mql.yaml` → **valid policy bundle(s)**
- Version bumped `1.0.1` → `1.0.2`.

## Left for maintainers (VERIFY)
- **ntp-authentication-enabled**: the exact stronger-algorithm keyword (e.g. `hmac-sha2-256`) and which IOS-XE releases accept it was not confirmed against live firmware. The guidance recommends HMAC-SHA2 conceptually without asserting a specific command form; confirm the precise keyword for the target releases before treating it as canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)