### PR TITLE
✨ windows: adopt typed LSA/SMB resources + add WinRM and Print Spooler checks

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -85,6 +85,12 @@ policies:
           - uid: mondoo-windows-security-turn-off-multicast-name-resolution-is-set-to-enabled
           - uid: mondoo-windows-security-wdigest-authentication-is-set-to-disabled
           - uid: mondoo-windows-security-additional-LSA-protection
+          - uid: mondoo-windows-security-winrm-service-disallow-basic-authentication
+          - uid: mondoo-windows-security-winrm-service-disallow-unencrypted-traffic
+          - uid: mondoo-windows-security-winrm-client-disallow-basic-authentication
+          - uid: mondoo-windows-security-winrm-client-disallow-unencrypted-traffic
+          - uid: mondoo-windows-security-print-spooler-disable-remote-rpc-endpoint
+          - uid: mondoo-windows-security-print-spooler-restrict-driver-installation-to-administrators
       - title: Auditing
         filters: |
           asset.family.contains('windows')
@@ -285,7 +291,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RunAsPPL' ).data == 1
+      windows.lsa.runAsPpl == 1
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/
@@ -3765,7 +3771,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).data == 0
+      windows.smb.serverConfiguration.smb1Enabled == false
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-security
@@ -5206,7 +5212,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RestrictAnonymousSAM' ).data == 1
+      windows.lsa.restrictAnonymousSam == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -5303,7 +5309,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RestrictAnonymous' ).data == 1
+      windows.lsa.restrictAnonymous == 1
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -5400,7 +5406,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'DisableDomainCreds' ).data == 1
+      windows.lsa.disableDomainCreds == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -5497,7 +5503,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'EveryoneIncludesAnonymous' ).data == 0
+      windows.lsa.everyoneIncludesAnonymous == false
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -5838,7 +5844,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa', name: 'restrictremotesam' ).data == 'O:BAG:BAD:(A;;RC;;;BA)'
+      windows.lsa.restrictRemoteSam == 'O:BAG:BAD:(A;;RC;;;BA)'
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-policies
@@ -6137,7 +6143,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'UseMachineId' ).data == 1
+      windows.lsa.useMachineId == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6231,7 +6237,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0', name: 'AllowNullSessionFallback' ).data == 0
+      windows.lsa.ntlm.allowNullSessionFallback == false
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6325,7 +6331,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\pku2u', name: 'AllowOnlineID' ).data == 0
+      windows.lsa.ntlm.allowOnlineId == false
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6547,7 +6553,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'NoLMHash' ).data == 1
+      windows.lsa.noLmHash == true
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6644,7 +6650,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'LmCompatibilityLevel' ).data == 5
+      windows.lsa.lmCompatibilityLevel == 5
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6855,7 +6861,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0', name: 'NTLMMinServerSec' ).data == 537395200
+      windows.lsa.ntlm.ntlmMinServerSec == 537395200
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -6962,7 +6968,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0', name: 'NTLMMinClientSec' ).data == 537395200
+      windows.lsa.ntlm.ntlmMinClientSec == 537395200
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/
@@ -8872,7 +8878,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest', name: 'UseLogonCredential' ).data == 0
+      windows.lsa.ntlm.useLogonCredential == false
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/
@@ -8968,3 +8974,543 @@ queries:
       windows.computerInfo.OsProductType != 2
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionPipes' ).data == empty
+  - uid: mondoo-windows-security-winrm-service-disallow-basic-authentication
+    title: Ensure WinRM service does not allow Basic authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      windows.winrm.service.allowBasic == false
+    docs:
+      refs:
+        - url: https://learn.microsoft.com/en-us/windows/win32/winrm/installation-and-configuration-for-windows-remote-management
+          title: Windows Remote Management documentation
+      desc: |-
+        Basic authentication transmits credentials as an unprotected, base64-encoded string that any party able to observe the traffic can trivially decode. When the WinRM service accepts Basic authentication, an attacker who can reach the management endpoint can capture or replay administrator credentials. Disabling Basic authentication forces clients to use a stronger scheme such as Kerberos or Negotiate.
+
+        **Why this matters**
+
+        - **Credential protection:** Strong authentication schemes never expose a reusable, decodable credential on the wire.
+        - **Lateral movement resistance:** Remote management endpoints are a prime target for attackers moving between hosts; weak auth makes that movement easier.
+
+        The recommended state for this setting is: `Disabled`.
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service`.
+        3. Inspect the `AllowBasic` value.
+
+        The system passes when `AllowBasic` is set to `0`. It fails if the value is missing or set differently.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service' -Name 'AllowBasic'
+           ```
+
+        The system passes when `AllowBasic` is set to `0`. It fails if the value is missing or set differently.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Disabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Remote Management (WinRM)\WinRM Service\Allow Basic authentication
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'AllowBasic' -Value 0 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Disable WinRM service Basic authentication
+              hosts: windows
+              tasks:
+                - name: Set WinRM Service AllowBasic to 0 (Disabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service
+                    name: AllowBasic
+                    data: 0
+                    type: dword
+            ```
+  - uid: mondoo-windows-security-winrm-service-disallow-unencrypted-traffic
+    title: Ensure WinRM service does not allow unencrypted traffic
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-2-2-7
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      windows.winrm.service.allowUnencryptedTraffic == false
+    docs:
+      refs:
+        - url: https://learn.microsoft.com/en-us/windows/win32/winrm/installation-and-configuration-for-windows-remote-management
+          title: Windows Remote Management documentation
+      desc: |-
+        When the WinRM service allows unencrypted traffic, management commands and their responses travel across the network in cleartext, exposing credentials, command output, and other sensitive data to interception and tampering. Requiring encryption ensures all remote management traffic is protected in transit.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** Encryption prevents disclosure of credentials and command output to anyone observing the network.
+        - **Integrity in transit:** Encrypted channels detect and prevent tampering with management commands.
+
+        The recommended state for this setting is: `Disabled`.
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service`.
+        3. Inspect the `AllowUnencryptedTraffic` value.
+
+        The system passes when `AllowUnencryptedTraffic` is set to `0`. It fails if the value is missing or set differently.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service' -Name 'AllowUnencryptedTraffic'
+           ```
+
+        The system passes when `AllowUnencryptedTraffic` is set to `0`. It fails if the value is missing or set differently.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Disabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Remote Management (WinRM)\WinRM Service\Allow unencrypted traffic
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'AllowUnencryptedTraffic' -Value 0 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Disable WinRM service unencrypted traffic
+              hosts: windows
+              tasks:
+                - name: Set WinRM Service AllowUnencryptedTraffic to 0 (Disabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service
+                    name: AllowUnencryptedTraffic
+                    data: 0
+                    type: dword
+            ```
+  - uid: mondoo-windows-security-winrm-client-disallow-basic-authentication
+    title: Ensure WinRM client does not allow Basic authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-3
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      windows.winrm.client.allowBasic == false
+    docs:
+      refs:
+        - url: https://learn.microsoft.com/en-us/windows/win32/winrm/installation-and-configuration-for-windows-remote-management
+          title: Windows Remote Management documentation
+      desc: |-
+        Basic authentication transmits credentials as an unprotected, base64-encoded string that any party able to observe the traffic can trivially decode. When the WinRM client is permitted to use Basic authentication, it can be coerced into sending administrator credentials in an easily recovered form to a malicious or impersonated endpoint. Disabling Basic authentication forces the client to use a stronger scheme such as Kerberos or Negotiate.
+
+        **Why this matters**
+
+        - **Credential protection:** Strong authentication schemes never expose a reusable, decodable credential on the wire.
+        - **Resistance to rogue endpoints:** A client that refuses Basic authentication cannot be tricked into leaking credentials to an attacker-controlled server.
+
+        The recommended state for this setting is: `Disabled`.
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client`.
+        3. Inspect the `AllowBasic` value.
+
+        The system passes when `AllowBasic` is set to `0`. It fails if the value is missing or set differently.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic'
+           ```
+
+        The system passes when `AllowBasic` is set to `0`. It fails if the value is missing or set differently.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Disabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Remote Management (WinRM)\WinRM Client\Allow Basic authentication
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'AllowBasic' -Value 0 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Disable WinRM client Basic authentication
+              hosts: windows
+              tasks:
+                - name: Set WinRM Client AllowBasic to 0 (Disabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client
+                    name: AllowBasic
+                    data: 0
+                    type: dword
+            ```
+  - uid: mondoo-windows-security-winrm-client-disallow-unencrypted-traffic
+    title: Ensure WinRM client does not allow unencrypted traffic
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-2-2-7
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      windows.winrm.client.allowUnencryptedTraffic == false
+    docs:
+      refs:
+        - url: https://learn.microsoft.com/en-us/windows/win32/winrm/installation-and-configuration-for-windows-remote-management
+          title: Windows Remote Management documentation
+      desc: |-
+        When the WinRM client allows unencrypted traffic, management commands and their responses travel across the network in cleartext, exposing credentials, command output, and other sensitive data to interception and tampering. Requiring encryption ensures all remote management traffic the client initiates is protected in transit.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** Encryption prevents disclosure of credentials and command output to anyone observing the network.
+        - **Integrity in transit:** Encrypted channels detect and prevent tampering with management commands.
+
+        The recommended state for this setting is: `Disabled`.
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client`.
+        3. Inspect the `AllowUnencryptedTraffic` value.
+
+        The system passes when `AllowUnencryptedTraffic` is set to `0`. It fails if the value is missing or set differently.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowUnencryptedTraffic'
+           ```
+
+        The system passes when `AllowUnencryptedTraffic` is set to `0`. It fails if the value is missing or set differently.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Disabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Remote Management (WinRM)\WinRM Client\Allow unencrypted traffic
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'AllowUnencryptedTraffic' -Value 0 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Disable WinRM client unencrypted traffic
+              hosts: windows
+              tasks:
+                - name: Set WinRM Client AllowUnencryptedTraffic to 0 (Disabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client
+                    name: AllowUnencryptedTraffic
+                    data: 0
+                    type: dword
+            ```
+  - uid: mondoo-windows-security-print-spooler-disable-remote-rpc-endpoint
+    title: Ensure the Print Spooler does not accept remote RPC connections
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      windows.spooler.registerRemoteRpcEndpoint == false
+    docs:
+      refs:
+        - url: https://support.microsoft.com/en-us/topic/kb5005010-restricting-installation-of-new-printer-drivers-after-applying-the-july-6-2021-updates-31b91c02-05bc-4ada-a7ea-183b129578a7
+          title: KB5005010 - Print Spooler security hardening
+      desc: |-
+        The Print Spooler service exposes a remote RPC endpoint that lets other hosts submit print jobs and driver operations over the network. This endpoint has been the entry point for severe remote-code-execution and privilege-escalation vulnerabilities, most notably the PrintNightmare family. Disabling the remote RPC endpoint removes that network-reachable attack surface while leaving local printing intact.
+
+        **Why this matters**
+
+        - **Attack surface reduction:** A spooler that does not accept remote connections cannot be exploited remotely through the print RPC interface.
+        - **Least functionality:** Most workstations and member servers do not need to receive print jobs from the network, so the remote endpoint is unnecessary exposure.
+
+        The recommended state for this setting is `0` (remote connections disabled). On a dedicated print server, enable this only with the other spooler hardening controls in place.
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers`.
+        3. Inspect the `RegisterSpoolerRemoteRpcEndPoint` value.
+
+        The system passes when `RegisterSpoolerRemoteRpcEndPoint` is set to `0`. It fails if the value is missing or set to `1`.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers' -Name 'RegisterSpoolerRemoteRpcEndPoint'
+           ```
+
+        The system passes when `RegisterSpoolerRemoteRpcEndPoint` is set to `0`. It fails if the value is missing or set to `1`.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Disabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Printers\Allow Print Spooler to accept client connections
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'RegisterSpoolerRemoteRpcEndPoint' -Value 0 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Disable Print Spooler remote RPC endpoint
+              hosts: windows
+              tasks:
+                - name: Set RegisterSpoolerRemoteRpcEndPoint to 0 (Disabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers
+                    name: RegisterSpoolerRemoteRpcEndPoint
+                    data: 0
+                    type: dword
+            ```
+  - uid: mondoo-windows-security-print-spooler-restrict-driver-installation-to-administrators
+    title: Ensure Point and Print driver installation is restricted to admins
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      windows.spooler.pointAndPrint.restrictDriverInstallationToAdministrators == true
+    docs:
+      refs:
+        - url: https://support.microsoft.com/en-us/topic/kb5005652-manage-new-point-and-print-default-driver-installation-behavior-cve-2021-34481-873642bf-2634-49c5-a23b-6d8e9a302872
+          title: KB5005652 - Point and Print default driver installation behavior
+      desc: |-
+        Point and Print lets a workstation download and install a printer driver from a print server. When any user may install those drivers, a standard user (or an attacker who has compromised one) can install a malicious or vulnerable driver and gain SYSTEM privileges, the core PrintNightmare privilege-escalation technique. Restricting driver installation to administrators closes that escalation path.
+
+        **Why this matters**
+
+        - **Least privilege:** Installing a kernel-loaded printer driver is a privileged action that should be reserved for administrators.
+        - **Privilege-escalation resistance:** Standard users cannot leverage Point and Print to run attacker-supplied code as SYSTEM.
+
+        The recommended state for this setting is: `Enabled` (driver installation restricted to administrators).
+      audit: |
+        ### Audit via Registry Editor
+
+        1. Press **Windows + R**, type `regedit`, and press **Enter**.
+        2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint`.
+        3. Inspect the `RestrictDriverInstallationToAdministrators` value.
+
+        The system passes when `RestrictDriverInstallationToAdministrators` is set to `1` or is not configured, because the post-mitigation Windows default restricts installation to administrators. It fails when the value is explicitly set to `0`.
+
+        ### Audit via PowerShell
+
+        1. Open an elevated PowerShell session.
+        2. Read the value:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint' -Name 'RestrictDriverInstallationToAdministrators'
+           ```
+
+        The system passes when `RestrictDriverInstallationToAdministrators` is `1` or absent (default-restricted). It fails when the value is explicitly set to `0`.
+      remediation:
+        - id: grouppolicy
+          desc: |
+            **Using Group Policy**
+
+            To establish the recommended configuration via GP, set the following UI path to `Enabled`:
+
+            ```text
+            Computer Configuration\Policies\Administrative Templates\Printers\Limits print driver installation to Administrators
+            ```
+        - id: powershell
+          desc: |
+            **Using PowerShell**
+
+            To establish the recommended configuration via PowerShell, run the following commands:
+
+            ```powershell
+            $RegistryPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
+            If (-NOT (Test-Path $RegistryPath)) {
+                New-Item -Path $RegistryPath -Force | Out-Null
+            }
+            New-ItemProperty -Path $RegistryPath -Name 'RestrictDriverInstallationToAdministrators' -Value 1 -PropertyType DWORD -Force
+            ```
+        - id: ansible
+          desc: |
+            **Using Ansible**
+
+            ```yaml
+            ---
+            - name: Restrict Point and Print driver installation to administrators
+              hosts: windows
+              tasks:
+                - name: Set RestrictDriverInstallationToAdministrators to 1 (Enabled)
+                  ansible.windows.win_regedit:
+                    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint
+                    name: RestrictDriverInstallationToAdministrators
+                    data: 1
+                    type: dword
+            ```


### PR DESCRIPTION
## What

cnquery's 2026-06-20 batch (#8555–#8576) added a large set of typed Windows MQL resources, and #8583 remodeled the binary registry settings on those resources as typed **bools** instead of `0`/`1` ints. This bumps the `mql/v13` dependency to a commit that includes both and puts the resources to use in `mondoo-windows-security`.

### Dependency
- `go.mondoo.com/mql/v13` → `v13.23.1-0.20260621200812-41a8371f3faf` (commit `41a8371f3`, includes all 14 new Windows resources **and** the bool modeling from #8583). Required because the new resources and their bool typing didn't exist in the previously-pinned versions.

### Migrations — 15 checks moved from raw `registrykey` to typed resources
Same registry data source (these resources read the registry directly), so semantics are preserved while gaining null-vs-0 handling and command-free reads. Binary on/off settings are compared against bool literals (`== true` / `== false`); graded settings stay integer comparisons:

| Resource | Bool checks (`== true`/`== false`) | Int checks |
|---|---|---|
| `windows.lsa` | RestrictAnonymousSAM, DisableDomainCreds, EveryoneIncludesAnonymous, UseMachineId, NoLMHash | RunAsPPL, RestrictAnonymous, LmCompatibilityLevel |
| `windows.lsa.ntlm` | AllowNullSessionFallback, AllowOnlineID (PKU2U), WDigest UseLogonCredential | NTLMMinServerSec, NTLMMinClientSec |
| `windows.lsa` (string) | — | restrictremotesam (SDDL string) |
| `windows.smb.serverConfiguration` | SMBv1 server (`smb1Enabled == false`) | — |

**SEHOP was intentionally left on the registry read** — `windows.exploitProtection` is PowerShell-cmdlet-backed, so migrating it would change the data source and could turn passing checks into errors on hosts without the cmdlet.

### New checks — 6, for domains with no prior coverage
All carry verified `compliance/*` tags across the policy's 13 frameworks (control UIDs checked against `cnspec-enterprise-policies/frameworks/`).

- **WinRM** (`windows.winrm`): client & service — disallow Basic authentication, disallow unencrypted traffic (4 checks; bool fields). Maps to authentication-strength (Basic) and encryption-in-transit (unencrypted) controls respectively.
- **Print Spooler** (`windows.spooler`): disable remote RPC endpoint (`registerRemoteRpcEndpoint == false`, PrintNightmare attack-surface, impact 90), restrict Point-and-Print driver installation to administrators (`restrictDriverInstallationToAdministrators == true`, privilege escalation, impact 80).

Impacts anchored to siblings: WinRM `80` (matches `require-secure-rpc`=80); Spooler remote-RPC `90` (between network-hardening 80 and SMBv1 100).

## Verification
- `cnspec policy lint content/mondoo-windows-security.mql.yaml` → `valid policy bundle(s)` (only pre-existing `auditpol` deprecation warnings remain). The bool comparisons compile cleanly against the bool-typed resources.
- `go build ./...` succeeds with the bumped dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
