### PR TITLE
🐛 k8s: fix controller manifest examples (wrong kind/nesting) + control-plane guidance

### DIFF
--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-best-practices
     name: Mondoo Kubernetes Best Practices
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
@@ -161,11 +161,15 @@ queries:
                   image: images.my-company.example/app:v1
         ```
 
+        Give the Deployment a `selector` and pod labels that do not collide with the standalone Pod's labels. If they match, the new controller may adopt or fight over the existing Pod instead of creating its own.
+
         After the controller-managed Pod is running, delete the standalone Pod:
 
         ```bash
         kubectl delete pod <pod-name> -n <namespace>
         ```
+
+        If the standalone Pod was serving traffic, expect a brief gap while the controller-managed Pod takes over.
     refs:
       - url: https://kubernetes.io/docs/concepts/workloads/controllers/
         title: Kubernetes Workload Resources
@@ -1807,7 +1811,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -1849,7 +1854,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -1891,7 +1897,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -1935,7 +1942,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -1977,7 +1985,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -2019,7 +2028,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -2061,7 +2071,8 @@ queries:
             - name: example-app
               image: index.docker.io/yournamespace/repository
         ```
-      remediation: Remove the `hostAliases` setting from the Pod spec. Instead, use a proper DNS service or Kubernetes DNS for managing DNS entries.
+      remediation: |
+        Remove the `hostAliases` setting from the Pod spec. `hostAliases` injects static entries into each container's `/etc/hosts`, which drifts from cluster DNS over time. The entries are easy to forget and keep resolving to stale addresses long after the real target moves, which hides outages and routes traffic to the wrong place. Resolve names through cluster DNS instead. Create a headless Service for in-cluster targets, or an `ExternalName` Service to alias an external hostname, so name resolution stays in one managed place.
     refs:
       - url: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
         title: Adding entries to Pod /etc/hosts with HostAliases
