### PR TITLE
✨ non-aws: 12 security checks across digitalocean/hetzner/openstack

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.1.0
+    version: 2.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -57,12 +57,14 @@ policies:
         checks:
           - uid: mondoo-digitalocean-security-db-firewall-configured
           - uid: mondoo-digitalocean-security-db-in-private-network
+          - uid: mondoo-digitalocean-security-db-not-internet-reachable
           - uid: mondoo-digitalocean-security-db-engine-supported-version
           - uid: mondoo-digitalocean-security-db-ca-certificate-not-expired
       - title: Load Balancers
         filters: asset.platform == "digitalocean-loadbalancer"
         checks:
           - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
+          - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy
           - uid: mondoo-digitalocean-security-lb-in-vpc
       - title: Kubernetes (DOKS)
         filters: asset.platform == "digitalocean-kubernetes-cluster"
@@ -72,6 +74,7 @@ policies:
           - uid: mondoo-digitalocean-security-doks-sso-enabled
           - uid: mondoo-digitalocean-security-doks-sso-required
           - uid: mondoo-digitalocean-security-doks-in-vpc
+          - uid: mondoo-digitalocean-security-doks-control-plane-firewall-enabled
       - title: TLS Certificates
         filters: asset.platform == "digitalocean"
         checks:
@@ -107,6 +110,7 @@ policies:
         filters: asset.platform == "digitalocean"
         checks:
           - uid: mondoo-digitalocean-security-gradientai-agent-not-publicly-deployed
+          - uid: mondoo-digitalocean-security-gradientai-agent-has-guardrails
           - uid: mondoo-digitalocean-security-gradientai-knowledge-base-not-public
     scoring_system: highest impact
 queries:
@@ -1252,6 +1256,93 @@ queries:
     mql: |
       terraform.state.resources.where(type == "digitalocean_database_cluster").all(values.private_network_uuid != empty)
 
+  # No Terraform variants: internetReachable resolves the cluster's live public connection
+  # endpoint against its effective trusted-source firewall rules. The digitalocean_database_cluster
+  # Terraform resource exposes neither the resolved public reachability nor the evaluated
+  # trusted-source decision, so there is nothing equivalent to assert in HCL, plan, or state.
+  # The db-in-private-network and db-firewall-configured checks already cover the
+  # Terraform-expressible posture.
+  - uid: mondoo-digitalocean-security-db-not-internet-reachable
+    title: Ensure managed databases are not reachable from the internet
+    impact: 85
+    filters: asset.platform == "digitalocean-database"
+    mql: |
+      digitalocean.database.internetReachable == false
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    docs:
+      desc: |
+        This check ensures that no managed database cluster is reachable from the public internet. `internetReachable` is true when the cluster has a public connection endpoint and its trusted-source firewall rules admit any address, including the case where no trusted sources are configured at all and the public endpoint is left open to every host. It is a higher-fidelity signal than the presence of a public endpoint alone because it accounts for whether the trusted-source rules actually restrict access.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** A database that no internet host can reach is removed from the pool of targets for credential-stuffing and protocol-level attacks against the database engine.
+        - **Misconfiguration resilience:** Correlating the public endpoint with the trusted-source rules catches the common failure where a cluster keeps its public endpoint and the trusted-source list is empty or world-open.
+        - **Defense in depth:** Keeping the cluster private supplements engine authentication, so a weak or leaked credential is not directly exploitable from the internet.
+
+        **Risk mitigation**
+
+        - **Data exfiltration:** Removes the direct internet path an attacker would use to reach the database with stolen or brute-forced credentials.
+        - **Internet-wide scanning:** Takes the database endpoint off the public scanning grid entirely.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Databases** and open each cluster.
+        3. On the **Overview** tab, review the **Connection Details** for a public host, and on the **Settings** tab review the **Trusted Sources** list.
+
+        A passing database cluster either exposes no public connection endpoint or restricts its trusted sources to specific resources or CIDRs. A failing database cluster exposes a public endpoint while its trusted sources admit any address or are empty.
+
+        ### Audit via CLI
+
+        1. List clusters and inspect each cluster's trusted-source firewall rules:
+
+        ```bash
+        doctl databases list --format ID,Name,Engine
+        doctl databases firewalls list <database-id>
+        ```
+
+        A passing database cluster returns trusted-source rules that name specific droplets, tags, Kubernetes clusters, or narrow CIDRs. A failing database cluster returns an `ip_addr` rule of `0.0.0.0/0` or `::/0`, or no trusted-source rules at all while a public endpoint is in use.
+      remediation:
+        - id: console
+          desc: |
+            To close the internet-reachable path in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Databases** and open the affected cluster.
+            2. On the **Settings** tab, edit **Trusted Sources** and add the specific droplets, tags, Kubernetes clusters, or narrow CIDRs that need access.
+            3. Remove any trusted-source entry of `0.0.0.0/0` or `::/0`, and confirm at least one restrictive trusted source remains so the public endpoint is no longer open to every host.
+            4. Where the cluster does not need a public edge, attach it to a VPC and connect over the private endpoint instead.
+        - id: cli
+          desc: |
+            To restrict the trusted sources on the command line using the `doctl` CLI, replace any world-open rule with specific sources:
+
+            ```bash
+            doctl databases firewalls append <database-id> --rule ip_addr:203.0.113.10
+            doctl databases firewalls append <database-id> --rule droplet:<droplet-id>
+            doctl databases firewalls list <database-id>
+            ```
+
+            After confirming the restrictive rules are in place, remove the world-open rule by re-applying the full rule set without it using `doctl databases firewalls replace <database-id> --rule ...`.
+        # No Terraform remediation: internetReachable is a runtime correlation of the live
+        # public endpoint with the effective trusted-source rules and has no single
+        # configuration analog. Express the desired posture with the db-in-private-network
+        # and db-firewall-configured Terraform remediations instead.
+    refs:
+      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
+        title: Secure a managed database cluster
+
   - uid: mondoo-digitalocean-security-db-engine-supported-version
     title: Ensure managed database engines are not running an EOL version
     impact: 70
@@ -1665,6 +1756,92 @@ queries:
         values["forwarding_rule"].none(_["entry_protocol"] == "http") ||
         values.redirect_http_to_https == true
       )
