### PR TITLE
🐛 azure: Entra rename, Flexible Server portal paths, destructive-action warnings

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.2.1
+    version: 9.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -2708,6 +2708,8 @@ queries:
               purge_protection_enabled = true
             }
             ```
+
+            Once purge protection is enabled it cannot be disabled. The vault and its secrets are then protected for the full soft-delete retention period and cannot be purged early.
         - id: bicep
           desc: |
             To ensure Key Vaults are configured with Recovery features in Bicep:
@@ -2724,6 +2726,8 @@ queries:
               }
             }
             ```
+
+            Once purge protection is enabled it cannot be disabled. The vault and its secrets are then protected for the full soft-delete retention period and cannot be purged early.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/general/security-features
         title: Azure Key Vault Security
@@ -3850,9 +3854,9 @@ queries:
         **Manual Audit via Azure Portal:**
 
         1. Log in to Azure Portal at https://portal.azure.com.
-        2. Navigate to `Azure Database for PostgreSQL server`.
+        2. Navigate to `Azure Database for PostgreSQL flexible servers`.
         3. Select each database server to review its settings.
-        4. Under `Connection security`, confirm that `Enforce SSL connection` is set to `ENABLED`. This setting should be consistent across all PostgreSQL database servers to ensure uniform security posture.
+        4. Under `Settings`, select `Server parameters` and confirm that `require_secure_transport` is set to `ON`. This setting should be consistent across all PostgreSQL flexible servers to ensure uniform security posture.
 
         **Automated Audit with Azure CLI:**
 
@@ -3879,12 +3883,12 @@ queries:
             To ensure SSL connection enabled for PostgreSQL database servers using the Azure Portal, enforce SSL connections:
 
             1. Access the Azure Portal at https://portal.azure.com.
-            2. Navigate to `Azure Database for PostgreSQL server`.
-            3. For each server, access `Connection security`.
-            4. Locate the `SSL settings` and set `Enforce SSL connection` to `ENABLED`.
-            5. Apply the changes to ensure that the setting is enforced across all servers.
+            2. Navigate to `Azure Database for PostgreSQL flexible servers`.
+            3. For each server, under `Settings`, select `Server parameters`.
+            4. Locate the `require_secure_transport` parameter and set its value to `ON`.
+            5. Select `Save` to apply the change.
 
-            Consistency in enforcement is key. Verify that all PostgreSQL servers within your Azure environment have this setting enabled to maintain a high security standard.
+            Consistency in enforcement is key. Verify that all PostgreSQL flexible servers within your Azure environment have this setting enabled to maintain a high security standard.
         - id: cli
           desc: |
             To ensure SSL connection enabled for PostgreSQL database servers using the Azure CLI, for a batch update or to automate the enforcement across multiple servers, use the Azure CLI:
@@ -4019,10 +4023,10 @@ queries:
         **Manual Audit via Azure Portal:**
 
         1. Log in to the Azure Portal at https://portal.azure.com.
-        2. Navigate to `Azure Database for MySQL servers`.
+        2. Navigate to `Azure Database for MySQL flexible servers`.
         3. Select each server to inspect its settings.
-        4. Under `Connection security`, verify that `Enforce SSL connection` is set to `ENABLED`.
-        5. Additionally, ensure that the server is configured to use the latest supported TLS version, such as TLS 1.2 or higher.
+        4. Under `Settings`, select `Server parameters` and verify that `require_secure_transport` is set to `ON`.
+        5. Additionally, verify that the `tls_version` parameter is set to `TLSv1.2` so older protocol versions are rejected.
 
         **Automated Audit with Azure CLI:**
 
@@ -4039,11 +4043,11 @@ queries:
             To ensure SSL is enabled with latest TLS for MySQL Database Server using the Azure Portal, enforce SSL connections and ensure the use of the latest TLS version:
 
             1. Access the Azure Portal at https://portal.azure.com.
-            2. Navigate to `Azure Database for MySQL servers`.
-            3. For each server, go to `Connection security`.
-            4. Set `Enforce SSL connection` to `ENABLED`.
-            5. Select the latest supported TLS version from the dropdown menu to ensure maximum security.
-            6. Apply these settings to ensure compliance across all MySQL servers.
+            2. Navigate to `Azure Database for MySQL flexible servers`.
+            3. For each server, under `Settings`, select `Server parameters`.
+            4. Set the `require_secure_transport` parameter value to `ON`.
+            5. Set the `tls_version` parameter value to `TLSv1.2` so older protocol versions are rejected.
+            6. Select `Save` to apply these settings across all MySQL flexible servers.
 
             Regular reviews and updates of these settings are recommended to adapt to new TLS versions as they become available, ensuring that the security configurations remain up-to-date.
         - id: cli
