### PR TITLE
🐛 fortios: multi-VDOM config-global prereq + firmware/UTM/admin-port safety

### DIFF
--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-fortios-security
     name: Mondoo Fortinet FortiOS Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -168,13 +168,13 @@ queries:
             get system status
             ```
 
-            Back up the configuration before upgrading:
+            Back up the configuration before upgrading. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if the upgrade has to be rolled back:
 
             ```
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. The device reboots during the upgrade and traffic is interrupted until it comes back up, so run this during a maintenance window:
+            Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If your current version is several releases behind the GA target, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time rather than jumping directly. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```
             execute restore image tftp <filename> <tftp_server_ip>
@@ -259,13 +259,13 @@ queries:
             get system status
             ```
 
-            Back up the configuration before upgrading:
+            Back up the configuration before upgrading. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if the upgrade has to be rolled back:
 
             ```
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. The device reboots during the upgrade and traffic is interrupted until it comes back up, so run this during a maintenance window:
+            Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If the target Mature release is several versions ahead, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```
             execute restore image tftp <filename> <tftp_server_ip>
@@ -354,13 +354,13 @@ queries:
             get system status
             ```
 
-            Back up the configuration:
+            Back up the configuration. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if an upgrade hop has to be rolled back:
 
             ```
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade through each required intermediate version:
+            Follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade through each required intermediate version. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** Run the command once per hop in the supported sequence rather than jumping straight to the target version, because skipping intermediate releases can corrupt the configuration migration. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```
             execute restore image tftp <filename> <tftp_server_ip>
@@ -433,6 +433,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             ```
             config system global
                 set admintimeout 5
@@ -498,13 +500,17 @@ queries:
             **Using the FortiGate web interface**
 
             1. Navigate to **System > Settings**
-            2. Under **Administration Settings**, change the **HTTPS port** to a non-standard port (e.g., 8443)
+            2. Under **Administration Settings**, change the **HTTPS port** to a non-standard port such as 8443
             3. Click **Apply**
 
-            **Important**: Ensure all administrators are informed of the port change and update any bookmarks or management tools accordingly.
+            **Important**: Choose a port that does not overlap the SSL-VPN listening `port`, which commonly uses 443 or 8443. If the admin HTTPS port and the SSL-VPN port collide, one of the services fails to bind and either administrators or VPN users lose access. After you apply the change, the web session disconnects and you must reconnect to the new port, for example `https://<device-ip>:8443`. Inform all administrators of the new port and update any bookmarks or management tools accordingly.
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
+
+            Pick a port that does not overlap the SSL-VPN listening `port`, which commonly uses 443 or 8443. If `admin-sport` collides with the SSL-VPN port, one of the two services fails to bind and either administrators or VPN users lose access.
 
             ```
             config system global
@@ -574,6 +580,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             ```
             config system global
@@ -645,6 +653,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             ```
             config system global
@@ -870,6 +880,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             FortiOS 7.0 and later select the DNS transport with the `protocol` option:
 
             ```
@@ -953,6 +965,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             ```
             config system ntp
                 set ntpsync enable
@@ -1028,6 +1042,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             ```
             config system ntp
@@ -1109,6 +1125,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             ```
             config log setting
                 set fwpolicy-implicit-log enable
@@ -1180,6 +1198,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             ```
             config log setting
                 set local-in-deny-unicast enable
@@ -1239,6 +1259,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             The global extended log format option is available only in the CLI:
 
@@ -1301,6 +1323,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             The user anonymization option is available only in the CLI:
 
@@ -1376,6 +1400,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             ```
             config log syslogd setting
@@ -1461,6 +1487,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             **Option 1: Syslog**
 
             ```
@@ -1544,6 +1572,8 @@ queries:
           desc: |
             **Using the CLI**
 
+            On a multi-VDOM device, first run `config global`.
+
             ```
             config log fortianalyzer setting
                 set enc-algorithm high
@@ -1614,6 +1644,8 @@ queries:
         - id: cli
           desc: |
             **Using the CLI**
+
+            On a multi-VDOM device, first run `config global`.
 
             ```
             config log fortianalyzer setting
@@ -1945,10 +1977,13 @@ queries:
           desc: |
             **Using the CLI**
 
