### PR TITLE
🐛 vmware: PowerCLI -Force/Connect-VIServer + vSphere Client rename + lockout warnings

### DIFF
--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline
     name: Mondoo VMware vSphere ESXi Security
-    version: 2.0.3
+    version: 2.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -138,7 +138,7 @@ queries:
           desc: |
             To set the account lockout to 15 minutes using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `System`.
             3. Select `Advanced System Settings` then select `Edit`.
             4. Enter `Security.AccountUnlockTime` in the filter.
@@ -300,7 +300,7 @@ queries:
           desc: |
             To enable bidirectional CHAP authentication for iSCSI traffic using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `Storage`.
             3. Select `Storage Adapters` then select the iSCSI Adapter.
             4. Under `Properties` select `Edit` next to `Authentication`.
@@ -395,10 +395,16 @@ queries:
             esxcli network ip dns server add --server=192.0.2.53
             ```
 
-            If the management interface currently obtains its settings from DHCP, convert it to a static configuration. Supply the address and netmask explicitly, and perform this change from the DCUI or a console session because it can interrupt management connectivity:
+            If the management interface currently obtains its settings from DHCP, convert it to a static configuration. Supply the address and netmask explicitly:
 
             ```bash
             esxcli network ip interface ipv4 set --interface-name=vmk0 --type=static --ipv4=192.0.2.10 --netmask=255.255.255.0
+            ```
+
+            **Warning:** Reconfiguring a management VMkernel interface can strand the host at the wrong address and cut off management connectivity. Run this from the DCUI or a direct console session, not over an SSH or vSphere connection that depends on the interface, and have console access ready in case the host becomes unreachable. Confirm that `vmk0` is the management interface before changing it, since the management VMkernel is not always `vmk0`. After setting a static address you may also need to set the default gateway explicitly:
+
+            ```bash
+            esxcli network ip route ipv4 add --gateway=192.0.2.1 --network=default
             ```
         # No Terraform remediation: the host DNS configuration is runtime network state with no Terraform resource.
     refs:
@@ -539,7 +545,7 @@ queries:
           desc: |
             To set the timeout to the desired value using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `System`.
             3. Select `Advanced System Settings` then select `Edit`.
             4. Enter `ESXiShellInteractiveTimeOut` in the filter.
@@ -686,7 +692,7 @@ queries:
           desc: |
             To enable lockdown mode using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `System` and select `Security Profile`.
             3. Across from `Lockdown Mode` select `Edit`.
             4. Select the radio button for `Normal`.
@@ -773,10 +779,16 @@ queries:
             6. Select `OK`.
         - id: powershell
           desc: |
-            To implement the recommended NTP configuration state using PowerCLI. If an internal NTP server is used, replace pool.ntp.org with the IP address or fully qualified domain name of the internal NTP server:
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
 
             ```powershell
-            $ntpServers = "pool.ntp.org", "pool2.ntp.org"
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
+            To implement the recommended NTP configuration state using PowerCLI, run the following. If an internal NTP server is used, replace the pool hostnames with the IP address or fully qualified domain name of the internal NTP server:
+
+            ```powershell
+            $ntpServers = "0.pool.ntp.org", "1.pool.ntp.org"
             Get-VMHost | Add-VMHostNtpServer -NtpServer $ntpServers
             Get-VMHost | Get-VMHostService | Where-Object { $_.Key -eq "ntpd" } | Set-VMHostService -Policy On
             Get-VMHost | Get-VMHostService | Where-Object { $_.Key -eq "ntpd" } | Start-VMHostService
@@ -841,7 +853,7 @@ queries:
 
             1. Select the host
             2. Select `Configure` then expand `System` then select `Advanced System Settings`.
-            3. Select `Edit` then enter `Syslog.global.LogDir` in the filter.
+            3. Select `Edit` then enter `Syslog.global.logDir` in the filter.
             4. Set `Syslog.global.logDir` to a persistent location specified as [datastorename] path\_to\_file where the path is relative to the datastore. For example, [datastore1] /systemlogs.
             5. Select `OK`.
         - id: powershell
@@ -925,7 +937,7 @@ queries:
           desc: |
             To stop using the native VLAN ID for port groups using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `Networking`.
             3. Select `Virtual switches`.
             4. Expand the Standard vSwitch.
@@ -1022,7 +1034,7 @@ queries:
           desc: |
             To set port groups to values other than 4095 and 0 unless VGT is required using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `Networking`.
             3. Select `Virtual switches`.
             4. Expand the Standard vSwitch.
@@ -1176,12 +1188,14 @@ queries:
           desc: |
             To disable SSH using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure` then expand `System` and select `Services`.
             3. Select `SSH` then select `Edit Startup Policy`.
             4. Set the Startup Policy is set to `Start and Stop Manually`.
             5. Select `OK`.
             6. While `SSH` is still selected, select `Stop`.
