### PR TITLE
🐛 ai-security: real uninstall paths (config deletion is not uninstall) + multi-tool examples

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-ai-security
     name: Mondoo AI Security
-    version: 2.0.1
+    version: 2.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -149,7 +149,9 @@ queries:
             3. On Windows, open **Settings > Apps > Installed apps**, locate the tool, and select **Uninstall**.
         - id: cli
           desc: |
-            To identify, terminate, and uninstall an unapproved AI tool from the command line, search for the same executable names the check matches. The commands below use Ollama as the example; repeat the kill and uninstall steps for each unapproved tool you find.
+            To identify, terminate, and uninstall an unapproved AI tool from the command line, search for the same executable names the check matches. Killing the process stops data egress now; uninstalling the package removes the tool so it cannot be relaunched. The commands below use Ollama as the example; repeat the kill and uninstall steps for each unapproved tool you find.
+
+            The uninstall id rarely matches the process name, so look it up before running the uninstall command: `winget search <tool>` on Windows, `brew info <tool>` on macOS, or `dpkg -l | grep <tool>` (`rpm -qa | grep <tool>`) on Linux. For example, LM Studio runs as `lm-studio` but installs as `ElementLabs.LMStudio` (`winget`) or the `lm-studio` cask (`brew uninstall --cask lm-studio`).
 
             macOS:
 
@@ -281,7 +283,9 @@ queries:
             2. On macOS, quit the application and drag it from `/Applications` to the Trash. If the tool shipped with an uninstaller app, run that instead so package receipts are removed.
         - id: cli
           desc: |
-            To remove an unapproved AI package using the system package manager, with Ollama as the example:
+            To remove an unapproved AI package using the system package manager, with Ollama as the example. Removing the package takes the tool off the endpoint so it cannot be relaunched.
+
+            The package id rarely matches the process name, so look it up before running the uninstall command: `winget search <tool>` on Windows, `brew info <tool>` on macOS, or `dpkg -l | grep <tool>` (`rpm -qa | grep <tool>`) on Linux. For example, LM Studio runs as `lm-studio` but installs as `ElementLabs.LMStudio` (`winget`) or the `lm-studio` cask (`brew uninstall --cask lm-studio`).
 
             macOS:
 
@@ -807,7 +811,17 @@ queries:
       remediation:
         - id: cli
           desc: |
