### PR TITLE
feat(azure): keyless (WIF) onboarding for cnspec integrate azure

### DIFF
--- a/apps/cnspec/cmd/integrate.go
+++ b/apps/cnspec/cmd/integrate.go
@@ -43,6 +43,7 @@ func init() {
 	integrateAzureCmd.Flags().Bool("scan-vms", false, "Enable scanning Azure VMs using RunCommand")
 	integrateAzureCmd.Flags().StringSlice("allow", []string{}, "Set the Azure subscriptions to include in scanning")
 	integrateAzureCmd.Flags().StringSlice("deny", []string{}, "Set the Azure subscriptions to exclude from scanning")
+	integrateAzureCmd.Flags().Bool("use-wif", false, "Use Workload Identity Federation (keyless) instead of a certificate")
 	// providing both, --deny and --allow, is not allowed
 	integrateAzureCmd.MarkFlagsMutuallyExclusive("allow", "deny")
 
@@ -186,6 +187,7 @@ NOTE that --allow and --deny are mutually exclusive and can't be used together.`
 				viper.BindPFlag("allow", cmd.Flags().Lookup("allow")),
 				viper.BindPFlag("deny", cmd.Flags().Lookup("deny")),
 				viper.BindPFlag("scan-vms", cmd.Flags().Lookup("scan-vms")),
+				viper.BindPFlag("use-wif", cmd.Flags().Lookup("use-wif")),
 			}
 			return errors.Join(errs...)
 		},
@@ -198,6 +200,7 @@ NOTE that --allow and --deny are mutually exclusive and can't be used together.`
 				allow           = viper.GetStringSlice("allow")
 				deny            = viper.GetStringSlice("deny")
 				scanVMs         = viper.GetBool("scan-vms")
+				useWIF          = viper.GetBool("use-wif")
 			)
 
 			// Verify if space exists, which verifies we have access to the Mondoo Platform
@@ -275,6 +278,7 @@ NOTE that --allow and --deny are mutually exclusive and can't be used together.`
 				Allow:   allow,
 				Deny:    deny,
 				ScanVMs: scanVMs,
+				UseWIF:  useWIF,
 			})
 			if err != nil {
 				return errors.Wrap(err, "unable to generate automation code")

--- a/internal/onboarding/aws_test.go
+++ b/internal/onboarding/aws_test.go
@@ -57,7 +57,7 @@ func TestGenerateAwsHCL_KeyBased(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }

--- a/internal/onboarding/azure.go
+++ b/internal/onboarding/azure.go
@@ -24,6 +24,10 @@ type AzureIntegration struct {
 	Allow   []string
 	Deny    []string
 	ScanVMs bool
+	// UseWIF opts into Workload Identity Federation (keyless) instead of a certificate.
+	// When true, GenerateAzureHCL emits azuread_application_federated_identity_credential
+	// instead of tls_private_key / tls_self_signed_cert / azuread_application_certificate.
+	UseWIF bool
 }
 
 // GenerateAzureHCL generates automation code to create an Azure integration.
@@ -134,6 +138,44 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 				"depends_on":          []any{resourceTimeSleep.TraverseRef()},
 			}),
 		)
+	)
+
+	// Build the integration attributes, dynamic objects list, and depends_on list differently
+	// depending on whether we are in WIF (keyless) mode or the default certificate mode.
+	var (
+		integrationAttributes tfgen.Attributes
+		dynamicObjects        []tfgen.Object
+		integrationDependsOn  []any
+	)
+
+	if integration.UseWIF {
+		// WIF (keyless) mode: omit TLS/cert resources; the mondoo integration itself is
+		// created first so that its computed wif_subject / wif_issuer_url are available to
+		// the azuread_application_federated_identity_credential that follows.
+		integrationAttributes = tfgen.Attributes{
+			"name":      integration.Name,
+			"tenant_id": dataADClientConfig.TraverseRef("tenant_id"),
+			"client_id": resourceAdApplication.TraverseRef("client_id"),
+			"scan_vms":  integration.ScanVMs,
+			"use_wif":   true,
+		}
+		dynamicObjects = []tfgen.Object{
+			providerMondoo,
+			providerAzureAD,
+			providerAzureRM,
+			dataADClientConfig,
+			resourceADServicePrincipal,
+			resourceAdApplication,
+			resourceADReadersDirectoryRole,
+			resourceADReadersRoleAssignment,
+			resourceTimeSleep,
+		}
+		integrationDependsOn = []any{
+			resourceADServicePrincipal.TraverseRef(),
+			resourceADReadersRoleAssignment.TraverseRef(),
+		}
+	} else {
+		// Certificate mode (default): existing behaviour — unchanged.
 		integrationAttributes = tfgen.Attributes{
 			"name":      integration.Name,
 			"tenant_id": dataADClientConfig.TraverseRef("tenant_id"),
@@ -145,26 +187,25 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 				),
 			},
 		}
