### PR TITLE
✨ azure: add 3 storage container security checks

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -68,6 +68,9 @@ policies:
           - uid: mondoo-azure-security-default-network-access-rule-storage-accounts-deny
           - uid: mondoo-azure-security-storage-blob-soft-delete-enabled
           - uid: mondoo-azure-security-storage-container-soft-delete-enabled
+          - uid: mondoo-azure-security-storage-container-no-anonymous-access
+          - uid: mondoo-azure-security-storage-container-immutability-policy-locked
+          - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied
           - uid: mondoo-azure-security-storage-min-tls-version
           - uid: mondoo-azure-security-storage-cross-tenant-replication-disabled
           - uid: mondoo-azure-security-storage-sftp-disabled
@@ -5712,6 +5715,421 @@ queries:
     mql: |
       bicep.resources.where(type == "Microsoft.Storage/storageAccounts/blobServices").all(
         properties["containerDeleteRetentionPolicy"]["days"] > 0
+      )
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access
+    title: Ensure Azure Storage blob containers disallow anonymous public access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-azure-security-storage-container-no-anonymous-access-azure
+        tags:
+          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-no-anonymous-access-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that individual blob containers set their public access level to "None" so that blobs and container listings cannot be read by unauthenticated clients. Even when an account permits anonymous access, the access level is decided per container, and a container set to "Blob" or "Container" serves its contents to anyone on the internet without credentials.
+
+        **Why this matters**
+
+        - **Unauthenticated data exposure:** A container set to "Blob" allows anyone to read any blob whose name they know, and a container set to "Container" additionally allows anonymous listing of every blob, turning a single setting into a full data disclosure.
+        - **Account-level controls are not sufficient:** Disabling anonymous access at the account level is a prerequisite, but each container still carries its own access level, so a container can remain world-readable until that per-container setting is corrected.
+        - **Automated discovery:** Anonymously accessible containers are continuously enumerated by internet-wide scanners, so a misconfigured container is typically found and harvested within hours.
+        - **No attribution:** Anonymous reads do not carry an identity and do not appear in authentication logs, so a disclosure through a public container cannot be traced to a specific actor or quantified after the fact.
+
+        **Risk mitigation**
+
+        - **Closes per-container exposure:** Setting every container to "None" guarantees that blob access always requires an authenticated and authorized request, regardless of the account-level toggle.
+        - **Consistent least-privilege posture:** Enforcing private containers across the account removes the inconsistency where some containers are reachable anonymously while others are not.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Storage accounts** in the Azure Portal.
+        2. Select the storage account and open **Containers** under **Data storage**.
+        3. For each container, review the **Public access level** column and confirm it is set to **Private**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az storage container list --account-name <StorageAccountName> --query "[].{name:name, publicAccess:properties.publicAccess}"
+        ```
+
+        Any container whose public access level is **Blob** or **Container** fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To set a blob container to private using the Azure Portal:
+
+            1. Navigate to **Storage accounts** in the Azure Portal.
+            2. Select the storage account and open **Containers** under **Data storage**.
+            3. Select the container, then select **Change access level**.
+            4. Set **Public access level** to **Private (no anonymous access)**.
+            5. Select **OK**.
+        - id: cli
+          desc: |
+            To set a blob container to private using the Azure CLI:
+
+            ```bash
+            az storage container set-permission --name <ContainerName> --account-name <StorageAccountName> --auth-mode login --public-access off
+            ```
+        - id: terraform
+          desc: |
+            To set a blob container to private in Terraform:
+
+            ```hcl
+            resource "azurerm_storage_container" "example" {
+              name                  = "examplecontainer"
+              storage_account_id    = azurerm_storage_account.example.id
+              container_access_type = "private"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set a blob container to private in Bicep:
+
+            ```bicep
+            resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+              parent: blobServices
+              name: 'examplecontainer'
+              properties: {
+                publicAccess: 'None'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure
+        title: Configure anonymous read access for containers and blobs
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access-azure
+    filters: |
+      asset.platform == "azure-storage-account"
+    mql: |
+      azure.subscription.storage.account.containers.all(
+        publicAccess != "Blob" && publicAccess != "Container"
+      )
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container")
+    mql: |
+      terraform.resources("azurerm_storage_container").all(
+        arguments['container_access_type'] == null ||
+        arguments['container_access_type'] == "private"
+      )
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_storage_container")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_storage_container").all(
+        change.after.container_access_type == null ||
+        change.after.container_access_type == "private"
+      )
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_storage_container")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_storage_container").all(
+        values.container_access_type == null ||
+        values.container_access_type == "private"
+      )
+  - uid: mondoo-azure-security-storage-container-no-anonymous-access-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/blobServices/containers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/blobServices/containers").all(
+        properties["publicAccess"] == null ||
+        properties["publicAccess"] == "None"
+      )
+  - uid: mondoo-azure-security-storage-container-immutability-policy-locked
+    title: Ensure Azure Storage container immutability policies are locked
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-16
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
+      compliance/iso-27001-2022: iso-27001-2022-a-5-33
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-7-1-1
+    variants:
+      - uid: mondoo-azure-security-storage-container-immutability-policy-locked-azure
+        tags:
+          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that any time-based immutability policy configured on a blob container is in the "Locked" state. An immutability policy enforces write-once, read-many retention, but while it remains "Unlocked" it can be shortened or deleted at any time, which means the retention guarantee is not yet binding and the protected data can still be altered or removed.
+
+        **Why this matters**
+
+        - **Unlocked policies are reversible:** An unlocked immutability policy can be edited or removed by anyone with management access, so data the policy appears to protect can be silently deleted or overwritten until the policy is locked.
+        - **Regulatory retention depends on locking:** Records-retention regimes that require WORM storage are only satisfied once the policy is locked, because an unlocked policy does not provide a tamper-proof retention guarantee.
+        - **Ransomware and insider resistance:** A locked policy prevents both external attackers with stolen credentials and malicious insiders from destroying retained data within the retention period, which an unlocked policy cannot guarantee.
+        - **Audit evidence integrity:** Logs and evidence stored under an unlocked policy can be tampered with, undermining their value during investigations or audits.
+
+        **Risk mitigation**
+
+        - **Binding retention:** Locking the policy makes the retention period immutable for its duration, converting a reversible configuration into an enforced control.
+        - **Tamper protection:** A locked policy blocks deletion and modification of protected blobs regardless of the caller's privileges, closing the path to destruction of retained records.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Storage accounts** in the Azure Portal.
+        2. Select the storage account and open **Containers** under **Data storage**.
+        3. Select a container, then open **Access policy** and review the **Immutable blob storage** section.
+        4. For each container that has a time-based retention policy, confirm the policy state is **Locked** rather than **Unlocked**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az storage container immutability-policy show --account-name <StorageAccountName> --container-name <ContainerName> --resource-group-name <ResourceGroupName> --query "state"
+        ```
+
+        A container whose policy state is **Unlocked** fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To lock a container immutability policy using the Azure Portal:
+
+            1. Navigate to **Storage accounts** in the Azure Portal.
+            2. Select the storage account and open **Containers** under **Data storage**.
+            3. Select the container, then open **Access policy**.
+            4. Under **Immutable blob storage**, open the time-based retention policy and select **Lock policy**.
+            5. Confirm the action. Locking is irreversible, so verify the retention period before locking.
+        - id: cli
+          desc: |
+            To lock a container immutability policy using the Azure CLI:
+
+            ```bash
+            az storage container immutability-policy lock --account-name <StorageAccountName> --container-name <ContainerName> --resource-group-name <ResourceGroupName> --if-match <Etag>
+            ```
+        - id: terraform
+          desc: |
+            To create a locked container immutability policy in Terraform, set `locked` to `true`:
+
+            ```hcl
+            resource "azurerm_storage_container_immutability_policy" "example" {
+              storage_container_resource_manager_id = azurerm_storage_container.example.resource_manager_id
+              immutability_period_in_days            = 30
+              locked                                 = true
+            }
+            ```
+        # No Bicep remediation: locking a time-based immutability policy is an imperative operation performed against the live container after creation; ARM and Bicep templates can define the policy but cannot transition it to the Locked state declaratively.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-time-based-retention-policy-overview
+        title: Time-based retention policies for immutable blob data
+  - uid: mondoo-azure-security-storage-container-immutability-policy-locked-azure
+    filters: |
+      asset.platform == "azure-storage-account"
+    mql: |
+      azure.subscription.storage.account.containers.where(immutabilityPolicyState != "").all(
+        immutabilityPolicyState == "Locked"
+      )
+  - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container_immutability_policy")
+    mql: |
+      terraform.resources("azurerm_storage_container_immutability_policy").all(
+        arguments['locked'] == true
+      )
+  - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_storage_container_immutability_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_storage_container_immutability_policy").all(
+        change.after.locked == true
+      )
+  - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_storage_container_immutability_policy")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_storage_container_immutability_policy").all(
+        values.locked == true
+      )
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied
+    title: Ensure Azure Storage containers deny encryption scope override
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-azure
+        tags:
+          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that blob containers assigned a default encryption scope also deny encryption scope override, so every blob written to the container is encrypted under the intended scope. When override is permitted, a client can write a blob under a different encryption scope, bypassing the customer-managed key or isolation boundary that the default scope was chosen to enforce.
+
+        **Why this matters**
+
+        - **Defeats key isolation:** Encryption scopes are commonly used to encrypt different tenants or datasets under separate customer-managed keys; allowing override lets a writer place data under the wrong key, collapsing the isolation the scope was meant to provide.
+        - **Weakens customer-managed key guarantees:** A container whose default scope is backed by a customer-managed key loses that guarantee for any blob written under an overriding scope, including the service-managed default.
+        - **Silent configuration drift:** Override happens at write time per blob and leaves no obvious signal at the container level, so encryption posture can degrade without any visible change to the container configuration.
+        - **Compliance scope erosion:** Controls that depend on data being encrypted under a specific key are only effective if that key cannot be bypassed at write time.
+
+        **Risk mitigation**
+
+        - **Enforced encryption boundary:** Denying override guarantees that every blob in the container is encrypted under the default scope, preserving the intended key and isolation boundary.
+        - **Predictable key management:** With override denied, key rotation and revocation on the default scope reliably govern all data in the container.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Storage accounts** in the Azure Portal.
+        2. Select the storage account and open **Containers** under **Data storage**.
+        3. Select a container that has a default encryption scope, then review its **Encryption scope** settings.
+        4. Confirm that overriding the default encryption scope is not allowed for the container.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az storage container-rm show --account-name <StorageAccountName> --container-name <ContainerName> --resource-group-name <ResourceGroupName> --query "{defaultEncryptionScope:defaultEncryptionScope, denyEncryptionScopeOverride:denyEncryptionScopeOverride}"
+        ```
+
+        A container that has a default encryption scope but reports `denyEncryptionScopeOverride` as `false` fails this check.
+      remediation:
+        - id: portal
+          desc: |
+            To deny encryption scope override using the Azure Portal:
+
+            1. Navigate to **Storage accounts** in the Azure Portal.
+            2. Select the storage account and select **Add container** under **Containers**.
+            3. Expand **Advanced**, select the default encryption scope, and enable **Use this encryption scope for all blobs in the container**.
+            4. Create the container. Because override can only be fixed at creation, recreate any existing non-compliant container with this setting and migrate its data.
+        - id: cli
+          desc: |
+            To create a container that denies encryption scope override using the Azure CLI:
+
+            ```bash
+            az storage container-rm create --account-name <StorageAccountName> --container-name <ContainerName> --resource-group-name <ResourceGroupName> --default-encryption-scope <EncryptionScopeName> --deny-encryption-scope-override true
+            ```
+        - id: terraform
+          desc: |
+            To deny encryption scope override in Terraform, set `encryption_scope_override_enabled` to `false`:
+
+            ```hcl
+            resource "azurerm_storage_container" "example" {
+              name                              = "examplecontainer"
+              storage_account_id                = azurerm_storage_account.example.id
+              default_encryption_scope          = azurerm_storage_encryption_scope.example.name
+              encryption_scope_override_enabled = false
+            }
+            ```
+        - id: bicep
+          desc: |
+            To deny encryption scope override in Bicep:
+
+            ```bicep
+            resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+              parent: blobServices
+              name: 'examplecontainer'
+              properties: {
+                defaultEncryptionScope: 'exampleScope'
+                denyEncryptionScopeOverride: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/blobs/encryption-scope-overview
+        title: Encryption scopes for Blob storage
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-azure
+    filters: |
+      asset.platform == "azure-storage-account"
+    mql: |
+      azure.subscription.storage.account.containers.where(defaultEncryptionScope != "").all(
+        denyEncryptionScopeOverride == true
+      )
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container")
+    mql: |
+      terraform.resources("azurerm_storage_container").all(
+        arguments['default_encryption_scope'] == null ||
+        arguments['encryption_scope_override_enabled'] == false
+      )
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_storage_container")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_storage_container").all(
+        change.after.default_encryption_scope == null ||
+        change.after.encryption_scope_override_enabled == false
+      )
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_storage_container")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_storage_container").all(
+        values.default_encryption_scope == null ||
+        values.encryption_scope_override_enabled == false
+      )
+  - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Storage/storageAccounts/blobServices/containers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Storage/storageAccounts/blobServices/containers").all(
+        properties["defaultEncryptionScope"] == null ||
+        properties["denyEncryptionScopeOverride"] == true
       )
   - uid: mondoo-azure-security-storage-min-tls-version
     title: Ensure Azure Storage accounts enforce minimum TLS 1.2

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.2.2
+    version: 9.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## Summary

