### PR TITLE
🐛 google-workspace: clarify 2SV enforcement + portable date in Reports-API snippets

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-google-workspace-security
     name: Mondoo Google Workspace Security
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -110,13 +110,15 @@ queries:
       remediation:
         - id: console
           desc: |
+            This check passes only when 2-step verification is enforced for every user. Allowing users to turn on 2-step verification permits self-enrollment but does not enforce it, so that step alone does not satisfy the check. You must turn on enforcement.
+
             To enforce 2-step verification for Google Workspace users:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
             2. Go to **Security** > **Authentication** > **2-step verification**.
-            3. Check **Allow users to turn on 2-step verification** and click **Save**.
+            3. Check **Allow users to turn on 2-step verification** and click **Save**. This permits enrollment but is a prerequisite only and does not by itself make the check pass.
             4. Notify all users to enroll in 2-step verification, and track enrollment progress under **Reporting** > **Reports** > **User Reports** > **Security**.
-            5. Once users have enrolled, return to **Security** > **Authentication** > **2-step verification** and under **Enforcement** select **Turn on enforcement from** with a date that gives remaining users time to enroll.
+            5. Turn on enforcement: return to **Security** > **Authentication** > **2-step verification** and under **Enforcement** select **Turn on enforcement from** with a date that gives remaining users time to enroll. This enforcement step is what makes the check pass.
             6. Set a **New user enrollment period** such as one week so new accounts can sign in once and enroll before enforcement applies to them.
             7. Click **Save**.
 
@@ -176,7 +178,8 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
-        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
+        # GNU date (Linux) uses -d; BSD date (macOS) uses -v. This tries both so the snippet is portable.
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -v-2d +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
           "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin"
         ```
@@ -245,7 +248,8 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
-        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
+        # GNU date (Linux) uses -d; BSD date (macOS) uses -v. This tries both so the snippet is portable.
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -v-2d +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
           "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin"
         ```
@@ -309,7 +313,8 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
-        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
+        # GNU date (Linux) uses -d; BSD date (macOS) uses -v. This tries both so the snippet is portable.
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -v-2d +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
           "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_less_secure_apps_access_allowed"
         ```
@@ -318,14 +323,16 @@ queries:
       remediation:
         - id: console
           desc: |
-            Google removed support for less secure apps from Google Workspace in 2024, and the **Less secure apps** setting no longer appears in the Admin console. Sign-ins that use only a username and password are rejected for Gmail, Google Calendar, and Google Contacts, so any account still reporting less secure app access reflects stale report data or a legacy configuration set through the API.
+            This remediation is informational. Google removed support for less secure apps from Google Workspace in 2024, and the **Less secure apps** setting no longer appears in the Admin console. Sign-ins that use only a username and password are rejected for Gmail, Google Calendar, and Google Contacts, so there is no live setting to disable. Any account still reporting less secure app access reflects residual legacy state: stale report data, or a value that was set through the API before the feature was removed.
 
-            To clear remaining legacy access:
+            Because the control no longer exists, no configuration change is required to make the environment safe. The steps below only clean up leftover legacy access and report noise:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/) using your administrator account.
             2. Go to **Security** > **Access and data control** > **API controls** and review which apps are granted access to Google Workspace data.
             3. Identify users or devices still connecting through IMAP, POP, or SMTP with passwords and migrate them to clients that support OAuth.
             4. Remove app passwords that are no longer needed by having each user visit [App passwords](https://myaccount.google.com/apppasswords) and delete unused entries.
+
+            Note for maintainers: because less secure app access can no longer be enabled in Google Workspace, this control reports only residual legacy state and may warrant deprecation or a lower impact in a future revision.
 
             For more details, see [Transition from less secure apps to OAuth](https://support.google.com/a/answer/14114704).
     refs:
@@ -381,7 +388,8 @@ queries:
         Query the Google Admin SDK Reports API and inspect the result:
 
         ```bash
-        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d)
+        # GNU date (Linux) uses -d; BSD date (macOS) uses -v. This tries both so the snippet is portable.
+        REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -v-2d +%Y-%m-%d)
         curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
           "https://admin.googleapis.com/admin/reports/v1/usage/users/all/dates/$REPORT_DATE?parameters=accounts:is_super_admin,accounts:num_security_keys"
         ```


### PR DESCRIPTION
## What

Remediation-quality fixes to `content/mondoo-google-workspace-security.mql.yaml`. Version bumped `1.2.2` to `1.2.3`. Only remediation/desc/audit prose and code were touched; no mql, filters, uid, title, impact, or tags changed.

### two-step-verification-enforced (console) — finding #7
The check asserts `isEnforcedIn2Sv == true`, but "Allow users to turn on 2-step verification" only permits self-enrollment. A reader who stopped after "Allow" + Save believed they were done while the check still failed.

- Made turning on enforcement ("Turn on enforcement from") the headline action.
- Added an up-front note that enforcement is required for the check to pass and that allowing users to turn on 2SV is a prerequisite only.
- Marked the "Allow users to turn on" step explicitly as a prerequisite that does not by itself satisfy the check.

### Reports-API snippets — portable date (finding #39)
`REPORT_DATE=$(date -d "2 days ago" ...)` is GNU-only and fails on macOS/BSD before curl runs. Fixed once and applied across all four Reports-API snippets (limit-super-admins audit + console, less-secure-app-access audit, hardware-2FA audit):

```bash
# GNU date (Linux) uses -d; BSD date (macOS) uses -v. This tries both so the snippet is portable.
REPORT_DATE=$(date -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -v-2d +%Y-%m-%d)
```

### less-secure-app-access-should-not-be-allowed (console) — finding #8
Google removed less secure app support from Workspace in 2024; the control can only clean up residual legacy state. Reframed the remediation as informational, made clear no configuration change is required for safety, and added a maintainer note that the control may warrant deprecation or a lower impact in a future revision. Per the task scope, MQL and impact were left unchanged.

## Deferred / notes for maintainers

- The less-secure-app-access control remains at impact 70 and active. The PR only reframes the prose and flags the deprecation question in a maintainer note; changing impact/MQL is out of scope for this prose-only pass.

## Validation

- `cnspec policy lint content/mondoo-google-workspace-security.mql.yaml` → valid policy bundle(s).
- No em-dashes, `--`, or parenthetical asides introduced in prose.

## VERIFY items

- Confirm the BSD/GNU `date` fallback (`date -v-2d`) is acceptable house style for portable shell snippets, vs. a note that the snippet assumes GNU `date`.
- Maintainers to decide whether less-secure-app-access should be deprecated or have its impact lowered now that the underlying control no longer exists in Google Workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)