### PR TITLE
🐛 junos: add config-mode entry + commit-confirmed safety to remediations

### DIFF
--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -444,11 +444,17 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enter configuration mode and disable SSH TCP forwarding:
+            Disabling TCP forwarding can break active tunnels and management workflows that rely on it. Enter configuration mode and disable SSH TCP forwarding, committing with automatic rollback:
 
             ```
             configure
             set system services ssh no-tcp-forwarding
+            commit confirmed 5
+            ```
+
+            `commit confirmed 5` automatically rolls back the change after 5 minutes unless it is confirmed. Verify that management access and any required workflows still work, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -880,11 +886,17 @@ queries:
             show configuration system services ssh
             ```
 
-            Then enter configuration mode, disable FTP, and commit:
+            Then enter configuration mode, disable FTP, and commit with automatic rollback in case the SSH path is not actually available:
 
             ```
             configure
             delete system services ftp
+            commit confirmed 5
+            ```
+
+            `commit confirmed 5` automatically rolls back the change after 5 minutes unless it is confirmed. Confirm that SSH and SCP file transfer still work, then make the change permanent:
+
+            ```
             commit
             ```
 

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-junos-security
     name: Mondoo Juniper Junos Security
-    version: 1.1.1
+    version: 1.1.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -151,9 +151,10 @@ queries:
 
             Before denying root login, verify that at least one named account with the super-user class exists and that you can open an SSH session with it. Denying root login while root is the only usable account cuts off remote management.
 
-            Disable root login via SSH and commit with automatic rollback in case access is lost:
+            Enter configuration mode, disable root login via SSH, and commit with automatic rollback in case access is lost:
 
             ```
+            configure
             set system services ssh root-login deny
             commit confirmed 5
             ```
@@ -161,6 +162,7 @@ queries:
             Or allow key-based root login only:
 
             ```
+            configure
             set system services ssh root-login deny-password
             commit confirmed 5
             ```
@@ -225,9 +227,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            The `set` command appends to the existing cipher list, so first remove the current list including any weak entries, then configure only strong ciphers. Commit with automatic rollback so a cipher mismatch with your SSH client cannot lock you out:
+            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing cipher list, so first remove the current list including any weak entries, then configure only strong ciphers. Commit with automatic rollback so a cipher mismatch with your SSH client cannot lock you out:
 
             ```
+            configure exclusive
             delete system services ssh ciphers
             set system services ssh ciphers aes256-gcm@openssh.com
             set system services ssh ciphers aes128-gcm@openssh.com
@@ -297,9 +300,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            The `set` command appends to the existing MAC list, so first remove the current list including any weak entries, then configure only strong MACs. Commit with automatic rollback so a MAC mismatch with your SSH client cannot lock you out:
+            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing MAC list, so first remove the current list including any weak entries, then configure only strong MACs. Commit with automatic rollback so a MAC mismatch with your SSH client cannot lock you out:
 
             ```
+            configure exclusive
             delete system services ssh macs
             set system services ssh macs hmac-sha2-256
             set system services ssh macs hmac-sha2-512
@@ -368,9 +372,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
+            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. The `group-exchange-sha2` keyword selects the SHA-256 variant of Diffie-Hellman group exchange, which replaces the weak SHA-1 `group-exchange-sha1` that this check flags. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
 
             ```
+            configure exclusive
             delete system services ssh key-exchange
             set system services ssh key-exchange curve25519-sha256
             set system services ssh key-exchange ecdh-sha2-nistp256
@@ -439,9 +444,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable SSH TCP forwarding:
+            Enter configuration mode and disable SSH TCP forwarding:
 
             ```
+            configure
             set system services ssh no-tcp-forwarding
             commit
             ```
@@ -499,9 +505,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure an SSH connection limit:
+            Enter configuration mode and configure an SSH connection limit:
 
             ```
+            configure
             set system services ssh connection-limit 5
             commit
             ```
@@ -559,9 +566,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure an SSH rate limit:
+            Enter configuration mode and configure an SSH rate limit:
 
             ```
+            configure
             set system services ssh rate-limit 4
             commit
             ```
