### PR TITLE
🐛 github-best-practices: portable base64/printf in contents-API cli blocks

### DIFF
--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-repository-best-practices
     name: Mondoo GitHub Repository Best Practices
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices
@@ -89,6 +89,8 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
+            You need write access to the repository to commit a new file.
+
             1. Navigate to your repository on GitHub.
             2. Click on the "Add file" button.
             3. Select "Create new file".
@@ -122,16 +124,20 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             ```bash
             gh api --method PUT /repos/OWNER/REPO/contents/SUPPORT.md \
               -f message="Add support resources" \
-              -f content="$(cat <<'CONTENT' | base64
+              -f content="$(cat <<'CONTENT' | base64 | tr -d '\n'
             # Support
 
             For help, open an issue or contact support@example.com
             CONTENT
             )"
             ```
+
+            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project
         title: Adding support resources to your project
@@ -179,6 +185,8 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
+            You need write access to the repository to commit a new file.
+
             1. Navigate to your repository on GitHub.
             2. Click on the "Add file" button.
             3. Select "Create new file".
@@ -205,16 +213,20 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             ```bash
             gh api --method PUT /repos/OWNER/REPO/contents/CODE_OF_CONDUCT.md \
               -f message="Add code of conduct" \
-              -f content="$(cat <<'CONTENT' | base64
+              -f content="$(cat <<'CONTENT' | base64 | tr -d '\n'
             # Code of Conduct
 
             This project follows the Contributor Covenant Code of Conduct.
             CONTENT
             )"
             ```
+
+            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
         title: Adding a CODE_OF_CONDUCT.md to your project
@@ -351,13 +363,17 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             Create a .gitignore file in an existing repository:
 
             ```bash
             gh api --method PUT /repos/OWNER/REPO/contents/.gitignore \
               -f message="Add .gitignore" \
-              -f content="$(gh api /gitignore/templates/Go --jq '.source' | base64)"
+              -f content="$(gh api /gitignore/templates/Go --jq '.source' | base64 | tr -d '\n')"
             ```
+
+            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
     refs:
       - url: https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
         title: Ignoring files
@@ -401,6 +417,8 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
+            You need write access to the repository to edit and commit the file.
+
             1. Navigate to your repository on GitHub.
             2. Open the `README.md` file and click the pencil icon to edit it.
             3. Add a section that names the people or teams responsible for the project. For example:
@@ -419,6 +437,8 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             Fetch the current README, add an authors section, and update:
 
             ```bash
@@ -427,17 +447,17 @@ queries:
             SHA=$(echo "$README" | jq -r '.sha')
             CONTENT=$(echo "$README" | jq -r '.content' | base64 -d)
 
+            # Build the new content
+            NEW_CONTENT=$(printf '%s\n\n## Authors\n\n- Author Name\n' "$CONTENT")
+
             # Append authors section and update
             gh api --method PUT /repos/OWNER/REPO/contents/README.md \
               -f message="Add authors section" \
               -f sha="$SHA" \
-              -f content="$(echo "${CONTENT}
-
-            ## Authors
-
-            - Author Name
-            " | base64)"
+              -f content="$(printf '%s' "$NEW_CONTENT" | base64 | tr -d '\n')"
             ```
+
+            Use `printf '%s'` rather than `echo` so README content containing backticks, `$`, or backslashes (common in code fences) is preserved instead of being interpreted by the shell. The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns; the GitHub contents API rejects base64 content that contains newlines.
         # No Terraform remediation: the fix appends an authors section to an existing README.md, and github_repository_file would overwrite the entire file with static content.
     refs:
       - url: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
@@ -503,16 +523,20 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             ```bash
             gh api --method PUT /repos/OWNER/REPO/contents/README.md \
               -f message="Add README" \
-              -f content="$(cat <<'CONTENT' | base64
+              -f content="$(cat <<'CONTENT' | base64 | tr -d '\n'
             # Project Name
 
             A brief description of the project.
             CONTENT
             )"
             ```
+
+            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
     refs:
       - url: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
         title: About READMEs
@@ -556,6 +580,8 @@ queries:
           desc: |
             **Using the GitHub web UI**
 