+
+  # No Terraform variants: tlsCipherPolicy reflects the minimum TLS cipher policy resolved by
+  # the DigitalOcean load balancer service. The digitalocean_loadbalancer Terraform resource
+  # has no argument that selects between the DEFAULT and STRONG cipher policies, so the setting
+  # cannot be asserted in HCL, plan, or state.
+  - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy
+    title: Ensure TLS load balancers enforce the strong TLS cipher policy
+    impact: 70
+    filters: asset.platform == "digitalocean-loadbalancer"
+    mql: |
+      digitalocean.loadBalancer {
+        forwardingRules.none(_["entry_protocol"] == "https" || _["entry_protocol"] == "tls") || tlsCipherPolicy == "STRONG"
+      }
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    docs:
+      desc: |
+        This check ensures that any load balancer terminating TLS uses the `STRONG` minimum TLS cipher policy rather than the `DEFAULT` policy. The `STRONG` policy negotiates only TLS 1.2 and later with a restricted set of modern, forward-secret cipher suites, whereas the default policy permits a broader, weaker set for backward compatibility.
+
+        **Why this matters**
+
+        - **Modern ciphers only:** The strong policy removes cipher suites that lack forward secrecy or rely on weaker primitives, so captured traffic cannot be decrypted later if a key is compromised.
+        - **Downgrade resistance:** Restricting the negotiable protocol versions and ciphers narrows the room an attacker has to force a client onto a weaker connection.
+        - **Compliance alignment:** Frameworks that require strong cryptography for data in transit are satisfied by the restricted policy but not by the permissive default.
+
+        **Risk mitigation**
+
+        - **Traffic interception:** Enforcing strong cipher suites keeps TLS sessions resistant to passive decryption and known cipher-level attacks.
+        - **Standards drift:** Pinning the load balancer to the strong policy prevents weak ciphers from being negotiated as client populations change over time.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Networking** > **Load Balancers** and open each load balancer that has an HTTPS or TLS forwarding rule.
+        3. Go to **Settings** and review the **TLS Cipher Policy** value.
+
+        A passing load balancer terminating TLS shows the cipher policy set to **Strong**. A failing load balancer terminating TLS shows the **Default** cipher policy.
+
+        ### Audit via CLI
+
+        1. List load balancers and inspect the `tls_cipher_policy` field alongside the forwarding rules:
+
+        ```bash
+        doctl compute load-balancer list --output json | jq -r '.[] | [.id, .name, .tls_cipher_policy] | @tsv'
+        ```
+
+        A passing load balancer that terminates TLS returns `STRONG`. A failing load balancer that terminates TLS returns `DEFAULT` or an empty value.
+      remediation:
+        - id: console
+          desc: |
+            To enforce the strong cipher policy in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Networking** > **Load Balancers** and open the affected load balancer.
+            2. Go to **Settings** and set the **TLS Cipher Policy** to **Strong**.
+            3. Confirm that clients still negotiate successfully, since the strong policy drops TLS 1.1 and older and legacy ciphers.
+        - id: cli
+          desc: |
+            The `doctl compute load-balancer update` command replaces the full load balancer configuration, so any attribute you do not pass is reset to its default. Read the current configuration first, then re-apply it together with the strong cipher policy:
+
+            ```bash
+            doctl compute load-balancer get "<lb-id>" \
+              --format Name,Region,ForwardingRules,DropletIDs --no-header
+            doctl compute load-balancer update "<lb-id>" \
+              --name "<name>" \
+              --region "<region>" \
+              --forwarding-rules "<current-forwarding-rules>" \
+              --droplet-ids "<droplet-ids>" \
+              --tls-cipher-policy strong
+            ```
+        # No Terraform remediation: the digitalocean_loadbalancer resource has no argument for the
+        # minimum TLS cipher policy, so the STRONG policy cannot be set through Terraform.
+    refs:
+      - url: https://docs.digitalocean.com/products/networking/load-balancers/how-to/ssl-termination/
+        title: Load balancer SSL termination
 
   - uid: mondoo-digitalocean-security-lb-in-vpc
     title: Ensure load balancers are deployed inside a VPC
@@ -2335,6 +2512,95 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_kubernetes_cluster")
     mql: |
       terraform.state.resources.where(type == "digitalocean_kubernetes_cluster").all(values.vpc_uuid != empty)
+
+  # No Terraform variants: the control-plane firewall is enforced by the managed DOKS control
+  # plane and surfaced as live posture. controlPlaneFirewallEnabled is null until the feature is
+  # configured through the API, and the check correlates that flag with the resolved
+  # allowed-address list to reject a world-open allowlist. Expressing both the null-until-set
+  # state and the public-CIDR exclusion across digitalocean_kubernetes_cluster HCL, plan, and
+  # state would be fragile, so this check is runtime-only.
+  - uid: mondoo-digitalocean-security-doks-control-plane-firewall-enabled
+    title: Ensure DOKS clusters restrict API server access with a firewall
+    impact: 90
+    filters: asset.platform == "digitalocean-kubernetes-cluster"
+    mql: |
+      digitalocean.kubernetes.cluster.controlPlaneFirewallEnabled == true
+      digitalocean.kubernetes.cluster.controlPlaneFirewallAllowedAddresses == empty || digitalocean.kubernetes.cluster.controlPlaneFirewallAllowedAddresses.containsNone(["0.0.0.0/0", "::/0"])
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    docs:
+      desc: |
+        This check ensures that every DigitalOcean Kubernetes (DOKS) cluster enables the control-plane firewall and does not list `0.0.0.0/0` or `::/0` among its allowed addresses. The control-plane firewall restricts which source addresses can reach the cluster's Kubernetes API server. When it is disabled, the API server accepts connections from any internet host; when it is enabled but allows any address, the restriction is effectively removed.
+
+        **Why this matters**
+
+        - **The API server is the cluster's control surface:** Anyone who can reach the Kubernetes API server can attempt authentication, exploit an API-level vulnerability, or probe for misconfigurations that grant access to workloads and secrets.
+        - **Authentication is not the only layer:** Even with strong authentication, an internet-reachable API server remains a target for credential attacks and for any future flaw in the API server itself.
+        - **A scoped allowlist contains blast radius:** Restricting the API server to known administrative and CI/CD source ranges removes it from internet-wide scanning entirely.
+
+        **Risk mitigation**
+
+        - **Cluster takeover:** Limiting which sources can reach the API server cuts off the primary network path an attacker would use to compromise the control plane.
+        - **Internet-wide scanning:** A firewalled API server is not discoverable by mass scanners probing for exposed Kubernetes endpoints.
+
+        Administrative and CI/CD source ranges that legitimately need API access should be added to the allowed-address list rather than leaving the firewall open.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Kubernetes** and open each cluster.
+        3. On the **Settings** tab, review the **Control plane firewall** configuration.
+
+        A passing cluster has the control plane firewall enabled with the allowed addresses scoped to specific trusted CIDRs. A failing cluster has the firewall disabled, or enabled with `0.0.0.0/0` or `::/0` in the allowed addresses.
+
+        ### Audit via CLI
+
+        1. List clusters, then inspect each cluster's control-plane firewall settings:
+
+        ```bash
+        doctl kubernetes cluster list --format ID,Name
+        doctl kubernetes cluster get <cluster-id> --output json | jq -r '.[] | [.name, .control_plane_firewall.enabled, (.control_plane_firewall.allowed_addresses | join(","))] | @tsv'
+        ```
+
+        A passing cluster returns `true` for the firewall with an allowed-address list that excludes `0.0.0.0/0` and `::/0`. A failing cluster returns `false`, or `true` with an unrestricted address in the list.
+      remediation:
+        - id: console
+          desc: |
+            To restrict API server access in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Kubernetes** and open the affected cluster.
+            2. On the **Settings** tab, enable the **Control plane firewall**.
+            3. Add the specific administrative and CI/CD source CIDRs that need API access, and ensure neither `0.0.0.0/0` nor `::/0` is present.
+            4. Confirm that your management tooling can still reach the cluster after the change.
+        - id: cli
+          desc: |
+            To enable and scope the control-plane firewall on the command line using the `doctl` CLI:
+
+            ```bash
+            doctl kubernetes cluster update <cluster-id> \
+              --enable-control-plane-firewall=true \
+              --control-plane-firewall-allowed-addresses "203.0.113.0/24,198.51.100.10/32"
+            ```
+
+            Replace the addresses with the trusted source ranges that need API access. Verify connectivity from an allowed range afterward.
+        # No Terraform remediation: controlPlaneFirewallEnabled is a managed control-plane posture
+        # surfaced only by the live API; the digitalocean_kubernetes_cluster resource does not
+        # express the control-plane firewall, so it cannot be remediated through Terraform.
+    refs:
+      - url: https://docs.digitalocean.com/products/kubernetes/how-to/configure-control-plane-firewall/
+        title: Configure the DOKS control plane firewall
 
   # No Terraform variants: this check inspects the certificate's notAfter validity
   # window — runtime telemetry set at issuance, not a configuration field. The