+
+            **Warning:** Stopping the SSH service ends any SSH session that is currently connected to the host. Perform this change from the vSphere Client or the host console (DCUI) rather than from an SSH session you depend on. If lockdown mode is enabled, SSH cannot be re-enabled from a local SSH session, so make sure you retain vSphere Client or DCUI access before disabling it.
 
             **Impact:**
 
@@ -1194,6 +1208,8 @@ queries:
             Get-VMHost | Get-VMHostService | Where-Object { $_.Key -eq "TSM-SSH" } | Set-VMHostService -Policy Off
             Get-VMHost | Get-VMHostService | Where-Object { $_.Key -eq "TSM-SSH" } | Stop-VMHostService -Confirm:$false
             ```
+
+            **Warning:** Run this from a vCenter-connected PowerCLI session, not from an SSH session on the host, because stopping the service ends any active SSH connection. With lockdown mode enabled, SSH cannot be re-enabled locally, so confirm you retain vSphere Client or DCUI access first.
         # No Terraform remediation: SSH service state and startup policy are runtime host configuration with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-strict-lockdown-mode-is-enabled
@@ -1250,7 +1266,7 @@ queries:
           desc: |
             To enable lockdown mode using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System` and select `Security Profile`.
             3. Across from `Lockdown Mode` select `Edit`.
             4. Select the radio button for `Strict`.
@@ -1331,7 +1347,7 @@ queries:
           desc: |
             To correct the DCUI timeout setting using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then under `System` select `Advanced System Settings`.
             3. Select `Edit` then enter `UserVars.DcuiTimeOut` in the filter.
             4. Change the current value to 600 seconds or less.
@@ -1339,7 +1355,7 @@ queries:
           desc: |
             To correct the DCUI timeout setting using PowerCLI:
 
-            ```
+            ```powershell
             Get-VMHost | Get-AdvancedSetting -Name UserVars.DcuiTimeOut | Set-AdvancedSetting -Value 600
             ```
         # No Terraform remediation: the DCUI timeout is a runtime host advanced setting with no Terraform resource.
@@ -1411,7 +1427,7 @@ queries:
           desc: |
             To configure per-VM salting using PowerCLI:
 
-            ```
+            ```powershell
             Get-VMHost | Get-AdvancedSetting -Name Mem.ShareForceSalting | Set-AdvancedSetting -Value 2
             ```
         # No Terraform remediation: the Transparent Page Sharing salt setting is a runtime host advanced setting with no Terraform resource.
@@ -1612,7 +1628,7 @@ queries:
           desc: |
             To disable the ESXi shell using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System` and select `Services`.
             3. Select `ESXi Shell`, then select `Edit Startup Policy`.
             4. Set the Startup Policy is set to `Start and Stop Manually`.
@@ -1680,7 +1696,7 @@ queries:
           desc: |
             To set the host image profile acceptance level using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then under `System` and select `Security Profile`.
             3. Under `Host Image Profile Acceptance Level` select `Edit`
             4. In the dropdown select one of the following - `VMware Certified`, `VMware Accepted`, or `Partner Supported`.
@@ -1755,7 +1771,7 @@ queries:
           desc: |
             To set the maximum failed login attempts correctly using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System`.
             3. Select `Advanced System Settings` then select `Edit`.
             4. Enter `Security.AccountLockFailures` in the filter.
@@ -1829,7 +1845,7 @@ queries:
           desc: |
             To set the timeout to the desired value using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System`.
             3. Select `Advanced System Settings`, then select `Edit`.
             4. Enter `ESXiShellTimeOut` in the filter.
@@ -1904,7 +1920,7 @@ queries:
           desc: |
             To disable the SLP service using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System` and select `Services`.
             3. Select `slpd`, then select `Stop`.
             4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
