### PR TITLE
📄 clarify MAC-policy audit check inspects persistent rules, not runtime

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7525,13 +7525,35 @@ queries:
 
         Logging events that alter SELinux modes, AppArmor profiles, or related configuration files helps ensure that all security policy changes are tracked and attributable. This supports continuous monitoring, strengthens control over access enforcement, and enhances trust in the system's security model.
       audit: |
-        Run this command to confirm the audit rules for Mandatory Access Control modification events are loaded:
+        This check inspects the **persistent** audit rule files on disk — the `.rules` files in `/etc/audit/rules.d/` and the compiled `/etc/audit/audit.rules` — rather than the ruleset currently loaded in the kernel. The rules must be present in these files so they are reapplied on every boot.
+
+        Confirm the rules are written to a persistent rules file:
+
+        ```bash
+        grep -rs -- '-k MAC-policy' /etc/audit/rules.d/ /etc/audit/audit.rules
+        ```
+
+        The check passes when the persistent rules define a complete Mandatory Access Control set with the `MAC-policy` key and `wa` permissions — either both AppArmor paths:
+
+        ```
+        -w /etc/apparmor -p wa -k MAC-policy
+        -w /etc/apparmor.d -p wa -k MAC-policy
+        ```
+
+        or both SELinux paths:
+
+        ```
+        -w /etc/selinux -p wa -k MAC-policy
+        -w /usr/share/selinux -p wa -k MAC-policy
+        ```
+
+        You can also confirm the rules are active in the running kernel:
 
         ```bash
         auditctl -l | grep -- '-k MAC-policy'
         ```
 
-        A passing result lists the expected audit rules with the `MAC-policy` key. A failing result returns no matching rules.
+        Note that `auditctl -l` reports the *running* ruleset, which can differ from what is stored on disk. If `auditctl -l` lists the rules but this check still reports a failure, the rules were loaded into the kernel but are not persisted in a `.rules` file under `/etc/audit/rules.d/` (or in `/etc/audit/audit.rules`). Persist them to a rules file and reload — see the remediation below.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## What

Rewrites the `audit:` guidance for **Ensure Mandatory Access Control modification events are audited** (`mondoo-linux-security-events-that-modify-the-systems-mandatory-access-controls-are-collected`) in `content/mondoo-linux-security.mql.yaml`.

## Why

The check evaluates the **persistent** auditd rule files on disk through the `auditd.rules` resource:

```
auditdRuleFiles = auditd.rules.files + auditd.rules(path: "/etc/audit/audit.rules").files
```

i.e. `/etc/audit/rules.d/*.rules` and the compiled `/etc/audit/audit.rules`. This is correct — CIS requires MAC-policy audit rules to be persisted so they are reapplied on every boot.

The previous `audit:` text, however, told users to verify with:

```bash
auditctl -l | grep -- '-k MAC-policy'
```

`auditctl -l` reports the ruleset **currently loaded in the kernel**, which can diverge from what is on disk. When rules are loaded into the kernel but not persisted to a `.rules` file (or persisted somewhere the resource does not read), `auditctl -l` lists them yet the check reports a failure. Users reasonably conclude the rule is "in place" and read the result as a false negative.

I verified the check logic itself is correct: with the rules present in a persistent rules file the check returns `true`; with them absent it returns `false`. The gap was purely in the audit guidance pointing at runtime state instead of the persisted files the check actually measures.

## Change

- The audit section now inspects the persistent rule files (`grep -rs -- '-k MAC-policy' /etc/audit/rules.d/ /etc/audit/audit.rules`).
- Lists the exact AppArmor / SELinux rule sets that satisfy the check.
- Keeps `auditctl -l` as a secondary runtime check and explains the runtime-vs-disk distinction, pointing users to persist + reload when the two diverge.

Docs-only change; the MQL is unchanged. `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)