### PR TITLE
🧹 Ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 
 # vim swap files
 *.swp
+*.swo


### PR DESCRIPTION
Adds `*.swp`/`*.swo` to `.gitignore` so Vim swap files are not accidentally committed.

Follow-up to a swap file that slipped into a commit in mql-enterprise-providers; this brings the rest of the repos in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)