### PR TITLE
✨ openstack: score security-group checks per-asset on openstack-security-group

### DIFF
--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -51,7 +51,9 @@ policies:
         checks:
           - uid: mondoo-openstack-security-no-unrestricted-ssh
           - uid: mondoo-openstack-security-no-unrestricted-rdp
+          - uid: mondoo-openstack-security-no-unrestricted-winrm
           - uid: mondoo-openstack-security-no-unrestricted-db-ports
+          - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports
           - uid: mondoo-openstack-security-no-all-ports-open
           - uid: mondoo-openstack-security-port-security-enabled
           - uid: mondoo-openstack-security-firewall-policy-audited
@@ -905,6 +907,10 @@ queries:
         tags:
           mondoo.com/filter-title: OpenStack Project
           mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-ssh-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
+          mondoo.com/filter-icon: openstack
       - uid: mondoo-openstack-security-no-unrestricted-ssh-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -990,6 +996,12 @@ queries:
         rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 22 && portRangeMax >= 22
         )
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-ssh-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        portRangeMin <= 22 && portRangeMax >= 22
       )
   - uid: mondoo-openstack-security-no-unrestricted-ssh-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")
@@ -1154,6 +1166,10 @@ queries:
         tags:
           mondoo.com/filter-title: OpenStack Project
           mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-rdp-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
+          mondoo.com/filter-icon: openstack
       - uid: mondoo-openstack-security-no-unrestricted-rdp-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -1240,6 +1256,12 @@ queries:
           portRangeMin <= 3389 && portRangeMax >= 3389
         )
       )
+  - uid: mondoo-openstack-security-no-unrestricted-rdp-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        portRangeMin <= 3389 && portRangeMax >= 3389
+      )
   - uid: mondoo-openstack-security-no-unrestricted-rdp-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")
     mql: |
