### PR TITLE
✨ freebsd: add time-synchronization and pkg signature-verification checks

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.0.4
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -124,6 +124,16 @@ policies:
           asset.platform == "freebsd"
         checks:
           - uid: mondoo-freebsd-security-firewall-is-enabled
+      - title: System Services
+        filters: |
+          asset.platform == "freebsd"
+        checks:
+          - uid: mondoo-freebsd-security-time-synchronization-is-enabled
+      - title: Software Integrity
+        filters: |
+          asset.platform == "freebsd"
+        checks:
+          - uid: mondoo-freebsd-security-pkg-signature-verification-is-enabled
     scoring_system: highest impact
 queries:
   - uid: mondoo-freebsd-security-aslr-is-enabled
@@ -5230,4 +5240,214 @@ queries:
               ansible.builtin.service:
                 name: ipfw
                 state: started
+            ```
+  - uid: mondoo-freebsd-security-time-synchronization-is-enabled
+    title: Ensure a time synchronization daemon is enabled
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a7
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      service("ntpd").enabled && service("ntpd").running ||
+      service("openntpd").enabled && service("openntpd").running ||
+      service("chronyd").enabled && service("chronyd").running
+    docs:
+      refs:
+        - url: https://man.freebsd.org/cgi/man.cgi?query=ntpd&sektion=8
+          title: FreeBSD ntpd(8)
+      desc: |
+        This check verifies that a time synchronization daemon is enabled and running. FreeBSD ships `ntpd` in the base system, but it is not enabled by default; OpenNTPD and chrony are available as alternatives from packages.
+
+        **Why this matters**
+
+        - **Log and forensic correlation:** Accurate clocks let events from multiple hosts be lined up on a single timeline. Skewed clocks make it impossible to reconstruct the true order of events during an incident investigation.
+        - **Kerberos and certificate validity:** Kerberos authentication rejects tickets when clocks drift beyond a few minutes, and TLS certificate `notBefore`/`notAfter` checks depend on a correct system time. A drifting clock breaks authentication and can cause valid certificates to be rejected or expired ones to be accepted.
+        - **Audit-trail integrity:** Time stamps on audit and system logs are only trustworthy when the clock is synchronized to an authoritative source, which is a prerequisite for many compliance regimes.
+      audit: |
+        To verify that a time synchronization daemon is active, run the following commands:
+
+        ```bash
+        service ntpd status
+        sysrc -n ntpd_enable
+        ```
+
+        If `service ntpd status` reports the service is running and `ntpd_enable` is `YES`, the check passes. If you run OpenNTPD or chrony instead, check the equivalent service and rc.conf variable (`service openntpd status` / `sysrc -n openntpd_enable`, or `service chronyd status` / `sysrc -n chronyd_enable`). If no time synchronization daemon is enabled and running, the check fails.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Enable and start `ntpd` from the base system. The `ntpd_sync_on_start` option steps the clock at startup so large initial offsets are corrected immediately rather than slewed slowly:
+
+            ```bash
+            sysrc ntpd_enable="YES"
+            sysrc ntpd_sync_on_start="YES"
+            service ntpd start
+            ```
+        - id: sh
+          desc: |
+            **Using a Shell Script**
+
+            ```sh
+            #!/bin/sh
+            set -e
+
+            echo "Enabling time synchronization daemon (ntpd)..."
+            sysrc ntpd_enable="YES"
+            sysrc ntpd_sync_on_start="YES"
+            service ntpd start 2>/dev/null || service ntpd onestart 2>/dev/null || true
+
+            echo "ntpd enabled and started."
+            ```
+        - id: ansible
+          desc: |
+            To enable a time synchronization daemon using Ansible:
+
+            1. Add the following tasks to a playbook targeting the FreeBSD host.
+            2. Run the playbook.
+
+            ```yaml
+            - name: Enable ntpd in rc.conf
+              community.general.sysrc:
+                name: "{{ item.name }}"
+                value: "{{ item.value }}"
+              loop:
+                - { name: ntpd_enable, value: 'YES' }
+                - { name: ntpd_sync_on_start, value: 'YES' }
+
+            - name: Start the ntpd service
+              ansible.builtin.service:
+                name: ntpd
+                state: started
+            ```
+  - uid: mondoo-freebsd-security-pkg-signature-verification-is-enabled
+    title: Ensure pkg repository signature verification is enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-d
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-id-ra-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-14
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+    docs:
+      refs:
+        - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
+          title: FreeBSD pkg.conf(5)
+      desc: |
+        This check verifies that the base FreeBSD pkg repository enforces fingerprint-based signature verification, so that tampered or man-in-the-middle-modified packages are rejected at install time. The default `/etc/pkg/FreeBSD.conf` sets `signature_type: "fingerprints"`; downgrading it to `"none"` disables verification entirely.
+
+        **Why this matters**
+
+        - **Supply-chain integrity:** Packages are downloaded from a network mirror. Without signature verification, an attacker who controls a mirror or sits on the network path can substitute a malicious package that runs with root privileges during installation.
+        - **Tamper detection:** Fingerprint verification checks each package against trusted signing keys, so any modification to the package contents in transit or at rest on the mirror causes the install to fail rather than silently proceed.
+        - **Trusted provenance:** Enforcing signatures guarantees that installed software originates from the official FreeBSD signing infrastructure rather than an unverified source.
+
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf`. The audit step shows how to confirm the effective signature setting across all configured repositories.
+      audit: |
+        To verify that signature verification is enabled for the base repository, inspect its configuration:
+
+        ```bash
+        cat /etc/pkg/FreeBSD.conf
+        ```
+
+        If the `FreeBSD` repository block sets `signature_type: "fingerprints"`, the check passes. If it sets `signature_type: "none"`, verification is disabled and the check fails.
+
+        To confirm the effective per-repository setting across all configured repositories, run:
+
+        ```bash
+        pkg -vv | grep -i signature_type
+        ```
+
+        Every active repository should report `signature_type = "fingerprints"`. A repository reporting `"none"` accepts unsigned packages and the check fails.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            1. Restore fingerprint verification for the base repository by editing `/etc/pkg/FreeBSD.conf` so the `FreeBSD` block contains:
+
+                ```ini
+                signature_type: "fingerprints",
+                fingerprints: "/usr/share/keys/pkg"
+                ```
+
+            2. Ensure the fingerprint keys are present. They ship with the base system under `/usr/share/keys/pkg`:
+
+                ```bash
+                ls /usr/share/keys/pkg/trusted
+                ```
+
+            If the directory is missing or empty, reinstall the keys from your FreeBSD source tree or restore them from a known-good host before re-running `pkg update`.
+        - id: sh
+          desc: |
+            **Using a Shell Script**
+
+            ```sh
+            #!/bin/sh
+            set -e
+
+            CONF=/etc/pkg/FreeBSD.conf
+
+            echo "Restoring pkg signature verification..."
+            if grep -q 'signature_type:[[:space:]]*"none"' "$CONF" 2>/dev/null; then
+              sed -i '' 's/signature_type:[[:space:]]*"none"/signature_type: "fingerprints"/' "$CONF"
+              echo "signature_type set to fingerprints in $CONF."
+            fi
+
+            if [ ! -d /usr/share/keys/pkg/trusted ]; then
+              echo "WARNING: /usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update." >&2
+            fi
+
+            echo "pkg signature verification configured."
+            ```
+        - id: ansible
+          desc: |
+            To restore pkg signature verification using Ansible:
+
+            1. Add the following tasks to a playbook targeting the FreeBSD host.
+            2. Run the playbook.
+
+            ```yaml
+            - name: Enforce fingerprint signature verification for the base repository
+              ansible.builtin.lineinfile:
+                path: /etc/pkg/FreeBSD.conf
+                regexp: '^\s*signature_type:'
+                line: '  signature_type: "fingerprints",'
+
+            - name: Ensure the fingerprints path is configured
+              ansible.builtin.lineinfile:
+                path: /etc/pkg/FreeBSD.conf
+                regexp: '^\s*fingerprints:'
+                line: '  fingerprints: "/usr/share/keys/pkg"'
+
+            - name: Confirm the trusted fingerprint keys are present
+              ansible.builtin.stat:
+                path: /usr/share/keys/pkg/trusted
+              register: pkg_keys
+
+            - name: Fail when the fingerprint keys are missing
+              ansible.builtin.fail:
+                msg: "/usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update."
+              when: not pkg_keys.stat.exists
             ```

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -5259,9 +5259,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      service("ntpd").enabled && service("ntpd").running ||
-      service("openntpd").enabled && service("openntpd").running ||
-      service("chronyd").enabled && service("chronyd").running
+      ["ntpd", "openntpd", "chronyd"].any(service(_).enabled && service(_).running)
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=ntpd&sektion=8
@@ -5350,6 +5348,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
@@ -5363,7 +5362,9 @@ queries:
         - **Tamper detection:** Fingerprint verification checks each package against trusted signing keys, so any modification to the package contents in transit or at rest on the mirror causes the install to fail rather than silently proceed.
         - **Trusted provenance:** Enforcing signatures guarantees that installed software originates from the official FreeBSD signing infrastructure rather than an unverified source.
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf`. The audit step shows how to confirm the effective signature setting across all configured repositories.
+        **Scope**
+
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`, failing if either the base repo is downgraded from `fingerprints` or a custom repo sets `signature_type: "none"`. The audit step shows how to confirm the effective signature setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -5347,7 +5347,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
       files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
     docs:
       refs:
@@ -5364,7 +5364,9 @@ queries:
 
         **Scope**
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`, failing if either the base repo is downgraded from `fingerprints` or a custom repo sets `signature_type: "none"`. The audit step shows how to confirm the effective signature setting across all configured repositories with `pkg -vv`.
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository, or if a custom repo explicitly disables verification with `signature_type: "none"`.
+
+        FreeBSD's `pkg` supports two verification mechanisms — `fingerprints` (the official repository's default, validated against the keys in `/usr/share/keys/pkg`) and `pubkey` — and both provide signature enforcement. The custom-repo condition therefore rejects only `signature_type: "none"`; a custom repo using `fingerprints` or `pubkey` is accepted. Because an omitted `signature_type` defaults to no verification, ensure every custom repo declares a verification type explicitly. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6493,8 +6493,8 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
-      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*"(fingerprints|pubkey)"/))
+      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*["']?fingerprints\b/)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*["']?(fingerprints|pubkey)\b/))
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6405,9 +6405,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      service("ntpd").enabled && service("ntpd").running ||
-      service("openntpd").enabled && service("openntpd").running ||
-      service("chronyd").enabled && service("chronyd").running
+      ["ntpd", "openntpd", "chronyd"].any(service(_).enabled && service(_).running)
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=ntpd&sektion=8
@@ -6496,6 +6494,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
@@ -6509,7 +6508,9 @@ queries:
         - **Tamper detection:** Fingerprint verification checks each package against trusted signing keys, so any modification to the package contents in transit or at rest on the mirror causes the install to fail rather than silently proceed.
         - **Trusted provenance:** Enforcing signatures guarantees that installed software originates from the official FreeBSD signing infrastructure rather than an unverified source.
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf`. The audit step shows how to confirm the effective signature setting across all configured repositories.
+        **Scope**
+
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`, failing if either the base repo is downgraded from `fingerprints` or a custom repo sets `signature_type: "none"`. The audit step shows how to confirm the effective signature setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6493,7 +6493,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
       files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
     docs:
       refs:
@@ -6510,7 +6510,9 @@ queries:
 
         **Scope**
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`, failing if either the base repo is downgraded from `fingerprints` or a custom repo sets `signature_type: "none"`. The audit step shows how to confirm the effective signature setting across all configured repositories with `pkg -vv`.
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository, or if a custom repo explicitly disables verification with `signature_type: "none"`.
+
+        FreeBSD's `pkg` supports two verification mechanisms — `fingerprints` (the official repository's default, validated against the keys in `/usr/share/keys/pkg`) and `pubkey` — and both provide signature enforcement. The custom-repo condition therefore rejects only `signature_type: "none"`; a custom repo using `fingerprints` or `pubkey` is accepted. Because an omitted `signature_type` defaults to no verification, ensure every custom repo declares a verification type explicitly. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -5347,8 +5347,8 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
-      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*"(fingerprints|pubkey)"/))
+      file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*["']?fingerprints\b/)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*["']?(fingerprints|pubkey)\b/))
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6494,7 +6494,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
-      files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*"(fingerprints|pubkey)"/))
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
@@ -6510,9 +6510,9 @@ queries:
 
         **Scope**
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository, or if a custom repo explicitly disables verification with `signature_type: "none"`.
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository. For custom repositories, every `.conf` file that defines a repository with a `url` must positively declare an enforcing `signature_type`.
 