@@ -6024,7 +6028,7 @@ queries:
 
         1. Navigate to **SQL servers** in the Azure Portal.
         2. Select a server and go to **Microsoft Entra ID** under **Settings**.
-        3. Verify that an Azure AD administrator is configured.
+        3. Verify that a Microsoft Entra ID administrator is configured.
 
         **Automated Audit with Azure CLI:**
 
@@ -6039,7 +6043,7 @@ queries:
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the server.
             3. Go to **Microsoft Entra ID** under **Settings**.
-            4. Select **Set admin** and choose an Azure AD user or group.
+            4. Select **Set admin** and choose a Microsoft Entra ID user or group.
             5. Select **Save**.
         - id: cli
           desc: |
@@ -7954,7 +7958,7 @@ queries:
 
         - **Least privilege enforcement:** RBAC allows Kubernetes permissions to be scoped to specific namespaces, resource types, and verbs, limiting what each identity can do within the cluster.
         - **Reduced blast radius:** If a service account or user credential is compromised, RBAC limits the attacker to the permissions assigned to that identity rather than full cluster access.
-        - **Azure AD integration:** RBAC enables binding Kubernetes roles to Azure AD users and groups, centralizing identity management and enabling conditional access policies.
+        - **Microsoft Entra ID integration:** RBAC enables binding Kubernetes roles to Microsoft Entra ID users and groups, centralizing identity management and enabling conditional access policies.
         - **Audit accountability:** Every API server request is authorized against an RBAC policy, producing a clear record of which identity performed which action.
 
         **Risk mitigation**
@@ -8603,9 +8607,9 @@ queries:
         **Why this matters**
 
         - **Static credential elimination:** FTP basic auth credentials do not support MFA or conditional access and cannot be scoped to a single identity, making them a weak link in deployment security.
-        - **Attack surface reduction:** Disabling basic auth removes FTP as a viable deployment path for attackers, forcing the use of Azure AD-backed methods that support modern access controls.
+        - **Attack surface reduction:** Disabling basic auth removes FTP as a viable deployment path for attackers, forcing the use of Microsoft Entra ID-backed methods that support modern access controls.
         - **Brute force prevention:** FTP endpoints accepting basic auth are common targets for credential stuffing; disabling basic auth removes the endpoint from consideration entirely.
-        - **Deployment auditability:** Azure AD-authenticated deployment methods tie every deployment to a specific identity, enabling clear accountability in audit logs.
+        - **Deployment auditability:** Microsoft Entra ID-authenticated deployment methods tie every deployment to a specific identity, enabling clear accountability in audit logs.
 
         **Risk mitigation**
 
@@ -8758,19 +8762,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that basic authentication for the SCM (Kudu) publishing endpoint is disabled on Azure App Service web apps. The SCM site provides access to deployment logs, file system browsing, process inspection, and remote code execution capabilities; protecting it with Azure AD authentication rather than static credentials is essential.
+        This check ensures that basic authentication for the SCM (Kudu) publishing endpoint is disabled on Azure App Service web apps. The SCM site provides access to deployment logs, file system browsing, process inspection, and remote code execution capabilities; protecting it with Microsoft Entra ID authentication rather than static credentials is essential.
 
         **Why this matters**
 
         - **High-privilege endpoint protection:** The Kudu endpoint exposes powerful deployment and diagnostic functionality; basic auth credentials protecting it are a single point of failure with no MFA or conditional access support.
         - **Static credential risk:** SCM basic auth uses the same shared publishing-profile credentials as FTP, which cannot be scoped to individual identities and are frequently stored in CI/CD systems.
-        - **Azure AD enforcement:** Disabling basic auth forces clients to authenticate via Azure AD, enabling MFA, conditional access policies, and identity-based audit logging for every SCM interaction.
+        - **Microsoft Entra ID enforcement:** Disabling basic auth forces clients to authenticate via Microsoft Entra ID, enabling MFA, conditional access policies, and identity-based audit logging for every SCM interaction.
         - **Credential leak impact reduction:** Even if publishing credentials are leaked, disabling basic auth prevents them from being used to access the SCM endpoint.
 
         **Risk mitigation**
 
         - **Remote code execution prevention:** An attacker with basic auth credentials and network access to the SCM endpoint can deploy arbitrary code; disabling basic auth removes that path entirely.
