### PR TITLE
📝 Add PR-review guidance for bots to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,35 @@ Never edit these files manually. Regenerate with `make cnspec/generate`:
 - `*.vtproto.pb.go` — Optimized vtproto marshaling.
 - `*_gen.go` — Generated via `go generate`.
 
+## Reviewing pull requests (for bots & automated reviewers)
+
+This section is for any automated reviewer (mondoo-code-review, Claude, etc.) commenting on PRs in this repo. **Most false positives come from guessing how MQL behaves instead of verifying it.** Before asserting that a query is wrong, that a field doesn't exist, or that precedence/grouping is off, confirm it against the references below. If you cannot verify a claim, frame it as a question ("Does `x` exist on this resource?"), not a defect.
+
+### Verify before you claim
+
+- **Resource & field existence** — Do not assume a resource or field is missing. Check what the provider actually exposes:
+  - [Resources by Provider](https://mondoo.com/docs/mql/resources/) — canonical list of resources and their fields, grouped by provider (aws-pack, azure-pack, gcp-pack, core-pack, …).
+  - [Built-in Functions](https://mondoo.com/docs/mql/functions) — `parse.json`, `parse.date`, `regex`, list ops (`all`, `any`, `where`, `contains`, `none`, `map`), etc.
+  - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt) — single raw-text dump of all docs; grep it when you need to confirm a field or function quickly.
+  - Locally, the *installed* provider schema is authoritative for what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. The source of truth in code is `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql).
+  - To check a real query end to end: `cnquery run <provider> -c '<mql>'` (no TTY needed) or `cnspec policy lint ./content/<file>.mql.yaml`. **Run the query before claiming it returns the wrong thing.**
+- **Operator precedence** — MQL precedence is fixed; consult [`mqlc/parser/operators.go`](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) before flagging precedence. Notably `&&` binds tighter than `||`, so `a || b && c` already parses as `a || (b && c)` — that is usually intentional, not a bug.
+
+### MQL gotchas that cause false positives
+
+- **No parenthesized grouping.** MQL does **not** support `()` to group boolean expressions — `( a == 1 ) || ( b > 0 && b <= 5 )` fails to compile (`expected operand, got token "("`). Do **not** suggest adding parens "for clarity." Authors rely on `&&` > `||` precedence, or split into separate `.any()`/`.all()` calls.
+- **`.all()` / `.none()` on `null` fails; on `[]` it passes vacuously.** An absent HCL/map key (e.g. `values['x']` when `x` is missing) is `null`, not an empty list, so `values['x'].all(...)` *errors* when the block is absent. Don't recommend rewriting `blocks.where(type=='x').all(y)` (vacuously true when nothing matches) into `values['x'].all(y)` — it silently flips absent-case behavior. The null-safe form is `values['x'] == empty || values['x'].all(y)`.
+- **`!= ""` is not null-safe.** `"" == empty` is true, but `null != ""` is also true — use `!= empty` for null-safe non-empty assertions.
+- **`filters:` is asset selection, not logic.** `filters:` only selects which assets a check applies to (`asset.platform == "..."`). Predicate logic (`field != empty`, `flag == true`, …) belongs in `mql:`. Don't flag a query for "duplicating" a condition that legitimately lives in `mql:` rather than `filters:`, and don't suggest lifting predicates into `filters:` — that silently drops assets from scoring. Multi-line `filters:` join with explicit `&&`; multi-line `mql:` uses newline-as-AND.
+- **Newline-as-AND in `mql:`.** Multiple lines in an `mql:` block are implicitly AND-ed. A query that "looks like it ignores" an earlier line is usually relying on this — verify before flagging.
+
+### Policy/content specifics
+
+`content/` holds the security policies (`*.mql.yaml`). See `content/CLAUDE.md` for authoring rules (variants, compliance tags, MQL idioms, validation) and `policy/CLAUDE.md` for engine internals. When reviewing content:
+
+- **Compliance tags** — never assume a `compliance/*` tag is correct because a neighboring check has it. Verify the control against the framework text before flagging or endorsing.
+- **Variant siblings are not interchangeable** — the Terraform/HCL version of a check is often stricter than the plan/state version; don't recommend unifying them by copying one body into another.
+
 ## Resources
 
 - [cnspec Documentation](https://mondoo.com/docs/cnspec/)


### PR DESCRIPTION
## What

Adds a **Reviewing pull requests (for bots & automated reviewers)** section to `CLAUDE.md`, aimed at any automated reviewer (mondoo-code-review, Claude, etc.) commenting on PRs in this repo.

## Why

Most review false positives come from guessing how MQL behaves instead of verifying it — flagging a field as missing, a query as wrong, or precedence/grouping as off without confirming against the docs or running the query.

## What's in it

- **Verify before you claim** — where to confirm resource/field existence (Resources-by-Provider docs, built-in functions, `llms-full.txt`, the installed provider schema, the `.lr` source), how to actually run a query (`cnquery run`, `cnspec policy lint`), and the operator-precedence reference.
- **MQL gotchas that cause false positives** — no parenthesized grouping; `.all()`/`.none()` on `null` fails while `[]` passes vacuously (the `== empty ||` guard); `!= ""` is not null-safe (use `!= empty`); `filters:` is asset selection, not logic; newline-as-AND in `mql:`.
- **Policy/content specifics** — compliance-tag verification and variant-sibling caveats, with pointers to `content/CLAUDE.md` / `policy/CLAUDE.md`.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)