@@ -3751,6 +4017,80 @@ queries:
     refs:
       - url: https://docs.digitalocean.com/products/gradientai-platform/
         title: DigitalOcean GradientAI platform
+  # No Terraform variants: GradientAI agents are managed through the GradientAI API and control
+  # panel; the digitalocean Terraform provider has no resource representing an agent or its
+  # attached guardrails, so there is nothing to assert in HCL, plan, or state.
+  - uid: mondoo-digitalocean-security-gradientai-agent-has-guardrails
+    title: Ensure GradientAI agents have a content guardrail attached
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    mql: |
+      digitalocean.gradientai.agents.all(guardrails.where(isAttached == true).length > 0)
+    docs:
+      desc: |
+        This check ensures that every GradientAI agent has at least one content guardrail attached. Guardrails inspect the prompts an agent receives and the responses it returns, blocking content that violates the configured policy and returning a canned response instead. An agent with no attached guardrail applies no content filtering to its inputs or outputs.
+
+        **Why this matters**
+
+        - **Prompt-injection resistance:** A guardrail can intercept adversarial prompts that attempt to override the agent's instructions or extract its system prompt and connected data.
+        - **Output safety:** Guardrails keep an agent from returning sensitive, unsafe, or policy-violating content to its users.
+        - **Consistent enforcement:** Attaching a guardrail enforces content policy at the platform layer rather than relying on the agent's instruction text alone, which a determined user can work around.
+
+        **Risk mitigation**
+
+        - **Data leakage:** A guardrail reduces the chance that an agent grounded on private knowledge bases discloses that content in response to a crafted prompt.
+        - **Abuse:** Filtering inputs and outputs limits how an exposed agent can be misused for harmful generation.
+
+        Agents that are intentionally unfiltered for a trusted internal audience can be exempted from this check.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Open the **GradientAI** platform and select each agent.
+        3. Review the agent's **Guardrails** configuration.
+
+        A passing account has every agent with at least one attached guardrail. A failing account has one or more agents with no guardrail attached.
+
+        ### Audit via CLI
+
+        1. List the GradientAI agents and review their attached guardrails:
+
+        ```bash
+        doctl genai agent list --output json | jq -r '.[] | [.name, .uuid, ([.guardrails[]? | select(.is_attached)] | length)] | @tsv'
+        ```
+
+        A passing account returns an attached-guardrail count of at least 1 for every agent. A failing account returns `0` for one or more agents.
+      remediation:
+        - id: console
+          desc: |
+            To attach a content guardrail using the DigitalOcean Cloud Control Panel:
+
+            1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+            2. Open the **GradientAI** platform and select the agent.
+            3. Open the **Guardrails** configuration, attach an appropriate guardrail, and set its default response.
+            4. Redeploy the agent so the guardrail takes effect.
+        # No CLI remediation: doctl genai exposes agent lifecycle operations but no command to
+        # attach a guardrail to an agent; guardrail attachment is performed through the GradientAI
+        # control panel or the GradientAI API.
+        # No Terraform remediation: GradientAI agents have no digitalocean Terraform resource, so
+        # guardrail attachment cannot be expressed in Terraform.
+    refs:
+      - url: https://docs.digitalocean.com/products/gradientai-platform/
+        title: DigitalOcean GradientAI platform
+
   # No Terraform variants: GradientAI knowledge bases are managed through the GradientAI
   # API and control panel; the digitalocean Terraform provider has no resource representing
   # a knowledge base or its public flag, so there is nothing to assert in HCL, plan, or state.

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 2.1.0
+    version: 2.2.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -42,6 +42,7 @@ policies:
           - uid: mondoo-hetzner-security-firewall-no-unrestricted-rdp
           - uid: mondoo-hetzner-security-firewall-no-unrestricted-db-ports
           - uid: mondoo-hetzner-security-firewall-no-all-ports-open
+          - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress
           - uid: mondoo-hetzner-security-firewall-has-rules
       - title: Load Balancers
         checks:
@@ -1129,6 +1130,165 @@ queries:
           _['direction'] != "in" ||
           _['port'].notIn(["any", "1-65535", "0-65535"]) ||
           _['source_ips'].containsNone(["0.0.0.0/0", "::/0"])
