### PR TITLE
🐛 cisco-nxos: persist config in remediations + SNMPv3 prerequisites

### DIFF
--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-nxos-security
     name: Mondoo Cisco NX-OS Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -174,6 +174,12 @@ queries:
             ```
 
             The new host key invalidates cached host keys on SSH clients. Update known hosts entries on management stations after the change.
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-ssh-scp.html
         title: Cisco NX-OS SSH Configuration Guide
@@ -238,6 +244,12 @@ queries:
             ```
 
             The new host key invalidates cached host keys on SSH clients. Update known hosts entries on management stations after the change.
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-ssh-scp.html
         title: Cisco NX-OS SSH Configuration Guide
@@ -295,6 +307,12 @@ queries:
             ```
             configure terminal
             ssh login-attempts 3
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-ssh-scp.html
@@ -361,6 +379,12 @@ queries:
             ```
             show running-config aaa | include "authentication login"
             ```
+
+            NX-OS does not automatically persist running-config changes. Once you have confirmed access still works, save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-aaa.html
         title: Cisco NX-OS AAA Configuration Guide
@@ -425,6 +449,12 @@ queries:
             ```
 
             Adjust the VRF and source interface to match how the device reaches the TACACS+ server.
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-aaa.html
         title: Cisco NX-OS AAA Configuration Guide
@@ -481,6 +511,12 @@ queries:
             ```
             configure terminal
             password strength-check
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
@@ -547,6 +583,12 @@ queries:
             ```
             encryption re-encrypt obfuscated
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
         title: Cisco NX-OS Encryption Configuration Guide
@@ -612,6 +654,12 @@ queries:
             ```
             show running-config | include ^username
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
         title: Cisco NX-OS User Account Configuration Guide
@@ -668,6 +716,12 @@ queries:
             ```
             configure terminal
             userpassphrase min-length 15 max-length 127
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
@@ -736,6 +790,12 @@ queries:
             exit
             system login quiet-mode access-class LOGIN-QUIET-MODE
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
         title: Cisco NX-OS Login Configuration Guide
@@ -794,6 +854,12 @@ queries:
             ntp server <ntp-server-ip-1> use-vrf management
             ntp server <ntp-server-ip-2> use-vrf management
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-ntp.html
         title: Cisco NX-OS NTP Configuration Guide
@@ -849,6 +915,12 @@ queries:
             ```
             configure terminal
             clock timezone EST -5 0
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-ntp.html
@@ -909,6 +981,12 @@ queries:
             logging server <syslog-server-ip> 6 use-vrf management
             logging source-interface mgmt0
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-system-message-logging.html
         title: Cisco NX-OS Logging Configuration Guide
@@ -966,6 +1044,12 @@ queries:
             configure terminal
             logging timestamp milliseconds
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-system-message-logging.html
         title: Cisco NX-OS Logging Configuration Guide
@@ -1022,6 +1106,12 @@ queries:
             ```
             configure terminal
             logging source-interface mgmt0
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-system-message-logging.html
@@ -1083,6 +1173,12 @@ queries:
             no snmp-server community private
             snmp-server community <unique-string> group network-operator
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-snmp.html
         title: Cisco NX-OS SNMP Configuration Guide
@@ -1134,11 +1230,22 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enforce SNMPv3 encryption globally:
+            Before enforcing global privacy, make sure at least one SNMPv3 user is configured with both authentication and privacy. Global privacy enforcement requires every SNMP request to use SNMPv3 with encryption, so it silently stops all SNMPv1 and SNMPv2c community access. If no SNMPv3 auth and priv user exists when you enforce this, SNMP management of the device breaks entirely.
+
+            Create an SNMPv3 user with SHA authentication and AES-128 privacy, then enforce global privacy:
 
             ```
             configure terminal
+            snmp-server user <username> network-operator auth sha <auth-password> priv aes-128 <priv-password>
             snmp-server globalEnforcePriv
+            ```
+
+            The `snmp-server globalEnforcePriv` token is valid NX-OS syntax. Migrate any monitoring systems that still rely on v2c community strings to SNMPv3 before applying this change.
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-snmp.html
@@ -1194,7 +1301,9 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create an ACL that permits only authorized management stations, then bind it to each SNMP community. The ACL must exist before it is referenced. Include every monitoring system in the ACL; any station not permitted loses SNMP access to the device as soon as the ACL is applied.
+            The preferred fix is to migrate SNMP management to SNMPv3, which provides per-user authentication and encryption rather than shared community strings. Applying ACLs to v2c communities is a stopgap that limits which hosts can poll the device but does not encrypt the traffic or authenticate individual users. See the check that enforces SNMPv3 encryption globally for the SNMPv3 migration path.
+
+            If you must keep v2c communities in the interim, create an ACL that permits only authorized management stations, then bind it to each SNMP community. The ACL must exist before it is referenced. Include every monitoring system in the ACL; any station not permitted loses SNMP access to the device as soon as the ACL is applied.
 
             ```
             configure terminal
@@ -1202,6 +1311,12 @@ queries:
               permit ip <nms-ip>/32 any
             exit
             snmp-server community <community> use-ipv4acl SNMP-MGMT
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/system-management/cisco-nexus-9000-nx-os-system-management-configuration-guide-105x/m-configuring-snmp.html
@@ -1260,6 +1375,12 @@ queries:
             configure terminal
             no boot poap enable
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/fundamentals/cisco-nexus-9000-nx-os-fundamentals-configuration-guide-105x/m-using-poap.html
         title: Cisco NX-OS POAP Configuration Guide
@@ -1317,6 +1438,12 @@ queries:
             ```
             configure terminal
             copp profile strict
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-copp.html
@@ -1378,6 +1505,12 @@ queries:
             line vty
             exec-timeout 10
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
         title: Cisco NX-OS Line Configuration Guide
