### PR TITLE
🐛 content: export internet-exposure inventory for the attack graph

### DIFF
--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-asset-inventory-aws
     name: AWS Asset Inventory Pack
-    version: 1.1.0
+    version: 1.2.0
     license: BUSL-1.1
     require:
       - provider: aws
@@ -38,6 +38,7 @@ packs:
         filters: asset.runtime == "aws"
         queries:
           - uid: mondoo-asset-inventory-aws-vpcs
+          - uid: mondoo-asset-inventory-aws-vpc-subnets
       - uid: mondoo-asset-inventory-aws-ec2-group
         title: Amazon EC2
         filters: asset.runtime == "aws"
@@ -45,6 +46,13 @@ packs:
           - uid: mondoo-asset-inventory-aws-ec2-security-groups
           - uid: mondoo-asset-inventory-aws-ec2-volumes
           - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
+          - uid: mondoo-asset-inventory-aws-ec2-instances-exposure
+          - uid: mondoo-asset-inventory-aws-eips
+      - uid: mondoo-asset-inventory-aws-elb-group
+        title: Elastic Load Balancing
+        filters: asset.runtime == "aws"
+        queries:
+          - uid: mondoo-asset-inventory-aws-elb-loadbalancers
       - uid: mondoo-asset-inventory-aws-rds-group
         title: Amazon RDS
         filters: asset.runtime == "aws"
@@ -81,6 +89,11 @@ packs:
         filters: asset.runtime == "aws"
         queries:
           - uid: mondoo-asset-inventory-aws-cloudtrail-trails
+      - uid: mondoo-asset-inventory-aws-waf-group
+        title: AWS WAF
+        filters: asset.runtime == "aws"
+        queries:
+          - uid: mondoo-asset-inventory-aws-waf-acls
 
 queries:
   - uid: mondoo-asset-inventory-aws-account-id
@@ -117,6 +130,45 @@ queries:
     filters: asset.platform == "aws-vpc"
     mql: |
       aws.vpc
+
+  - uid: mondoo-asset-inventory-aws-vpc-subnets
+    title: VPC subnets and route tables
+    docs:
+      desc: |
+        Lists VPC subnets with whether they auto-assign public IPs and their route
+        table routes (including internet-gateway routes), so public vs. private
+        subnet placement can be determined for internet-exposure analysis.
+    variants:
+      - uid: mondoo-asset-inventory-aws-vpc-subnets-all
+      - uid: mondoo-asset-inventory-aws-vpc-subnets-single
+  - uid: mondoo-asset-inventory-aws-vpc-subnets-all
+    filters: asset.platform == "aws"
+    mql: |
+      aws.vpcs {
+        id
+        subnets {
+          id
+          mapPublicIpOnLaunch
+          routeTable {
+            id
+            routeEntries { destinationCidrBlock gatewayId natGatewayId state }
+          }
+        }
+      }
+  - uid: mondoo-asset-inventory-aws-vpc-subnets-single
+    filters: asset.platform == "aws-vpc"
+    mql: |
+      aws.vpc {
+        id
+        subnets {
+          id
+          mapPublicIpOnLaunch
+          routeTable {
+            id
+            routeEntries { destinationCidrBlock gatewayId natGatewayId state }
+          }
+        }
+      }
 
   - uid: mondoo-asset-inventory-aws-iam-users
     title: IAM users
@@ -224,6 +276,138 @@ queries:
       - mql: aws.ec2.instance.state != "terminated"
     mql: |
       aws.ec2.instance
