### PR TITLE
🐛 windows-workstation: resolve antivirus Tamper-Protection contradiction + soften update-time claim

### DIFF
--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-workstation-security
     name: Mondoo Microsoft Windows Workstation Security
-    version: 0.4.1
+    version: 0.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -307,7 +307,7 @@ queries:
             4. In the same dialog, set **Scheduled install day** to **0 - Every day**.
             5. Select **Apply** > **OK**.
 
-            Critical operating system updates and service packs then download and install every day, at 3:00 A.M. by default.
+            Critical operating system updates and service packs then download and install every day at a scheduled time. The install time is configurable through the **Scheduled install time** setting in the same policy.
         - id: powershell
           desc: |
             **Using PowerShell**
@@ -413,19 +413,28 @@ queries:
           desc: |
             **Using the Windows interface**
 
-            If a third-party antivirus product is installed, enable its real-time protection and update its definitions using that product's console. The steps below enable Microsoft Defender Antivirus.
+            If a third-party antivirus product is installed, enable its real-time protection and update its definitions using that product's console. The steps below enable Microsoft Defender Antivirus. Active malware protection is what blocks threats as files are accessed, so the goal is to confirm real-time protection is on and signatures are current.
+
+            The Windows Security path is the supported route on modern Windows because it works whether or not Tamper Protection is enabled.
+
+            1. Open **Windows Security** and select **Virus & threat protection**.
+            2. Under **Virus & threat protection settings**, select **Manage settings**.
+            3. Turn **Real-time protection** on.
+            4. Return to **Virus & threat protection**, open **Protection updates**, and select **Check for updates** so the signatures are current.
+
+            **Using Group Policy (Tamper Protection must be off)**
+
+            Tamper Protection blocks changes to Microsoft Defender settings made through Group Policy, PowerShell, or the registry. The steps in this section and the PowerShell commands below only take effect when Tamper Protection is turned off. If Tamper Protection is on, use the Windows Security steps above instead.
 
             1. Select the Start menu.
             2. In the search bar, type Group Policy. Then select Edit Group Policy from the listed results. The Local Group Policy Editor opens.
             3. Select Computer Configuration > Administrative Templates > Windows Components > Microsoft Defender Antivirus.
             4. Scroll to the bottom of the list and select Turn off Microsoft Defender Antivirus.
-            5. Select Disabled or Not configured. It might feel counter-intuitive to select these options because the names suggest that you're turning Microsoft Defender Antivirus off. Don't worry, these options actually ensure that it's turned on.
+            5. Select Disabled or Not configured. The names suggest that you are turning Microsoft Defender Antivirus off, but selecting Disabled or Not configured keeps it turned on.
             6. Select Apply > OK.
             7. Open Windows Security > Virus & threat protection > Protection updates and select Check for updates so the signatures are current.
 
-            Note: When Tamper Protection is enabled, changes made through PowerShell or the registry are blocked. Turn real-time protection on through Windows Security under Virus & threat protection settings instead.
-
-            Alternatively, run these commands one at a time in an elevated PowerShell session:
+            With Tamper Protection off, you can also run these commands one at a time in an elevated PowerShell session:
 
             ```powershell
             Set-MpPreference -DisableRealtimeMonitoring $false


### PR DESCRIPTION
Remediation-quality fixes to `content/mondoo-windows-workstation-security.mql.yaml`. Prose and code only; no changes to mql/filters/uid/title/impact/tags. Version bumped 0.4.1 to 0.4.2.

## Fixes

### `antivirus-installed` GUI remediation
The PowerShell snippet under the GUI method (`Set-MpPreference -DisableRealtimeMonitoring $false`) directly contradicted the note above it stating that Tamper Protection blocks PowerShell and registry changes. A junior would run blocked commands and assume they succeeded.

- Lead with the Windows Security **Virus & threat protection** real-time-protection toggle as the primary, supported path that works regardless of Tamper Protection state.
- Demote the Group Policy double-negative procedure to a secondary section, explicitly gated on Tamper Protection being off.
- State plainly that the Group Policy, PowerShell, and registry paths only take effect with Tamper Protection turned off; otherwise use the Windows Security route.
- Added a brief "why" line: active malware protection blocks threats as files are accessed.

### `automatic-update-is-enabled` GUI remediation
Softened the "at 3:00 A.M. by default" claim to "at a scheduled time," and noted the install time is configurable via the **Scheduled install time** setting. The node naming (**Manage end user experience**) already varied by build and is documented in the step.

## VERIFY
- **Windows 11 default automatic-update install time:** Confirmed via Microsoft / WSUS Group Policy docs that when no schedule is specified, the default is every day at 3:00 A.M. (`ScheduledInstallTime` defaults to `3`). The value is configurable, so the prose was softened to "at a scheduled time" per the task rather than asserting the default.

## Validation
- `cnspec policy lint content/mondoo-windows-workstation-security.mql.yaml` → valid policy bundle(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)