### PR TITLE
🐛 bigip: GCM/AEAD cipher guidance + map backend-auth field names

### DIFF
--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-bigip-security
     name: Mondoo F5 BIG-IP Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -389,36 +389,45 @@ queries:
       remediation:
         - id: console
           desc: |
-            To remove weak ciphers from client SSL profiles using the BIG-IP Configuration utility:
+            The most maintainable approach on BIG-IP 13.0 and later is a cipher group built from F5's `f5-secure` cipher rule, which resolves to ECDHE key exchange with AES-GCM suites only. To configure one using the BIG-IP Configuration utility:
 
-            1. Navigate to **Local Traffic → Profiles → SSL → Client**
-            2. Click on the affected profile
-            3. Set the **Configuration** selector to **Advanced**
-            4. In the **Ciphers** setting, select **Cipher String** and enter a list built only from strong suites, for example:
-               `ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES`
-            5. Click **Update**
+            1. Navigate to **Local Traffic → Ciphers → Groups** and click **Create**
+            2. Give the group a name, add the `f5-secure` rule to the **Allowed** column, and click **Finished**
+            3. Navigate to **Local Traffic → Profiles → SSL → Client** and click the affected profile
+            4. Set the **Configuration** selector to **Advanced**
+            5. In the **Ciphers** setting, select **Cipher Group** and choose the group you created
+            6. Click **Update**
+
+            If you must specify a cipher string directly instead of a group, select **Cipher String** and enter a list restricted to AES-GCM suites, for example `ECDHE+AES-GCM:DHE+AES-GCM`. Prefer GCM, an authenticated AEAD mode, over the older CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext as part of decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
 
             **Note**: Clients that support only the removed cipher suites can no longer connect to virtual servers using this profile. Validate the change against your client population in a maintenance window.
         - id: cli
           desc: |
-            To remove weak ciphers from client SSL profiles using tmsh:
+            On BIG-IP 13.0 and later, the recommended approach is a cipher group built from F5's `f5-secure` cipher rule, which resolves to ECDHE key exchange with AES-GCM suites only:
 
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
-            2. Update the cipher string on the client SSL profile:
+            2. Create a cipher group that allows the `f5-secure` rule:
 
                ```
-               tmsh modify ltm profile client-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
+               tmsh create ltm cipher group secure-gcm allow add { f5-secure }
                ```
-            3. From the advanced shell, list the cipher suites the string expands to and confirm no weak suites remain:
+            3. Attach the cipher group to the client SSL profile. The `ciphers none` argument clears any inline cipher string so the group takes effect:
 
                ```
-               tmm --clientciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
+               tmsh modify ltm profile client-ssl <profile-name> cipher-group secure-gcm ciphers none
                ```
-            4. Save the configuration:
+            4. Confirm the group resolves to AES-GCM suites only and that no weak suites remain:
+
+               ```
+               tmsh show ltm cipher group secure-gcm
+               ```
+            5. Save the configuration:
 
                ```
                tmsh save sys config
                ```
+
+            If your release does not support cipher groups, set an inline cipher string restricted to AES-GCM suites instead with `tmsh modify ltm profile client-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`, then verify the expansion with `tmm --clientciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`. Prefer GCM, an authenticated AEAD mode, over CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext during decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
     refs:
       - url: https://my.f5.com/manage/s/article/K13156
         title: F5 - Configuring the cipher strength for SSL profiles
@@ -551,6 +560,10 @@ queries:
         - Compliance frameworks such as PCI DSS require authentication of all parties in a communication channel.
 
         Enabling server authentication ensures the BIG-IP validates the backend server's certificate against a trusted CA before establishing the connection.
+
+        **Mapping the setting across the GUI, tmsh, and the scanner**
+
+        The same control has a different label in each place a junior engineer encounters it. In the BIG-IP Configuration utility it is the **Server Certificate** setting under **Server Authentication**, with the values **ignore** and **require**. In tmsh that setting is the `peer-cert-mode` field, where **ignore** maps to `peer-cert-mode ignore` and **require** maps to `peer-cert-mode require`. To satisfy the control, configure **Server Certificate: require**, which is `peer-cert-mode require`. When auditing a profile by hand, the `peer-cert-mode` value is the field to read.
       audit: |
         ### Audit via the BIG-IP Configuration utility
 


### PR DESCRIPTION
Remediation-quality fixes to `content/mondoo-bigip-security.mql.yaml` from the small-policies audit (findings #35 and #36). Prose, audit, and remediation only — no changes to `mql`/`filters`/`uid`/`title`/`impact`/`tags`. Version bumped `1.0.1` → `1.0.2`.

## Finding #35 — client-ssl-secure-ciphers (console + cli)

The previous "strong suites" example was `ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES`, which still admits the non-GCM CBC suites `ECDHE+AES` and `DHE+AES`.

- Lead both remediation methods with an F5 **cipher group** built from the built-in `f5-secure` cipher rule (BIG-IP 13.0+), which resolves to ECDHE key exchange with AES-GCM suites only.
- cli now uses `tmsh create ltm cipher group secure-gcm allow add { f5-secure }`, attaches it with `cipher-group ... ciphers none`, and verifies with `tmsh show ltm cipher group`.
- Keep an inline AES-GCM-only string (`ECDHE+AES-GCM:DHE+AES-GCM`) as the fallback for releases without cipher groups.
- Add a one-line "why": GCM is an authenticated AEAD mode that authenticates the ciphertext during decryption, closing the padding-oracle/timing weaknesses (BEAST, Lucky 13) that affect CBC suites.

## Finding #36 — server-ssl-authenticate-backend (desc)

Added a paragraph mapping the control across the three places an engineer sees it: GUI **Server Certificate** (ignore/require) → tmsh `peer-cert-mode` (ignore/require). Configuring **Server Certificate: require** = `peer-cert-mode require` satisfies the control; `peer-cert-mode` is the field to read when auditing by hand.

## VERIFY items

1. **Cipher guidance (verified against F5 docs):** F5 ships the built-in `f5-secure` cipher rule described as maximizing regulatory compliance and resolving to ECDHE + AES-GCM suites. Cipher group create syntax (`create ltm cipher group <name> allow add { <rule> }`) and attaching via `cipher-group` with `ciphers none` confirmed against the F5 tmsh reference and DevCentral. The MQL only rejects rc4/des/3des/null/export, so both the cipher-group and the AES-GCM inline string pass the check.

2. **Backend-auth field mapping — possible MQL discrepancy (out of scope to fix here, flagging for follow-up):** Per F5 docs, the GUI **Server Certificate** require/ignore control is the tmsh **`peer-cert-mode`** field. The separate `authenticate` field on a server-ssl profile only takes `always`/`once` (authentication *frequency*), never `none`. The check's MQL is `bigip.serverSslProfiles.none(authenticate == "none")`, and the cnquery bigip provider populates `authenticate` from the F5 REST `authenticate` JSON property (`always`/`once`). That means `authenticate == "none"` may never match and the check could pass unconditionally. Per the task constraints I did not touch the MQL; I wrote the desc mapping to the correct `peer-cert-mode` field rather than asserting `authenticate` reads require/ignore. Recommend a follow-up to point the MQL at `peerCertMode`/`peer-cert-mode` (requires a provider field if not yet exposed).

## Validation

- `cnspec policy lint content/mondoo-bigip-security.mql.yaml` → valid policy bundle(s)
- No em-dashes, `--`, or parenthetical asides in the edited prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)