-        - **Deployment pipeline security:** Requiring Azure AD authentication for SCM access ensures that revoked identities lose access immediately, rather than retaining it through long-lived static credentials.
+        - **Deployment pipeline security:** Requiring Microsoft Entra ID authentication for SCM access ensures that revoked identities lose access immediately, rather than retaining it through long-lived static credentials.
       audit: |
         **Manual Audit via Azure Portal:**
 
@@ -10134,14 +10138,14 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that workload identity is enabled on AKS clusters, allowing pods to authenticate to Azure services using short-lived Azure AD federated tokens rather than long-lived secrets stored in the cluster. Workload identity is disabled by default and requires both the OIDC issuer and the workload identity webhook to be activated.
+        This check ensures that workload identity is enabled on AKS clusters, allowing pods to authenticate to Azure services using short-lived Microsoft Entra ID federated tokens rather than long-lived secrets stored in the cluster. Workload identity is disabled by default and requires both the OIDC issuer and the workload identity webhook to be activated.
 
         **Why this matters**
 
-        - **Eliminates stored secrets:** Pods receive short-lived, automatically rotated Azure AD tokens via projected service account tokens, removing the need for static service principal passwords or connection strings in Kubernetes Secrets.
+        - **Eliminates stored secrets:** Pods receive short-lived, automatically rotated Microsoft Entra ID tokens via projected service account tokens, removing the need for static service principal passwords or connection strings in Kubernetes Secrets.
         - **Per-workload identity granularity:** Each pod can be bound to a distinct Azure Managed Identity, enabling fine-grained RBAC at the resource level rather than sharing a single cluster-wide credential.
-        - **Centralized identity lifecycle:** Azure AD handles credential issuance, rotation, and revocation, so there is no separate secret rotation pipeline to maintain or audit.
-        - **Conditional access enforcement:** Azure AD policies (MFA, IP restrictions, sign-in risk) can be applied to workload identities, adding controls that are impossible with static connection strings.
+        - **Centralized identity lifecycle:** Microsoft Entra ID handles credential issuance, rotation, and revocation, so there is no separate secret rotation pipeline to maintain or audit.
+        - **Conditional access enforcement:** Microsoft Entra ID policies such as MFA, IP restrictions, and sign-in risk can be applied to workload identities, adding controls that are impossible with static connection strings.
 
         **Risk mitigation**
 
@@ -16155,7 +16159,7 @@ queries:
 
             1. Navigate to **Azure Cosmos DB** in the Azure Portal.
             2. Select the Cosmos DB account and go to **Networking** > **Private endpoint connections**.
-            3. Select **+ Private endpoint** and configure a private endpoint in the target virtual network.
+            3. Select **+ Private endpoint** and configure a private endpoint in the target virtual network. Integrate it with a Private DNS Zone so that clients resolve the account name to its private IP.
         - id: cli
           desc: |
             To ensure Cosmos DB accounts have private endpoints configured using the Azure CLI, disable public network access and create a private endpoint for the Cosmos DB account:
@@ -16172,6 +16176,8 @@ queries:
               --group-id Sql \
               --connection-name example-cosmosdb-psc
             ```
+
+            Create and validate the private endpoint and its Private DNS Zone before disabling public network access. Disabling public access severs every connection that reaches the account over its public path and can break production until clients resolve and reach the private endpoint.
         - id: bicep
           desc: |
             To ensure Cosmos DB accounts have private endpoints configured in Bicep:
@@ -16288,6 +16294,8 @@ queries:
             ```bash
             az resource update --ids $(az cosmosdb show --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --query id -o tsv) --set properties.cors='[{"allowedOrigins":"https://specific-domain.com"}]'
             ```
+
+            This `--set` overwrites the entire CORS configuration rather than editing a single field. Re-specify `allowedMethods` and `allowedHeaders` for every rule you intend to keep, otherwise a working policy can be narrowed to allow only the origins listed here.
         - id: terraform
           desc: |
             To ensure Azure Cosmos DB accounts do not allow wildcard CORS origins in Terraform:
@@ -16448,6 +16456,8 @@ queries:
             ```bash
             az cosmosdb update --name <CosmosDBAccountName> --resource-group <ResourceGroupName> --backup-policy-type Continuous
             ```
+
+            Switching from periodic to continuous backup is a one-way migration that cannot be reversed, and continuous backup carries different cost and tier implications. Confirm the change is intended before applying.
         - id: terraform
           desc: |
             To ensure Azure Cosmos DB accounts use continuous backup policy in Terraform:
@@ -19398,9 +19408,11 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            To delete an overly permissive firewall rule using the Azure CLI, supply the full ARM resource ID of the rule (allowing 0.0.0.0–255.255.255.255). <FirewallRuleResourceId> is the full ARM ID of the overly-permissive firewall rule.
+            To delete an overly permissive firewall rule using the Azure CLI, first list the firewall rules to obtain the resource ID of the rule that allows 0.0.0.0 through 255.255.255.255, then delete it by ID:
 
             ```bash
