### PR TITLE
📝 docs: replace cnquery references with mql

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 cnspec is an open-source, cloud-native security and policy project that assesses infrastructure security and compliance. It finds vulnerabilities and misconfigurations across cloud environments, Kubernetes, containers, servers, SaaS products, and more.
 
-**cnspec is built on top of cnquery** (`go.mondoo.com/cnquery/v12`). cnquery provides the MQL query engine, provider system, and resource framework; cnspec adds policy evaluation, scoring, compliance frameworks, and security assessments.
+**cnspec is built on top of mql** (`go.mondoo.com/mql/v13`). mql provides the MQL query engine, provider system, and resource framework; cnspec adds policy evaluation, scoring, compliance frameworks, and security assessments.
 
 ## Where things live
 
@@ -33,8 +33,8 @@ Run after modifying `.proto` files, policy bundle structures, or reporter config
 
 ```bash
 make prep                # Install required tools (first time only)
-make prep/repos          # Clone/verify cnquery dependency (required for proto compilation)
-make prep/repos/update   # Update cnquery dependency
+make prep/repos          # Clone/verify mql dependency (required for proto compilation)
+make prep/repos/update   # Update mql dependency
 make cnspec/generate     # Regenerate all generated code (proto, policy, reporter)
 ```
 
@@ -72,7 +72,7 @@ cnspec policy lint ./content/mondoo-linux-security.mql.yaml     # Lint one polic
 ### Dependency management
 
 - **Forbidden packages**: do not use `github.com/pkg/errors` (use `github.com/cockroachdb/errors`) or `github.com/mitchellh/mapstructure` (use `github.com/go-viper/mapstructure/v2`).
-- When proto files reference cnquery types, ensure the cnquery repo is present via `make prep/repos`.
+- When proto files reference mql types, ensure the mql repo is present via `make prep/repos`.
 
 ### Error handling
 
@@ -100,5 +100,5 @@ Never edit these files manually. Regenerate with `make cnspec/generate`:
 - [MQL Documentation](https://mondoo.com/docs/mql/) · [Built-in Functions](https://mondoo.com/docs/mql/functions) · [Resources by Provider](https://mondoo.com/docs/mql/resources/)
 - [MQL operator precedence](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) — reference for operator precedence during policy reviews
 - [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro/)
-- [cnquery Repository](https://github.com/mondoohq/cnquery)
+- [mql Repository](https://github.com/mondoohq/mql)
 - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ prep: prep/tools
 # An alternative (especially for local development) is to soft-link a local copy of the repo
 # yourself. We don't pin submodules at this time, but we may want to check if they are up to date here.
 prep/repos:
-	test -x mql || git clone https://github.com/mondoohq/cnquery.git mql
+	test -x mql || git clone https://github.com/mondoohq/mql.git mql
 
 prep/repos/update: prep/repos
 	cd mql; git checkout main && git pull; cd -;

--- a/policy/CLAUDE.md
+++ b/policy/CLAUDE.md
@@ -4,16 +4,16 @@ Policy engine internals. Loaded automatically when working under `policy/`.
 
 For policy *content* authoring (writing `.mql.yaml` files), see `content/CLAUDE.md`.
 
-## cnspec vs cnquery
+## cnspec vs mql
 
-**cnspec is built on top of cnquery** — it's not just a dependency relationship:
+**cnspec is built on top of mql** — it's not just a dependency relationship:
 
-- **cnquery provides**: MQL query engine, provider system, resource framework, data gathering.
+- **mql provides**: MQL query engine, provider system, resource framework, data gathering.
 - **cnspec adds**: Policy evaluation, scoring, compliance frameworks, security assessments, risk factors.
 - **Shared runtime**: Both use the same provider system (`providers.Runtime`) for connecting to target systems.
-- **Import path**: cnspec imports `go.mondoo.com/cnquery/v12` extensively.
+- **Import path**: cnspec imports `go.mondoo.com/mql/v13` extensively.
 
-When working on cnspec, you may need to understand or modify cnquery components.
+When working on cnspec, you may need to understand or modify mql components.
 
 ## Policy engine flow
 
@@ -39,7 +39,7 @@ The policy execution pipeline has four main stages.
 ### 3. Execution
 
 - Orchestrated by `GraphExecutor` in [executor/graph.go](executor/graph.go).
-- Queries executed via cnquery's `llx.MQLExecutorV2`.
+- Queries executed via mql's `llx.MQLExecutorV2`.
 - Results collected through `BufferedCollector` pattern.
 - Handles: data points, scores, risk factors, upstream transmission.
 
@@ -81,7 +81,7 @@ Results → Reporters (console, SARIF, JUnit, etc.)
 
 ## Provider system
 
-The provider system (inherited from cnquery) enables scanning diverse targets.
+The provider system (inherited from mql) enables scanning diverse targets.
 
 **Connection flow**:
 
@@ -142,4 +142,4 @@ Never edit these files manually:
 - `*.vtproto.pb.go` — Optimized vtproto marshaling.
 - `*_gen.go` — Generated via `go generate`.
 
-Regenerate with `make cnspec/generate` after source changes. When proto files reference cnquery types, ensure the cnquery repo is present via `make prep/repos`.
+Regenerate with `make cnspec/generate` after source changes. When proto files reference mql types, ensure the mql repo is present via `make prep/repos`.


### PR DESCRIPTION
## Summary

cnspec now builds on the standalone **mql** project (`go.mondoo.com/mql/v13`) rather than cnquery. This updates the agent-guidance docs and the build to match reality:

- **`CLAUDE.md`** — "built on top of mql" + import path, `prep/repos` comments, proto-types dependency note, and the repository link (now `mondoohq/mql`).
- **`policy/CLAUDE.md`** — `## cnspec vs mql` section, import path `go.mondoo.com/mql/v13`, `llx.MQLExecutorV2` and provider-system attributions, and proto-types note.
- **`Makefile`** — `prep/repos` clones `https://github.com/mondoohq/mql.git` instead of `cnquery.git`.

## Verification

- Confirmed `go.mod` already requires `go.mondoo.com/mql/v13` and Go sources import it.
- Confirmed the `mondoohq/mql` GitHub repo exists.
- `grep cnquery` returns no remaining references in the three updated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)