### PR TITLE
🐛 okta: correct OIE MFA policy surfaces + self-lockout warnings + consolidated password TF

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.4
+    version: 2.3.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -155,12 +155,14 @@ queries:
           desc: |
             ### Reduce the number of super administrators
 
-            Super admin access in Okta can be granted to individual users and to groups. This check evaluates groups that hold the super admin role, so pay particular attention to group-based assignments.
+            Super admin access in Okta can be granted to individual users and to groups. This check evaluates groups that hold the super admin role, so pay particular attention to group-based assignments. Keeping the super admin pool small limits the blast radius if one of those high-value accounts is phished or taken over.
 
-            1. In the Admin Console, go to **Security > Administrators**.
-            2. Filter the admin list by the **Super Administrator** role to see every user and group that grants super admin access.
-            3. For each group that grants the super admin role, go to **Directory > Groups**, open the group, and remove members who do not require that level of access.
-            4. For users who still need administrative rights, assign a narrower standard role such as Organization Administrator, Application Administrator, or Read-Only Administrator instead of super admin.
+            Before you remove any super admin grant, confirm that at least one other verified super admin retains working access, and confirm your own continued access before revoking your own grant. Removing the last super admin, or revoking your own without a tested alternative, can leave the org without full administrative control.
+
+            1. In the Admin Console, open the administrators area. In the current Admin Console the exact navigation label varies, so look for the administrators or admin-roles section under Security.
+            2. Filter the admin list by the super administrator role to see every user and group that grants super admin access.
+            3. For each group that grants super admin, open the group and review who holds it. Note that removing a member from the group is not the same as removing the group's admin-role assignment: as long as the group still carries the super admin role, remaining and future members inherit it. To stop a group from granting super admin entirely, remove the admin-role assignment from the group rather than emptying its membership.
+            4. For users who still need administrative rights, assign a narrower standard role scoped to their job instead of super admin. Confirm the exact role names available in your org, since admin-role labels have changed across Okta releases.
             5. Review super admin assignments on a recurring schedule so unneeded grants are revoked promptly.
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/healthinsight-security-task-recomendations.htm
@@ -259,6 +261,8 @@ queries:
         - id: console
           desc: |
             ### Add blocked IP addresses to a blocklist network zone
+
+            This control configures a manually maintained network-zone blocklist: a list of IP addresses and ranges you explicitly choose to deny. It is distinct from Okta ThreatInsight, which automatically scores and acts on IP addresses based on Okta's threat reputation data. The two features are complementary and configured in different places, so enabling ThreatInsight does not populate a blocklist zone, and a blocklist zone does not replace ThreatInsight.
 
             1. In the Admin Console, go to **Security > Networks**.
             2. Open the default **BlockedIpZone**, or select **Add Zone > IP Zone** to create a dedicated blocklist zone.
@@ -650,6 +654,8 @@ queries:
             3. Select **Edit** on that policy and set at least one factor, such as Okta Verify, to **Required**.
             4. Select **Update Policy**.
             5. To prompt users to enroll, edit the policy rule and choose to enroll users the first time they sign in or the first time they are challenged for MFA.
+
+            Before requiring a factor for everyone, account for service, break-glass, and API-only accounts that cannot complete interactive enrollment. Requiring a factor org-wide can lock those accounts out. Place them in a dedicated group and scope or exclude that group from the required-factor policy, and confirm at least one break-glass admin retains working access before you save.
         - id: terraform
           desc: |
             The default MFA enrollment policy applies to all users in the org:
@@ -761,11 +767,15 @@ queries:
           desc: |
             ### Limit session idle time and session lifetime
 
+            This check evaluates the global sign-on policy, which controls the Okta session itself. On Okta Identity Engine this is the Global Session Policy, the correct surface for session idle time and session lifetime. Shorter limits reduce the window in which a hijacked or abandoned session can be abused.
+
             1. On Okta Identity Engine orgs, go to **Security > Global Session Policy**. On Okta Classic Engine orgs, go to **Security > Authentication** and select the **Sign On** tab.
             2. For each active policy rule, select **Edit**.
             3. Set the maximum session idle time to 2 hours or less.
             4. Set the maximum session lifetime to 24 hours or less.
             5. Select **Update Rule**.