@@ -2851,7 +2862,9 @@ queries:
         kubectl taint nodes <control-plane-node> node-role.kubernetes.io/control-plane:NoSchedule
         ```
 
-        Most Kubernetes distributions (kubeadm, EKS, GKE, AKS) apply this taint by default. If it has been removed, re-apply it and migrate any user workloads to worker nodes.
+        Most Kubernetes distributions, including kubeadm, EKS, GKE, and AKS, apply this taint by default. If it has been removed, re-apply it and migrate any user workloads to worker nodes.
+
+        Adding the taint immediately evicts any running pods that do not tolerate it, so plan for a brief disruption to those workloads. Do not apply this on single-node clusters such as kind, minikube, or k3s. On a single node the control plane and your workloads share the same machine, and the taint would make everything unschedulable.
     refs:
       - url: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
         title: Kubernetes Taints and Tolerations

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-security
     name: Mondoo Kubernetes Cluster and Workload Security
-    version: 2.0.1
+    version: 2.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -282,6 +282,8 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--anonymous-auth', or running with 'authentication.anonymous.enabled' defined in the kubelet configuration file, ensure that the value is set to 'false'.
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Set the '--anonymous-auth' CLI parameter and/or the 'authentication.anonymous.enabled' field in the kubelet configuration file to 'false'.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/#kubelet-authentication
@@ -321,7 +323,9 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--event-qps', or running with 'eventRecordQPS' defined in the kubelet configuration file, ensure that the value is set to '0'.
       remediation: |
-        Set the '--event-qps' CLI parameter and/or the 'eventRecordQPS' field in the kubelet configuration file to '0'.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
+        Set the `--event-qps` CLI parameter and/or the `eventRecordQPS` field in the kubelet configuration file to `0`. A value of `0` removes the rate limit so the kubelet records every event. It does not disable events, even though `0` may read that way.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -360,6 +364,8 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--make-iptables-util-chains', or running with 'makeIPTablesUtilChains' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Set the '--make-iptables-util-chains' CLI parameter and/or the 'makeIPTablesUtilChains' field in the kubelet configuration file to 'true'.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
@@ -399,7 +405,11 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--protect-kernel-defaults', or running with 'protectKernelDefaults' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
-        Set the '--protect-kernel-defaults' CLI parameter and/or the 'protectKernelDefaults' field in the kubelet configuration file to 'true'.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
+        Set the `--protect-kernel-defaults` CLI parameter and/or the `protectKernelDefaults` field in the kubelet configuration file to `true`.
+
+        When this is `true`, the kubelet refuses to start if the node's kernel sysctls do not already match the values it expects. Set the required sysctls on the node first, for example through `/etc/sysctl.d/` or your node provisioning tooling, then enable this setting. If the kubelet fails to start after the change, `journalctl -u kubelet` reports which sysctl is mismatched.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -438,6 +448,8 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--read-only-port', or running with 'readOnlyPort' defined in the kubelet configuration file, ensure that the value is either '0' or simply not set ('0' is the default).
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Set the '--read-only-port' CLI parameter or the 'readOnlyPort' field in the kubelet configuration file to '0'.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
@@ -477,6 +489,8 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--authorization-mode', or running with 'authorization.mode' defined in the kubelet configuration file, ensure that the value is not set to 'AlwaysAllow'.
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         If the kubelet is configured with the CLI parameter '--authorization-mode', set it to something that isn't 'AlwaysAllow' (eg 'Webhook').
 
         If the kubelet is configured via the kubelet config file with the 'authorization.mode' parameter, set it to something that isn't 'AlwaysAllow' (eg. 'Webhook').
@@ -538,6 +552,8 @@ queries:
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Define the list of allowed TLS ciphers to include only items from the strong list of ciphers.
 
         If the kubelet is configured with the CLI parameter '--tls-cipher-suites', update the list (or define the parameter) to only include strong ciphers.
@@ -586,6 +602,8 @@ queries:
 
         Check the kubelet configuration file to see whether 'tlsCertFile' and 'tlsPrivateKeyFile' are set to a non-empty path/string.
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Configure the kubelet to use a user-provided certificate/key pair for serving up HTTPS.
 
         After acquiring the TLS certificate/key pair, update the kubelet configuration file
@@ -629,6 +647,8 @@ queries:
       audit: |
         Check the kubelet CLI parameters to ensure '--rotate-certificates' is not set to false, and that the kubelet config file has not set 'rotateCertificates' to false.
       remediation: |
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+
         Depending on where the configuration behavior is defined (CLI parameters override config file values), update the kubelet CLI parameters to set '--rotate-certificates' to true, and/or update the kubelet configuration to set 'rotateCertificates' to true.
     refs:
       - url: https://kubernetes.io/docs/tasks/tls/certificate-rotation/
@@ -1443,12 +1463,12 @@ queries:
            ```
 
         If `--insecure-port` is set to `0` (or the argument is absent on a Kubernetes version where the insecure port has been removed), the check passes. If `--insecure-port` is set to any non-zero value, the check fails.
-      remediation: |-
-        Find the kube-apiserver process and check the `insecure-port` argument. If the argument is set to `0`, then the kube-apiserver is not listening on an insecure HTTP port:
+      remediation: |
+        This applies to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and this is handled for you.
 
-        ```bash
-        ps aux | grep kube-apiserver
-        ```
+        The `--insecure-port` and `--insecure-bind-address` flags were removed in Kubernetes 1.20, and the insecure port no longer exists on supported clusters. On 1.20 and later, no action is needed beyond confirming you are on a supported version.
+
+        On a self-managed cluster older than 1.20, back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, ensure no `--insecure-port` (set it to `0`) and no `--insecure-bind-address` remain, then save the file so the kubelet restarts the static pod. The strongest fix is to upgrade to a supported Kubernetes version where the insecure port is gone entirely.
     refs:
       - url: https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security
         title: Controlling Access to the Kubernetes API - Transport security
