### PR TITLE
🧹 stackit: bump Mondoo STACKIT Security policy to 1.1.0

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-stackit-security
     name: Mondoo STACKIT Security
-    version: 1.0.0
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## What

Bumps `mondoo-stackit-security` from **1.0.0 → 1.1.0**.

The policy was extended in [#2961](https://github.com/mondoohq/cnspec/pull/2961):
- Discovered sub-assets (databases, servers, SKE clusters, buckets, Secrets Manager) are now scored **individually** via per-asset checks, matching the AWS/Azure model.
- Added two SKE **Kubernetes API-server ACL** checks (ACL enabled + not open to `0.0.0.0/0`).

A minor version bump reflects the added coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