@@ -622,9 +630,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set a password interactively. Junos prompts for the password and stores only the hash:
+            Enter configuration mode, then set a password interactively. Junos prompts for the password and stores only the hash:
 
             ```
+            configure
             set system login user <username> authentication plain-text-password
             commit
             ```
@@ -632,6 +641,7 @@ queries:
             Or supply a pre-computed password hash directly:
 
             ```
+            configure
             set system login user <username> authentication encrypted-password "<hash>"
             commit
             ```
@@ -639,6 +649,7 @@ queries:
             Or configure SSH key authentication:
 
             ```
+            configure
             set system login user <username> authentication ssh-ed25519 "<public-key>"
             commit
             ```
@@ -646,6 +657,7 @@ queries:
             If the account is no longer needed, remove it instead of adding credentials:
 
             ```
+            configure
             delete system login user <username>
             commit
             ```
@@ -705,9 +717,10 @@ queries:
 
             Do not demote the account you are currently logged in with, and always keep at least one working super-user account. The `operator` class cannot enter configuration mode, so accounts moved to it lose the ability to change the device configuration.
 
-            Reassign users who do not need full access to a more restrictive login class, committing with automatic rollback:
+            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session, then reassign users who do not need full access to a more restrictive login class, committing with automatic rollback:
 
             ```
+            configure exclusive
             set system login user <username> class operator
             commit confirmed 5
             ```
@@ -715,6 +728,7 @@ queries:
             Or create a custom login class with targeted permissions:
 
             ```
+            configure exclusive
             set system login class limited-admin permissions configure
             set system login class limited-admin permissions view
             set system login user <username> class limited-admin
@@ -785,16 +799,18 @@ queries:
 
             Before removing Telnet, ensure SSH is enabled and verify that you can open an SSH session to the device. If Telnet is your only working management path, removing it without a tested SSH login cuts off remote access.
 
-            Enable SSH if it is not already configured:
+            Enter configuration mode and enable SSH if it is not already configured:
 
             ```
+            configure
             set system services ssh
             commit
             ```
 
-            Open an SSH session to confirm access, then remove Telnet with automatic rollback:
+            Open an SSH session to confirm access, then enter configuration mode and remove Telnet with automatic rollback:
 
             ```
+            configure
             delete system services telnet
             commit confirmed 5
             ```
@@ -858,17 +874,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable FTP and use SCP instead:
-
-            ```
-            delete system services ftp
-            commit
-            ```
-
-            SCP is automatically available when SSH is enabled. From operational mode, verify SSH is configured:
+            SCP is automatically available when SSH is enabled. First, from operational mode, verify SSH is configured so you retain a secure file-transfer path after FTP is removed:
 
             ```
             show configuration system services ssh
+            ```
+
+            Then enter configuration mode, disable FTP, and commit:
+
+            ```
+            configure
+            delete system services ftp
+            commit
             ```
 
             To transfer files using SCP from an external host:
@@ -930,9 +947,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable the finger service:
+            Enter configuration mode and disable the finger service:
 
             ```
+            configure
             delete system services finger
             commit
             ```
@@ -993,9 +1011,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Remove default communities and configure unique strings:
+            Enter configuration mode, remove default communities, and configure unique strings:
 
             ```
+            configure
             delete snmp community public
             delete snmp community private
             set snmp community <unique-string> authorization read-only
@@ -1056,10 +1075,17 @@ queries:
           desc: |
             **Using the CLI**
 
-            Change all SNMP communities to read-only:
+            Removing read-write access stops any management system that relies on SNMP SET operations from making changes through this community, so confirm no orchestration or monitoring tooling depends on write access first. Enter configuration mode, change the community to read-only, and commit with automatic rollback so a loss of expected management access can be recovered:
 
             ```
+            configure
             set snmp community <community-name> authorization read-only
+            commit confirmed 5
+            ```
+
+            Confirm that monitoring still works as expected, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -1116,11 +1142,18 @@ queries:
           desc: |
             **Using the CLI**
 