@@ -1436,6 +1569,12 @@ queries:
             configure terminal
             line console
             exec-timeout 10
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
@@ -1501,6 +1640,12 @@ queries:
             ```
 
             From a permitted management station, open a new SSH session to confirm access before closing your existing one.
+
+            NX-OS does not automatically persist running-config changes. Once you have confirmed remote access still works, save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x/m-configuring-user-accounts-and-rbac.html
         title: Cisco NX-OS Line Configuration Guide
@@ -1558,6 +1703,12 @@ queries:
             configure terminal
             banner motd @Authorized access only. All activity is monitored and logged.@
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/fundamentals/cisco-nexus-9000-nx-os-fundamentals-configuration-guide-105x.html
         title: Cisco NX-OS Banner Configuration Guide
@@ -1613,6 +1764,12 @@ queries:
             ```
             configure terminal
             banner exec @This system is for authorized use only. All activity is logged.@
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/fundamentals/cisco-nexus-9000-nx-os-fundamentals-configuration-guide-105x.html
@@ -1673,6 +1830,12 @@ queries:
             configure terminal
             hostname <unique-descriptive-name>
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/fundamentals/cisco-nexus-9000-nx-os-fundamentals-configuration-guide-105x.html
         title: Cisco NX-OS System Configuration Guide
@@ -1729,6 +1892,12 @@ queries:
             configure terminal
             no ip source-route
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x.html
         title: Cisco NX-OS Security Configuration Guide
@@ -1781,12 +1950,20 @@ queries:
           desc: |
             **Using the CLI**
 
+            Apply this change to every routed interface flagged by the audit, not just one. The check fails while any interface still has `ip directed-broadcast` enabled, so repeat the interface block for each affected interface.
+
             Disable IP directed broadcast on interfaces:
 
             ```
             configure terminal
             interface <interface>
             no ip directed-broadcast
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/security/cisco-nexus-9000-nx-os-security-configuration-guide-105x.html
@@ -1858,6 +2035,12 @@ queries:
             ```
             show bgp sessions
             ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
+            ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/unicast-routing/cisco-nexus-9000-nx-os-unicast-routing-configuration-guide-105x/m-configuring-bgp.html
         title: Cisco NX-OS BGP Configuration Guide
@@ -1917,6 +2100,12 @@ queries:
             configure terminal
             router bgp <as-number>
             log-neighbor-changes
+            ```
+
+            NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/unicast-routing/cisco-nexus-9000-nx-os-unicast-routing-configuration-guide-105x/m-configuring-bgp.html
@@ -2002,6 +2191,12 @@ queries:
 
             ```
             show ip ospf neighbors
+            ```
+
+            NX-OS does not automatically persist running-config changes. Once the adjacency has reformed, save the configuration so the change survives a reload:
+
+            ```
+            copy running-config startup-config
             ```
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/unicast-routing/cisco-nexus-9000-nx-os-unicast-routing-configuration-guide-105x/m-configuring-ospfv2.html


### PR DESCRIPTION
## Summary

Remediation-quality fixes for the Cisco NX-OS security policy (`content/mondoo-cisco-nxos-security.mql.yaml`), driven by the network-device remediation audit. Prose-only and code-example changes; no `mql`/`filters`/`uid`/`title`/`impact`/`tags` were touched. Policy `version` bumped `1.0.1` → `1.0.2`.

## Persistence (systemic, all 31 CLI remediations)

NX-OS does not automatically persist running-config changes, and unlike IOS it has no `write memory` fallback, so every passing fix was silently lost on the next reload. Every `id: cli` remediation block now ends with a `copy running-config startup-config` step and one short sentence explaining that NX-OS does not auto-persist. On lockout-sensitive changes (AAA, VTY ACL, OSPF) the save step is placed after the existing "verify access still works" step.

## SNMP

- **snmp-encryption-enforced**: Added a prerequisite note that `snmp-server globalEnforcePriv` requires at least one SNMPv3 user with both auth and priv already configured, and warns that enforcing global privacy silently stops all v2c community access. Added a `snmp-server user ... auth sha ... priv aes-128 ...` example and an explicit note that the `globalEnforcePriv` token is valid NX-OS syntax. (The earlier "invalid token" claim was a false positive.)
- **snmp-communities-acl**: Added that the preferred fix is migrating to SNMPv3 and that community ACLs are a v2c stopgap, cross-referencing the encryption-enforced check.

## Other accessibility fixes

- **ip-directed-broadcast-disabled**: Noted the fix must be applied to every routed interface flagged by the audit, not just one, since the check fails while any interface still has it enabled.

## Left for maintainers (VERIFY)

- **system-login-block**: The remediation uses `system login block-for 60 attempts 3 within 60` and `system login quiet-mode access-class ...`. This is classic IOS login-block syntax; NX-OS often throttles via AAA instead. The command was left unchanged because it could not be confirmed against current NX-OS firmware. If it is not accepted on current NX-OS, the remediation is inaccurate and should be reworked. Only the save step was added.

## Validation

`cnspec policy lint content/mondoo-cisco-nxos-security.mql.yaml` → valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)