### PR TITLE
🐛 atlassian: warn on IP-allowlist self-lockout + disruptive admin actions

### DIFF
--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-atlassian-security
     name: Mondoo Atlassian Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -115,7 +115,10 @@ queries:
             4. Open **Security > IP allowlists**.
             5. Select **IP allowlist**, name the allowlist, and add the IP ranges of corporate offices, VPN exit nodes, and approved cloud egress points.
             6. Apply the allowlist to the products you want to protect and select **Create allowlist**.
-            7. Select **Activate IP allowlist** so the policy status changes to enabled. An allowlist that is created but never activated does not restrict access.
+            7. Before activating, confirm your own egress IP is covered. Activation takes effect immediately and denies every source outside the listed ranges, so an allowlist that omits the address you are currently connecting from will lock you out the moment it becomes enabled. From the network you administer from, check your public egress address and verify it falls inside one of the ranges you added. If you connect through a corporate VPN, list the VPN exit ranges rather than your local address, because your apparent source IP is the VPN exit. Account for every administrator's network so no one is stranded.
+            8. Select **Activate IP allowlist** so the policy status changes to enabled. An allowlist that is created but never activated does not restrict access.
+
+            If you do lock yourself out, an organization administrator on a still-allowed network can sign in and correct the ranges. If no administrator can reach the console, open a case with Atlassian Support to restore access, because the allowlist cannot be edited from a blocked address.
     refs:
       - url: https://support.atlassian.com/security-and-access-policies/docs/specify-ip-addresses-for-product-access/
         title: Specify IP addresses for product access
@@ -185,7 +188,7 @@ queries:
             3. Open **Directory > Domains** and select **Add domain**.
             4. Enter the domain name and choose a verification method: copy a TXT record to your DNS, upload an HTML file to the root folder of the domain's website, or verify through a connected identity provider such as Google Workspace or Microsoft Entra ID.
             5. Publish the verification record or file, then return to the page and complete verification.
-            6. After the domain shows as verified, stay on **Directory > Domains** and select **Claim accounts** to bring existing and future accounts at the domain under organization control.
+            6. After the domain shows as verified, stay on **Directory > Domains** and select **Claim accounts** to bring existing and future accounts at the domain under organization control. Claiming accounts is disruptive: every existing Atlassian account at the domain, including personal accounts an employee may have created for non-work use, is converted into a managed account that your organization governs and may be billed for. Review the list of accounts that will be claimed first, communicate the change to affected users, and confirm the billing impact before you proceed, because claiming converts accounts in bulk and there is no per-account undo.
     refs:
       - url: https://support.atlassian.com/user-management/docs/verify-a-domain-to-manage-accounts/
         title: Verify a domain to manage accounts


### PR DESCRIPTION
## What

Adds operational warnings to remediation steps for irreversible or disruptive Atlassian admin actions in `content/mondoo-atlassian-security.mql.yaml`. Prose-only changes to remediation steps; no MQL, filters, UIDs, titles, impact, or tags were touched. Policy version bumped 1.0.1 to 1.0.2.

From `/tmp/remediation-quality-audit/small-policies.md` (finding #33 + the policy's systemic line on missing operational warnings).

### IP allowlist self-lockout (finding #33)

`admin-ip-allowlist-enabled` console remediation previously activated the allowlist with no warning that activation is immediate and denies every source outside the listed ranges, locking out the activating admin if their own egress IP is omitted.

- Added a pre-activation step to verify your own public egress address falls inside an added range, with a note that VPN users must list the VPN exit ranges rather than their local address, and to account for every administrator's network.
- Added the recovery path: an org admin on a still-allowed network can correct the ranges, or open a case with Atlassian Support if no admin can reach the console, since the allowlist cannot be edited from a blocked address.

### Claim accounts disruption (systemic line)

`admin-verified-domains-configured` console remediation invokes **Claim accounts** with no warning. Added a note that claiming converts existing accounts at the domain in bulk, including personal accounts, into managed accounts the org governs and may be billed for, with no per-account undo, and to review/communicate/confirm billing impact first.

## Validation

- `cnspec policy lint content/mondoo-atlassian-security.mql.yaml` → valid
- `python3 content/validation/validate_remediation_commands.py atlassian` → 4 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)