-	)
-
-	dynamicObjects := []tfgen.Object{
-		providerMondoo,
-		providerAzureAD,
-		providerAzureRM,
-		dataADClientConfig,
-		resourceTLSPrivateKey,
-		resourceTLSSelfSignedCert,
-		resourceADApplicationCertificate,
-		resourceADServicePrincipal,
-		resourceAdApplication,
-		resourceADReadersDirectoryRole,
-		resourceADReadersRoleAssignment,
-		resourceTimeSleep,
-	}
-	integrationDependsOn := []any{
-		resourceADServicePrincipal.TraverseRef(),
-		resourceADApplicationCertificate.TraverseRef(),
-		resourceADReadersRoleAssignment.TraverseRef(),
+		dynamicObjects = []tfgen.Object{
+			providerMondoo,
+			providerAzureAD,
+			providerAzureRM,
+			dataADClientConfig,
+			resourceTLSPrivateKey,
+			resourceTLSSelfSignedCert,
+			resourceADApplicationCertificate,
+			resourceADServicePrincipal,
+			resourceAdApplication,
+			resourceADReadersDirectoryRole,
+			resourceADReadersRoleAssignment,
+			resourceTimeSleep,
+		}
+		integrationDependsOn = []any{
+			resourceADServicePrincipal.TraverseRef(),
+			resourceADApplicationCertificate.TraverseRef(),
+			resourceADReadersRoleAssignment.TraverseRef(),
+		}
 	}
 
 	// Allow and Deny are mutually exclusive and can't be added together
@@ -199,6 +240,22 @@ func GenerateAzureHCL(integration AzureIntegration) (string, error) {
 		tfgen.HclResourceWithAttributes(integrationAttributes),
 	)
 	dynamicObjects = append(dynamicObjects, resourceMondooIntegration)
