### PR TITLE
🐛 arista-eos: persist config in remediations + lockout/MFA warnings

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-arista-eos-security
     name: Mondoo Arista EOS Security
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -171,17 +171,24 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable AAA accounting for all commands:
+            Enter global configuration mode and enable AAA accounting for all commands:
 
             ```
             configure
             aaa accounting commands all default start-stop logging
             ```
 
-            Configure syslog server to receive accounting records:
+            Configure a syslog server to receive accounting records:
 
             ```
             logging host <syslog-server-ip>
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
@@ -232,11 +239,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable AAA accounting for exec sessions:
+            Enter global configuration mode and enable AAA accounting for exec sessions:
 
             ```
             configure
             aaa accounting exec default start-stop logging
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
@@ -287,11 +301,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable AAA accounting for system events:
+            Enter global configuration mode and enable AAA accounting for system events:
 
             ```
             configure
             aaa accounting system default start-stop logging
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
@@ -343,7 +364,9 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure AAA authentication for console and remote access:
+            Changing the default login method to an AAA server group is the classic way to lock yourself out of the device. Before you begin, confirm a local user with a valid secret already exists so the `local` fallback works, and keep your current session open throughout. After applying the change, verify that you can log in from a second, separate session before you disconnect the first one.
+
+            Enter global configuration mode and configure AAA authentication for console and remote access:
 
             ```
             configure
@@ -352,6 +375,13 @@ queries:
             ```
 
             The `local` fallback ensures access is maintained if AAA servers are unreachable.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -402,7 +432,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable authentication failure logging:
+            Enter global configuration mode and enable authentication failure logging:
 
             ```
             configure
@@ -413,6 +443,13 @@ queries:
 
             ```
             logging host <siem-server-ip>
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
@@ -463,12 +500,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable AAA authorization for console access:
+            Enter global configuration mode and enable AAA authorization for console access:
 
             ```
             configure
             aaa authorization console
             aaa authorization commands all default local
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
@@ -523,7 +567,9 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set SHA-512 as the default secret hashing algorithm, then configure the admin account. Do not place a cleartext password after the `sha512` keyword, because that keyword expects an already computed hash and a cleartext value stored there makes the account unusable. Supply the password with the cleartext marker `0` and let EOS hash it:
+            Set SHA-512 as the default secret hashing algorithm, then configure the admin account. Do not place a cleartext password after the `sha512` keyword, because that keyword expects an already computed hash and a cleartext value stored there makes the account unusable. Supply the password with the cleartext marker `0` and let EOS hash it.
+
+            Enter global configuration mode, then the `management defaults` sub-mode to set the hash, return to global configuration mode with `exit`, and create the admin account:
 
             ```
             configure
@@ -534,6 +580,13 @@ queries:
             ```
 
             Verify with `show running-config section username` that the admin entry shows `secret sha512` followed by a hash.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -582,7 +635,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure an idle timeout for console sessions. EOS expresses the timeout in minutes under the `management console` block:
+            Configure an idle timeout for console sessions. EOS expresses the timeout in minutes under the `management console` block. Enter global configuration mode, then the `management console` sub-mode, and set the timeout:
 
             ```
             configure
@@ -591,6 +644,13 @@ queries:
             ```
 
             A value of 0 disables the timeout, so choose a nonzero value that matches your security policy.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -641,7 +701,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure the DNS domain name:
+            Enter global configuration mode and configure the DNS domain name:
 
             ```
             configure
@@ -649,6 +709,13 @@ queries:
             ```
 
             Verify with `show hostname` that the fully qualified domain name now includes the domain suffix.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -673,18 +740,18 @@ queries:
       arista.eos.sshSettings.idleTimeout > 0
     docs:
       desc: |
-        This check verifies that an exec timeout is configured to automatically disconnect idle sessions. Exec timeouts ensure that forgotten or unattended sessions are terminated before they can be exploited.
+        This check verifies that an SSH idle timeout is configured to automatically disconnect inactive remote management sessions. An SSH idle timeout ensures that forgotten or unattended sessions are terminated before they can be exploited.
 
         **Why this matters**
 
