### PR TITLE
✨ k8s: add 6 RBAC and Pod Security admission checks

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-security
     name: Mondoo Kubernetes Cluster and Workload Security
-    version: 2.0.2
+    version: 2.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -87,6 +87,19 @@ policies:
         filters: asset.platform == "k8s-cluster"
         checks:
           - uid: mondoo-kubernetes-security-no-hostpath-persistent-volumes
+      - title: Kubernetes RBAC Security
+        filters: |
+          asset.platform == "k8s-cluster" || asset.platform == "k8s-manifest"
+        checks:
+          - uid: mondoo-kubernetes-security-serviceaccount-no-cluster-admin
+          - uid: mondoo-kubernetes-security-serviceaccount-no-privilege-escalation
+          - uid: mondoo-kubernetes-security-rbac-no-wildcard-rules
+          - uid: mondoo-kubernetes-security-rbac-restrict-cluster-admin-bindings
+          - uid: mondoo-kubernetes-security-rbac-no-cluster-wide-secret-read
+      - title: Kubernetes Namespace Security
+        filters: asset.platform == "k8s-namespace"
+        checks:
+          - uid: mondoo-kubernetes-security-namespace-enforces-pod-security
       - title: Kubernetes CronJobs Security
         filters: asset.platform == "k8s-cronjob"
         checks:
@@ -12554,3 +12567,490 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file
         title: Kubernetes - Static token file