+        )
+      )
+
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress
+    title: Ensure no firewall allows unrestricted outbound on all ports
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-2
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-hetzner
+        tags:
+          mondoo.com/filter-title: Hetzner Cloud
+          mondoo.com/filter-icon: hetzner
+      - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Hetzner Cloud Firewall defines an outbound rule that permits traffic on all ports (`any`, `1-65535`, or `0-65535`) to the public internet at destination `0.0.0.0/0` or `::/0`. Hetzner allows all outbound traffic by default when a firewall defines no egress rules, so this check flags the case where an explicit egress rule widens outbound access back to every port and every destination.
+
+        **Why this matters**
+
+        - **Exfiltration path:** An all-ports egress rule to the internet lets a compromised server reach any external host on any port, which is the channel data theft and command-and-control traffic use.
+        - **Defeats egress hardening:** Defining narrow egress rules is only effective if a broad all-ports rule does not sit alongside them and re-open everything.
+        - **Containment:** Restricting outbound destinations and ports limits how far a compromised workload can pivot or call out.
+
+        **Risk mitigation**
+
+        - **Command-and-control:** Scoping egress to the specific destinations and ports a workload needs removes the open channel malware uses to reach external infrastructure.
+        - **Data exfiltration:** Constraining outbound traffic reduces the routes by which sensitive data can leave the environment.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Firewalls** and open each firewall.
+        3. Review the **Rules** tab, focusing on outbound rules.
+        4. Check whether any outbound rule has the port set to `Any`, `1-65535`, or `0-65535` with a destination of `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`).
+
+        A passing firewall defines no outbound rule permitting the full port range to the public internet. A failing firewall has an outbound rule with an unrestricted port range and an unrestricted destination.
+
+        ### Audit via CLI
+
+        1. List all firewalls and inspect their rules:
+
+        ```bash
+        hcloud firewall list -o columns=id,name
+        hcloud firewall describe <firewall> -o json
+        ```
+
+        Review the `rules` array for entries where `direction` is `out`, `port` is `any`, `1-65535`, or `0-65535`, and `destination_ips` contains `0.0.0.0/0` or `::/0`.
+
+        A passing firewall returns no such rule. A failing firewall returns at least one outbound rule that opens the full port range to an unrestricted destination.
+      remediation:
+        - id: console
+          desc: |
+            Remove the wide-open outbound rule and replace it with narrow rules that permit only the specific ports and destinations the workload needs to reach.
+        - id: cli
+          desc: |
+            `delete-rule` removes one rule at a time, matched by direction, protocol, port, and destination. Because the check fails on any outbound all-ports rule, repeat the deletion for every protocol that has a wide-open rule and for every unrestricted destination, including IPv6.
+
+            Run `hcloud firewall describe <firewall> -o json` first to enumerate the offending rules, then delete each one:
+
+            ```bash
+            hcloud firewall delete-rule <firewall> \
+              --direction out --protocol tcp --port any --destination-ips 0.0.0.0/0
+            hcloud firewall delete-rule <firewall> \
+              --direction out --protocol tcp --port any --destination-ips ::/0
+            hcloud firewall delete-rule <firewall> \
+              --direction out --protocol udp --port any --destination-ips 0.0.0.0/0
+            hcloud firewall delete-rule <firewall> \
+              --direction out --protocol udp --port any --destination-ips ::/0
+            ```
+
+            Adjust the `--port` value to match the rule actually in place (`any`, `1-65535`, or `0-65535`). After deleting the wide-open rules, add narrow per-destination rules that permit only the required outbound ports.
+        - id: terraform
+          desc: |
+            Never declare an outbound `rule` whose `port` is `any`, `1-65535`, or `0-65535` with `destination_ips` of `0.0.0.0/0` or `::/0`. Replace it with narrow per-destination rules:
+
+            ```hcl
+            resource "hcloud_firewall" "default" {
+              name = "default"
+
+              rule {
+                direction       = "out"
+                protocol        = "tcp"
+                port            = "443"
+                destination_ips = ["0.0.0.0/0", "::/0"]
+              }
+
+              rule {
+                direction       = "out"
+                protocol        = "tcp"
+                port            = "5432"
+                destination_ips = ["10.0.0.0/16"]
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/firewalls/overview/
+        title: Hetzner Cloud Firewalls overview
+
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-hetzner
+    filters: asset.platform == "hetzner-firewall"
+    mql: |
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "any" && _["destinationIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "any" && _["destinationIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "1-65535" && _["destinationIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "1-65535" && _["destinationIps"].contains("::/0"))
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "0-65535" && _["destinationIps"].contains("0.0.0.0/0"))
+      hetzner.firewall.rules.none(_["direction"] == "out" && _["port"] == "0-65535" && _["destinationIps"].contains("::/0"))
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcloud_firewall")
+    mql: |
+      terraform.resources("hcloud_firewall").all(
+        blocks.where(type == "rule").all(
+          arguments['direction'] != "out" ||
+          arguments['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          arguments['destination_ips'].containsNone(["0.0.0.0/0", "::/0"])
+        )
+      )
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "hcloud_firewall")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "hcloud_firewall").all(
+        change.after.rule == null || change.after.rule.all(
+          _['direction'] != "out" ||
+          _['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          _['destination_ips'].containsNone(["0.0.0.0/0", "::/0"])
+        )
+      )
+  - uid: mondoo-hetzner-security-firewall-no-unrestricted-egress-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "hcloud_firewall")
+    mql: |
+      terraform.state.resources.where(type == "hcloud_firewall").all(
+        values.rule == null || values.rule.all(
+          _['direction'] != "out" ||
+          _['port'].notIn(["any", "1-65535", "0-65535"]) ||
+          _['destination_ips'].containsNone(["0.0.0.0/0", "::/0"])
         )
       )
 

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.2.0
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -40,6 +40,8 @@ policies:
           - uid: mondoo-openstack-security-app-credentials-restricted
           - uid: mondoo-openstack-security-app-credentials-have-expiry
           - uid: mondoo-openstack-security-trust-impersonation-expiry
+          - uid: mondoo-openstack-security-user-mfa-enabled
+          - uid: mondoo-openstack-security-user-lockout-not-bypassed
       - title: Compute (Nova)
         checks:
           - uid: mondoo-openstack-security-server-uses-keypair
@@ -52,6 +54,7 @@ policies:
           - uid: mondoo-openstack-security-no-unrestricted-db-ports
           - uid: mondoo-openstack-security-no-all-ports-open
           - uid: mondoo-openstack-security-port-security-enabled
+          - uid: mondoo-openstack-security-firewall-policy-audited
       - title: Block Storage (Cinder)
         checks:
           - uid: mondoo-openstack-security-volume-encrypted
@@ -65,6 +68,8 @@ policies:
       - title: Load Balancers (Octavia)
         checks:
           - uid: mondoo-openstack-security-listener-modern-tls
+          - uid: mondoo-openstack-security-listener-no-plaintext-internet
+          - uid: mondoo-openstack-security-listener-restricts-source-cidrs
       - title: Shared File Systems (Manila)
         checks:
           - uid: mondoo-openstack-security-share-not-public
@@ -73,9 +78,11 @@ policies:
         checks:
           - uid: mondoo-openstack-security-cluster-template-tls-enabled
           - uid: mondoo-openstack-security-cluster-template-no-insecure-registry
+          - uid: mondoo-openstack-security-cluster-template-no-floating-ip
       - title: Databases (Trove)
         checks:
           - uid: mondoo-openstack-security-database-not-public
+          - uid: mondoo-openstack-security-database-supported-version
     scoring_system: highest impact
 queries:
   - uid: mondoo-openstack-security-app-credentials-restricted
@@ -196,6 +203,248 @@ queries:
     mql: |
       terraform.state.resources.where(type == "openstack_identity_application_credential_v3").all(
         values.unrestricted != true
+      )
+
+  - uid: mondoo-openstack-security-user-mfa-enabled
+    title: Ensure Keystone users have multi-factor authentication enabled
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-4-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-openstack-security-user-mfa-enabled-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-user-mfa-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-user-mfa-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-user-mfa-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Keystone user has `multi_factor_auth_enabled` set to true. Without multi-factor authentication, a single password is the only barrier to a user's access, so a phished, reused, or brute-forced password grants an attacker the full set of roles the account holds.
+
+        **Why this matters**
+
+        - **Password compromise is common:** Credential phishing, reuse, and brute force routinely defeat single-factor authentication, and a privileged Keystone account is a high-value target.
+        - **Roles travel with the account:** A compromised user inherits every project and domain role assigned to it, so the blast radius of a stolen password can be large.
+        - **Defense beyond the password:** Requiring a second factor means a leaked password alone is not enough to authenticate.
+
+        **Risk mitigation**
+
+        - **Account takeover:** A second factor blocks an attacker who has only obtained the user's password.
+        - **Lateral movement:** Containing account compromise at the authentication step limits an attacker's ability to assume the account's roles across projects.
+
+        Service accounts that authenticate with application credentials rather than interactive logins may be exempted where MFA does not apply to their flow.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as an administrator.
+        2. Open **Identity** then **Users**.
+        3. Select each user and review whether multi-factor authentication is enabled.
+
+        A passing result shows multi-factor authentication enabled for every user; a failing result shows one or more users without it.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack user show <user> -f json
+        ```
+
+        A passing result shows the `options` field with `multi_factor_auth_enabled` set to `true`; a failing result shows it absent or `false`.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Identity → Users** in Horizon as an administrator.
+            2. Edit each user and enable multi-factor authentication.
+            3. Configure the required authentication rules and confirm the user can still authenticate with the second factor before relying on the change.
+        - id: cli
+          desc: |
+            Enable MFA on the user and define the rule set that the user must satisfy. The rule below requires a password plus a TOTP code:
+
+            ```bash
+            openstack user set <user> \
+              --multi-factor-auth-enabled \
+              --multi-factor-auth-rule password,totp
+            ```
+        - id: terraform
+          desc: |
+            Set `multi_factor_auth_enabled = true` and define `multi_factor_auth_rule` on the `openstack_identity_user_v3` resource:
+
+            ```hcl
+            resource "openstack_identity_user_v3" "operator" {
+              name                     = "operator"
+              default_project_id       = openstack_identity_project_v3.ops.id
+              multi_factor_auth_enabled = true
+
+              multi_factor_auth_rule {
+                rule = ["password", "totp"]
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/keystone/latest/admin/configure-mfa.html
+        title: OpenStack Keystone multi-factor authentication
+
+  - uid: mondoo-openstack-security-user-mfa-enabled-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.users.all(multiFactorAuthEnabled == true)
+  - uid: mondoo-openstack-security-user-mfa-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_identity_user_v3")
+    mql: |
+      terraform.resources("openstack_identity_user_v3").all(
+        arguments['multi_factor_auth_enabled'] == true
+      )
+  - uid: mondoo-openstack-security-user-mfa-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_identity_user_v3")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_identity_user_v3").all(
+        change.after.multi_factor_auth_enabled == true
+      )
+  - uid: mondoo-openstack-security-user-mfa-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_identity_user_v3")
+    mql: |
+      terraform.state.resources.where(type == "openstack_identity_user_v3").all(
+        values.multi_factor_auth_enabled == true
+      )
+
+  - uid: mondoo-openstack-security-user-lockout-not-bypassed
+    title: Ensure Keystone users are not exempt from account lockout
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    variants:
+      - uid: mondoo-openstack-security-user-lockout-not-bypassed-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Keystone user has `ignore_lockout_failure_attempts` set to true. When that option is set, the account is exempt from the lockout that normally suspends a user after a configured number of failed authentication attempts, leaving it open to unlimited password guessing.
+
+        **Why this matters**
+
+        - **Brute-force exposure:** An account exempt from lockout can be subjected to unlimited online password-guessing attempts with no automatic throttle.
+        - **Silent weakening:** The exemption is a per-user override that quietly removes a domain-wide protection for that account, which is easy to miss in a review.
+        - **High-value targets:** Operators sometimes set the exemption on automation or admin accounts, which are exactly the accounts an attacker most wants to brute force.
+
+        **Risk mitigation**
+
+        - **Credential guessing:** Keeping lockout in force ensures repeated failed attempts suspend the account rather than continuing indefinitely.
+        - **Consistent policy:** Removing the override re-applies the domain's account-lockout protection uniformly across users.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as an administrator.
+        2. Open **Identity** then **Users**.
+        3. Review each user's options for a lockout-exemption setting.
+
+        A passing result shows no user exempt from lockout; a failing result shows a user with the lockout exemption set.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack user show <user> -f json
+        ```
+
+        A passing result shows the `options` field with `ignore_lockout_failure_attempts` absent or `false`; a failing result shows it set to `true`.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Identity → Users** in Horizon as an administrator.
+            2. Edit each affected user and clear the lockout-exemption option so standard account-lockout applies.
+            3. Confirm the lockout policy is configured at the domain or deployment level so the account is now protected.
+        - id: cli
+          desc: |
+            Clear the exemption so the user is subject to the configured lockout policy:
+
+            ```bash
+            openstack user set <user> --ignore-lockout-failure-attempts False
+            ```
+        - id: terraform
+          desc: |
+            Either omit `ignore_lockout_failure_attempts` on the `openstack_identity_user_v3` resource (the default is `false`) or set it explicitly:
+
+            ```hcl
+            resource "openstack_identity_user_v3" "operator" {
+              name                            = "operator"
+              default_project_id              = openstack_identity_project_v3.ops.id
+              ignore_lockout_failure_attempts = false
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/keystone/latest/admin/configuration.html
+        title: OpenStack Keystone security compliance and lockout
+
+  - uid: mondoo-openstack-security-user-lockout-not-bypassed-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.users.all(ignoreLockoutFailureAttempts == false)
+  - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_identity_user_v3")
+    mql: |
+      terraform.resources("openstack_identity_user_v3").all(
+        arguments['ignore_lockout_failure_attempts'] != true
+      )
+  - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_identity_user_v3")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_identity_user_v3").all(
+        change.after.ignore_lockout_failure_attempts != true
+      )
+  - uid: mondoo-openstack-security-user-lockout-not-bypassed-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_identity_user_v3")
+    mql: |
+      terraform.state.resources.where(type == "openstack_identity_user_v3").all(
+        values.ignore_lockout_failure_attempts != true
       )
 
   - uid: mondoo-openstack-security-app-credentials-have-expiry
@@ -759,6 +1008,128 @@ queries:
     mql: |
       terraform.state.resources.where(type == "openstack_networking_secgroup_rule_v2").where(values.direction == "ingress").where(values.remote_ip_prefix == "0.0.0.0/0" || values.remote_ip_prefix == "::/0").where(values.protocol == "tcp" || values.protocol == "").none(
         values.port_range_min <= 22 && values.port_range_max >= 22
+      )
+
+  - uid: mondoo-openstack-security-firewall-policy-audited
+    title: Ensure FWaaS firewall policies have been audited
+    impact: 40
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/pci-dss-4: pcidss-requirement-1-2-7
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-firewall-policy-audited-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-firewall-policy-audited-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-firewall-policy-audited-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-firewall-policy-audited-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Neutron FWaaS v2 firewall policy has `audited` set to true, marking that an administrator has reviewed the policy's ordered rule set. Neutron resets the audited flag to false whenever the policy or any of its rules change, so a policy that reports audited has been reviewed since its last modification.
+
+        **Why this matters**
+
+        - **Rules drift:** Firewall rule sets accumulate edits over time, and an unreviewed policy may permit access that no one has confirmed is still required.
+        - **Explicit sign-off:** The audited flag records a deliberate review rather than relying on the assumption that the rules are still correct.
+        - **Change detection:** Because the flag clears on any change, an unaudited policy is a signal that rules were modified without a follow-up review.
+
+        **Risk mitigation**
+
+        - **Stale permissive rules:** Requiring review before a policy is marked audited catches rules that have outlived their purpose.
+        - **Unverified changes:** The reset-on-change behavior surfaces edits that have not been reviewed, prompting a fresh look before the policy is trusted.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Network** then **Firewalls** and review the firewall policies.
+        3. Check whether each policy shows as audited.
+
+        A passing result shows every firewall policy marked audited; a failing result shows a policy that has not been audited since its last change.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack firewall group policy list
+        openstack firewall group policy show <policy>
+        ```
+
+        A passing result shows `audited` set to `True` for every policy; a failing result shows `audited` set to `False`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open **Network → Firewalls** in Horizon and select each firewall policy.
+            2. Review the ordered rule set and confirm every rule is still required and correctly scoped.
+            3. Mark the policy audited once the review is complete. Any later change to the policy or its rules clears the flag and requires a fresh review.
+        - id: cli
+          desc: |
+            After reviewing the policy's rules, mark it audited:
+
+            ```bash
+            openstack firewall group policy set --audited <policy>
+            ```
+
+            Re-run the review and set the flag again after any later change, since Neutron clears it on modification.
+        - id: terraform
+          desc: |
+            Set `audited = true` on the `openstack_fw_policy_v2` resource after the rule list has been reviewed:
+
+            ```hcl
+            resource "openstack_fw_policy_v2" "perimeter" {
+              name    = "perimeter"
+              audited = true
+              rules = [
+                openstack_fw_rule_v2.allow_https.id,
+              ]
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/neutron/latest/admin/fwaas-v2-scenario.html
+        title: OpenStack Neutron FWaaS v2
+
+  - uid: mondoo-openstack-security-firewall-policy-audited-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.firewallPolicies.all(audited == true)
+  - uid: mondoo-openstack-security-firewall-policy-audited-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_fw_policy_v2")
+    mql: |
+      terraform.resources("openstack_fw_policy_v2").all(
+        arguments['audited'] == true
+      )
+  - uid: mondoo-openstack-security-firewall-policy-audited-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_fw_policy_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_fw_policy_v2").all(
+        change.after.audited == true
+      )
+  - uid: mondoo-openstack-security-firewall-policy-audited-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_fw_policy_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_fw_policy_v2").all(
+        values.audited == true
       )
 
   - uid: mondoo-openstack-security-no-unrestricted-rdp
@@ -1912,6 +2283,220 @@ queries:
         )
       )
 
+  # No Terraform variants: this check scopes to internet-facing load balancers using the runtime
+  # exposure correlation (a VIP on an external network or with a floating IP plus a listener open
+  # to the world) and then asserts no plaintext listener. The internet-exposure determination is
+  # resolved from live Neutron and Octavia state and has no analog in openstack_lb_loadbalancer_v2
+  # or openstack_lb_listener_v2 HCL; the listener-modern-tls check already covers the
+  # Terraform-expressible TLS posture per listener.
+  - uid: mondoo-openstack-security-listener-no-plaintext-internet
+    title: Ensure internet-facing Octavia load balancers enforce TLS
+    impact: 85
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.loadBalancers.where(exposure.internetReachable == true).all(enforcesTls == true)
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    docs:
+      desc: |
+        This check ensures that every internet-facing Octavia load balancer terminates or forwards traffic only over encrypted protocols, with no plaintext listener. A load balancer is treated as internet-facing when its VIP sits on an external network or has a floating IP and at least one listener is open to the world. A plaintext listener such as `HTTP`, `TCP`, `UDP`, `SCTP`, or `PROMETHEUS` on such a load balancer carries client traffic in the clear across the public internet.
+
+        **Why this matters**
+
+        - **Credential and session protection:** A plaintext listener exposes authentication tokens, session cookies, and form data to any host on the network path.
+        - **No transport integrity:** Without TLS, an on-path attacker can read and modify traffic, not just observe it.
+        - **Consistent posture:** Requiring encrypted listeners on every public-facing load balancer removes the gap a single forgotten HTTP listener would leave.
+
+        **Risk mitigation**
+
+        - **Traffic interception:** Encrypting all internet-facing listeners keeps client traffic confidential across untrusted networks.
+        - **Downgrade and injection:** Eliminating plaintext listeners removes the unencrypted path an attacker could steer clients onto.
+
+        A load balancer that is only reachable inside the project network, or one that intentionally redirects HTTP to an HTTPS listener, can be reviewed against its intended design.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Network** then **Load Balancers**.
+        3. For each load balancer whose VIP is on an external network or has a floating IP, open the **Listeners** tab and review the protocol of every listener.
+
+        A passing internet-facing load balancer has only `HTTPS`, `TERMINATED_HTTPS`, or otherwise encrypted listeners. A failing internet-facing load balancer has a plaintext `HTTP`, `TCP`, `UDP`, `SCTP`, or `PROMETHEUS` listener.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack loadbalancer list
+        openstack loadbalancer listener list --loadbalancer <id>
+        ```
+
+        A passing internet-facing load balancer lists only encrypted listener protocols. A failing internet-facing load balancer lists a plaintext protocol.
+      remediation:
+        - id: console
+          desc: |
+            1. Open **Network → Load Balancers** in Horizon and select the internet-facing load balancer.
+            2. On the **Listeners** tab, replace each plaintext listener with a `TERMINATED_HTTPS` listener and an attached TLS certificate, or move the service behind an HTTPS listener.
+            3. Where an HTTP listener must remain for redirects, configure it to redirect to the HTTPS listener rather than serving content.
+        - id: cli
+          desc: |
+            Create an encrypted listener and remove the plaintext one. The TLS material is referenced from a Barbican container:
+
+            ```bash
+            openstack loadbalancer listener create <lb> \
+              --name https --protocol TERMINATED_HTTPS --protocol-port 443 \
+              --default-tls-container-ref <barbican-container-ref>
+            openstack loadbalancer listener delete <plaintext-listener>
+            ```
+        # No Terraform remediation: the internet-facing determination is a runtime correlation of
+        # the VIP's external-network or floating-IP placement with its open listeners and has no
+        # single configuration analog. Use the listener-modern-tls Terraform remediation to define
+        # encrypted listeners.
+    refs:
+      - url: https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html
+        title: OpenStack Octavia listener configuration
+
+  - uid: mondoo-openstack-security-listener-restricts-source-cidrs
+    title: Ensure Octavia listeners restrict allowed source CIDRs
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-listener-restricts-source-cidrs-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that every Octavia listener defines an `allowed_cidrs` allow-list that does not include `0.0.0.0/0` or `::/0`. When `allowed_cidrs` is empty, the listener accepts connections from any source. Defining a restrictive allow-list scopes the listener to the networks that legitimately need it.
+
+        **Why this matters**
+
+        - **Reduced exposure:** Scoping a listener to known client networks keeps it off the public scanning grid and out of reach of arbitrary internet hosts.
+        - **Defense in depth:** A source allow-list at the listener supplements security groups and network ACLs, so a gap in one layer does not fully expose the service.
+        - **Administrative endpoints:** Management and internal listeners are frequently left world-open by default when they should only ever be reached from a bastion or an internal range.
+
+        **Risk mitigation**
+
+        - **Internet-wide scanning:** Restricting source CIDRs removes the listener from mass-scanning campaigns probing every reachable port.
+        - **Targeted abuse:** Limiting which networks can connect narrows who can attempt to exploit the backend the listener fronts.
+
+        Listeners that intentionally serve the public internet can be exempted from this check.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Network** then **Load Balancers** and select each load balancer.
+        3. On the **Listeners** tab, review the allowed CIDRs configured on every listener.
+
+        A passing listener defines an allowed-CIDR list scoped to specific networks. A failing listener has no allowed CIDRs or includes `0.0.0.0/0` or `::/0`.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack loadbalancer listener show <listener> -f json
+        ```
+
+        A passing listener returns an `allowed_cidrs` list that excludes `0.0.0.0/0` and `::/0`. A failing listener returns an empty `allowed_cidrs` or one containing a world-open range.
+      remediation:
+        - id: console
+          desc: |
+            1. Open **Network → Load Balancers** in Horizon and select the load balancer.
+            2. On the **Listeners** tab, edit the listener and set the allowed CIDRs to the specific client networks that need access.
+            3. Confirm legitimate clients fall within the configured ranges before removing broad access.
+        - id: cli
+          desc: |
+            Set the allowed CIDRs on the listener to the networks that need access. Repeat `--allowed-cidr` for each range:
+
+            ```bash
+            openstack loadbalancer listener set <listener> \
+              --allowed-cidr 203.0.113.0/24 \
+              --allowed-cidr 198.51.100.0/24
+            ```
+        - id: terraform
+          desc: |
+            Set `allowed_cidrs` on the `openstack_lb_listener_v2` resource to the trusted client networks, never `0.0.0.0/0` or `::/0`:
+
+            ```hcl
+            resource "openstack_lb_listener_v2" "api" {
+              name            = "api"
+              protocol        = "TERMINATED_HTTPS"
+              protocol_port   = 443
+              loadbalancer_id = openstack_lb_loadbalancer_v2.web.id
+              allowed_cidrs   = ["203.0.113.0/24", "198.51.100.0/24"]
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html
+        title: OpenStack Octavia listener access control
+
+  - uid: mondoo-openstack-security-listener-restricts-source-cidrs-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.listeners.all(openToWorld == false)
+  - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_lb_listener_v2")
+    mql: |
+      terraform.resources("openstack_lb_listener_v2").all(
+        arguments['allowed_cidrs'] != null &&
+        arguments['allowed_cidrs'].length > 0 &&
+        arguments['allowed_cidrs'].containsNone(["0.0.0.0/0", "::/0"])
+      )
+  - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_lb_listener_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_lb_listener_v2").all(
+        change.after.allowed_cidrs != null &&
+        change.after.allowed_cidrs.length > 0 &&
+        change.after.allowed_cidrs.containsNone(["0.0.0.0/0", "::/0"])
+      )
+  - uid: mondoo-openstack-security-listener-restricts-source-cidrs-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_lb_listener_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_lb_listener_v2").all(
+        values.allowed_cidrs != null &&
+        values.allowed_cidrs.length > 0 &&
+        values.allowed_cidrs.containsNone(["0.0.0.0/0", "::/0"])
+      )
+
   # No Terraform variants: terraform-provider-openstack has no Keystone trust resource. Trusts are created imperatively (CLI/API or by the Keystone-to-Keystone federation flow), so there is no HCL/plan/state representation to assert against. Re-evaluate if an openstack_identity_trust_v3 resource is added upstream.
   - uid: mondoo-openstack-security-trust-impersonation-expiry
     title: Ensure Keystone trusts allowing impersonation have an expiration