+
+  - uid: mondoo-asset-inventory-aws-ec2-instances-exposure
+    title: EC2 instance internet exposure
+    docs:
+      desc: |
+        For every non-terminated EC2 instance, returns its internet-exposure
+        analysis: whether it is reachable from the internet, whether it has a
+        public IP, whether it sits in a public subnet, the security-group ingress
+        rules that open it, and any internet-facing load balancers that front it.
+    variants:
+      - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
+      - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-single
+  - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.instances.where(state != "terminated") {
+        instanceId
+        publicIp
+        privateIp
+        state
+        vpc { id }
+        subnet { id mapPublicIpOnLaunch }
+        securityGroups { id }
+        exposure {
+          internetReachable
+          hasPublicIp
+          inPublicSubnet
+          securityGroupAllowsIngress
+          networkAclAllowsIngress
+          openIngressRules { ipProtocol fromPort toPort ipRanges ipv6Ranges }
+          internetFacingLoadBalancers { arn name dnsName }
+        }
+      }
+  - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-single
+    filters:
+      - mql: asset.platform == "aws-ec2-instance"
+      - mql: aws.ec2.instance.state != "terminated"
+    mql: |
+      aws.ec2.instance {
+        instanceId
+        publicIp
+        privateIp
+        state
+        vpc { id }
+        subnet { id mapPublicIpOnLaunch }
+        securityGroups { id }
+        exposure {
+          internetReachable
+          hasPublicIp
+          inPublicSubnet
+          securityGroupAllowsIngress
+          networkAclAllowsIngress
+          openIngressRules { ipProtocol fromPort toPort ipRanges ipv6Ranges }
+          internetFacingLoadBalancers { arn name dnsName }
+        }
+      }
+
+  - uid: mondoo-asset-inventory-aws-eips
+    title: Elastic IP addresses
+    docs:
+      desc: |
+        Lists Elastic IP addresses and the instance / network interface they are
+        associated with, mapping externally routable public IPs to resources.
+    variants:
+      - uid: mondoo-asset-inventory-aws-eips-all
+  - uid: mondoo-asset-inventory-aws-eips-all
+    filters: asset.platform == "aws"
+    mql: |
+      aws.ec2.eips {
+        publicIp
+        attached
+        privateIpAddress
+        networkInterfaceId
+        region
+        instance { instanceId }
+      }
+
+  - uid: mondoo-asset-inventory-aws-elb-loadbalancers
+    title: Load balancers (ALB/NLB/GWLB)
+    docs:
+      desc: |
+        Lists Elastic Load Balancers with their scheme (internet-facing vs.
+        internal), listeners, security groups, internet-exposure breakdown, and the
+        targets they route to (EC2 instances / Lambda functions, plus registered
+        instances for classic load balancers).
+    variants:
+      - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
+      - uid: mondoo-asset-inventory-aws-elb-loadbalancers-single
+  - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
+    filters: asset.platform == "aws"
+    mql: |
+      aws.elb.loadBalancers {
+        arn
+        name
+        scheme
+        elbType
+        dnsName
+        region
+        securityGroups { id }
+        listeners { port protocol }
+        targetGroups {
+          arn
+          targetType
+          port
+          ec2Targets { instanceId }
+          lambdaTargets { name }
+        }
+        instances { instanceId }
+        exposure { internetReachable publiclyAccessible securityGroupAllowsIngress }
+      }
+  - uid: mondoo-asset-inventory-aws-elb-loadbalancers-single
+    filters: asset.platform == "aws-elb-loadbalancer"
+    mql: |
+      aws.elb.loadbalancer {
+        arn
+        name
+        scheme
+        elbType
+        dnsName
+        region
+        securityGroups { id }
+        listeners { port protocol }
+        targetGroups {
+          arn
+          targetType
+          port
+          ec2Targets { instanceId }
+          lambdaTargets { name }
+        }
+        instances { instanceId }
+        exposure { internetReachable publiclyAccessible securityGroupAllowsIngress }
+      }
 
   - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data
     title: RDS database clusters configuration
@@ -340,3 +524,22 @@ queries:
     filters: asset.platform == "aws-cloudtrail-trail"
     mql: |
       aws.cloudtrail.trail
+
+  - uid: mondoo-asset-inventory-aws-waf-acls
+    title: WAF web ACLs
+    docs:
+      desc: |
+        Lists WAFv2 web ACLs and the ARNs of the resources (e.g. Application Load
+        Balancers) they protect, so internet-facing entry points can be checked for
+        an attached web application firewall.
+    variants:
+      - uid: mondoo-asset-inventory-aws-waf-acls-all
+  - uid: mondoo-asset-inventory-aws-waf-acls-all
+    filters: asset.platform == "aws"
+    mql: |
+      aws.waf.acls {
+        arn
+        name
+        scope
+        associatedResources
+      }

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -285,36 +285,16 @@ queries:
         analysis: whether it is reachable from the internet, whether it has a
         public IP, whether it sits in a public subnet, the security-group ingress
         rules that open it, and any internet-facing load balancers that front it.
+
+        Scoped to the AWS account scan (no `-single` variant): the exposure
+        analysis is account-wide — `internetFacingLoadBalancers` requires
+        enumerating the account's load balancers and target groups.
     variants:
       - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
-      - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-single
   - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
     filters: asset.platform == "aws"
     mql: |
       aws.ec2.instances.where(state != "terminated") {
-        instanceId
-        publicIp
-        privateIp
-        state
-        vpc { id }
-        subnet { id mapPublicIpOnLaunch }
-        securityGroups { id }
-        exposure {
-          internetReachable
-          hasPublicIp
-          inPublicSubnet
-          securityGroupAllowsIngress
-          networkAclAllowsIngress
-          openIngressRules { ipProtocol fromPort toPort ipRanges ipv6Ranges }
-          internetFacingLoadBalancers { arn name dnsName }
-        }
-      }
-  - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-single
-    filters:
-      - mql: asset.platform == "aws-ec2-instance"
-      - mql: aws.ec2.instance.state != "terminated"
-    mql: |
-      aws.ec2.instance {
         instanceId
         publicIp
         privateIp
@@ -365,35 +345,15 @@ queries:
         internal), listeners, security groups, internet-exposure breakdown, and the
         targets they route to (EC2 instances / Lambda functions, plus registered
         instances for classic load balancers).
