### PR TITLE
🎉 hetzner+digitalocean: filter on specific platforms, add 7 checks

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 1.4.2
+    version: 2.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -45,31 +45,32 @@ policies:
           - uid: mondoo-digitalocean-security-droplet-in-vpc
           - uid: mondoo-digitalocean-security-droplet-firewall-coverage
       - title: Cloud Firewalls
-        filters: asset.platform == "digitalocean"
+        filters: asset.platform == "digitalocean-firewall"
         checks:
           - uid: mondoo-digitalocean-security-firewall-no-unrestricted-ssh
           - uid: mondoo-digitalocean-security-firewall-no-unrestricted-rdp
           - uid: mondoo-digitalocean-security-firewall-no-unrestricted-db-ports
           - uid: mondoo-digitalocean-security-firewall-no-all-ports-open
       - title: Managed Databases
-        filters: asset.platform == "digitalocean"
+        filters: asset.platform == "digitalocean-database"
         checks:
           - uid: mondoo-digitalocean-security-db-firewall-configured
           - uid: mondoo-digitalocean-security-db-in-private-network
           - uid: mondoo-digitalocean-security-db-engine-supported-version
           - uid: mondoo-digitalocean-security-db-ca-certificate-not-expired
       - title: Load Balancers
-        filters: asset.platform == "digitalocean"
+        filters: asset.platform == "digitalocean-loadbalancer"
         checks:
           - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
           - uid: mondoo-digitalocean-security-lb-in-vpc
       - title: Kubernetes (DOKS)
-        filters: asset.platform == "digitalocean"
+        filters: asset.platform == "digitalocean-kubernetes-cluster"
         checks:
           - uid: mondoo-digitalocean-security-doks-auto-upgrade-enabled
           - uid: mondoo-digitalocean-security-doks-supported-version
           - uid: mondoo-digitalocean-security-doks-sso-enabled
           - uid: mondoo-digitalocean-security-doks-sso-required
+          - uid: mondoo-digitalocean-security-doks-in-vpc
       - title: TLS Certificates
         filters: asset.platform == "digitalocean"
         checks:
@@ -78,14 +79,21 @@ policies:
         filters: asset.platform == "digitalocean"
         checks:
           - uid: mondoo-digitalocean-security-cdn-has-certificate
-      - title: Spaces
+      - title: Spaces Access Keys
         filters: asset.platform == "digitalocean"
         checks:
           - uid: mondoo-digitalocean-security-spaces-key-has-scoped-grants
+      - title: Spaces Buckets
+        filters: asset.platform == "digitalocean-spaces-bucket"
+        checks:
           - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable
           - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-writable
+          - uid: mondoo-digitalocean-security-spaces-bucket-not-authenticated-readable
+          - uid: mondoo-digitalocean-security-spaces-bucket-policy-not-public
           - uid: mondoo-digitalocean-security-spaces-bucket-encryption-enabled
           - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled
+          - uid: mondoo-digitalocean-security-spaces-bucket-mfa-delete-enabled
+          - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin
       - title: App Platform
         filters: asset.platform == "digitalocean"
         checks:
@@ -501,11 +509,9 @@ queries:
         title: Configure Cloud Firewall rules
 
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-ssh-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-firewall"
     mql: |
-      digitalocean.firewalls.all(
-        ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "22")
-      )
+      digitalocean.firewall.ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "22")
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-ssh-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |
@@ -638,11 +644,9 @@ queries:
         title: Configure Cloud Firewall rules
 
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-rdp-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-firewall"
     mql: |
-      digitalocean.firewalls.all(
-        ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "3389")
-      )
+      digitalocean.firewall.ingressRules.where(openToInternet).none(protocol == "tcp" && ports == "3389")
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-rdp-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |
@@ -778,11 +782,9 @@ queries:
         title: Configure Cloud Firewall rules
 
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-db-ports-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-firewall"
     mql: |
-      digitalocean.firewalls.all(
-        ingressRules.where(openToInternet).none(protocol == "tcp" && ports.in(["3306", "5432", "27017", "6379", "9092", "9200"]))
-      )
+      digitalocean.firewall.ingressRules.where(openToInternet).none(protocol == "tcp" && ports.in(["3306", "5432", "27017", "6379", "9092", "9200"]))
   - uid: mondoo-digitalocean-security-firewall-no-unrestricted-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |
@@ -923,11 +925,9 @@ queries:
         title: Configure Cloud Firewall rules
 
   - uid: mondoo-digitalocean-security-firewall-no-all-ports-open-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-firewall"
     mql: |
-      digitalocean.firewalls.all(
-        ingressRules.where(openToInternet).none(ports.in(["0", "all", "1-65535", "0-65535"]))
-      )
+      digitalocean.firewall.ingressRules.where(openToInternet).none(ports.in(["0", "all", "1-65535", "0-65535"]))
   - uid: mondoo-digitalocean-security-firewall-no-all-ports-open-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_firewall")
     mql: |
@@ -981,7 +981,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      digitalocean.databases.all(firewallRules != empty)
+      digitalocean.database.firewallRules != empty
     docs:
       desc: |
         This check ensures that every managed database cluster has at least one Trusted Sources entry, restricting inbound connections to specific Droplets, tags, Kubernetes clusters, applications, or IP addresses. By default, a newly created managed database cluster accepts connections from any source that presents valid credentials.
@@ -1153,9 +1153,9 @@ queries:
         title: Connect to a managed database cluster
 
   - uid: mondoo-digitalocean-security-db-in-private-network-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-database"
     mql: |
-      digitalocean.databases.all(privateNetworkUuid != "")
+      digitalocean.database.privateNetworkUuid != ""
   - uid: mondoo-digitalocean-security-db-in-private-network-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_database_cluster")
     mql: |
@@ -1310,14 +1310,14 @@ queries:
         title: Upgrade a managed database major version
 
   - uid: mondoo-digitalocean-security-db-engine-supported-version-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-database"
     mql: |