@@ -1502,12 +1522,10 @@ queries:
            ```
 
         If `--anonymous-auth` is set to `false`, the check passes. If it is set to `true` or is absent, the check fails.
-      remediation: |-
-        Find the kube-apiserver process and check the `--anonymous-auth` argument. If the argument is set to `false`, then the kube-apiserver does not allow anonymous authentication:
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        ```bash
-        ps aux | grep kube-apiserver
-        ```
+        Set `--anonymous-auth=false` on the API server so unauthenticated requests are rejected.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
         title: Anonymous requests
@@ -2952,7 +2970,9 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -3006,28 +3026,38 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      securityContext:
+                        allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: false
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      securityContext:
+                        allowPrivilegeEscalation: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3070,28 +3100,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: true
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: false
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3134,28 +3170,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: true
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: false
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3198,28 +3240,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: true
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: false
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3262,28 +3310,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: true
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              securityContext:
-                allowPrivilegeEscalation: false
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  securityContext:
+                    allowPrivilegeEscalation: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3405,7 +3459,9 @@ queries:
                 privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -3471,40 +3527,54 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3547,40 +3617,48 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3623,40 +3701,48 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3699,40 +3785,48 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3775,40 +3869,48 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3851,40 +3953,48 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: true
         ```
       remediation: |
-        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration:
+        Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Alternatively, set `privileged` to `false` explicitly. The manifest below shows that configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                privileged: false
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    privileged: false
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -3940,6 +4050,10 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
         apiVersion: v1
@@ -3992,28 +4106,40 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4056,28 +4182,36 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4120,28 +4254,36 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4184,28 +4326,36 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4248,28 +4398,36 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4312,28 +4470,36 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
 
+        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+
+        The corrected manifest:
+
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                readOnlyRootFilesystem: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    readOnlyRootFilesystem: true
         ```
     refs:
       - url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -4408,7 +4574,11 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -4481,56 +4651,76 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  securityContext:
+                    runAsNonRoot: true
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
+                      securityContext:
+                        runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  securityContext:
+                    runAsNonRoot: true
+                  containers:
+                    - name: container-name
+                      image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -4577,56 +4767,68 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -4673,56 +4875,68 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -4770,56 +4984,68 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -4866,56 +5092,68 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -4962,56 +5200,68 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
-              securityContext:
-                runAsNonRoot: true
+          template:
+            spec:
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
+                  securityContext:
+                    runAsNonRoot: true
         ```
 
         The same setting can also be applied to every container at the pod level. The manifest below shows that variation:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          securityContext:
-            runAsNonRoot: true
-          containers:
-            - name: container-name
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: container-name
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
@@ -5062,7 +5312,11 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -5114,26 +5368,38 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostNetwork: true
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostNetwork: false
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5175,26 +5441,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5236,26 +5510,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5297,26 +5579,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5359,26 +5649,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5421,26 +5719,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostNetwork: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostNetwork: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostNetwork: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5490,7 +5796,11 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         apiVersion: v1
@@ -5540,25 +5850,37 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostPID: true
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostPID: false
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5599,25 +5921,33 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5658,25 +5988,33 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5717,25 +6055,33 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5776,25 +6122,33 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5836,25 +6190,33 @@ queries:
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostPID: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostPID: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostPID: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -5905,7 +6267,11 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
         apiVersion: v1