@@ -2004,7 +2020,7 @@ queries:
           desc: |
             To disable the SNMP service using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `System` and select `Services`.
             3. Select `snmpd`, then select `Stop`.
             4. Select `Edit Startup Policy` and set it to `Start and stop manually`.
@@ -2098,7 +2114,7 @@ queries:
           desc: |
             To set the policy to reject forged transmissions using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `Networking`.
             3. Select `Virtual switches`, then select `Edit`.
             4. Select `Security`.
@@ -2115,6 +2131,8 @@ queries:
             ```bash
             esxcli network vswitch standard policy security set -v vSwitch2 -f false
             ```
+
+            Replace `vSwitch2` with the target switch and run the command for each standard vSwitch on the host. List them with `esxcli network vswitch standard list`. Distributed switches and any per-port-group security overrides are configured separately and are not changed by this command.
         - id: terraform
           desc: |
             To reject forged transmits on a standard vSwitch using Terraform, set `allow_forged_transmits` to `false` on the `vsphere_host_virtual_switch` resource:
@@ -2201,7 +2219,7 @@ queries:
           desc: |
             To set the MAC Address Change policy to reject using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `Networking`.
             3. Select `Virtual switches`, then select `Edit`.
             4. Select `Security`.
@@ -2218,6 +2236,8 @@ queries:
             ```bash
             esxcli network vswitch standard policy security set -v vSwitch2 -m false
             ```
+
+            Replace `vSwitch2` with the target switch and run the command for each standard vSwitch on the host. List them with `esxcli network vswitch standard list`. Distributed switches and any per-port-group security overrides are configured separately and are not changed by this command.
         - id: terraform
           desc: |
             To reject MAC address changes on a standard vSwitch using Terraform, set `allow_mac_changes` to `false` on the `vsphere_host_virtual_switch` resource:
@@ -2304,7 +2324,7 @@ queries:
           desc: |
             To set the Promiscuous Mode policy to reject using the vSphere Client:
 
-            1. From the vSphere Web Client, select the host.
+            1. From the vSphere Client, select the host.
             2. Select `Configure`, then expand `Networking`.
             3. Select `Virtual switches`, then select `Edit`.
             4. Select `Security`.
@@ -2321,6 +2341,8 @@ queries:
             ```bash
             esxcli network vswitch standard policy security set -v vSwitch2 -p false
             ```
+
+            Replace `vSwitch2` with the target switch and run the command for each standard vSwitch on the host. List them with `esxcli network vswitch standard list`. Distributed switches and any per-port-group security overrides are configured separately and are not changed by this command.
         - id: terraform
           desc: |
             To reject promiscuous mode on a standard vSwitch using Terraform, set `allow_promiscuous` to `false` on the `vsphere_host_virtual_switch` resource:

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-security-baseline
     name: Mondoo VMware vSphere Security Baseline
-    version: 2.1.2
+    version: 2.1.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -269,10 +269,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable Autologon using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.autologon.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.autologon.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -367,10 +373,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable BIOS BBS using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.bios.bbs.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.bios.bbs.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -466,10 +478,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Drag and Drop Version Get feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.vmxDnDVersionGet.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.vmxDnDVersionGet.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -565,10 +583,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Drag and Drop Version Set feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.guestDnDVersionSet.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.guestDnDVersionSet.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -664,10 +688,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the GetCreds feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.getCreds.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.getCreds.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -763,10 +793,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Guest Host Interaction Launch Menu feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.launchmenu.change" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.launchmenu.change" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -862,10 +898,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Guest Host Interaction Protocol Handler feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.protocolhandler.info.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.protocolhandler.info.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -961,10 +1003,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Guest Host Interaction Tray Icon feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.trayicon.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.ghi.trayicon.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -1056,10 +1104,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable hardware-based 3D acceleration using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "mks.enable3d" -value $false
+            Get-VM | New-AdvancedSetting -Name "mks.enable3d" -value $false -Force
             ```
         - id: terraform
           desc: |
@@ -1158,10 +1212,16 @@ queries:
             This will cause the VMX process to not respond to commands from the tools process. Setting isolation.tools.hgfsServerSet.disable to TRUE disables the registration of the guest's HGFS server with the host. APIs that use HGFS to transfer files to and from the guest operating system, such as some VIX commands or the VMware Tools auto-upgrade utility, will not function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Host Guest File System Server using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.hgfsServerSet.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.hgfsServerSet.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -1253,10 +1313,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To prevent host information from being sent to guests using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "tools.guestlib.enableHostInfo" -value $false
+            Get-VM | New-AdvancedSetting -Name "tools.guestlib.enableHostInfo" -value $false -Force
             ```
         - id: terraform
           desc: |