-      digitalocean.databases.where(engine == "pg").all(version.notIn(["9", "9.5", "9.6", "10", "11", "12", "13"]))
-      digitalocean.databases.where(engine == "mysql").all(version.notIn(["5.6", "5.7"]))
-      digitalocean.databases.where(engine == "redis").all(version.notIn(["4", "5", "6"]))
-      digitalocean.databases.where(engine == "mongodb").all(version.notIn(["3.6", "4.0", "4.2", "4.4", "5.0"]))
-      digitalocean.databases.where(engine == "kafka").all(version.notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"]))
-      digitalocean.databases.where(engine == "opensearch").all(version.notIn(["1.0", "1.1", "1.2", "1.3"]))
+      digitalocean.database.engine != "pg" || digitalocean.database.version.notIn(["9", "9.5", "9.6", "10", "11", "12", "13"])
+      digitalocean.database.engine != "mysql" || digitalocean.database.version.notIn(["5.6", "5.7"])
+      digitalocean.database.engine != "redis" || digitalocean.database.version.notIn(["4", "5", "6"])
+      digitalocean.database.engine != "mongodb" || digitalocean.database.version.notIn(["3.6", "4.0", "4.2", "4.4", "5.0"])
+      digitalocean.database.engine != "kafka" || digitalocean.database.version.notIn(["2.8", "3.0", "3.1", "3.2", "3.3", "3.4"])
+      digitalocean.database.engine != "opensearch" || digitalocean.database.version.notIn(["1.0", "1.1", "1.2", "1.3"])
   - uid: mondoo-digitalocean-security-db-engine-supported-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_database_cluster")
     mql: |
@@ -1365,7 +1365,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
-      digitalocean.databases.all(certificates(pem: caCertificate).all(notAfter > time.now))
+      digitalocean.database {
+        certificates(pem: caCertificate).all(notAfter > time.now)
+      }
     docs:
       desc: |
         This check ensures that every managed database cluster advertises a CA certificate whose validity window has not passed. Clients verify the cluster's TLS endpoint by pinning to this CA; once it expires, every connection that performs TLS verification fails its handshake.
@@ -1552,11 +1554,11 @@ queries:
         title: Load balancer SSL termination and redirect
 
   - uid: mondoo-digitalocean-security-lb-http-redirected-to-https-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-loadbalancer"
     mql: |
-      digitalocean.loadBalancers.all(
+      digitalocean.loadBalancer {
         forwardingRules.none(_["entry_protocol"] == "http") || redirectHttpToHttps == true
-      )
+      }
   - uid: mondoo-digitalocean-security-lb-http-redirected-to-https-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_loadbalancer")
     mql: |
@@ -1694,9 +1696,9 @@ queries:
         title: DigitalOcean VPC overview
 
   - uid: mondoo-digitalocean-security-lb-in-vpc-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-loadbalancer"
     mql: |
-      digitalocean.loadBalancers.all(vpc != null)
+      digitalocean.loadBalancer.vpc != null
   - uid: mondoo-digitalocean-security-lb-in-vpc-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_loadbalancer")
     mql: |
@@ -1819,9 +1821,9 @@ queries:
         title: Upgrade a DOKS cluster
 
   - uid: mondoo-digitalocean-security-doks-auto-upgrade-enabled-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-kubernetes-cluster"
     mql: |
-      digitalocean.kubernetesClusters.all(autoUpgrade == true)
+      digitalocean.kubernetes.cluster.autoUpgrade == true
   - uid: mondoo-digitalocean-security-doks-auto-upgrade-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_kubernetes_cluster")
     mql: |
@@ -1944,11 +1946,9 @@ queries:
         title: DOKS supported Kubernetes releases
 
   - uid: mondoo-digitalocean-security-doks-supported-version-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-kubernetes-cluster"
     mql: |
-      digitalocean.kubernetesClusters.all(
-        version == /^1\.(3[0-9]|[4-9][0-9]|[1-9][0-9]{2})\./
-      )
+      digitalocean.kubernetes.cluster.version == /^1\.(3[0-9]|[4-9][0-9]|[1-9][0-9]{2})\./
   - uid: mondoo-digitalocean-security-doks-supported-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_kubernetes_cluster")
     mql: |
@@ -1991,7 +1991,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      digitalocean.kubernetesClusters.all(ssoEnabled == true)
+      digitalocean.kubernetes.cluster.ssoEnabled == true
     docs:
       desc: |
         This check ensures that every DOKS cluster has Single Sign-On (SSO) configured against an OIDC identity provider. Without SSO configured, cluster authentication relies entirely on static kubeconfig tokens with no identity-provider integration.
@@ -2070,7 +2070,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
-      digitalocean.kubernetesClusters.all(ssoRequired == true)
+      digitalocean.kubernetes.cluster.ssoRequired == true
     docs:
       desc: |
         This check ensures that every DOKS cluster has SSO both configured and required for all cluster authentication, so that kubectl access is authenticated through the OIDC identity provider rather than through static tokens. Enabling SSO without requiring it leaves static-token paths active.
@@ -2126,6 +2126,132 @@ queries:
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/manage-cluster-access/
         title: Manage DOKS cluster access
+
+  - uid: mondoo-digitalocean-security-doks-in-vpc
+    title: Ensure DOKS clusters are deployed inside a VPC
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-digitalocean-security-doks-in-vpc-digitalocean
+        tags:
+          mondoo.com/filter-title: DigitalOcean
+          mondoo.com/filter-icon: digitalocean
+      - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every DigitalOcean Kubernetes (DOKS) cluster is deployed inside a Virtual Private Cloud (VPC). When a cluster is not assigned a VPC at creation time, its worker nodes communicate over the default network rather than an isolated private network boundary.
+
+        **Why this matters**
+
+        - **Network segmentation:** A VPC gives the cluster's worker nodes a private network boundary that contains intra-cluster and node-to-resource traffic instead of routing it across the shared default network.
+        - **Private connectivity:** VPC membership lets the cluster reach managed databases, Droplets, and load balancers in the same VPC over private IPs, keeping that traffic off public addresses.
+        - **Lateral movement containment:** A compromised node in a VPC-isolated cluster has a narrower reachable network than one on the default network, limiting how far an attacker can pivot.
+
+        **Risk mitigation**
+
+        - **Reduced attack surface:** Keeping node-to-resource traffic on a private network removes the exposure window that arises when those connections traverse public interfaces.
+        - **Defense in depth:** VPC isolation supplements Kubernetes-level network policies and cloud firewalls, so a single misconfiguration in one layer does not immediately expose the cluster's internal traffic.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Kubernetes** and open each cluster.
+        3. On the **Overview** tab, check the **VPC Network** assignment.
+
+        A passing cluster shows a named VPC. A failing cluster shows no VPC or only the default network.
+
+        ### Audit via CLI
+
+        1. List all clusters and inspect each cluster's VPC UUID:
+
+        ```bash
+        doctl kubernetes cluster list --output json | jq -r '.[] | [.id, .name, .vpc_uuid] | @tsv'
+        ```
+
+        A passing cluster returns a non-empty `vpc_uuid`. A failing cluster returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            DigitalOcean does not support moving an existing DOKS cluster into a different VPC. The fix is to create a replacement cluster in the target VPC and migrate workloads, so plan for a cutover.
+
+            1. Navigate to **Kubernetes** and create a new cluster.
+            2. In the creation flow, select the target VPC under **VPC Network**.
+            3. Re-deploy workloads (for example with `kubectl` or your GitOps pipeline) to the new cluster and verify connectivity.
+            4. Repoint ingress and DNS, then delete the original cluster.
+        - id: cli
+          desc: |
+            Create a replacement cluster inside the target VPC and migrate workloads, since the VPC cannot be changed in place:
+
+            ```bash
+            doctl kubernetes cluster create <new-name> \
+              --region <region> \
+              --vpc-uuid <vpc-uuid> \
+              --node-pool "name=default;size=s-1vcpu-2gb;count=3"
+            ```
+
+            Migrate workloads to the new cluster, verify, then delete the original.
+        - id: terraform
+          desc: |
+            To deploy a DOKS cluster inside a VPC in Terraform, set `vpc_uuid` on the `digitalocean_kubernetes_cluster` resource:
+
+            ```hcl
+            resource "digitalocean_kubernetes_cluster" "example" {
+              name     = "example"
+              region   = "nyc3"
+              version  = "1.31.1-do.0"
+              vpc_uuid = digitalocean_vpc.example.id
+
+              node_pool {
+                name       = "default"
+                size       = "s-1vcpu-2gb"
+                node_count = 3
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.digitalocean.com/products/networking/vpc/
+        title: DigitalOcean VPC overview
+
+  - uid: mondoo-digitalocean-security-doks-in-vpc-digitalocean
+    filters: asset.platform == "digitalocean-kubernetes-cluster"
+    mql: |
+      digitalocean.kubernetes.cluster.vpc != null
+  - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_kubernetes_cluster")
+    mql: |
+      terraform.resources("digitalocean_kubernetes_cluster").all(arguments.vpc_uuid != empty)
+  - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_kubernetes_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "digitalocean_kubernetes_cluster").all(change.after.vpc_uuid != empty)
+  - uid: mondoo-digitalocean-security-doks-in-vpc-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_kubernetes_cluster")
+    mql: |
+      terraform.state.resources.where(type == "digitalocean_kubernetes_cluster").all(values.vpc_uuid != empty)
 
   # No Terraform variants: this check inspects the certificate's notAfter validity
   # window — runtime telemetry set at issuance, not a configuration field. The
@@ -2586,9 +2712,9 @@ queries:
         title: Spaces S3 compatibility reference
 
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-spaces-bucket"
     mql: |
-      digitalocean.spacesBuckets.none(publicReadAcl)
+      digitalocean.spacesBucket.publicReadAcl == false
   - uid: mondoo-digitalocean-security-spaces-bucket-not-publicly-readable-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
     mql: |
@@ -2621,7 +2747,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      digitalocean.spacesBuckets.none(publicWriteAcl)
+      digitalocean.spacesBucket.publicWriteAcl == false
     docs:
       desc: |
         This check ensures that no Spaces bucket grants the `WRITE` permission to the `AllUsers` group. An anonymously writable bucket lets any unauthenticated caller upload, overwrite, or delete objects, turning the bucket into a free hosting and laundering point for malicious payloads.
@@ -2706,7 +2832,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
-      digitalocean.spacesBuckets.all(encryptionEnabled)
+      digitalocean.spacesBucket.encryptionEnabled
     docs:
       desc: |
         This check ensures that every Spaces bucket has a default server-side encryption configuration set. When default encryption is configured, every object written to the bucket is encrypted at rest by the platform, removing the need for clients to remember to apply per-request encryption.
@@ -2897,9 +3023,9 @@ queries:
         title: Spaces S3 compatibility reference
 
   - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-digitalocean
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-spaces-bucket"
     mql: |
-      digitalocean.spacesBuckets.all(versioningStatus == "Enabled")
+      digitalocean.spacesBucket.versioningStatus == "Enabled"
   - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
     mql: |
@@ -2912,6 +3038,389 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_bucket")
     mql: |
       terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(values["versioning"] != null && values["versioning"].any(_["enabled"] == true))
+
+  # No Terraform variants: the AuthenticatedUsers ACL grant is applied through the
+  # S3-compatible API; the digitalocean_spaces_bucket.acl argument exposes only
+  # "private" and "public-read", so there is no HCL surface for the authenticated-read
+  # grant. The runtime variant catches buckets where it was set out of band.
+  - uid: mondoo-digitalocean-security-spaces-bucket-not-authenticated-readable
+    title: Ensure Spaces buckets do not grant read access to all authenticated users
+    impact: 80
+    filters: asset.platform == "digitalocean-spaces-bucket"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.spacesBucket.authenticatedReadAcl == false
+    docs:
+      desc: |
+        This check ensures that no Spaces bucket grants the `READ` permission to the `AuthenticatedUsers` group. In the S3-compatible ACL model that DigitalOcean Spaces implements, `AuthenticatedUsers` is not limited to the bucket owner's account — it covers every authenticated S3-compatible principal, including any DigitalOcean or AWS account on the internet. A bucket with this grant is effectively listable and readable by anyone willing to authenticate.
+
+        **Why this matters**
+
+        - **Near-public exposure:** The `AuthenticatedUsers` group is satisfied by any valid S3-compatible credential, so an `authenticated-read` grant exposes object listings and contents to essentially the entire authenticated internet, not to a trusted subset.
+        - **Misleading ACL label:** Operators often read `authenticated-read` as "only my account," when it actually means "any authenticated account," making it a quietly over-permissive setting that survives review.
+        - **Data leak path:** Logs, backups, and uploads accumulated in such a bucket are reachable by outside accounts without any per-bucket authorization, the same exposure class as a fully public bucket but harder to spot.
+
+        **Risk mitigation**
+
+        - **Owner-scoped access:** Removing the `AuthenticatedUsers` grant restores access to the bucket owner and explicitly granted principals only, forcing all other retrieval through scoped Spaces access keys or pre-signed URLs.
+        - **Reviewable intent:** A private bucket ACL makes any future grant an explicit, auditable decision rather than a label that hides cross-account reach.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Spaces Object Storage** and open each bucket.
+        3. Spaces does not surface the `AuthenticatedUsers` ACL grant in the panel; inspect it with the S3-compatible API in the CLI step below.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket ACL with the S3-compatible API and look for an `AuthenticatedUsers` grantee:
+
+        ```bash
+        doctl spaces buckets list
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-acl --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns grants only to the bucket owner. A failing bucket returns a grant where `Grantee.URI` is `http://acs.amazonaws.com/groups/global/AuthenticatedUsers` and `Permission` is `READ` or `FULL_CONTROL`.
+      remediation:
+        - id: console
+          desc: |
+            Spaces does not expose the `AuthenticatedUsers` grant in the Cloud Control Panel; reset the ACL to private with the S3-compatible API shown in the CLI remediation below, then confirm the bucket no longer carries the grant.
+        - id: cli
+          desc: |
+            DigitalOcean Spaces is S3-compatible, so manage its ACLs with the AWS CLI pointed at the Spaces endpoint. The `<spaces-key>` and `<spaces-secret>` come from the **Spaces Keys** page in the API section of the control panel, not the DigitalOcean API token, and `<region>` is the Spaces region slug such as `nyc3`.
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-acl --bucket <bucket> --acl private \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            If specific accounts genuinely need access, grant them individually with `--grant-read id=<canonical-id>` rather than re-applying the `authenticated-read` group grant.
+        # No Terraform remediation: the digitalocean_spaces_bucket.acl argument accepts only "private" and "public-read"; the authenticated-read group grant is applied through the runtime S3 API and has no Terraform analog.
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  # No Terraform variants: a bucket policy is declared in a separate
+  # digitalocean_spaces_bucket_policy resource whose `policy` is a free-form JSON
+  # document keyed to the bucket by name, so asserting "no policy grants public access"
+  # requires parsing that JSON and correlating it back to each bucket — awkward to do
+  # reliably in MQL on Terraform sources. The runtime variant inspects the resolved
+  # policy document directly.
+  - uid: mondoo-digitalocean-security-spaces-bucket-policy-not-public
+    title: Ensure Spaces bucket policies do not grant public access
+    impact: 90
+    filters: asset.platform == "digitalocean-spaces-bucket"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.spacesBucket.policy == null ||
+      digitalocean.spacesBucket.policy["Statement"].where(_["Effect"] == "Allow").all(_["Principal"] != "*")
+    docs:
+      desc: |
+        This check ensures that no Spaces bucket policy contains an `Allow` statement whose `Principal` is the anonymous wildcard `"*"`. A bucket policy is evaluated independently of the bucket ACL, so a policy that allows `"*"` grants unauthenticated access to every caller even when the ACL is private. This is the bucket-policy counterpart to the ACL-based public-read and public-write checks.
+
+        **Why this matters**
+
+        - **ACL-independent exposure:** Access controls on Spaces come from both the ACL and the bucket policy; a wildcard-principal policy statement opens the bucket to anyone regardless of how restrictive the ACL is.
+        - **Broad action grants:** Policy statements often grant `s3:GetObject`, `s3:ListBucket`, or `s3:*`; with `Principal: "*"` these actions become available to the entire internet without credentials.
+        - **Easy to overlook:** Because the policy is a separate JSON document from the ACL, a public policy can be present on a bucket whose ACL review came back clean, leaving a gap that ACL-only checks miss.
+
+        **Risk mitigation**
+
+        - **Principal scoping:** Replacing `"*"` with specific account or Spaces-key principals confines policy-granted access to known identities.
+        - **Layered review:** Auditing the policy alongside the ACL closes the most common path by which a bucket ends up effectively public despite a private ACL.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the affected bucket under **Spaces Object Storage**.
+        3. On the **Settings** tab, review any attached bucket policy for a statement whose `Principal` is `"*"` with `Effect: "Allow"`.
+
+        A passing bucket has no policy, or no `Allow` statement with a `"*"` principal. A failing bucket has an `Allow` statement granting access to `"*"`.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket policy with the S3-compatible API and inspect its statements:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-policy --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com \
+          | jq -r '.Policy | fromjson | .Statement[] | [.Effect, (.Principal|tostring)] | @tsv'
+        ```
+
+        A passing bucket returns `NoSuchBucketPolicy` or no `Allow` statement with a `"*"` principal. A failing bucket returns an `Allow` statement whose principal is `"*"`.
+      remediation:
+        - id: console
+          desc: |
+            Spaces bucket policies are managed through the S3-compatible API rather than the Cloud Control Panel. Use the CLI remediation below to remove or scope the public statement, then confirm the change on the bucket's **Settings** tab.
+        - id: cli
+          desc: |
+            DigitalOcean Spaces is S3-compatible, so manage its policy with the AWS CLI pointed at the Spaces endpoint. The `<spaces-key>` and `<spaces-secret>` come from the **Spaces Keys** page in the API section of the control panel, not the DigitalOcean API token, and `<region>` is the Spaces region slug such as `nyc3`.
+
+            If the bucket does not need a policy at all, delete it:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api delete-bucket-policy --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            If a policy is required, re-apply it with each statement's `Principal` scoped to specific account or Spaces-key identities instead of `"*"`:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-policy --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com \
+                --policy file://scoped-policy.json
+            ```
+        # No Terraform remediation: the bucket policy lives in a separate digitalocean_spaces_bucket_policy resource holding a free-form JSON document; an HCL snippet cannot assert that an arbitrary bucket's policy omits a wildcard principal.
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  # No Terraform variants: MFA delete is enabled through the S3-compatible
+  # PutBucketVersioning call with an MFA serial and code; the digitalocean_spaces_bucket
+  # resource has no argument for it, so there is no HCL surface to inspect.
+  - uid: mondoo-digitalocean-security-spaces-bucket-mfa-delete-enabled
+    title: Ensure Spaces buckets require MFA to delete object versions
+    impact: 50
+    filters: asset.platform == "digitalocean-spaces-bucket"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: false
+    mql: |
+      digitalocean.spacesBucket.mfaDeleteEnabled == true
+    docs:
+      desc: |
+        This check ensures that every Spaces bucket requires multi-factor authentication to permanently delete object versions or to suspend versioning. MFA delete hardens a versioned bucket so that a leaked or compromised access key alone cannot erase the retained version history that versioning is meant to protect.
+
+        **Why this matters**
+
+        - **Tamper resistance for backups:** Object versioning preserves prior revisions, but without MFA delete a single compromised key can still issue per-version deletes; MFA delete forces a second factor before any version is permanently removed.
+        - **Ransomware and insider resilience:** Requiring an MFA code to delete versions or disable versioning closes the path by which an attacker with stolen credentials destroys the recovery copies before exfiltration or extortion.
+        - **Defense in depth for retention:** MFA delete complements versioning and lifecycle retention, ensuring the controls that guarantee recoverability cannot be silently undone with key access alone.
+
+        **Risk mitigation**
+
+        - **Protected version history:** With MFA delete enabled, the version history remains available for recovery even if a write-capable key is compromised.
+        - **Higher bar for destructive actions:** The second factor requirement means permanently destructive operations require interactive, authenticated action rather than an automated API call with a leaked key.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Spaces does not surface MFA delete state in the panel; inspect it with the S3-compatible API in the CLI step below.
+
+        ### Audit via CLI
+
+        1. Query the bucket's versioning configuration, which reports the MFA delete state:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-versioning --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns `"MFADelete": "Enabled"`. A failing bucket returns `"MFADelete": "Disabled"` or omits the field.
+      remediation:
+        - id: console
+          desc: |
+            MFA delete cannot be configured from the Cloud Control Panel; it is set through the S3-compatible API using the root account's MFA device, as shown in the CLI remediation below.
+        - id: cli
+          desc: |
+            MFA delete is enabled through the S3-compatible `PutBucketVersioning` call and requires the serial number of the account's MFA device together with the current code. The `<spaces-key>` and `<spaces-secret>` come from the **Spaces Keys** page, and `<region>` is the Spaces region slug such as `nyc3`.
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-versioning --bucket <bucket> \
+                --versioning-configuration Status=Enabled,MFADelete=Enabled \
+                --mfa "<mfa-serial> <mfa-code>" \
+                --endpoint-url https://<region>.digitaloceanspaces.com
+            ```
+
+            Versioning must be enabled for MFA delete to apply. Verify the new state with `aws s3api get-bucket-versioning`.
+        # No Terraform remediation: MFA delete requires an interactive MFA serial and code on the PutBucketVersioning call; the digitalocean_spaces_bucket resource models no such argument, so there is no Terraform analog.
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin
+    title: Ensure Spaces bucket CORS rules do not allow all origins
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-digitalocean
+        tags:
+          mondoo.com/filter-title: DigitalOcean
+          mondoo.com/filter-icon: digitalocean
+      - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Spaces bucket has a CORS rule whose allowed origins include the wildcard `"*"`. A wildcard origin lets any website instruct a visitor's browser to issue cross-origin requests against the bucket, weakening the same-origin protections that normally isolate web applications from each other.
+
+        **Why this matters**
+
+        - **Cross-origin data reach:** A `"*"` allowed origin permits scripts on any site to read responses from the bucket in the browser context, which can expose objects intended only for a specific application's front end.
+        - **Credentialed request risk:** Combined with permissive methods, a wildcard origin broadens the set of sites that can drive authenticated browser requests against the bucket, expanding the surface for cross-site abuse.
+        - **Overly broad by default:** Wildcard origins are frequently copied from quick-start examples and left in place, granting far wider browser access than the single front-end domain the bucket actually serves.
+
+        **Risk mitigation**
+
+        - **Origin allowlisting:** Restricting allowed origins to the specific scheme-and-host front ends that need browser access confines cross-origin requests to trusted applications.
+        - **Least-privilege CORS:** Pairing a narrow origin list with only the required methods and headers keeps the bucket's browser-accessible surface limited to its intended use.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the affected bucket under **Spaces Object Storage**.
+        3. On the **Settings** tab, review the **CORS Configurations** and check whether any rule's **Origin** is `*`.
+
+        A passing bucket has no CORS rule with a `*` origin. A failing bucket has at least one CORS rule whose allowed origin is `*`.
+
+        ### Audit via CLI
+
+        1. Retrieve the bucket CORS configuration with the S3-compatible API:
+
+        ```bash
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api get-bucket-cors --bucket <bucket> \
+            --endpoint-url https://<region>.digitaloceanspaces.com
+        ```
+
+        A passing bucket returns no rule with `"AllowedOrigins": ["*"]`. A failing bucket returns at least one rule whose `AllowedOrigins` contains `*`.
+      remediation:
+        - id: console
+          desc: |
+            To fix this in the DigitalOcean Cloud Control Panel:
+
+            1. Open the bucket under **Spaces Object Storage** and go to the **Settings** tab.
+            2. Edit each CORS configuration whose **Origin** is `*` and replace it with the specific scheme-and-host origins that need browser access, for example `https://app.example.com`.
+            3. Save the configuration.
+        - id: cli
+          desc: |
+            DigitalOcean Spaces is S3-compatible, so manage CORS with the AWS CLI pointed at the Spaces endpoint. The `<spaces-key>` and `<spaces-secret>` come from the **Spaces Keys** page, and `<region>` is the Spaces region slug such as `nyc3`. Re-apply the CORS configuration with explicit origins instead of `*`:
+
+            ```bash
+            AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+              aws s3api put-bucket-cors --bucket <bucket> \
+                --endpoint-url https://<region>.digitaloceanspaces.com \
+                --cors-configuration '{
+                  "CORSRules": [{
+                    "AllowedOrigins": ["https://app.example.com"],
+                    "AllowedMethods": ["GET"],
+                    "AllowedHeaders": ["*"]
+                  }]
+                }'
+            ```
+        - id: terraform
+          desc: |
+            To scope CORS in Terraform, set `allowed_origins` on each `cors_rule` block of `digitalocean_spaces_bucket` to specific origins instead of `*`:
+
+            ```hcl
+            resource "digitalocean_spaces_bucket" "example" {
+              name   = "example-bucket"
+              region = "nyc3"
+              acl    = "private"
+
+              cors_rule {
+                allowed_origins = ["https://app.example.com"]
+                allowed_methods = ["GET"]
+                allowed_headers = ["*"]
+                max_age_seconds = 3000
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+        title: Spaces S3 compatibility reference
+
+  - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-digitalocean
+    filters: asset.platform == "digitalocean-spaces-bucket"
+    mql: |
+      digitalocean.spacesBucket.corsRules.none(_["allowedOrigins"].contains("*"))
+  - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.resources("digitalocean_spaces_bucket").all(
+        blocks.where(type == "cors_rule").none(arguments["allowed_origins"].contains("*"))
+      )
+  - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "digitalocean_spaces_bucket").all(
+        change.after["cors_rule"] == empty ||
+        change.after["cors_rule"].none(_["allowed_origins"].contains("*"))
+      )
+  - uid: mondoo-digitalocean-security-spaces-bucket-cors-no-wildcard-origin-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_spaces_bucket")
+    mql: |
+      terraform.state.resources.where(type == "digitalocean_spaces_bucket").all(
+        values["cors_rule"] == empty ||
+        values["cors_rule"].none(_["allowed_origins"].contains("*"))
+      )
 
   # No Terraform variants: this check inspects the scheme of each app's live_url,
   # which is a read-only computed attribute. App Platform always provisions managed

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 1.0.3
+    version: 2.0.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -41,10 +41,12 @@ policies:
           - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp
           - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports
           - uid: mondoo-hetzner-security-firewall-no-all-ports-open
+          - uid: mondoo-hetzner-security-firewall-has-rules
       - title: Load Balancers
         checks:
           - uid: mondoo-hetzner-security-lb-http-redirected-to-https
           - uid: mondoo-hetzner-security-lb-https-service-has-certificate
+          - uid: mondoo-hetzner-security-lb-in-private-network
       - title: TLS Certificates
         checks:
           - uid: mondoo-hetzner-security-cert-not-expired
@@ -521,17 +523,13 @@ queries:
         title: Hetzner Cloud Firewalls overview
 
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-firewall"
     mql: |
-      hetzner.firewalls.all(
-        rules.none(
-          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("0.0.0.0/0")
-        )
+      hetzner.firewall.rules.none(
+        _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("0.0.0.0/0")
       )
-      hetzner.firewalls.all(
-        rules.none(
-          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("::/0")
-        )
+      hetzner.firewall.rules.none(
+        _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "22" && _["sourceIps"].contains("::/0")
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
@@ -670,17 +668,13 @@ queries:
         title: Hetzner Cloud Firewalls overview
 
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-firewall"
     mql: |
-      hetzner.firewalls.all(
-        rules.none(
-          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("0.0.0.0/0")
-        )
+      hetzner.firewall.rules.none(
+        _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("0.0.0.0/0")
       )
-      hetzner.firewalls.all(
-        rules.none(
-          _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("::/0")
-        )
+      hetzner.firewall.rules.none(
+        _["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3389" && _["sourceIps"].contains("::/0")
       )
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
@@ -820,22 +814,22 @@ queries:
         title: Hetzner Cloud Firewalls overview
 
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-firewall"
     mql: |
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("::/0")))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "3306" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "5432" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "27017" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "6379" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9092" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "9200" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["protocol"] == "tcp" && _["port"] == "1433" && _["sourceIps"].contains("::/0"))
   - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
     mql: |
@@ -994,14 +988,14 @@ queries:
         title: Hetzner Cloud Firewalls overview
 
   - uid: mondoo-hetzner-security-firewall-no-all-ports-open-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-firewall"
     mql: |
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("::/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("0.0.0.0/0")))
-      hetzner.firewalls.all(rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("::/0")))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "any" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "1-65535" && _["sourceIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "in" && _["port"] == "0-65535" && _["sourceIps"].contains("::/0"))
   - uid: mondoo-hetzner-security-firewall-no-all-ports-open-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
     mql: |
@@ -1031,6 +1025,128 @@ queries:
           _['port'].notIn(["any", "1-65535", "0-65535"]) ||
           _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
+      )
+
+  - uid: mondoo-hetzner-security-firewall-has-rules
+    title: Ensure firewalls define at least one rule
+    impact: 40
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-hetzner-security-firewall-has-rules-hetzner
+        tags:
+          mondoo.com/filter-title: Hetzner Cloud
+          mondoo.com/filter-icon: hetzner
+      - uid: mondoo-hetzner-security-firewall-has-rules-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hetzner-security-firewall-has-rules-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hetzner-security-firewall-has-rules-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Hetzner Cloud Firewall defines at least one rule. A Hetzner firewall evaluates inbound traffic against its rule set and drops anything not explicitly allowed, while outbound traffic is permitted unless an outbound rule restricts it. A firewall with no rules is therefore almost always an unfinished or mistakenly-emptied configuration rather than an intentional control.
+
+        **Why this matters**
+
+        - **False sense of protection:** An applied-but-empty firewall appears in the console as if the attached servers are governed by a rule set, when in fact no inbound service has been deliberately allowed and no egress is constrained at all.
+        - **Configuration drift signal:** A firewall created during provisioning but never populated with rules indicates an incomplete change; surfacing it prompts an operator to either finish the configuration or remove the unused artifact.
+        - **No egress filtering:** Because Hetzner allows all outbound traffic by default, an empty firewall provides no constraint on data leaving the server, missing an opportunity to limit exfiltration paths.
+
+        **Risk mitigation**
+
+        - **Explicit intent:** Requiring at least one rule forces a deliberate decision about which inbound ports are allowed and, where appropriate, which egress destinations are permitted.
+        - **Reduced attack surface:** A populated rule set that allows only required ports — paired with outbound rules where egress control is needed — keeps the firewall doing meaningful work rather than acting as a placeholder.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Firewalls** and open each firewall.
+        3. Review the **Rules** tab.
+
+        A passing firewall lists at least one inbound or outbound rule. A failing firewall shows an empty rule set.
+
+        ### Audit via CLI
+
+        1. List all firewalls and inspect their rules:
+
+        ```bash
+        hcloud firewall list -o columns=id,name
+        hcloud firewall describe <firewall> -o json
+        ```
+
+        A passing firewall returns a non-empty `rules` array. A failing firewall returns an empty `rules` array (`[]`).
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Firewalls** and open the affected firewall.
+            2. On the **Rules** tab, add the inbound rules required by the workload (scoped to trusted source CIDRs) and any outbound rules needed to constrain egress.
+            3. If the firewall is an unused artifact, delete it instead so it does not imply coverage that does not exist.
+        - id: cli
+          desc: |
+            ```bash
+            hcloud firewall add-rule <firewall> \
+              --direction in --protocol tcp --port 443 --source-ips 0.0.0.0/0
+            ```
+
+            Add the specific rules the workload requires. Delete the firewall instead if it is not needed.
+        - id: terraform
+          desc: |
+            Declare at least one `rule` block on every `hcloud_firewall`:
+
+            ```hcl
+            resource "hcloud_firewall" "default" {
+              name = "default"
+
+              rule {
+                direction  = "in"
+                protocol   = "tcp"
+                port       = "443"
+                source_ips = ["0.0.0.0/0", "::/0"]
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-firewall-has-rules-hetzner
+    filters: asset.platform == "hetzner-firewall"
+    mql: |
+      hetzner.firewall.rules != empty
+  - uid: mondoo-hetzner-security-firewall-has-rules-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
+    mql: |
+      terraform.resources("hcloud_firewall").all(blocks.where(type == "rule") != empty)
+  - uid: mondoo-hetzner-security-firewall-has-rules-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "hcloud_firewall")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "hcloud_firewall").all(
+        change.after.rule != null && change.after.rule != []
+      )
+  - uid: mondoo-hetzner-security-firewall-has-rules-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "hcloud_firewall")
+    mql: |
+      terraform.state.resources.where(type == "hcloud_firewall").all(
+        values.rule != null && values.rule != []
       )
 
   - uid: mondoo-hetzner-security-lb-http-redirected-to-https
