### PR TITLE
🐛 dockerfile-security: GPG-key import over flag removal + USER ownership note + cleanup consistency

### DIFF
--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-docker-security
     name: Mondoo Dockerfile Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -176,16 +176,25 @@ queries:
       remediation:
         - id: dockerfile
           desc: |
-            Remove the `--allow-insecure-repositories` option from APT commands and configure APT to use signed, secure repositories:
+            The proper fix is to make APT trust the repository, then remove the bypass. Removing `--allow-insecure-repositories` on its own breaks installs from an unsigned or keyless repository, because APT then refuses packages it cannot verify. Import the repository's GPG signing key so verification succeeds, then drop the flag.
+
+            Fetch the publisher's key, store it in `/etc/apt/keyrings`, and pin it to the repository with `signed-by` so only that key can authorize packages from that source:
 
             ```dockerfile
             # Instead of:
             RUN apt-get update --allow-insecure-repositories && apt-get install -y package
 
             # Use:
-            RUN apt-get update && apt-get install -y --no-install-recommends package && \
+            RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+                install -m 0755 -d /etc/apt/keyrings && \
+                curl -fsSL https://repo.example.com/gpg | gpg --dearmor -o /etc/apt/keyrings/example.gpg && \
+                echo "deb [signed-by=/etc/apt/keyrings/example.gpg] https://repo.example.com/apt stable main" \
+                  > /etc/apt/sources.list.d/example.list && \
+                apt-get update && apt-get install -y --no-install-recommends package && \
                 rm -rf /var/lib/apt/lists/*
             ```
+
+            With the key imported, APT validates package signatures and the insecure flag is no longer needed. The `rm -rf /var/lib/apt/lists/*` step clears the package index cache so it does not persist in the image layer.
     refs:
       - url: https://docs.docker.com/build/building/best-practices/
         title: Dockerfile Best Practices
@@ -346,7 +355,8 @@ queries:
             RUN sudo apt-get install -y package
 
             # Use:
-            RUN apt-get install -y --no-install-recommends package
+            RUN apt-get update && apt-get install -y --no-install-recommends package && \
+                rm -rf /var/lib/apt/lists/*
             USER appuser
             ```
     refs:
@@ -394,17 +404,33 @@ queries:
       remediation:
         - id: dockerfile
           desc: |
-            Remove GPG bypass options from package manager commands so signature verification stays enabled. For YUM and DNF, drop `--nogpgcheck`; for zypper, drop `--no-gpg-checks`:
+            The proper fix is to import the repository's GPG signing key so signature verification succeeds, then remove the bypass flag. Dropping `--nogpgcheck` or `--no-gpg-checks` on its own breaks installs from an unsigned or keyless repository, because the package manager then refuses packages whose signatures it cannot verify against a trusted key.
+
+            For YUM and DNF, import the publisher's key with `rpm --import`, then install without the bypass:
 
             ```dockerfile
             # Instead of:
             RUN dnf install -y --nogpgcheck package
+
+            # Use:
+            RUN rpm --import https://repo.example.com/RPM-GPG-KEY-example && \
+                dnf install -y package && \
+                dnf clean all && rm -rf /var/cache/dnf
+            ```
+
+            For zypper, import the key the same way, then install without `--no-gpg-checks`:
+
+            ```dockerfile
+            # Instead of:
             RUN zypper --no-gpg-checks install -y package
 
             # Use:
-            RUN dnf install -y package && dnf clean all
-            RUN zypper install -y package && zypper clean --all
+            RUN rpm --import https://repo.example.com/RPM-GPG-KEY-example && \
+                zypper install -y package && \
+                zypper clean --all
             ```
+
+            With the key imported, signature verification passes and the bypass flag is no longer needed. The `dnf clean all` / `zypper clean --all` and `rm -rf /var/cache/dnf` steps clear the package caches so they do not persist in the image layer.
     refs:
       - url: https://docs.docker.com/build/building/best-practices/
         title: Dockerfile Best Practices
@@ -471,6 +497,17 @@ queries:
             ```dockerfile
             USER 10001:10001
             ```
+
+            After the `USER` switch, the process can no longer write to files and directories that earlier steps created as root. Anything the application needs to write at runtime, such as application directories, cache paths, log directories, or a writable temp area, must be owned by the new user. Place the `USER` instruction after those steps and grant ownership with `chown` so the switch does not break the running container:
+
+            ```dockerfile
+            RUN groupadd -r appgroup && useradd -r -g appgroup appuser && \
+                mkdir -p /app/data && chown -R appuser:appgroup /app
+            WORKDIR /app
+            USER appuser
+            ```
+
+            For files brought in with `COPY`, set ownership at copy time with `COPY --chown=appuser:appgroup` rather than running a separate `chown`, which avoids duplicating the file data into an extra image layer.
     refs:
       - url: https://docs.docker.com/build/building/best-practices/#user
         title: Dockerfile Best Practices - USER Instruction


### PR DESCRIPTION
## What

Remediation-quality fixes for the **Mondoo Dockerfile Security** policy (`content/mondoo-dockerfile-security.mql.yaml`). Prose and code in `remediation:`/`desc:`/`audit:` only; no `mql`/`filters`/`uid`/`title`/`impact`/`tags` changes. Version bumped `1.3.1` → `1.3.2`.

### GPG key import over bare flag removal

- **`no-insecure-certificate-validation-apt`** and **`no-gpg-skip-yum`**: the previous remediations told the reader to drop `--allow-insecure-repositories` / `--nogpgcheck` / `--no-gpg-checks` and stop. Removing the bypass flag alone breaks installs from an unsigned or keyless repository, because the package manager then refuses packages it cannot verify. The proper fix is to make the package manager trust the repository first.
  - apt: fetch the publisher's key into `/etc/apt/keyrings` and pin it with `signed-by`, then drop the flag.
  - yum/dnf/zypper: `rpm --import` the publisher's key, then install without the bypass.
  - Each now explains *why* removing the flag alone breaks installs.

### USER ownership/write-access note

- **`non-root-user`**: added a warning that files created earlier as root are not writable after the `USER` switch. Shows placing `USER` after `chown`-ing app/cache/log/temp dirs, and recommends `COPY --chown` to avoid an extra layer.

### Cleanup hygiene consistency

- **`no-sudo-commands`**: the "Use:" apt snippet now models the full hardened idiom (`apt-get update` + `--no-install-recommends` + `rm -rf /var/lib/apt/lists/*`), so a junior copying the "fixed" example does not produce a Dockerfile that itself fails sibling checks.

## Validation

- `cnspec policy lint content/mondoo-dockerfile-security.mql.yaml` → **valid policy bundle(s)**.
- No em-dashes, `--` prose dashes, or parenthetical asides introduced.

## VERIFY

- The GPG-import snippets use placeholder hosts/key URLs (`repo.example.com`, `RPM-GPG-KEY-example`). They illustrate the pattern; real repos substitute their own published key URL and `apt`/`yum` source path. Maintainers may wish to confirm the keyring/`signed-by` idiom matches their preferred house style for apt key handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)