### PR TITLE
upload: allow callers to supply an HTTP client for findings upload

### DIFF
--- a/upload/findings.go
+++ b/upload/findings.go
@@ -44,6 +44,13 @@ func IsNoCredentials(err error) bool {
 type Opts struct {
 	ConfigPath string
 	ScopeMrn   string
+
+	// HTTPClient, when set, is used for both the resolver RPCs and the
+	// signed-URL PUT, letting callers supply an instrumented client (tracing,
+	// metrics, custom transport). When nil, default clients are used. The PUT
+	// enforces findingsUploadTimeout: if the supplied client has no timeout, a
+	// shallow copy is used for the PUT so the caller's client is left untouched.
+	HTTPClient *http.Client
 }
 
 // UploadFindings uploads FEX/VEX documents to Mondoo Platform as third-party
@@ -69,7 +76,7 @@ func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument,
 		return fmt.Errorf("create auth plugin: %w", err)
 	}
 
-	resolver, err := policy.NewPolicyResolverClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	resolver, err := policy.NewPolicyResolverClient(creds.ApiEndpoint, resolverHTTPClient(opts.HTTPClient), plugin)
 	if err != nil {
 		return fmt.Errorf("create policy resolver client: %w", err)
 	}
@@ -86,11 +93,10 @@ func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument,
 		return fmt.Errorf("marshal findings: %w", err)
 	}
 
-	httpClient, err := newHTTPClient()
+	httpClient, err := putHTTPClient(opts.HTTPClient)
 	if err != nil {
 		return fmt.Errorf("create http client: %w", err)
 	}
-	httpClient.Timeout = findingsUploadTimeout
 
 	if err := doUpload(ctx, resolver, httpClient, data, spaceMrn); err != nil {
 		return err
@@ -98,6 +104,36 @@ func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument,
 
 	log.Info().Int("findings", len(docs)).Str("source", source).Msg("uploaded findings to Mondoo Platform")
 	return nil
+}
+
+// resolverHTTPClient returns the client used for the resolver RPCs: the
+// caller-supplied client when set, otherwise ranger's default.
+func resolverHTTPClient(c *http.Client) *http.Client {
+	if c != nil {
+		return c
+	}
+	return ranger.DefaultHttpClient()
+}
+
+// putHTTPClient returns the client used for the signed-URL PUT, bounded by
+// findingsUploadTimeout so a stalled connection can't hang indefinitely. When
+// the caller supplies a client with no timeout of its own, a shallow copy is
+// returned (the timeout is set on the copy, not the caller's shared client).
+func putHTTPClient(c *http.Client) (*http.Client, error) {
+	if c == nil {
+		nc, err := newHTTPClient()
+		if err != nil {
+			return nil, err
+		}
+		nc.Timeout = findingsUploadTimeout
+		return nc, nil
+	}
+	if c.Timeout == 0 {
+		clone := *c
+		clone.Timeout = findingsUploadTimeout
+		return &clone, nil
+	}
+	return c, nil
 }
 
 // uploadResolver is the slice of the PolicyResolver client the findings upload

--- a/upload/findings_test.go
+++ b/upload/findings_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,4 +99,43 @@ func TestDoUpload(t *testing.T) {
 	assert.Equal(t, 1, resolver.getCalls)
 	assert.Equal(t, "sess-123", resolver.completedSession)
 	assert.Equal(t, req.SpaceMrn, resolver.completedScope)
+}
+
+func TestResolverHTTPClient(t *testing.T) {
+	// nil falls back to a non-nil default client.
+	assert.NotNil(t, resolverHTTPClient(nil))
+
+	// a supplied client is used as-is.
+	custom := &http.Client{}
+	assert.Same(t, custom, resolverHTTPClient(custom))
+}
+
+func TestPutHTTPClient(t *testing.T) {
+	t.Run("nil builds a default client with the upload timeout", func(t *testing.T) {
+		c, err := putHTTPClient(nil)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		assert.Equal(t, findingsUploadTimeout, c.Timeout)
+	})
+
+	t.Run("client without a timeout is cloned, caller left untouched", func(t *testing.T) {
+		caller := &http.Client{Transport: http.DefaultTransport}
+		c, err := putHTTPClient(caller)
+		require.NoError(t, err)
+		// A copy is returned with the upload timeout set...
+		assert.NotSame(t, caller, c)
+		assert.Equal(t, findingsUploadTimeout, c.Timeout)
+		// ...and the same transport is preserved (so instrumentation survives).
+		assert.Same(t, caller.Transport, c.Transport)
+		// ...while the caller's client is unchanged.
+		assert.Equal(t, time.Duration(0), caller.Timeout)
+	})
+
+	t.Run("client with its own timeout is used as-is", func(t *testing.T) {
+		caller := &http.Client{Timeout: 30 * time.Second}
+		c, err := putHTTPClient(caller)
+		require.NoError(t, err)
+		assert.Same(t, caller, c)
+		assert.Equal(t, 30*time.Second, c.Timeout)
+	})
 }


### PR DESCRIPTION
`UploadFindings` builds its own resolver and PUT clients (`ranger.DefaultHttpClient()` / `newHTTPClient()`), so a caller can't supply an instrumented client. Downstream consumers that wrap their HTTP transport for tracing/metrics lose that instrumentation on the upload's RPCs and signed-URL PUT once they switch to this package.

### Change
Add an optional `Opts.HTTPClient`:
- when **set**, it's used for both the resolver RPCs and the signed-URL PUT;
- when **nil**, the previous default clients are used — fully backward compatible (existing `Opts{ConfigPath, ScopeMrn}` callers are unaffected).

The PUT still enforces `findingsUploadTimeout`. If a supplied client has no timeout of its own, a **shallow copy** is used for the PUT so the caller's shared client — and its transport/instrumentation — is left untouched; a client that already sets a timeout is used as-is.

Factored behind two small helpers (`resolverHTTPClient`, `putHTTPClient`) with unit tests covering the nil/clone/as-is paths (including that the clone preserves the caller's transport and doesn't mutate the caller's client).

`go build`, `go vet`, and `go test ./upload/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)