+            az resource list --resource-group-name <ResourceGroupName> --resource-type "Microsoft.DBforPostgreSQL/servers/firewallRules" --query "[].id" -o tsv
+
             az resource delete --resource-ids <FirewallRuleResourceId>
             ```
         - id: terraform
@@ -20620,10 +20632,12 @@ queries:
             7. Select **Save**.
         - id: cli
           desc: |
-            To delete an overly permissive firewall rule using the Azure CLI, supply the full ARM resource ID of the rule (allowing 0.0.0.0–255.255.255.255). <FirewallRuleResourceId> is the full ARM ID of the overly-permissive firewall rule.
+            To delete an overly permissive firewall rule using the Azure CLI, first list the rules to find the name of the rule that allows 0.0.0.0 through 255.255.255.255, then delete it by name:
 
             ```bash
-            az resource delete --resource-ids <FirewallRuleResourceId>
+            az mysql server firewall-rule list --resource-group-name <ResourceGroupName> --server-name <ServerName> -o table
+
+            az mysql server firewall-rule delete --resource-group-name <ResourceGroupName> --server-name <ServerName> --firewall-rule-name <RuleName>
             ```
         - id: terraform
           desc: |
@@ -22770,6 +22784,8 @@ queries:
             ```bash
             az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --versions "SMB3.0;SMB3.1.1"
             ```
+
+            This flag sets the complete list of allowed SMB versions rather than adding to it. Any version not listed is rejected, so clients that negotiate a removed version lose connectivity. Confirm no client depends on an excluded version before applying.
         - id: terraform
           desc: |
             To ensure Azure Storage accounts only allow SMB 3.0 and later in Terraform:
@@ -22924,8 +22940,10 @@ queries:
             To ensure Azure Storage accounts use strong SMB channel encryption using the Azure CLI:
 
             ```bash
-            az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --channel-encryption "AES-128-CCM;AES-128-GCM;AES-256-GCM"
+            az storage account file-service-properties update --account-name <StorageAccountName> --resource-group <ResourceGroupName> --channel-encryption "AES-256-GCM;AES-128-GCM"
             ```
+
+            Do not include `AES-128-CCM` in the allowed set. It is the weakest of the supported ciphers and offering it defeats the goal of enforcing strong SMB channel encryption.
         - id: terraform
           desc: |
             To ensure Azure Storage accounts use strong SMB channel encryption in Terraform:
@@ -22940,7 +22958,7 @@ queries:
 
               share_properties {
                 smb {
-                  channel_encryption_type = ["AES-128-CCM", "AES-128-GCM", "AES-256-GCM"]
+                  channel_encryption_type = ["AES-256-GCM", "AES-128-GCM"]
                 }
               }
             }
@@ -23077,6 +23095,8 @@ queries:
             ```bash
             az network vnet-gateway create --name <GatewayName> --resource-group <ResourceGroupName> --vnet <VNetName> --gateway-type Vpn --vpn-type RouteBased --sku VpnGw2 --vpn-gateway-generation Generation2
             ```
+
+            Recreating a VPN gateway is destructive. It drops all live tunnels, may assign a new public IP, and requires updating peer and on-premises device configurations. Plan a maintenance window and expect connectivity loss until the new gateway and its connections are reconfigured.
         - id: terraform
           desc: |
             To ensure VPN gateways use Generation2 for stronger cryptographic standards in Terraform:
@@ -23249,6 +23269,8 @@ queries:
             ```bash
             az disk update --name <DiskName> --resource-group <ResourceGroupName> --public-network-access Disabled --network-access-policy DenyAll
             ```
+
+            Setting `DenyAll` and disabling public access stops SAS-URI based disk export, import, and download over the internet. If those workflows are in use, configure private endpoints with Azure Private Link first so the operations continue to work.
         - id: terraform
           desc: |
             To ensure public network access is disabled for Azure managed disks in Terraform:
@@ -24825,20 +24847,13 @@ queries:
             ```
         - id: bicep
           desc: |