@@ -5956,25 +6322,37 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostIPC: true
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  hostIPC: false
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6016,25 +6394,33 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6064,25 +6450,33 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6113,25 +6507,33 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6162,25 +6564,33 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6211,25 +6621,33 @@ queries:
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostIPC: true
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: true
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration:
+        Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+
+        The corrected manifest:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          hostIPC: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              hostIPC: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
@@ -6358,25 +6776,33 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  serviceAccount: some-account
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  serviceAccountName: ""
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6385,29 +6811,37 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  automountServiceAccountToken: false
+                  containers:
+                    - name: example-app
+                      image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6448,25 +6882,29 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccount: some-account
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: ""
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6475,29 +6913,33 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              automountServiceAccountToken: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6538,25 +6980,29 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccount: some-account
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: ""
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6565,29 +7011,33 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              automountServiceAccountToken: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6628,25 +7078,29 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccount: some-account
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: ""
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6655,29 +7109,33 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              automountServiceAccountToken: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6718,25 +7176,29 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccount: some-account
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: ""
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6745,29 +7207,33 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              automountServiceAccountToken: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6808,25 +7274,29 @@ queries:
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          serviceAccount: some-account
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccount: some-account
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Check that Pods do not set the '.spec.serviceAccountName' to the empty string (which is interpreted as 'default'), or to 'default'.
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          serviceAccountName: ""
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: ""
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
@@ -6835,29 +7305,33 @@ queries:
         Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
 
         Or if the Pod doesn't interact with the Kubernetes API, set the Pod's `.spec.automountServiceAccountToken` field to false so that no ServiceAccount is available to the Pod. For example:
 
         ```yaml
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         metadata:
           name: example-app
         spec:
-          automountServiceAccountToken: false
-          containers:
-            - name: example-app
-              image: index.docker.io/yournamespace/repository
+          template:
+            spec:
+              automountServiceAccountToken: false
+              containers:
+                - name: example-app
+                  image: index.docker.io/yournamespace/repository
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/service-accounts/
@@ -6915,7 +7389,11 @@ queries:
               imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
@@ -6969,26 +7447,38 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7032,26 +7522,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7105,26 +7603,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7178,26 +7684,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7251,26 +7765,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7324,26 +7846,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
       remediation: |
-        Set `imagePullPolicy` to `Always` on each container, and pin `image` to a specific tag or SHA digest. The manifest below shows the required configuration:
+        For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
+
+        Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              imagePullPolicy: Always
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  imagePullPolicy: Always
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -7454,30 +7984,38 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      resources:
+                        limits:
+                          cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      resources:
+                        limits:
+                          cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7521,30 +8059,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7588,30 +8130,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7655,30 +8201,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7722,30 +8272,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7789,30 +8343,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
       remediation: |
         Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  cpu: "500m"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      cpu: "500m"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7914,30 +8472,38 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      resources:
+                        limits:
+                          memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      resources:
+                        limits:
+                          memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -7983,30 +8549,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -8052,30 +8622,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -8121,30 +8695,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -8190,30 +8768,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -8259,30 +8841,34 @@ queries:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
       remediation: |
         Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
         spec:
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              resources:
-                limits:
-                  memory: "1Gi"
+          template:
+            spec:
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  resources:
+                    limits:
+                      memory: "1Gi"
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -9532,7 +10118,7 @@ queries:
         kubectl get jobs -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
-        For any ReplicaSets that bind to a host port, update the Jobs to ensure they do not bind to a host port:
+        For any Jobs that bind to a host port, update the Jobs to ensure they do not bind to a host port:
 
         ```yaml
         apiVersion: batch/v1
@@ -10581,7 +11167,9 @@ queries:
         kubectl get pods -A -o json | jq -r '.items[] | select( .spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to drop ALL capabilities, then add back only the specific capabilities required:
+        Update Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: v1
@@ -10640,7 +11228,9 @@ queries:
         kubectl get daemonsets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update DaemonSets to drop ALL capabilities, then add back only the specific capabilities required:
+        Update DaemonSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: apps/v1
@@ -10701,7 +11291,9 @@ queries:
         kubectl get replicasets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update ReplicaSets to drop ALL capabilities, then add back only the specific capabilities required:
+        Update ReplicaSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: apps/v1
@@ -10762,7 +11354,9 @@ queries:
         kubectl get jobs -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Jobs to drop ALL capabilities, then add back only the specific capabilities required:
+        Update Jobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: batch/v1
@@ -10823,7 +11417,9 @@ queries:
         kubectl get deployments -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Deployments to drop ALL capabilities, then add back only the specific capabilities required:
+        Update Deployments to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: apps/v1
@@ -10884,7 +11480,9 @@ queries:
         kubectl get statefulsets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update StatefulSets to drop ALL capabilities, then add back only the specific capabilities required:
+        Update StatefulSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: apps/v1
@@ -10945,7 +11543,9 @@ queries:
         kubectl get cronjobs -A -o json | jq -r '.items[] | select( .spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update CronJobs to drop ALL capabilities, then add back only the specific capabilities required:
