### PR TITLE
✨ bump mql to expose `providers delete` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f
-	go.mondoo.com/mql/v13 v13.26.1
+	go.mondoo.com/mql/v13 v13.26.2-0.20260701163953-bee0986499aa
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f h1:iqu3c+zoWBcfcCvmik7YCF+93LezrHHZ8YDGaJQC4T8=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.26.1 h1:QcYzxWIQmtYzeizQojw2g0lLx9LL9IBMcnYnvU6sksE=
-go.mondoo.com/mql/v13 v13.26.1/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
+go.mondoo.com/mql/v13 v13.26.2-0.20260701163953-bee0986499aa h1:AOehQ+8YVRPzbeGqbiEEG9mz/G2incfcwl+0KjCiVRw=
+go.mondoo.com/mql/v13 v13.26.2-0.20260701163953-bee0986499aa/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/test/cli/testdata/cnspec_providers.ct
+++ b/test/cli/testdata/cnspec_providers.ct
@@ -6,6 +6,7 @@ Usage:
   cnspec providers [command]
 
 Available Commands:
+  delete      Remove an installed provider from disk
   info        Show detailed information about one or more providers
   install     Install or update a provider
   list        List all providers on the system


### PR DESCRIPTION
## What

Bumps `go.mondoo.com/mql/v13` to `v13.26.2-0.20260701163953-bee0986499aa`, which includes the new `providers delete <name>` subcommand ([mondoohq/mql#8866](https://github.com/mondoohq/mql/pull/8866)).

## How

cnspec reuses mql's `ProvidersCmd` wholesale (`apps/cnspec/cmd/providers.go` just does `rootCmd.AddCommand(cnquery_app.ProvidersCmd)`), so the new `delete` subcommand comes along for free — no additional wiring needed.

Now available:

```
cnspec providers delete aws          # remove an installed provider
cnspec providers delete all --yes    # remove every installed provider (requires --yes)
```

`delete all` without `--yes` refuses with a confirmation hint.

## Test

- `go mod tidy` clean (only `go.mod`/`go.sum` changed).
- `go build ./apps/...` passes.
- Verified `cnspec providers delete --help` renders the new command and the `all` + `--yes` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)