### PR TITLE
🐛 chef-infra-client: align permission remediation with check target + parameterize install version

### DIFF
--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-client
     name: Mondoo Chef Infra Client Security
-    version: 1.3.3
+    version: 1.3.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -100,17 +100,17 @@ queries:
         stat -c '%a %U:%G %n' /etc/chef
         ```
 
-        If the output is `700 root:root /etc/chef`, the directory is correctly restricted and the check passes. Mode `750` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
+        If the output is `750 root:root /etc/chef`, the directory is correctly restricted and the check passes. The stricter mode `700` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Run these commands to set proper permissions on your /etc/chef directory:
+            Run these commands to set the target permissions on your /etc/chef directory. Mode `750` lets `root` write the directory while the root group can list it and other users have no access, which is what this check asserts:
 
             ```bash
             chown root:root /etc/chef
-            chmod 700 /etc/chef
+            chmod 750 /etc/chef
             ```
 
             To verify the permissions were applied correctly:
@@ -119,18 +119,20 @@ queries:
             stat -c '%a %U:%G %n' /etc/chef
             ```
 
-            Expected output: `700 root:root /etc/chef`
+            Expected output: `750 root:root /etc/chef`
+
+            If your environment has no need for root-group read access, you can apply the stricter mode `700`, which this check also accepts.
         - id: chef
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /etc/chef directory:
+            Use this Chef Infra recipe code to set the target permissions on your /etc/chef directory:
 
             ```ruby
             directory '/etc/chef' do
               owner 'root'
               group 'root'
-              mode '0700'
+              mode '0750'
             end
             ```
     refs:
@@ -184,17 +186,17 @@ queries:
         stat -c '%a %U:%G %n' /var/chef
         ```
 
-        If the output is `700 root:root /var/chef`, the directory is correctly restricted and the check passes. Mode `750` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
+        If the output is `750 root:root /var/chef`, the directory is correctly restricted and the check passes. The stricter mode `700` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Run these commands to set proper permissions on your /var/chef directory:
+            Run these commands to set the target permissions on your /var/chef directory. Mode `750` lets `root` write the directory while the root group can list it and other users have no access, which is what this check asserts:
 
             ```bash
             chown root:root /var/chef
-            chmod 700 /var/chef
+            chmod 750 /var/chef
             ```
 
             To verify the permissions were applied correctly:
@@ -203,18 +205,20 @@ queries:
             stat -c '%a %U:%G %n' /var/chef
             ```
 
-            Expected output: `700 root:root /var/chef`
+            Expected output: `750 root:root /var/chef`
+
+            If your environment has no need for root-group read access, you can apply the stricter mode `700`, which this check also accepts.
         - id: chef
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /var/chef directory:
+            Use this Chef Infra recipe code to set the target permissions on your /var/chef directory:
 
             ```ruby
             directory '/var/chef' do
               owner 'root'
               group 'root'
-              mode '0700'
+              mode '0750'
             end
             ```
     refs:
@@ -268,17 +272,17 @@ queries:
         stat -c '%a %U:%G %n' /var/log/chef
         ```
 
-        If the output is `700 root:root /var/log/chef`, the directory is correctly restricted and the check passes. Mode `750` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
+        If the output is `750 root:root /var/log/chef`, the directory is correctly restricted and the check passes. The stricter mode `700` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Run these commands to set proper permissions on your /var/log/chef directory:
+            Run these commands to set the target permissions on your /var/log/chef directory. Mode `750` lets `root` write the directory while the root group can list it and other users have no access, which is what this check asserts:
 
             ```bash
             chown root:root /var/log/chef
-            chmod 700 /var/log/chef
+            chmod 750 /var/log/chef
             ```
 
             To verify the permissions were applied correctly:
@@ -287,18 +291,20 @@ queries:
             stat -c '%a %U:%G %n' /var/log/chef
             ```
 
-            Expected output: `700 root:root /var/log/chef`
+            Expected output: `750 root:root /var/log/chef`
+
+            If your environment has no need for root-group read access, you can apply the stricter mode `700`, which this check also accepts.
         - id: chef
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /var/log/chef directory:
+            Use this Chef Infra recipe code to set the target permissions on your /var/log/chef directory:
 
             ```ruby
             directory '/var/log/chef' do
               owner 'root'
               group 'root'
-              mode '0700'
+              mode '0750'
             end
             ```
     refs:
@@ -353,17 +359,17 @@ queries:
         stat -c '%a %U:%G %n' /etc/chef/client.rb
         ```
 
-        If the output is `600 root:root /etc/chef/client.rb`, the file is correctly restricted and the check passes. Mode `640` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
+        If the output is `640 root:root /etc/chef/client.rb`, the file is correctly restricted and the check passes. The stricter mode `600` with group `root` is also accepted. Any other owner, group, or mode means the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Run these commands to set proper permissions on your /etc/chef/client.rb file:
+            Run these commands to set the target permissions on your /etc/chef/client.rb file. Mode `640` lets `root` write the file while the root group can read it and other users have no access, which is what this check asserts:
 
             ```bash
             chown root:root /etc/chef/client.rb
-            chmod 600 /etc/chef/client.rb
+            chmod 640 /etc/chef/client.rb
             ```
 
             To verify the permissions were applied correctly:
@@ -372,18 +378,20 @@ queries:
             stat -c '%a %U:%G %n' /etc/chef/client.rb
             ```
 
-            Expected output: `600 root:root /etc/chef/client.rb`
+            Expected output: `640 root:root /etc/chef/client.rb`
+
+            If your environment has no need for root-group read access, you can apply the stricter mode `600`, which this check also accepts.
         - id: chef
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /etc/chef/client.rb file:
+            Use this Chef Infra recipe code to set the target permissions on your /etc/chef/client.rb file:
 
             ```ruby
             file '/etc/chef/client.rb' do
               owner 'root'
               group 'root'
-              mode '0600'
+              mode '0640'
             end
             ```
     refs:
@@ -599,16 +607,26 @@ queries:
             chef-client -v
             ```
 
-            2. Install the latest supported release with the Chef install script. The same command works on Debian, Ubuntu, RHEL, CentOS, and Amazon Linux:
+            2. Install a supported release with the Chef install script. Set `CHEF_VERSION` to a major version that still receives security maintenance per the [Chef Supported Versions documentation](https://docs.chef.io/versions/); this check accepts major versions 18 through 22. The same command works on Debian, Ubuntu, RHEL, CentOS, and Amazon Linux:
 
             ```bash
-            curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v 18
+            CHEF_VERSION=18
+            curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v "${CHEF_VERSION}"
             ```
 
             For nodes running Cinc Client, use the Cinc install script instead:
 
             ```bash
-            curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc -v 18
+            CINC_VERSION=18
+            curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc -v "${CINC_VERSION}"
+            ```
+
+            **Caution**: These commands pipe a remotely fetched script straight into `sudo bash`, which runs whatever the server returns as root. Before trusting it on production nodes, download the script first, inspect it, and run the saved copy:
+
+            ```bash
+            curl -L https://omnitruck.chef.io/install.sh -o /tmp/chef-install.sh
+            less /tmp/chef-install.sh
+            sudo bash /tmp/chef-install.sh -P chef -v "${CHEF_VERSION}"
             ```
 
             3. Verify the upgrade was successful:


### PR DESCRIPTION
## What

Remediation-quality fixes to `content/mondoo-chef-infra-client.mql.yaml`. Only remediation, audit, and desc prose/code were changed. No MQL, filters, UIDs, titles, impacts, or tags were touched.

### Permission checks: align remediation with the documented target (finding #14)

The directory checks (`etc-chef-directory-permissions`, `var-chef-directory-permissions`, `var-log-chef-directory-permissions`) and the `client-rb-permissions` file check had titles and audit text stating 750 (640 for the file) as the target, but the cli and Chef remediation set and verified the stricter 700 (600). An operator targeting the documented value was silently pushed onto a different mode.

The MQL for these checks accepts both modes (it asserts no group-read requirement and forbids group-write/other access). The remediation, expected output, and recipe `mode` now match each title's stated 750/640 target, with a one-line note that the stricter 700/600 is an accepted optional hardening step.

`client-pem-permissions` was left at mode 600: its title already states "mode 600 or 640", so 600 is within the documented target, and the existing remediation already explains why 600 is used.

### EOL check: parameterize install version and warn on curl-to-sudo-bash (finding #24)

`non-eol-infra-client` hardcoded `-v 18` in the install command, which goes stale as the supported window advances (the MQL accepts majors 18 through 22). The version is now a `CHEF_VERSION`/`CINC_VERSION` variable with a pointer to the Chef Supported Versions docs. A caution was added explaining that piping a fetched script into `sudo bash` runs it as root, with a download-inspect-run alternative.

## Validation

- `cnspec policy lint content/mondoo-chef-infra-client.mql.yaml` → valid policy bundle
- `version:` bumped 1.3.3 → 1.3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)