+  - uid: mondoo-kubernetes-security-serviceaccount-no-cluster-admin
+    title: Service accounts should not be bound to cluster-admin
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedNamespaces
+        title: Namespaces to exclude from RBAC and Pod Security checks
+        mql: |
+          return ["kube-system", "kube-public", "kube-node-lease"]
+    mql: |
+      k8s.serviceaccounts.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( isClusterAdmin == false )
+    docs:
+      desc: |
+        This check ensures that no service account is granted the built-in `cluster-admin` role, or an equivalent role that grants unrestricted access through wildcard verbs, API groups, and resources. Service accounts are non-human identities consumed by workloads, and a workload that runs as a cluster-admin service account holds full control of every resource in the cluster.
+
+        **Why this matters**
+
+        A service account with cluster-admin access removes every authorization boundary for the pods that use it:
+
+        - **Full cluster compromise:** anyone who compromises a single pod inherits its token and can read every Secret, create privileged pods on any node, and modify or delete any resource in the cluster.
+        - **Lateral movement and persistence:** an attacker can create new bindings, deploy backdoors, and disable security controls cluster-wide.
+        - **No blast-radius containment:** the principle of least privilege is the primary defense against a compromised workload; a cluster-admin service account defeats it entirely.
+
+        Workloads should be granted only the specific permissions they need, scoped to the namespaces they operate in.
+      audit: |
+        List the subjects bound to the `cluster-admin` ClusterRole and look for any `ServiceAccount` entries:
+
+        ```bash
+        kubectl get clusterrolebindings -o json | jq -r '.items[] | select(.roleRef.name == "cluster-admin") | .subjects[]? | select(.kind == "ServiceAccount") | "\(.namespace)/\(.name)"'
+        ```
+
+        You can also test a specific service account directly:
+
+        ```bash
+        kubectl auth can-i '*' '*' --as=system:serviceaccount:<namespace>:<name> --all-namespaces
+        ```
+
+        If `kubectl auth can-i` returns `yes` for `'*' '*'`, the service account is cluster-admin and the check fails. The check passes when no service account outside the excluded system namespaces resolves to cluster-admin.
+      remediation:
+        - id: kubectl
+          desc: |
+            Remove the cluster-admin grant from the service account and replace it with a narrowly scoped Role bound only in the namespaces the workload uses:
+
+            ```bash
+            # Remove the offending binding
+            kubectl delete clusterrolebinding <binding-name>
+
+            # Grant only the permissions the workload needs, scoped to its namespace
+            kubectl create role app-reader --verb=get,list,watch --resource=pods,configmaps -n <namespace>
+            kubectl create rolebinding app-reader-binding --role=app-reader --serviceaccount=<namespace>:<name> -n <namespace>
+            ```
+        - id: manifest
+          desc: |
+            Define a least-privilege Role and bind the service account to it instead of `cluster-admin`. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: app-reader
+              namespace: my-namespace
+            rules:
+              - apiGroups: [""]
+                resources: ["pods", "configmaps"]
+                verbs: ["get", "list", "watch"]
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: app-reader-binding
+              namespace: my-namespace
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: app-reader
+            subjects:
+              - kind: ServiceAccount
+                name: my-app
+                namespace: my-namespace
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+        title: Kubernetes - Using RBAC Authorization
+      - url: https://kubernetes.io/docs/concepts/security/rbac-good-practices/
+        title: Kubernetes - RBAC Good Practices
+  - uid: mondoo-kubernetes-security-serviceaccount-no-privilege-escalation
+    title: Service accounts should not be able to escalate RBAC privileges
+    impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedNamespaces
+        title: Namespaces to exclude from RBAC and Pod Security checks
+        mql: |
+          return ["kube-system", "kube-public", "kube-node-lease"]
+    mql: |
+      k8s.serviceaccounts.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( canEscalatePrivileges == false )
+    docs:
+      desc: |
+        This check ensures that no service account is bound to a role that allows RBAC privilege escalation. The `escalate` and `bind` verbs on roles and bindings, and the `impersonate` verb on users, groups, or service accounts, let a subject grant itself more privileges than it currently holds — bypassing the protections that normally stop a user from creating a role more powerful than their own.
+
+        **Why this matters**
+
+        Privilege-escalation verbs turn a limited foothold into full control:
+
+        - **`escalate`** lets a subject create or edit a Role or ClusterRole containing permissions it does not already have, defeating the built-in escalation prevention.
+        - **`bind`** lets a subject bind any existing role — including `cluster-admin` — to itself or another identity.
+        - **`impersonate`** lets a subject act as any other user, group, or service account, including cluster administrators.
+
+        A workload holding any of these verbs is effectively one step away from cluster-admin, so they should never be granted to application service accounts.
+      audit: |
+        Inspect the Roles and ClusterRoles bound to your service accounts for the `escalate`, `bind`, or `impersonate` verbs:
+
+        ```bash
+        kubectl get clusterroles,roles -A -o json | jq -r '.items[] | select(.rules[]? | (.verbs[]? | test("^(escalate|bind|impersonate|\\*)$"))) | "\(.kind) \(.metadata.namespace // "-")/\(.metadata.name)"'
+        ```
+
+        Then confirm which service accounts are bound to those roles with `kubectl get rolebindings,clusterrolebindings -A`. The check fails when a service account outside the excluded namespaces is bound to a role granting any of these verbs, and passes otherwise.
+      remediation:
+        - id: kubectl
+          desc: |
+            Remove the `escalate`, `bind`, and `impersonate` verbs (and any wildcard `*` verb that covers them) from the roles bound to the service account, then re-grant only the concrete verbs the workload needs:
+
+            ```bash
+            kubectl edit clusterrole <role-name>   # remove escalate/bind/impersonate and wildcard verbs
+            # or rebind the service account to a purpose-built least-privilege role
+            kubectl create role app-role --verb=get,list,watch --resource=pods -n <namespace>
+            kubectl create rolebinding app-binding --role=app-role --serviceaccount=<namespace>:<name> -n <namespace>
+            ```
+        - id: manifest
+          desc: |
+            Define roles that enumerate only the concrete verbs a workload needs and never include `escalate`, `bind`, `impersonate`, or wildcard verbs. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: app-role
+              namespace: my-namespace
+            rules:
+              - apiGroups: [""]
+                resources: ["pods"]
+                verbs: ["get", "list", "watch"]
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping
+        title: Kubernetes - Privilege Escalation Prevention
+      - url: https://kubernetes.io/docs/concepts/security/rbac-good-practices/
+        title: Kubernetes - RBAC Good Practices
+  - uid: mondoo-kubernetes-security-rbac-no-wildcard-rules
+    title: Roles and cluster roles should not use wildcard permissions
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedNamespaces
+        title: Namespaces to exclude from RBAC and Pod Security checks
+        mql: |
+          return ["kube-system", "kube-public", "kube-node-lease"]
+      - uid: mondooKubernetesSecurityExcludedClusterRoles
+        title: Cluster roles to exclude from RBAC checks
+        mql: |
+          # Built-in cluster roles that use wildcards by design, such as cluster-admin
+          return ["cluster-admin"]
+    mql: |
+      k8s.clusterroles.where( name != /^system:/ && name.in(props.mondooKubernetesSecurityExcludedClusterRoles) == false ).all( hasWildcardRule == false )
+      k8s.roles.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( hasWildcardRule == false )
+    docs:
+      desc: |
+        This check ensures that Roles and ClusterRoles do not use the wildcard `*` for verbs, API groups, or resources. A wildcard rule grants every current and future permission in its scope, which almost always exceeds what a workload or user actually needs and silently expands as new APIs are added to the cluster.
+
+        **Why this matters**
+
+        Wildcard rules break the principle of least privilege in ways that are hard to reason about:
+
+        - **Unbounded access:** `resources: ["*"]` and `verbs: ["*"]` grant access to Secrets, RBAC objects, and every other resource, including ones that did not exist when the role was written.
+        - **Hidden escalation paths:** a wildcard over `rbac.authorization.k8s.io` includes the `escalate` and `bind` verbs, opening a path to cluster-admin.
+        - **Audit blindness:** reviewers cannot tell from a wildcard rule what the workload actually uses, so over-grants go unnoticed.
+
+        Roles should enumerate the specific API groups, resources, and verbs a subject requires.
+      audit: |
+        List the Roles and ClusterRoles that contain a wildcard in their verbs, API groups, or resources:
+
+        ```bash
+        kubectl get clusterroles,roles -A -o json | jq -r '.items[] | select(.rules[]? | (.verbs[]? == "*") or (.apiGroups[]? == "*") or (.resources[]? == "*")) | "\(.kind) \(.metadata.namespace // "-")/\(.metadata.name)"'
+        ```
+
+        Built-in `system:` roles and the default `cluster-admin` role are expected to contain wildcards and are excluded. The check fails when any other Role or ClusterRole uses a wildcard rule.
+      remediation:
+        - id: kubectl
+          desc: |
+            Replace wildcard rules with explicit API groups, resources, and verbs. Inspect the role, determine what the workload actually calls, and rewrite it:
+
+            ```bash
+            kubectl edit clusterrole <role-name>   # replace "*" with concrete verbs/resources/apiGroups
+            ```
+        - id: manifest
+          desc: |
+            Enumerate the concrete permissions instead of using `*`. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: app-role
+            rules:
+              - apiGroups: ["apps"]
+                resources: ["deployments"]
+                verbs: ["get", "list", "watch"]
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/concepts/security/rbac-good-practices/#least-privilege
+        title: Kubernetes - RBAC Good Practices (Least Privilege)
+      - url: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+        title: Kubernetes - Using RBAC Authorization
+  - uid: mondoo-kubernetes-security-rbac-restrict-cluster-admin-bindings
+    title: Cluster role bindings should not grant cluster-admin
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedClusterRoleBindings
+        title: Cluster role bindings to exclude from RBAC checks
+        mql: |
+          # Built-in bindings that grant cluster-admin by design, such as the cluster-admin binding to system:masters
+          return ["cluster-admin"]
+    mql: |
+      k8s.clusterrolebindings.where( name != /^system:/ && name.in(props.mondooKubernetesSecurityExcludedClusterRoleBindings) == false ).all( grantsClusterAdmin == false )
+    docs:
+      desc: |
+        This check ensures that ClusterRoleBindings do not grant the `cluster-admin` role — or any ClusterRole with wildcard verbs, API groups, and resources — to users, groups, or service accounts. A cluster-admin binding hands its subjects unrestricted control of every resource in the cluster.
+
+        **Why this matters**
+
+        Cluster-admin bindings are the single largest concentration of privilege in a cluster:
+
+        - **Unrestricted control:** subjects can read every Secret, schedule privileged pods on any node, and modify or delete any resource.
+        - **Large attack surface:** every user, group, or service account in the binding becomes a path to full cluster compromise.
+        - **Hard to revoke quietly:** broad bindings accumulate over time and are rarely reviewed, so stale admin grants persist long after they are needed.
+
+        Cluster-admin should be reserved for a small, deliberately managed set of break-glass identities, not granted through everyday bindings.
+      audit: |
+        List the ClusterRoleBindings that reference `cluster-admin` or another role granting unrestricted access, along with their subjects:
+
+        ```bash
+        kubectl get clusterrolebindings -o json | jq -r '.items[] | select(.roleRef.name == "cluster-admin") | "\(.metadata.name): \(.subjects // [] | map("\(.kind)/\(.name)") | join(", "))"'
+        ```
+
+        The built-in `cluster-admin` and `system:` bindings are expected and excluded. The check fails when any other ClusterRoleBinding grants cluster-admin to a subject.
+      remediation:
+        - id: kubectl
+          desc: |
+            Delete the over-broad binding and replace it with a binding to a least-privilege role, or scope the access to specific namespaces with a RoleBinding:
+
+            ```bash
+            kubectl delete clusterrolebinding <binding-name>
+            # Grant scoped access where it is actually needed
+            kubectl create rolebinding app-binding --clusterrole=view --serviceaccount=<namespace>:<name> -n <namespace>
+            ```
+        - id: manifest
+          desc: |
+            Bind subjects to a narrowly scoped role rather than `cluster-admin`. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: app-binding
+              namespace: my-namespace
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: view
+            subjects:
+              - kind: ServiceAccount
+                name: my-app
+                namespace: my-namespace
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/concepts/security/rbac-good-practices/#least-privilege
+        title: Kubernetes - RBAC Good Practices (Least Privilege)
+      - url: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+        title: Kubernetes - User-facing Roles
+  - uid: mondoo-kubernetes-security-rbac-no-cluster-wide-secret-read
+    title: Cluster roles should not grant cluster-wide read access to secrets
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedClusterRoles
+        title: Cluster roles to exclude from RBAC checks
+        mql: |
+          # Built-in cluster roles that read secrets by design, such as cluster-admin
+          return ["cluster-admin"]
+    mql: |
+      k8s.clusterroles.where( name != /^system:/ && name.in(props.mondooKubernetesSecurityExcludedClusterRoles) == false ).all( canReadSecrets == false )
+    docs:
+      desc: |
+        This check ensures that no ClusterRole grants read access (`get`, `list`, or `watch`) to Secrets across the whole cluster. A ClusterRole applies to every namespace, so cluster-wide Secret read access exposes credentials, tokens, and keys belonging to every team and workload in the cluster.
+
+        **Why this matters**
+
+        Secrets hold the cluster's most sensitive data, and broad read access undermines every secret-based control:
+
+        - **Credential theft:** `list` and `watch` on Secrets return the decoded values, so a subject can harvest database passwords, TLS private keys, and service-account tokens cluster-wide.
+        - **Token replay:** stolen service-account tokens let an attacker authenticate as other workloads and move laterally.
+        - **Need-to-know violation:** a workload almost never needs Secrets outside its own namespace; cluster-wide read access is far broader than required.
+
+        Secret access should be granted with namespaced Roles, scoped to the specific Secrets a workload consumes.
+      audit: |
+        List the ClusterRoles that grant read verbs on Secrets:
+
+        ```bash
+        kubectl get clusterroles -o json | jq -r '.items[] | select(.rules[]? | ((.resources[]? == "secrets" or .resources[]? == "*") and (.verbs[]? | test("^(get|list|watch|\\*)$")))) | .metadata.name'
+        ```
+
+        Built-in `system:` ClusterRoles and `cluster-admin` are expected and excluded. The check fails when any other ClusterRole grants cluster-wide read access to Secrets.
+      remediation:
+        - id: kubectl
+          desc: |
+            Remove Secret read access from the ClusterRole and grant it instead through a namespaced Role scoped to the Secrets the workload actually uses:
+
+            ```bash
+            kubectl edit clusterrole <role-name>   # remove the secrets read rule
+            kubectl create role secret-reader --verb=get --resource=secrets --resource-name=<secret-name> -n <namespace>
+            kubectl create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=<namespace>:<name> -n <namespace>
+            ```
+        - id: manifest
+          desc: |
+            Scope Secret access to a namespaced Role and, where possible, to specific Secret names with `resourceNames`. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: secret-reader
+              namespace: my-namespace
+            rules:
+              - apiGroups: [""]
+                resources: ["secrets"]
+                resourceNames: ["my-app-secret"]
+                verbs: ["get"]
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/concepts/security/rbac-good-practices/#secrets
+        title: Kubernetes - RBAC Good Practices (Secrets)
+      - url: https://kubernetes.io/docs/concepts/configuration/secret/
+        title: Kubernetes - Secrets
+  - uid: mondoo-kubernetes-security-namespace-enforces-pod-security
+    title: Namespaces should enforce Pod Security Standards admission
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    props:
+      - uid: mondooKubernetesSecurityExcludedNamespaces
+        title: Namespaces to exclude from RBAC and Pod Security checks
+        mql: |
+          return ["kube-system", "kube-public", "kube-node-lease"]
+    mql: |
+      k8s.namespace.name.in(props.mondooKubernetesSecurityExcludedNamespaces) || k8s.namespace.enforcesPodSecurity == true
+    docs:
+      desc: |
+        This check ensures that each namespace enforces a non-privileged Pod Security Standards level by setting the `pod-security.kubernetes.io/enforce` label to `baseline` or `restricted`. Pod Security admission rejects pods that violate the configured level at creation time; a namespace without an enforce label admits any pod, including privileged ones.
+
+        **Why this matters**
+
+        Per-workload security controls only help if something stops insecure pods from being created in the first place:
+
+        - **Defense at admission:** an enforced baseline or restricted level blocks privileged containers, host namespace sharing, and dangerous capabilities before the pod ever runs.
+        - **Closes the bypass:** without enforcement, the `audit` and `warn` modes only log or warn, so a violating pod is still admitted and runs.
+        - **Consistent guardrails:** namespace-level enforcement applies to every current and future workload in the namespace, regardless of who deploys it.
+
+        Set the enforce label on every workload namespace; reserve the `privileged` level for system namespaces that genuinely require it.
+      audit: |
+        List the Pod Security enforce label on every namespace:
+
+        ```bash
+        kubectl get namespaces -o custom-columns='NAME:.metadata.name,ENFORCE:.metadata.labels.pod-security\.kubernetes\.io/enforce'
+        ```
+
+        A namespace passes when the enforce label is `baseline` or `restricted`. It fails when the label is absent, empty, or set to `privileged`. System namespaces listed in the exclusion property are not evaluated.
+      remediation:
+        - id: kubectl
+          desc: |
+            Apply the Pod Security enforce label to the namespace. Start with `baseline` and move to `restricted` once workloads comply:
+
+            ```bash
+            kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=baseline --overwrite
+            ```
+        - id: manifest
+          desc: |
+            Set the Pod Security Standards labels in the namespace definition. Apply the manifest with `kubectl apply -f <file>.yaml`:
+
+            ```yaml
+            ---
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: my-namespace
+              labels:
+                pod-security.kubernetes.io/enforce: baseline
+                pod-security.kubernetes.io/audit: restricted
+                pod-security.kubernetes.io/warn: restricted
+            ```
+    refs:
+      - url: https://kubernetes.io/docs/concepts/security/pod-security-admission/
+        title: Kubernetes - Pod Security Admission
+      - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+        title: Kubernetes - Pod Security Standards


