### PR TITLE
🐛 snowflake: fix invalid MFA/password-policy SQL + boolean column comparisons

### DIFF
--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-snowflake-security
     name: Mondoo Snowflake Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -134,6 +134,8 @@ queries:
             4. Follow the Duo enrollment prompts.
 
             Administrators can monitor enrollment from **Admin** → **Users & Roles** → **Users**, where the **MFA** column shows enrolled vs not enrolled.
+
+            Note: this check reads the Duo MFA flag specifically, so a user who enrolls a non-Duo factor such as TOTP or a passkey still fails it. To enforce those factors and satisfy the check, pair this step with the SQL authentication-policy remediation, which requires MFA regardless of the enrollment method.
         - id: sql
           desc: |
             Run as `ACCOUNTADMIN` in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
@@ -159,15 +161,9 @@ queries:
             ALTER ACCOUNT SET AUTHENTICATION POLICY require_mfa_policy;
             ```
 
-            **Legacy account parameter (still supported)**
+            Snowflake has no account parameter that toggles MFA on its own. Enforcement comes entirely from the authentication policy above, so the `MFA_AUTHENTICATION_METHODS` and `MFA_ENROLLMENT` settings are what require users to register and use a second factor.
 
-            On accounts not yet using authentication policies, the older parameter forces MFA enrollment on the next login:
-
-            ```sql
-            ALTER ACCOUNT SET REQUIRE_MFA = TRUE;
-            ```
-
-            Note: `REQUIRE_MFA` only enforces enrollment for *new* logins — it does not retroactively log out sessions that authenticated before the change.
+            Note: the policy enforces MFA enrollment on the next login. It does not retroactively log out sessions that authenticated before the policy was attached.
         - id: terraform
           desc: |
             The `snowflakedb/snowflake` provider cannot set a per-user Duo enrollment flag, but it can enforce MFA account-wide with an authentication policy. Define a `snowflake_authentication_policy` that requires MFA enrollment and attach it to the account:
@@ -361,8 +357,8 @@ queries:
                 ```sql
                 SELECT NAME, CREATED_ON, LAST_SUCCESS_LOGIN, MUST_CHANGE_PASSWORD
                 FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-                WHERE MUST_CHANGE_PASSWORD = 'true'
-                  AND DISABLED = 'false';
+                WHERE MUST_CHANGE_PASSWORD = TRUE
+                  AND DISABLED = FALSE;
                 ```
 
                 `ACCOUNT_USAGE` views can lag the live state by up to ~3 hours. For an authoritative snapshot, run `SHOW USERS;` and inspect the `must_change_password` column.
@@ -603,7 +599,7 @@ queries:
 
                 ```sql
                 ALTER PASSWORD POLICY <policy_name> SET
-                  PASSWORD_MAX_RETRIES       = 5,
+                  PASSWORD_MAX_RETRIES       = 5
                   PASSWORD_LOCKOUT_TIME_MINS = 15;
                 ```
 
@@ -713,9 +709,11 @@ queries:
             **Using Snowsight**
 
             1. In Snowsight, go to **Admin** → **Security** → **Network Policies**.
-            2. Click **+ Network Policy**, give it a name, and add **Allowed IP addresses** (CIDR ranges representing your office, VPN, or data center egress).
+            2. Click **+ Network Policy**, give it a name, and add **Allowed IP addresses** as CIDR ranges representing your office, VPN, or data center egress.
             3. Save the policy.
-            4. Open **Account Details** (top-right user menu) → **Network policy** and select the policy you just created so it is enforced account-wide.
+            4. Open **Account Details** from the top-right user menu, then **Network policy**, and select the policy you just created so it is enforced account-wide.
+
+            > **Warning:** Attaching a network policy that omits your own current public IP locks you, and everyone else outside the allowed ranges, out of the account. Confirm your egress IP is covered before you attach the policy, because the lockout takes effect immediately.
         - id: sql
           desc: |
             Run as `ACCOUNTADMIN` (or `SECURITYADMIN`) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
@@ -729,7 +727,7 @@ queries:
                 SHOW PARAMETERS LIKE 'NETWORK_POLICY' IN ACCOUNT;
                 ```
 
-            2. Create the policy with the CIDR ranges your organization actually uses (replace the example ranges):
+            2. Create the policy with the CIDR ranges your organization actually uses. The `203.0.113.0/24` and `198.51.100.0/24` values below are reserved documentation ranges from RFC 5737, so they are placeholders you must replace with your real egress ranges. Be sure the list includes your own current public IP, or attaching the policy will lock you out:
 
                 ```sql
                 CREATE NETWORK POLICY <policy_name>
@@ -737,7 +735,7 @@ queries:
                   BLOCKED_IP_LIST = ();
                 ```
 
-            3. Attach it to the account:
+            3. Attach it to the account. This takes effect immediately, so anyone connecting from outside the allowed ranges, including you, loses access at once:
 
                 ```sql
                 ALTER ACCOUNT SET NETWORK_POLICY = <policy_name>;
@@ -840,8 +838,10 @@ queries:
 
             1. In Snowsight, go to **Admin** → **Security** → **Network Policies**.
             2. Open the policy whose **Allowed IPs** include `0.0.0.0/0` (or the IPv6 wildcard `::/0`).
-            3. Replace `0.0.0.0/0` with the specific CIDR ranges your organization actually uses (office, VPN, data-center egress).
+            3. Replace `0.0.0.0/0` with the specific CIDR ranges your organization actually uses, such as office, VPN, and data center egress.
             4. Save the policy.
+
+            > **Warning:** Removing the wildcard restricts access immediately. Confirm your own current public IP is one of the allowed ranges before you save, or you will lock yourself out of the account.
         - id: sql
           desc: |
             Run as `ACCOUNTADMIN` (or `SECURITYADMIN`) in a Snowsight worksheet, via SnowSQL, or with the Snowflake CLI.
@@ -853,7 +853,7 @@ queries:
                 DESC NETWORK POLICY <policy_name>;
                 ```
 
