### PR TITLE
🐛 dns: add registrar DS-record step to DNSSEC remediation

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -265,6 +265,8 @@ queries:
         A passing result shows one or more DNSKEY records published for the domain. A failing result shows an empty answer section, indicating DNSSEC is not enabled.
       remediation: |
         * Enable DNSSEC for your domain through your DNS hosting provider or domain registrar's control panel, following their instructions for signing the zone.
+        * Publish the DS (Delegation Signer) record at your domain registrar so it appears in the parent zone. Signing the zone at the DNS host only generates the keys. Until the matching DS record exists in the parent zone, resolvers have no trust anchor and DNSSEC validation never activates. This missing DS-record step is the most common reason DNSSEC appears configured but provides no protection. If your DNS host and registrar are different providers, copy the DS record (or the DNSKEY values used to build it) from the host into the registrar's DNSSEC settings.
+        * Verify the DS record is live in the parent zone with `dig DS <domain>`. An empty answer section means the registrar has not published it yet and the chain of trust is broken.
         * Monitor DNSSEC signatures so they remain valid and do not expire. Set up alerts or reminders for signature expiration dates.
         * Verify proper configuration with `dig DNSKEY <domain>` and `dig +dnssec <domain>`, and address any validation warnings promptly.
         * Establish a process for periodic DNSSEC reviews to ensure ongoing compliance and security.


### PR DESCRIPTION
## Summary

Remediation-quality fix for `content/mondoo-dns-security.mql.yaml`, from the small-policies remediation-quality audit. The audit found this policy "generally solid and current," with one gap.

## Change

**`mondoo-dns-security-dnssec-enabled` remediation** (audit finding #20)

The existing remediation covered signing the zone at the DNS host and verifying DNSKEY records, but omitted the registrar DS-record step. Signing the zone only generates the keys; until the matching DS (Delegation Signer) record is published in the parent zone, resolvers have no trust anchor and DNSSEC validation never activates. This is the single most common reason DNSSEC appears configured but provides no protection, and a frequent junior-engineer mistake.

Added a remediation step to:
- Publish the DS record at the registrar so it lands in the parent zone, with the "why" explained.
- Handle the split DNS-host/registrar case (copy the DS record or DNSKEY values across).
- Verify the DS record is live with `dig DS <domain>`.

Only remediation prose/code was edited; no changes to mql/filters/uid/title/impact/tags. Version bumped 1.3.1 -> 1.3.2.

## Validation

`cnspec policy lint content/mondoo-dns-security.mql.yaml` -> valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)