@@ -1136,11 +1252,9 @@ queries:
         title: Hetzner Cloud Load Balancers overview
 
   - uid: mondoo-hetzner-security-lb-http-redirected-to-https-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-loadbalancer"
     mql: |
-      hetzner.loadBalancers.all(
-        services.where(protocol == "http").all(http["redirect_http"] == true)
-      )
+      hetzner.loadBalancer.services.where(protocol == "http").all(http["redirect_http"] == true)
   - uid: mondoo-hetzner-security-lb-http-redirected-to-https-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_load_balancer_service")
     mql: |
@@ -1276,11 +1390,9 @@ queries:
         title: Hetzner Cloud Load Balancers overview
 
   - uid: mondoo-hetzner-security-lb-https-service-has-certificate-hetzner
-    filters: asset.platform == "hetzner-project"
+    filters: asset.platform == "hetzner-loadbalancer"
     mql: |
-      hetzner.loadBalancers.all(
-        services.where(protocol == "https").all(certificates != empty)
-      )
+      hetzner.loadBalancer.services.where(protocol == "https").all(certificates != empty)
   - uid: mondoo-hetzner-security-lb-https-service-has-certificate-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_load_balancer_service")
     mql: |
@@ -1302,6 +1414,110 @@ queries:
         values.protocol != "https" ||
         values.http.any(_['certificates'] != null && _['certificates'] != [])
       )