-        FreeBSD's `pkg` supports two verification mechanisms — `fingerprints` (the official repository's default, validated against the keys in `/usr/share/keys/pkg`) and `pubkey` — and both provide signature enforcement. The custom-repo condition therefore rejects only `signature_type: "none"`; a custom repo using `fingerprints` or `pubkey` is accepted. Because an omitted `signature_type` defaults to no verification, ensure every custom repo declares a verification type explicitly. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
+        FreeBSD's `pkg` supports two verification mechanisms that both enforce signatures. The `fingerprints` type is the official repository's default and validates packages against the trusted keys in `/usr/share/keys/pkg`, while `pubkey` validates against a configured public key. A custom repository using either type is accepted. Because an omitted `signature_type` defaults to no verification, a repository that declares no type at all fails this check just as one setting `signature_type: "none"` does. Configuration files that only disable a repository and set no `url` need not declare a signature type. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -5348,7 +5348,7 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       file("/etc/pkg/FreeBSD.conf").exists && file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
-      files.find(from: "/usr/local/etc/pkg/repos", regex: "[.]conf$", type: "file").list.all(content.contains(/signature_type:\s*"none"/) == false)
+      files.find(from: "/usr/local/etc/pkg/repos", regex: ".*[.]conf$", type: "file").list.all(content.contains(/url:/) == false || content.contains(/signature_type:\s*"(fingerprints|pubkey)"/))
     docs:
       refs:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
