### PR TITLE
🐛 aws: fix S3 bucket policy checks erroring on policy-less buckets

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -63383,12 +63383,7 @@ queries:
   - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
-      aws.s3.bucket.policy == null ||
-      aws.s3.bucket.policy.statements.where(_['Effect'] == "Allow").none(
-        _['Principal'] == "*" ||
-        _['Principal']['AWS'] == "*" ||
-        _['Principal']['AWS'] != null && _['Principal']['AWS'].contains("*")
-      )
+      aws.s3.bucket.policyStatements.where(effect == "Allow").none(hasPublicPrincipal)
   - uid: mondoo-aws-security-s3-bucket-policy-no-public-principal-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
     mql: |
@@ -63596,17 +63591,7 @@ queries:
   - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
-      aws.s3.bucket.policy != null &&
-      aws.s3.bucket.policy.statements.any(
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == "false" ||
-        _['Effect'] == "Deny" &&
-        _['Condition'] != null &&
-        _['Condition']['Bool'] != null &&
-        _['Condition']['Bool']['aws:SecureTransport'] == false
-      )
+      aws.s3.bucket.enforceSslOnly
   - uid: mondoo-aws-security-s3-bucket-policy-secure-transport-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
     mql: |


### PR DESCRIPTION
## Problem

The `aws` variants of two S3 bucket-policy checks throw a hard **Error** (not a pass/fail) on every bucket that has **no bucket policy**:

- `mondoo-aws-security-s3-bucket-policy-secure-transport-aws`
- `mondoo-aws-security-s3-bucket-policy-no-public-principal-aws`

Both dereference `aws.s3.bucket.policy.statements` directly:

```mql
# secure-transport
aws.s3.bucket.policy != null && aws.s3.bucket.policy.statements.any(...)
# no-public-principal
aws.s3.bucket.policy == null || aws.s3.bucket.policy.statements.where(...).none(...)
```

When a bucket has no policy, `aws.s3.bucket.policy` is `null`, so the `policy.statements...` sub-expression is a null dereference. The `&&`/`||` short-circuits the boolean *score*, but the scan still collects the **failed datapoint**, so the check surfaces as `! Error`. This was found while scanning an AWS account (`cnspec scan aws`) — every bucket without a policy produced two spurious errors.

## Fix

Rewrite both `aws` variants against the bucket's null-safe, purpose-built provider fields, which return `false` / an empty list when there is no policy:

```mql
# secure-transport
aws.s3.bucket.enforceSslOnly
# no-public-principal
aws.s3.bucket.policyStatements.where(effect == "Allow").none(hasPublicPrincipal)
```

- `enforceSslOnly` is equivalent to the old condition (a `Deny` keyed on `aws:SecureTransport == false`) and additionally handles the list form of the condition value.
- `hasPublicPrincipal` flags `Allow` statements with a wildcard (`"*"`) principal — which **matches the Terraform variant** of the same check (`Principal == "*" || Principal["AWS"] == "*"`). The old AWS variant's extra `.contains("*")` additionally flagged partial-wildcard ARNs (e.g. `arn:aws:iam::*:root`), which are authenticated cross-account principals, not *anonymous* access; dropping it aligns the two variants.

## Verification

`cnspec policy lint` passes. Verified against live buckets with the aws provider:

| Bucket | `enforceSslOnly` | `policyStatements.where(effect=="Allow").none(hasPublicPrincipal)` |
|---|---|---|
| no policy | `false` (clean) | `true` (clean) |
| with policy | `false` (clean) | `true` (clean) |

No more `! Error` — both return clean booleans on policy-less buckets.

## Compatibility

Requires aws provider **>= 13.37.1** (`hasPublicPrincipal`); `enforceSslOnly` is `>= 13.33.2`, `policyStatements` `>= 13.32.2`.