### PR TITLE
🐛 github: surface Rulesets, reconcile new-repos UI paths, enforce-admins/signed-commits prerequisites

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.3
+    version: 1.8.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -56,7 +56,7 @@ policies:
     scoring_system: highest impact
   - uid: mondoo-github-repository-security
     name: Mondoo GitHub Repository Security
-    version: 1.8.3
+    version: 1.8.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -190,7 +190,7 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Authentication security**.
+        2. Go to **Settings** > **Security** > **Authentication security**.
         3. Review the "Two-factor authentication" section.
 
         If two-factor authentication is required for everyone in the organization, the check passes. If it is not required, the check fails.
@@ -208,6 +208,8 @@ queries:
         - id: github
           desc: |
             **Using the GitHub web UI**
+
+            You must be an organization owner to change this setting.
 
             To enable two-factor authentication for all users in your GitHub organization, follow these steps:
               1. Navigate to your organization on GitHub.
@@ -606,14 +608,25 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, configure the desired protection options, such as required pull request reviews and status checks.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To create a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Select **New ruleset** > **New branch ruleset**.
+              4. Set the enforcement status to **Active** and add a branch targeting rule that matches your default branch, such as `main` or `master`.
+              5. Enable the desired protections, such as requiring a pull request before merging and requiring status checks to pass.
+              6. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, configure the desired protection options, such as required pull request reviews and status checks.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -729,14 +742,25 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule covering your release branches, for example the pattern `release/*`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, configure the desired protection options, such as required pull request reviews and status checks.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To create a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Select **New ruleset** > **New branch ruleset**.
+              4. Set the enforcement status to **Active** and add a branch targeting rule covering your release branches, for example the pattern `release/*`.
+              5. Enable the desired protections, such as requiring a pull request before merging and requiring status checks to pass.
+              6. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule covering your release branches, for example the pattern `release/*`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, configure the desired protection options, such as required pull request reviews and status checks.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -856,14 +880,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, make sure **Allow force pushes** is unchecked.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [Allow force pushes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#allow-force-pushes) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To block force pushes with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch, such as `main` or `master`.
+              4. Enable **Block force pushes**.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, make sure **Allow force pushes** is unchecked.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Allow force pushes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#allow-force-pushes), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -993,14 +1027,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule covering your release branches, for example the pattern `release/*`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, make sure **Allow force pushes** is unchecked.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [Allow force pushes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#allow-force-pushes) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To block force pushes with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your release branches, for example the pattern `release/*`.
+              4. Enable **Block force pushes**.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule covering your release branches, for example the pattern `release/*`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, make sure **Allow force pushes** is unchecked.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Allow force pushes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#allow-force-pushes), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1106,14 +1150,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, check the box for **Require conversation resolution before merging**.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [Require conversation resolution before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-conversation-resolution-before-merging) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To require conversation resolution with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch, such as `main` or `master`.
+              4. Enable **Require conversation resolution before merging**.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, check the box for **Require conversation resolution before merging**.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Require conversation resolution before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-conversation-resolution-before-merging), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1242,14 +1296,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, check the box for **Require status checks to pass before merging** and select the status checks to require.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [Require status checks before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To require status checks with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch, such as `main` or `master`.
+              4. Enable **Require status checks to pass** and add the status checks to require.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, check the box for **Require status checks to pass before merging** and select the status checks to require.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Require status checks before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1384,14 +1448,26 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch (e.g., `main` or `master`).
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, check the box for **Require signed commits**.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) and [Require signed commits](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits) in the GitHub documentation.
+            Prerequisite: before enabling this, ensure contributors have configured local commit signing with GPG, SSH, or S/MIME and registered their signing key with GitHub. Once **Require signed commits** is enforced, unsigned commits are rejected, so any contributor who has not set up signing will be unable to merge.
+
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To require signed commits with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch, such as `main` or `master`.
+              4. Enable **Require signed commits**.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, check the box for **Require signed commits**.
+              6. Save the branch protection rule.
+
+            For more details, see [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification), [Require signed commits](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1512,14 +1588,26 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," add or edit a rule for your default branch (e.g., `main` or `master`).
-            4. Ensure **Protect matching branches** is enabled.
-            5. In the rule settings, check the box for **Do not allow bypassing the above settings**.
-            6. Save the branch protection rule.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [Do not allow bypassing the above settings](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#do-not-allow-bypassing-the-above-settings) in the GitHub documentation.
+            Caution: enforcing this applies the branch protection rules to administrators as well, so admins lose the ability to make emergency pushes that bypass the rules. Before enabling it, confirm a break-glass process exists, for example a documented procedure to temporarily disable enforcement under approval, so the team is not locked out during an incident.
+
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. Rulesets do not have an admin bypass by default; you control who may bypass through the ruleset's bypass list. To enforce protection for everyone with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch, such as `main` or `master`.
+              4. Leave the **Bypass list** empty, or add only the break-glass actors you intend to allow.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," add or edit a rule for your default branch, such as `main` or `master`.
+              4. Ensure **Protect matching branches** is enabled.
+              5. In the rule settings, check the box for **Do not allow bypassing the above settings**.
+              6. Save the branch protection rule.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), [Do not allow bypassing the above settings](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#do-not-allow-bypassing-the-above-settings), and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1534,6 +1622,8 @@ queries:
         - id: cli
           desc: |
             **Using GitHub CLI**
+
+            Caution: this applies branch protection to administrators as well, removing their ability to bypass the rules for emergency pushes. Confirm a break-glass process exists before running it.
 
             ```bash
             gh api --method POST \
@@ -2042,10 +2132,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "Secret scanning" section.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm **Secret scanning** is set to **Enabled**.
 
-        If "Automatically enable for new repositories" is enabled for secret scanning, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables secret scanning, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "Secret scanning."
 
         ### Audit via CLI
 
@@ -2165,10 +2255,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "Secret scanning" section and its push protection option.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm **Push protection** is set to **Enabled** under secret scanning.
 
-        If "Automatically enable for new repositories" is enabled for push protection, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables push protection, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "Secret scanning."
 
         ### Audit via CLI
 
@@ -2288,10 +2378,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "Dependabot alerts" section.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm **Dependabot alerts** is set to **Enabled**.
 
-        If "Automatically enable for new repositories" is enabled for Dependabot alerts, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables Dependabot alerts, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "Dependabot alerts."
 
         ### Audit via CLI
 
@@ -2411,10 +2501,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "Dependabot security updates" section.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm **Dependabot security updates** is set to **Enabled**.
 
-        If "Automatically enable for new repositories" is enabled for Dependabot security updates, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables Dependabot security updates, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "Dependabot security updates."
 
         ### Audit via CLI
 
@@ -3260,14 +3350,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," click **Edit** next to the default branch rule (or **Add rule** if none exists).
-            4. Check **Require a pull request before merging**.
-            5. Under that option, check **Require approvals** and set the required number of approvals to at least 1.
-            6. Click **Save changes**.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To require pull request reviews with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch.
+              4. Enable **Require a pull request before merging** and set **Required approvals** to at least 1.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," click **Edit** next to the default branch rule (or **Add rule** if none exists).
+              4. Check **Require a pull request before merging**.
+              5. Under that option, check **Require approvals** and set the required number of approvals to at least 1.
+              6. Click **Save changes**.
+
+            For more details, see [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3398,14 +3498,24 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
-            1. Navigate to your repository on GitHub.
-            2. Go to **Settings** > **Branches**.
-            3. Under "Branch protection rules," click **Edit** next to the default branch rule.
-            4. Check **Restrict who can push to matching branches**.
-            5. Check **Restrict pushes that create matching branches**.
-            6. Click **Save changes**.
+            You must have admin access to the repository to change branch protection.
 
-            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#restrict-who-can-push-to-matching-branches) in the GitHub documentation.
+            GitHub now recommends Repository Rulesets as the modern mechanism for protecting branches. To block branch creation with a ruleset:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Rules** > **Rulesets**.
+              3. Create or edit an active branch ruleset that targets your default branch.
+              4. Enable **Restrict creations**.
+              5. Save the ruleset.
+
+            Classic branch protection rules remain available as an alternative:
+              1. Navigate to your repository on GitHub.
+              2. Go to **Settings** > **Branches**.
+              3. Under "Branch protection rules," click **Edit** next to the default branch rule.
+              4. Check **Restrict who can push to matching branches**.
+              5. Check **Restrict pushes that create matching branches**.
+              6. Click **Save changes**.
+
+            For more details, see [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#restrict-who-can-push-to-matching-branches) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3660,10 +3770,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "GitHub Advanced Security" section.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm GitHub Advanced Security features are set to **Enabled**.
 
-        If "Automatically enable for new repositories" is enabled for GitHub Advanced Security, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables GitHub Advanced Security, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "GitHub Advanced Security."
 
         ### Audit via CLI
 
@@ -3784,10 +3894,10 @@ queries:
         ### Audit via Console
 
         1. Navigate to your organization on GitHub.
-        2. Go to **Settings** > **Code security and analysis**.
-        3. Review the "Dependency graph" section.
+        2. Go to **Settings**. In the sidebar under **Security**, select **Advanced Security** > **Configurations**.
+        3. Review the security configuration applied as the default for new repositories and confirm **Dependency graph** is set to **Enabled**.
 
-        If "Automatically enable for new repositories" is enabled for the dependency graph, the check passes. If it is disabled, the check fails.
+        If the default configuration for new repositories enables the dependency graph, the check passes. If it does not, the check fails. On organizations that have not yet migrated to security configurations, this setting appears on the legacy **Settings** > **Code security and analysis** page under "Dependency graph."
 
         ### Audit via CLI
 


### PR DESCRIPTION
## Summary

Remediation-quality pass on `content/mondoo-github-security.mql.yaml`. Edits are confined to `remediation:`/`audit:`/`desc:` prose; no `mql:`, `filters:`, `uid:`, `title:`, `impact:`, or `tags:` were changed. Both policy versions bumped `1.8.3` -> `1.8.4`.

## Changes

### Branch-protection group: surface Repository Rulesets
The branch-protection checks routed only to classic Settings > Branches and never mentioned Repository Rulesets, GitHub's currently recommended mechanism. Each web UI remediation now leads with a Rulesets path (Settings > Rules > Rulesets) and keeps classic branch protection as the alternative. Applied to:
- `ensure-default-branch-protection`
- `ensure-release-branch-protection`
- `prevent-force-pushes-default-branch`
- `prevent-force-pushes-release-branch`
- `require-pull-request-reviews`
- `require-conversation-resolution`
- `require-status-checks-before-merging`
- `required-signed-commits`
- `enforce-branch-protection`
- `block-creations-default-branch`

Also added the repo-admin role prerequisite to these web UI methods.

### Org "new repos" group: audit-vs-remediation contradiction reconciled
Six checks had an `audit:` Console step pointing at the legacy Settings > Code security and analysis page while their `remediation:` already said that page was replaced by security configurations. Reconciled each audit Console step to the current Settings > Security > Advanced Security > Configurations location, with a note that the legacy page only appears for un-migrated orgs:
- `secret-scanning-new-repos`
- `secret-scanning-push-protection-new-repos`
- `dependabot-alerts-new-repos`
- `dependabot-security-updates-new-repos`
- `advanced-security-new-repos`
- `dependency-graph-new-repos`

### `enforce-branch-protection`
Added a caution (web UI and CLI methods) that enforcement applies the rules to admins too, removing their ability to make emergency bypass pushes, and that a break-glass process should exist before enabling.

### `two-factor-auth` (org)
Reconciled the audit Console path to Settings > Security > Authentication security (matching the remediation) and stated org-owner is required.

### `required-signed-commits`
Added a prerequisite that contributors must configure local commit signing (GPG/SSH/S-MIME) and register their key before enforcing, otherwise merges are blocked.

## Validation
- `cnspec policy lint content/mondoo-github-security.mql.yaml` -> valid policy bundle(s)
- `python3 content/validation/validate_remediation_commands.py github` -> 83 passed, 0 failed (gh on PATH)

## Left for maintainers (VERIFY)
These were flagged in the audit but not changed, because resolving them requires confirming GitHub API/intent that should not be guessed:
- **`actions-require-sha-pinning`** (cli/audit): the audit/CLI uses `.sha_pinning_required` on `/repos/{o}/{r}/actions/permissions`. The field's existence and any org/enterprise plan-gating is uncertain. Confirm the field exists; if gated, document the prerequisite and the repo-admin role.
- **`default-permission-level`** (desc/audit): the desc/audit treat "No permission" (none) as a misconfiguration, but the MQL requires exactly `== "read"`, so the strictest option (none) would fail the check. Confirm intent: if "none" is acceptable, the MQL/desc should accept read-or-none; otherwise the desc framing should be reconciled. Not changed because it touches MQL intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)