### PR TITLE
🐛 gitlab: tier prerequisites + modern approval-rule endpoint + parameterized branch audit

### DIFF
--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gitlab-security
     name: Mondoo GitLab Security
-    version: 1.8.2
+    version: 1.8.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -662,6 +662,8 @@ queries:
       remediation:
         - id: gitlab
           desc: |
+            Merge request approval rules require a GitLab Premium or Ultimate subscription. On the Free tier the **Approvals required** setting is not available, so this control cannot be configured there.
+
             To require merge request approvals using the GitLab web UI:
 
             1. Navigate to your project.
@@ -673,23 +675,18 @@ queries:
             For more details, see [Merge request approval rules](https://docs.gitlab.com/user/project/merge_requests/approvals/rules.html).
         - id: cli
           desc: |
+            Merge request approval rules require a GitLab Premium or Ultimate subscription. The commands below have no effect on the Free tier, where this control is unavailable.
+
             To require merge request approvals using the `glab` CLI:
 
-            Set the project-wide approval requirement:
-
-            ```bash
-            glab api --method POST projects/PROJECT_ID/approvals \
-              -f approvals_before_merge=1
-            ```
-
-            To additionally enforce the requirement with a named approval rule:
+            Create an approval rule that requires at least one approval. The rule-based approval API is the supported way to set the requirement, because the project-level `approvals_before_merge` field on the `/approvals` endpoint is read-only and no longer accepts updates:
 
             ```bash
             glab api --method POST projects/PROJECT_ID/approval_rules \
               -f name=Default -f approvals_required=1
             ```
 
-            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html).
+            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html#create-project-level-rule).
         - id: terraform
           desc: |
             To require merge request approvals using Terraform:
@@ -782,6 +779,8 @@ queries:
       remediation:
         - id: gitlab
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. On the Free tier the **Approval settings** section is not available, so this control cannot be configured there.
+
             To prevent merge request authors from approving their own requests using the GitLab web UI:
 
             1. Navigate to your project.
@@ -793,6 +792,8 @@ queries:
             For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
         - id: cli
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
+
             To prevent merge request authors from approving their own requests using the `glab` CLI:
 
             ```bash
@@ -908,6 +909,8 @@ queries:
       remediation:
         - id: gitlab
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. On the Free tier the **Approval settings** section is not available, so this control cannot be configured there.
+
             To reset merge request approvals when new commits are pushed using the GitLab web UI:
 
             1. Navigate to your project.
@@ -919,6 +922,8 @@ queries:
             For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html#remove-all-approvals-when-commits-are-added-to-the-source-branch).
         - id: cli
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
+
             To reset merge request approvals when new commits are pushed using the `glab` CLI:
 
             ```bash
@@ -1033,6 +1038,8 @@ queries:
       remediation:
         - id: gitlab
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. On the Free tier the **Approval settings** section is not available, so this control cannot be configured there.
+
             To prevent committers from approving merge requests they contributed to using the GitLab web UI:
 
             1. Navigate to your project.
@@ -1044,6 +1051,8 @@ queries:
             For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
         - id: cli
           desc: |
+            Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
+
             To prevent committers from approving merge requests they contributed to using the `glab` CLI:
 
             ```bash
@@ -1149,10 +1158,10 @@ queries:
 
         ### Audit via CLI
 
-        Query the force-push setting for the default protected branch with the `glab` CLI:
+        Query the force-push setting for the default protected branch with the `glab` CLI. Replace BRANCH_NAME with the name of the project's default branch, because not every project uses `main` and querying the wrong name returns a misleading 404:
 
         ```bash
-        glab api projects/PROJECT_ID/protected_branches/main | jq '.allow_force_push'
+        glab api projects/PROJECT_ID/protected_branches/BRANCH_NAME | jq '.allow_force_push'
         ```
 
         A passing project returns `false`. A failing project returns `true`.


### PR DESCRIPTION
## Summary

Remediation-quality fixes to `content/mondoo-gitlab-security.mql.yaml`, addressing findings #9, #10, and #41 from the small-policies remediation audit. Edits are confined to remediation/audit prose and code; no `mql`, `filters`, `uid`, `title`, `impact`, or `tags` were changed. Policy `version` bumped `1.8.2` → `1.8.3`.

## Changes

### Tier-gating silence (audit #10)
The MR approval checks gate their MQL to non-Free namespaces (`gitlab.namespace.plan != "free"`), but the remediation never told a junior the feature is Premium/Ultimate-only, so Free users hunt for nonexistent UI. Added a one-line tier prerequisite ("requires GitLab Premium or Ultimate") to the `gitlab` and `cli` remediation methods of:

- `mondoo-gitlab-security-approvals-required`
- `mondoo-gitlab-security-no-author-approval`
- `mondoo-gitlab-security-reset-approvals-on-push`
- `mondoo-gitlab-security-no-committer-approval`

This mirrors how the `continuous-vulnerability-scanning` check already states "requires a GitLab Ultimate subscription."

### Modern approval-rule endpoint (audit #9)
The `approvals-required` cli remediation led with `POST projects/:id/approvals -f approvals_before_merge=1`. The project-level `approvals_before_merge` field on the `/approvals` endpoint is read-only and no longer accepts updates. The remediation now leads with the rule-based path `POST projects/:id/approval_rules -f name=Default -f approvals_required=1`, matching the Terraform variant which already uses `gitlab_project_approval_rule`. Added a one-line "why" explaining the `/approvals` field is read-only.

### Parameterized branch audit (audit #41)
The `no-force-push-default-branch` audit CLI hardcoded `protected_branches/main` while the remediation correctly used `BRANCH_NAME`. Parameterized the audit to `BRANCH_NAME` and added the "why" (non-`main` defaults otherwise return a misleading 404).

## VERIFY items

- **Approval-rule endpoint form:** The exact `glab api --method POST projects/PROJECT_ID/approval_rules -f name=Default -f approvals_required=1` form is confirmed valid by the gitlab remediation validator (`glab __complete` introspection) — `[PASS]`.

## Validation

- `cnspec policy lint content/mondoo-gitlab-security.mql.yaml` → valid policy bundle
- `python3 content/validation/validate_remediation_commands.py gitlab` → all `[PASS]`, 0 `[FAIL]` (glab on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)