### PR TITLE
🐛 edr: explain CrowdStrike CID + note other vendors' enrollment

### DIFF
--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-edr-policy
     name: Mondoo Endpoint Detection and Response (EDR)
-    version: 1.6.1
+    version: 1.6.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -114,7 +114,11 @@ queries:
             3. Push the package to the endpoint, or distribute the installer through your software-deployment tooling, and verify enrollment in the device inventory.
         - id: cli
           desc: |-
-            To install an EDR agent from the command line, run the vendor's installer for the endpoint's platform. CrowdStrike Falcon examples:
+            To install an EDR agent from the command line, run the vendor's installer for the endpoint's platform. The CrowdStrike Falcon examples below use `FALCON_CID`, your Customer ID from the Falcon console under Host setup and management > Sensor downloads. The CID is tenant-specific and sensitive, so treat it as a secret and source it from a secure variable rather than hardcoding it.
+
+            Other supported vendors use their own enrollment mechanism instead of a CID. For example, SentinelOne sensors enroll with a site or group token, and Microsoft Defender for Endpoint enrolls with the tenant onboarding package. Use the enrollment value your vendor documents.
+
+            CrowdStrike Falcon examples:
 
             On Linux:
 


### PR DESCRIPTION
## What

Improves the remediation quality of the `ensure-edr-agent-is-installed` check in `content/mondoo-edr-policy.mql.yaml`. Addresses finding #37 from the small-policies remediation-quality audit.

## Why

The `cli` remediation block showed the CrowdStrike `FALCON_CID` as a literal install argument with no explanation, and presented CrowdStrike as the only path despite the policy supporting roughly nine EDR vendors. A junior engineer following it could not tell what the CID is, where to get it, or that it is sensitive, and might read CrowdStrike as the only supported option.

## Changes

- Added one line defining the CID as the Customer ID from the Falcon console, noting it is tenant-specific and sensitive and should be sourced from a secure variable rather than hardcoded.
- Added a one-line note that other vendors use their own enrollment mechanism, for example a SentinelOne site or group token, or the Microsoft Defender for Endpoint onboarding package.
- Bumped policy `version` 1.6.1 to 1.6.2.

Only remediation prose was changed. No changes to MQL, filters, UIDs, titles, impact, or tags.

## Validation

`cnspec policy lint content/mondoo-edr-policy.mql.yaml` reports a valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)