@@ -1257,6 +1279,148 @@ queries:
     mql: |
       terraform.state.resources.where(type == "openstack_networking_secgroup_rule_v2").where(values.direction == "ingress").where(values.remote_ip_prefix == "0.0.0.0/0" || values.remote_ip_prefix == "::/0").where(values.protocol == "tcp" || values.protocol == "").none(
         values.port_range_min <= 3389 && values.port_range_max >= 3389
+      )
+
+  - uid: mondoo-openstack-security-no-unrestricted-winrm
+    title: Ensure no security group allows unrestricted inbound WinRM (5985, 5986)
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-no-unrestricted-winrm-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-winrm-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on the Windows Remote Management ports 5985 (HTTP) or 5986 (HTTPS) from the public internet at `0.0.0.0/0` or `::/0`. WinRM drives PowerShell Remoting and remote administration on Windows hosts, so an internet-exposed listener is a direct path to remote command execution.
+
+        **Why this matters**
+
+        - **Remote command execution:** WinRM is a management channel that runs commands on the host; an open listener exposes that channel to the entire internet.
+        - **Credential attacks:** Mass-scanning campaigns spray known credentials and NTLM relay attempts against any reachable WinRM endpoint.
+        - **Reduced attack surface:** Keeping WinRM off the open internet removes it from automated exploitation entirely.
+
+        **Risk mitigation**
+
+        - **Lateral movement:** Confines WinRM access to trusted CIDRs, a bastion host, or a VPN so administration comes only from known sources.
+        - **Host takeover:** Removes a remote-management vector that leads directly to full control of the Windows instance.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Network** then **Security Groups**.
+        3. For each security group, open **Manage Rules** and review the ingress rules.
+
+        A passing result shows no ingress rule allowing TCP port 5985 or 5986 from `0.0.0.0/0` or `::/0`; a failing result shows such a rule.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack security group rule list <group>
+        ```
+
+        A passing result shows no ingress TCP rule covering port 5985 or 5986 with a remote IP prefix of `0.0.0.0/0` or `::/0`; a failing result shows one.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Network → Security Groups** in Horizon and open the affected security group.
+            2. Add a new ingress rule covering TCP ports 5985 and 5986 with **CIDR** set to a specific trusted range.
+            3. Confirm WinRM still works from the trusted range, then delete the rule open to `0.0.0.0/0` or `::/0`. Removing the open rule drops live WinRM sessions that arrived through it.
+        - id: cli
+          desc: |
+            ```bash
+            # Add the scoped rule first so management access survives the change
+            openstack security group rule create windows-sg \
+              --ingress --protocol tcp --dst-port 5985:5986 --remote-ip 203.0.113.0/24
+            # Then remove the world-open rule; live sessions through it are dropped
+            openstack security group rule delete 4a4ee176-43e6-4b48-8bcf-5acd1c403fbf
+            ```
+        - id: terraform
+          desc: |
+            Scope inbound WinRM `remote_ip_prefix` to a specific trusted CIDR, never `0.0.0.0/0` or `::/0`:
+
+            ```hcl
+            resource "openstack_networking_secgroup_rule_v2" "winrm" {
+              direction         = "ingress"
+              ethertype         = "IPv4"
+              protocol          = "tcp"
+              port_range_min    = 5985
+              port_range_max    = 5986
+              remote_ip_prefix  = "203.0.113.0/24"
+              security_group_id = openstack_networking_secgroup_v2.windows.id
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/security-guide/networking.html
+        title: OpenStack Neutron security groups
+
+  - uid: mondoo-openstack-security-no-unrestricted-winrm-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.securityGroups.all(
+        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+          portRangeMin <= 5985 && portRangeMax >= 5985 ||
+          portRangeMin <= 5986 && portRangeMax >= 5986
+        )
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-winrm-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        portRangeMin <= 5985 && portRangeMax >= 5985 ||
+        portRangeMin <= 5986 && portRangeMax >= 5986
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.resources("openstack_networking_secgroup_rule_v2").where(arguments['direction'] == "ingress").where(arguments['remote_ip_prefix'] == "0.0.0.0/0" || arguments['remote_ip_prefix'] == "::/0").where(arguments['protocol'] == "tcp" || arguments['protocol'] == "").none(
+        arguments['port_range_min'] <= 5985 && arguments['port_range_max'] >= 5985 ||
+        arguments['port_range_min'] <= 5986 && arguments['port_range_max'] >= 5986
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_networking_secgroup_rule_v2").where(change.after.direction == "ingress").where(change.after.remote_ip_prefix == "0.0.0.0/0" || change.after.remote_ip_prefix == "::/0").where(change.after.protocol == "tcp" || change.after.protocol == "").none(
+        change.after.port_range_min <= 5985 && change.after.port_range_max >= 5985 ||
+        change.after.port_range_min <= 5986 && change.after.port_range_max >= 5986
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-winrm-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_networking_secgroup_rule_v2").where(values.direction == "ingress").where(values.remote_ip_prefix == "0.0.0.0/0" || values.remote_ip_prefix == "::/0").where(values.protocol == "tcp" || values.protocol == "").none(
+        values.port_range_min <= 5985 && values.port_range_max >= 5985 ||
+        values.port_range_min <= 5986 && values.port_range_max >= 5986
       )
 
   - uid: mondoo-openstack-security-no-unrestricted-db-ports
@@ -1280,6 +1444,10 @@ queries:
       - uid: mondoo-openstack-security-no-unrestricted-db-ports-openstack
         tags:
           mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-db-ports-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
           mondoo.com/filter-icon: openstack
       - uid: mondoo-openstack-security-no-unrestricted-db-ports-terraform-hcl
         tags:
@@ -1374,6 +1542,19 @@ queries:
           portRangeMin <= 1521 && portRangeMax >= 1521
         )
       )