-        Without an exec timeout, idle management sessions remain open indefinitely. If exec timeouts are not configured:
+        Without an SSH idle timeout, inactive remote management sessions remain open indefinitely. If the SSH idle timeout is not configured:
 
         - Forgotten sessions can be accessed by unauthorized users who gain access to the terminal.
         - Unattended sessions on shared workstations pose a significant security risk.
         - Security framework requirements for session management cannot be met.
         - Connection resources remain consumed by idle sessions, potentially blocking legitimate access.
 
-        Configuring exec timeouts ensures that idle sessions are automatically closed, reducing the attack surface and freeing resources for active users.
+        Configuring an SSH idle timeout ensures that inactive sessions are automatically closed, reducing the attack surface and freeing resources for active users.
       audit: |
         Verify the remote session idle timeout from the Arista EOS CLI:
 
@@ -698,7 +765,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure an idle timeout for remote management sessions. EOS expresses the timeout in minutes under the `management ssh` block:
+            Configure an SSH idle timeout for remote management sessions. EOS expresses the timeout in minutes under the `management ssh` block. Enter global configuration mode, then the `management ssh` sub-mode, and set the timeout:
 
             ```
             configure
@@ -707,6 +774,13 @@ queries:
             ```
 
             A value of 0 disables the timeout, so choose a nonzero value that matches your security policy.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -759,7 +833,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure a descriptive, unique hostname:
+            Enter global configuration mode and configure a descriptive, unique hostname:
 
             ```
             configure
@@ -767,6 +841,13 @@ queries:
             ```
 
             Use naming conventions that include location, function, or other identifying information.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
         title: Arista EOS System Configuration Guide
@@ -817,7 +898,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable HTTPS for the management API first, then disable HTTP. Commands take effect immediately, so removing the HTTP listener before HTTPS is running can cut off any management session or automation that currently uses HTTP:
+            Enable HTTPS for the management API first, then disable HTTP. Commands take effect immediately, so removing the HTTP listener before HTTPS is running can cut off any management session or automation that currently uses HTTP. Enter global configuration mode, then the `management api http-commands` sub-mode, and adjust the protocols:
 
             ```
             configure
@@ -827,6 +908,13 @@ queries:
             ```
 
             Verify with `show management api http-commands` that the HTTPS server is running before closing your session.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
         title: Arista EOS Management API Configuration Guide
@@ -877,12 +965,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable HTTPS for the management API:
+            Enable HTTPS for the management API. Enter global configuration mode, then the `management api http-commands` sub-mode, and enable the protocol:
 
             ```
             configure
             management api http-commands
             protocol https
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-management-api
@@ -936,7 +1031,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure descriptive names for all interfaces:
+            Configure descriptive names for all interfaces. Enter global configuration mode, then the interface sub-mode for each port, and set its description:
 
             ```
             configure
@@ -945,6 +1040,13 @@ queries:
             ```
 
             For example: `description Uplink to Core Switch 1 Gi0/1`
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -993,11 +1095,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure buffered logging with appropriate size:
+            Enter global configuration mode and configure buffered logging with an appropriate size:
 
             ```
             configure
             logging buffered 100000 informational
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
@@ -1049,11 +1158,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable system logging:
+            Enter global configuration mode and enable system logging:
 
             ```
             configure
             logging on
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
@@ -1105,12 +1221,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure one or more remote syslog servers:
+            Enter global configuration mode and configure one or more remote syslog servers:
 
             ```
             configure
             logging host <syslog-server-ip>
             logging trap informational
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
@@ -1161,12 +1284,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure logging levels for important subsystems (informational or debugging):
+            Enter global configuration mode and set logging levels for important subsystems, choosing informational or debugging as appropriate:
 
             ```
             configure
             logging level all informational
             logging level security debugging
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-logging
@@ -1218,7 +1348,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure a login banner with appropriate legal language:
+            Enter global configuration mode and configure a login banner with appropriate legal language. The `banner login` command starts a text-entry mode that ends when you type `EOF` on its own line:
 
             ```
             configure
