### PR TITLE
🐛 panos: add config-mode entry + lockout warning to remediations

### DIFF
--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 2.0.1
+    version: 2.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1003,9 +1003,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create a zone protection profile with flood and reconnaissance protection, then apply it to a zone. Reconnaissance protection entries are keyed by threat ID: 8001 is TCP port scan, 8002 is host sweep, and 8003 is UDP port scan.
+            Create a zone protection profile with flood and reconnaissance protection, then apply it to a zone. Reconnaissance protection entries are keyed by threat ID: 8001 is TCP port scan, 8002 is host sweep, and 8003 is UDP port scan. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network profiles zone-protection-profile <profile-name> flood tcp-syn enable yes
             set network profiles zone-protection-profile <profile-name> flood udp enable yes
             set network profiles zone-protection-profile <profile-name> flood icmp enable yes
@@ -1091,9 +1092,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable packet buffer protection on a zone:
+            Enable packet buffer protection on a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set zone <zone-name> network enable-packet-buffer-protection yes
             commit
             ```
@@ -1168,9 +1170,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure log forwarding on a zone:
+            Configure log forwarding on a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set zone <zone-name> network log-setting <log-forwarding-profile>
             commit
             ```
@@ -1260,10 +1263,16 @@ queries:
           desc: |
             **Using the CLI**
 
-            Review the rulebase, then replace each wildcard member list with specific values. The `set` command appends members to an existing list, so delete each list first to remove the `any` entry:
+            Review the rulebase from the operational prompt:
 
             ```
             show running security-policy
+            ```
+
+            Then enter configuration mode and replace each wildcard member list with specific values. The `set` command appends members to an existing list, so delete each list first to remove the `any` entry. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
+
+            ```
+            configure
             delete rulebase security rules <rule-name> application
             set rulebase security rules <rule-name> application [ <app1> <app2> ]
             delete rulebase security rules <rule-name> service
@@ -1349,9 +1358,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Replace the application list with specific App-IDs. The `set` command appends members to an existing list, so delete the list first to remove the `any` entry:
+            Replace the application list with specific App-IDs. The `set` command appends members to an existing list, so delete the list first to remove the `any` entry. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             delete rulebase security rules <rule-name> application
             set rulebase security rules <rule-name> application [ <app1> <app2> ]
             delete rulebase security rules <rule-name> service
@@ -1440,9 +1450,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Attach a security profile group to a rule:
+            Attach a security profile group to a rule. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase security rules <rule-name> profile-setting group <profile-group-name>
             commit
             ```
@@ -1450,6 +1461,7 @@ queries:
             Or attach individual profiles:
 
             ```
+            configure
             set rulebase security rules <rule-name> profile-setting profiles virus <av-profile>
             set rulebase security rules <rule-name> profile-setting profiles spyware <as-profile>
             set rulebase security rules <rule-name> profile-setting profiles vulnerability <vp-profile>
@@ -1531,9 +1543,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Attach a URL filtering profile to a rule:
+            Attach a URL filtering profile to a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase security rules <rule-name> profile-setting profiles url-filtering <url-profile>
             commit
             ```
@@ -1611,9 +1624,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable session-end logging on a rule:
+            Enable session-end logging on a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase security rules <rule-name> log-end yes
             commit
             ```
@@ -1688,10 +1702,16 @@ queries:
           desc: |
             **Using the CLI**
 
-            Review and remove disabled rules:
+            Review the rulebase from the operational prompt:
 
             ```
             show running security-policy
+            ```
+
+            Then enter configuration mode and remove each disabled rule. The `delete` command edits the candidate configuration; `commit` activates the change on the running configuration.
+
+            ```
+            configure
             delete rulebase security rules <disabled-rule-name>
             commit
             ```
@@ -1770,9 +1790,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Attach a WildFire Analysis profile to a rule:
+            Attach a WildFire Analysis profile to a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase security rules <rule-name> profile-setting profiles wildfire-analysis <wf-profile>
             commit
             ```
@@ -1856,9 +1877,12 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create a deny-all profile for untrusted interfaces and a restricted profile for trusted interfaces, then assign each interface the appropriate profile:
+            Create a deny-all profile for untrusted interfaces and a restricted profile for trusted interfaces, then assign each interface the appropriate profile. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
+
+            Before you commit, confirm that you are not removing your own management path. A deny-all profile or an incorrect `permitted-ip` on the interface you administer the firewall through will sever your access. The commit is atomic and applies immediately, so verify that a trusted interface with the correct services and permitted IP addresses still reaches the management plane.
 
             ```
+            configure
             set network profiles interface-management-profile deny-all ping no
             set network interface ethernet <untrusted-interface> layer3 interface-management-profile deny-all
             set network profiles interface-management-profile mgmt-trusted https yes
@@ -1944,9 +1968,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Replace DHCP with a static address. Perform this change during a maintenance window: the address change interrupts traffic on the interface, and any static routes, NAT rules, or IKE gateways that reference the old address must be updated in the same commit.
+            Replace DHCP with a static address. Perform this change during a maintenance window: the address change interrupts traffic on the interface, and any static routes, NAT rules, or IKE gateways that reference the old address must be updated in the same commit. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network interface ethernet <interface> layer3 ip <address/mask>
             delete network interface ethernet <interface> layer3 dhcp-client
             commit
@@ -2025,9 +2050,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Assign an interface to a zone:
+            Assign an interface to a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set zone <zone-name> network layer3 <interface-name>
             commit
             ```