@@ -1351,10 +1417,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To limit informational messages from the VM to the VMX file using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "tools.setInfo.sizeLimit" -value 1048576
+            Get-VM | New-AdvancedSetting -Name "tools.setInfo.sizeLimit" -value 1048576 -Force
             ```
         - id: terraform
           desc: |
@@ -1453,10 +1525,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the memSchedFakeSampleStats feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.memSchedFakeSampleStats.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.memSchedFakeSampleStats.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -1531,6 +1609,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To convert nonpersistent disks to persistent mode using PowerCLI, run the following command. The VM must be powered off before changing disk persistence:
 
             ```powershell
@@ -1618,6 +1702,12 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To limit a VM to one remote console connection using PowerCLI, run the following command for each VM. The `-Force` flag overwrites the value on VMs where the parameter already exists:
 
             ```powershell
@@ -1687,15 +1777,30 @@ queries:
 
         The check passes when no virtual machine has any `pciPassthru` advanced parameter defined. It fails for any VM where the command returns one or more matching parameters.
       remediation:
+        - id: vsphere-client
+          desc: |
+            To remove PCI and PCIe device pass-through using the vSphere Client:
+
+            1. Select the VM then select `Actions` followed by `Edit Settings`.
+            2. On the `Virtual Hardware` tab, locate any `PCI device` entries and remove them.
+            3. Select the `VM Options` tab, expand `Advanced`, and select `EDIT CONFIGURATION`.
+            4. Remove any parameters whose name contains `pciPassthru`.
+            5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
-            To disable PCI and PCIe device pass-through using PowerCLI, remove all `pciPassthru` advanced parameters from each VM:
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
+            To remove all `pciPassthru` advanced parameters from each VM, run:
 
             ```powershell
             Get-VM | Get-AdvancedSetting -Name "pciPassthru*" | Remove-AdvancedSetting -Confirm:$false
             ```
 
-            Also remove any `PCI device` entries from the VM hardware list using `Edit Settings` in the vSphere Client.
+            Removing the underlying `PCI device` hardware entries is not exposed by PowerCLI; complete that step with the vSphere Client method above.
         # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
@@ -1782,10 +1887,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Request Disk Topology feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.dispTopoRequest.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.dispTopoRequest.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -1881,10 +1992,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Shell Action feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.ghi.host.shellAction.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.ghi.host.shellAction.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -1975,15 +2092,19 @@ queries:
             4. Select `ADD CONFIGURATION PARAMS` then input `log.keepOld` with a value of `10`.
             5. Select `OK`, then `OK` again.
 
-            **Impact:**
-
-            A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+            **Warning:** Do not disable logging to satisfy this control. Disabling VM logging removes the audit and troubleshooting record this check is meant to preserve, makes incident investigation and vendor support far harder, and weakens security visibility. Keep logging enabled and tune the rotation count and size instead.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To set the number of VM log files to `10` using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "log.keepOld" -value "10"
+            Get-VM | New-AdvancedSetting -Name "log.keepOld" -value "10" -Force
             ```
         - id: terraform
           desc: |
@@ -2079,10 +2200,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Trash Folder State feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.trashFolderState.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.trashFolderState.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2185,6 +2312,8 @@ queries:
               efi_secure_boot_enabled = true
             }
             ```
+
+            **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before applying this change to existing virtual machines.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-898217D4-689D-4EB5-866C-888353FE241C.html
         title: Enable or Disable UEFI Secure Boot for a Virtual Machine
@@ -2257,10 +2386,16 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To prevent unauthorized device connections using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.device.connectable.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.device.connectable.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2343,10 +2478,16 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To prevent unauthorized device modifications and disconnections using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.device.edit.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.device.edit.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2442,10 +2583,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity Active feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityActive.disable" -value $True
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityActive.disable" -value $True -Force
             ```
         - id: terraform
           desc: |