@@ -1229,6 +1359,13 @@ queries:
             result in civil and/or criminal penalties. All activities performed
             on this device are logged and monitored.
             EOF
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
@@ -1282,18 +1419,25 @@ queries:
           desc: |
             **Using the CLI**
 
-            Assign appropriate roles to users instead of granting blanket privilege 15:
+            Enter global configuration mode and assign appropriate roles to users instead of granting blanket privilege 15:
 
             ```
             configure
             username <username> privilege 1 role <appropriate-role>
             ```
 
-            Create custom roles if needed:
+            Create custom roles if needed. The `role` command enters a role sub-mode where you add privilege statements:
 
             ```
             role <role-name>
                <privilege statements>
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
@@ -1344,13 +1488,20 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure an MOTD banner:
+            Enter global configuration mode and configure an MOTD banner. The `banner motd` command starts a text-entry mode that ends when you type `EOF` on its own line:
 
             ```
             configure
             banner motd
             <your message here>
             EOF
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
@@ -1401,14 +1552,23 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure console authentication to use RADIUS or TACACS+ with MFA:
+            Directing console logins to a RADIUS or TACACS+ server group is necessary for multifactor authentication, but it is not sufficient on its own. This command alone can still allow single-factor logins if the AAA server only checks a password. The second factor must be enforced on the AAA server itself, such as RSA SecurID, Duo Security push or one-time passcode, or certificate-based authentication.
+
+            Enter global configuration mode and direct console authentication to the AAA server group:
 
             ```
             configure
             aaa authentication login console group radius local
             ```
 
-            Ensure the RADIUS/TACACS+ server is configured for multifactor authentication (e.g., RSA SecurID, Duo Security, or certificate-based authentication).
+            On the RADIUS or TACACS+ server, require a second factor for these logins so that a stolen or guessed password alone cannot authenticate.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-section-aaa-authorization-and-accounting
         title: Arista EOS AAA Configuration Guide
@@ -1458,7 +1618,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Assign a password to every account configured with `nopassword`. Setting a secret replaces the `nopassword` attribute in the running-config:
+            Enter global configuration mode and assign a password to every account configured with `nopassword`. Setting a secret replaces the `nopassword` attribute in the running-config:
 
             ```
             configure
@@ -1472,6 +1632,13 @@ queries:
             ```
 
             Verify with `show running-config section username` that no entry still contains the `nopassword` keyword.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1521,7 +1688,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure NTP servers for time synchronization:
+            Enter global configuration mode and configure NTP servers for time synchronization:
 
             ```
             configure
@@ -1530,6 +1697,13 @@ queries:
             ```
 
             Use multiple NTP servers for redundancy.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1579,7 +1753,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure at least two NTP servers for redundancy:
+            Enter global configuration mode and configure at least two NTP servers for redundancy:
 
             ```
             configure
@@ -1587,7 +1761,14 @@ queries:
             ntp server <secondary-ntp-server>
             ```
 
-            Use NTP servers from reliable sources (e.g., NIST, internal stratum 1/2 servers).
+            Use NTP servers from reliable sources such as NIST time servers or internal stratum 1 or 2 servers.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-ntp
         title: Arista EOS NTP Configuration Guide
@@ -1638,7 +1819,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure a minimum password length (15 characters recommended for high security):
+            Configure a minimum password length. A length of 15 characters is recommended for high security. Enter global configuration mode, then the `management security` sub-mode, and set the minimum length:
 
             ```
             configure
@@ -1646,7 +1827,14 @@ queries:
             password minimum length 15
             ```
 
-            For environments requiring compliance with specific standards (e.g., DISA STIG), 15 characters is mandatory.
+            For environments that must comply with specific standards such as DISA STIG, 15 characters is mandatory.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1696,7 +1884,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            EOS does not store local user passwords in cleartext when the `secret` keyword is used. To ensure all secrets are hashed with the strongest available algorithm, set SHA-512 as the default hashing algorithm:
+            EOS does not store local user passwords in cleartext when the `secret` keyword is used. To ensure all secrets are hashed with the strongest available algorithm, set SHA-512 as the default hashing algorithm. Enter global configuration mode, then the `management defaults` sub-mode, and set the hash:
 
             ```
             configure
@@ -1705,6 +1893,13 @@ queries:
             ```
 
             Re-enter any existing user secrets afterward so they are stored with the new algorithm, and verify with `show running-config section username` that each entry shows `secret sha512`.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -1756,7 +1951,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Remove default community strings and configure secure, unique strings:
+            Enter global configuration mode, remove default community strings, and configure secure, unique strings:
 
             ```
             configure
@@ -1769,6 +1964,13 @@ queries:
 
             ```
             snmp-server user <username> <group> v3 auth sha <password> priv aes <privpassword>
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
@@ -1819,15 +2021,29 @@ queries:
           desc: |
             **Using the CLI**
 
-            Remove trap destinations that use default community strings, then re-add them with a secure community string:
+            The real fix is to send traps using SNMPv3 with authentication and privacy, because SNMPv3 encrypts the notification and authenticates its source. SNMP v2c sends traps in cleartext even with a non-default community string, so anyone who can capture the traffic still reads the contents. Configure an SNMPv3 user and point the trap host at it. Enter global configuration mode first:
 
             ```
             configure
+            snmp-server user <username> <group> v3 auth sha <password> priv aes <privpassword>
+            snmp-server host <server-ip> version 3 priv <username>
+            ```
+
+            If your monitoring system cannot yet accept SNMPv3, replacing the default community string with a strong, unique one is only a minimum stopgap that does not encrypt the traffic:
+
+            ```
             no snmp-server host <server-ip>
             snmp-server host <server-ip> version 2c <secure-community-string>
             ```
 
             Verify with `show running-config | include snmp-server host` that no destination uses the `public` or `private` community string.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-snmp
         title: Arista EOS SNMP Configuration Guide
@@ -1877,7 +2093,9 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable SSH management access:
+            Before enabling SSH, make sure the prerequisites for key generation are in place. SSH needs host keys, and EOS cannot generate them until the device has a hostname and a DNS domain name configured, so the SSH service may not come up otherwise. Set the hostname and domain name first if they are missing. The domain name is covered by a separate check in this policy.
+
+            Enter global configuration mode, then the `management ssh` sub-mode, and enable the service:
 
             ```
             configure
@@ -1885,10 +2103,17 @@ queries:
             no shutdown
             ```
 
-            Harden the SSH service while in the same configuration block, for example by setting an idle timeout:
+            Harden the SSH service while still in the `management ssh` sub-mode, for example by setting an idle timeout:
 
             ```
             idle-timeout 10
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
@@ -1939,7 +2164,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Verify SSH access works before disabling Telnet. If your current session runs over Telnet, the `shutdown` command disconnects it immediately, so establish and test an SSH session first:
+            Verify SSH access works before disabling Telnet. If your current session runs over Telnet, the `shutdown` command disconnects it immediately, so establish and test an SSH session first. Enter global configuration mode, then the `management ssh` sub-mode, and enable SSH:
 
             ```
             configure
@@ -1947,12 +2172,19 @@ queries:
             no shutdown
             ```
 
-            After confirming you can log in over SSH, disable Telnet:
+            After confirming you can log in over SSH, enter the `management telnet` sub-mode and disable Telnet:
 
             ```
             configure
             management telnet
             shutdown
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
@@ -2003,11 +2235,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure the timezone to UTC or GMT:
+            Enter global configuration mode and set the timezone to UTC or GMT:
 
             ```
             configure
             clock timezone UTC
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-system-configuration
@@ -2063,7 +2302,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable unused interfaces:
+            Disable unused interfaces. Enter global configuration mode, then the interface sub-mode for each unused port, and shut it down:
 
             ```
             configure
@@ -2072,6 +2311,13 @@ queries:
             ```
 
             For interfaces that may be used in the future, add a description noting their intended purpose.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-interfaces
         title: Arista EOS Interface Configuration Guide
@@ -2121,12 +2367,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            Move all access ports from VLAN 1 to appropriate user VLANs:
+            Move all access ports from VLAN 1 to appropriate user VLANs. Enter global configuration mode, then the interface sub-mode for each access port, and set its access VLAN:
 
             ```
             configure
             interface <interface>
             switchport access vlan <appropriate-vlan>