### PR DESCRIPTION
## What

Adds **6 new checks** to `mondoo-kubernetes-security` that use the RBAC and Pod Security rollup predicates shipped in `mondoohq/mql` **k8s-13.3.0** (#8575 typed RBAC rules, #8584/#8585 RBAC access rollups, #8574 Pod Security Standards). These assess **RBAC least-privilege** and **admission-time enforcement** — control areas the policy previously did not cover.

These are checks **#1–#6** from the menu in the companion PR #2923.

| UID | Impact | MQL |
|---|---|---|
| `serviceaccount-no-cluster-admin` | 100 | `k8s.serviceaccounts…all(isClusterAdmin == false)` |
| `serviceaccount-no-privilege-escalation` | 95 | `…all(canEscalatePrivileges == false)` |
| `rbac-no-wildcard-rules` | 85 | `k8s.clusterroles/roles…all(hasWildcardRule == false)` |
| `rbac-restrict-cluster-admin-bindings` | 100 | `k8s.clusterrolebindings…all(grantsClusterAdmin == false)` |
| `rbac-no-cluster-wide-secret-read` | 90 | `k8s.clusterroles…all(canReadSecrets == false)` |
| `namespace-enforces-pod-security` | 100 | `k8s.namespace.enforcesPodSecurity == true` |

## Design

- **Two new groups**: *Kubernetes RBAC Security* (runs on `k8s-cluster` + `k8s-manifest` assets) and *Kubernetes Namespace Security* (runs on `k8s-namespace` assets).
- **Configurable exclusions via props** so the checks aren't noisy on healthy clusters:
  - `mondooKubernetesSecurityExcludedNamespaces` → `kube-system`, `kube-public`, `kube-node-lease`
  - `mondooKubernetesSecurityExcludedClusterRoles` / `…ClusterRoleBindings` → `cluster-admin` (built-ins that are wildcard/cluster-admin by design)
  - Cluster-scoped checks also skip built-in `system:`-prefixed roles/bindings.
- Full `docs:` (desc / audit / remediation) with `kubectl` and `manifest` remediation entries per content authoring standards.
- Policy version **2.0.2 → 2.1.0**.

## Compliance tags

Mapped to the **least-privilege / access-control** control family and **verified against the framework definitions** in `cnspec-enterprise-policies/frameworks/`:
- `nist-sp-800-53-rev5-ac-6` (Least Privilege), `nist-sp-800-171--3-1-5` (least privilege incl. privileged accounts)
- `cloud-controls-matrix-4-iam-05` (**Least Privilege** — note: stricter fit than the IAM-04 "Separation of Duties" used by some older checks)
- `iso-27001-2022-a-8-2` (Privileged access rights), `vda-isa-5-4-2-1` (access rights assigned and managed)
- `nist-csf-1-pr-ac-4` / `nist-csf-2-pr-aa-05` (least privilege), `pcidss-requirement-7-2-1`, `soc2-control-cc6-3-1`, `hipaa §164.312(a)(1)`, `nis-2-21-2-i`, `dora-art-9`; `bsi-sys-1-5: false` (no strict fit).

Each of the six checks restricts excessive privilege, so this is a deliberate strict mapping rather than a copy from a neighbor.

## Requirements

Requires the **k8s provider ≥ 13.3.0**.

## Verification

- `cnspec policy lint` → valid.
- `validate_remediation_commands.py kubernetes` → **88 passed, 0 failed** (all 6 new checks' kubectl commands valid).
- Scanned over-privileged + hardened RBAC manifests: all 6 **fail** on the over-privileged manifest and **pass** on the hardened one, with system-namespace and built-in-role exclusions confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)