+
+  # No Terraform variants: a load balancer's private-network attachment is expressed
+  # by a separate `hcloud_load_balancer_network` resource keyed by `load_balancer_id`,
+  # not by an argument on `hcloud_load_balancer`. Asserting "every load balancer has an
+  # attachment" requires correlating that separate resource back to each load balancer,
+  # which is awkward to express reliably in MQL on Terraform sources. The runtime variant
+  # reads the resolved private-network attachments directly. Terraform remediation is
+  # still provided below because the fix is a self-contained resource.
+  - uid: mondoo-hetzner-security-lb-in-private-network
+    title: Ensure load balancers are attached to a private network
+    impact: 70
+    filters: asset.platform == "hetzner-loadbalancer"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      hetzner.loadBalancer.privateNet != empty
+    docs:
+      desc: |
+        This check ensures that every Hetzner Cloud load balancer is attached to at least one private network. When a load balancer reaches its targets only over the public network, traffic between the load balancer and the backend servers traverses public-facing interfaces instead of staying on an isolated RFC-1918 network.
+
+        **Why this matters**
+
+        - **Private backend path:** A load balancer on a private network forwards to its targets over private IPs, keeping the load-balancer-to-backend hop entirely inside the project's private network rather than on public addresses.
+        - **Reduced public exposure:** Without a private network attachment, backend servers must expose the forwarded ports on their public interface for the load balancer to reach them, widening the internet-facing surface.
+        - **Network segmentation:** Shared private-network membership lets firewall rules treat the load balancer and its backends as an internal trust zone, which is not possible when the forwarding path is public.
+
+        **Risk mitigation**
+
+        - **Traffic isolation:** Keeping load-balancer-to-target traffic on a private network removes it from public routing paths, eliminating the interception opportunity that a public forwarding path creates.
+        - **Tighter backend firewalls:** With a private path in place, backend servers can restrict the forwarded ports to the private network range instead of accepting them from the internet.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Load Balancers** and open each load balancer.
+        3. Click the **Networking** tab and review the **Private Networks** section.
+
+        A passing load balancer shows at least one private network attached. A failing load balancer shows an empty **Private Networks** section.
+
+        ### Audit via CLI
+
+        1. List all load balancers and inspect their private network attachments:
+
+        ```bash
+        hcloud load-balancer list -o columns=id,name
+        hcloud load-balancer describe <lb> -o json | grep -A5 'private_net'
+        ```
+
+        A passing load balancer returns a non-empty `private_net` array. A failing load balancer returns an empty `private_net` array (`[]`).
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Networks** and create a network if one does not already exist.
+            2. Open the affected load balancer and go to **Networking**.
+            3. Click **Attach to Network** and select the target network. Enable **Use private IP for targets** so forwarding uses the private path.
+        - id: cli
+          desc: |
+            ```bash
+            hcloud load-balancer attach-to-network <lb> --network <network>
+            ```
+        - id: terraform
+          desc: |
+            Attach every `hcloud_load_balancer` to a network with an `hcloud_load_balancer_network` resource. Set `use_private_ip = true` on the load balancer's targets so forwarding uses the private path:
+
+            ```hcl
+            resource "hcloud_network" "main" {
+              name     = "main"
+              ip_range = "10.0.0.0/16"
+            }
+
+            resource "hcloud_network_subnet" "main" {
+              network_id   = hcloud_network.main.id
+              type         = "cloud"
+              network_zone = "eu-central"
+              ip_range     = "10.0.1.0/24"
+            }
+
+            resource "hcloud_load_balancer" "example" {
+              name               = "example"
+              load_balancer_type = "lb11"
+              location           = "nbg1"
+            }
+
+            resource "hcloud_load_balancer_network" "example" {
+              load_balancer_id = hcloud_load_balancer.example.id
+              network_id       = hcloud_network.main.id
+              depends_on       = [hcloud_network_subnet.main]
+            }
+            ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+        title: Hetzner Cloud Load Balancers overview
 
   # No Terraform variants: certificate expiration (`notValidAfter`) is runtime metadata derived from the certificate material, not a configurable field on `hcloud_managed_certificate` / `hcloud_uploaded_certificate`. The Terraform config carries no signal about the current expiry date.
   - uid: mondoo-hetzner-security-cert-not-expired


### PR DESCRIPTION
## What

[mondoohq/mql#8534](https://github.com/mondoohq/mql/pull/8534) (hetzner 13.3.0, digitalocean 13.7.0) splits a project/account into **specific child assets** during discovery (default `auto`), binding the singular MQL resource to each child asset:

| Provider | New platforms |
|---|---|
| Hetzner | `hetzner-firewall`, `hetzner-loadbalancer` |
| DigitalOcean | `digitalocean-firewall`, `-database`, `-loadbalancer`, `-kubernetes-cluster`, `-spaces-bucket` |

### Rework
Per-resource checks now run on their specific platform using the bound **singular** resource (`hetzner.firewall.rules…`, `digitalocean.spacesBucket…`) instead of the aggregated project/account list, so each resource is scored as its own asset. Terraform variants are unchanged. DigitalOcean group filters are retargeted to match, and the Spaces group is split into account-level **Spaces Access Keys** and per-bucket **Spaces Buckets**. Both policies are bumped to a new **major** version (Hetzner `2.0.0`, DigitalOcean `2.0.0`) since the asset-attachment behavior changes.

> Note: under `--discover none` (no child assets) the per-resource checks no longer run. This is acceptable since discovery defaults to `auto`; that flag is an explicit opt-out.

### New checks (7)
Surfaced by the fields expanded in the provider PRs:

**Hetzner**
- `firewall-has-rules` — firewall defines at least one rule (hygiene, impact 40)
- `lb-in-private-network` — load balancer attached to a private network (70)

**DigitalOcean**
- `doks-in-vpc` — DOKS cluster deployed inside a VPC (70)
- `spaces-bucket-not-authenticated-readable` — no `AuthenticatedUsers` read grant (80)
- `spaces-bucket-policy-not-public` — bucket policy has no `Allow` to `Principal: "*"` (90)
- `spaces-bucket-mfa-delete-enabled` — MFA required to delete object versions (50)
- `spaces-bucket-cors-no-wildcard-origin` — CORS rules do not allow `*` origin (50)

Each new check ships full `desc`/`audit`/`remediation` (all supported methods, including Terraform where a real resource exists) and compliance tags anchored to the same-objective sibling check, with network-segmentation control UIDs verified against the framework YAML.

## Testing
- `cnspec policy lint` passes for both policies
- `validate_remediation_commands.py {hetzner,digitalocean}` pass (new `doctl`/`hcloud` commands validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)