-            2. Replace the open `0.0.0.0/0` (and/or IPv6 `::/0`) entry with the specific CIDR ranges your organization actually uses:
+            2. Replace the open `0.0.0.0/0` (and/or IPv6 `::/0`) entry with the specific CIDR ranges your organization actually uses. The `203.0.113.0/24` and `198.51.100.0/24` values below are reserved documentation ranges from RFC 5737, so replace them with your real egress ranges. Removing the wildcard restricts access immediately, so make sure the new list includes your own current public IP or you will be locked out:
 
                 ```sql
                 ALTER NETWORK POLICY <policy_name>
@@ -965,7 +965,7 @@ queries:
                 SELECT NAME, DEFAULT_ROLE
                 FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
                 WHERE DEFAULT_ROLE = 'ACCOUNTADMIN'
-                  AND DISABLED = 'false';
+                  AND DISABLED = FALSE;
                 ```
 
             2. For each affected user, change their default role to the least-privilege role they need day-to-day (`SYSADMIN`, `SECURITYADMIN`, or a custom role):
@@ -1081,9 +1081,9 @@ queries:
 
                 ```sql
                 ALTER PASSWORD POLICY <policy_name> SET
-                  PASSWORD_MIN_UPPER_CASE_CHARS = 1,
-                  PASSWORD_MIN_LOWER_CASE_CHARS = 1,
-                  PASSWORD_MIN_NUMERIC_CHARS    = 1,
+                  PASSWORD_MIN_UPPER_CASE_CHARS = 1
+                  PASSWORD_MIN_LOWER_CASE_CHARS = 1
+                  PASSWORD_MIN_NUMERIC_CHARS    = 1
                   PASSWORD_MIN_SPECIAL_CHARS    = 1;
                 ```
 


### PR DESCRIPTION
Remediation-quality fixes to `content/mondoo-snowflake-security.mql.yaml`. Prose-and-example only: no changes to MQL, filters, UIDs, titles, impact, or compliance tags. Version bumped `1.2.0` → `1.2.1`.

## MFA enforcement (mfa-enabled-for-active-users)

- **Removed the bogus `ALTER ACCOUNT SET REQUIRE_MFA = TRUE` block.** Snowflake has no supported `REQUIRE_MFA` account parameter, so the "legacy account parameter (still supported)" SQL would fail or mislead. Remediation now relies entirely on the authentication-policy path (`MFA_AUTHENTICATION_METHODS` / `MFA_ENROLLMENT`), with a short note explaining that those settings are what enforce MFA.
- **Console: added a note that the check reads the Duo flag specifically.** A user who enrolls a non-Duo factor (TOTP, passkey) still fails the check, so the note steers them to pair Snowsight enrollment with the SQL authentication-policy remediation.

## Password policy SQL (lockout + complexity)

- Made the multi-property `ALTER PASSWORD POLICY ... SET` blocks consistent with the documented `CREATE PASSWORD POLICY` form. **VERIFIED against Snowflake docs:** the canonical grammar for both `CREATE PASSWORD POLICY` and `ALTER PASSWORD POLICY ... SET` separates properties with whitespace/newlines and **no commas** — the documented examples use no commas. The original report assumed the fix was to *add* commas to `CREATE`; verification showed the opposite, so the comma-free `CREATE` blocks were already correct and the comma-using `ALTER` blocks were the inconsistent ones. Removed the commas from the two multi-property `ALTER ... SET` blocks to align everything to the documented grammar. (Snowflake's parser tolerates commas in `ALTER ... SET` in practice, but the documented/portable form is comma-free.)
  - Refs: https://docs.snowflake.com/en/sql-reference/sql/create-password-policy and https://docs.snowflake.com/en/sql-reference/sql/alter-password-policy

## ACCOUNT_USAGE boolean columns (no-users-pending-password-change + sibling)

- `SNOWFLAKE.ACCOUNT_USAGE.USERS` exposes `MUST_CHANGE_PASSWORD` and `DISABLED` as BOOLEAN columns. Changed the string comparisons (`= 'true'` / `= 'false'`) to boolean literals (`= TRUE` / `= FALSE`) so the "find affected users" queries return rows. Fixed in both the pending-password-change check and the no-accountadmin-default-role check (its `DISABLED = 'false'` had the same bug; `DEFAULT_ROLE` stays a quoted string).

## Network policy self-lockout (network-policies-configured + no-unrestricted-access)

- Added warnings (console and SQL, both checks) that attaching/narrowing a network policy that omits the admin's current public IP locks the admin out immediately. Advise confirming your own egress IP is covered before applying.
- Flagged the example CIDRs `203.0.113.0/24` and `198.51.100.0/24` as RFC 5737 reserved documentation ranges (placeholders) that must be replaced with real egress ranges.

## VERIFY items confirmed during this work

- **`REQUIRE_MFA` account parameter does not exist** — confirmed via Snowflake docs; block removed.
- **`CREATE PASSWORD POLICY` separator** — confirmed comma-free is the documented canonical form; aligned `ALTER` to match rather than adding commas to `CREATE`.
- **`ACCOUNT_USAGE.USERS` column types** — `MUST_CHANGE_PASSWORD` and `DISABLED` are BOOLEAN; switched to boolean literals.

## Validation

`cnspec policy lint content/mondoo-snowflake-security.mql.yaml` → valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)