### PR TITLE
🐛 aws: fix Lambda URL auth check erroring on functions with no URL

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -68467,7 +68467,7 @@ queries:
   - uid: mondoo-aws-security-lambda-function-url-auth-required-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |
-      aws.lambda.function.urlConfig == null || aws.lambda.function.urlConfig.authType != "NONE"
+      aws.lambda.function.urlConfigAuthType != "NONE"
   - uid: mondoo-aws-security-lambda-function-url-auth-required-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_function_url")
     mql: |


### PR DESCRIPTION
## Problem

`mondoo-aws-security-lambda-function-url-auth-required-aws` dereferences the nullable `urlConfig` sub-resource:

```mql
aws.lambda.function.urlConfig == null || aws.lambda.function.urlConfig.authType != "NONE"
```

On a function with **no URL configured**, `urlConfig` is null and `urlConfig.authType` is a null dereference. The `||` short-circuits the boolean score, but the scan still collects the failed datapoint, so the check reports a hard **Error** on every function without a URL (the common case). Same class of bug as the S3 bucket-policy checks fixed in #2946.

## Fix

Read the auth type directly off the function — `""` when no URL is configured — so there's no nullable sub-resource traversal:

```mql
aws.lambda.function.urlConfigAuthType != "NONE"
```

(`"" != "NONE"` → pass when no URL; `AWS_IAM` → pass; `NONE` → fail.)

## Dependency

`aws.lambda.function.urlConfigAuthType` is a new aws-provider field added in mondoohq/mql#8760 (requires that provider release).

## Verification

`cnspec policy lint` passes. Verified against live functions: those with no URL resolve `urlConfigAuthType: ""` and the check passes cleanly (no error).