+  - uid: mondoo-openstack-security-no-unrestricted-db-ports-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        portRangeMin <= 3306 && portRangeMax >= 3306 ||
+        portRangeMin <= 5432 && portRangeMax >= 5432 ||
+        portRangeMin <= 27017 && portRangeMax >= 27017 ||
+        portRangeMin <= 6379 && portRangeMax >= 6379 ||
+        portRangeMin <= 11211 && portRangeMax >= 11211 ||
+        portRangeMin <= 9200 && portRangeMax >= 9200 ||
+        portRangeMin <= 1433 && portRangeMax >= 1433 ||
+        portRangeMin <= 1521 && portRangeMax >= 1521
+      )
   - uid: mondoo-openstack-security-no-unrestricted-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")
     mql: |
@@ -1414,6 +1595,170 @@ queries:
         values.port_range_min <= 1521 && values.port_range_max >= 1521
       )
 
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports
+    title: Ensure no security group allows unrestricted inbound orchestration ports
+    impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-openstack
+        tags:
+          mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that no Neutron security group has an ingress rule that allows traffic from the public internet at `0.0.0.0/0` or `::/0` to container and cluster orchestration control planes, covering the Kubernetes API server on 6443, the kubelet API on 10250, etcd on 2379 and 2380, and the Docker daemon on 2375 and 2376. These endpoints expose cluster control and container runtimes that assume a private management network.
+
+        **Why this matters**
+
+        - **Cluster takeover:** The Kubernetes API server and kubelet API accept administrative and workload-execution requests; reaching them from the internet invites full cluster compromise.
+        - **Unauthenticated by default:** The plaintext Docker daemon on 2375 and etcd peer traffic on 2380 ship without authentication, so an open port is direct access to the runtime and its data.
+        - **Designed for private networks:** Orchestration control planes expect to sit behind a private network or VPN, not on the open internet.
+
+        **Risk mitigation**
+
+        - **Secrets exposure:** Keeps etcd — which stores Kubernetes secrets and cluster state — off the internet where it could be read or tampered with.
+        - **Container escape pivot:** Removes runtime endpoints from internet-wide scanning that probes for exposed Docker and Kubernetes APIs to deploy malicious workloads.
+      audit: |
+        ### Audit via Horizon
+
+        1. Sign in to the OpenStack Horizon dashboard as a project member.
+        2. Open **Network** then **Security Groups**.
+        3. For each security group, open **Manage Rules** and review the ingress rules.
+
+        A passing result shows no ingress rule allowing an orchestration port such as 6443, 10250, 2379, 2380, 2375, or 2376 from `0.0.0.0/0` or `::/0`; a failing result shows such a rule.
+
+        ### Audit via CLI
+
+        Run the OpenStack CLI and inspect the result:
+
+        ```bash
+        openstack security group rule list <group>
+        ```
+
+        A passing result shows no ingress rule covering an orchestration control-plane port with a remote IP prefix of `0.0.0.0/0` or `::/0`; a failing result shows one.
+      remediation:
+        - id: console
+          desc: |
+            1. Navigate to **Network → Security Groups** in Horizon and open the affected security group.
+            2. Add a replacement ingress rule for the orchestration port with **CIDR** scoped to a specific trusted range, or a **Remote Security Group** rule that allows only the cluster's own security group.
+            3. Confirm cluster nodes and operators can still reach the control plane, then delete the rule open to `0.0.0.0/0` or `::/0`. Removing the open rule drops connections established through it.
+        - id: cli
+          desc: |
+            ```bash
+            # Add the scoped rule first so the cluster keeps control-plane access
+            openstack security group rule create k8s-sg \
+              --ingress --protocol tcp --dst-port 6443 --remote-ip 203.0.113.0/24
+            # Then remove the world-open rule; connections established through it are dropped
+            openstack security group rule delete 4a4ee176-43e6-4b48-8bcf-5acd1c403fbf
+            ```
+        - id: terraform
+          desc: |
+            Constrain orchestration ingress with `remote_group_id` or a private `remote_ip_prefix`, never `0.0.0.0/0` or `::/0`:
+
+            ```hcl
+            resource "openstack_networking_secgroup_rule_v2" "k8s_api" {
+              direction         = "ingress"
+              ethertype         = "IPv4"
+              protocol          = "tcp"
+              port_range_min    = 6443
+              port_range_max    = 6443
+              remote_ip_prefix  = "203.0.113.0/24"
+              security_group_id = openstack_networking_secgroup_v2.k8s.id
+            }
+            ```
+    refs:
+      - url: https://docs.openstack.org/security-guide/networking.html
+        title: OpenStack Neutron security groups
+      - url: https://kubernetes.io/docs/reference/networking/ports-and-protocols/
+        title: Kubernetes ports and protocols
+
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-openstack
+    filters: asset.platform == "openstack-project"
+    mql: |
+      openstack.securityGroups.all(
+        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+          portRangeMin <= 6443 && portRangeMax >= 6443 ||
+          portRangeMin <= 10250 && portRangeMax >= 10250 ||
+          portRangeMin <= 2379 && portRangeMax >= 2379 ||
+          portRangeMin <= 2380 && portRangeMax >= 2380 ||
+          portRangeMin <= 2375 && portRangeMax >= 2375 ||
+          portRangeMin <= 2376 && portRangeMax >= 2376
+        )
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        portRangeMin <= 6443 && portRangeMax >= 6443 ||
+        portRangeMin <= 10250 && portRangeMax >= 10250 ||
+        portRangeMin <= 2379 && portRangeMax >= 2379 ||
+        portRangeMin <= 2380 && portRangeMax >= 2380 ||
+        portRangeMin <= 2375 && portRangeMax >= 2375 ||
+        portRangeMin <= 2376 && portRangeMax >= 2376
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.resources("openstack_networking_secgroup_rule_v2").where(arguments['direction'] == "ingress").where(arguments['remote_ip_prefix'] == "0.0.0.0/0" || arguments['remote_ip_prefix'] == "::/0").where(arguments['protocol'] == "tcp" || arguments['protocol'] == "").none(
+        arguments['port_range_min'] <= 6443 && arguments['port_range_max'] >= 6443 ||
+        arguments['port_range_min'] <= 10250 && arguments['port_range_max'] >= 10250 ||
+        arguments['port_range_min'] <= 2379 && arguments['port_range_max'] >= 2379 ||
+        arguments['port_range_min'] <= 2380 && arguments['port_range_max'] >= 2380 ||
+        arguments['port_range_min'] <= 2375 && arguments['port_range_max'] >= 2375 ||
+        arguments['port_range_min'] <= 2376 && arguments['port_range_max'] >= 2376
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "openstack_networking_secgroup_rule_v2").where(change.after.direction == "ingress").where(change.after.remote_ip_prefix == "0.0.0.0/0" || change.after.remote_ip_prefix == "::/0").where(change.after.protocol == "tcp" || change.after.protocol == "").none(
+        change.after.port_range_min <= 6443 && change.after.port_range_max >= 6443 ||
+        change.after.port_range_min <= 10250 && change.after.port_range_max >= 10250 ||
+        change.after.port_range_min <= 2379 && change.after.port_range_max >= 2379 ||
+        change.after.port_range_min <= 2380 && change.after.port_range_max >= 2380 ||
+        change.after.port_range_min <= 2375 && change.after.port_range_max >= 2375 ||
+        change.after.port_range_min <= 2376 && change.after.port_range_max >= 2376
+      )
+  - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "openstack_networking_secgroup_rule_v2")
+    mql: |
+      terraform.state.resources.where(type == "openstack_networking_secgroup_rule_v2").where(values.direction == "ingress").where(values.remote_ip_prefix == "0.0.0.0/0" || values.remote_ip_prefix == "::/0").where(values.protocol == "tcp" || values.protocol == "").none(
+        values.port_range_min <= 6443 && values.port_range_max >= 6443 ||
+        values.port_range_min <= 10250 && values.port_range_max >= 10250 ||
+        values.port_range_min <= 2379 && values.port_range_max >= 2379 ||
+        values.port_range_min <= 2380 && values.port_range_max >= 2380 ||
+        values.port_range_min <= 2375 && values.port_range_max >= 2375 ||
+        values.port_range_min <= 2376 && values.port_range_max >= 2376
+      )
+
   - uid: mondoo-openstack-security-no-all-ports-open
     title: Ensure no security group allows unrestricted inbound traffic to all ports
     impact: 100
