### PR TITLE
🐛 windows: fix auditpol Success/Failure over-enable + EventLog Retention DWORD + script-side warnings

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Mondoo Microsoft Windows Security
-    version: 2.4.1
+    version: 2.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -588,7 +588,7 @@ queries:
             }
 
             # Now set the value
-            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType String -Force
+            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType DWORD -Force
             ```
         - id: ansible
           desc: |
@@ -603,7 +603,7 @@ queries:
                     path: HKLM:\Software\Policies\Microsoft\Windows\EventLog\Application
                     name: Retention
                     data: "0"
-                    type: string
+                    type: dword
             ```
   - uid: mondoo-windows-security-application-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure Application log file size is set to 32,768 KB or greater"
@@ -913,7 +913,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9217-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9217-69AE-11D9-BED3-505054503030}" /success:disable /failure:enable
             ```
         - id: ansible
           desc: |
@@ -929,7 +929,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9217-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:disable /failure:enable
             ```
   - uid: mondoo-windows-security-audit-application-group-management-is-set-to-success-and-failure
     title: Ensure 'Audit Application Group Management' is set to 'Success and Failure'
@@ -1112,7 +1112,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE922F-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE922F-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -1128,7 +1128,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE922F-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-authentication-policy-change-is-set-to-include-success
     title: Ensure 'Audit Authentication Policy Change' is set to include 'Success'
@@ -1212,7 +1212,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9230-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9230-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -1228,7 +1228,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9230-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-authorization-policy-change-is-set-to-include-success
     title: Ensure 'Audit Authorization Policy Change' is set to include 'Success'
@@ -1306,7 +1306,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9231-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9231-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -1322,7 +1322,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9231-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-credential-validation-is-set-to-success-and-failure
     title: Ensure 'Audit Credential Validation' is set to 'Success and Failure'
@@ -1489,7 +1489,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9244-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9244-69AE-11D9-BED3-505054503030}" /success:disable /failure:enable
             ```
         - id: ansible
           desc: |
@@ -1505,7 +1505,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9244-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:disable /failure:enable
             ```
   - uid: mondoo-windows-security-audit-file-share-is-set-to-success-and-failure
     title: Ensure 'Audit File Share' is set to 'Success and Failure'
@@ -1770,7 +1770,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9249-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9249-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -1786,7 +1786,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9249-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-ipsec-driver-is-set-to-success-and-failure
     title: Ensure 'Audit IPsec Driver' is set to 'Success and Failure'
@@ -1961,7 +1961,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9216-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9216-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -1977,7 +1977,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9216-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-logon-is-set-to-success-and-failure
     title: Ensure 'Audit Logon' is set to 'Success and Failure'
@@ -2457,7 +2457,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9234-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9234-69AE-11D9-BED3-505054503030}" /success:disable /failure:enable
             ```
         - id: ansible
           desc: |
@@ -2473,7 +2473,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9234-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:disable /failure:enable
             ```
   - uid: mondoo-windows-security-audit-other-system-events-is-set-to-success-and-failure
     title: Ensure 'Audit Other System Events' is set to 'Success and Failure'
@@ -2650,7 +2650,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9248-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9248-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -2666,7 +2666,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9248-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-process-creation-is-set-to-include-success
     title: Ensure 'Audit Process Creation' is set to include 'Success'
@@ -2744,7 +2744,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -2760,7 +2760,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-removable-storage-is-set-to-success-and-failure
     title: Ensure 'Audit Removable Storage' is set to 'Success and Failure'
@@ -2940,7 +2940,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9237-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9237-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -2956,7 +2956,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9237-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-security-state-change-is-set-to-include-success
     title: Ensure 'Audit Security State Change' is set to include 'Success'
@@ -3033,7 +3033,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9210-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9210-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -3049,7 +3049,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9210-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-security-system-extension-is-set-to-include-success
     title: Ensure 'Audit Security System Extension' is set to include 'Success'
@@ -3127,7 +3127,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE9211-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE9211-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -3143,7 +3143,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9211-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-sensitive-privilege-use-is-set-to-success-and-failure
     title: Ensure 'Audit Sensitive Privilege Use' is set to 'Success and Failure'
