### PR TITLE
🐛 unifi: reconcile auto-upgrade path + operational-impact warnings on snooping/DoH/SSH

### DIFF
--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-unifi-security
     name: Mondoo Ubiquiti UniFi Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -892,6 +892,8 @@ queries:
       remediation:
         - id: console
           desc: |
+            Threat Management and IPS require a UniFi gateway such as a UDM or USG and download a signature set before they can block traffic. The exact path varies by controller version.
+
             To enable Threat Management in IPS mode using the UniFi Network web application:
 
             1. Go to **Settings > Security > Threat Management**.
@@ -962,6 +964,8 @@ queries:
       remediation:
         - id: console
           desc: |
+            DNS filtering is part of Threat Management and requires a UniFi gateway such as a UDM or USG, along with a downloaded signature set. The exact path varies by controller version.
+
             To enable DNS filtering using the UniFi Network web application:
 
             1. Go to **Settings > Security > Threat Management**.
@@ -1018,11 +1022,13 @@ queries:
       remediation:
         - id: console
           desc: |
+            The internal honeypot is part of Threat Management and requires a UniFi gateway such as a UDM or USG, along with a downloaded signature set. The exact path varies by controller version.
+
             To enable the internal honeypot using the UniFi Network web application:
 
             1. Go to **Settings > Security > Threat Management**.
             2. Enable **Internal Honeypot**.
-            3. Select the network and the IP address to use for the honeypot.
+            3. Select the network and choose an unused IP address on that network so it does not conflict with a real host.
         # No cli remediation: the internal honeypot is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360006893234
@@ -1472,6 +1478,8 @@ queries:
 
             1. Go to **Settings > Networks > Global Switch Settings**.
             2. Enable **DHCP Snooping**.
+
+            **Caution:** Any uplink port that carries the legitimate DHCP server must be marked as trusted. Otherwise DHCP snooping drops the upstream DHCP responses and clients cannot obtain or renew leases. After enabling, verify that clients still renew their leases successfully.
         # No cli remediation: global switch settings are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/360042281174
@@ -1723,6 +1731,8 @@ queries:
       remediation:
         - id: console
           desc: |
+            **Warning:** Do not disable password authentication until at least one key-based login is confirmed working. If you disable it first, you can lose SSH access to every device.
+
             To disable device SSH password authentication using the UniFi Network web application:
 
             1. Go to **Settings > System > Advanced**.
@@ -1905,8 +1915,8 @@ queries:
           desc: |
             To enable automatic firmware upgrades using the UniFi Network web application:
 
-            1. Go to **Settings > System > Updates**.
-            2. Enable automatic updates for device firmware.
+            1. Go to **Settings > System > Firmware**. The exact path varies by controller version.
+            2. Enable **Auto Update** for device firmware.
             3. Configure the update window to a low-traffic period.
         # No cli remediation: the auto-update setting is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
         - id: terraform
@@ -2054,7 +2064,7 @@ queries:
             1. Go to **Settings > System > Remote Logging**.
             2. Enable **Remote Syslog**.
             3. Configure the syslog server IP address and port.
-            4. Enable **Log All Contents** for comprehensive logging.
+            4. Optionally enable **Log All Contents** for comprehensive logging. This greatly increases log volume and may include sensitive data, so enable it only if the syslog target is sized and access-controlled for it.
         # No cli remediation: remote logging is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
     refs:
       - url: https://help.ui.com/hc/en-us/articles/204909374
@@ -2123,9 +2133,10 @@ queries:
 
             1. Go to **Settings > Routing > Port Forwarding**.
             2. Review all enabled port forwarding rules.
-            3. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080.
-            4. Remove or disable any rule whose destination IP belongs to an adopted UniFi device such as an access point, switch, or gateway.
-            5. Use a VPN to access management interfaces remotely instead of port forwarding.
+            3. Confirm whether each rule serves a legitimate application before removing it, since a rule on port 443 may front a real internal HTTPS service rather than a management interface. For a rule you must keep, restrict the allowed source IPs or move the service behind a VPN instead of deleting it.
+            4. Remove or disable any rules forwarding ports 22, 443, 8443, or 8080 that do not serve a legitimate application.
+            5. Remove or disable any rule whose destination IP belongs to an adopted UniFi device such as an access point, switch, or gateway.
+            6. Use a VPN to access management interfaces remotely instead of port forwarding.
         # No cli remediation: port forwarding rules are controller-managed; the device SSH CLI cannot change them and the controller overwrites local changes on provision.
         - id: terraform
           desc: |