-            To ensure AKS uses WireGuard for transit encryption in Bicep, note: WireGuard transit encryption is configured through the Azure CNI Overlay networking profile. Bicep support for the `advancedNetworking.security` property may be limited. Use Azure CLI to enable WireGuard on AKS clusters.
-
-            ```bicep
-            resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
-              name: 'example-aks'
-              location: resourceGroup().location
-              properties: {
-                networkProfile: {
-                  networkPlugin: 'azure'
-                  networkPluginMode: 'overlay'
-                }
-                // WireGuard enablement may require CLI post-deployment
-              }
-            }
+            ```text
+            # No Bicep remediation: WireGuard transit encryption is part of
+            # Advanced Container Networking Services and requires the Cilium
+            # data plane. The managedClusters resource type does not expose a
+            # property to enable it, so it must be configured with the Azure
+            # CLI (az aks update --enable-acns --acns-transit-encryption-type
+            # WireGuard) after the cluster is provisioned.
             ```
         - id: terraform
           desc: |
@@ -25092,6 +25107,8 @@ queries:
             ```bash
             az webapp config access-restriction add --resource-group <ResourceGroupName> --name <AppName> --scm-site true --rule-name DenyAll --priority 100 --action Deny --ip-address 0.0.0.0/0
             ```
+
+            A blanket SCM deny blocks all Kudu access, not just SSH. It also stops Kudu deployments and ZIP or Run-From-Package pushes. If deployment access is needed, scope the rule to specific trusted source ranges instead of denying all traffic.
 
             Alternatively, use a custom container that does not include an SSH server to eliminate SSH access entirely.
         - id: bicep
@@ -25652,9 +25669,11 @@ queries:
             1. Navigate to **App Services** in the Azure Portal.
             2. Select the App Service instance.
             3. Go to **Networking** > **Access restriction**.
-            4. Set **Unmatched rule action** to **Deny**.
-            5. Add allow rules for trusted IP ranges.
+            4. Add allow rules for all trusted IP ranges first, including the operator and management ranges you use to reach the app.
+            5. Set **Unmatched rule action** to **Deny**.
             6. Select **Save**.
+
+            Add the allow rules before switching the unmatched action to Deny. Setting Deny without first allowing your own source range can lock out all access, including the operators making the change.
         - id: cli
           desc: |
             To ensure App Service IP restrictions default to deny using the Azure CLI:
@@ -25998,7 +26017,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            To ensure SQL Server uses Azure AD-only authentication using the Azure Portal:
+            To ensure SQL Server uses Microsoft Entra ID-only authentication using the Azure Portal:
 
             1. Navigate to **SQL servers** in the Azure Portal.
             2. Select the SQL server.
@@ -26007,14 +26026,14 @@ queries:
             5. Select **Save**.
         - id: cli
           desc: |
-            To ensure SQL Server uses Azure AD-only authentication using the Azure CLI:
+            To ensure SQL Server uses Microsoft Entra ID-only authentication using the Azure CLI:
 
             ```bash
             az sql server ad-only-auth enable --resource-group <ResourceGroupName> --name <ServerName>
             ```
         - id: terraform
           desc: |
-            To ensure SQL Server uses Azure AD-only authentication in Terraform:
+            To ensure SQL Server uses Microsoft Entra ID-only authentication in Terraform:
 
             ```hcl
             resource "azurerm_mssql_server" "example" {
@@ -26024,7 +26043,7 @@ queries:
               version                      = "12.0"
 
               azuread_administrator {
-                login_username              = "AzureAD Admin"
+                login_username              = "Microsoft Entra Admin"
                 object_id                   = data.azuread_group.sql_admins.object_id
                 azuread_authentication_only = true
               }
@@ -26032,7 +26051,7 @@ queries:
             ```
         - id: bicep
           desc: |
-            To ensure SQL Server uses Azure AD-only authentication in Bicep:
+            To ensure SQL Server uses Microsoft Entra ID-only authentication in Bicep:
 
             ```bicep
             resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
@@ -26042,7 +26061,7 @@ queries:
                 administrators: {
                   azureADOnlyAuthentication: true
                   administratorType: 'ActiveDirectory'
-                  login: 'AzureAD Admin'
+                  login: 'Microsoft Entra Admin'
                   sid: azureAdGroupObjectId
                   tenantId: subscription().tenantId
                 }
@@ -26820,7 +26839,13 @@ queries:
             Configure the customer-managed key encryption settings on the cluster through the Azure Portal at creation time or with the REST API.
         - id: terraform
           desc: |
-            Customer-managed key encryption requires the Azure Cache for Redis Enterprise tier. The `azurerm_redis_cache` resource cannot express CMK encryption because the standard cache tiers do not support it. Manage Enterprise-tier CMK encryption through the REST API or the azapi provider.
+            ```text
+            # No Terraform remediation: customer-managed key encryption
+            # requires the Azure Cache for Redis Enterprise tier, and the
+            # azurerm_redis_cache resource has no CMK field because the
+            # standard cache tiers do not support it. Configure Enterprise
+            # CMK through the Azure Portal or the REST API.
+            ```
         - id: bicep
           desc: |
             Customer-managed key encryption requires the Azure Cache for Redis Enterprise tier. To configure CMK in Bicep:
@@ -31364,7 +31389,7 @@ queries:
         properties["managedVirtualNetwork"] == "default"
       )
   - uid: mondoo-azure-security-synapse-aad-only-auth