+
+            An aggressive idle timeout forces more frequent re-authentication and will interrupt active admin sessions, so choose a limit that balances exposure against operational friction.
         - id: terraform
           desc: |
             ```hcl
@@ -991,7 +1001,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
         2. Review the **Report Suspicious Activity** option.
         3. Confirm the option is enabled.
 
@@ -1012,7 +1022,7 @@ queries:
           desc: |
             ### Enable suspicious activity reporting
 
-            1. In the Admin Console, go to **Settings > Account**.
+            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **Report suspicious activity via email** to **Enabled**. This adds a Report Suspicious Activity button to the new sign-on, authenticator enrolled, authenticator reset, and password changed notification emails.
             4. Select **Save**.
@@ -1097,7 +1107,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
         2. Review the option that emails users about sign-in from a new device.
         3. Confirm the option is enabled.
 
@@ -1118,7 +1128,7 @@ queries:
           desc: |
             ### Enable sign-on notification emails for end users
 
-            1. In the Admin Console, go to **Settings > Account**.
+            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **New sign-on notification email** to **Enabled**.
             4. Select **Save**.
@@ -1199,7 +1209,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
         2. Review the option that emails users about MFA factor enrollment.
         3. Confirm the option is enabled.
 
@@ -1220,7 +1230,7 @@ queries:
           desc: |
             ### Enable factor enrollment notifications for end users
 
-            1. In the Admin Console, go to **Settings > Account**.
+            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **MFA enrolled notification email** to **Enabled**.
             4. Select **Save**.
@@ -1301,7 +1311,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
         2. Review the option that emails users about MFA factor resets.
         3. Confirm the option is enabled.
 
@@ -1322,7 +1332,7 @@ queries:
           desc: |
             ### Enable factor reset notifications for end users
 
-            1. In the Admin Console, go to **Settings > Account**.
+            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **MFA reset notification email** to **Enabled**.
             4. Select **Save**.
@@ -1403,7 +1413,7 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, go to **Settings > Account** and locate the security notification email settings.
+        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
         2. Review the option that emails users when their password is changed.
         3. Confirm the option is enabled.
 
@@ -1424,7 +1434,7 @@ queries:
           desc: |
             ### Enable password changed notifications for end users
 
-            1. In the Admin Console, go to **Settings > Account**.
+            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **Password changed notification email** to **Enabled**.
             4. Select **Save**.
@@ -1535,6 +1545,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_min_length = 15
@@ -1642,6 +1654,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_max_lockout_attempts = 5
@@ -1747,6 +1761,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_min_lowercase = 1
@@ -1852,6 +1868,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_min_number = 1
@@ -1957,6 +1975,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_min_symbol = 1
@@ -2063,6 +2083,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_min_age_minutes = 60
@@ -2169,6 +2191,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_exclude_username = true
@@ -2275,6 +2299,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_exclude_first_name = true
@@ -2381,6 +2407,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_exclude_last_name = true
@@ -2487,6 +2515,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_dictionary_lookup = true
@@ -2593,6 +2623,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_max_age_days = 90
@@ -2699,6 +2731,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_expire_warn_days = 15
@@ -2805,6 +2839,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_history_count = 24
@@ -2911,6 +2947,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_auto_unlock_minutes = 30
@@ -3017,6 +3055,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               password_show_lockout_failures = true
@@ -3123,6 +3163,8 @@ queries:
             4. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               email_recovery = "ACTIVE"
@@ -3230,6 +3272,8 @@ queries:
             5. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               sms_recovery = "INACTIVE"
@@ -3337,6 +3381,8 @@ queries:
             5. Select **Update Policy**.
         - id: terraform
           desc: |
+            Set this attribute inside your single, consolidated `okta_policy_password_default` resource alongside your other password settings. The snippet below shows only the attribute relevant to this check. Applying a standalone resource that defines just this one attribute resets every other password setting on the default policy back to the Terraform provider defaults, so merge it with your existing definition rather than applying it on its own.
+
             ```hcl
             resource "okta_policy_password_default" "default" {
               question_recovery = "INACTIVE"
@@ -3644,12 +3690,21 @@ queries:
           desc: |
             ### Require MFA in sign-on policy rules
 
-            1. On Okta Identity Engine orgs, go to **Security > Global Session Policy**. On Okta Classic Engine orgs, go to **Security > Authentication** and select the **Sign On** tab.
-            2. For each active policy, review its rules and select **Edit** on each rule.
-            3. On Identity Engine, set **Establish the user session with** to require a password and another factor. On Classic Engine, select **Prompt for Factor** and choose how often users are prompted.
-            4. Select **Update Rule**.
+            This check evaluates the global sign-on policy, which on Okta Identity Engine is the Global Session Policy. That policy establishes the Okta session itself. On Identity Engine, per-app MFA at access time is enforced separately by Authentication Policies, so harden both surfaces for complete coverage.
 
-            Repeat for all active sign-on policy rules so no rule allows password-only sign-in.
+            On Okta Identity Engine orgs:
+
+            1. Go to **Security > Global Session Policy**.
+            2. For each active rule, select **Edit** and set **Establish the user session with** to require a password and another factor, then select **Update Rule**.
+            3. Go to **Security > Authentication Policies** to enforce MFA at the point each application is accessed. Open each policy, edit its rules, and require a second factor for app access.
+
+            On Okta Classic Engine orgs:
+
+            1. Go to **Security > Authentication** and select the **Sign On** tab.
+            2. For each active policy, review its rules and select **Edit** on each rule.
+            3. Select **Prompt for Factor** and choose how often users are prompted, then select **Update Rule**.
+
+            Repeat for all active rules so no rule allows password-only sign-in. Requiring a second factor blocks an attacker who holds only a stolen or guessed password.
         - id: terraform
           desc: |
             ```hcl


### PR DESCRIPTION
## Summary

Remediation-quality fixes to `content/mondoo-okta-security.mql.yaml` (version 2.3.4 → 2.3.5). Prose/code-only edits to `remediation`/`audit` blocks; no `mql`/`filters`/`uid`/`title`/`impact`/`tags` changes. Lint passes.

### OIE MFA / session policy surfaces
- **`signon-requires-mfa` (console):** The runtime check reads the `OKTA_SIGN_ON` policy (`okta.policies.signOn` → `actions.signon.requireFactor`), which on Okta Identity Engine is the **Global Session Policy**. Clarified that this is the surface the check evaluates and added that on OIE per-app MFA at access time is enforced separately by **Security > Authentication Policies**. Both surfaces are now presented; harden both for full coverage. Added the "why".
- **`okta-enforce-session-lifetime` (console):** Same `OKTA_SIGN_ON` source; session idle/lifetime genuinely live in the Global Session Policy on OIE, so the existing path is correct. Clarified that this controls the Okta session itself and added a re-authentication-friction caution that an aggressive idle timeout interrupts active admin sessions.

### Self-lockout / break-glass warnings
- **`limit-super-admins` (console):** Added a warning to retain at least one verified super admin and confirm access before revoking your own grant. Clarified that removing a member from a group is not the same as removing the group's admin-role assignment. Hedged on admin-role labels (names have drifted across releases) and softened the navigation path.
- **`okta-mfa-access` (console):** Added a warning that requiring a factor for Everyone can lock out service/break-glass/API-only accounts that cannot enroll; recommend scoping/excluding them via a dedicated group and confirming a break-glass admin retains access.

### Drifted console paths / feature clarification
- **Notification checks (5):** `Settings > Account` for security-notification emails has drifted; replaced the hard assertion with a "location varies in the current Admin Console, historically under Settings > Account" hedge in both audit and remediation steps.
- **`threatinsight-block-suspicious-ip-addresses` (console):** Clarified this configures a manually maintained network-zone blocklist, distinct from automated Okta ThreatInsight IP reputation; the two are complementary and configured separately.

### Terraform password policy consolidation
- **`password-settings-*` (18 checks, terraform):** Added a note to each that the attribute belongs in one consolidated `okta_policy_password_default` resource; applying a standalone single-attribute resource resets the rest of the policy to provider defaults.

## VERIFY items (could not confirm against a live current Admin Console)
- Exact current Admin Console location of the security notification email settings (the five notification checks). Hedged rather than asserting a stale path.
- Current admin-role names available in `limit-super-admins` and the exact admin-role-assignment navigation path. Hedged.
- OIE Authentication Policies navigation label (`Security > Authentication Policies`) for `signon-requires-mfa`.

## Validation
- `cnspec policy lint content/mondoo-okta-security.mql.yaml` → valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)