Adds three **container-level** checks to `mondoo-azure-security`. Today the policy's storage checks operate almost entirely at the storage-**account** level; the only container-named check (`storage-container-soft-delete-enabled`) is actually evaluated on the account. These add genuine per-container coverage using the provider's `azure.subscription.storage.account.containers` resource.

| Check | Asserts | Impact |
|---|---|---|
| `storage-container-no-anonymous-access` | Each container's public access level is `None` (no anonymous blob read/list). Distinct from the account-level `allowBlobPublicAccess` gate — the per-container ACL is the actual exposure surface. | 80 |
| `storage-container-immutability-policy-locked` | Containers with a time-based immutability (WORM) policy have it in the `Locked` state. An `Unlocked` policy can be shortened or deleted, so the retention guarantee is not yet binding. | 70 |
| `storage-container-encryption-scope-override-denied` | Containers with a default encryption scope set `denyEncryptionScopeOverride`, so all blobs are encrypted under the intended (often CMK-backed) scope. | 70 |

All assertions are null-safe: the provider defaults `publicAccess`/`defaultEncryptionScope`/`immutabilityPolicyState` to empty string and `denyEncryptionScopeOverride` to false, and checks 2 and 3 only evaluate containers that actually have a policy / default scope (`.where(...)`), avoiding false positives on containers that don't use those features.