@@ -2110,9 +2136,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Update an IKE gateway to use IKEv2. Setting the version to IKEv2 only drops the tunnel until the remote peer also negotiates IKEv2, so coordinate the change or use `ikev2-preferred` during migration:
+            Update an IKE gateway to use IKEv2. Setting the version to IKEv2 only drops the tunnel until the remote peer also negotiates IKEv2, so coordinate the change or use `ikev2-preferred` during migration. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network ike gateway <gateway-name> protocol version ikev2
             commit
             ```
@@ -2194,9 +2221,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Switch the gateway from pre-shared key to certificate authentication. The tunnel stays down until the remote peer is also reconfigured for certificate authentication, so coordinate the change:
+            Switch the gateway from pre-shared key to certificate authentication. The tunnel stays down until the remote peer is also reconfigured for certificate authentication, so coordinate the change. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             delete network ike gateway <gateway-name> authentication pre-shared-key
             set network ike gateway <gateway-name> authentication certificate local-certificate name <cert-name>
             set network ike gateway <gateway-name> authentication certificate certificate-profile <profile-name>
@@ -2279,9 +2307,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable dead peer detection for IKEv1 gateways and the liveness check for IKEv2 gateways:
+            Enable dead peer detection for IKEv1 gateways and the liveness check for IKEv2 gateways. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network ike gateway <gateway-name> protocol ikev1 dpd enable yes interval 5 retry 5
             set network ike gateway <gateway-name> protocol ikev2 dpd enable yes interval 5
             commit
@@ -2363,9 +2392,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Change the IKEv1 exchange mode:
+            Change the IKEv1 exchange mode. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network ike gateway <gateway-name> protocol ikev1 exchange-mode main
             commit
             ```
@@ -2443,9 +2473,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable anti-replay on an IPsec tunnel:
+            Enable anti-replay on an IPsec tunnel. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network tunnel ipsec <tunnel-name> anti-replay yes
             commit
             ```
@@ -2525,9 +2556,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Assign an IP address to the tunnel interface if it does not already have one, then enable tunnel monitoring:
+            Assign an IP address to the tunnel interface if it does not already have one, then enable tunnel monitoring. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network interface tunnel units <tunnel-interface> ip <local-address/mask>
             set network tunnel ipsec <tunnel-name> tunnel-monitor enable yes destination-ip <remote-ip>
             commit
@@ -2612,9 +2644,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Attach a decryption profile to a decryption rule:
+            Attach a decryption profile to a decryption rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase decryption rules <rule-name> profile <decryption-profile>
             commit
             ```
@@ -2692,9 +2725,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable TLS failure logging on a decryption rule:
+            Enable TLS failure logging on a decryption rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set rulebase decryption rules <rule-name> log-fail yes
             commit
             ```
@@ -2777,9 +2811,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Add a default route to a virtual router:
+            Add a default route to a virtual router. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network virtual-router <vr-name> routing-table ip static-route default-route destination 0.0.0.0/0 nexthop ip-address <gateway-ip> interface <egress-interface>
             commit
             ```
@@ -2861,9 +2896,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create an MD5 authentication profile and reference it from the OSPF interface. Adjacencies drop until neighbors are configured with the same key:
+            Create an MD5 authentication profile and reference it from the OSPF interface. Adjacencies drop until neighbors are configured with the same key. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
             set network virtual-router <vr-name> protocol ospf area <area-id> interface <interface-name> authentication <profile-name>
             commit
@@ -2946,9 +2982,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create an MD5 authentication profile and reference it from the OSPF virtual link. The virtual link drops until the remote end is configured with the same key:
+            Create an MD5 authentication profile and reference it from the OSPF virtual link. The virtual link drops until the remote end is configured with the same key. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
             set network virtual-router <vr-name> protocol ospf area <transit-area-id> virtual-link <link-name> authentication <profile-name>
             commit
@@ -3027,9 +3064,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable RFC 1583 compatibility on OSPF:
+            Disable RFC 1583 compatibility on OSPF. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network virtual-router <vr-name> protocol ospf rfc1583 no
             commit
             ```
@@ -3107,9 +3145,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure OSPF to reject default routes:
+            Configure OSPF to reject default routes. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
             ```
+            configure
             set network virtual-router <vr-name> protocol ospf reject-default-route yes
             commit
             ```


### PR DESCRIPTION
## Summary

Remediation-quality fixes for `content/mondoo-panos-security.mql.yaml`, addressing the systemic PAN-OS findings in the network-devices remediation audit. Version bumped `2.0.1` → `2.0.2`.

## Changes

### Config-mode entry (systemic)
Every `set`/`delete`-based `id: cli` remediation block previously assumed the reader was already in configuration mode. Pasted from the default operational prompt, the commands fail. All 27 affected blocks now begin with `configure`.

### Operational `show` separated from config commands
Two blocks (`no-allow-any-rules` and `no-disabled-rules`) mixed an operational `show running security-policy` with config-mode `delete`/`set`/`commit` in a single paste-able sequence. The operational `show` is now in its own fence ahead of the `configure` step.

### Candidate-vs-running config explained
Each affected block now states that `set`/`delete` edit the candidate configuration and that `commit` activates the change on the running configuration.

### Lockout warning (`interface-management-profile`)
Added a caution to confirm you are not removing your own management path before commit. A deny-all profile or wrong `permitted-ip` on the management-reachable interface severs admin access, and the commit is atomic and applies immediately.

## VERIFY items resolved
- **ipsec anti-replay leaf name**: confirmed `anti-replay yes` is correct and consistent with this check's audit section (which references `anti-replay no`/`anti-replay yes`). No change to the leaf name was needed beyond prepending `configure`.

## Left for maintainers (VERIFY)
None outstanding. The audit flagged only "leaf-name" VERIFY suspects for PAN-OS; the single concrete one (ipsec anti-replay) was confirmed against the in-file audit and required no leaf-name change.

## Validation
`cnspec policy lint content/mondoo-panos-security.mql.yaml` → valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)