@@ -1435,6 +1780,10 @@ queries:
       - uid: mondoo-openstack-security-no-all-ports-open-openstack
         tags:
           mondoo.com/filter-title: OpenStack Project
+          mondoo.com/filter-icon: openstack
+      - uid: mondoo-openstack-security-no-all-ports-open-openstack-security-group
+        tags:
+          mondoo.com/filter-title: OpenStack Security Group
           mondoo.com/filter-icon: openstack
       - uid: mondoo-openstack-security-no-all-ports-open-terraform-hcl
         tags:
@@ -1524,6 +1873,13 @@ queries:
           portRangeMin == 0 && portRangeMax == 0 ||
           portRangeMin <= 1 && portRangeMax >= 65535
         )
+      )
+  - uid: mondoo-openstack-security-no-all-ports-open-openstack-security-group
+    filters: asset.platform == "openstack-security-group"
+    mql: |
+      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").none(
+        portRangeMin == 0 && portRangeMax == 0 ||
+        portRangeMin <= 1 && portRangeMax >= 65535
       )
   - uid: mondoo-openstack-security-no-all-ports-open-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_secgroup_rule_v2")


### PR DESCRIPTION
## Summary

Content-side follow-up to [mondoohq/server#16569](https://github.com/mondoohq/server/pull/16569) and [mondoohq/mql#8552](https://github.com/mondoohq/mql/pull/8552), which discover each OpenStack Neutron security group as its own `openstack-security-group` asset (`cnspec scan openstack --discover security-groups`).

### Refactor: per-asset variants

Adds an `-openstack-security-group` variant (`asset.platform == "openstack-security-group"`) to each of the four security-group checks, scoring **per-asset** against the singular bound `openstack.securityGroup` resource — mirroring the DigitalOcean `digitalocean-firewall` convention (singular bound resource, not the list):

- `no-unrestricted-ssh`
- `no-unrestricted-rdp`
- `no-unrestricted-db-ports`
- `no-all-ports-open`

The existing project-level (`openstack-project`, aggregate `.all()`) and Terraform variants are untouched, so a plain project scan behaves exactly as before — the new variant only activates on opt-in discovery.

### New checks (same control family)

Two new checks in the same "restrict unrestricted public ingress to a sensitive port" family, each with the full variant set (openstack-project + openstack-security-group + terraform-hcl/plan/state) and Terraform remediation:

| Check | Ports | Impact |
|---|---|---|
| `no-unrestricted-winrm` | WinRM 5985 / 5986 | 100 (anchors to RDP) |
| `no-unrestricted-mgmt-ports` | Kubernetes API 6443, kubelet 10250, etcd 2379/2380, Docker daemon 2375/2376 | 95 (anchors to db-ports) |

### Compliance

Both new checks reuse the mapping shared by the existing SSH/RDP/db-ports checks — verified, not copied: this is the policy's established boundary-protection control objective. Spot-checked against the framework text:

- `nist-sp-800-53-rev5-sc-7` — **Boundary Protection**
- `pcidss-requirement-1-3-1` — "Inbound traffic to the CDE is restricted… to only traffic that is necessary. All other traffic is specifically denied."

Version 1.3.0 → 1.4.0.

## Testing

- `cnspec policy lint content/mondoo-openstack-security.mql.yaml` — valid bundle, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)