-            Cline reads agent skills from the shared `~/.agents/skills` directory rather than its own configuration folder. Remove the skill definitions there, and remove the Cline configuration directory as well. The shared directory may also be used by other agents that follow the same skills convention; if an approved tool relies on it, delete only the unapproved skill subfolders instead of the whole directory.
+            Cline runs as a VS Code extension. Deleting its configuration directory does not uninstall the agent: the extension stays installed and regenerates its configuration the next time the editor starts. Uninstall the extension first, then remove the leftover configuration.
+
+            Uninstall the Cline extension from whichever editor has it installed:
+
+            ```bash
+            code --uninstall-extension saoudrizwan.claude-dev       # VS Code
+            cursor --uninstall-extension saoudrizwan.claude-dev     # Cursor
+            windsurf --uninstall-extension saoudrizwan.claude-dev   # Windsurf
+            ```
+
+            Cline reads agent skills from the shared `~/.agents/skills` directory rather than its own configuration folder. Remove the skill definitions there, and remove the Cline configuration directory as well. The shared directory may also be used by other agents that follow the same skills convention; if an approved tool relies on it, delete only the unapproved skill subfolders instead of the whole directory. Removing these directories deletes any saved Cline history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -885,7 +899,17 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Roo Code configuration from the command line:
+            Roo Code runs as a VS Code extension. Deleting its configuration directory does not uninstall the agent: the extension stays installed and regenerates `~/.roo` the next time the editor starts. Uninstall the extension first, then remove the leftover configuration.
+
+            Uninstall the Roo Code extension from whichever editor has it installed:
+
+            ```bash
+            code --uninstall-extension rooveterinaryinc.roo-cline       # VS Code
+            cursor --uninstall-extension rooveterinaryinc.roo-cline     # Cursor
+            windsurf --uninstall-extension rooveterinaryinc.roo-cline   # Windsurf
+            ```
+
+            Then remove the configuration directory. This deletes any saved Roo Code history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -960,7 +984,17 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Continue configuration from the command line:
+            Continue runs as an editor extension. Deleting its configuration directory does not uninstall the agent: the extension stays installed and regenerates `~/.continue` the next time the editor starts. Uninstall the extension first, then remove the leftover configuration.
+
+            Uninstall the Continue extension from whichever VS Code-compatible editor has it installed:
+
+            ```bash
+            code --uninstall-extension continue.continue       # VS Code
+            cursor --uninstall-extension continue.continue     # Cursor
+            windsurf --uninstall-extension continue.continue   # Windsurf
+            ```
+
+            In a JetBrains IDE, remove the Continue plugin from **Settings > Plugins** instead. Then remove the configuration directory. This deletes any saved Continue history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1035,7 +1069,11 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Trae configuration from the command line:
+            Trae is a standalone AI editor application. Deleting its configuration directory does not uninstall the application: the binary stays installed and regenerates `~/.trae` the next time it starts. Uninstall the application first, then remove the leftover configuration.
+
+            On macOS, quit Trae and drag the application from `/Applications` to the Trash. On Windows, open **Settings > Apps > Installed apps**, locate Trae, and select **Uninstall**. On Linux, remove it through the package manager or installer you used to install it.
+
+            Then remove the configuration directory. This deletes any saved Trae history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1110,7 +1148,11 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the OpenCode configuration from the command line:
+            OpenCode is a command-line agent. Deleting its configuration directory does not uninstall the agent: the binary stays on the `PATH` and regenerates `~/.config/opencode` the next time it runs. Uninstall the binary first, then remove the leftover configuration.
+
+            Uninstall it with the same tool you used to install it. If it was installed with npm, run `npm uninstall -g opencode-ai`; if it was installed with Homebrew, run `brew uninstall opencode`; otherwise remove the `opencode` binary from the install location reported by `which opencode`.
+
+            Then remove the configuration directory. This deletes any saved OpenCode history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1185,7 +1227,11 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Kiro configuration from the command line:
+            Kiro is a standalone AI editor application. Deleting its configuration directory does not uninstall the application: the binary stays installed and regenerates `~/.kiro` the next time it starts. Uninstall the application first, then remove the leftover configuration.
+
+            On macOS, quit Kiro and drag the application from `/Applications` to the Trash. On Windows, open **Settings > Apps > Installed apps**, locate Kiro, and select **Uninstall**. On Linux, remove it through the package manager or installer you used to install it.
+
+            Then remove the configuration directory. This deletes any saved Kiro history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1260,7 +1306,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Pi agent configuration from the command line:
+            Deleting Pi's configuration directory does not uninstall the agent: the binary or extension stays installed and regenerates `~/.pi/agent` the next time it runs. Uninstall the agent first, then remove the leftover configuration.
+
+            Remove the Pi agent through the mechanism you used to install it: uninstall the extension or plugin from your editor, run the package manager command for the agent (for example `npm uninstall -g <package>`), or delete the binary from the location reported by `which pi`. Then remove the configuration directory. This deletes any saved Pi history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1335,7 +1383,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Mistral Vibe configuration from the command line:
+            Mistral Vibe is a command-line agent. Deleting its configuration directory does not uninstall the agent: the binary stays on the `PATH` and regenerates `~/.vibe` the next time it runs. Uninstall the binary first, then remove the leftover configuration.
+
+            Uninstall it with the same tool you used to install it. If it was installed with npm, run the matching `npm uninstall -g <package>` command; otherwise remove the binary from the location reported by `which vibe`. Then remove the configuration directory. This deletes any saved Mistral Vibe history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1410,7 +1460,11 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Antigravity configuration from the command line:
+            Antigravity is a standalone AI editor application. Deleting its configuration directory does not uninstall the application: the binary stays installed and regenerates `~/.gemini/antigravity` the next time it starts. Uninstall the application first, then remove the leftover configuration.
+
+            On macOS, quit Antigravity and drag the application from `/Applications` to the Trash. On Windows, open **Settings > Apps > Installed apps**, locate Antigravity, and select **Uninstall**. On Linux, remove it through the package manager or installer you used to install it.
+
+            Then remove the configuration directory. This deletes any saved Antigravity history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1485,7 +1539,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the IBM Bob configuration from the command line:
+            Deleting IBM Bob's configuration directory does not uninstall the agent: the agent stays installed and regenerates `~/.bob` the next time it runs. Uninstall the agent first, then remove the leftover configuration.
+
+            Remove IBM Bob through the mechanism you used to install it: uninstall the agent's extension or plugin from your editor, run the package manager command for the agent, or delete its binary from the install location. Then remove the configuration directory. This deletes any saved IBM Bob history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1560,7 +1616,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the OpenClaw configuration from the command line:
+            Deleting OpenClaw's configuration directory does not uninstall the agent: the agent stays installed and regenerates `~/.openclaw` the next time it runs. Uninstall the agent first, then remove the leftover configuration.
+
+            Remove OpenClaw through the mechanism you used to install it: uninstall the agent's extension or plugin from your editor, run the package manager command for the agent, or delete its binary from the install location. Then remove the configuration directory. This deletes any saved OpenClaw history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1635,7 +1693,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Snowflake Cortex configuration from the command line:
+            Deleting Snowflake Cortex Code's configuration directory does not uninstall the agent: the agent stays installed and regenerates `~/.snowflake/cortex` the next time it runs. Uninstall the agent first, then remove the leftover configuration.
+
+            Remove Snowflake Cortex Code through the mechanism you used to install it: uninstall the agent's extension or plugin from your editor, run the package manager command for the agent, or delete its binary from the install location. Then remove the configuration directory. This deletes any saved Snowflake Cortex history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1710,7 +1770,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Junie configuration from the command line:
+            Junie runs as a JetBrains IDE plugin. Deleting its configuration directory does not uninstall the agent: the plugin stays installed and regenerates `~/.junie` the next time the IDE starts. Uninstall the plugin first, then remove the leftover configuration.
+
+            In the JetBrains IDE, open **Settings > Plugins**, find Junie on the **Installed** tab, and uninstall it (or disable it if uninstall is not offered), then restart the IDE. Then remove the configuration directory. This deletes any saved Junie history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1785,7 +1847,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Augment configuration from the command line:
+            Augment runs as an editor extension or plugin. Deleting its configuration directory does not uninstall the agent: the extension stays installed and regenerates `~/.augment` the next time the editor starts. Uninstall the extension first, then remove the leftover configuration.
+
+            In a VS Code-compatible editor, open the Extensions view (`Cmd+Shift+X` on macOS, `Ctrl+Shift+X` on Windows and Linux), search for Augment, and click **Uninstall**; in a JetBrains IDE, remove the Augment plugin from **Settings > Plugins**. Then remove the configuration directory. This deletes any saved Augment history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -1945,7 +2009,17 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Kilo Code configuration from the command line:
+            Kilo Code runs as a VS Code extension. Deleting its configuration directory does not uninstall the agent: the extension stays installed and regenerates `~/.kilocode` the next time the editor starts. Uninstall the extension first, then remove the leftover configuration.
+
+            Uninstall the Kilo Code extension from whichever editor has it installed:
+
+            ```bash
+            code --uninstall-extension kilocode.kilo-code       # VS Code
+            cursor --uninstall-extension kilocode.kilo-code     # Cursor
+            windsurf --uninstall-extension kilocode.kilo-code   # Windsurf
+            ```
+
+            Then remove the configuration directory. This deletes any saved Kilo Code history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -2020,7 +2094,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the OpenHands configuration from the command line:
+            OpenHands is a command-line agent. Deleting its configuration directory does not uninstall the agent: the binary or container image stays available and regenerates `~/.openhands` the next time it runs. Uninstall the agent first, then remove the leftover configuration.
+
+            Uninstall it with the same tool you used to install it: if it was installed with `uv`/`pip`, remove the `openhands-ai` package; if it runs as a Docker container, stop the container and remove its image. Then remove the configuration directory. This deletes any saved OpenHands history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -2095,7 +2171,13 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the Qwen Code configuration from the command line:
+            Qwen Code is a command-line agent installed through npm. Deleting its configuration directory does not uninstall the agent: the binary stays on the `PATH` and regenerates `~/.qwen` the next time it runs. Uninstall the binary first, then remove the leftover configuration.
+
+            ```bash
+            npm uninstall -g @qwen-code/qwen-code
+            ```
+
+            Then remove the configuration directory. This deletes any saved Qwen Code history and settings, so confirm the contents before deleting.
 
             macOS and Linux:
 
