### PR TITLE
feat(upload): add UploadFindings for third-party findings ingest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260614185306-5101ee5e7783
-	go.mondoo.com/mql/v13 v13.23.0
+	go.mondoo.com/mql/v13 v13.23.1-0.20260618164738-079a6f192558
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260614185306-5101ee5e7783 h1:TneVvppW7ATvu+65W1SB1a8psDPmNaKjhM47bCV1AhQ=
 go.mondoo.com/mondoo-go v0.0.0-20260614185306-5101ee5e7783/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.23.0 h1:/nSL9C0HjOKz2qiNGjrsFBat+b0309ho4tZOc7Eva/Y=
-go.mondoo.com/mql/v13 v13.23.0/go.mod h1:z1KYwwLQnSwyWiLjpsFNZCli4vh5U/V0cQUB1ST9LfQ=
+go.mondoo.com/mql/v13 v13.23.1-0.20260618164738-079a6f192558 h1:XOr8xf1ySRIj6JRMMZTL9FXcnTQRhNuZEHGbLbWZr/M=
+go.mondoo.com/mql/v13 v13.23.1-0.20260618164738-079a6f192558/go.mod h1:z1KYwwLQnSwyWiLjpsFNZCli4vh5U/V0cQUB1ST9LfQ=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/upload/findings.go
+++ b/upload/findings.go
@@ -1,0 +1,245 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/v13/policy"
+	cliconfig "go.mondoo.com/mql/v13/cli/config"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	ranger "go.mondoo.com/ranger-rpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// findingsUploadTimeout bounds a single signed-URL PUT so a stalled connection
+// can't hang indefinitely (the proxy-aware client has no timeout of its own).
+// Retry/backoff of the upload operation itself is handled by upstream.WithRetry.
+const findingsUploadTimeout = 2 * time.Minute
+
+// ErrNoCredentials is returned when no service account config can be found. Use
+// IsNoCredentials to let callers degrade to a local-only run.
+var ErrNoCredentials = errors.New("no Mondoo service account credentials found")
+
+// IsNoCredentials reports whether the error indicates missing credentials.
+func IsNoCredentials(err error) bool {
+	return errors.Is(err, ErrNoCredentials)
+}
+
+// Opts selects the Mondoo service-account config and target scope for a findings
+// upload. ConfigPath is optional — when empty the standard config resolution
+// (MONDOO_CONFIG_PATH, MONDOO_CONFIG_BASE64, AWS SSM, ~/.config/mondoo/mondoo.yml)
+// applies. ScopeMrn overrides the scope from the config when set.
+type Opts struct {
+	ConfigPath string
+	ScopeMrn   string
+}
+
+// UploadFindings uploads FEX/VEX documents to Mondoo Platform as third-party
+// findings: it resolves credentials, requests a signed object-storage URL via
+// the PolicyResolver, PUTs the protojson-encoded request, then signals
+// completion. Each step is retried on transient (network/5xx/429) failures so a
+// blip doesn't discard the collected scan data. source identifies the producing
+// tool (e.g. "xgrep"). Returns ErrNoCredentials when no config is found (check
+// with IsNoCredentials).
+func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument, source string) error {
+	if len(docs) == 0 {
+		log.Debug().Msg("no findings to upload")
+		return nil
+	}
+
+	creds, spaceMrn, err := LoadCredentials(opts)
+	if err != nil {
+		return err
+	}
+
+	plugin, err := upstream.NewServiceAccountRangerPlugin(creds)
+	if err != nil {
+		return fmt.Errorf("create auth plugin: %w", err)
+	}
+
+	resolver, err := policy.NewPolicyResolverClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	if err != nil {
+		return fmt.Errorf("create policy resolver client: %w", err)
+	}
+
+	data, err := protojson.Marshal(&fex.FindingsUploadRequest{
+		Findings:         docs,
+		Source:           source,
+		MondooEnrichment: true,
+		SpaceMrn:         spaceMrn,
+		CreateAssets:     true,
+		ImportStartedAt:  timestamppb.Now(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal findings: %w", err)
+	}
+
+	httpClient, err := newHTTPClient()
+	if err != nil {
+		return fmt.Errorf("create http client: %w", err)
+	}
+	httpClient.Timeout = findingsUploadTimeout
+
+	if err := doUpload(ctx, resolver, httpClient, data, spaceMrn); err != nil {
+		return err
+	}
+
+	log.Info().Int("findings", len(docs)).Str("source", source).Msg("uploaded findings to Mondoo Platform")
+	return nil
+}
+
+// uploadResolver is the slice of the PolicyResolver client the findings upload
+// needs. *policy.PolicyResolverClient satisfies it; a fake stands in for tests.
+type uploadResolver interface {
+	GetUploadURL(ctx context.Context, in *policy.GetUploadURLReq) (*policy.GetUploadURLResp, error)
+	ReportUploadCompleted(ctx context.Context, in *policy.ReportUploadCompletedReq) (*policy.Empty, error)
+}
+
+// doUpload runs the signed-URL upload handshake: request a URL, PUT the payload,
+// then report completion. Split out from UploadFindings so it can be tested
+// against a fake resolver and an httptest server without real credentials.
+func doUpload(ctx context.Context, resolver uploadResolver, httpClient *http.Client, data []byte, spaceMrn string) error {
+	// A fresh signed URL is fetched per attempt (signed URLs expire quickly, so
+	// reusing one across a backoff window would PUT against an expired URL and
+	// 403), so GetUploadURL and the PUT live in the same retry block. The PUT to
+	// object storage is idempotent (same object), so a retry is safe.
+	// uploadSessionID is captured from the attempt whose PUT succeeds and used for
+	// ReportUploadCompleted below.
+	var uploadSessionID string
+	if err := upstream.WithRetry(ctx, "upload findings", func() (bool, time.Duration, error) {
+		resp, err := resolver.GetUploadURL(ctx, &policy.GetUploadURLReq{
+			Kind:     policy.UploadURLKind_UPLOAD_URL_KIND_THIRD_PARTY_FINDINGS,
+			ScopeMrn: spaceMrn,
+		})
+		if err != nil {
+			return upstream.RetryableRPCError(err), 0, fmt.Errorf("get upload URL: %w", err)
+		}
+		uploadURL := resp.GetUploadUrl()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL.GetUrl(), bytes.NewReader(data))
+		if err != nil {
+			return false, 0, err
+		}
+		req.ContentLength = int64(len(data))
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range uploadURL.GetHeaders() {
+			req.Header.Set(k, v)
+		}
+		httpResp, err := httpClient.Do(req)
+		if err != nil {
+			return true, 0, err // network error: retry
+		}
+		defer func() { _ = httpResp.Body.Close() }()
+		if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+			body, _ := io.ReadAll(io.LimitReader(httpResp.Body, 1<<20))
+			return upstream.RetryableHTTPStatus(httpResp.StatusCode), upstream.RetryAfter(httpResp.Header),
+				fmt.Errorf("upload failed with status %d: %s", httpResp.StatusCode, string(body))
+		}
+		uploadSessionID = resp.GetUploadSessionId()
+		return false, 0, nil
+	}); err != nil {
+		return err
+	}
+
+	return upstream.RetryRPC(ctx, "signal upload completed", func() error {
+		_, err := resolver.ReportUploadCompleted(ctx, &policy.ReportUploadCompletedReq{
+			UploadSessionId: uploadSessionID,
+			ScopeMrn:        spaceMrn,
+		})
+		return err
+	})
+}
+
+// LoadCredentials resolves the service-account credentials and scope MRN from
+// opts, for callers that drive their own Mondoo RPC with the same auth as the
+// findings upload. Returns ErrNoCredentials when no config is found (check with
+// IsNoCredentials).
+func LoadCredentials(opts Opts) (*upstream.ServiceAccountCredentials, string, error) {
+	creds, err := loadServiceAccount(opts.ConfigPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	spaceMrn := opts.ScopeMrn
+	if spaceMrn == "" {
+		spaceMrn = creds.GetScopeMrn()
+	}
+	if spaceMrn == "" {
+		spaceMrn = creds.GetParentMrn()
+	}
+	if spaceMrn == "" {
+		return nil, "", fmt.Errorf("scope MRN is required (use --scope-mrn or set scope_mrn in config)")
+	}
+
+	return creds, spaceMrn, nil
+}
+
+// ValidateCredentials checks connectivity to Mondoo Platform with the given
+// credentials, so a caller can fail fast before collecting findings.
+func ValidateCredentials(ctx context.Context, creds *upstream.ServiceAccountCredentials) error {
+	plugin, err := upstream.NewServiceAccountRangerPlugin(creds)
+	if err != nil {
+		return err
+	}
+
+	client, err := upstream.NewAgentManagerClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.PingPong(ctx, &upstream.Ping{})
+	return err
+}
+
+// configMu serializes access to cli/config's process-global state. InitViperConfig
+// reads a package-level path (UserProvidedPath) and populates the global viper
+// instance, so concurrent callers would otherwise race on that shared state.
+var configMu sync.Mutex
+
+// loadServiceAccount resolves Mondoo service account credentials via mql's
+// canonical config loader (cli/config). InitViperConfig handles every config
+// source the Mondoo CLI supports — the explicit path, MONDOO_CONFIG_PATH,
+// MONDOO_CONFIG_BASE64, AWS SSM Parameter Store, and autodetection of the
+// default ~/.config/mondoo/mondoo.yml — and GetServiceCredential parses the
+// loaded config into the upstream credential type (including SSH/WIF token
+// exchange). Returns ErrNoCredentials when no credentials are configured.
+func loadServiceAccount(configPath string) (*upstream.ServiceAccountCredentials, error) {
+	cfg, err := readMondooConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read mondoo config: %w", err)
+	}
+
+	creds := cfg.GetServiceCredential()
+	if creds == nil {
+		return nil, ErrNoCredentials
+	}
+	if creds.Mrn == "" {
+		return nil, fmt.Errorf("invalid service account: missing mrn")
+	}
+
+	return creds, nil
+}
+
+// readMondooConfig points cli/config at configPath, (re)loads the global viper
+// instance, and reads it back. The whole sequence holds configMu so a concurrent
+// caller can't repopulate the global viper between InitViperConfig and Read and
+// hand us the wrong config; defer also keeps the lock held if Read panics.
+func readMondooConfig(configPath string) (*cliconfig.Config, error) {
+	configMu.Lock()
+	defer configMu.Unlock()
+	cliconfig.UserProvidedPath = configPath
+	cliconfig.InitViperConfig()
+	return cliconfig.Read()
+}