@@ -3421,7 +3421,7 @@ queries:
             To establish the recommended configuration via PowerShell, run the following commands:
 
             ```powershell
-            Auditpol /set /subcategory:"{0CCE921B-69AE-11D9-BED3-505054503030}" /success:enable /failure:enable
+            Auditpol /set /subcategory:"{0CCE921B-69AE-11D9-BED3-505054503030}" /success:enable /failure:disable
             ```
         - id: ansible
           desc: |
@@ -3437,7 +3437,7 @@ queries:
                   ansible.windows.win_command:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE921B-69AE-11D9-BED3-505054503030}"
-                      /success:enable /failure:enable
+                      /success:enable /failure:disable
             ```
   - uid: mondoo-windows-security-audit-system-integrity-is-set-to-success-and-failure
     title: Ensure 'Audit System Integrity' is set to 'Success and Failure'
@@ -4620,10 +4620,14 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            On a domain member this account policy is enforced by the Default Domain Policy GPO. A local `secedit` change is overwritten the next time Group Policy refreshes, so make this change in the domain GPO for domain-joined systems. The `Out-File` command writes the import file as Unicode, which `secedit` requires; verify the encoding if you adapt the script.
+
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("PasswordHistorySize = \d+", "PasswordHistorySize = 24") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("PasswordHistorySize = \d+", "PasswordHistorySize = 24") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -4724,10 +4728,14 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            On a domain member this account policy is enforced by the Default Domain Policy GPO. A local `secedit` change is overwritten the next time Group Policy refreshes, so make this change in the domain GPO for domain-joined systems. The `Out-File` command writes the import file as Unicode, which `secedit` requires; verify the encoding if you adapt the script.
+
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("MaximumPasswordAge = -?\d+", "MaximumPasswordAge = 365") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("MaximumPasswordAge = -?\d+", "MaximumPasswordAge = 365") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -4824,10 +4832,14 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            On a domain member this account policy is enforced by the Default Domain Policy GPO. A local `secedit` change is overwritten the next time Group Policy refreshes, so make this change in the domain GPO for domain-joined systems. The `Out-File` command writes the import file as Unicode, which `secedit` requires; verify the encoding if you adapt the script.
+
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("MinimumPasswordAge = \d+", "MinimumPasswordAge = 1") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("MinimumPasswordAge = \d+", "MinimumPasswordAge = 1") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -4926,19 +4938,19 @@ queries:
             **Impact:**
 
             Requirements for extremely long passwords can actually decrease the security of an organization, because users might leave the information in an insecure location or lose it. If very long passwords are required, mistyped passwords could cause account lockouts and increase the volume of help desk calls. If your organization has issues with forgotten passwords due to password length requirements, consider teaching your users about passphrases, which are often easier to remember and, due to the larger number of character combinations, much harder to discover.
-
-            **Note:**
-            Older versions of Windows such as Windows 98 and Windows NT 4.0 do not support passwords that are longer than 14 characters. Computers that run these older operating systems are unable to authenticate with computers or domains that use accounts that require long passwords.
         - id: powershell
           desc: |
             **Using PowerShell**
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Note:**
+            This check compares the configured minimum length against the `mondooWindowsSecurityMinimumPasswordLength` property, which defaults to 14. If you raise that property, set the same value in the command below so the configured policy matches the value the check requires. On a domain member, apply this through the Default Domain Policy GPO, because a local `secedit` change is overwritten when Group Policy refreshes. The `Out-File` command writes the import file as Unicode, which `secedit` requires.
+
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("MinimumPasswordLength = \d+", "MinimumPasswordLength = 14") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("MinimumPasswordLength = \d+", "MinimumPasswordLength = 14") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -4950,7 +4962,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            Use this Ansible playbook to set minimum password length:
+            Use this Ansible playbook to set minimum password length. The value must match the `mondooWindowsSecurityMinimumPasswordLength` property, which defaults to 14. If you raise that property, set the same value here.
 
             ```yaml
             ---
@@ -5147,10 +5159,14 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            On a domain member this account policy is enforced by the Default Domain Policy GPO. A local `secedit` change is overwritten the next time Group Policy refreshes, so make this change in the domain GPO for domain-joined systems. The `Out-File` command writes the import file as Unicode, which `secedit` requires; verify the encoding if you adapt the script.
+
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("LSAAnonymousNameLookup = \d+", "LSAAnonymousNameLookup = 0") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("LSAAnonymousNameLookup = \d+", "LSAAnonymousNameLookup = 0") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -5234,7 +5250,7 @@ queries:
 
             **Impact:**
 