@@ -5364,9 +5364,9 @@ queries:
 
         **Scope**
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository, or if a custom repo explicitly disables verification with `signature_type: "none"`.
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository. For custom repositories, every `.conf` file that defines a repository with a `url` must positively declare an enforcing `signature_type`.
 
-        FreeBSD's `pkg` supports two verification mechanisms — `fingerprints` (the official repository's default, validated against the keys in `/usr/share/keys/pkg`) and `pubkey` — and both provide signature enforcement. The custom-repo condition therefore rejects only `signature_type: "none"`; a custom repo using `fingerprints` or `pubkey` is accepted. Because an omitted `signature_type` defaults to no verification, ensure every custom repo declares a verification type explicitly. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
+        FreeBSD's `pkg` supports two verification mechanisms that both enforce signatures. The `fingerprints` type is the official repository's default and validates packages against the trusted keys in `/usr/share/keys/pkg`, while `pubkey` validates against a configured public key. A custom repository using either type is accepted. Because an omitted `signature_type` defaults to no verification, a repository that declares no type at all fails this check just as one setting `signature_type: "none"` does. Configuration files that only disable a repository and set no `url` need not declare a signature type. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.1.1
+    version: 1.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -124,6 +124,16 @@ policies:
           asset.platform == "freebsd"
         checks:
           - uid: mondoo-freebsd-security-firewall-is-enabled
+      - title: System Services
+        filters: |
+          asset.platform == "freebsd"
+        checks:
+          - uid: mondoo-freebsd-security-time-synchronization-is-enabled
+      - title: Software Integrity
+        filters: |
+          asset.platform == "freebsd"
+        checks:
+          - uid: mondoo-freebsd-security-pkg-signature-verification-is-enabled
     scoring_system: highest impact
 queries:
   - uid: mondoo-freebsd-security-aslr-is-enabled
@@ -6376,4 +6386,214 @@ queries:
                 notifies :start, 'service[ipfw]', :delayed
               end
             end
