### PR TITLE
✨ stackit: score discovered sub-assets individually (per-asset checks)

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -38,30 +38,25 @@ policies:
         If you have questions, reach out to Mondoo at hello@mondoo.com.
     groups:
       - title: STACKIT Compute
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-compute-server-has-security-group
           - uid: mondoo-stackit-security-compute-volume-encrypted
       - title: STACKIT Networking
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-network-no-public-ssh
           - uid: mondoo-stackit-security-network-no-public-rdp
           - uid: mondoo-stackit-security-network-no-unrestricted-ingress
           - uid: mondoo-stackit-security-network-alb-target-security-groups
       - title: STACKIT Object Storage
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-objectstorage-bucket-object-lock
           - uid: mondoo-stackit-security-objectstorage-bucket-retention
       - title: STACKIT File Storage
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-sfs-resourcepool-restricted-ipacl
           - uid: mondoo-stackit-security-sfs-export-policy-restricted
           - uid: mondoo-stackit-security-sfs-resourcepool-snapshot-policy
       - title: STACKIT Managed Databases
-        filters: asset.platform == "stackit-project"
         docs:
           desc: |
             These checks cover the STACKIT managed-database engines (PostgreSQL Flex, MongoDB Flex, and SQLServer Flex).
@@ -86,31 +81,25 @@ policies:
           - uid: mondoo-stackit-security-db-mongodb-high-availability
           - uid: mondoo-stackit-security-db-sqlserver-high-availability
       - title: STACKIT Secrets Manager
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-secretsmanager-acl-restricted
       - title: STACKIT Identity & Access
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-serviceaccount-key-bounded-validity
           - uid: mondoo-stackit-security-serviceaccount-token-bounded-validity
       - title: STACKIT Key Management
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-kms-key-not-pending-deletion
           - uid: mondoo-stackit-security-kms-key-healthy-state
       - title: STACKIT Kubernetes (SKE)
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-ske-cluster-healthy
           - uid: mondoo-stackit-security-ske-cluster-auto-update
       - title: STACKIT Telemetry
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-telemetry-token-expiry-set
           - uid: mondoo-stackit-security-telemetry-token-not-expired
       - title: STACKIT Model Serving
-        filters: asset.platform == "stackit-project"
         checks:
           - uid: mondoo-stackit-security-modelserving-token-expiry-set
           - uid: mondoo-stackit-security-modelserving-token-not-expired
@@ -119,9 +108,9 @@ queries:
   - uid: mondoo-stackit-security-compute-server-has-security-group
     title: Ensure STACKIT servers are attached to a security group
     impact: 60
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-server"
     mql: |
-      stackit.servers.all(securityGroups.length > 0)
+      stackit.server.securityGroups.length > 0
     docs:
       desc: |
         This check ensures that every STACKIT compute server is associated with at least one security group. Security groups are the primary mechanism for controlling inbound and outbound network traffic to a server; a server with no security group attached has no stateful network filtering applied at the instance level.
@@ -370,9 +359,9 @@ queries:
   - uid: mondoo-stackit-security-objectstorage-bucket-object-lock
     title: Ensure STACKIT Object Storage buckets have Object Lock enabled
     impact: 70
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-object-storage-bucket"
     mql: |
-      stackit.objectStorage.buckets.all(objectLockEnabled == true)
+      stackit.objectStorage.bucket.objectLockEnabled == true
     docs:
       desc: |
         This check ensures that STACKIT Object Storage buckets have Object Lock (write-once-read-many, WORM) enabled. Object Lock protects objects from being overwritten or deleted for a defined retention period, which is important for compliance, ransomware resilience, and audit-log integrity.
@@ -404,9 +393,9 @@ queries:
   - uid: mondoo-stackit-security-objectstorage-bucket-retention
     title: Ensure Object-Locked buckets define a default retention period
     impact: 60
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-object-storage-bucket"
     mql: |
-      stackit.objectStorage.buckets.where(objectLockEnabled == true).all(defaultRetentionDays > 0)
+      stackit.objectStorage.bucket.objectLockEnabled == false || stackit.objectStorage.bucket.defaultRetentionDays > 0
     docs:
       desc: |
         This check ensures that STACKIT Object Storage buckets which have Object Lock enabled also define a default retention period greater than zero. Object Lock without a default retention leaves new objects unprotected unless retention is set per-object, which is easy to miss.