+            ```
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
@@ -2177,7 +2430,9 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set SHA-512 as the default secret hashing algorithm, then re-enter each user password. Do not place a cleartext password after the `sha512` keyword, because that keyword expects an already computed hash. Supply the password with the cleartext marker `0` and let EOS hash it:
+            Set SHA-512 as the default secret hashing algorithm, then re-enter each user password. Do not place a cleartext password after the `sha512` keyword, because that keyword expects an already computed hash. Supply the password with the cleartext marker `0` and let EOS hash it.
+
+            Enter global configuration mode, then the `management defaults` sub-mode to set the hash, return to global configuration mode with `exit`, and re-enter each user secret:
 
             ```
             configure
@@ -2188,6 +2443,13 @@ queries:
             ```
 
             Verify with `show running-config section username` that every entry shows `secret sha512` followed by a hash.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-user-security
         title: Arista EOS User Security Configuration Guide
@@ -2238,7 +2500,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure descriptive names for all VLANs:
+            Configure descriptive names for all VLANs. Enter global configuration mode, then the `vlan` sub-mode for each VLAN, and set its name:
 
             ```
             configure
@@ -2247,6 +2509,13 @@ queries:
             ```
 
             For example: `name GUEST_WIFI`, `name PROD_SERVERS`, `name MGMT_NETWORK`
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -2299,7 +2568,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure a dedicated native VLAN (other than 1) for trunk ports:
+            Configure a dedicated native VLAN other than VLAN 1 for trunk ports. Enter global configuration mode, then the interface sub-mode for each trunk port, and set its native VLAN:
 
             ```
             configure
@@ -2308,6 +2577,13 @@ queries:
             ```
 
             Consider using an unused VLAN as the native VLAN and don't assign any access ports to it.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-vlans
         title: Arista EOS VLAN Configuration Guide
@@ -2361,7 +2637,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create a route map and apply it inbound on each BGP peer:
+            Create a route map and apply it inbound on each BGP peer. Enter global configuration mode, define the route map in its sub-mode, then enter the `router bgp` sub-mode to apply it to the neighbor:
 
             ```
             configure
@@ -2373,6 +2649,13 @@ queries:
             ```
 
             Define a prefix list that includes only the prefixes expected from each peer.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-bgp-configuration
         title: Arista EOS BGP Configuration Guide
@@ -2426,7 +2709,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create a route map and apply it outbound on each BGP peer:
+            Create a route map and apply it outbound on each BGP peer. Enter global configuration mode, define the route map in its sub-mode, then enter the `router bgp` sub-mode to apply it to the neighbor:
 
             ```
             configure
@@ -2438,6 +2721,13 @@ queries:
             ```
 
             Define a prefix list that includes only the prefixes intended for advertisement to each peer.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-bgp-configuration
         title: Arista EOS BGP Configuration Guide
@@ -2490,7 +2780,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure descriptions for all BGP peers:
+            Configure descriptions for all BGP peers. Enter global configuration mode, then the `router bgp` sub-mode, and set each neighbor description:
 
             ```
             configure
@@ -2499,6 +2789,13 @@ queries:
             ```
 
             Include the peer organization, circuit ID, and purpose in the description.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-bgp-configuration
         title: Arista EOS BGP Configuration Guide
@@ -2623,7 +2920,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Add an explicit deny entry at the end of each standard ACL. Use a sequence number higher than every existing entry so the deny stays last:
+            Add an explicit deny entry at the end of each standard ACL. Use a sequence number higher than every existing entry so the deny stays last. Enter global configuration mode, then the `ip access-list standard` sub-mode, and add the entry:
 
             ```
             configure