+            ```
+  - uid: mondoo-freebsd-security-time-synchronization-is-enabled
+    title: Ensure a time synchronization daemon is enabled
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a7
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      service("ntpd").enabled && service("ntpd").running ||
+      service("openntpd").enabled && service("openntpd").running ||
+      service("chronyd").enabled && service("chronyd").running
+    docs:
+      refs:
+        - url: https://man.freebsd.org/cgi/man.cgi?query=ntpd&sektion=8
+          title: FreeBSD ntpd(8)
+      desc: |
+        This check verifies that a time synchronization daemon is enabled and running. FreeBSD ships `ntpd` in the base system, but it is not enabled by default; OpenNTPD and chrony are available as alternatives from packages.
+
+        **Why this matters**
+
+        - **Log and forensic correlation:** Accurate clocks let events from multiple hosts be lined up on a single timeline. Skewed clocks make it impossible to reconstruct the true order of events during an incident investigation.
+        - **Kerberos and certificate validity:** Kerberos authentication rejects tickets when clocks drift beyond a few minutes, and TLS certificate `notBefore`/`notAfter` checks depend on a correct system time. A drifting clock breaks authentication and can cause valid certificates to be rejected or expired ones to be accepted.
+        - **Audit-trail integrity:** Time stamps on audit and system logs are only trustworthy when the clock is synchronized to an authoritative source, which is a prerequisite for many compliance regimes.
+      audit: |
+        To verify that a time synchronization daemon is active, run the following commands:
+
+        ```bash
+        service ntpd status
+        sysrc -n ntpd_enable
+        ```
+
+        If `service ntpd status` reports the service is running and `ntpd_enable` is `YES`, the check passes. If you run OpenNTPD or chrony instead, check the equivalent service and rc.conf variable (`service openntpd status` / `sysrc -n openntpd_enable`, or `service chronyd status` / `sysrc -n chronyd_enable`). If no time synchronization daemon is enabled and running, the check fails.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            Enable and start `ntpd` from the base system. The `ntpd_sync_on_start` option steps the clock at startup so large initial offsets are corrected immediately rather than slewed slowly:
+
+            ```bash
+            sysrc ntpd_enable="YES"
+            sysrc ntpd_sync_on_start="YES"
+            service ntpd start
+            ```
+        - id: sh
+          desc: |
+            **Using a Shell Script**
+
+            ```sh
+            #!/bin/sh
+            set -e
+
+            echo "Enabling time synchronization daemon (ntpd)..."
+            sysrc ntpd_enable="YES"
+            sysrc ntpd_sync_on_start="YES"
+            service ntpd start 2>/dev/null || service ntpd onestart 2>/dev/null || true
+
+            echo "ntpd enabled and started."
+            ```
+        - id: ansible
+          desc: |
+            To enable a time synchronization daemon using Ansible:
+
+            1. Add the following tasks to a playbook targeting the FreeBSD host.
+            2. Run the playbook.
+
+            ```yaml
+            - name: Enable ntpd in rc.conf
+              community.general.sysrc:
+                name: "{{ item.name }}"
+                value: "{{ item.value }}"
+              loop:
+                - { name: ntpd_enable, value: 'YES' }
+                - { name: ntpd_sync_on_start, value: 'YES' }
+
+            - name: Start the ntpd service
+              ansible.builtin.service:
+                name: ntpd
+                state: started
+            ```
+  - uid: mondoo-freebsd-security-pkg-signature-verification-is-enabled
+    title: Ensure pkg repository signature verification is enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-d
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-id-ra-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-14
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
+    docs:
+      refs:
+        - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
+          title: FreeBSD pkg.conf(5)
+      desc: |
+        This check verifies that the base FreeBSD pkg repository enforces fingerprint-based signature verification, so that tampered or man-in-the-middle-modified packages are rejected at install time. The default `/etc/pkg/FreeBSD.conf` sets `signature_type: "fingerprints"`; downgrading it to `"none"` disables verification entirely.
+
+        **Why this matters**
+
+        - **Supply-chain integrity:** Packages are downloaded from a network mirror. Without signature verification, an attacker who controls a mirror or sits on the network path can substitute a malicious package that runs with root privileges during installation.
+        - **Tamper detection:** Fingerprint verification checks each package against trusted signing keys, so any modification to the package contents in transit or at rest on the mirror causes the install to fail rather than silently proceed.
+        - **Trusted provenance:** Enforcing signatures guarantees that installed software originates from the official FreeBSD signing infrastructure rather than an unverified source.
+
+        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf`. The audit step shows how to confirm the effective signature setting across all configured repositories.
+      audit: |
+        To verify that signature verification is enabled for the base repository, inspect its configuration:
+
+        ```bash
+        cat /etc/pkg/FreeBSD.conf
+        ```
+
+        If the `FreeBSD` repository block sets `signature_type: "fingerprints"`, the check passes. If it sets `signature_type: "none"`, verification is disabled and the check fails.
+
+        To confirm the effective per-repository setting across all configured repositories, run:
+
+        ```bash
+        pkg -vv | grep -i signature_type
+        ```
+
+        Every active repository should report `signature_type = "fingerprints"`. A repository reporting `"none"` accepts unsigned packages and the check fails.
+      remediation:
+        - id: cli
+          desc: |
+            **Using the CLI**
+
+            1. Restore fingerprint verification for the base repository by editing `/etc/pkg/FreeBSD.conf` so the `FreeBSD` block contains:
+
+                ```ini
+                signature_type: "fingerprints",
+                fingerprints: "/usr/share/keys/pkg"
+                ```
+
+            2. Ensure the fingerprint keys are present. They ship with the base system under `/usr/share/keys/pkg`:
+
+                ```bash
+                ls /usr/share/keys/pkg/trusted
+                ```
+
+            If the directory is missing or empty, reinstall the keys from your FreeBSD source tree or restore them from a known-good host before re-running `pkg update`.
+        - id: sh
+          desc: |
+            **Using a Shell Script**
+
+            ```sh
+            #!/bin/sh
+            set -e
+
+            CONF=/etc/pkg/FreeBSD.conf
+
+            echo "Restoring pkg signature verification..."
+            if grep -q 'signature_type:[[:space:]]*"none"' "$CONF" 2>/dev/null; then
+              sed -i '' 's/signature_type:[[:space:]]*"none"/signature_type: "fingerprints"/' "$CONF"
+              echo "signature_type set to fingerprints in $CONF."
+            fi
+
+            if [ ! -d /usr/share/keys/pkg/trusted ]; then
+              echo "WARNING: /usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update." >&2
+            fi
+
+            echo "pkg signature verification configured."
+            ```
+        - id: ansible
+          desc: |
+            To restore pkg signature verification using Ansible:
+
+            1. Add the following tasks to a playbook targeting the FreeBSD host.
+            2. Run the playbook.
+
+            ```yaml
+            - name: Enforce fingerprint signature verification for the base repository
+              ansible.builtin.lineinfile:
+                path: /etc/pkg/FreeBSD.conf
+                regexp: '^\s*signature_type:'
+                line: '  signature_type: "fingerprints",'
+
+            - name: Ensure the fingerprints path is configured
+              ansible.builtin.lineinfile:
+                path: /etc/pkg/FreeBSD.conf
+                regexp: '^\s*fingerprints:'
+                line: '  fingerprints: "/usr/share/keys/pkg"'
+
+            - name: Confirm the trusted fingerprint keys are present
+              ansible.builtin.stat:
+                path: /usr/share/keys/pkg/trusted
+              register: pkg_keys
+
+            - name: Fail when the fingerprint keys are missing
+              ansible.builtin.fail:
+                msg: "/usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update."
+              when: not pkg_keys.stat.exists
             ```