+
+        Scoped to the AWS account scan (no `-single` variant): target groups and
+        their registered targets are enumerated account-wide.
     variants:
       - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
-      - uid: mondoo-asset-inventory-aws-elb-loadbalancers-single
   - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
     filters: asset.platform == "aws"
     mql: |
       aws.elb.loadBalancers {
-        arn
-        name
-        scheme
-        elbType
-        dnsName
-        region
-        securityGroups { id }
-        listeners { port protocol }
-        targetGroups {
-          arn
-          targetType
-          port
-          ec2Targets { instanceId }
-          lambdaTargets { name }
-        }
-        instances { instanceId }
-        exposure { internetReachable publiclyAccessible securityGroupAllowsIngress }
-      }
-  - uid: mondoo-asset-inventory-aws-elb-loadbalancers-single
-    filters: asset.platform == "aws-elb-loadbalancer"
-    mql: |
-      aws.elb.loadbalancer {
         arn
         name
         scheme

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -339,6 +339,10 @@ queries:
       desc: |
         Lists Elastic IP addresses and the instance / network interface they are
         associated with, mapping externally routable public IPs to resources.
+
+        Elastic IPs are enumerated only at the account level — there is no
+        standalone `aws-eip` asset platform — so this query has no `-single`
+        variant (same pattern as the ACM and Access Analyzer queries above).
     variants:
       - uid: mondoo-asset-inventory-aws-eips-all
   - uid: mondoo-asset-inventory-aws-eips-all

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-kubernetes-inventory
     name: Kubernetes Inventory Pack
-    version: 1.2.0
+    version: 1.3.0
     license: BUSL-1.1
     require:
       - provider: k8s
@@ -51,6 +51,24 @@ packs:
               desc: Lists all nodes in the Kubernetes cluster with their status.
             mql: |
               k8s.nodes
+          - uid: k8s-cluster-node-instances
+            title: Cluster node cloud provider IDs
+            docs:
+              desc: |
+                Maps each node to its cloud provider ID (for AWS, providerID is
+                "aws:///<az>/<instance-id>"), bridging Kubernetes nodes to the
+                underlying EC2 instances for internet-exposure attribution.
+            mql: |
+              k8s.nodes { name providerID }
+          - uid: k8s-cluster-pod-nodes
+            title: Pod-to-node placement
+            docs:
+              desc: |
+                Maps each pod to the node it runs on, so workloads fronted by an
+                internet-facing ingress/load balancer can be traced down to the
+                specific node (and, via the node provider ID, the EC2 instance).
+            mql: |
+              k8s.pods { namespace name nodeName }
           - uid: k8s-cluster-clusterroles
             title: Cluster RBAC ClusterRoles
             docs:


### PR DESCRIPTION
Adds AWS + Kubernetes inventory queries so the data needed to build an internet-exposure attack graph (Internet → LB/SG → instance, pod → node → EC2) is exported, rather than left uncomputed. All backing MQL resources already exist in the provider; this only wires them into the inventory packs.

AWS (mondoo-asset-inventory-aws, 1.1.0 → 1.2.0):
- ec2-instances-exposure: per-instance aws.ec2.instance.exposure (internetReachable, hasPublicIp, inPublicSubnet, securityGroupAllowsIngress, networkAclAllowsIngress, openIngressRules, internetFacingLoadBalancers).
- elb-loadbalancers: scheme/type/listeners/securityGroups/exposure plus the targets each LB routes to (targetGroups.ec2Targets / lambdaTargets, and classic instances) — the load-balancer → instance edge.
- eips: Elastic IP → instance / network-interface mapping.
- vpc-subnets: subnet mapPublicIpOnLaunch + route table routeEntries (public vs. private subnet placement).
- waf-acls: WAFv2 web ACLs + associatedResources (which ALBs sit behind a WAF).

Kubernetes (mondoo-kubernetes-inventory, 1.2.0 → 1.3.0):
- node-instances: k8s.nodes providerID (node → EC2 instance bridge).
- pod-nodes: k8s.pods nodeName (pod → node placement), to trace internet-facing ingress workloads down to the hosting node/instance.

Both packs pass `cnspec policy lint`.