### PR TITLE
🧹 Rename portainer platform to portainer-server, drop saas tag

### DIFF
--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -8,7 +8,7 @@ policies:
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: portainer,saas
+      mondoo.com/platform: portainer,cloud
     require:
       - provider: portainer
       - provider: terraform
@@ -148,7 +148,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowPrivilegedModeForRegularUsers == false
       portainer.environments.all(securitySettings['allowPrivilegedModeForRegularUsers'] != true)
@@ -249,7 +249,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowBindMountsForRegularUsers == false
       portainer.environments.all(securitySettings['allowBindMountsForRegularUsers'] != true)
@@ -350,7 +350,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowDeviceMappingForRegularUsers == false
       portainer.environments.all(securitySettings['allowDeviceMappingForRegularUsers'] != true)
@@ -451,7 +451,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowHostNamespaceForRegularUsers == false
       portainer.environments.all(securitySettings['allowHostNamespaceForRegularUsers'] != true)
@@ -552,7 +552,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowContainerCapabilitiesForRegularUsers == false
       portainer.environments.all(securitySettings['allowContainerCapabilitiesForRegularUsers'] != true)
@@ -653,7 +653,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/access
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.allowVolumeBrowserForRegularUsers == false
       portainer.environments.all(securitySettings['allowVolumeBrowserForRegularUsers'] != true)
@@ -754,7 +754,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings/authentication
         title: Portainer Authentication Settings
   - uid: mondoo-portainer-security-settings-external-authentication-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.authenticationMethod != "internal"
   - uid: mondoo-portainer-security-settings-external-authentication-terraform-hcl
@@ -857,7 +857,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings/authentication
         title: Portainer Authentication Settings
   - uid: mondoo-portainer-security-settings-minimum-password-length-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     props:
       - uid: mondooPortainerSecurityMinPasswordLength
         mql: "12"
@@ -965,7 +965,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings
         title: Portainer Settings
   - uid: mondoo-portainer-security-settings-session-timeout-finite-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.userSessionTimeout != "0"
   - uid: mondoo-portainer-security-settings-session-timeout-finite-terraform-hcl
@@ -1069,7 +1069,7 @@ queries:
       - url: https://docs.portainer.io/admin/users
         title: Portainer User Management
   - uid: mondoo-portainer-security-users-limit-administrators-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     props:
       - uid: mondooPortainerSecurityMaxAdministrators
         mql: "5"
@@ -1119,7 +1119,7 @@ queries:
       - uid: mondooPortainerSecurityMaxApiTokenAge
         title: Maximum age in days for a user API token before it should be rotated
         mql: "90"
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.users.all(tokenIssueAt == null || tokenIssueAt > time.now - props.mondooPortainerSecurityMaxApiTokenAge * time.day)
     docs:
@@ -1245,7 +1245,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings/edge
         title: Portainer Edge Compute Settings
   - uid: mondoo-portainer-security-settings-edge-no-trust-on-first-connect-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.enableEdgeComputeFeatures == false || portainer.settings.trustOnFirstConnect == false
   - uid: mondoo-portainer-security-settings-edge-no-trust-on-first-connect-terraform-hcl
@@ -1342,7 +1342,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings/edge
         title: Portainer Edge Compute Settings
   - uid: mondoo-portainer-security-settings-edge-enforce-edge-id-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.enableEdgeComputeFeatures == false || portainer.settings.enforceEdgeId == true
   - uid: mondoo-portainer-security-settings-edge-enforce-edge-id-terraform-hcl
@@ -1441,7 +1441,7 @@ queries:
       - url: https://docs.portainer.io/admin/settings/kubernetes
         title: Portainer Kubernetes Settings
   - uid: mondoo-portainer-security-settings-disable-kube-shell-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.settings.disableKubeShell == true
   - uid: mondoo-portainer-security-settings-disable-kube-shell-terraform-hcl
@@ -1544,7 +1544,7 @@ queries:
       - url: https://docs.portainer.io/admin/environments/add/docker/agent
         title: Portainer Docker Agent Environments
   - uid: mondoo-portainer-security-environments-agent-tls-enabled-portainer
-    filters: asset.platform == "portainer"
+    filters: asset.platform == "portainer-server"
     mql: |
       portainer.environments.where(type == "agent-docker" || type == "agent-kubernetes").all(tlsEnabled == true)
   # The Terraform variants assert `tls_enabled != false` rather than `== true`: the provider


### PR DESCRIPTION
## What

[mondoohq/mql#8808](https://github.com/mondoohq/mql/pull/8808) renamed the Portainer provider's **platform** from `portainer` to `portainer-server`. The platform ID format (`.../instance/<id>`), the MQL resource name (`portainer`), and the provider plugin name are all unchanged — so asset identity and the `portainer.settings.*` / `portainer.environments.*` queries are unaffected.

This PR updates the `mondoo-portainer-security` policy accordingly:

- Updated all 15 runtime variant filters from `asset.platform == "portainer"` to `asset.platform == "portainer-server"`.
- Fixed the `mondoo.com/platform` tag. Its second value is the **technology group**, which was wrongly set to `saas`. Portainer is a self-hosted, on-prem container-management control plane, so the technology group is `cloud` — matching the on-prem cloud convention (`openstack,cloud`, `oci,cloud`, `aws,cloud`, …). The high-level platform family stays `portainer`, giving `portainer,cloud`.

## Out of scope (intentionally unchanged)

- `require: - provider: portainer` — provider plugin name is unchanged.
- `portainer.*` MQL queries — resource name is unchanged.
- Variant UID suffixes (`...-portainer`) — UIDs are stable identifiers; renaming would churn scoring identity and compliance maps for no functional gain.

## Validation

`cnspec policy lint ./content/mondoo-portainer-security.mql.yaml` → valid policy bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)