@@ -2220,8 +2231,10 @@ queries:
           desc: |
             To enable DNS over HTTPS using the UniFi Network web application:
 
-            1. Go to **Settings > Security > DNS Shield** or **Settings > Internet**.
+            1. Go to **Settings > Security > DNS Shield** or **Settings > Internet**. The exact path varies by controller version.
             2. Enable **DNS over HTTPS**.
+
+            **Caution:** DoH bypasses local and split-horizon DNS, so forcing it at the gateway can break resolution of internal name zones. Choose an upstream and mode that remain compatible with your internal name resolution.
         # No cli remediation: DNS over HTTPS is a controller-managed site setting; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
         - id: terraform
           desc: |
@@ -2369,6 +2382,8 @@ queries:
             1. Go to **Settings > Networks**.
             2. Select each LAN network.
             3. Under advanced settings, enable **IGMP Snooping**.
+
+            **Caution:** IGMP snooping requires an active IGMP querier on the VLAN. Without one, multicast applications such as mDNS, AirPlay, Sonos, and IPTV can stop working because their traffic is pruned. UniFi enables a querier alongside snooping, but test these applications on one network before rolling the change out broadly.
         # No cli remediation: network configuration is controller-managed; the device SSH CLI cannot change it and the controller overwrites local changes on provision.
         - id: terraform
           desc: |


### PR DESCRIPTION
## Summary

Remediation-quality fixes to `content/mondoo-unifi-security.mql.yaml` (version `1.3.1` → `1.3.2`). Edits touch only remediation prose; no `mql`, `filters`, `uid`, `title`, `impact`, or `tags` were changed. Terraform blocks were left untouched. Lint passes.

## Path reconciliation

- **U1 — auto-upgrade-enabled:** the `console` remediation pointed at `Settings > System > Updates`, contradicting the check's own `audit:` path (`Settings > System > Firmware` → `Auto Update`). Aligned the console steps to the audit's location and control name, and added a "the exact path varies by controller version" hedge.

## Prerequisite + version hedges

- **U2 — ips / dns-filtering / honeypot:** added a one-line prerequisite that Threat Management and IPS require a UniFi gateway (UDM/USG) and a downloaded signature set, plus a "the exact path varies by controller version" hedge mirroring the DPI and geo-IP checks.
- **U9 — dns-over-https:** added the version-varies hedge on the two alternative paths.

## Operational-impact warnings

- **U3 — dhcp-snooping:** caution that uplink ports carrying the legitimate DHCP server must be trusted, and to verify client lease renewal after enabling.
- **U4 — igmp-snooping:** caveat that an IGMP querier must exist on the VLAN or multicast apps (mDNS/AirPlay/Sonos/IPTV) can break; test before broad rollout.
- **U5 — ssh-password-auth-disabled:** elevated to a bold warning not to disable password auth until a key-based login is confirmed working.
- **U6 — no-port-forwards-to-mgmt:** confirm each rule serves a legitimate app before removing it, and restrict source IPs / move behind VPN rather than blindly deleting.
- **U7 — honeypot:** choose an unused IP on the network so it does not conflict with a real host.
- **U8 — remote-syslog:** noted "Log All Contents" greatly increases log volume and may include sensitive data; enable only if the syslog target is sized and access-controlled.
- **U9 — dns-over-https:** noted DoH bypasses local/split-horizon DNS and to choose a mode compatible with internal name resolution.

## VERIFY items (unresolved UI paths)

These UI paths could not be confirmed against a live current controller; each carries the version-varies hedge so a junior on a different version knows the path may differ:

- **U1:** `Settings > System > Firmware` → `Auto Update` — aligned to the audit's wording (the more consistent of the two paths) but not independently verified against a current controller.
- **U2:** `Settings > Security > Threat Management` for IPS / DNS filtering / honeypot.
- **U9:** `Settings > Security > DNS Shield` vs `Settings > Internet` for DoH.

## Validation

- `cnspec policy lint content/mondoo-unifi-security.mql.yaml` → valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)