-            None - this is the default behavior. It will be impossible to establish trusts with Windows NT 4.0-based domains. Also, client computers that run older versions of the Windows operating system such as Windows NT 3.51 and Windows 95 will experience problems when they try to use resources on the server.
+            None on supported systems. This is the default behavior on current versions of Windows.
         - id: powershell
           desc: |
             **Using PowerShell**
@@ -5331,7 +5347,7 @@ queries:
 
             **Impact:**
 
-            It will be impossible to establish trusts with Windows NT 4.0-based domains. Also, client computers that run older versions of the Windows operating system such as Windows NT 3.51 and Windows 95 will experience problems when they try to use resources on the server. Users who access file and print servers anonymously will be unable to list the shared network resources on those servers; the users will have to authenticate before they can view the lists of shared folders and printers. However, even with this policy setting enabled, anonymous users will have access to resources with permissions that explicitly include the built-in group, `ANONYMOUS LOGON`.
+            Users who access file and print servers anonymously will be unable to list the shared network resources on those servers; the users will have to authenticate before they can view the lists of shared folders and printers. However, even with this policy setting enabled, anonymous users will have access to resources with permissions that explicitly include the built-in group, `ANONYMOUS LOGON`.
         - id: powershell
           desc: |
             **Using PowerShell**
@@ -5638,11 +5654,23 @@ queries:
             $RegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters'
             $Name         = 'NullSessionPipes'
 
-            # Member servers: allow no anonymous pipes
-            $Value = @()
+            # WARNING: Do not clear this list on a domain controller. Domain
+            # controllers require the LSARPC, NETLOGON, and SAMR pipes for
+            # legacy authentication. The branch below selects the correct value
+            # automatically based on the product type, so verify the detected
+            # role before applying the change.
 
