### PR TITLE
✨ Convert account-level checks to query granular cloud assets

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -44077,9 +44077,9 @@ queries:
         title: SQL Vulnerability Assessment helps you identify database vulnerabilities
   - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-sql-server"
     mql: |
-      azure.subscription.sql.servers.all(vulnerabilityAssessmentSettings.recurringScanEnabled == true)
+      azure.subscription.sql.server.vulnerabilityAssessmentSettings.recurringScanEnabled == true
   - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mssql_server_vulnerability_assessment")
     mql: |
@@ -44269,9 +44269,9 @@ queries:
         title: Azure Web Application Firewall on Azure Application Gateway
   - uid: mondoo-azure-security-appgw-waf-prevention-mode-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.network.applicationGateways.all(policy != null && policy.mode == "Prevention")
+      azure.subscription.networkService.applicationGateway.policy != null && azure.subscription.networkService.applicationGateway.policy.mode == "Prevention"
   - uid: mondoo-azure-security-appgw-waf-prevention-mode-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_web_application_firewall_policy")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.3.0
+    version: 9.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -37528,7 +37528,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Compute Image
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-hcl
         tags:
@@ -37616,12 +37616,10 @@ queries:
       - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-compute-image'
     mql: |
-      gcp.project.computeService.images.all(
-        imageEncryptionKey != empty &&
-        imageEncryptionKey['kmsKeyName'] != empty
-      )
+      gcp.project.computeService.image.imageEncryptionKey != empty &&
+      gcp.project.computeService.image.imageEncryptionKey['kmsKeyName'] != empty
   - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_image')
@@ -37668,7 +37666,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP IAM Service Account
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-hcl
         tags:
@@ -37750,11 +37748,9 @@ queries:
       - url: https://cloud.google.com/iam/docs/service-account-impersonation
         title: Service account impersonation
   - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-iam-service-account'
     mql: |
-      gcp.project.iamService.serviceAccounts.all(
-        canBeImpersonated == false
-      )
+      gcp.project.iam.serviceAccount.canBeImpersonated == false
   - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_service_account_iam_member' || nameLabel == 'google_service_account_iam_binding')
@@ -37817,7 +37813,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Cloud KMS
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-hcl
         tags:
@@ -37900,11 +37896,9 @@ queries:
       - url: https://cloud.google.com/kms/docs/iam
         title: Cloud KMS permissions and roles
   - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-kms-keyring'
     mql: |
-      gcp.project.kmsService.keyrings.all(
-        public == false
-      )
+      gcp.project.kms.keyring.public == false
   - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.3.3
+    version: 9.3.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## What

Several security checks filtered on the broad cloud-account platform (`asset.platform == "azure"` / `"gcp"`) and iterated an entire account/project collection with `.all(...)`, even though their parent `variants:` blocks were already labeled for a **specific** asset (e.g. *Azure SQL Server*, *GCP Compute Image*). cnquery now exposes these as individual scannable assets, so the runtime variant should run **per asset** rather than aggregating across the whole account.

This converts each such runtime variant to filter on the dedicated object platform and query the singular, auto-bound resource — so each asset is discovered and scored individually.

## Changes

| Check (runtime variant) | Filter: before → after | MQL: before → after |
|---|---|---|
| `sql-server-vulnerability-assessment-recurring-scans` | `azure` → `azure-sql-server` | `azure.subscription.sql.servers.all(…)` → `azure.subscription.sql.server.vulnerabilityAssessmentSettings.recurringScanEnabled == true` |
| `appgw-waf-prevention-mode` | `azure` → `azure-application-gateway` | `azure.subscription.network.applicationGateways.all(…)` → `azure.subscription.networkService.applicationGateway.policy …` |
| `compute-image-cmek-encryption` | `gcp` → `gcp-compute-image` | `gcp.project.computeService.images.all(…)` → `gcp.project.computeService.image.imageEncryptionKey …` |
| `iam-service-account-not-impersonatable` | `gcp` → `gcp-iam-service-account` | `gcp.project.iamService.serviceAccounts.all(…)` → `gcp.project.iam.serviceAccount.canBeImpersonated == false` |
| `cloud-kms-keyring-not-publicly-accessible` | `gcp` → `gcp-kms-keyring` | `gcp.project.kmsService.keyrings.all(…)` → `gcp.project.kms.keyring.public == false` |

The three GCP variants also get descriptive `mondoo.com/filter-title` tags (GCP Compute Image / GCP IAM Service Account / GCP Cloud KMS); the Azure variants were already correctly titled.

Parent `docs`, compliance tags, impact, and the Terraform/Bicep variants are unchanged — only the live-cloud runtime variant moves to the granular asset, matching the established per-asset idiom already used elsewhere (e.g. `compute-vm-no-public-ip`, `compute-image-iam-no-public-principals`).

## Notes / scope

- The singular accessors and fields were verified against the provider LR schemas, and the established per-asset variants in these same policies use identical idioms.
- AWS is already fully migrated — every resource with a dedicated asset platform already has a per-asset variant; the remaining `asset.platform == "aws"` checks are genuinely account-scoped (IAM credential report, account public-access block, GuardDuty/Config/SecurityHub, CloudWatch metric-filter alarms) or target services with no dedicated asset.
- **Azure VM checks (`vm-secure-boot-enabled`, `vm-vtpm-enabled`) are intentionally left on the account collection** and not converted.

## Test

`cnspec policy lint` passes for both bundles (pre-existing deprecation warnings on unrelated vertexai queries are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)