-    title: Ensure Synapse uses Azure AD-only authentication
+    title: Ensure Synapse uses Microsoft Entra ID-only authentication
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -31403,17 +31428,17 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that Azure Synapse Analytics workspaces are configured to use Azure Active Directory (Azure AD) only authentication, disabling local SQL authentication.
+        This check ensures that Azure Synapse Analytics workspaces are configured to use Microsoft Entra ID only authentication, disabling local SQL authentication.
 
         **Why this matters**
 
-        - **Centralized identity management**: Azure AD-only authentication ensures all access is managed through a centralized identity provider with support for multi-factor authentication, conditional access, and identity governance.
+        - **Centralized identity management**: Microsoft Entra ID-only authentication ensures all access is managed through a centralized identity provider with support for multi-factor authentication, conditional access, and identity governance.
         - **Eliminate password-based attacks**: Disabling SQL authentication removes the risk of brute force attacks, credential stuffing, and password spraying against SQL administrator accounts.
 
         **Risk mitigation**
 
-        - Configure an Azure AD administrator for the Synapse workspace before enabling Azure AD-only authentication.
-        - Ensure all applications and users accessing the workspace are registered in Azure AD and have appropriate role assignments.
+        - Configure a Microsoft Entra ID administrator for the Synapse workspace before enabling Microsoft Entra ID-only authentication.
+        - Ensure all applications and users accessing the workspace are registered in Microsoft Entra ID and have appropriate role assignments.
       audit: |
         ### Audit via Portal
 
@@ -31440,7 +31465,7 @@ queries:
       remediation:
         - id: portal
           desc: |