@@ -2541,10 +2688,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity Interlock feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityInterlockOperation.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unityInterlockOperation.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2640,10 +2793,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2739,10 +2898,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity Push Update feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.push.update.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.push.update.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2838,10 +3003,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity Taskbar feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.taskbar.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.taskbar.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -2937,10 +3108,16 @@ queries:
             Some automated tools and processes may cease to function.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable the Unity Window Contents feature using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.windowContents.disable" -value $True
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.unity.windowContents.disable" -value $True -Force
             ```
         - id: terraform
           desc: |
@@ -3009,6 +3186,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To remove all CD/DVD drives from VMs using PowerCLI, run the following command:
 
             ```powershell
@@ -3072,6 +3255,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To remove all floppy drives from VMs using PowerCLI, run the following command:
 
             ```powershell
@@ -3135,6 +3324,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To remove all parallel ports from VMs using PowerCLI, run the following script:
 
             ```powershell
@@ -3210,6 +3405,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To remove all serial ports from VMs using PowerCLI, run the following script:
 
             ```powershell
@@ -3285,6 +3486,12 @@ queries:
       remediation:
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To remove all USB devices from VMs using PowerCLI, run the following command:
 
             ```powershell
@@ -3375,10 +3582,16 @@ queries:
             Inability to shrink virtual machine disks in the event that a datastore runs out of space.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable virtual disk shrinking using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskShrink.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskShrink.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -3470,10 +3683,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable virtual disk wiping using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskWiper.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.diskWiper.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -3730,10 +3949,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable VM Console Copy operations using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.copy.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.copy.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -3825,10 +4050,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable VM Console Drag and Drop operations using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.dnd.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.dnd.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -3920,10 +4151,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable VM Console GUI Options using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.setGUIOptions.enable" -value $false
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.setGUIOptions.enable" -value $false -Force
             ```
         - id: terraform
           desc: |
@@ -4015,10 +4252,16 @@ queries:
             5. Select `OK`, then `OK` again.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To disable VM Console Paste operations using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "isolation.tools.paste.disable" -value $true
+            Get-VM | New-AdvancedSetting -Name "isolation.tools.paste.disable" -value $true -Force
             ```
         - id: terraform
           desc: |
@@ -4109,15 +4352,19 @@ queries:
             4. Select `ADD CONFIGURATION PARAMS` then input `log.rotateSize` with a value of `1024000`.
             5. Select `OK`, then `OK` again.
 
-            **Impact:**
-
-            A more extreme strategy is to disable logging altogether for the virtual machine. Disabling logging makes troubleshooting challenging and support difficult. Do not consider disabling logging unless the log file rotation approach proves insufficient.
+            **Warning:** Do not disable logging to satisfy this control. Disabling VM logging removes the audit and troubleshooting record this check is meant to preserve, makes incident investigation and vendor support far harder, and weakens security visibility. Keep logging enabled and tune the rotation count and size instead.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To limit the VM log file size using PowerCLI, run the following command for each VM:
 
             ```powershell
-            Get-VM | New-AdvancedSetting -Name "log.rotateSize" -value "1024000"
+            Get-VM | New-AdvancedSetting -Name "log.rotateSize" -value "1024000" -Force
             ```
         - id: terraform
           desc: |
@@ -5102,6 +5349,12 @@ queries:
             4. Select the key provider and apply the change. A rolling disk-group reformat may occur.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To enable vSAN data-at-rest encryption using PowerCLI:
 
             ```powershell
@@ -5191,6 +5444,12 @@ queries:
             Data-in-transit encryption does not require an external key provider; vSAN manages the keys internally.
         - id: powershell
           desc: |
+            This requires VMware PowerCLI. First connect to vCenter Server with `Connect-VIServer`:
+
+            ```powershell
+            Connect-VIServer -Server <vcenter-fqdn>
+            ```
+
             To enable vSAN data-in-transit encryption using PowerCLI:
 
             ```powershell