-            Restrict SNMP communities to specific client addresses:
+            A client list blocks every source address that is not explicitly permitted, so include all of your existing SNMP pollers or they will stop receiving data. Enter configuration mode, restrict the community to specific client addresses, and commit with automatic rollback so a missed poller can be recovered:
 
             ```
+            configure
             set snmp community <community-name> clients <management-host>/32
             set snmp community <community-name> clients <management-network>/24
+            commit confirmed 5
+            ```
+
+            Confirm that all expected pollers still reach the device, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -1181,9 +1214,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure a remote syslog host:
+            Enter configuration mode and configure a remote syslog host:
 
             ```
+            configure
             set system syslog host <syslog-server> any notice
             set system syslog host <syslog-server> authorization info
             set system syslog host <syslog-server> interactive-commands info
@@ -1244,18 +1278,28 @@ queries:
           desc: |
             **Using the CLI**
 
-            Configure TLS transport for encrypted and reliable log delivery. The collector must accept syslog over TLS, which conventionally uses port 6514:
+            Confirm the collector is listening for syslog on the chosen transport and port before you commit. If the device sends to a transport the collector does not accept, log delivery stops silently and you lose audit visibility.
+
+            Enter configuration mode and configure TLS transport for encrypted and reliable log delivery. The collector must accept syslog over TLS, which conventionally uses port 6514. Commit with automatic rollback so a transport mismatch can be recovered:
 
             ```
+            configure
             set system syslog host <syslog-server> transport tls
             set system syslog host <syslog-server> port 6514
-            commit
+            commit confirmed 5
             ```
 
-            If the collector does not support TLS, configure TCP transport. TCP provides reliable delivery but does not encrypt log data in transit:
+            If the collector does not support TLS, configure TCP transport instead. TCP provides reliable delivery but does not encrypt log data in transit:
 
             ```
+            configure
             set system syslog host <syslog-server> transport tcp
+            commit confirmed 5
+            ```
+
+            Confirm the collector is receiving logs over the new transport, then make the change permanent:
+
+            ```
             commit
             ```
     refs:
@@ -1316,9 +1360,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable logging on security policies:
+            Enter configuration mode and enable logging on security policies:
 
             ```
+            configure
             set security policies from-zone <src> to-zone <dst> policy <name> then log session-init
             set security policies from-zone <src> to-zone <dst> policy <name> then log session-close
             commit
@@ -1378,9 +1423,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Create and apply a screen profile to the untrust zone:
+            Enter configuration mode, then create and apply a screen profile to the untrust zone:
 
             ```
+            configure
             set security screen ids-option untrust-screen icmp ping-death
             set security screen ids-option untrust-screen ip source-route-option
             set security screen ids-option untrust-screen tcp syn-flood
@@ -1445,28 +1491,19 @@ queries:
           desc: |
             **Using the CLI**
 
-            If the device is managed through the untrust zone, removing the `all` keyword also removes SSH and every other inbound service. Explicitly allow the secure services you still need in the same commit, and use automatic rollback in case access is lost.
+            If the device is managed through the untrust zone, removing the `all` keyword also removes SSH and every other inbound service. The removals and the explicit re-add of SSH must be staged and committed together in a single commit, or a commit between the deletes and the re-add will cut off management access. Enter configuration mode with `configure exclusive` so no other administrator can commit a partial change, and end with `commit confirmed 5` so access is automatically restored if the change locks you out.
 
-            Remove the `all` keyword and the insecure host-inbound services from the untrust zone:
+            Remove the `all` keyword and the insecure host-inbound services, re-add only the secure services you still need such as SSH or IKE, and commit the whole change atomically with automatic rollback:
 
             ```
+            configure exclusive
             delete security zones security-zone untrust host-inbound-traffic system-services all
             delete security zones security-zone untrust host-inbound-traffic system-services telnet
             delete security zones security-zone untrust host-inbound-traffic system-services ftp
             delete security zones security-zone untrust host-inbound-traffic system-services finger
             delete security zones security-zone untrust host-inbound-traffic system-services http
             delete security zones security-zone untrust host-inbound-traffic system-services snmp