@@ -2352,6 +2937,135 @@ queries:
         values.tls_disabled != true
       )
 
+  - uid: mondoo-openstack-security-cluster-template-no-floating-ip
+    title: Ensure Magnum cluster templates do not enable floating IPs
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-cluster-template-no-floating-ip-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Magnum cluster template sets `floating_ip_enabled = true`. When floating IPs are enabled, cluster nodes including the control plane are assigned public addresses at creation time, placing the Kubernetes API server and the nodes directly on the internet. Every cluster built from the template inherits that posture.
+
+        **Why this matters**
+
+        - **Control plane on the internet:** A control-plane node with a floating IP exposes the Kubernetes API server to the public internet, where it becomes a target for credential attacks and API-level exploits.
+        - **Node exposure:** Worker nodes with public addresses widen the attack surface to every service that binds to a node interface.
+        - **Template inheritance:** A single template with floating IPs enabled silently exposes every cluster created from it, so the fix belongs at the template.
+
+        **Risk mitigation**
+
+        - **Cluster takeover:** Keeping nodes on the private network removes the direct internet path to the control plane.
+        - **Reduced attack surface:** Without floating IPs, the cluster is reachable only through a deliberately placed load balancer or bastion rather than on every node.
+
+        Clusters that genuinely require public node addressing should front the API server with a load balancer and restrict access there rather than assigning floating IPs to every node.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Container Infra** then **Cluster Templates**.
+        3. Select each template and review whether **Enable Floating IP** is set.
+
+        A passing result shows floating IPs disabled for every template; a failing result shows a template with floating IPs enabled.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack coe cluster template show <template>
+        ```
+
+        A passing result shows `floating_ip_enabled` set to `False`; a failing result shows it set to `True`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open **Container Infra → Cluster Templates** in Horizon.
+            2. If no cluster references the template, fix it with the CLI, since Horizon does not expose template patching.
+            3. If clusters reference the template, create a replacement template with **Enable Floating IP** left unset, rebuild each cluster from it, move workloads, then delete the old clusters and template.
+        - id: cli
+          desc: |
+            Magnum locks a cluster template once any cluster references it, so a referenced template cannot be changed in place. Create a replacement template with floating IPs disabled and rebuild clusters from it:
+
+            ```bash
+            # A referenced template cannot be patched; create a replacement with floating IPs disabled
+            openstack coe cluster template create secure-template-v2 \
+              --image fedora-coreos-38 --keypair ops-key \
+              --external-network public --coe kubernetes \
+              --flavor m1.small --docker-volume-size 10 \
+              --master-lb-enabled --floating-ip-disabled
+            ```
+
+            Rebuild clusters from the new template, move workloads, then retire the old clusters and template.
+        - id: terraform
+          desc: |
+            Either omit `floating_ip_enabled` on `openstack_containerinfra_clustertemplate_v1` (the default is `false`) or set it explicitly, and front the API server with a load balancer:
+
+            ```hcl
+            resource "openstack_containerinfra_clustertemplate_v1" "k8s" {
+              name                = "k8s"
+              image               = "fedora-coreos"
+              coe                 = "kubernetes"
+              external_network_id = openstack_networking_network_v2.public.id
+              floating_ip_enabled = false
+              master_lb_enabled   = true
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/magnum/latest/user/index.html
+        title: OpenStack Magnum cluster templates
+
+  - uid: mondoo-openstack-security-cluster-template-no-floating-ip-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.clusterTemplates.all(floatingIpEnabled == false)
+  - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.resources("openstack_containerinfra_clustertemplate_v1").all(
+        arguments['floating_ip_enabled'] != true
+      )
+  - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        change.after.floating_ip_enabled != true
+      )
+  - uid: mondoo-openstack-security-cluster-template-no-floating-ip-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_containerinfra_clustertemplate_v1")
+    mql: |
+      terraform.state.resources.where(type == "openstack_containerinfra_clustertemplate_v1").all(
+        values.floating_ip_enabled != true
+      )
+
   - uid: mondoo-openstack-security-cluster-template-no-insecure-registry
     title: Ensure Magnum cluster templates do not allow insecure registries
     impact: 80
