### PR TITLE
🐛 m365: Entra/Defender naming currency + PowerShell module prerequisites

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.4.2
+    version: 2.4.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -78,7 +78,7 @@ policies:
     scoring_system: highest impact
 queries:
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-sign-in-risk-policies
-    title: Enable Azure AD Identity Protection sign-in risk policies
+    title: Enable Microsoft Entra ID Protection sign-in risk policies
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -288,7 +288,7 @@ queries:
           body["grantControls"]["builtInControls"].any(_ == "mfa")
       )
   - uid: mondoo-m365-security-enable-azure-ad-identity-protection-user-risk-policies
-    title: Enable Azure AD Identity Protection user risk policies
+    title: Enable Microsoft Entra ID Protection user risk policies
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
@@ -1137,7 +1137,7 @@ queries:
       )
   # No Terraform variants: the security defaults toggle has no azuread Terraform resource and can only be changed through the Graph API or portal.
   - uid: mondoo-m365-security-ensure-security-defaults-is-disabled-on-azure-active-directory
-    title: Ensure Security Defaults is disabled on Azure Active Directory
+    title: Ensure Security Defaults is disabled on Microsoft Entra ID
     filters: |
       asset.platform == "microsoft365"
     impact: 80
@@ -1431,14 +1431,22 @@ queries:
           desc: |
             **Using the Microsoft Intune admin center:**
 
+            Android Enterprise is the recommended enrollment model. Android Enterprise work profile and fully managed devices enforce storage encryption automatically, so provisioning these devices through Android Enterprise satisfies the encryption requirement without a separate device restrictions setting.
+
             1. Sign in to the Microsoft Intune admin center at https://intune.microsoft.com.
             2. Go to `Devices` > `Manage devices` > `Configuration`.
             3. Select `Create` > `New policy`.
-            4. For `Platform`, select `Android device administrator`. For `Profile type`, select `Device restrictions`.
-            5. In the `Password` section, set `Encryption` to `Require`.
-            6. Assign the profile to the appropriate device groups and select `Create`.
+            4. For `Platform`, select `Android Enterprise`. For `Profile type`, select `Device restrictions` for the relevant management mode such as `Fully Managed, Dedicated, and Corporate-Owned Work Profile`.
+            5. Confirm the device password and encryption settings enforce encryption, then assign the profile to the appropriate device groups and select `Create`.
 
-            Note that Microsoft has deprecated Android device administrator management. Devices managed through Android Enterprise enforce storage encryption automatically, so this setting applies to remaining device administrator profiles.
+            **Legacy fallback using Android device administrator:**
+
+            Microsoft has deprecated Android device administrator management, and Intune has wound down support for device administrator enrollment. Use this path only for remaining device administrator profiles that have not yet migrated to Android Enterprise.
+
+            1. In `Devices` > `Manage devices` > `Configuration`, select `Create` > `New policy`.
+            2. For `Platform`, select `Android device administrator`. For `Profile type`, select `Device restrictions`.
+            3. In the `Password` section, set `Encryption` to `Require`.
+            4. Assign the profile to the appropriate device groups and select `Create`.
         - id: powershell
           desc: |
             **Using Microsoft Graph PowerShell**
@@ -1679,6 +1687,8 @@ queries:
           desc: |
             **To set Microsoft 365 passwords to never expire:**
 
+            Never-expiring passwords are only safe when they sit behind other controls. Confirm that multifactor authentication is enforced for all users and that Microsoft Entra Password Protection is enabled to block weak and breached passwords before removing expiration. Without those controls, a compromised password stays valid indefinitely.
+
             1. Navigate to the `Microsoft 365 admin center` at https://admin.microsoft.com.
             2. Go to `Settings` > `Org settings`.
             3. Under the `Security & privacy` tab, locate and select `Password expiration policy`.
@@ -1780,7 +1790,7 @@ queries:
             v=spf1 include:spf.protection.outlook.com include:<other-system> -all
             ```
 
-            3. Use the Microsoft 365 Defender portal to validate your SPF record configuration. Refer to this article for detailed guidance: [https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing).
+            3. Use the Microsoft Defender portal to validate your SPF record configuration. Refer to this article for detailed guidance: [https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/how-office-365-uses-spf-to-prevent-spoofing).
         - id: cli
           desc: |
             **Using CLI tools**
@@ -2022,7 +2032,7 @@ queries:
           desc: |
             **To enable DKIM signing:**
 
-            1. Navigate to the [Microsoft 365 Defender portal](https://security.microsoft.com).
+            1. Navigate to the [Microsoft Defender portal](https://security.microsoft.com).
             2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies**.
             3. Select **Email authentication settings** > **DKIM**.
             4. For each domain, select the domain and toggle **Sign messages for this domain with DKIM signatures** to **Enabled**.
@@ -2030,6 +2040,8 @@ queries:
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
+
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
 
             ```powershell
             Connect-ExchangeOnline
@@ -2114,7 +2126,7 @@ queries:
           desc: |
             **To configure Safe Links policies:**
 