### PR DESCRIPTION
Remediation-quality fixes to the two VMware vSphere policies, driven by a remediation-quality audit. Only remediation/desc/audit prose and code were changed; no `mql`, `filters`, `uid`, `title`, `impact`, or `tags` were modified, and no method ids were renamed. Both policies' patch versions are bumped.

## vSphere VM (`mondoo-vmware-vsphere.mql.yaml`, 2.1.2 -> 2.1.3)

- **V1 (`-Force`):** Added `-Force` to all 32 `New-AdvancedSetting` remediation commands so they overwrite an existing wrong value instead of erroring on exactly the VMs the check flags. (The remote-console check already used `-Force`.)
- **V3 (Connect-VIServer):** Prepended a "this requires VMware PowerCLI; connect with `Connect-VIServer`" step to all 42 PowerCLI remediation blocks so each is runnable in isolation, matching the audit blocks.
- **V4 (UEFI Secure Boot Terraform):** Repeated the console method's "switching BIOS to EFI can make an installed guest unbootable; verify compatibility first" warning in the Terraform block.
- **V5 (VM log files / size):** Reframed the "disable logging altogether" Impact note as a do-not-disable-logging warning, for both the log-count and log-size checks.
- **V6 (PCI/PCIe passthrough):** Split the single PowerCLI method that ended by telling the user to finish in the console into a self-contained `vsphere-client` method (PCI device + advanced-param removal) plus the PowerCLI advanced-param cleanup.

## vSphere ESXi (`mondoo-vmware-vsphere-esxi.mql.yaml`, 2.0.3 -> 2.0.4)

- **E4 (Web Client rename):** Replaced the retired Flash "vSphere Web Client" with "vSphere Client" across all 18 occurrences.
- **E1 (SSH disable lockout):** Added a warning to disable SSH from the vSphere Client/DCUI rather than the SSH session being terminated, plus the lockdown-mode re-enable caveat (both the console and PowerCLI methods).
- **E3 (static DNS):** Strengthened the warning: run from DCUI/console, confirm `vmk0` is the management interface, have console access ready, and noted the gateway may need `esxcli network ip route ipv4 add`.
- **E5 (persistent logging):** Fixed `Syslog.global.LogDir` to `Syslog.global.logDir`.
- **E7 (NTP PowerCLI):** Added the `Connect-VIServer` step and swapped `pool2.ntp.org` for realistic placeholders (`0.pool.ntp.org`, `1.pool.ntp.org`).
- **E9 (vSwitch security):** Noted the command must run for each standard vSwitch (with `esxcli network vswitch standard list`) and that dvSwitch/port-group overrides are set separately, across all three vSwitch checks.
- **E10 (code fences):** Tagged the two bare ``` fences (dcui-timeout, salt-per-vm) as ```powershell.

## Left for maintainers (VERIFY)

These were intentionally not changed because they require checking against current Broadcom-era VMware docs:

- **V2 (`vvtd_enabled` in the VBS Terraform block):** Audit flags `vvtd_enabled` (IO-MMU / VT-d) as not a VBS prerequisite and absent from the prose/console steps. Left as-is pending confirmation of whether to drop it or document it.
- **V7 (vSAN data-at-rest PowerCLI uses `Get-KmsCluster`):** Snippet assumes an external KMS; the console offers Native Key Provider too. The Connect-VIServer prereq was added, but the external-KMS-vs-NKP gap is left for review.
- **E2 (MOB `vim-cmd` claim):** The "must disable MOB from the vSphere interface, not via `vim-cmd`" and "cannot disable under lockdown mode" claims read as folklore; substantiate or remove against ESXi 7.x/8.x docs (the `Config.HostAgent.plugins.solo.enableMob` advanced setting is the supported path).
- **E6 (SNMPv3 esxcli flags):** The `--v3targets` example likely also needs `--engineid` and a configured v3 `--users` before a v3 target works; verify the full flag set.
- **E8 (`secureBoot.py` path):** Verify `/usr/lib/vmware/secureboot/bin/secureBoot.py -c` path and flags on ESXi 8.x; it is the only remediation method for that check.

## Validation

Both policies pass `cnspec policy lint`:

```
content/mondoo-vmware-vsphere.mql.yaml      -> valid policy bundle(s)
content/mondoo-vmware-vsphere-esxi.mql.yaml -> valid policy bundle(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)