-            # Domain controllers: allow only the required pipes
-            # $Value = @('LSARPC','NETLOGON','SAMR')
+            # ProductType 2 indicates a domain controller; anything else is a
+            # member server or workstation.
+            $ProductType = (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
+
+            If ($ProductType -eq 2) {
+                # Domain controllers: allow only the required pipes
+                $Value = @('LSARPC','NETLOGON','SAMR')
+            } Else {
+                # Member servers and workstations: allow no anonymous pipes
+                $Value = @()
+            }
 
             # Create the key if it does not exist
             If (-NOT (Test-Path $RegistryPath)) {
@@ -5864,6 +5892,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            The SDDL `O:BAG:BAD:(A;;RC;;;BA)` grants remote SAM read access only to the local Administrators group and denies it to everyone else. If you run Microsoft Defender for Identity, add its service account to this SDDL before you apply the change, otherwise its lateral-movement detection loses the remote SAM visibility it depends on.
+
             ```powershell
             $RegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa'
             $Name         = 'restrictremotesam'
@@ -5880,6 +5912,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            The SDDL `O:BAG:BAD:(A;;RC;;;BA)` grants remote SAM read access only to the local Administrators group and denies it to everyone else. If you run Microsoft Defender for Identity, add its service account to this SDDL before you apply the change, otherwise its lateral-movement detection loses the remote SAM visibility it depends on.
 
             ```yaml
             - name: Restrict remote calls to SAM to Administrators
@@ -6457,6 +6493,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            The value `2147483640` is a bitmask that enables AES128_HMAC_SHA1 (8), AES256_HMAC_SHA1 (16), and the reserved future encryption types (2147483616). It excludes the legacy DES and RC4 types. Before you enforce this, confirm that your domain controllers and user accounts support AES Kerberos encryption, because removing RC4 while a dependency remains can break Kerberos authentication. Test in a pilot group first.
+
             ```powershell
             $RegistryPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters'
             $Name         = 'SupportedEncryptionTypes'
@@ -6473,6 +6513,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            The value `2147483640` is a bitmask that enables AES128_HMAC_SHA1 (8), AES256_HMAC_SHA1 (16), and the reserved future encryption types (2147483616). It excludes the legacy DES and RC4 types. Before you enforce this, confirm that your domain controllers and user accounts support AES Kerberos encryption, because removing RC4 while a dependency remains can break Kerberos authentication. Test in a pilot group first.
 
             ```yaml
             - name: Limit Kerberos encryption types to AES and newer
@@ -6656,6 +6700,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            Setting `LmCompatibilityLevel` to `5` refuses LM and NTLM authentication and accepts only NTLMv2. This can break authentication for legacy clients and applications across the domain. Test the change in a pilot group first and confirm that no systems still depend on LM or NTLM before you enforce it broadly.
+
             ```powershell
             $RegistryPath = 'HKLM:\System\CurrentControlSet\Control\Lsa'
             $Name         = 'LmCompatibilityLevel'
@@ -6672,6 +6720,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            Setting `LmCompatibilityLevel` to `5` refuses LM and NTLM authentication and accepts only NTLMv2. This can break authentication for legacy clients and applications across the domain. Test the change in a pilot group first and confirm that no systems still depend on LM or NTLM before you enforce it broadly.
 
             ```yaml
             - name: Set LAN Manager authentication to NTLMv2 only
@@ -6856,6 +6908,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Note:**
+
+            The value `537395200` is a bitmask that combines `NTLMv2 session security required` (0x00080000) and `128-bit encryption required` (0x20000000). It maps to the policy state `Require NTLMv2 session security, Require 128-bit encryption`.
+
             ```powershell
             $RegistryPath = 'HKLM:\System\CurrentControlSet\Control\Lsa\MSV1_0'
             $Name         = 'NTLMMinServerSec'
@@ -6872,6 +6928,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Note:**
+
+            The value `537395200` is a bitmask that combines `NTLMv2 session security required` (0x00080000) and `128-bit encryption required` (0x20000000). It maps to the policy state `Require NTLMv2 session security, Require 128-bit encryption`.
 
             ```yaml
             - name: Set NTLM SSP server minimum security
@@ -6955,6 +7015,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Note:**
+
+            The value `537395200` is a bitmask that combines `NTLMv2 session security required` (0x00080000) and `128-bit encryption required` (0x20000000). It maps to the policy state `Require NTLMv2 session security, Require 128-bit encryption`.
+
             ```powershell
             $RegistryPath = 'HKLM:\System\CurrentControlSet\Control\Lsa\MSV1_0'
             $Name         = 'NTLMMinClientSec'
@@ -6971,6 +7035,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Note:**
+
+            The value `537395200` is a bitmask that combines `NTLMv2 session security required` (0x00080000) and `128-bit encryption required` (0x20000000). It maps to the policy state `Require NTLMv2 session security, Require 128-bit encryption`.
 
             ```yaml
             - name: Set NTLM SSP client minimum security
@@ -7300,6 +7368,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
+
             ```powershell
             $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
             $Name         = 'fEncryptRPCTraffic'
@@ -7316,6 +7388,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
 
             ```yaml
             - name: Set secure RPC communication
@@ -7406,6 +7482,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
+
             ```powershell
             $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
             $Name         = 'SecurityLayer'
@@ -7422,6 +7502,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
 
             ```yaml
             - name: Ensure RDP connections use SSL security layer
@@ -7521,6 +7605,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
+
             ```powershell
             $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
             $Name         = 'UserAuthentication'
@@ -7537,6 +7625,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
 
             ```yaml
             - name: Ensure Network Level Authentication is required for RDP
@@ -7636,7 +7728,7 @@ queries:
             }
 
             # Now set the value
-            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType String -Force
+            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType DWORD -Force
             ```
         - id: ansible
           desc: |
@@ -7651,7 +7743,7 @@ queries:
                     path: HKLM:\Software\Policies\Microsoft\Windows\EventLog\Security
                     name: Retention
                     data: "0"
-                    type: string
+                    type: dword
             ```
   - uid: mondoo-windows-security-security-specify-the-maximum-log-file-size-kb-is-set-to-enabled-196608
     title: "Ensure Security log file size is set to 196,608 KB or greater"
@@ -7838,6 +7930,10 @@ queries:
 
             To establish the recommended configuration via PowerShell, run the following commands:
 
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
+
             ```powershell
             $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'
             $Name         = 'MinEncryptionLevel'
@@ -7854,6 +7950,10 @@ queries:
         - id: ansible
           desc: |
             **Using Ansible**
+
+            **Warning:**
+
+            This change affects how Remote Desktop accepts connections and takes effect on new sessions. Verify that your RDP clients support the required security settings before you enforce it, because an incompatible client can be unable to reconnect and an administrator working over RDP can be locked out. Apply the change during a maintenance window and confirm access from a separate session before disconnecting.
 
             ```yaml
             - name: Ensure RDP client connection encryption is set to High Level
@@ -8181,7 +8281,7 @@ queries:
             }
 
             # Now set the value
