### PR TITLE
🐛 mcp: note transport variability (stdio/SSE) + structural prompt-injection guidance

### DIFF
--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-mcp-security
     name: Mondoo Model Context Protocol (MCP) Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -92,6 +92,8 @@ queries:
 
         ### Audit via the JSON-RPC interface
 
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
+
         1. Send a `tools/list` request to the server endpoint:
 
            ```bash
@@ -171,11 +173,13 @@ queries:
 
         1. Connect an MCP client to the server and invoke `tools/list` and `prompts/list`.
         2. Read the `name`, `title`, and `description` fields of each returned tool and prompt.
-        3. Look for imperative phrasing aimed at the model, role-override wording such as "act as" or "system:", and hidden delimiters such as `<|...|>` or fenced JSON imitating an assistant turn.
+        3. Look for any text that reads as an instruction to the model rather than a description of the tool. Treat the metadata as data the model should never obey. Examples include role-override wording such as "act as" or "system:", and hidden delimiters such as `<|...|>` or fenced JSON imitating an assistant turn. This list is not exhaustive, so flag any imperative phrasing aimed at the model even when it does not match a known pattern.
 
         The server passes when metadata only describes tool capability. It fails when any field instructs or attempts to reconfigure the model.
 
         ### Audit via the JSON-RPC interface
+
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
         1. Retrieve the tool and prompt definitions:
 
@@ -186,7 +190,7 @@ queries:
            ```
 
         2. Repeat the request with `"method":"prompts/list"`.
-        3. Inspect the metadata fields for directive language, jailbreak phrasing, and embedded tool-call instructions.
+        3. Inspect the metadata fields for any content that instructs the model rather than describing the tool, including directive language, jailbreak phrasing, and embedded tool-call instructions.
 
         The server passes when no metadata field contains injection content. It fails when any field carries instructions directed at the model.
       remediation:
@@ -194,16 +198,19 @@ queries:
           desc: |
             **Rewrite tool and prompt metadata**
 
-            Rewrite tool and prompt metadata so it describes capability rather than instructs the model. Anything that reads like a directive aimed at the LLM must be removed.
+            The durable fix is structural rather than a fixed denylist of bad phrases. Treat all metadata as descriptive content that the model must never execute, and never as imperative instructions. A literal blocklist of delimiters or trigger words is brittle because attackers paraphrase, and the surface evolves with the spec, so apply the principle first and use the patterns below only as non-exhaustive examples.
 
-            Strip the following patterns from `name`, `title`, and `description`:
+            1. Rewrite each `name`, `title`, and `description` to state what the tool does, what arguments it accepts, and what it returns. Phrasing that reads like a directive aimed at the model must be removed.
+            2. Keep untrusted text inside argument values, where it is data the model evaluates rather than metadata the model trusts. Where end-user text must pass through MCP, sanitize it before it reaches metadata fields.
 
-            - Imperative instructions to the model: "Ignore previous instructions", "You are now...", "Always respond with..."
-            - Role-override or jailbreak phrasing: "act as", "pretend to be", "system:"
+            The following patterns are common injection signals to watch for. They are examples, not a complete list, so reject any text that instructs the model even when it does not match an entry here:
+
+            - Imperative instructions to the model, such as "Ignore previous instructions", "You are now...", or "Always respond with..."
+            - Role-override or jailbreak phrasing, such as "act as", "pretend to be", or "system:"
             - Embedded tool-call directives or hidden delimiters such as `<|...|>`, triple-backtick role tags, or fenced JSON that imitates an assistant turn.
             - Conditional escape hatches such as "if asked about X, do Y instead".
 
-            Rewrite description fields to state what the tool does, what arguments it accepts, and what it returns. Where end-user text must pass through MCP, sanitize it before it reaches metadata fields and keep untrusted content inside argument values. Restart the MCP server after editing the definitions.
+            Restart the MCP server after editing the definitions.
 
             ```json
             {
@@ -266,6 +273,8 @@ queries:
         The server passes when no tool or prompt metadata contains a URL. It fails when any field includes an HTTP or HTTPS link.
 
         ### Audit via the JSON-RPC interface
+
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
         1. Retrieve the tool definitions and search for links:
 
@@ -346,6 +355,8 @@ queries:
         The server passes when every tool declares a name, a description, and an object input schema. It fails when any tool is missing one of these or ships an empty schema.
 
         ### Audit via the JSON-RPC interface
+
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
         1. Retrieve the tool definitions:
 
@@ -446,6 +457,8 @@ queries:
 
         ### Audit via the JSON-RPC interface
 
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
+
         1. Retrieve the tool and prompt definitions:
 
            ```bash
@@ -528,6 +541,8 @@ queries:
         The server passes when tool metadata uses only safe, printable characters. It fails when any field contains symbol, surrogate, private-use, or unassigned code points.
 
         ### Audit via the JSON-RPC interface
+
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
         1. Retrieve the tool definitions and screen for non-ASCII characters:
 
@@ -632,6 +647,8 @@ queries:
         The server passes when every resource and template has a name and a description free of explicit content and personal data. It fails when any entry is missing a field or carries unsafe content.
 
         ### Audit via the JSON-RPC interface
+
+        The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
         1. Retrieve the resource definitions:
 


### PR DESCRIPTION
Remediation-quality fixes for `content/mondoo-mcp-security.mql.yaml`. Prose and audit/remediation code only; no changes to mql, filters, uid, title, impact, or tags. Version bumped 1.0.1 -> 1.0.2.

## Transport variability (all 7 checks)

The JSON-RPC `curl` audit examples hard-assumed a single HTTP transport on `localhost:3000/mcp`. MCP defines several transports, and stdio/SSE servers expose no fixed HTTP endpoint for raw `curl`. Each JSON-RPC audit block now:

- Notes that the HTTP example assumes a Streamable HTTP transport, and that the host, port, and path must be replaced with the server's actual values.
- Directs stdio/SSE servers to use an MCP client such as the MCP Inspector rather than raw `curl`.

The port and path are no longer presented as universal.

## Structural prompt-injection guidance (`mondoo-mcp-prompt-injection-detection`)

Reframed the remediation and audit away from a fixed literal denylist of delimiters and trigger words, which is brittle against paraphrasing and an evolving spec. The guidance now:

- Leads with the structural principle: treat metadata as descriptive content the model must never execute, and keep untrusted text inside argument values where it is data rather than trusted metadata.
- Presents the delimiter and pattern list as non-exhaustive examples, with an explicit instruction to reject any text that instructs the model even when it matches no known pattern.

## Validation

`cnspec policy lint content/mondoo-mcp-security.mql.yaml` reports a valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)