@@ -2552,6 +3266,93 @@ queries:
               --nic net-id=6f2c1b3a-7e8d-4a5b-9c0d-1e2f3a4b5c6d
             ```
         # No Terraform remediation: see the note above the check — the public/private posture is a property of the network the instance attaches to, not a setting on the openstack_db_instance_v1 resource itself.
+    refs:
+      - url: https://docs.openstack.org/trove/latest/user/index.html
+        title: OpenStack Trove database instances
+
+  # No Terraform variants: the set of end-of-life datastore versions is defined per deployment by
+  # the operator's configured Trove datastores rather than a fixed managed catalog, and the version
+  # lives in the nested datastore block of openstack_db_instance_v1. A static EOL allowlist asserted
+  # against HCL, plan, or state would be unreliable across deployments, so this check is runtime-only.
+  - uid: mondoo-openstack-security-database-supported-version
+    title: Ensure Trove database instances run a supported engine version
+    impact: 70
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.databaseInstances.where(datastoreType.downcase == "mysql").all(datastoreVersion.notIn(["5.5", "5.6", "5.7"]))
+      openstack.databaseInstances.where(datastoreType.downcase == "mariadb").all(datastoreVersion.notIn(["5.5", "10.0", "10.1", "10.2", "10.3", "10.4", "10.5"]))
+      openstack.databaseInstances.where(datastoreType.downcase == "postgresql").all(datastoreVersion.notIn(["9.4", "9.5", "9.6", "10", "11", "12", "13"]))
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    docs:
+      desc: |
+        This check ensures that Trove managed database instances are not running a MySQL, MariaDB, or PostgreSQL engine version that has reached end of life upstream. End-of-life engines no longer receive security patches, so newly disclosed vulnerabilities in them go unfixed. The version ranges flagged here track the upstream end-of-life dates and may need adjustment as additional versions age out.
+
+        **Why this matters**
+
+        - **No security patches:** An end-of-life database engine does not receive fixes for newly disclosed CVEs, so known vulnerabilities accumulate without remediation.
+        - **Active exploitation:** Known-exploited flaws in older MySQL, MariaDB, and PostgreSQL releases are routinely weaponized against reachable database listeners.
+        - **Compliance exposure:** Most frameworks require software components to receive vendor security support, which end-of-life engines no longer do.
+
+        **Risk mitigation**
+
+        - **Patch coverage:** Moving to a supported major version restores the flow of security patches and closes accumulating CVE exposure.
+        - **Supported upgrade path:** Acting before an engine reaches end of life avoids a more disruptive cold migration later.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Database** then **Instances**.
+        3. Review the datastore type and version for each instance.
+
+        A passing instance runs a datastore version still supported upstream. A failing instance runs an end-of-life version such as MySQL 5.6 or 5.7, MariaDB 10.5 or older, or PostgreSQL 13 or older.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result. Treat the datastore versions the deployment currently offers as the authoritative supported set:
+
+        ```bash
+        openstack database instance list
+        openstack datastore version list <datastore>
+        ```
+
+        A passing instance runs a version the operator still offers and that upstream still supports. A failing instance runs a version past its upstream end-of-life date.
+      remediation:
+        - id: console
+          desc: |
+            Trove does not perform an in-place major-version upgrade through Horizon. Create a replacement instance on a supported datastore version and migrate the data:
+
+            1. Open **Database → Instances** and note the datastore type, version, flavor, and network of the affected instance.
+            2. Launch a new instance on a supported datastore version with the same flavor and network.
+            3. Migrate the data with the engine's native tools, repoint applications, and delete the original instance once verified.
+        - id: cli
+          desc: |
+            Create a replacement instance on a supported datastore version and migrate the data, since Trove does not perform an in-place major-version upgrade:
+
+            ```bash
+            openstack datastore version list mysql
+            openstack database instance create db-upgraded \
+              --flavor m1.small --size 10 \
+              --datastore mysql --datastore-version 8.0 \
+              --nic net-id=6f2c1b3a-7e8d-4a5b-9c0d-1e2f3a4b5c6d
+            ```
+
+            Migrate the data with the engine's native tools, repoint applications, then delete the original instance.
+        # No Terraform remediation: Trove does not support an in-place major-version upgrade, and the
+        # supported version set is deployment-specific, so the fix is a data migration to a new
+        # instance rather than a Terraform field change.
     refs:
       - url: https://docs.openstack.org/trove/latest/user/index.html
         title: OpenStack Trove database instances


### PR DESCRIPTION
Adds 12 security-focused checks to the DigitalOcean, Hetzner, and OpenStack policies, built on provider fields surfaced in the recent provider work. Each check ships full `desc`/`audit`/`remediation`, compliance tags **verified against the enterprise framework control text** (not copied from siblings — the existing DO/OpenStack siblings carry a bulk identity-proofing map that is wrong for most objectives), and Terraform variants where a real provider analog exists.

## Checks

**DigitalOcean** (`2.1.0` → `2.2.0`)
1. `doks-control-plane-firewall-enabled` — restrict the Kubernetes API server with the control-plane firewall (enabled + no `0.0.0.0/0`/`::/0` in allowed addresses). impact 90
2. `db-not-internet-reachable` — managed DB has no internet-reachable endpoint (`internetReachable` correlation). impact 85
3. `lb-strong-tls-cipher-policy` — TLS load balancers use the `STRONG` cipher policy. impact 70
4. `gradientai-agent-has-guardrails` — every GenAI agent has an attached content guardrail. impact 60

**Hetzner** (`2.1.0` → `2.2.0`)

6. `firewall-no-unrestricted-egress` — no firewall opens all outbound ports to `0.0.0.0/0`/`::/0`. impact 70 *(full TF variants)*

**OpenStack** (`1.2.0` → `1.3.0`)

7. `user-mfa-enabled` — Keystone users require MFA. impact 85 *(full TF variants)*
8. `user-lockout-not-bypassed` — users are not exempt from account lockout. impact 70 *(full TF variants)*
9. `listener-no-plaintext-internet` — internet-facing Octavia LBs enforce TLS (`enforcesTls` + exposure). impact 85
10. `cluster-template-no-floating-ip` — Magnum templates do not assign floating IPs to nodes. impact 80 *(full TF variants)*
11. `database-supported-version` — Trove engines are not EOL. impact 70
12. `firewall-policy-audited` — FWaaS policies are audited. impact 40 *(full TF variants)*
13. `listener-restricts-source-cidrs` — Octavia listeners scope `allowed_cidrs`. impact 60 *(full TF variants)*

(Numbering matches the original suggestion list; #5 — Hetzner LB exposure — was not requested.)

## Terraform variants

Config-backed checks (#6, #7, #8, #10, #12, #13) ship `hcl`/`plan`/`state` variants. Runtime-only checks (#1, #2, #3, #4, #9, #11) carry a `# No Terraform variants:` comment explaining the limitation — exposure correlations resolved from live state, managed control-plane posture, the GenAI API surface (no TF resource), and the operator-defined Trove version catalog.

## Compliance tags

Mapped by true control objective and verified against each framework YAML in `cnspec-enterprise-policies/frameworks/`:
- Network ingress/isolation → `sc-7`, `a-8-22`, `pci 1-3-1`/`1-4-1`, `pr-ir-01`, `ivs-06`
- Egress → `a-8-20`, `800-171 3-13-6`, `pci 1-3-2`
- TLS in transit → `cek-04`, `a-8-24`, `sc-8`, `pci 4-2-1` (matches the in-repo `listener-modern-tls` set)
- MFA → `iam-14`, `ia-2`, `pci 8-4-2`, `pr-aa-03`
- Lockout → `ac-7`, `800-171 3-1-8`, `pci 8-3-4` (`false` where no strict fit)
- Supported version → `a-8-8`, `si-2`, `pci 6-3-3`, `tvm-03`
- FWaaS audited → `pci 1-2-7`, `cm-6`, `a-8-9` (config-review, `false` where no fit)
- AI guardrails (#4) → all `false`; no framework in the set covers AI content-safety

## Validation

- `cnspec policy lint` passes for all three policies; the new fields resolve against the installed providers.
- `validate_remediation_commands.py digitalocean` → 55 passed, 0 failed
- `validate_remediation_commands.py hetzner` → 57 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)