@@ -541,9 +530,9 @@ queries:
   - uid: mondoo-stackit-security-db-postgres-acl-restricted
     title: Ensure PostgreSQL Flex instances do not allow access from the internet
     impact: 90
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-postgres-flex-instance"
     mql: |
-      stackit.postgresFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
+      stackit.postgresFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
       desc: |
         This check ensures that STACKIT PostgreSQL Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
@@ -582,9 +571,9 @@ queries:
   - uid: mondoo-stackit-security-db-postgres-backups
     title: Ensure PostgreSQL Flex instances have a backup schedule configured
     impact: 60
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-postgres-flex-instance"
     mql: |
-      stackit.postgresFlex.instances.all(backupSchedule != "")
+      stackit.postgresFlex.instance.backupSchedule != ""
     docs:
       desc: |
         This check ensures that STACKIT PostgreSQL Flex instances have a backup schedule configured. Regular automated backups are essential for recovery from data loss, corruption, or ransomware.
@@ -624,9 +613,9 @@ queries:
   - uid: mondoo-stackit-security-db-mongodb-acl-restricted
     title: Ensure MongoDB Flex instances do not allow access from the internet
     impact: 90
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-mongodb-flex-instance"
     mql: |
-      stackit.mongoDbFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
+      stackit.mongoDbFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
       desc: |
         This check ensures that STACKIT MongoDB Flex instances do not include `0.0.0.0/0` in their access control list (ACL). Internet-reachable databases are a primary target for data theft and extortion.
@@ -665,9 +654,9 @@ queries:
   - uid: mondoo-stackit-security-db-mongodb-backups
     title: Ensure MongoDB Flex instances have a backup schedule configured
     impact: 60
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-mongodb-flex-instance"
     mql: |
-      stackit.mongoDbFlex.instances.all(backupSchedule != "")
+      stackit.mongoDbFlex.instance.backupSchedule != ""
     docs:
       desc: |
         This check ensures that STACKIT MongoDB Flex instances have a backup schedule configured. Automated backups provide recovery points after data loss, corruption, or ransomware.
@@ -707,9 +696,9 @@ queries:
   - uid: mondoo-stackit-security-db-sqlserver-acl-restricted
     title: Ensure SQLServer Flex instances do not allow access from the internet
     impact: 90
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-sqlserver-flex-instance"
     mql: |
-      stackit.sqlServerFlex.instances.all(acl.none(_ == "0.0.0.0/0" || _ == "::/0"))
+      stackit.sqlServerFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
       desc: |
         This check ensures that STACKIT SQLServer Flex instances do not include `0.0.0.0/0` in their access control list (ACL). A database reachable from the entire internet is exposed to brute-force, exploitation, and data-exfiltration attempts.
@@ -748,9 +737,9 @@ queries:
   - uid: mondoo-stackit-security-db-sqlserver-backups
     title: Ensure SQLServer Flex instances have a backup schedule configured
     impact: 60
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-sqlserver-flex-instance"
     mql: |
-      stackit.sqlServerFlex.instances.all(backupSchedule != "")
+      stackit.sqlServerFlex.instance.backupSchedule != ""
     docs:
       desc: |
         This check ensures that STACKIT SQLServer Flex instances have a backup schedule configured. Automated backups provide recovery points after data loss, corruption, or ransomware.
@@ -790,9 +779,9 @@ queries:
   - uid: mondoo-stackit-security-db-postgres-high-availability
     title: Ensure PostgreSQL Flex instances run with multiple replicas
     impact: 40
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-postgres-flex-instance"
     mql: |
-      stackit.postgresFlex.instances.all(replicas >= 2)
+      stackit.postgresFlex.instance.replicas >= 2
     docs:
       desc: |
         This check ensures that STACKIT PostgreSQL Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss. This mirrors the Multi-AZ / high-availability checks applied to managed databases on other clouds.
@@ -835,9 +824,9 @@ queries:
   - uid: mondoo-stackit-security-db-mongodb-high-availability
     title: Ensure MongoDB Flex instances run with multiple replicas
     impact: 40
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-mongodb-flex-instance"
     mql: |
-      stackit.mongoDbFlex.instances.all(replicas >= 2)
+      stackit.mongoDbFlex.instance.replicas >= 2
     docs:
       desc: |
         This check ensures that STACKIT MongoDB Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss.
@@ -883,9 +872,9 @@ queries:
   - uid: mondoo-stackit-security-db-sqlserver-high-availability
     title: Ensure SQLServer Flex instances run with multiple replicas
     impact: 40
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-sqlserver-flex-instance"
     mql: |