+        Update CronJobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+
+        Example manifest:
 
         ```yaml
         apiVersion: batch/v1
@@ -11084,14 +11684,16 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--authorization-mode` includes both `Node` and `RBAC` and does not include `AlwaysAllow`, the check passes. If `Node` or `RBAC` is missing, or `AlwaysAllow` is present, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Set the API server `--authorization-mode` flag so it includes `Node,RBAC` and never includes `AlwaysAllow`:
 
         ```bash
         --authorization-mode=Node,RBAC
         ```
 
-        Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` (kubeadm) or your distribution's API server configuration and restart the API server pod.
+        Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` (kubeadm) or your distribution's API server configuration and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authorization/
         title: Kubernetes Authorization Overview
@@ -11134,8 +11736,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `AlwaysAdmit` does not appear in the `--enable-admission-plugins` list, the check passes. If `AlwaysAdmit` is present, the check fails.
-      remediation: |-
-        Remove `AlwaysAdmit` from the API server `--enable-admission-plugins` flag and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Remove `AlwaysAdmit` from the API server `--enable-admission-plugins` flag and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwaysadmit
         title: Kubernetes - AlwaysAdmit Admission Controller
@@ -11176,8 +11780,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `NodeRestriction` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
-      remediation: |-
-        Add `NodeRestriction` to the API server `--enable-admission-plugins` flag and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Add `NodeRestriction` to the API server `--enable-admission-plugins` flag and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
         title: Kubernetes - NodeRestriction Admission Controller
@@ -11218,8 +11824,18 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `PodSecurity` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
-      remediation: |-
-        Add `PodSecurity` to the API server `--enable-admission-plugins` flag and label namespaces with `pod-security.kubernetes.io/enforce=baseline` (or `restricted`) as appropriate.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        The actionable step is almost always labeling namespaces, not editing the flag. The `PodSecurity` plugin is enabled by default on Kubernetes 1.25 and later, so on a current cluster it is usually already on. Apply a Pod Security Standard to each namespace with a label:
+
+        ```bash
+        kubectl label ns <namespace> pod-security.kubernetes.io/enforce=baseline
+        ```
+
+        Use `enforce=restricted` for the strictest profile. Test it first, because `enforce=restricted` can reject existing workloads that do not meet the profile. You can preview the impact without enforcing by setting `pod-security.kubernetes.io/warn` or `audit` labels before switching `enforce`.
+
+        Only if you are on a self-managed control plane older than 1.25, or you removed the plugin, add `PodSecurity` to the API server `--enable-admission-plugins` flag.
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-admission/
         title: Kubernetes - Pod Security Admission
@@ -11260,7 +11876,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `EventRateLimit` appears in the `--enable-admission-plugins` list, the check passes. If it is missing, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Add `EventRateLimit` to the API server `--enable-admission-plugins` flag and supply a configuration file via `--admission-control-config-file`.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#eventratelimit
@@ -11302,8 +11920,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-log-path` is set to a non-empty file location, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
-        Set the API server `--audit-log-path` flag to a writable file location such as `/var/log/kubernetes/audit.log` and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Set the API server `--audit-log-path` flag to a writable file location such as `/var/log/kubernetes/audit.log` and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
         title: Kubernetes - Auditing
@@ -11344,8 +11964,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-policy-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
-        Create an audit policy YAML and pass it to the API server via `--audit-policy-file=/etc/kubernetes/audit-policy.yaml`. Restart the API server after the file is in place.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Create an audit policy YAML and pass it to the API server via `--audit-policy-file=/etc/kubernetes/audit-policy.yaml`. Save the manifest so the kubelet restarts the static pod after the file is in place.
     refs:
       - url: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy
         title: Kubernetes - Audit policy
@@ -11386,8 +12008,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--audit-log-maxage` is set to `30` or higher, the check passes. If the argument is absent or set to a value below `30`, the check fails.
-      remediation: |-
-        Set the API server `--audit-log-maxage=30` (or a higher value matching your retention policy) and restart the API server. Forward audit logs to a long-term store such as a SIEM in addition to local retention.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Set the API server `--audit-log-maxage=30` (or a higher value matching your retention policy) and save the file so the kubelet restarts the static pod. Forward audit logs to a long-term store such as a SIEM in addition to local retention.
     refs:
       - url: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#log-backend
         title: Kubernetes - Audit log backend options