--- a/upload/findings_test.go
+++ b/upload/findings_test.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// fakeResolver stands in for *policy.PolicyResolverClient. It hands out the test
+// server URL and records the completion call.
+type fakeResolver struct {
+	uploadURL        string
+	sessionID        string
+	getCalls         int
+	completedSession string
+	completedScope   string
+}
+
+func (f *fakeResolver) GetUploadURL(_ context.Context, in *policy.GetUploadURLReq) (*policy.GetUploadURLResp, error) {
+	f.getCalls++
+	// The findings upload must request the third-party-findings kind.
+	if in.Kind != policy.UploadURLKind_UPLOAD_URL_KIND_THIRD_PARTY_FINDINGS {
+		return nil, assert.AnError
+	}
+	return &policy.GetUploadURLResp{
+		UploadSessionId: f.sessionID,
+		UploadUrl: &policy.UploadURL{
+			Url:     f.uploadURL,
+			Headers: map[string]string{"x-test": "1"},
+		},
+	}, nil
+}
+
+func (f *fakeResolver) ReportUploadCompleted(_ context.Context, in *policy.ReportUploadCompletedReq) (*policy.Empty, error) {
+	f.completedSession = in.UploadSessionId
+	f.completedScope = in.ScopeMrn
+	return &policy.Empty{}, nil
+}
+
+func TestDoUpload(t *testing.T) {
+	var (
+		gotBody   []byte
+		gotMethod string
+		gotCType  string
+		gotHeader string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotCType = r.Header.Get("Content-Type")
+		gotHeader = r.Header.Get("x-test")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resolver := &fakeResolver{uploadURL: srv.URL, sessionID: "sess-123"}
+
+	docs := fex.FexToDocuments([]*fex.FindingExchange{
+		{Id: "f1", Summary: "SQL injection", Status: fex.Status_STATUS_AFFECTED, Source: &fex.Source{Name: "xgrep"}},
+	})
+	req := &fex.FindingsUploadRequest{
+		Findings:     docs,
+		Source:       "xgrep",
+		CreateAssets: true,
+		SpaceMrn:     "//captain.api.mondoo.app/spaces/test",
+	}
+	data, err := protojson.Marshal(req)
+	require.NoError(t, err)
+
+	err = doUpload(context.Background(), resolver, srv.Client(), data, req.SpaceMrn)
+	require.NoError(t, err)
+
+	// The signed-URL PUT carried the protojson request, content type, and the
+	// resolver-provided header.
+	assert.Equal(t, http.MethodPut, gotMethod)
+	assert.Equal(t, "application/json", gotCType)
+	assert.Equal(t, "1", gotHeader)
+
+	var roundtrip fex.FindingsUploadRequest
+	require.NoError(t, protojson.Unmarshal(gotBody, &roundtrip))
+	assert.Equal(t, "xgrep", roundtrip.Source)
+	assert.True(t, roundtrip.CreateAssets)
+	require.Len(t, roundtrip.Findings, 1)
+	assert.Equal(t, "f1", roundtrip.Findings[0].GetFex().GetId())
+
+	// Completion was signaled for the session whose PUT succeeded.
+	assert.Equal(t, 1, resolver.getCalls)
+	assert.Equal(t, "sess-123", resolver.completedSession)
+	assert.Equal(t, req.SpaceMrn, resolver.completedScope)
+}


### PR DESCRIPTION
## What

Adds `upload.UploadFindings` — a reusable orchestrator for uploading **FEX** (Finding Exchange) documents to Mondoo Platform as third-party findings:

1. Resolve service-account credentials (`LoadCredentials`, with `ErrNoCredentials`/`IsNoCredentials` for graceful degradation).
2. Request a signed object-storage URL via the `PolicyResolver` (`GetUploadURL`, kind `UPLOAD_URL_KIND_THIRD_PARTY_FINDINGS`).
3. PUT the protojson `FindingsUploadRequest` to it (in-memory, reusing the existing proxy-aware `newHTTPClient`).
4. `ReportUploadCompleted`.

Each step is retried on transient (network/5xx/429) failures. Also adds `ValidateCredentials` (PingPong reachability).

## Why here (cnspec, not mql/fex)

The signed-URL RPC lives in cnspec's `PolicyResolver`, and **cnspec depends on mql, not the reverse** — so the helper can't live next to the FEX types in mql without inverting the module dependency. cnspec's `upload` package already had the proxy-aware PUT helper, so the complete orchestrator belongs here.

This resolves the long-standing TODO in mhunt's internal `fex/upload.go` ("add in-memory upload to cnspec upload package so we can use it directly"); mhunt can migrate to this shared helper. **xgrep** is the first new consumer — it will call this to publish SAST findings (`xgrep scan --report mondoo`), in a follow-up PR once this releases.

## Notes

- Bumps mql to the `fex`-bearing pseudo-version (`v13.23.1-0.20260618164738-...`), the same one mhunt uses.
- Transport core is split behind a small `uploadResolver` interface so it's tested hermetically (`findings_test.go`: httptest signed-URL PUT + fake resolver, asserting the protojson body and completion call).

## Test

`go test ./upload/...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)