### PR TITLE
🧹 m365: use typed dns.spf/dns.dmarc parsers in email-auth checks

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -1750,7 +1750,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).params['TXT']['rData'].any(/v=spf1 /))
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).spf != empty)
     docs:
       desc: |
         This check ensures that every Exchange Online domain has a published SPF (Sender Policy Framework) TXT record that explicitly authorizes Microsoft's mail servers. By default no SPF record is created automatically when a domain is added to Microsoft 365; it must be published manually at the DNS provider.
@@ -2960,8 +2960,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/v=DMARC1/))
-      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns("_dmarc." + id).params['TXT']['rData'].any(/p=quarantine|p=reject/))
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).dmarc.version == "DMARC1")
+      microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).dmarc.policy == /quarantine|reject/)
     docs:
       desc: |
         This check ensures that every verified custom domain publishes a DMARC record with an enforcing policy of `quarantine` or `reject`. DMARC (Domain-based Message Authentication, Reporting, and Conformance) tells receiving mail servers what to do with messages that fail SPF and DKIM alignment.


### PR DESCRIPTION
## What

Simplifies the three SPF/DMARC email-authentication checks in `mondoo-m365-security` to use the typed `dns.spf` / `dns.dmarc` resources instead of hand-parsing raw TXT records via `dns(...).params['TXT']['rData']` regex matching.

| Before | After |
|---|---|
| `dns(id).params['TXT']['rData'].any(/v=spf1 /)` | `dns(id).spf != empty` |
| `dns("_dmarc." + id).params['TXT']['rData'].any(/v=DMARC1/)` | `dns(id).dmarc.version == "DMARC1"` |
| `dns("_dmarc." + id).params['TXT']['rData'].any(/p=quarantine\|p=reject/)` | `dns(id).dmarc.policy == /quarantine\|reject/` |

## Why

- These are the same typed resources already used throughout `mondoo-email-security`, so this brings the m365 email-auth checks in line with the rest of the content.
- The `dns.dmarc` accessor resolves the `_dmarc` subdomain internally, so the `"_dmarc." + id` string concatenation is no longer needed.
- Reading the parsed `version` / `policy` fields is more robust than regex-matching raw record strings.

The DKIM check is intentionally left as-is — there is no typed DKIM accessor that fits it.

## Testing

`cnspec policy lint ./content/mondoo-m365-security.mql.yaml` → valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)