@@ -11428,7 +12052,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--encryption-provider-config` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Create an `EncryptionConfiguration` file specifying a strong provider (`aescbc`, `kms`, or `secretbox`) and pass it to the API server with `--encryption-provider-config=/etc/kubernetes/enc/enc.yaml`. Prefer a KMS provider in production. Re-write existing secrets so they are encrypted with the new keys:
 
         ```bash
@@ -11475,8 +12101,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--tls-min-version` is set to `VersionTLS12` or `VersionTLS13`, or the argument is absent on a version that defaults to TLS 1.2, the check passes. If it is set to `VersionTLS10` or `VersionTLS11`, the check fails.
-      remediation: |-
-        Set the API server `--tls-min-version=VersionTLS12` (or `VersionTLS13` if your client population supports it) and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Set the API server `--tls-min-version=VersionTLS12` (or `VersionTLS13` if your client population supports it) and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
         title: kube-apiserver - Reference
@@ -11520,7 +12148,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--tls-cipher-suites` is set and contains no RC4 or 3DES ciphers (`TLS_RSA_WITH_3DES`, `TLS_RSA_WITH_RC4`, `TLS_ECDHE_RSA_WITH_RC4`, `TLS_ECDHE_ECDSA_WITH_RC4`), the check passes. If the argument is absent or includes any of those weak ciphers, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Set `--tls-cipher-suites` to a hardened list, for example:
 
         ```text
@@ -11566,8 +12196,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--client-ca-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
-        Set the API server `--client-ca-file` to the path of the cluster CA bundle (typically `/etc/kubernetes/pki/ca.crt` on kubeadm clusters) and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Set the API server `--client-ca-file` to the path of the cluster CA bundle (typically `/etc/kubernetes/pki/ca.crt` on kubeadm clusters) and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
         title: Kubernetes - X.509 client certs
@@ -11610,8 +12242,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If both `--kubelet-client-certificate` and `--kubelet-client-key` are set to non-empty paths, the check passes. If either argument is absent or empty, the check fails.
-      remediation: |-
-        Generate an API-server client cert/key signed by the cluster CA and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. Restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Generate an API-server client cert/key signed by the cluster CA and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. Save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: Control Plane to Node communication
@@ -11651,8 +12285,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--kubelet-https` is absent (the default is `true`) or set to `true`, the check passes. If it is explicitly set to `false`, the check fails.
-      remediation: |-
-        Remove any `--kubelet-https=false` argument from the API server configuration and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Remove any `--kubelet-https=false` argument from the API server configuration and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/
         title: Control Plane Node communication
@@ -11693,8 +12329,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--kubelet-certificate-authority` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
-        Pass `--kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt` (or the cluster's kubelet CA bundle) to the API server and restart it.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Pass `--kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt`, or the cluster's kubelet CA bundle, to the API server.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: API server to kubelet
@@ -11736,7 +12374,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile` are all set to non-empty paths, the check passes. If any of the three arguments is absent or empty, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Generate API-server-to-etcd certs from the etcd CA and pass them as `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile`. Confirm etcd is configured with the matching peer/server certificates.
     refs:
       - url: https://kubernetes.io/docs/setup/best-practices/certificates/
@@ -11777,8 +12417,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--service-account-lookup` is absent (the default is `true`) or set to `true`, the check passes. If it is explicitly set to `false`, the check fails.
-      remediation: |-
-        Either remove the `--service-account-lookup=false` argument or set `--service-account-lookup=true` explicitly, and restart the API server.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Either remove the `--service-account-lookup=false` argument or set `--service-account-lookup=true` explicitly, and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/
         title: Managing Service Accounts
@@ -11819,7 +12461,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--service-account-key-file` is set to a non-empty path, the check passes. If the argument is absent or empty, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Configure `--service-account-key-file=/etc/kubernetes/pki/sa.pub` (kubeadm default) and the matching `--service-account-signing-key-file=/etc/kubernetes/pki/sa.key` on the API server, then restart it.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-signing-key
@@ -11860,8 +12504,10 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--profiling` is set to `false`, the check passes. If it is set to `true` or is absent, the check fails.
-      remediation: |-
-        Set `--profiling=false` on the API server and restart it.
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
+        Set `--profiling=false` on the API server.
     refs:
       - url: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
         title: kube-apiserver - Reference
@@ -11901,7 +12547,9 @@ queries:
         ```
 
         On kubeadm clusters you can also run `ps -ef | grep kube-apiserver`. If `--token-auth-file` is absent or empty, the check passes. If the argument is set to a file path, the check fails.
