### PR TITLE
🐛 slack: add SSO/Enterprise-Grid caveats to admin 2FA remediation

### DIFF
--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.6.1
+    version: 1.6.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -163,7 +163,7 @@ queries:
         1. Sign in to your Slack workspace as an owner or admin.
         2. Open **Tools & settings > Manage members**.
         3. Filter the list to show **Workspace Admins** and **Workspace Owners**.
-        4. Review the **2FA** column for each administrator and confirm the method shown is an authentication app rather than SMS.
+        4. Review the **2FA** column for each administrator and confirm the method shown is an authentication app rather than SMS. On Enterprise Grid the **2FA** column may be absent, in which case use the API audit below.
 
         A passing result shows every administrator using an authentication app for two-factor authentication; a failing result shows an administrator with two-factor authentication disabled or set to SMS.
 
@@ -181,9 +181,11 @@ queries:
         Slack does not provide a workspace setting that forces a specific two-factor method, so each administrator must switch their own account from SMS to an authentication app:
 
         1. Sign in to your Slack workspace as an owner or admin and open **Tools & settings > Manage members**.
-        2. Review the 2FA column to identify administrators using SMS or no second factor.
+        2. Review the **2FA** column to identify administrators using SMS or no second factor. The **2FA** column is not shown on every plan and may be absent on Enterprise Grid; when it is missing, use the API audit above to identify affected administrators.
         3. Ask each affected administrator to open their [account settings](https://slack.com/account/settings), expand **Two-Factor Authentication**, and select the option to use an authentication app such as Google Authenticator or 1Password.
         4. Confirm in **Manage members** that every admin and owner now shows an authentication app as their 2FA method.
+
+        If your workspace or organization signs in through single sign-on, the per-account Slack two-factor settings are unavailable. Enforce multi-factor authentication in your identity provider instead, and require an authenticator app or a phishing-resistant method for administrator accounts there.
 
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
@@ -257,6 +259,8 @@ queries:
         3. Select the **Authentication** tab.
         4. Next to **Workspace-wide two-factor authentication**, click **Expand**, then activate two-factor authentication for the workspace.
         5. Members who have not yet enrolled are signed out and prompted to set up two-factor authentication the next time they sign in.
+
+        **Warning:** Activating workspace-wide two-factor authentication immediately signs out every member who has not already enrolled and blocks them from working until they complete enrollment. Notify members in advance, and consider enabling it outside core working hours so unenrolled users are not interrupted mid-task.
 
         If your workspace signs in through single sign-on, enforce multi-factor authentication in your identity provider instead, because Slack two-factor authentication is unavailable when SSO is enabled.
 


### PR DESCRIPTION
## Summary

Remediation-quality fixes for `content/mondoo-slack-security.mql.yaml`, addressing finding #34 from the small-policies remediation audit. The admin 2FA check assumed a single non-Grid Admin Settings UI with a "2FA column" present on every plan, and the SSO caveat only existed in the all-users check.

## Changes

- **`admins-secure-2fa-methods`**
  - Audit: note the **2FA** column may be absent on Enterprise Grid and to use the API audit instead.
  - Remediation: same Enterprise-Grid caveat with API fallback, plus the SSO caveat directing admins to enforce MFA in their identity provider (Slack's per-account 2FA settings are unavailable under SSO).
- **`use-strong-factors`**
  - Added a warning that activating workspace-wide two-factor authentication immediately signs out unenrolled members and blocks them until they enroll, with guidance to notify members and enable it outside core working hours.

Prose only. No changes to `mql`, `filters`, `uid`, `title`, `impact`, or `tags`. Version bumped `1.6.1` → `1.6.2`.

## Validation

- `cnspec policy lint content/mondoo-slack-security.mql.yaml` → valid
- `python3 content/validation/validate_remediation_commands.py slack` → 8 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)