+            You need write access to the repository to edit and commit the file.
+
             1. Navigate to your repository on GitHub.
             2. Open the `README.md` file and click the pencil icon to edit it.
             3. Add a section titled "Getting started" that covers:
@@ -570,6 +596,8 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             Fetch the current README, append a getting started section, and update the file:
 
             ```bash
@@ -578,21 +606,19 @@ queries:
             SHA=$(echo "$README" | jq -r '.sha')
             CONTENT=$(echo "$README" | jq -r '.content' | base64 -d)
 
+            # Build the new content
+            NEW_CONTENT=$(printf '%s\n\n## Getting started\n\n1. Install the project.\n2. Configure required settings.\n3. Run the project.\n' "$CONTENT")
+
             # Append a getting started section and update
             gh api --method PUT /repos/OWNER/REPO/contents/README.md \
               -f message="Add getting started guide" \
               -f sha="$SHA" \
-              -f content="$(echo "${CONTENT}
-
-            ## Getting started
-
-            1. Install the project.
-            2. Configure required settings.
-            3. Run the project.
-            " | base64)"
+              -f content="$(printf '%s' "$NEW_CONTENT" | base64 | tr -d '\n')"
             ```
 
             Replace the placeholder steps with real installation and usage instructions for your project.
+
+            Use `printf '%s'` rather than `echo` so README content containing backticks, `$`, or backslashes (common in code fences) is preserved instead of being interpreted by the shell. The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns; the GitHub contents API rejects base64 content that contains newlines.
         # No Terraform remediation: the fix appends a getting started section to an existing README.md, and github_repository_file would overwrite the entire file with static content.
     refs:
       - url: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
@@ -667,6 +693,8 @@ queries:
           desc: |
             **Using GitHub CLI**
 
+            Run `gh auth login` first so the CLI has a token with write access to the repository.
+
             Check if a license exists:
 
             ```bash
@@ -678,8 +706,10 @@ queries:
             ```bash
             gh api --method PUT /repos/OWNER/REPO/contents/LICENSE \
               -f message="Add license" \
-              -f content="$(gh api /licenses/apache-2.0 --jq '.body' | base64)"
+              -f content="$(gh api /licenses/apache-2.0 --jq '.body' | base64 | tr -d '\n')"
             ```
+
+            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository
         title: Adding a license to a repository


### PR DESCRIPTION
## Summary

Remediation-quality fixes for `mondoo-github-best-practices.mql.yaml`. Version bumped `1.2.1` → `1.2.2`.

### Portable base64 (finding #15)

macOS and BSD `base64` wrap output at 76 columns by default, and GitHub's contents API rejects base64 content that contains newlines. The seven CLI remediation blocks that pipe heredoc or command output to `base64` for the contents API therefore failed silently for macOS users. Every contents-API base64 call now ends with `| tr -d '\n'`, with a one-line note explaining the platform caveat:

- support-resources
- code-of-conduct
- gitignore
- include-authors
- readme
- readme-getting-started
- license

`base64 -d` decode calls in audit blocks are correctly left untouched.

### Safe content round-tripping (finding #16)

The include-authors and getting-started README-append blocks used `echo "${CONTENT}..."`, which mangles content containing backticks, `$`, or backslashes (common in README code fences). These now build the new content with `printf '%s'` and pipe through `base64 | tr -d '\n'`, preserving the original bytes.

### Prerequisites

Added the missing prerequisites flagged in the report:

- Web UI paths now note write access is required.
- CLI paths now note to run `gh auth login` first.

## Validation

- `cnspec policy lint content/mondoo-github-best-practices.mql.yaml` → valid policy bundle
- `python3 content/validation/validate_remediation_commands.py github` → 83 passed, 0 failed

## VERIFY

- The heredoc form `cat <<'CONTENT' | base64 | tr -d '\n'` followed by the heredoc body relies on standard shell pipeline ordering (heredoc feeds `cat`; `tr` consumes `base64`). Confirmed correct, but worth a reviewer glance.
- No mql/filters/uid/title/impact/tags were changed; only remediation/desc/audit prose and code plus the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)