-            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType String -Force
+            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType DWORD -Force
             ```
         - id: ansible
           desc: |
@@ -8196,7 +8296,7 @@ queries:
                     path: HKLM:\Software\Policies\Microsoft\Windows\EventLog\Setup
                     name: Retention
                     data: "0"
-                    type: string
+                    type: dword
             ```
   - uid: mondoo-windows-security-setup-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure Setup log file size is set to 32,768 KB or greater"
@@ -8511,7 +8611,7 @@ queries:
             }
 
             # Now set the value
-            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType String -Force
+            New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType DWORD -Force
             ```
         - id: ansible
           desc: |
@@ -8526,7 +8626,7 @@ queries:
                     path: HKLM:\Software\Policies\Microsoft\Windows\EventLog\System
                     name: Retention
                     data: "0"
-                    type: string
+                    type: dword
             ```
   - uid: mondoo-windows-security-system-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure System log file size is set to 32,768 KB or greater"


### PR DESCRIPTION
This PR fixes confirmed copy-paste defects in the remediation guidance of `content/mondoo-windows-security.mql.yaml` and adds operator-facing warnings that previously lived only in the Group Policy blurbs. Only `remediation:`/`desc:`/`audit:` prose and code were touched; no `mql`/`filters`/`uid`/`title`/`impact`/`tags` were changed. Version bumped 2.4.1 → 2.4.2.

## HIGH-severity defects

**1. auditpol Success/Failure over-enabling (14 checks)**
The `powershell` and `ansible` remediations ran `auditpol /set ... /success:enable /failure:enable` (both dimensions) on checks whose title, audit text, and MQL assert a single dimension. The scripts were cloned from the "Success and Failure" checks without trimming, so the fix configured a stricter state than the control requires and flooded the Security log. Now:
- "include **Success**" checks use `/success:enable /failure:disable`
- "include **Failure**" checks use `/success:disable /failure:enable`
- "Success and Failure" checks are unchanged.

**2. EventLog `Retention` typed as String instead of DWORD**
The Application/Security/Setup/System "Control Event Log behavior when the log file reaches its maximum size" checks wrote `Retention` with `-PropertyType String` / `type: string`, while the audit reads it numerically and Group Policy writes REG_DWORD. Changed to DWORD with value `0`. The brief named 3 checks; the Security check had the identical defect and was fixed as well (4 total). The unrelated remote-SAM SDDL check keeps its String type.

**3. Named-pipes PowerShell snippet wiped required DC pipes**
The snippet defaulted to clearing all pipes (`$Value = @()`), which removes LSARPC/NETLOGON/SAMR on a domain controller. Added an explicit `ProductType -eq 2` DC-vs-member branch (mirroring the Ansible `is_domain_controller` gate) plus a prominent warning.

## Script-side warnings and value decoding

- RDP secure-RPC / security-layer / NLA / encryption-level: added new-session and client-compatibility lockout warnings to the script methods.
- LM/NTLM `LmCompatibilityLevel=5`: added pilot-test / legacy-dependency warning.
- Kerberos enctypes: decoded `2147483640` (AES128 + AES256 + future) and carried the AES-prerequisite warning into the scripts.
- Remote-SAM SDDL `O:BAG:BAD:(A;;RC;;;BA)`: noted it grants remote SAM only to Administrators and that Microsoft Defender for Identity environments must add its service account.
- secedit password-policy checks: added the Default Domain Policy GPO-override caution to the remediation body and `-Encoding Unicode` on `Out-File`.
- Minimum password length: noted the value must match the `mondooWindowsSecurityMinimumPasswordLength` property, not the literal 14.
- NTLM SSP servers/clients: decoded `537395200` (NTLMv2 + 128-bit).
- Trimmed dead-OS impact text (NT 3.51 / 95 / NT 4.0) from the anonymous-SAM-enumeration checks.

## VERIFY items (review before merge)
- EventLog `Retention = 0` DWORD: confirmed against the audit logic ("passes when Retention is 0") and Group Policy REG_DWORD behavior; recommend a final check against a live host.
- secedit `Out-File -Encoding Unicode`: added because secedit can reject the default encoding; confirm on a live host.

## Validation
`cnspec policy lint content/mondoo-windows-security.mql.yaml` → **valid policy bundle(s)**. Remaining warnings are pre-existing `auditpol`/`auditpol.entry` deprecated-resource warnings unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)