-      stackit.sqlServerFlex.instances.all(replicas >= 2)
+      stackit.sqlServerFlex.instance.replicas >= 2
     docs:
       desc: |
         This check ensures that STACKIT SQLServer Flex instances run with at least two replicas, providing high availability. A single-replica instance has no automatic failover, so a node failure causes downtime and potential data loss.
@@ -908,9 +897,9 @@ queries:
   - uid: mondoo-stackit-security-secretsmanager-acl-restricted
     title: Ensure Secrets Manager instances do not allow access from the internet
     impact: 85
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-secrets-manager-instance"
     mql: |
-      stackit.secretsManager.instances.all(acls.none(_ == "0.0.0.0/0" || _ == "::/0"))
+      stackit.secretsManager.instance.acls.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
       desc: |
         This check ensures that STACKIT Secrets Manager instances do not include `0.0.0.0/0` in their access control list. Secrets Manager stores sensitive credentials; exposing its API to the entire internet broadens the attack surface around your most sensitive data.
@@ -1041,9 +1030,9 @@ queries:
   - uid: mondoo-stackit-security-ske-cluster-healthy
     title: Ensure STACKIT SKE clusters are not in an unhealthy state
     impact: 40
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-ske-cluster"
     mql: |
-      stackit.ske.clusters.all(status != "STATE_UNHEALTHY")
+      stackit.ske.cluster.status != "STATE_UNHEALTHY"
     docs:
       desc: |
         This check ensures that no STACKIT Kubernetes Engine (SKE) cluster reports an unhealthy state. An unhealthy cluster may not be applying security updates, may have degraded control-plane components, and may not be enforcing intended policy. (Hibernated clusters are a valid operational state and are not flagged.)
@@ -1063,9 +1052,9 @@ queries:
   - uid: mondoo-stackit-security-ske-cluster-auto-update
     title: Ensure STACKIT SKE clusters enable Kubernetes version auto-update
     impact: 50
-    filters: asset.platform == "stackit-project"
+    filters: asset.platform == "stackit-ske-cluster"
     mql: |
-      stackit.ske.clusters.all(maintenance['autoUpdate']['kubernetesVersion'] == true)
+      stackit.ske.cluster.maintenance['autoUpdate']['kubernetesVersion'] == true
     docs:
       desc: |
         This check ensures that STACKIT Kubernetes Engine (SKE) clusters have automatic Kubernetes version updates enabled in their maintenance configuration. Clusters that do not auto-update can fall behind on security patches and run unsupported Kubernetes versions.

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -1078,15 +1078,7 @@ queries:
               project_id = var.project_id
               name       = "example"
 