## Variants & remediation

- No-anonymous-access and encryption-scope-override: runtime (`azure-storage-account`) + Terraform HCL/plan/state + Bicep, with `portal`/`cli`/`terraform`/`bicep` remediation.
- Immutability-policy-locked: runtime + Terraform HCL/plan/state. **Bicep variant and remediation are intentionally omitted** — locking a policy is an imperative post-create operation (`az storage container immutability-policy lock`) with no declarative ARM/Bicep analog; a `# No Bicep remediation:` comment documents this in-line.

## Compliance tags

Verified against each framework's control text in `cnspec-enterprise-policies/frameworks/`, not copied from siblings:
- **Checks 1 & 3** reuse the access-control / encryption-at-rest control sets after confirming each control fits at container granularity. Note check 1 uses `nis-2-21-2-i` (*Access control and asset management*) — the account-level sibling's `nis-2-21-2-e` is actually *Vulnerability handling*, a pre-existing mismapping worth fixing separately.
- **Check 2** (WORM/records integrity) maps only where a strict records-protection/integrity control exists (`iso-27001-2022-a-5-33` Protection of records, `csa ...dsp-16` Data Retention, `hipaa ...312-c-1-integrity`, `nist sc-28`, `vda-isa-5-7-1-1`) and is `false` elsewhere rather than forcing a backup/access stand-in.

## Validation

- `cnspec policy lint content/mondoo-azure-security.mql.yaml` → valid bundle.
- `python3 content/validation/validate_remediation_commands.py azure` → **350 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)