@@ -3048,6 +3130,8 @@ queries:
 
             This playbook deletes a single named MCP server from each agent's `mcpServers` object using a JSON patch, leaving the rest of the configuration file intact, and removes the Claude Code MCP cache file so the deleted server no longer appears in its inventory. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. Each patched file is backed up before modification.
 
+            The `mcpServers` path is not the same in every agent. Claude Code's `~/.claude.json` nests MCP servers per project rather than only at the top level, so a top-level `/mcpServers` patch can silently no-op and leave a project-scoped server in place; the `failed_when: false` guard hides that. For Claude Code, prefer running `claude mcp remove <name>` (covered by the command-line remediation) instead of patching the file, and confirm the project-scoped path for any agent whose configuration does not expose servers at top-level `mcpServers`.
+
             ```yaml
             ---
             - name: Remove an unapproved MCP server
@@ -3102,7 +3186,7 @@ queries:
       ).length == 0
     docs:
       desc: |
-        Local LLM inference runtimes such as Ollama, LM Studio, llama.cpp, LocalAI, and GPT4All run model inference directly on the endpoint. While they keep prompts off remote APIs, they still allow data to be processed outside approved channels and can carry licensing exposure from the model weights they load. Endpoints should run only the LLM runtimes approved by the security team.
+        Local LLM inference runtimes such as Ollama, LM Studio, llama.cpp, LocalAI, GPT4All, and Jan run model inference directly on the endpoint. While they keep prompts off remote APIs, they still allow data to be processed outside approved channels and can carry licensing exposure from the model weights they load. Endpoints should run only the LLM runtimes approved by the security team.
 
         **Why this matters**
 
@@ -3130,7 +3214,7 @@ queries:
             2. On Windows, open **Settings > Apps > Installed apps**, locate the runtime, and select **Uninstall**.
         - id: cli
           desc: |
-            To stop and uninstall a local LLM runtime from the command line:
+            To stop and uninstall a local LLM runtime from the command line. Stopping the process halts inference immediately, and uninstalling the package removes the runtime so it cannot be relaunched. The commands below use Ollama as the example; the runtime name on your endpoint may differ, so look up the real package id first with `brew info`, `winget search`, or `dpkg -l` rather than assuming the install id matches the process name. LM Studio, GPT4All, LocalAI, and Jan are installed as standalone applications or containers and must be removed through their own uninstallers (for example `brew uninstall --cask lm-studio` or `winget uninstall ElementLabs.LMStudio` for LM Studio).
 
             macOS:
 
@@ -3157,7 +3241,7 @@ queries:
           desc: |
             To stop and remove local LLM runtimes with Ansible:
 
-            This playbook stops any running local LLM runtime process, then stops and removes the Ollama package and service. Ollama is the runtime distributed as a system package and service; LM Studio, GPT4All, and LocalAI are installed as standalone applications or containers and must be removed through their own uninstallers.
+            This playbook stops any running local LLM runtime process, then stops and removes the Ollama package and service. Ollama is the runtime distributed as a system package and service; LM Studio, GPT4All, LocalAI, and Jan are installed as standalone applications or containers and must be removed through their own uninstallers.
 
             ```yaml
             ---