+
+	if integration.UseWIF {
+		// In WIF mode the federated identity credential must be created after the
+		// mondoo_integration_azure resource, because it references the computed
+		// wif_subject and wif_issuer_url attributes that the integration exports.
+		resourceADFederatedCredential := tfgen.NewResource("azuread_application_federated_identity_credential", "mondoo",
+			tfgen.HclResourceWithAttributes(tfgen.Attributes{
+				"application_id": resourceAdApplication.TraverseRef("id"),
+				"display_name":   "mondoo",
+				"issuer":         resourceMondooIntegration.TraverseRef("wif_issuer_url"),
+				"subject":        resourceMondooIntegration.TraverseRef("wif_subject"),
+				"audiences":      []string{"api://AzureADTokenExchange"},
+			}),
+		)
+		dynamicObjects = append(dynamicObjects, resourceADFederatedCredential)
+	}
 
 	blocks, err := tfgen.ObjectsToBlocks(dynamicObjects...)
 	if err != nil {

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -4,6 +4,7 @@
 package onboarding_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -370,6 +371,7 @@ resource "mondoo_integration_azure" "this" {
 `
 	assert.Equal(t, expected, code)
 }
+
 func TestGenerateAzureHCLWIF(t *testing.T) {
 	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{
 		Name:    "x",
@@ -382,12 +384,41 @@ func TestGenerateAzureHCLWIF(t *testing.T) {
 	// WIF mode MUST contain the federated credential resource, use_wif flag, the correct
 	// WIF audience, and references to the integration's computed wif_subject / wif_issuer_url.
 	assert.Contains(t, code, `resource "azuread_application_federated_identity_credential"`)
-	assert.Contains(t, code, "use_wif")
+	assert.Regexp(t, regexp.MustCompile(`use_wif\s*=\s*true`), code)
 	assert.Contains(t, code, "api://AzureADTokenExchange")
 	assert.Contains(t, code, "mondoo_integration_azure.this.wif_subject")
 	assert.Contains(t, code, "mondoo_integration_azure.this.wif_issuer_url")
 
 	// WIF mode MUST NOT contain cert-based resources or attributes.
+	assert.NotContains(t, code, "tls_self_signed_cert")
+	assert.NotContains(t, code, "tls_private_key")
+	assert.NotContains(t, code, "azuread_application_certificate")
+	assert.NotContains(t, code, "pem_file")
+}
+
+// TestGenerateAzureHCLWIFCombination verifies that WIF mode combined with VM scanning and
+// a subscription allow-list produces all three feature groups correctly and still omits
+// every cert-based resource.
+func TestGenerateAzureHCLWIFCombination(t *testing.T) {
+	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{
+		UseWIF:  true,
+		ScanVMs: true,
+		Allow:   []string{"sub-1"},
+		Primary: "sub-1",
+	})
+	assert.Nil(t, err)
+
+	// WIF credential resource and flag must be present.
+	assert.Contains(t, code, `resource "azuread_application_federated_identity_credential"`)
+	assert.Regexp(t, regexp.MustCompile(`use_wif\s*=\s*true`), code)
+
+	// VM scanning role definition must be present.
+	assert.Regexp(t, regexp.MustCompile(`scan_vms\s*=\s*true`), code)
+
+	// Subscription allow-list must be present.
+	assert.Contains(t, code, `subscription_allow_list`)
+
+	// Cert-based resources must be absent.
 	assert.NotContains(t, code, "tls_self_signed_cert")
 	assert.NotContains(t, code, "tls_private_key")
 	assert.NotContains(t, code, "azuread_application_certificate")

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -19,7 +19,7 @@ func TestGenerateAzureHCL(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }
@@ -126,7 +126,7 @@ func TestGenerateAzureHCLFull(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }
@@ -267,7 +267,7 @@ func TestGenerateAzureHCLScanVMsForAllowedSubscriptions(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }
@@ -432,7 +432,7 @@ func TestGenerateAzureHCLScanVMsForAllSubscriptions(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }

--- a/internal/onboarding/azure_test.go
+++ b/internal/onboarding/azure_test.go
@@ -370,6 +370,30 @@ resource "mondoo_integration_azure" "this" {
 `
 	assert.Equal(t, expected, code)
 }
+func TestGenerateAzureHCLWIF(t *testing.T) {
+	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{
+		Name:    "x",
+		Space:   "s",
+		Primary: "sub",
+		UseWIF:  true,
+	})
+	assert.Nil(t, err)
+
+	// WIF mode MUST contain the federated credential resource, use_wif flag, the correct
+	// WIF audience, and references to the integration's computed wif_subject / wif_issuer_url.
+	assert.Contains(t, code, `resource "azuread_application_federated_identity_credential"`)
+	assert.Contains(t, code, "use_wif")
+	assert.Contains(t, code, "api://AzureADTokenExchange")
+	assert.Contains(t, code, "mondoo_integration_azure.this.wif_subject")
+	assert.Contains(t, code, "mondoo_integration_azure.this.wif_issuer_url")
+
+	// WIF mode MUST NOT contain cert-based resources or attributes.
+	assert.NotContains(t, code, "tls_self_signed_cert")
+	assert.NotContains(t, code, "tls_private_key")
+	assert.NotContains(t, code, "azuread_application_certificate")
+	assert.NotContains(t, code, "pem_file")
+}
+
 func TestGenerateAzureHCLScanVMsForAllSubscriptions(t *testing.T) {
 	code, err := subject.GenerateAzureHCL(subject.AzureIntegration{ScanVMs: true, Primary: "abc-123-xyz-456-1"})
 	assert.Nil(t, err)

--- a/internal/onboarding/constants.go
+++ b/internal/onboarding/constants.go
@@ -5,7 +5,7 @@ package onboarding
 
 const (
 	mondooProviderSource  = "mondoohq/mondoo"
-	mondooProviderVersion = "~> 0.19"
+	mondooProviderVersion = "~> 0.40"
 
 	requiredTerraformVersion = ">= 1.0.11"
 	installTerraformVersion  = "1.9.8"

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -21,7 +21,7 @@ func TestGenerateMs365HCL_Basic(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }
@@ -238,7 +238,7 @@ func TestGenerateMs365HCL_Minimal(t *testing.T) {
   required_providers {
     mondoo = {
       source  = "mondoohq/mondoo"
-      version = "~> 0.19"
+      version = "~> 0.40"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds Workload Identity Federation (WIF / keyless) support to `cnspec integrate azure`.

### New flag

```
cnspec integrate azure --use-wif ...
```

When `--use-wif` is passed the Terraform generated by `cnspec integrate azure` creates an **`azuread_application_federated_identity_credential`** instead of the certificate/TLS resources, enabling passwordless authentication to Azure without storing any secrets.

### Generated Terraform DAG (WIF mode)

```
azuread_application  →  mondoo_integration_azure (use_wif=true)
                              ↓ exports wif_subject, wif_issuer_url
         azuread_application_federated_identity_credential
               issuer   = mondoo_integration_azure.this.wif_issuer_url
               subject  = mondoo_integration_azure.this.wif_subject
               audiences = ["api://AzureADTokenExchange"]
```

The certificate flow (`cnspec integrate azure` without `--use-wif`) is **unchanged** — this is a purely additive change.

### Changes

| File | Change |
|---|---|
| `apps/cnspec/cmd/integrate.go` | `--use-wif` flag + viper binding + `UseWIF` wired into `AzureIntegration{}` |
| `internal/onboarding/azure.go` | `UseWIF bool` field on `AzureIntegration`; WIF branch in `GenerateAzureHCL` |
| `internal/onboarding/azure_test.go` | `TestGenerateAzureHCLWIF` — regexp assertion on `use_wif = true`; new `TestGenerateAzureHCLWIFCombination` for WIF+ScanVMs+allow-list |
| `internal/onboarding/constants.go` | Bump the shared `mondooProviderVersion` to `~> 0.40` (the release that adds `use_wif`/`wif_subject`/`wif_issuer_url`). This pin is shared by aws/azure/ms365 onboarding; the prior `~> 0.19` predated WIF. |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/onboarding/...` — all pass (golden HCL updated to `~> 0.40`)
- [ ] Acceptance: run `cnspec integrate azure --use-wif --space <id>` against a real Azure tenant and confirm the federated credential is created with the correct issuer/subject/audience and the integration reaches READY without any stored secret