-            1. Navigate to the [Microsoft 365 Defender portal](https://security.microsoft.com).
+            1. Navigate to the [Microsoft Defender portal](https://security.microsoft.com).
             2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies**.
             3. Select **Safe Links**.
             4. Click **Create** to create a new policy.
@@ -2128,6 +2140,8 @@ queries:
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
+
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
 
             ```powershell
             Connect-ExchangeOnline
@@ -2227,6 +2241,8 @@ queries:
           desc: |
             **Using Exchange Online PowerShell**
 
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
+
             ```powershell
             Connect-ExchangeOnline
 
@@ -2313,7 +2329,7 @@ queries:
           desc: |
             **To configure anti-phishing policies:**
 
-            1. Navigate to the [Microsoft 365 Defender portal](https://security.microsoft.com).
+            1. Navigate to the [Microsoft Defender portal](https://security.microsoft.com).
             2. Go to **Email & collaboration** > **Policies & rules** > **Threat policies**.
             3. Select **Anti-phishing**.
             4. Click **Create** to create a new policy (or edit the default policy).
@@ -2328,6 +2344,8 @@ queries:
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
+
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
 
             ```powershell
             Connect-ExchangeOnline
@@ -2426,6 +2444,8 @@ queries:
           desc: |
             **Using SharePoint Online PowerShell**
 
+            Requires the Microsoft.Online.SharePoint.PowerShell module and the SharePoint Administrator role.
+
             ```powershell
             Connect-SPOService -Url https://yourtenant-admin.sharepoint.com
 
@@ -2519,6 +2539,8 @@ queries:
           desc: |
             **Using Exchange Online PowerShell**
 
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
+
             ```powershell
             Connect-ExchangeOnline
 
@@ -2606,6 +2628,8 @@ queries:
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
+
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
 
             ```powershell
             Connect-ExchangeOnline
@@ -2697,6 +2721,8 @@ queries:
         - id: powershell
           desc: |
             **Using Exchange Online PowerShell**
+
+            Requires the ExchangeOnlineManagement module and an Exchange Administrator role.
 
             ```powershell
             Connect-ExchangeOnline
@@ -2888,7 +2914,8 @@ queries:
             ```powershell
             Connect-MgGraph -Scopes "RoleManagement.ReadWrite.Directory"
 
-            # Create an eligible assignment for a privileged role
+            # Create a bounded eligible assignment for a privileged role.
+            # Eligibility itself should be time-bound and reviewed periodically rather than permanent.
             $params = @{
                 action           = "adminAssign"
                 principalId      = "<user-object-id>"
@@ -2896,11 +2923,16 @@ queries:
                 directoryScopeId = "/"
                 scheduleInfo     = @{
                     startDateTime = (Get-Date)
-                    expiration    = @{ type = "noExpiration" }
+                    expiration    = @{
+                        type        = "afterDuration"
+                        duration    = "P180D"
+                    }
                 }
             }
             New-MgRoleManagementDirectoryRoleEligibilityScheduleRequest -BodyParameter $params
             ```
+
+            The eligible assignment grants the ability to activate the role, not standing access. Enforce just-in-time access by setting the `Activation maximum duration` value in the role's PIM **Settings**, so each activation is itself time-limited and expires automatically.
         # No Terraform remediation: Microsoft Entra PIM role eligibility has no resource in the azuread Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure


### PR DESCRIPTION
## Summary

Remediation-quality fixes for `content/mondoo-m365-security.mql.yaml`. Prose and example code only, plus three titles explicitly called out by the audit. No `mql`/`filters`/`uid`/`impact`/`tags` changes. Version bumped 2.4.2 → 2.4.3.

### Naming currency
- Retitled three checks whose titles still used retired names, keeping UIDs stable:
  - `...security-defaults-is-disabled-on-azure-active-directory` → "Ensure Security Defaults is disabled on Microsoft Entra ID"
  - `...enable-azure-ad-identity-protection-sign-in-risk-policies` → "Enable Microsoft Entra ID Protection sign-in risk policies"
  - `...enable-azure-ad-identity-protection-user-risk-policies` → "Enable Microsoft Entra ID Protection user risk policies"
- Replaced the stale "Microsoft 365 Defender portal" label with "Microsoft Defender portal" in all four occurrences. URLs unchanged.
- No residual "Azure AD"/"Azure Active Directory" prose remained in desc/remediation/audit; the only instances were the three titles above. API/HCL identifiers (e.g. the `azuread` Terraform provider in code comments) were left intact.

### PowerShell prerequisites
- Added "Requires the ExchangeOnlineManagement module and an Exchange Administrator role." to all 7 Exchange Online PowerShell remediation blocks that jumped straight to `Connect-ExchangeOnline`.
- Added "Requires the Microsoft.Online.SharePoint.PowerShell module and the SharePoint Administrator role." to the SharePoint remediation before `Connect-SPOService`.

### Content fixes
- **mobile-device-encryption:** Reworked the console remediation to lead with Android Enterprise (enforces storage encryption automatically) and demote the deprecated Android device administrator path to a clearly labeled legacy fallback.
- **require-pim-for-privileged-roles:** Replaced the example's `expiration = @{ type = 'noExpiration' }` (which contradicted the time-bound/JIT rationale) with a bounded `afterDuration`/`P180D` expiration, and added a note that eligible assignments grant activation rights, not standing access, with a pointer to the `Activation maximum duration` PIM setting.
- **passwords-are-not-set-to-expire:** Added a caveat that never-expire is only safe alongside enforced MFA and Microsoft Entra Password Protection.

## Validation
- `cnspec policy lint content/mondoo-m365-security.mql.yaml` → valid policy bundle.
- `python3 content/validation/validate_remediation_commands.py azure` → 345 passed, 0 failed (this target also validates the m365 policy's `az` commands).

## VERIFY items (carried from the audit, not resolved here)
- **Intune device-administrator removal timing:** The remediation now describes Android device administrator as a deprecated legacy fallback and states Intune has wound down support for device administrator enrollment. The exact deprecation/removal date (audit suggested ~2025) was not independently confirmed against current Microsoft docs and should be verified before relying on a specific date in the prose.
- **PIM duration value:** The example uses `P180D` as a reasonable bounded eligibility window; organizations should set this per their access-review cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)