+            Setting `utm-status enable` without an `ssl-ssh-profile` leaves the policy with no SSL/SSH inspection, so the antivirus, IPS, and web filter profiles never see inside encrypted sessions and the UTM stack is effectively bypassed for HTTPS and other TLS traffic. Always pair the UTM profiles with an inspection profile:
+
             ```
             config firewall policy
                 edit <policy-id>
                     set utm-status enable
+                    set ssl-ssh-profile "certificate-inspection"
                     set av-profile "default"
                     set ips-sensor "default"
                     set webfilter-profile "default"
@@ -1956,6 +1991,8 @@ queries:
                 next
             end
             ```
+
+            The `certificate-inspection` profile reads only the certificate metadata and works without further setup. The `deep-inspection` profile decrypts and re-encrypts TLS sessions and catches threats hidden inside encrypted payloads, but it requires deploying the FortiGate CA certificate to every client's trust store first, otherwise users get certificate warnings.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/178074/security-profiles
         title: FortiOS security profiles
@@ -2511,11 +2548,13 @@ queries:
             diagnose autoupdate status
             ```
 
-            Force a license check:
+            Once a valid contract is registered, refresh the FortiGuard packages:
 
             ```
             execute update-now
             ```
+
+            `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
         title: FortiOS FortiGuard configuration
@@ -2591,11 +2630,13 @@ queries:
             diagnose autoupdate status
             ```
 
-            Force a license check:
+            Once a valid contract is registered, refresh the FortiGuard packages:
 
             ```
             execute update-now
             ```
+
+            `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
         title: FortiOS FortiGuard configuration
@@ -2671,11 +2712,13 @@ queries:
             diagnose autoupdate status
             ```
 
-            Force a license check:
+            Once a valid contract is registered, refresh the FortiGuard packages:
 
             ```
             execute update-now
             ```
+
+            `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
         title: FortiOS FortiGuard configuration


### PR DESCRIPTION
Remediation-quality fixes to `content/mondoo-fortios-security.mql.yaml`. Edits touch only remediation/desc/audit prose and code; no mql, filters, uid, title, impact, or tags changed. Version bumped 1.0.1 -> 1.0.2.

## Multi-VDOM prerequisite

On a multi-VDOM FortiGate, global, log, NTP, and DNS settings live under `config global`; a junior in a VDOM shell hits a parse error. Prepended "On a multi-VDOM device, first run `config global`." to the 15 global-scoped CLI blocks:

- admin-timeout, admin-https-non-default-port, admin-ssh-non-default-port, admin-scp-disabled
- dns-over-tls, ntp-sync-enabled, ntp-servers-configured
- log-implicit-deny, log-local-in-denied-unicast, log-extended-format, log-no-user-anonymization
- log-syslog-enabled, log-external-destination, log-fortianalyzer-encryption, log-fortianalyzer-reliable

## admin-https-non-default-port

- CLI and console: warn that `admin-sport` must not overlap the SSL-VPN `port` (commonly 443/8443), or a service fails to bind and admins or VPN users lose access.
- Console: added a reconnect-on-new-port note.

## Firmware checks (supported-major-version, ga-release, mature-release)

- Stated that `execute restore image` reboots immediately with no confirmation prompt and interrupts all traffic.
- Stated each hop must follow the supported upgrade path and to back up plus verify health after each hop.

## policy-utm-enabled

- Added `set ssl-ssh-profile "certificate-inspection"`; explained UTM with no ssl-ssh-profile leaves encrypted traffic uninspected.
- Noted deep inspection requires deploying the FortiGate CA cert to client trust stores.

## fortiguard-antispam / webfilter / outbreak-prevention

- Clarified `execute update-now` only refreshes packages once a valid contract is registered; an expired license must be renewed and re-registered first.

## VERIFY items

- **`execute backup full-config` (audit flagged as likely invalid): NOT changed.** Verified against the FortiOS 7.4.x / 7.6.x [configuration-backups docs](https://docs.fortinet.com/document/fortigate/7.6.6/administration-guide/702257/configuration-backups-and-reset): `execute backup full-config` is a valid keyword on modern FortiOS and backs up user-specified plus default configuration, whereas `execute backup config` backs up only user-specified configuration. The audit's "likely not valid" claim is a false positive. Kept `full-config` and added a one-line note explaining it gives a complete restore point.

## Validation

`cnspec policy lint content/mondoo-fortios-security.mql.yaml` -> valid policy bundle(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)