-            ```
-
-            If management traffic such as SSH or IKE must still reach the device through this zone, allow only those services explicitly:
-
-            ```
             set security zones security-zone untrust host-inbound-traffic system-services ssh
-            ```
-
-            Commit with automatic rollback:
-
-            ```
             commit confirmed 5
             ```
 
@@ -1533,9 +1570,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable SYN flood protection:
+            Enter configuration mode and enable SYN flood protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> tcp syn-flood alarm-threshold 1024
             set security screen ids-option <screen-name> tcp syn-flood attack-threshold 200
             set security screen ids-option <screen-name> tcp syn-flood timeout 20
@@ -1595,9 +1633,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable ping-of-death protection:
+            Enter configuration mode and enable ping-of-death protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> icmp ping-death
             commit
             ```
@@ -1656,9 +1695,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable source route option protection:
+            Enter configuration mode and enable source route option protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> ip source-route-option
             commit
             ```
@@ -1716,9 +1756,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable land attack protection:
+            Enter configuration mode and enable land attack protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> tcp land
             commit
             ```
@@ -1776,9 +1817,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable teardrop protection:
+            Enter configuration mode and enable teardrop protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> ip tear-drop
             commit
             ```
@@ -1836,9 +1878,10 @@ queries:
           desc: |
             **Using the CLI**
 
-            Enable WinNuke protection:
+            Enter configuration mode and enable WinNuke protection:
 
             ```
+            configure
             set security screen ids-option <screen-name> tcp winnuke
             commit
             ```


### PR DESCRIPTION
## Summary

Remediation-quality fixes for `content/mondoo-junos-security.mql.yaml`, addressing the systemic gaps in the network-device remediation audit for Junos. The audit leaves the reader in operational mode, where `set`/`delete` are rejected, so every config-mode remediation was unrunnable as written. Only `remediation:`/`desc:`/`audit:` prose and code changed, plus a `version:` patch bump. No `mql:`, `filters:`, `uid:`, `title:`, `impact:`, or `tags:` were touched.

Version: **1.1.1 → 1.1.2**. Lint: `cnspec policy lint` reports **valid policy bundle**.

## Config-mode entry (systemic, ~24 checks)

Every `set`/`delete` remediation block now begins by entering configuration mode:

- `configure` for routine, additive changes (SSH limits, screen profiles, syslog host, policy logging, SNMP community setup, service removals).
- `configure exclusive` for management-risk changes where a concurrent commit could interfere or self-lockout is possible: the SSH cipher/MAC/key-exchange list rewrites, login-class reassignment, and the untrust-zone host-inbound change.

## Atomic untrust-zone change

`untrust-zone-minimal-services`: the `delete`s, the explicit `set ssh` re-add, and `commit confirmed 5` were previously split across three separate code blocks, inviting a premature `commit` that cuts SSH. They are now a single `configure exclusive` block ending in `commit confirmed 5`.

## Operational command no longer sandwiched

`ftp-disabled`: the operational `show configuration system services ssh` verification is moved ahead of the config-mode block so it no longer errors mid-session.

## Monitoring-loss safety on disruptive non-interactive changes

Added `commit confirmed 5` plus a brief monitoring-loss caveat to changes that can silently break monitoring or log delivery:

- `snmp-no-read-write` (SNMP SET-dependent tooling stops working)
- `snmp-client-lists` (pollers not in the client list stop receiving data)
- `syslog-secure-transport` (transport/port mismatch silently drops logs)

## VERIFY item resolved

`ssh-no-weak-key-exchanges` — `key-exchange group-exchange-sha2`: confirmed against the Juniper CLI reference that `group-exchange-sha2` is a valid keyword and is the SHA-2 (SHA-256) variant of Diffie-Hellman group exchange, the secure counterpart to the SHA-1 `group-exchange-sha1` that this check flags. Kept as-is and added a one-line note explaining what it selects.

## Left for maintainers (VERIFY)

None outstanding. The single VERIFY item from the audit (`group-exchange-sha2`) was confirmed valid and documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)