-            To ensure Synapse uses Azure AD-only authentication using the Azure Portal:
+            To ensure Synapse uses Microsoft Entra ID-only authentication using the Azure Portal:
 
             1. Navigate to the [Azure Portal](https://portal.azure.com).
             2. Go to **Azure Synapse Analytics** and select the target workspace.
@@ -31450,7 +31475,7 @@ queries:
             6. Select **Save**.
         - id: cli
           desc: |
-            To ensure Synapse uses Azure AD-only authentication using the Azure CLI:
+            To ensure Synapse uses Microsoft Entra ID-only authentication using the Azure CLI:
 
             ```bash
             # Set the Microsoft Entra admin
@@ -31469,7 +31494,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            To ensure Synapse uses Azure AD-only authentication in Terraform:
+            To ensure Synapse uses Microsoft Entra ID-only authentication in Terraform:
 
             ```hcl
             resource "azurerm_synapse_workspace" "example" {
@@ -31489,14 +31514,14 @@ queries:
 
             resource "azurerm_synapse_workspace_aad_admin" "example" {
               synapse_workspace_id = azurerm_synapse_workspace.example.id
-              login                = "AzureAD Admin"
+              login                = "Microsoft Entra Admin"
               object_id            = "00000000-0000-0000-0000-000000000000"
               tenant_id            = "00000000-0000-0000-0000-000000000000"
             }
             ```
         - id: bicep
           desc: |
-            To ensure Synapse uses Azure AD-only authentication in Bicep:
+            To ensure Synapse uses Microsoft Entra ID-only authentication in Bicep:
 
             ```bicep
             @secure()
@@ -31778,12 +31803,12 @@ queries:
 
         - The admin account uses shared credentials that cannot be attributed to individual users, making it impossible to audit who accessed or modified container images.
         - Admin credentials do not support multi-factor authentication or conditional access policies.
-        - Azure AD (Entra ID) authentication with RBAC provides individual identity tracking, fine-grained permissions, and integration with organizational security policies.
-        - CIS Azure Foundations Benchmark recommends disabling the admin user in favor of Azure AD-based authentication.
+        - Microsoft Entra ID authentication with RBAC provides individual identity tracking, fine-grained permissions, and integration with organizational security policies.
+        - CIS Azure Foundations Benchmark recommends disabling the admin user in favor of Microsoft Entra ID-based authentication.
 
         **Risk mitigation**
 
-        - **Identity tracking:** Azure AD authentication ensures all registry access is attributed to individual identities.
+        - **Identity tracking:** Microsoft Entra ID authentication ensures all registry access is attributed to individual identities.
         - **Least privilege:** RBAC enables fine-grained permissions instead of the all-or-nothing admin access.
         - **Credential management:** Eliminates shared credentials that could be leaked or misused.
       audit: |
@@ -34867,20 +34892,20 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that local authentication is disabled on Azure Log Analytics workspaces. When local authentication is enabled, clients can use workspace keys or shared access signatures to authenticate, bypassing Azure AD identity controls and conditional access policies.
+        This check ensures that local authentication is disabled on Azure Log Analytics workspaces. When local authentication is enabled, clients can use workspace keys or shared access signatures to authenticate, bypassing Microsoft Entra ID identity controls and conditional access policies.
 
         **Why this matters**
 
         - Local authentication uses shared keys that cannot be attributed to individual users, making it impossible to audit who accessed or modified log data.
         - Shared keys do not support multi-factor authentication, conditional access, or Privileged Identity Management.
-        - Disabling local authentication forces all access through Azure AD, ensuring identity governance policies are enforced.
+        - Disabling local authentication forces all access through Microsoft Entra ID, ensuring identity governance policies are enforced.
         - Log data often contains sensitive security events and diagnostic information that requires strict access controls.
 
         **Risk mitigation**
 
-        - **Identity tracking:** All workspace access is attributed to individual Azure AD identities.
-        - **Conditional access:** Azure AD policies such as MFA and location-based access apply to all log queries and ingestion.
-        - **Audit trail:** Azure AD sign-in logs capture all workspace access attempts.
+        - **Identity tracking:** All workspace access is attributed to individual Microsoft Entra ID identities.
+        - **Conditional access:** Microsoft Entra ID policies such as MFA and location-based access apply to all log queries and ingestion.
+        - **Audit trail:** Microsoft Entra ID sign-in logs capture all workspace access attempts.
       audit: |
         **Manual Audit via Azure Portal:**
 
@@ -42293,7 +42318,7 @@ queries:
 
             1. Sign in to the Azure Portal and open your **IoT Hub**.
             2. Under **Security settings**, select **Shared access policies**.
-            3. Set the **Access with shared access policies** option to **Deny**, leaving only **Microsoft Entra (Azure AD)** authentication enabled.
+            3. Set the **Access with shared access policies** option to **Deny**, leaving only **Microsoft Entra** authentication enabled.
             4. Select **Save**.
         - id: cli
           desc: |


### PR DESCRIPTION
## Summary

Remediation-quality fixes to `content/mondoo-azure-security.mql.yaml` from an audit of its 275 remediation blocks. Version bumped `9.2.1` → `9.2.2`. Only `desc:`/`audit:`/`remediation:` prose and code were touched (plus the no-remediation comment pattern); no `mql:`/`filters:`/`uid:`/`impact:`/`tags:` changes, and one `title:` change (Synapse) explicitly called for by the audit.

## Microsoft Entra ID rename (residual prose)

Replaced residual "Azure AD" / "Azure Active Directory" in `desc:`/`audit:`/`remediation:` prose and method intros. Left literal API/HCL enums (`azuread_authentication_only`, `azureADOnlyAuthentication`, REST URL paths), Microsoft Learn ref titles, the historical "formerly Azure Active Directory" clarifiers, and check `title:` fields untouched (except Synapse below).

- `sql-ad-only-authentication` — all four method intros; example login display strings updated to Entra branding.
- `synapse-aad-only-auth` — title + desc + all four method intros + example login string (title change explicitly requested by the audit).
- `sql-ad-admin-configured` — audit + portal steps.
- `iot-hub-local-auth-disabled` — dropped the transitional "Microsoft Entra (Azure AD)" label.
- `acr-admin-user-disabled`, AKS RBAC/workload-identity descs, App Service FTP/SCM descs, Log Analytics local-auth desc — desc prose.

## Flexible Server portal paths (HIGH findings 1 & 2)

- `ensure-that-ssl-enabled-postgresql` — rewrote audit + portal remediation from the retired Single Server "Connection security / Enforce SSL connection" blade to Flexible Server → Server parameters → `require_secure_transport` = ON.
- `ensure-that-ssl-enabled-latest-version-mysql` — same, plus `tls_version` = TLSv1.2.

## Cipher consistency (HIGH finding 6)

- `storage-smb-channel-encryption` — CLI changed to `AES-256-GCM;AES-128-GCM` (dropped weak AES-128-CCM) to match the Bicep variant; aligned the Terraform list too; added a note that AES-128-CCM defeats the strong-encryption goal.

## Honest no-remediation notes (findings 12 & 14)

- `aks-wireguard-transit-encryption` Bicep — replaced the snippet that only set unrelated `networkPluginMode: overlay` with a `# No Bicep remediation:` note pointing to the CLI.
- `redis-cmk-encryption` Terraform — replaced the `azapi` non-remediation with a `# No Terraform remediation:` note.

## Destructive / irreversible-action warnings (findings 7, 11, 16, 17, 21, 22, 23, 27)

- `vpn-gateway-generation2` CLI — recreate drops tunnels, may reissue public IP, needs peer reconfig.
- `cosmosdb-private-endpoints` — create/validate private endpoint + Private DNS Zone before disabling public access.
- `compute-disk-public-access-disabled` CLI — DenyAll breaks SAS-URI export/import/download.
- `cosmosdb-cors-no-wildcard` CLI — `--set` overwrites the whole CORS array; re-specify methods/headers.
- `cosmosdb-continuous-backup` CLI — periodic→continuous is irreversible with cost/tier implications.
- `ensure-the-kv-is-recoverable` Terraform + Bicep — purge protection cannot be disabled once enabled.
- `storage-smb-versions` CLI — flag sets the complete allowed list, not additive.
- `app-service-ssh-disabled` CLI — blanket SCM deny also blocks Kudu/ZIP/Run-From-Package deployments.
- `app-service-ip-restrictions-default-deny` portal — add allow rules (including operator range) before setting Deny to avoid lockout; reordered steps.

## Command-validity fix (finding 18)

- `mysql-server-firewall-no-public-ingress` — replaced the bare ARM-ID `az resource delete` with a `az mysql server firewall-rule list`/`delete` retrieve-then-delete sequence.
- `postgresql-server-firewall-no-public-ingress` — `az postgres server firewall-rule` no longer exists in the CLI (Single Server retired), so kept `az resource delete --resource-ids` but added an `az resource list` step to retrieve the ID. Also removed an em-dash from both intros.

## Validation

- `cnspec policy lint content/mondoo-azure-security.mql.yaml` → valid policy bundle.
- `python3 content/validation/validate_remediation_commands.py azure` → 347 passed, 0 failed.

## Left for maintainers (VERIFY items, not changed)

- `acr-content-trust-enabled` (finding 8) — Docker Content Trust / Notary v1 may be deprecated for ACR in favor of Notation/Notary v2; verify against Microsoft Learn.
- `defender-auto-provisioning-enabled` (finding 9) — legacy Log Analytics/MMA auto-provisioning toggle retired Aug 31 2024; consider reframing around Azure Monitor Agent / Defender for Servers.
- `mysql-server-ssl-enforcement-enabled` (finding 10) — MySQL Single Server retired Sept 2024; confirm intent to keep covering legacy instances.
- `iot-hub-local-auth-disabled` (finding 20) — confirm current portal label for the Entra option.
- Lower-priority items not addressed this pass: aks-etcd-kms terraform prereqs (#13), postgresql-flexible-server-geo-backup portal (#15), managed-hsm-soft-delete portal (#19), storage-cmk-encryption CLI prereq (#24), network-database-ports-restricted bicep inconsistency (#25), public-ip-ddos cost note (#28), compute-vm-password-auth portal (#29), auditing-retention "0" clause (#30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)