### PR TITLE
🐛 tailscale: recommend OAuth clients for automation + fix auto-update flag

### DIFF
--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.3.2
+    version: 1.3.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -25,6 +25,10 @@ policies:
         - Tailscale client software updates
         - User access controls and ACL configuration
         - Key expiry and rotation
+
+        **A note on API authentication**
+
+        The audit and command-line examples in this policy authenticate to the Tailscale API with a personal API key passed through HTTP basic auth, written as `curl -u "$TAILSCALE_API_KEY:"`. This is the simplest way to run a check interactively. Personal API keys are capped at a maximum lifetime of 90 days and must be rotated by hand, so they are a poor fit for unattended automation. For scheduled jobs and pipelines, Tailscale recommends an OAuth client instead. An OAuth client exchanges its credentials for a short-lived access token that you pass as a Bearer token, written as `curl -H "Authorization: Bearer $TAILSCALE_ACCESS_TOKEN"`, and each client is scoped to only the API capabilities it needs. Substitute Bearer-token authentication for the basic-auth examples below when wiring these commands into automation.
 
         Learn more about scanning Tailscale in the [cnspec Tailscale documentation](https://mondoo.com/docs/cnspec/saas/tailscale).
 
@@ -124,7 +128,7 @@ queries:
 
         ### Audit via API
 
-        Query the Tailscale API and inspect the result:
+        Query the Tailscale API and inspect the result. The example uses a personal API key for interactive use; for automation, authenticate with an OAuth client Bearer token as described in the policy overview.
 
         ```bash
         curl -s -u "$TAILSCALE_API_KEY:" \
@@ -260,7 +264,7 @@ queries:
 
         ### Audit via API
 
-        Query the Tailscale API and inspect the result:
+        Query the Tailscale API and inspect the result. The example uses a personal API key for interactive use; for automation, authenticate with an OAuth client Bearer token as described in the policy overview.
 
         ```bash
         curl -s -u "$TAILSCALE_API_KEY:" \
@@ -404,8 +408,10 @@ queries:
             Enable automatic updates on the device so future releases install without manual action:
 
             ```bash
-            sudo tailscale set --auto-update
+            sudo tailscale set --auto-update=true
             ```
+
+            Auto-update is not available on every install. It is unsupported on Tailscale clients installed through some Linux package managers and on static or musl builds, where the binary cannot replace itself. On those systems, keep the client current through the package manager or your patch management process instead.
 
             Where the client was installed through a package manager or app store, update through that channel instead:
 


### PR DESCRIPTION
Remediation-quality fixes for `content/mondoo-tailscale-security.mql.yaml`, addressing findings #11 and #38 from the small-policies remediation audit.

## API authentication currency (#11)

Every audit and CLI example in the policy authenticates to the Tailscale API with a personal API key over HTTP basic auth (`curl -u "$TAILSCALE_API_KEY:"`). Tailscale now recommends OAuth clients for automation, and personal API keys are capped at a 90-day lifetime, so the examples were steering operators toward the weaker path.

- Added a "note on API authentication" section to the policy overview: keeps the API-key example as the simple interactive case, explains the 90-day cap, and documents the OAuth client Bearer-token approach (`curl -H "Authorization: Bearer $TAILSCALE_ACCESS_TOKEN"`) as the recommended automation method, scoped per client.
- Added a one-line pointer to the OAuth approach in the `devices-authorized` and `key-expiry` audit-via-API blocks called out in the finding.

## Auto-update flag (#38)

`devices-client-up-to-date` CLI remediation:

- `sudo tailscale set --auto-update` → `sudo tailscale set --auto-update=true` (canonical form).
- Noted that auto-update is unavailable on some installs (certain Linux package managers, static/musl builds) and to use the package manager or patch management process there instead.

## Scope

- Edited prose and remediation code only. No changes to `mql`, `filters`, `uid`, `title`, `impact`, or `tags`.
- Version bumped 1.3.2 → 1.3.3.

## Validation

- `cnspec policy lint content/mondoo-tailscale-security.mql.yaml` → valid policy bundle.
- `python3 content/validation/validate_remediation_commands.py tailscale` → all endpoints PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)