-              node_pools = [
-                {
-                  name               = "np-example"
-                  machine_type       = "m1.medium"
-                  minimum            = 2
-                  maximum            = 3
-                  availability_zones = ["eu01-3"]
-                }
-              ]
+              # ... node_pools ...
 
               maintenance = {
                 enable_kubernetes_version_updates = true

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -95,6 +95,8 @@ policies:
         checks:
           - uid: mondoo-stackit-security-ske-cluster-healthy
           - uid: mondoo-stackit-security-ske-cluster-auto-update
+          - uid: mondoo-stackit-security-ske-apiserver-acl-enabled
+          - uid: mondoo-stackit-security-ske-apiserver-acl-restricted
       - title: STACKIT Telemetry
         checks:
           - uid: mondoo-stackit-security-telemetry-token-expiry-set
@@ -1088,6 +1090,86 @@ queries:
 
               maintenance = {
                 enable_kubernetes_version_updates = true
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
+        title: STACKIT Documentation - Kubernetes Engine (SKE)
+  - uid: mondoo-stackit-security-ske-apiserver-acl-enabled
+    title: Ensure STACKIT SKE clusters restrict Kubernetes API server access
+    impact: 80
+    filters: asset.platform == "stackit-ske-cluster"
+    mql: |
+      stackit.ske.cluster.apiServerAclEnabled == true
+    docs:
+      desc: |
+        This check ensures that a STACKIT Kubernetes Engine (SKE) cluster has the API-server access-control list (ACL) enabled. With the ACL disabled, the cluster's Kubernetes API server is reachable from any source address, exposing the control plane to the entire internet.
+
+        **Why this matters**
+
+        - **Control-plane exposure:** An unrestricted API server is continuously scanned and is a primary target for credential and exploit attacks.
+        - **Defense in depth:** An IP allow-list ensures only known networks can even attempt to authenticate to the cluster.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, open the SKE cluster settings and enable the API-server ACL, then add the CIDR ranges that should be allowed to reach the Kubernetes API.
+        - id: terraform
+          desc: |
+            Enable the API-server ACL and restrict it to known networks via the `extensions.acl` block on the `stackit_ske_cluster` resource:
+
+            ```hcl
+            resource "stackit_ske_cluster" "example" {
+              project_id = var.project_id
+              name       = "example"
+
+              # ... node_pools ...
+
+              extensions = {
+                acl = {
+                  enabled       = true
+                  allowed_cidrs = ["10.0.0.0/8"] # restrict to your admin/VPN networks
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.stackit.cloud/products/runtime/kubernetes-engine/
+        title: STACKIT Documentation - Kubernetes Engine (SKE)
+  - uid: mondoo-stackit-security-ske-apiserver-acl-restricted
+    title: Ensure STACKIT SKE API server ACL is not open to the internet
+    impact: 85
+    filters: asset.platform == "stackit-ske-cluster"
+    mql: |
+      stackit.ske.cluster.apiServerAclAllowedCidrs.none(_ == "0.0.0.0/0" || _ == "::/0")
+    docs:
+      desc: |
+        This check ensures that a STACKIT Kubernetes Engine (SKE) cluster's API-server access-control list does not allow `0.0.0.0/0` or `::/0`. An allow-list that includes the entire internet provides no protection — it is equivalent to disabling the ACL while appearing to be configured.
+
+        **Why this matters**
+
+        - **False sense of security:** A world-open entry in the allow-list defeats the purpose of the ACL.
+        - **Control-plane exposure:** Any host on the internet can reach the Kubernetes API server and attempt to authenticate.
+      remediation:
+        - id: console
+          desc: |
+            In the STACKIT Portal, edit the SKE cluster's API-server ACL and replace any `0.0.0.0/0` or `::/0` entry with the specific administrative or VPN CIDRs that require access.
+        - id: terraform
+          desc: |
+            Set `extensions.acl.allowed_cidrs` on the `stackit_ske_cluster` resource to specific networks, excluding `0.0.0.0/0` and `::/0`:
+
+            ```hcl
+            resource "stackit_ske_cluster" "example" {
+              project_id = var.project_id
+              name       = "example"
+
+              # ... node_pools ...
+
+              extensions = {
+                acl = {
+                  enabled       = true
+                  allowed_cidrs = ["10.0.0.0/8", "192.168.0.0/16"] # not 0.0.0.0/0
+                }
               }
             }
             ```


### PR DESCRIPTION
## What

Now that the STACKIT provider discovers sub-assets (databases, servers, SKE clusters, object-storage buckets, Secrets Manager) as individual assets, this restructures `mondoo-stackit-security` to **score each discovered asset on its own checks** — the same model the AWS and Azure policies use — instead of evaluating every resource collectively against the project root.

Depends on the STACKIT discovery + per-asset scoping in [mql#8803](https://github.com/mondoohq/mql/pull/8803).

## How

- **Groups are now plain containers** (no group-level `filters:`); each check carries its own `asset.platform` filter — mirroring the AWS policy.
- **15 checks** whose object type is discoverable now filter on the per-object platform and use the **singular** resource, e.g.:
  ```yaml
  filters: asset.platform == "stackit-postgres-flex-instance"
  mql: stackit.postgresFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
  ```
  Covers: compute server (security group), object-storage buckets (object lock + retention), the PostgreSQL/MongoDB/SQLServer Flex ACL/backup/HA checks, Secrets Manager ACL, and the SKE health/auto-update checks.
- **16 checks** stay scoped to `stackit-project` (security groups, ALB, volumes, SFS, service accounts, KMS, telemetry, model serving) because those object types are not discovered as separate assets.

## Validation

Provisioned a STACKIT project via Terraform (network/SG, PostgreSQL Flex, Secrets Manager, object-storage bucket, compute server, SKE cluster) with intentionally insecure settings, then scanned with `cnspec scan stackit --discover all`. Each asset was scored on its own checks and every expected pass/fail fired (e.g. world-open ACLs → CRITICAL on the DB/secrets assets, no object lock → HIGH on the bucket, auto-update disabled → MEDIUM on the SKE cluster). `cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
