### PR TITLE
🐛 chef-infra-server: lead TLS remediation with explicit ssl_protocols restriction

### DIFF
--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-server
     name: Mondoo Chef Infra Server Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -984,9 +984,7 @@ queries:
           desc: |
             **Using CLI**
 
-            The recommended remediation is to upgrade to Chef Infra Server 14.3.14 or later where TLS 1.2 is the default.
-
-            If you cannot upgrade immediately, you can manually configure nginx to disable older TLS versions:
+            The reliable fix is to explicitly restrict the protocols nginx offers. A default-driven TLS version is not enough: even on releases that default to TLS 1.2, the server can still negotiate TLS 1.0 and 1.1 unless you remove them explicitly. Setting `nginx['ssl_protocols']` guarantees that only the protocols you list are offered, which is exactly what this check verifies.
 
             1. Edit `/etc/opscode/chef-server.rb` and add one of the following:
 
@@ -1009,6 +1007,8 @@ queries:
             ```bash
             grep ssl_protocols /var/opt/opscode/nginx/etc/chef_https_lb.conf
             ```
+
+            Keeping Chef Infra Server on a current, supported release is a baseline that ships sensible TLS defaults and security fixes, but it does not replace the explicit `ssl_protocols` restriction above. Apply both.
 
             **Note**: Reconfiguring restarts the nginx front end and briefly interrupts client connections, so schedule this during a maintenance window. Ensure all Chef Infra Clients support TLS 1.2. Clients older than version 12.0 may need to be upgraded.
         - id: chef


### PR DESCRIPTION
## What

Remediation-quality fix for one finding in `content/mondoo-chef-infra-server.mql.yaml` (`secure-tls-only` check, `cli` remediation). Prose/code only; no changes to mql, filters, uid, title, impact, or tags.

### secure-tls-only (cli remediation)

The remediation previously led with: "upgrade to Chef Infra Server 14.3.14 or later where TLS 1.2 is the default." Two problems:

- **Stale version.** 14.3.14 is well behind the window the policy's own EOL check enforces (major 14-17).
- **Undercuts the check.** "TLS 1.2 is the default" still permits negotiating TLS 1.0/1.1 unless they are explicitly removed, so following the upgrade advice alone can leave the check failing and legacy protocols enabled.

Changes:

- Lead with the explicit `nginx['ssl_protocols']` restriction as the reliable fix, with a short "why" explaining that a default-driven TLS version is not sufficient because the server can still negotiate older protocols unless they are removed explicitly.
- Reframe keeping the server on a current, supported release as a baseline that complements, not replaces, the explicit restriction.

## Conventions

- Prose: no em-dashes, no `--`, no parenthetical asides; valid Markdown.
- expect.txt untouched.
- Version bumped 1.3.1 -> 1.3.2.

## Validation

`cnspec policy lint content/mondoo-chef-infra-server.mql.yaml` -> valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)