-      remediation: |-
+      remediation: |
+        These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
+
         Remove the `--token-auth-file` argument from the API server configuration and migrate users to OIDC, ServiceAccount tokens, or x509 client certificates.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file


### PR DESCRIPTION
## Summary

This is a remediation-quality pass over the Kubernetes policies, driven by an accuracy audit. It fixes the single highest-volume accuracy defect in the security policy and adds the missing "why"/safety guidance that junior engineers need.

## Wrong `kind`/nesting in controller manifests (S1) — 160 manifests fixed

The workload-controller checks fan out per kind (Pod/Deployment/StatefulSet/Job/CronJob/ReplicaSet/DaemonSet). Every non-Pod variant pasted a bare `kind: Pod` snippet that **cannot be applied** to the resource the check targets: a Deployment's `securityContext` lives at `spec.template.spec.containers[]`, and a CronJob's at `spec.jobTemplate.spec.template.spec.containers[]`.

Across 11 families (privilegedcontainer, allowprivilegeescalation, readonlyrootfilesystem, runasnonroot, hostnetwork, hostpid, hostipc, serviceaccount, imagepull, limitcpu, limitmemory), each of the 65 controller variants now uses its real `kind`, correct `apiVersion` (`apps/v1` or `batch/v1`), and correct nesting. The genuine `kind: Pod` checks are left alone. **160 example manifests rewritten.** All transformed manifests were verified to parse as valid YAML and resolve to `containers` at the right depth.

## Control-plane guidance (C13) — 30 checks

The ~30 api-server/kubelet checks told operators to "restart the API server" with no context. Added a shared preamble: these flags apply to self-managed control planes only; on EKS/GKE/AKS the control plane is provider-managed; on kubeadm the API server is a static pod, so you edit `/etc/kubernetes/manifests/kube-apiserver.yaml` and the kubelet auto-restarts it (back up first). Removed the incorrect `kubectl rollout restart` advice for the API server.

## Accuracy / "why" fixes

- **PodSecurity admission**: leads with the namespace-label step; notes the plugin is on by default since 1.25; warns `enforce=restricted` can reject existing workloads.
- **imagepull**: recommends digest pinning for true consistency; explains `imagePullPolicy: Always` is about freshness, not determinism.
- **insecure-port**: rewritten as a real fix/no-op, noting `--insecure-port` was removed in 1.20.
- **event-record-qps**: explains `0` means "unlimited," not "disabled."
- **protect-kernel-defaults**: warns the kubelet refuses to start if node sysctls do not match.
- **job-ports-hostport**: fixed the "For any ReplicaSets" copy-paste.

## Disruption / apply caveats (S3/S4)

Added rolling-restart, app-breakage, and `kubectl apply` / `kubectl edit` guidance to the `readOnlyRootFilesystem`, `drop: ["ALL"]`, and securityContext families.

## Best-practices policy

- **hostAliases**: DNS-drift rationale plus headless/ExternalName Service alternatives.
- **pod-no-owner**: label-collision and brief-gap caveats.
- **control-plane-taint**: eviction warning and single-node-cluster caveat.

## Versions

- `mondoo-kubernetes-security`: 2.0.1 → 2.0.2
- `mondoo-kubernetes-best-practices`: 1.2.1 → 1.2.2

## Validation

`cnspec policy lint` reports both bundles valid. Only `remediation`/`desc`/`audit` prose and code were changed; no `mql`/`filters`/`uid`/`title`/`impact`/`tags` were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)