@@ -3237,7 +3321,7 @@ queries:
       remediation:
         - id: cli
           desc: |
-            Identify the process bound to the flagged port and reconfigure it to bind to the loopback address only:
+            Identify the process bound to the flagged port and reconfigure it to bind to the loopback address only. Restricting the listener to `127.0.0.1` keeps the inference API reachable only from the local machine, so other hosts on the network can no longer submit prompts to it.
 
             macOS:
 
@@ -3247,6 +3331,8 @@ queries:
             ```
 
             Then quit and reopen the Ollama app so it picks up the new bind address.
+
+            Note that `launchctl setenv` applies only to the current login session and is lost on logout or reboot, and the Ollama menu-bar app does not reliably read it. For a fix that survives a restart, set the bind address in the Ollama app settings, or install a per-user LaunchAgent plist under `~/Library/LaunchAgents` that runs `launchctl setenv OLLAMA_HOST 127.0.0.1:11434` at login.
 
             Linux:
 


### PR DESCRIPTION
## Summary

Quality fixes to the `remediation:` guidance in `content/mondoo-ai-security.mql.yaml`. The core problem: most agent checks remediated with only `rm -rf ~/.<dir>`, which deletes config but leaves the agent installed, so the agent regenerates its config and the check flips back. This adds the real uninstall path to each affected check, plus several multi-tool accuracy fixes. No `mql`, `filters`, `uid`, `title`, `impact`, or `tags` were changed.

### Config-deletion is not uninstall (agent checks)

Each affected check now states that deleting the config directory does NOT uninstall the agent, adds the real uninstall path, and warns that `rm -rf` on home-dir paths loses user history/settings:

- **VS Code extension agents** — Cline (`saoudrizwan.claude-dev`), Roo (`rooveterinaryinc.roo-cline`), Continue (`continue.continue`), Kilo Code (`kilocode.kilo-code`): `code/cursor/windsurf --uninstall-extension <id>`.
- **JetBrains** — Junie: remove via **Settings > Plugins**. Augment: covers both the editor extension and the JetBrains plugin.
- **Standalone editor apps** — Trae, Kiro, Antigravity: OS uninstaller.
- **CLI/npm agents** — OpenCode (`npm uninstall -g opencode-ai` / `brew`), Qwen Code (`npm uninstall -g @qwen-code/qwen-code`), OpenHands (pip/Docker), Pi, Mistral Vibe: their own package-manager uninstallers.
- **Generic guidance** (install mechanism not confidently identified) — IBM Bob, OpenClaw, Snowflake Cortex Code: "uninstall the agent's extension/plugin/binary".

### Multi-tool / accuracy fixes

- **`no-unapproved-ai-processes` / `-packages`**: stop assuming uninstall id == executable name; instruct looking up the real package id first (`winget search` / `brew info` / `dpkg -l`) with a non-Ollama (LM Studio: `ElementLabs.LMStudio` / `lm-studio` cask) example.
- **`no-local-llm-runtimes`**: added Jan to the desc and broadened CLI/ansible beyond Ollama to LM Studio/GPT4All/LocalAI/Jan via their own uninstallers.
- **`no-local-llm-listening-ports`**: noted `launchctl setenv` is per-session and lost on logout/reboot and is not reliably read by the Ollama menu-bar app; recommends the Ollama app settings or a LaunchAgent plist for persistence.
- **`no-unapproved-mcp-servers`**: noted Claude Code's `~/.claude.json` nests MCP servers per project, so a top-level `/mcpServers` patch can silently no-op; recommends `claude mcp remove`.

### Notes / VERIFY items

- **`launchctl setenv` persistence** (VERIFY): per-session macOS behavior, lost on logout/reboot; the persistent path is the Ollama app settings or a LaunchAgent plist. Confirmed against well-established macOS launchd behavior.
- **Generic uninstall guidance** for IBM Bob, OpenClaw, and Snowflake Cortex Code: their install mechanism (extension vs CLI vs app) could not be confidently identified, so the guidance is intentionally generic.
- LM Studio package ids (`ElementLabs.LMStudio` / `lm-studio` cask) used as the worked non-Ollama example; verify against current registries before relying on them verbatim.

Bumps policy version `2.0.1` → `2.0.2`.

### Validation

`cnspec policy lint content/mondoo-ai-security.mql.yaml` → valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)