### PR DESCRIPTION
## What

Adds two new hardening checks to `mondoo-freebsd-security`, porting control patterns that landed for Linux and Nutanix in the last two weeks (time synchronization, package signature verification) but had **no FreeBSD coverage** (`grep` confirmed zero NTP/chrony and zero pkg-signature checks in the policy).

### 1. `mondoo-freebsd-security-time-synchronization-is-enabled` — impact 60
Asserts a time daemon is enabled **and** running:
```
service("ntpd").enabled && service("ntpd").running ||
service("openntpd").enabled && service("openntpd").running ||
service("chronyd").enabled && service("chronyd").running
```
FreeBSD ships `ntpd` in the base system but does not enable it by default. Clock sync underpins log/forensic correlation, Kerberos/cert validity, and audit-trail integrity. Anchored to `mondoo-freebsd-security-firewall-is-enabled` (impact 60).

### 2. `mondoo-freebsd-security-pkg-signature-verification-is-enabled` — impact 80
Asserts the base FreeBSD pkg repo enforces fingerprint signatures:
```
file("/etc/pkg/FreeBSD.conf").content.contains(/signature_type:\s*"fingerprints"/)
```
Downgrading `signature_type` to `"none"` disables verification, opening a supply-chain/MITM path to root-level code at install. Anchored down from `aslr-is-enabled` (impact 90) into the 80–89 band. The `audit:` step shows how to confirm the *effective* per-repo value via `pkg -vv`.

## Compliance tags

Verified **per-framework** against the enterprise framework definitions — not copied from neighbors. Highlights:

- **Time sync** → ISO 27001:2022 `a-8-17` (Clock synchronization), NIST 800-53 `sc-45` (System Time Synchronization), NIST 800-171 `3-3-7`, PCI DSS 4 `10.6.1`, CSA CCM `log-06`, BSI `sys-1-5-a7`. `false` where no control fits (DORA, HIPAA, NIS2, CSF 1/2, SOC2, VDA-ISA).
- **pkg signatures** → NIST 800-53 `cm-14` (Signed Components), ISO 27001:2022 `a-8-19`, NIST CSF1 `pr-ds-6`, CSF2 `id-ra-09`, NIST 800-171 `3-4-8`, NIS2 `21-2-d` (Supply chain). `false` where no control fits.

## Notes

- OS policy → `cli` / `sh` / `ansible` remediation (no Terraform variants, consistent with siblings).
- Policy version bumped `1.0.4` → `1.1.0`.
- `cnspec policy lint content/mondoo-freebsd-security.mql.yaml` → **valid policy bundle**. (The remediation CLI validator does not cover FreeBSD's `sysrc`/`pkg`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)