### PR TITLE
🧹 Update mondoo.com/docs URLs to their current canonical targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ This section is for any automated reviewer (mondoo-code-review, Claude, etc.) co
 ### Verify before you claim
 
 - **Resource & field existence** — Do not assume a resource or field is missing. Check what the provider actually exposes:
-  - [Resources by Provider](https://mondoo.com/docs/mql/resources/) — canonical list of resources and their fields, grouped by provider (aws-pack, azure-pack, gcp-pack, core-pack, …).
+  - [Resources by Provider](https://mondoo.com/docs/mql/resources) — canonical list of resources and their fields, grouped by provider (aws-pack, azure-pack, gcp-pack, core-pack, …).
   - [Built-in Functions](https://mondoo.com/docs/mql/functions) — `parse.json`, `parse.date`, `regex`, list ops (`all`, `any`, `where`, `contains`, `none`, `map`), etc.
   - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt) — single raw-text dump of all docs; grep it when you need to confirm a field or function quickly.
   - Locally, the *installed* provider schema is authoritative for what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. The source of truth in code is `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql).
@@ -125,9 +125,9 @@ This section is for any automated reviewer (mondoo-code-review, Claude, etc.) co
 
 ## Resources
 
-- [cnspec Documentation](https://mondoo.com/docs/cnspec/)
-- [MQL Documentation](https://mondoo.com/docs/mql/) · [Built-in Functions](https://mondoo.com/docs/mql/functions) · [Resources by Provider](https://mondoo.com/docs/mql/resources/)
+- [cnspec Documentation](https://mondoo.com/docs/cnspec)
+- [MQL Documentation](https://mondoo.com/docs/mql) · [Built-in Functions](https://mondoo.com/docs/mql/functions) · [Resources by Provider](https://mondoo.com/docs/mql/resources)
 - [MQL operator precedence](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) — reference for operator precedence during policy reviews
-- [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro/)
+- [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro)
 - [mql Repository](https://github.com/mondoohq/mql)
 - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt)

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ The Mondoo unified security platform finds and prioritizes vulnerabilities and m
 
 To get started, [contact us](https://mondoo.com/contact).
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.com/docs/) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.com/docs) or visit [mondoo.com](https://mondoo.com).
 
 ### Register cnspec with Mondoo Platform
 
-To use cnspec with Mondoo Platform, [generate a token in the Mondoo App](https://mondoo.com/docs/cnspec/cnspec-platform/), then run:
+To use cnspec with Mondoo Platform, [generate a token in the Mondoo App](https://mondoo.com/docs/cnspec/install/registration), then run:
 
 ```bash
 cnspec login --token TOKEN
@@ -205,7 +205,7 @@ A few examples can be found in the `examples` folder in this repo. You can run a
 cnspec scan local -f examples/example.mql.yaml
 ```
 
-If you're interested in writing your own policies or contributing policies back to the cnspec community, read Mondoo's [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro/).
+If you're interested in writing your own policies or contributing policies back to the cnspec community, read Mondoo's [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro).
 
 ## Supported targets
 
@@ -273,11 +273,11 @@ There are so many things cnspec can do, from testing your entire fleet for vulne
 
 Explore our:
 
-- [cnspec docs](https://mondoo.com/docs/cnspec/)
-- [Policy as code](https://mondoo.com/docs/cnspec/write-policies/write-intro/)
+- [cnspec docs](https://mondoo.com/docs/cnspec)
+- [Policy as code](https://mondoo.com/docs/cnspec/write-policies/write-intro)
 - [MQL](https://github.com/mondoohq/mql), our open source, cloud-native asset inventory framework
 - [MQL introduction](https://mondoohq.github.io/mql-intro/index.html)
-- [MQL resource packs](https://mondoo.com/docs/mql/resources/)
+- [MQL resource packs](https://mondoo.com/docs/mql/resources)
 - [HashiCorp Packer plugin](https://github.com/mondoohq/packer-plugin-mondoo) to integrate cnspec with HashiCorp Packer!
 
 ## Join the community!

--- a/apps/cnspec/cmd/policy-example.mql.yaml
+++ b/apps/cnspec/cmd/policy-example.mql.yaml
@@ -23,7 +23,7 @@ policies:
 
         ## Further information about MQL
 
-        More information about the Mondoo's Query Language (MQL) can be found [here](https://mondoo.com/docs/mql/mql.write/).
+        More information about the Mondoo's Query Language (MQL) can be found [here](https://mondoo.com/docs/mql/mql-write).
     groups:
       - filters:
           - mql: asset.family.contains("unix")

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -224,7 +224,7 @@ processes.list { name pid }
 files("/etc").where(name == /\.conf$/)
 ```
 
-For MQL resources available per provider, see [MQL resources documentation](https://mondoo.com/docs/mql/resources/).
+For MQL resources available per provider, see [MQL resources documentation](https://mondoo.com/docs/mql/resources).
 
 ## Linting and testing
 
@@ -310,7 +310,7 @@ python3 content/validation/dump_api_specs.py        # Tailscale + Atlassian API 
 
 ## Resources
 
-- [MQL Documentation](https://mondoo.com/docs/mql/)
+- [MQL Documentation](https://mondoo.com/docs/mql)
 - [MQL Built-in Functions](https://mondoo.com/docs/mql/functions)
-- [MQL Resources by Provider](https://mondoo.com/docs/mql/resources/) ([AWS](https://mondoo.com/docs/mql/resources/aws-pack/), [Azure](https://mondoo.com/docs/mql/resources/azure-pack/), [GCP](https://mondoo.com/docs/mql/resources/gcp-pack/), [Core](https://mondoo.com/docs/mql/resources/core-pack/))
-- [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro/)
+- [MQL Resources by Provider](https://mondoo.com/docs/mql/resources) ([AWS](https://mondoo.com/docs/mql/resources/aws), [Azure](https://mondoo.com/docs/mql/resources/azure), [GCP](https://mondoo.com/docs/mql/resources/gcp), [Core](https://mondoo.com/docs/mql/resources/core))
+- [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro)

--- a/content/README.md
+++ b/content/README.md
@@ -19,7 +19,7 @@ choco install cnspec
 # https://github.com/mondoohq/cnspec/releases
 ```
 
-For more installation options, see the [cnspec installation guide](https://mondoo.com/docs/cnspec/cnspec-adv-install/overview/).
+For more installation options, see the [cnspec installation guide](https://mondoo.com/docs/cnspec/install/overview).
 
 ### Verify installation
 
@@ -221,7 +221,7 @@ Policies use MQL to query system configurations, cloud resources, and applicatio
 - **Assertions**: Validate configurations meet security requirements
 - **Cross-Platform**: Same query syntax works across different operating systems and cloud providers
 
-For detailed MQL syntax and available resources, see the [MQL documentation](https://mondoo.com/docs/mql/).
+For detailed MQL syntax and available resources, see the [MQL documentation](https://mondoo.com/docs/mql).
 
 ### Example Policy Check
 

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -27,7 +27,7 @@ policies:
         - Firewall input filtering
         - Wireless authentication and Layer 2 hardening
 
-        Learn more about scanning MikroTik in the [cnspec documentation](https://mondoo.com/docs/cnspec/).
+        Learn more about scanning MikroTik in the [cnspec documentation](https://mondoo.com/docs/cnspec).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-nextdns-security.mql.yaml
+++ b/content/mondoo-nextdns-security.mql.yaml
@@ -26,7 +26,7 @@ policies:
 
         Each check evaluates an individual NextDNS profile, so when scanning a NextDNS account with asset discovery enabled every profile is assessed and scored independently.
 
-        Learn more about scanning NextDNS in the [cnspec documentation](https://mondoo.com/docs/cnspec/).
+        Learn more about scanning NextDNS in the [cnspec documentation](https://mondoo.com/docs/cnspec).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -33,7 +33,7 @@ policies:
         - [Nutanix v4 API Reference](https://developers.nutanix.com/)
         - [BSI IT-Grundschutz SYS.1.5 Virtualisation](https://www.bsi.bund.de/)
 
-        Learn more about scanning Nutanix in the [cnspec documentation](https://mondoo.com/docs/cnspec/).
+        Learn more about scanning Nutanix in the [cnspec documentation](https://mondoo.com/docs/cnspec).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     scoring_system: highest impact

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -28,7 +28,7 @@ policies:
         - Application sign-on and authentication policies
         - Threat insight and behavior detection
 
-        Learn more about scanning Okta in the [cnspec Okta documentation](https://mondoo.com/docs/cnspec/saas/okta).
+        Learn more about scanning Okta in the [cnspec Okta documentation](https://mondoo.com/docs/cnspec/identity/okta).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/querypacks/README.md
+++ b/content/querypacks/README.md
@@ -19,7 +19,7 @@ choco install cnspec
 # https://github.com/mondoohq/cnspec/releases
 ```
 
-For more installation options, see the [cnspec installation guide](https://mondoo.com/docs/cnspec/cnspec-adv-install/overview/).
+For more installation options, see the [cnspec installation guide](https://mondoo.com/docs/cnspec/install/overview).
 
 ### Verify installation
 
@@ -46,7 +46,7 @@ cnspec scan local -f mondoo-linux-inventory.mql.yaml
 
 After running a scan, cnspec displays the asset inventory.
 
-To learn more about querypacks, check out our [docs](https://mondoo.com/docs/cnquery/cnquery-run-pack).
+To learn more about querypacks, check out our [docs](https://mondoo.com/docs/cnspec/query-packs).
 
 ### Output Formats
 

--- a/content/querypacks/mondoo-dns-inventory.mql.yaml
+++ b/content/querypacks/mondoo-dns-inventory.mql.yaml
@@ -23,7 +23,7 @@ packs:
 
         ### Prerequisites
 
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql/)).
+        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
 
         ### Run query pack
 

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -23,7 +23,7 @@ packs:
 
         ### Prerequisites
 
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql/)).
+        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
 
         ### Run query pack
 

--- a/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -23,7 +23,7 @@ packs:
 
         ### Prerequisites
 
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql/)).
+        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
 
         ### Run query pack
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to cnspec Documentation
 
-This folder contains the user-facing documentation for cnspec. The content is synced to the [Mondoo docs site](https://mondoo.com/docs/cnspec/).
+This folder contains the user-facing documentation for cnspec. The content is synced to the [Mondoo docs site](https://mondoo.com/docs/cnspec).
 
 ## How the sync works
 


### PR DESCRIPTION
## What

Swept the codebase for `mondoo.com/docs` references, followed redirects on each, and updated the **32** (of 79) that no longer resolve directly. The other ~47 already point at canonical 200-OK pages and were left untouched.

### Page moves (path changed)

| Old | New |
|---|---|
| `…/cnquery/cnquery-run-pack` | `…/cnspec/query-packs` |
| `…/cnspec/cnspec-adv-install/overview/` | `…/cnspec/install/overview` |
| `…/cnspec/cnspec-platform/` | `…/cnspec/install/registration` |
| `…/cnspec/saas/okta` | `…/cnspec/identity/okta` |
| `…/mql/mql.write/` | `…/mql/mql-write` |
| `…/mql/resources/{aws,azure,core,gcp}-pack/` | `…/mql/resources/{aws,azure,core,gcp}` |

### Trailing-slash canonicalization

The site 301s these to the no-slash form: `…/docs/`, `…/cnspec/`, `…/mql/`, `…/mql/resources/`, `…/cnspec/write-policies/write-intro/`.

## Notes

- **`mql.write` → `mql-write`:** the site's redirect for the old path is lossy (lands on the generic `/mql` page), so this targets the real current article at `/mql/mql-write` (verified 200) instead of the degraded redirect.
- **`docs/*.mdx` left alone:** those use relative links (`/mql/mql-write`, no `/docs` prefix) — docs-site source, not `mondoo.com/docs` URLs.
- Changes are confined to markdown link text and YAML description strings; no code or query logic touched. Every new URL was re-verified to return a direct `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)