@@ -2632,6 +2929,13 @@ queries:
             ```
 
             The `log` keyword ensures denied traffic is recorded for security monitoring. This entry matches the same traffic as the implicit deny, so it does not change forwarding behavior for ACLs already ending in the implicit deny.
+
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
+
+            ```
+            end
+            write memory
+            ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-access-control-lists
         title: Arista EOS Access Control Lists Configuration Guide
@@ -2685,7 +2989,13 @@ queries:
           desc: |
             **Using the CLI**
 
-            Re-enter each deny entry with its existing sequence number and append the `log` keyword. Standard ACL entries take only a source address:
+            List the current entries first to capture each sequence number and source:
+
+            ```
+            show ip access-lists
+            ```
+
+            Re-enter each deny entry with its existing sequence number and append the `log` keyword. Standard ACL entries take only a source address. Enter global configuration mode, then the `ip access-list standard` sub-mode, and re-enter the deny entries:
 
             ```
             configure
@@ -2693,10 +3003,11 @@ queries:
             <sequence-number> deny <source> log
             ```
 
-            List the current entries first to capture each sequence number and source:
+            Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
             ```
-            show ip access-lists
+            end
+            write memory
             ```
     refs:
       - url: https://www.arista.com/en/um-eos/eos-access-control-lists


### PR DESCRIPTION
## Summary

Remediation-quality pass over `content/mondoo-arista-eos-security.mql.yaml`. The systemic gap: every CLI remediation in this policy edited running-config but none saved it. EOS does not auto-save, so every fix silently reverted on the next reload. This PR makes the remediations durable and easier to follow, and fixes several title-vs-remediation drifts flagged in the audit.

Version bumped 1.2.2 → 1.2.3. `cnspec policy lint` passes.

## Systemic fixes (all config-changing checks)

- **Persistence:** appended `end` then `write memory` to every CLI remediation that changes running-config (42 checks), each with one sentence explaining that EOS does not auto-save so the change is otherwise lost on reload.
- **Config-mode signaling:** made `configure` entry and nested sub-mode transitions (`management ssh`, `management console`, `management defaults`, `management security`, `management api http-commands`, `router bgp`, `vlan`, `interface`, `role`, `ip access-list standard`) explicit so a junior engineer can follow each block.
- `bgp-peers-established` is investigation-only (`show` commands), so it intentionally has no save step.

## Targeted fixes

- **`aaa-authentication-enabled`** — added a lockout warning: keep the current session open, confirm a local fallback user with a valid secret exists first, and verify login in a second session before disconnecting.
- **`multifactor-authentication`** — clarified that directing console logins to a RADIUS/TACACS+ group is necessary but not sufficient; the second factor must be enforced on the AAA server, and the config alone can still permit single-factor logins.
- **`snmp-traps-secured`** — recommend SNMPv3 auth+priv as the real fix (v2c is cleartext even with a custom community string); v2c-with-custom-string presented only as a minimum stopgap.
- **`exec-timeout-configured`** — aligned `desc:` terminology to "SSH idle timeout" to match the MQL and remediation (MQL unchanged).
- **`ssh-enabled`** — noted SSH needs host keys and a configured hostname/domain name before the service will come up, with a cross-reference to the domain-name check.

## Scope

Only `remediation:`/`desc:` prose and code were edited. No changes to `mql:`, `filters:`, `uid:`, `title:`, `impact:`, or `tags:`. No changes to `expect.txt`. Prose avoids em-dashes, `--`, and parenthetical asides.

## Left for maintainers (VERIFY)

These items from the audit were not applied because they require device/version verification I could not confirm:

- **`aaa-accounting-commands`** — remediation uses `aaa accounting commands all default start-stop logging` while the MQL matches exactly `...start-stop` (no `logging`). Need to confirm how current EOS renders this line in running-config; if it renders with `logging`, the device may not match the check. Same concern likely applies to the exec/system accounting siblings. Command and MQL left unchanged.
- **`admin-account-exists` / `service-password-encryption` / `users-with-encrypted-passwords`** — these reuse `management defaults` + `secret hash sha512`, which is EOS-version-dependent and may not exist on older trains. Need verification against current/LTS EOS; if version-gated, document a minimum version or a portable per-user `secret 0` form. Syntax left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)