### PR TITLE
✨ aws: add 19 exposure, auth, and encryption security checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -72290,6 +72290,9 @@ queries:
 
   # No Terraform variants: public snapshot sharing is imperative restore-attribute state with no aws_db_snapshot
   # analog; the runtime check inspects the live share attribute.
+  # Per-snapshot granularity (asset.platform == "aws-rds-snapshot") mirrors the sibling rds-snapshot-encrypted
+  # check: the provider discovers RDS snapshots as individual assets, whereas DocumentDB snapshots are only
+  # enumerable via aws.documentdb.snapshots, so documentdb-snapshot-not-public evaluates per-account by design.
   - uid: mondoo-aws-security-rds-snapshot-not-public-aws
     filters: asset.platform == "aws-rds-snapshot"
     mql: aws.rds.snapshot.isPublic == false
@@ -73773,31 +73776,31 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.cognito.userPools.all(
-        clients.all(preventUserExistenceErrors != "LEGACY")
+        clients.all(preventUserExistenceErrors == "ENABLED")
       )
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool_client")
     mql: |
       terraform.resources("aws_cognito_user_pool_client").all(
-        arguments.prevent_user_existence_errors != "LEGACY"
+        arguments.prevent_user_existence_errors == "ENABLED"
       )
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cognito_user_pool_client")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_cognito_user_pool_client").all(
-        change.after.prevent_user_existence_errors != "LEGACY"
+        change.after.prevent_user_existence_errors == "ENABLED"
       )
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cognito_user_pool_client")
     mql: |
       terraform.state.resources.where(type == "aws_cognito_user_pool_client").all(
-        values.prevent_user_existence_errors != "LEGACY"
+        values.prevent_user_existence_errors == "ENABLED"
       )
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Cognito::UserPoolClient")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Cognito::UserPoolClient").all(
-      properties['PreventUserExistenceErrors'] != "LEGACY"
+      properties['PreventUserExistenceErrors'] == "ENABLED"
       )
 
   - uid: mondoo-aws-security-kms-key-no-public-access

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -196,6 +196,7 @@ policies:
           - uid: mondoo-aws-security-rds-instance-cmk-encryption
           - uid: mondoo-aws-security-rds-snapshot-cmk-encryption
           - uid: mondoo-aws-security-rds-instance-not-internet-reachable
+          - uid: mondoo-aws-security-rds-snapshot-not-public
       - title: Amazon RDS Proxy
         checks:
           - uid: mondoo-aws-security-rds-proxy-tls-required
@@ -271,6 +272,7 @@ policies:
         checks:
           - uid: mondoo-aws-security-efs-encrypted-check
           - uid: mondoo-aws-security-efs-backup-enabled
+          - uid: mondoo-aws-security-efs-filesystem-no-public-access
       - title: AWS CloudWatch
         checks:
           - uid: mondoo-aws-security-cloudwatch-log-group-encrypted
@@ -326,6 +328,7 @@ policies:
           - uid: mondoo-aws-security-kms-grants-no-create-grant
           - uid: mondoo-aws-security-kms-no-wildcard-grant-principals
           - uid: mondoo-aws-security-kms-key-origin-aws-kms
+          - uid: mondoo-aws-security-kms-key-no-public-access
       - title: Amazon SageMaker
         checks:
           - uid: mondoo-aws-security-sagemaker-model-network-isolation
@@ -439,6 +442,7 @@ policies:
       - title: AWS Backup
         checks:
           - uid: mondoo-aws-security-backup-vault-encrypted
+          - uid: mondoo-aws-security-backup-vault-no-public-access
       - title: Amazon FSx
         checks:
           - uid: mondoo-aws-security-fsx-filesystem-encrypted
@@ -449,6 +453,26 @@ policies:
           - uid: mondoo-aws-security-codebuild-no-plaintext-credentials
           - uid: mondoo-aws-security-codebuild-source-ssl-verification
           - uid: mondoo-aws-security-codebuild-encryption-key-configured
+          - uid: mondoo-aws-security-codebuild-not-public
+      - title: AWS App Runner
+        checks:
+          - uid: mondoo-aws-security-apprunner-service-not-public
+      - title: AWS AppSync
+        checks:
+          - uid: mondoo-aws-security-appsync-api-not-public
+          - uid: mondoo-aws-security-appsync-api-not-api-key-only
+      - title: Amazon Q Business
+        checks:
+          - uid: mondoo-aws-security-qbusiness-application-no-anonymous-access
+      - title: AWS Lake Formation
+        checks:
+          - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals
+      - title: Amazon Aurora DSQL
+        checks:
+          - uid: mondoo-aws-security-dsql-cluster-cmk-encryption
+      - title: AWS Storage Gateway
+        checks:
+          - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption
       - title: Amazon Neptune
         checks:
           - uid: mondoo-aws-security-neptune-cluster-encrypted
@@ -459,6 +483,9 @@ policies:
           - uid: mondoo-aws-security-neptune-cluster-log-export
           - uid: mondoo-aws-security-neptune-no-default-security-groups
           - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade
+      - title: Amazon Neptune Analytics
+        checks:
+          - uid: mondoo-aws-security-neptune-analytics-graph-not-public
       - title: Amazon Inspector
         checks:
           - uid: mondoo-aws-security-inspector-ec2-scanning-enabled
@@ -506,6 +533,8 @@ policies:
           - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced
           - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced
           - uid: mondoo-aws-security-cognito-domain-min-tls-1-2
+          - uid: mondoo-aws-security-cognito-client-no-user-password-auth
+          - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors
       - title: Amazon Cognito Identity Pool
         checks:
           - uid: mondoo-aws-security-cognito-identity-pool-no-unauthenticated
@@ -544,6 +573,7 @@ policies:
           - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade
           - uid: mondoo-aws-security-documentdb-instance-public-access-check
           - uid: mondoo-aws-security-documentdb-instance-not-internet-reachable
+          - uid: mondoo-aws-security-documentdb-snapshot-not-public
       - title: AWS Glue
         checks:
           - uid: mondoo-aws-security-glue-job-security-configuration
@@ -598,6 +628,7 @@ policies:
           - uid: mondoo-aws-security-emr-not-publicly-accessible
           - uid: mondoo-aws-security-emr-log-cmk-encryption
           - uid: mondoo-aws-security-emr-studio-cmk-encryption
+          - uid: mondoo-aws-security-emr-block-public-access-enabled
       - title: Amazon DynamoDB DAX
         checks:
           - uid: mondoo-aws-security-dax-encryption-at-rest
@@ -652,6 +683,8 @@ policies:
       - title: Amazon Bedrock
         checks:
           - uid: mondoo-aws-security-bedrock-custom-model-cmk-encryption
+          - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated
+          - uid: mondoo-aws-security-bedrock-agentcore-runtime-no-plaintext-secrets
       - title: AWS WAF
         checks:
           - uid: mondoo-aws-security-waf-managed-rule-groups
@@ -72174,3 +72207,2154 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-advanced.html
         title: DNS Firewall Advanced threat protection
+
+  # ── New checks (batch 1: public/anonymous exposure) ──────────────────────────
+  - uid: mondoo-aws-security-rds-snapshot-not-public
+    title: Ensure RDS snapshots are not publicly accessible
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-rds-snapshot-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS RDS Snapshot
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon RDS and Aurora DB snapshots are not shared publicly. A snapshot's restore attribute can be set to `all`, which lets any AWS account copy or restore the snapshot without any key or IAM grant.
+
+        **Why this matters**
+
+        - **Full database disclosure:** A public snapshot exposes every row of the source database to anyone on the internet who copies or restores it.
+        - **Bypasses network and IAM controls:** A restored copy lives in the attacker's account, outside the security groups, VPC, and IAM policies that protect the live instance.
+        - **Easy to set accidentally:** Public sharing is a single attribute change and is a recurring cause of large-scale data leaks.
+
+        **Risk mitigation**
+
+        - **Private by default:** Keeping snapshots private ensures only the owning account can restore them.
+        - **Controlled sharing:** When sharing is required, share with specific account IDs rather than `all`.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [RDS Console](https://console.aws.amazon.com/rds/) and choose **Snapshots**.
+        2. Select a snapshot, then choose **Actions** → **Share snapshot**.
+        3. Confirm the visibility is **Private** and no `all` entry appears under shared accounts.
+
+        A passing snapshot is private. A failing snapshot lists `all` under the accounts it is shared with.
+
+        ### Audit via CLI
+
+        1. List snapshots whose restore attribute includes `all`:
+
+        ```bash
+        aws rds describe-db-snapshot-attributes --db-snapshot-identifier <snapshot-id> \
+          --query "DBSnapshotAttributesResult.DBSnapshotAttributes[?AttributeName=='restore'].AttributeValues" --output text
+        ```
+
+        A passing snapshot returns no `all` value. A failing snapshot returns `all`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the RDS console and choose **Snapshots**.
+            2. Select the snapshot and choose **Actions** → **Share snapshot**.
+            3. Remove the **Public** entry (`all`) and, if sharing is needed, add specific AWS account IDs instead.
+        - id: cli
+          desc: |
+            Remove public visibility from the snapshot restore attribute:
+
+            ```bash
+            aws rds modify-db-snapshot-attribute \
+              --db-snapshot-identifier <snapshot-id> \
+              --attribute-name restore \
+              --values-to-remove all
+            ```
+        # No Terraform remediation: public snapshot sharing is an imperative restore-attribute change with no
+        # aws_db_snapshot argument that models it; use the console or CLI above.
+        # No CloudFormation remediation: AWS::RDS::DBSnapshot does not expose the restore/share attribute; use
+        # the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html
+        title: AWS Documentation - Sharing a DB snapshot
+
+  # No Terraform variants: public snapshot sharing is imperative restore-attribute state with no aws_db_snapshot
+  # analog; the runtime check inspects the live share attribute.
+  - uid: mondoo-aws-security-rds-snapshot-not-public-aws
+    filters: asset.platform == "aws-rds-snapshot"
+    mql: aws.rds.snapshot.isPublic == false
+
+  - uid: mondoo-aws-security-documentdb-snapshot-not-public
+    title: Ensure DocumentDB snapshots are not publicly accessible
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-documentdb-snapshot-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon DocumentDB cluster snapshots are not shared publicly. A snapshot's restore attribute can be set to `all`, allowing any AWS account to copy or restore it without any IAM or key grant.
+
+        **Why this matters**
+
+        - **Full document store disclosure:** A public snapshot exposes every collection in the source cluster to anyone who restores it.
+        - **Bypasses live-cluster controls:** A restored copy runs outside the security groups, VPC, and IAM policies protecting the original cluster.
+        - **Accidental exposure:** Public sharing is a single attribute change and easy to apply by mistake.
+
+        **Risk mitigation**
+
+        - **Private by default:** Keeping snapshots private ensures only the owning account can restore them.
+        - **Controlled sharing:** Share with specific account IDs rather than `all` when sharing is required.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon DocumentDB Console](https://console.aws.amazon.com/docdb/) and choose **Snapshots**.
+        2. Select a snapshot, then review **Actions** → **Share snapshot**.
+        3. Confirm the snapshot is **Private** with no `all` entry.
+
+        A passing snapshot is private. A failing snapshot is shared with `all`.
+
+        ### Audit via CLI
+
+        1. Check the snapshot restore attribute for `all`:
+
+        ```bash
+        aws docdb describe-db-cluster-snapshot-attributes \
+          --db-cluster-snapshot-identifier <snapshot-id> \
+          --query "DBClusterSnapshotAttributesResult.DBClusterSnapshotAttributes[?AttributeName=='restore'].AttributeValues" --output text
+        ```
+
+        A passing snapshot returns no `all` value. A failing snapshot returns `all`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Amazon DocumentDB console and choose **Snapshots**.
+            2. Select the snapshot and choose **Actions** → **Share snapshot**.
+            3. Remove the **Public** entry (`all`); share with specific AWS account IDs if required.
+        - id: cli
+          desc: |
+            Remove public visibility from the cluster snapshot restore attribute:
+
+            ```bash
+            aws docdb modify-db-cluster-snapshot-attribute \
+              --db-cluster-snapshot-identifier <snapshot-id> \
+              --attribute-name restore \
+              --values-to-remove all
+            ```
+        # No Terraform remediation: public snapshot sharing is an imperative restore-attribute change with no
+        # aws_docdb_cluster_snapshot analog; use the console or CLI above.
+        # No CloudFormation remediation: there is no CloudFormation resource for DocumentDB snapshot sharing; use
+        # the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/backup_restore-share_cluster_snapshots.html
+        title: AWS Documentation - Sharing Amazon DocumentDB cluster snapshots
+
+  # No Terraform variants: public snapshot sharing is imperative restore-attribute state with no Terraform analog.
+  - uid: mondoo-aws-security-documentdb-snapshot-not-public-aws
+    filters: asset.platform == "aws"
+    mql: aws.documentdb.snapshots.all(isPublic == false)
+
+  - uid: mondoo-aws-security-neptune-analytics-graph-not-public
+    title: Ensure Neptune Analytics graphs do not allow public connectivity
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-neptune-analytics-graph-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon Neptune Analytics graphs are created without public connectivity. When public connectivity is enabled, the graph endpoint is reachable from the public internet rather than only from within the VPC.
+
+        **Why this matters**
+
+        - **Internet-exposed graph data:** A public endpoint places the graph database directly on the internet, where it can be probed and attacked.
+        - **Expanded attack surface:** Public reachability removes the network boundary that would otherwise force traffic through private, controlled paths.
+        - **Sensitive relationships:** Graph databases frequently hold identity, fraud, and knowledge-graph data whose relationships are highly sensitive.
+
+        **Risk mitigation**
+
+        - **Private access only:** Disabling public connectivity restricts access to VPC-internal clients and private endpoints.
+        - **Defense in depth:** Private endpoints complement IAM and security-group controls to keep the graph off the public internet.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Neptune Console](https://console.aws.amazon.com/neptune/) and choose **Graphs** under Neptune Analytics.
+        2. Select a graph and review its **Connectivity** settings.
+        3. Confirm **Public connectivity** is disabled.
+
+        A passing graph has public connectivity disabled. A failing graph has it enabled.
+
+        ### Audit via CLI
+
+        1. Inspect the graph's public connectivity flag:
+
+        ```bash
+        aws neptune-graph get-graph --graph-identifier <graph-id> \
+          --query "PublicConnectivity" --output text
+        ```
+
+        A passing graph returns `False`. A failing graph returns `True`.
+      remediation:
+        - id: console
+          desc: |
+            Public connectivity is set at graph creation and cannot be toggled on an existing graph. Recreate the graph with public connectivity disabled:
+
+            1. Open the Neptune console and choose **Graphs**.
+            2. Create a new graph and leave **Public connectivity** disabled.
+            3. Migrate data to the new graph and delete the exposed one.
+        - id: cli
+          desc: |
+            Create a replacement graph with public connectivity disabled, then migrate:
+
+            ```bash
+            aws neptune-graph create-graph \
+              --graph-name example-graph \
+              --no-public-connectivity \
+              --provisioned-memory 16
+            ```
+        # No Terraform remediation: public connectivity is fixed at graph creation; recreate the graph with the
+        # console or CLI above rather than mutating it in place.
+        # No CloudFormation remediation: AWS::NeptuneGraph::Graph public connectivity cannot be changed after
+        # creation; recreate via the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vpc.html
+        title: AWS Documentation - Neptune Analytics VPC connectivity
+
+  # No Terraform variants: Neptune Analytics graph public connectivity is fixed at creation and evaluated from
+  # live graph state; the runtime check reads the resolved connectivity flag.
+  - uid: mondoo-aws-security-neptune-analytics-graph-not-public-aws
+    filters: asset.platform == "aws"
+    mql: aws.neptuneAnalytics.graphs.all(publicConnectivity == false)
+
+  # ── New checks (batch 2: public/anonymous exposure, cont.) ───────────────────
+  - uid: mondoo-aws-security-backup-vault-no-public-access
+    title: Ensure AWS Backup vault policies do not grant public access
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-backup-vault-no-public-access-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS Backup vault access policies do not grant access to anonymous or wildcard (`"*"`) principals. A vault access policy with a wildcard principal lets any AWS account list, copy, or restore the recovery points stored in the vault.
+
+        **Why this matters**
+
+        - **Backups hold the crown jewels:** Vaults contain point-in-time copies of databases, file systems, and volumes — often the single most sensitive dataset in the account.
+        - **Cross-account exfiltration:** A wildcard principal lets an external account copy recovery points into its own account and restore them outside all of your controls.
+        - **Bypasses live-resource protections:** Restored data is detached from the security groups, IAM policies, and encryption context that guarded the source.
+
+        **Risk mitigation**
+
+        - **Scoped sharing:** Granting the vault policy only to specific account or role ARNs keeps recovery points reachable solely by intended principals.
+        - **Defense in depth:** A restrictive vault policy complements vault encryption and IAM to prevent accidental exposure.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AWS Backup Console](https://console.aws.amazon.com/backup/) and choose **Backup vaults**.
+        2. Select a vault and open the **Access policy** tab.
+        3. Review the policy for any `Allow` statement whose `Principal` is `"*"` or `{"AWS": "*"}`.
+
+        A passing vault has no policy or no wildcard-principal `Allow` statement. A failing vault grants access to `"*"`.
+
+        ### Audit via CLI
+
+        1. Retrieve the vault access policy and inspect the principals:
+
+        ```bash
+        aws backup get-backup-vault-access-policy --backup-vault-name <vault-name> \
+          --query 'Policy' --output text
+        ```
+
+        A passing vault returns no policy or no wildcard principal. A failing vault returns an `Allow` statement with `"Principal": "*"`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the AWS Backup console and choose **Backup vaults**.
+            2. Select the vault and open the **Access policy** tab.
+            3. Remove any `Allow` statement with `"Principal": "*"` or `{"AWS": "*"}`, or scope it to specific account/role ARNs.
+        - id: cli
+          desc: |
+            Replace the vault policy with one scoped to specific principals:
+
+            ```bash
+            aws backup put-backup-vault-access-policy \
+              --backup-vault-name <vault-name> \
+              --policy file://scoped-vault-policy.json
+            ```
+        - id: terraform
+          desc: |
+            Build the vault policy with `aws_iam_policy_document` scoped to explicit principals rather than embedding `Principal = "*"`:
+
+            ```hcl
+            data "aws_iam_policy_document" "vault" {
+              statement {
+                effect    = "Allow"
+                actions   = ["backup:CopyIntoBackupVault"]
+                resources = ["*"]
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:root"]
+                }
+              }
+            }
+
+            resource "aws_backup_vault_policy" "example" {
+              backup_vault_name = aws_backup_vault.example.name
+              policy            = data.aws_iam_policy_document.vault.json
+            }
+            ```
+        # No CloudFormation remediation: AWS::Backup::BackupVault embeds the access policy inline; scope its
+        # AccessPolicy principals using the console, CLI, or Terraform examples above.
+    refs:
+      - url: https://docs.aws.amazon.com/aws-backup/latest/devguide/creating-a-vault-access-policy.html
+        title: AWS Documentation - Setting access policies on backup vaults
+
+  - uid: mondoo-aws-security-backup-vault-no-public-access-aws
+    filters: asset.platform == "aws"
+    mql: aws.backup.vaults.all(isPublic == false)
+  - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_backup_vault_policy")
+    mql: |
+      terraform.resources("aws_backup_vault_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_backup_vault_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_backup_vault_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-backup-vault-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_backup_vault_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_backup_vault_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+
+  - uid: mondoo-aws-security-efs-filesystem-no-public-access
+    title: Ensure EFS file system policies do not grant public access
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-efs-filesystem-no-public-access-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Amazon EFS file system policies do not grant access to anonymous or wildcard (`"*"`) principals. A file system policy that allows a wildcard principal exposes the NFS file system to any AWS account.
+
+        **Why this matters**
+
+        - **Direct file access:** A public file system policy lets unintended principals mount and read the file data.
+        - **Shared application state:** EFS commonly stores application configuration, user uploads, and shared state whose exposure is high impact.
+        - **Silent broad grants:** Wildcard principals are easy to introduce and hard to notice without an automated control.
+
+        **Risk mitigation**
+
+        - **Scoped policy:** Granting the file system policy only to specific roles or accounts keeps the data reachable solely by intended workloads.
+        - **Defense in depth:** A restrictive policy complements encryption, mount-target security groups, and access points.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon EFS Console](https://console.aws.amazon.com/efs/) and select a file system.
+        2. Choose the **File system policy** tab.
+        3. Review the policy for any `Allow` statement whose `Principal` is `"*"` or `{"AWS": "*"}`.
+
+        A passing file system has no policy or no wildcard-principal `Allow`. A failing one grants access to `"*"`.
+
+        ### Audit via CLI
+
+        1. Retrieve the file system policy:
+
+        ```bash
+        aws efs describe-file-system-policy --file-system-id <fs-id> \
+          --query 'Policy' --output text
+        ```
+
+        A passing file system returns no policy or no wildcard principal. A failing one returns an `Allow` statement with `"Principal": "*"`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Amazon EFS console and select the file system.
+            2. Choose the **File system policy** tab and **Edit**.
+            3. Remove any `Allow` statement with `"Principal": "*"` or `{"AWS": "*"}`, or scope it to specific role/account ARNs.
+        - id: cli
+          desc: |
+            Replace the file system policy with one scoped to specific principals:
+
+            ```bash
+            aws efs put-file-system-policy \
+              --file-system-id <fs-id> \
+              --policy file://scoped-fs-policy.json
+            ```
+        - id: terraform
+          desc: |
+            Build the file system policy with `aws_iam_policy_document` scoped to explicit principals:
+
+            ```hcl
+            data "aws_iam_policy_document" "efs" {
+              statement {
+                effect    = "Allow"
+                actions   = ["elasticfilesystem:ClientMount", "elasticfilesystem:ClientWrite"]
+                resources = [aws_efs_file_system.example.arn]
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:role/AppRole"]
+                }
+              }
+            }
+
+            resource "aws_efs_file_system_policy" "example" {
+              file_system_id = aws_efs_file_system.example.id
+              policy         = data.aws_iam_policy_document.efs.json
+            }
+            ```
+        # No CloudFormation remediation: AWS::EFS::FileSystem embeds FileSystemPolicy inline; scope its principals
+        # using the console, CLI, or Terraform examples above.
+    refs:
+      - url: https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html
+        title: AWS Documentation - Using IAM to control file system data access
+
+  - uid: mondoo-aws-security-efs-filesystem-no-public-access-aws
+    filters: asset.platform == "aws"
+    mql: aws.efs.filesystems.all(isPublic == false)
+  - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_efs_file_system_policy")
+    mql: |
+      terraform.resources("aws_efs_file_system_policy").all(
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_efs_file_system_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_efs_file_system_policy").all(
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_efs_file_system_policy")
+    mql: |
+      terraform.state.resources.where(type == "aws_efs_file_system_policy").all(
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+
+  - uid: mondoo-aws-security-codebuild-not-public
+    title: Ensure CodeBuild project build results are not publicly visible
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-codebuild-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-codebuild-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codebuild-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codebuild-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-codebuild-not-public-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that AWS CodeBuild projects do not set `projectVisibility` to `PUBLIC_READ`. A public project exposes its build logs, environment details, and artifacts to anyone on the internet without authentication.
+
+        **Why this matters**
+
+        - **Secret leakage:** Build logs frequently contain tokens, environment variables, and connection strings that become world-readable when the project is public.
+        - **Source and pipeline disclosure:** Public builds reveal build commands, dependencies, and internal tooling that aid an attacker.
+        - **No authentication barrier:** `PUBLIC_READ` removes the requirement to be an authenticated principal to view results.
+
+        **Risk mitigation**
+
+        - **Private by default:** Keeping projects at `PRIVATE` requires IAM authorization to view build results.
+        - **Controlled disclosure:** If public build badges or logs are genuinely required, publish only vetted artifacts through a separate, sanitized channel.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [CodeBuild Console](https://console.aws.amazon.com/codesuite/codebuild/) and select a build project.
+        2. Choose **Edit** → **Project configuration**.
+        3. Confirm **Enable public build access** is turned off.
+
+        A passing project is private. A failing project has public build access enabled.
+
+        ### Audit via CLI
+
+        1. Check each project's visibility:
+
+        ```bash
+        aws codebuild batch-get-projects --names <project-name> \
+          --query 'projects[*].{Name:name,Visibility:projectVisibility}' --output table
+        ```
+
+        A passing project returns `PRIVATE`. A failing project returns `PUBLIC_READ`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the CodeBuild console and select the project.
+            2. Choose **Edit** → **Project configuration**.
+            3. Turn off **Enable public build access** and save.
+        - id: cli
+          desc: |
+            Set the project visibility back to private:
+
+            ```bash
+            aws codebuild update-project-visibility \
+              --project-arn <project-arn> \
+              --project-visibility PRIVATE
+            ```
+        - id: terraform
+          desc: |
+            Ensure `project_visibility` is `PRIVATE` (the default) on the CodeBuild project:
+
+            ```hcl
+            resource "aws_codebuild_project" "example" {
+              name               = "example"
+              project_visibility = "PRIVATE"
+              # ... service_role, source, environment, artifacts ...
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            Set the project `Visibility` to `PRIVATE`:
+
+            ```yaml
+            Resources:
+              Project:
+                Type: AWS::CodeBuild::Project
+                Properties:
+                  Name: example
+                  Visibility: PRIVATE
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/codebuild/latest/userguide/public-builds.html
+        title: AWS Documentation - Public build projects in AWS CodeBuild
+
+  - uid: mondoo-aws-security-codebuild-not-public-aws
+    filters: asset.platform == "aws"
+    mql: aws.codebuild.projects.all(projectVisibility != "PUBLIC_READ")
+  - uid: mondoo-aws-security-codebuild-not-public-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
+    mql: |
+      terraform.resources("aws_codebuild_project").all(
+        arguments.project_visibility != "PUBLIC_READ"
+      )
+  - uid: mondoo-aws-security-codebuild-not-public-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_codebuild_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_codebuild_project").all(
+        change.after.project_visibility != "PUBLIC_READ"
+      )
+  - uid: mondoo-aws-security-codebuild-not-public-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_codebuild_project")
+    mql: |
+      terraform.state.resources.where(type == "aws_codebuild_project").all(
+        values.project_visibility != "PUBLIC_READ"
+      )
+  - uid: mondoo-aws-security-codebuild-not-public-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::CodeBuild::Project")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::CodeBuild::Project").all(
+      properties['Visibility'] == empty || properties['Visibility'] != "PUBLIC_READ"
+      )
+
+  - uid: mondoo-aws-security-apprunner-service-not-public
+    title: Ensure App Runner services are not publicly accessible
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-apprunner-service-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that AWS App Runner services are not reachable from the public internet through a public ingress endpoint. When public network access is enabled, the service URL is served to any client on the internet. Services intended to sit behind a VPC, load balancer, or private endpoint should disable public ingress.
+
+        **Why this matters**
+
+        - **Direct internet exposure:** A public service endpoint is immediately reachable and scannable by anyone, expanding the attack surface of the application.
+        - **Bypasses perimeter controls:** Public ingress skips any WAF, private load balancer, or VPC boundary the organization relies on for internet-facing traffic.
+        - **Unintended defaults:** App Runner enables public ingress by default, so internal services are exposed unless explicitly restricted.
+
+        **Risk mitigation**
+
+        - **Private ingress:** Disabling public network access restricts the service to VPC clients reaching it through a private endpoint.
+        - **Controlled exposure:** Genuinely public applications should front App Runner with a WAF-protected distribution rather than exposing the raw service URL.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [App Runner Console](https://console.aws.amazon.com/apprunner/) and select a service.
+        2. Choose the **Networking** tab and review **Incoming network traffic**.
+        3. Confirm public network access is disabled for services that should be private.
+
+        A passing service uses private (VPC) incoming access. A failing service allows public incoming access.
+
+        ### Audit via CLI
+
+        1. Inspect the ingress configuration for each service:
+
+        ```bash
+        aws apprunner describe-service --service-arn <service-arn> \
+          --query 'Service.NetworkConfiguration.IngressConfiguration.IsPubliclyAccessible' --output text
+        ```
+
+        A passing service returns `False`. A failing service returns `True`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the App Runner console and select the service.
+            2. Choose the **Networking** tab and **Edit**.
+            3. Under **Incoming network traffic**, choose **Private endpoint (VPC)** and select the VPC ingress connection.
+        - id: cli
+          desc: |
+            Update the service to use private ingress:
+
+            ```bash
+            aws apprunner update-service \
+              --service-arn <service-arn> \
+              --network-configuration 'IngressConfiguration={IsPubliclyAccessible=false}'
+            ```
+        # No Terraform variants: the aws_apprunner_service ingress_configuration.is_publicly_accessible argument
+        # defaults to true when the block is omitted, so a nested-block HCL check would pass default-public
+        # services vacuously; the runtime check reads the resolved ingress state.
+        # No CloudFormation remediation: the resolved public-ingress state is evaluated at runtime; set
+        # NetworkConfiguration.IngressConfiguration.IsPubliclyAccessible=false in the template as shown, using
+        # the console or CLI above to remediate existing services.
+    refs:
+      - url: https://docs.aws.amazon.com/apprunner/latest/dg/network-pl.html
+        title: AWS Documentation - Enabling private endpoints for incoming traffic
+
+  # No Terraform variants: is_publicly_accessible defaults to true when the ingress block is omitted, so an HCL
+  # check would pass default-public services vacuously; the runtime check reads the resolved ingress state.
+  - uid: mondoo-aws-security-apprunner-service-not-public-aws
+    filters: asset.platform == "aws"
+    mql: aws.apprunner.services.all(isPubliclyAccessible == false)
+
+  - uid: mondoo-aws-security-appsync-api-not-public
+    title: Ensure AppSync GraphQL APIs use private visibility
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-appsync-api-not-public-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-appsync-api-not-public-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appsync-api-not-public-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appsync-api-not-public-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS AppSync GraphQL APIs use `PRIVATE` visibility so the endpoint is reachable only from within a VPC through interface endpoints, rather than `GLOBAL` visibility which exposes it on the public internet. Apply this to APIs that serve internal workloads; APIs intentionally serving public clients should be excluded from the check.
+
+        **Why this matters**
+
+        - **Internet-exposed API:** A `GLOBAL` endpoint is directly reachable from the internet, where it can be enumerated and attacked.
+        - **Schema and data reachability:** Public reachability combined with weak auth or introspection lets attackers map and query the API.
+        - **Default is public:** New AppSync APIs default to `GLOBAL`, so internal APIs are exposed unless explicitly set to `PRIVATE`.
+
+        **Risk mitigation**
+
+        - **VPC-only access:** `PRIVATE` visibility confines the API to private interface endpoints inside the VPC.
+        - **Defense in depth:** Private visibility complements authorization, WAF, and logging controls for GraphQL APIs.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AppSync Console](https://console.aws.amazon.com/appsync/) and select an API.
+        2. Open **Settings** and review the **API visibility** value.
+        3. Confirm internal APIs are set to **Private**.
+
+        A passing internal API shows `PRIVATE`. A failing internal API shows `GLOBAL`.
+
+        ### Audit via CLI
+
+        1. Check the visibility of each GraphQL API:
+
+        ```bash
+        aws appsync list-graphql-apis \
+          --query 'graphqlApis[*].{Name:name,Visibility:visibility}' --output table
+        ```
+
+        A passing internal API returns `PRIVATE`. A failing internal API returns `GLOBAL`.
+      remediation:
+        - id: console
+          desc: |
+            API visibility is fixed at creation. Recreate the API with private visibility:
+
+            1. Open the AppSync console and create a new API.
+            2. Under **API visibility**, choose **Private**.
+            3. Recreate resolvers and data sources, then delete the public API.
+        - id: cli
+          desc: |
+            Create a replacement API with `PRIVATE` visibility, then migrate:
+
+            ```bash
+            aws appsync create-graphql-api \
+              --name example-private \
+              --authentication-type AWS_IAM \
+              --visibility PRIVATE
+            ```
+        - id: terraform
+          desc: |
+            Set `visibility = "PRIVATE"` on the AppSync API (changing this forces replacement):
+
+            ```hcl
+            resource "aws_appsync_graphql_api" "example" {
+              name                = "example-private"
+              authentication_type = "AWS_IAM"
+              visibility          = "PRIVATE"
+            }
+            ```
+        # No CloudFormation remediation: AWS::AppSync::GraphQLApi Visibility is immutable after creation; recreate
+        # the API with Visibility set to PRIVATE using the console, CLI, or Terraform examples above.
+    refs:
+      - url: https://docs.aws.amazon.com/appsync/latest/devguide/using-private-apis.html
+        title: AWS Documentation - Using AWS AppSync Private APIs
+
+  - uid: mondoo-aws-security-appsync-api-not-public-aws
+    filters: asset.platform == "aws"
+    mql: aws.appsync.apis.all(visibility == "PRIVATE")
+  - uid: mondoo-aws-security-appsync-api-not-public-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appsync_graphql_api")
+    mql: |
+      terraform.resources("aws_appsync_graphql_api").all(
+        arguments.visibility == "PRIVATE"
+      )
+  - uid: mondoo-aws-security-appsync-api-not-public-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_appsync_graphql_api")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_appsync_graphql_api").all(
+        change.after.visibility == "PRIVATE"
+      )
+  - uid: mondoo-aws-security-appsync-api-not-public-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_appsync_graphql_api")
+    mql: |
+      terraform.state.resources.where(type == "aws_appsync_graphql_api").all(
+        values.visibility == "PRIVATE"
+      )
+
+  - uid: mondoo-aws-security-emr-block-public-access-enabled
+    title: Ensure EMR account-level block public access is enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-emr-block-public-access-enabled-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that the account-level EMR block public access configuration blocks public security group rules. This guardrail prevents launching a cluster whose security groups allow inbound traffic from the public internet on ports other than the configured exceptions.
+
+        **Why this matters**
+
+        - **Account-wide safety net:** Block public access stops publicly reachable clusters from being created even when a security group is misconfigured.
+        - **Protects big-data workloads:** EMR clusters process large volumes of sensitive data and expose service ports that must not face the internet.
+        - **Defense against drift:** The guardrail catches individual clusters that would otherwise slip through per-cluster review.
+
+        **Risk mitigation**
+
+        - **Prevents public clusters:** Blocking public security group rules keeps new clusters off the public internet by default.
+        - **Complements per-cluster checks:** The account guardrail backs up security-group and per-cluster public-access controls.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [EMR Console](https://console.aws.amazon.com/emr/) and choose **Block public access** under settings.
+        2. Confirm **Block public access** is **On**.
+
+        A passing account has block public access enabled. A failing account has it disabled.
+
+        ### Audit via CLI
+
+        1. Retrieve the account block public access configuration:
+
+        ```bash
+        aws emr get-block-public-access-configuration \
+          --query 'BlockPublicAccessConfiguration.BlockPublicSecurityGroupRules' --output text
+        ```
+
+        A passing account returns `True`. A failing account returns `False`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the EMR console and choose **Block public access**.
+            2. Turn **Block public access** **On** and save.
+        - id: cli
+          desc: |
+            Enable block public access at the account level:
+
+            ```bash
+            aws emr put-block-public-access-configuration \
+              --block-public-access-configuration 'BlockPublicSecurityGroupRules=true'
+            ```
+        # No Terraform variants: EMR block public access is a single account-level configuration evaluated from
+        # live account state; the runtime check reads the resolved configuration.
+        # No CloudFormation remediation: there is no CloudFormation resource for the EMR account block-public-access
+        # configuration; use the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-block-public-access.html
+        title: AWS Documentation - Using Amazon EMR block public access
+
+  # No Terraform variants: EMR block public access is a single account-level configuration read from live state.
+  - uid: mondoo-aws-security-emr-block-public-access-enabled-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.emr.blockPublicAccessConfiguration != empty &&
+      aws.emr.blockPublicAccessConfiguration['BlockPublicSecurityGroupRules'] == true
+
+  - uid: mondoo-aws-security-qbusiness-application-no-anonymous-access
+    title: Ensure Q Business applications do not allow anonymous access
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-qbusiness-application-no-anonymous-access-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon Q Business applications are not configured with the `ANONYMOUS` identity type. An anonymous application serves generative answers over connected enterprise content without authenticating the end user.
+
+        **Why this matters**
+
+        - **Unauthenticated access to enterprise data:** Q Business grounds answers in connected corporate sources; anonymous access can surface that content to unauthenticated users.
+        - **No per-user authorization:** Without an identity, access-control-list enforcement tied to the user cannot be applied to responses.
+        - **Data governance gap:** Anonymous mode removes the audit trail of who asked what against sensitive knowledge bases.
+
+        **Risk mitigation**
+
+        - **Authenticated identity:** Using IAM Identity Center or an IdP-backed identity type ties every request to an authenticated, authorized user.
+        - **ACL enforcement:** An authenticated identity enables document-level access control on retrieved content.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon Q Business Console](https://console.aws.amazon.com/amazonq/) and select an application.
+        2. Review the application's **Access management / user access** configuration.
+        3. Confirm the application uses an authenticated identity type rather than anonymous access.
+
+        A passing application uses an authenticated identity type. A failing application uses `ANONYMOUS`.
+
+        ### Audit via CLI
+
+        1. Inspect the identity type of each application:
+
+        ```bash
+        aws qbusiness get-application --application-id <application-id> \
+          --query 'identityType' --output text
+        ```
+
+        A passing application returns an authenticated value such as `AWS_IAM_IDC`. A failing application returns `ANONYMOUS`.
+      remediation:
+        - id: console
+          desc: |
+            The identity type is fixed at application creation. Recreate the application with an authenticated identity:
+
+            1. Open the Amazon Q Business console and create a new application.
+            2. Choose **AWS IAM Identity Center** (or an IdP-backed identity type) for user access.
+            3. Reconnect data sources and delete the anonymous application.
+        - id: cli
+          desc: |
+            Create a replacement application bound to IAM Identity Center, then migrate:
+
+            ```bash
+            aws qbusiness create-application \
+              --display-name example \
+              --identity-type AWS_IAM_IDC \
+              --identity-center-instance-arn <identity-center-arn>
+            ```
+        # No Terraform variants: the Q Business application identity type is fixed at creation and evaluated from
+        # live application state; the runtime check reads the resolved identity type.
+        # No CloudFormation remediation: the AWS::QBusiness::Application IdentityType is immutable after creation;
+        # recreate the application with an authenticated identity using the console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/create-app.html
+        title: AWS Documentation - Creating an Amazon Q Business application
+
+  # No Terraform variants: Q Business application identity type is fixed at creation and read from live state.
+  - uid: mondoo-aws-security-qbusiness-application-no-anonymous-access-aws
+    filters: asset.platform == "aws"
+    mql: aws.qBusiness.applications.all(identityType != "ANONYMOUS")
+
+  # ── New checks (batch 3: authentication, least privilege, encryption, secrets) ─
+  - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated
+    title: Ensure Bedrock AgentCore gateways require authentication
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon Bedrock AgentCore gateways set an inbound authorizer rather than `NONE`. A gateway with `authorizerType` set to `NONE` accepts tool-invocation requests without authenticating the caller.
+
+        **Why this matters**
+
+        - **Unauthenticated tool execution:** An AgentCore gateway brokers agent access to backend tools and APIs; without an authorizer, any caller that reaches the gateway URL can drive those actions.
+        - **Pivot into backends:** The gateway's targets (Lambda functions, OpenAPI/Smithy backends) run with the gateway's credentials, so unauthenticated access can reach internal systems.
+        - **Agentic blast radius:** Model-driven tool calls amplify the impact of an open endpoint far beyond a static API.
+
+        **Risk mitigation**
+
+        - **Enforced identity:** Requiring a JWT or IAM authorizer ties every invocation to an authenticated principal.
+        - **Least privilege:** Authenticated access is a prerequisite for scoping which callers may use which gateway targets.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon Bedrock Console](https://console.aws.amazon.com/bedrock/) and choose **AgentCore** → **Gateways**.
+        2. Select a gateway and review its **Inbound authentication** configuration.
+        3. Confirm an authorizer (Custom JWT or IAM) is configured.
+
+        A passing gateway uses an authorizer. A failing gateway has inbound authentication set to none.
+
+        ### Audit via CLI
+
+        1. Inspect the authorizer type for each gateway:
+
+        ```bash
+        aws bedrock-agentcore-control get-gateway --gateway-identifier <gateway-id> \
+          --query 'authorizerType' --output text
+        ```
+
+        A passing gateway returns `CUSTOM_JWT` or `AWS_IAM`. A failing gateway returns `NONE`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Bedrock console and choose **AgentCore** → **Gateways**.
+            2. Edit the gateway and configure **Inbound authentication** with a Custom JWT authorizer or AWS IAM.
+            3. Save and update clients to present credentials.
+        - id: cli
+          desc: |
+            Update the gateway to require an authorizer:
+
+            ```bash
+            aws bedrock-agentcore-control update-gateway \
+              --gateway-identifier <gateway-id> \
+              --authorizer-type CUSTOM_JWT \
+              --authorizer-configuration file://jwt-authorizer.json
+            ```
+        # No Terraform variants: Bedrock AgentCore gateways have no stable Terraform resource; the runtime check
+        # reads the resolved inbound authorizer type.
+        # No CloudFormation remediation: there is no CloudFormation resource for AgentCore gateways; use the
+        # console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-authentication.html
+        title: AWS Documentation - AgentCore Gateway authentication
+
+  # No Terraform variants: Bedrock AgentCore gateways have no stable Terraform resource; runtime state only.
+  - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated-aws
+    filters: asset.platform == "aws"
+    mql: aws.bedrock.agentCore.gateways.all(authorizerType != "NONE")
+
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only
+    title: Ensure AppSync GraphQL APIs do not use API key as the sole auth type
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-aws-security-appsync-api-not-api-key-only-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-appsync-api-not-api-key-only-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that AWS AppSync GraphQL APIs do not use `API_KEY` as their primary authentication type. API keys are static, long-lived shared secrets that identify no user and are trivially reusable if leaked.
+
+        **Why this matters**
+
+        - **Static shared secret:** An API key is a bearer credential with no user identity; anyone who obtains it can call the API.
+        - **Weak revocation story:** Leaked keys remain valid until manually rotated, and a single key is often shared across many clients.
+        - **No authorization context:** API-key auth cannot express per-user or per-role authorization on GraphQL operations.
+
+        **Risk mitigation**
+
+        - **Identity-based auth:** Using Amazon Cognito user pools, OIDC, IAM, or Lambda authorizers ties requests to authenticated principals.
+        - **Scoped access:** Identity-based authentication enables per-operation authorization rather than all-or-nothing key access.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [AppSync Console](https://console.aws.amazon.com/appsync/) and select an API.
+        2. Open **Settings** and review the **Default authorization mode**.
+        3. Confirm it is not **API key**.
+
+        A passing API uses Cognito, OIDC, IAM, or Lambda as its primary authorization mode. A failing API uses **API key**.
+
+        ### Audit via CLI
+
+        1. Check the primary authentication type of each API:
+
+        ```bash
+        aws appsync list-graphql-apis \
+          --query 'graphqlApis[*].{Name:name,Auth:authenticationType}' --output table
+        ```
+
+        A passing API returns a value other than `API_KEY`. A failing API returns `API_KEY`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the AppSync console and select the API.
+            2. Open **Settings** and change the **Default authorization mode** to Amazon Cognito user pools, OIDC, IAM, or a Lambda authorizer.
+            3. Update clients to send the new credentials.
+        - id: cli
+          desc: |
+            Update the API to an identity-based primary auth type:
+
+            ```bash
+            aws appsync update-graphql-api \
+              --api-id <api-id> \
+              --name <api-name> \
+              --authentication-type AMAZON_COGNITO_USER_POOLS \
+              --user-pool-config userPoolId=<pool-id>,awsRegion=<region>,defaultAction=DENY
+            ```
+        - id: terraform
+          desc: |
+            Set `authentication_type` to an identity-based mode on the AppSync API:
+
+            ```hcl
+            resource "aws_appsync_graphql_api" "example" {
+              name                = "example"
+              authentication_type = "AMAZON_COGNITO_USER_POOLS"
+
+              user_pool_config {
+                user_pool_id   = aws_cognito_user_pool.example.id
+                default_action = "DENY"
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            Set `AuthenticationType` to an identity-based mode:
+
+            ```yaml
+            Resources:
+              GraphQLApi:
+                Type: AWS::AppSync::GraphQLApi
+                Properties:
+                  Name: example
+                  AuthenticationType: AMAZON_COGNITO_USER_POOLS
+                  UserPoolConfig:
+                    UserPoolId: !Ref UserPool
+                    DefaultAction: DENY
+                    AwsRegion: !Ref AWS::Region
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html
+        title: AWS Documentation - Authorization and authentication in AWS AppSync
+
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only-aws
+    filters: asset.platform == "aws"
+    mql: aws.appsync.apis.all(authenticationType != "API_KEY")
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appsync_graphql_api")
+    mql: |
+      terraform.resources("aws_appsync_graphql_api").all(
+        arguments.authentication_type != "API_KEY"
+      )
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_appsync_graphql_api")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_appsync_graphql_api").all(
+        change.after.authentication_type != "API_KEY"
+      )
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_appsync_graphql_api")
+    mql: |
+      terraform.state.resources.where(type == "aws_appsync_graphql_api").all(
+        values.authentication_type != "API_KEY"
+      )
+  - uid: mondoo-aws-security-appsync-api-not-api-key-only-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::AppSync::GraphQLApi")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::AppSync::GraphQLApi").all(
+      properties['AuthenticationType'] == empty || properties['AuthenticationType'] != "API_KEY"
+      )
+
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth
+    title: Ensure Cognito app clients disable the USER_PASSWORD_AUTH flow
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-aws-security-cognito-client-no-user-password-auth-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-no-user-password-auth-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon Cognito user pool app clients do not enable the `ALLOW_USER_PASSWORD_AUTH` (or legacy `USER_PASSWORD_AUTH`) authentication flow. That flow sends the user's plaintext password to the Cognito API instead of using the Secure Remote Password (SRP) protocol.
+
+        **Why this matters**
+
+        - **Plaintext password transmission:** `USER_PASSWORD_AUTH` transmits the raw password to the service, defeating SRP's design goal of never sending the password.
+        - **Credential-stuffing exposure:** Password-based flows are directly usable by automated credential-stuffing and brute-force tooling.
+        - **Weaker than available default:** SRP-based `ALLOW_USER_SRP_AUTH` provides equivalent functionality without exposing the password.
+
+        **Risk mitigation**
+
+        - **SRP authentication:** Restricting clients to `ALLOW_USER_SRP_AUTH` keeps passwords off the wire.
+        - **Reduced attack surface:** Disabling the password flow removes a direct target for automated guessing attacks.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon Cognito Console](https://console.aws.amazon.com/cognito/) and select a user pool.
+        2. Choose **App integration** → the app client, then review **Authentication flows**.
+        3. Confirm **ALLOW_USER_PASSWORD_AUTH** is not enabled.
+
+        A passing client omits the password flow. A failing client has `ALLOW_USER_PASSWORD_AUTH` enabled.
+
+        ### Audit via CLI
+
+        1. Inspect the explicit auth flows of each app client:
+
+        ```bash
+        aws cognito-idp describe-user-pool-client \
+          --user-pool-id <pool-id> --client-id <client-id> \
+          --query 'UserPoolClient.ExplicitAuthFlows' --output text
+        ```
+
+        A passing client returns flows without `ALLOW_USER_PASSWORD_AUTH`. A failing client includes it.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Cognito console and select the user pool and app client.
+            2. Under **Authentication flows**, clear **ALLOW_USER_PASSWORD_AUTH** and enable **ALLOW_USER_SRP_AUTH** instead.
+            3. Save changes and update clients to use SRP.
+        - id: cli
+          desc: |
+            Update the client's explicit auth flows to exclude the password flow:
+
+            ```bash
+            aws cognito-idp update-user-pool-client \
+              --user-pool-id <pool-id> --client-id <client-id> \
+              --explicit-auth-flows ALLOW_USER_SRP_AUTH ALLOW_REFRESH_TOKEN_AUTH
+            ```
+        - id: terraform
+          desc: |
+            Set `explicit_auth_flows` on the app client to SRP-based flows only:
+
+            ```hcl
+            resource "aws_cognito_user_pool_client" "example" {
+              name         = "example"
+              user_pool_id = aws_cognito_user_pool.example.id
+
+              explicit_auth_flows = [
+                "ALLOW_USER_SRP_AUTH",
+                "ALLOW_REFRESH_TOKEN_AUTH",
+              ]
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            Set `ExplicitAuthFlows` to SRP-based flows only:
+
+            ```yaml
+            Resources:
+              UserPoolClient:
+                Type: AWS::Cognito::UserPoolClient
+                Properties:
+                  UserPoolId: !Ref UserPool
+                  ExplicitAuthFlows:
+                    - ALLOW_USER_SRP_AUTH
+                    - ALLOW_REFRESH_TOKEN_AUTH
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html
+        title: AWS Documentation - User pool authentication flow
+
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.cognito.userPools.all(
+        clients.all(
+          explicitAuthFlows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
+        )
+      )
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.resources("aws_cognito_user_pool_client").all(
+        arguments.explicit_auth_flows == empty ||
+        arguments.explicit_auth_flows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
+      )
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cognito_user_pool_client").all(
+        change.after.explicit_auth_flows == empty ||
+        change.after.explicit_auth_flows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
+      )
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.state.resources.where(type == "aws_cognito_user_pool_client").all(
+        values.explicit_auth_flows == empty ||
+        values.explicit_auth_flows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
+      )
+  - uid: mondoo-aws-security-cognito-client-no-user-password-auth-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Cognito::UserPoolClient")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::Cognito::UserPoolClient").all(
+      properties['ExplicitAuthFlows'] == empty ||
+      properties['ExplicitAuthFlows'].none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
+      )
+
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors
+    title: Ensure Cognito app clients prevent user existence errors
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-11
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
+    variants:
+      - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon Cognito user pool app clients set `PreventUserExistenceErrors` to `ENABLED` rather than the legacy behavior. When enabled, authentication and password-reset responses do not reveal whether a given username exists.
+
+        **Why this matters**
+
+        - **Account enumeration:** Legacy behavior returns distinct errors for existing vs. non-existing users, letting attackers enumerate valid accounts.
+        - **Targets follow-on attacks:** A confirmed list of valid usernames feeds credential-stuffing, phishing, and password-spray campaigns.
+        - **Information disclosure:** Differentiated error messages leak information that has no legitimate benefit to the client.
+
+        **Risk mitigation**
+
+        - **Uniform responses:** Enabling the setting returns generic errors that do not distinguish existing from non-existing users.
+        - **Reduced reconnaissance:** Uniform responses deny attackers a cheap way to validate usernames.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon Cognito Console](https://console.aws.amazon.com/cognito/) and select a user pool.
+        2. Choose **App integration** → the app client and review **Advanced authentication settings**.
+        3. Confirm **Prevent user existence errors** is enabled.
+
+        A passing client has the setting enabled. A failing client uses the legacy behavior.
+
+        ### Audit via CLI
+
+        1. Inspect the setting on each app client:
+
+        ```bash
+        aws cognito-idp describe-user-pool-client \
+          --user-pool-id <pool-id> --client-id <client-id> \
+          --query 'UserPoolClient.PreventUserExistenceErrors' --output text
+        ```
+
+        A passing client returns `ENABLED`. A failing client returns `LEGACY`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Cognito console and select the user pool and app client.
+            2. Under **Advanced authentication settings**, enable **Prevent user existence errors**.
+            3. Save changes.
+        - id: cli
+          desc: |
+            Enable the setting on the app client:
+
+            ```bash
+            aws cognito-idp update-user-pool-client \
+              --user-pool-id <pool-id> --client-id <client-id> \
+              --prevent-user-existence-errors ENABLED
+            ```
+        - id: terraform
+          desc: |
+            Set `prevent_user_existence_errors = "ENABLED"` on the app client:
+
+            ```hcl
+            resource "aws_cognito_user_pool_client" "example" {
+              name                          = "example"
+              user_pool_id                  = aws_cognito_user_pool.example.id
+              prevent_user_existence_errors = "ENABLED"
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            Set `PreventUserExistenceErrors` to `ENABLED`:
+
+            ```yaml
+            Resources:
+              UserPoolClient:
+                Type: AWS::Cognito::UserPoolClient
+                Properties:
+                  UserPoolId: !Ref UserPool
+                  PreventUserExistenceErrors: ENABLED
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-managing-errors.html
+        title: AWS Documentation - Managing error responses for user existence
+
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.cognito.userPools.all(
+        clients.all(preventUserExistenceErrors != "LEGACY")
+      )
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.resources("aws_cognito_user_pool_client").all(
+        arguments.prevent_user_existence_errors != "LEGACY"
+      )
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_cognito_user_pool_client").all(
+        change.after.prevent_user_existence_errors != "LEGACY"
+      )
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_cognito_user_pool_client")
+    mql: |
+      terraform.state.resources.where(type == "aws_cognito_user_pool_client").all(
+        values.prevent_user_existence_errors != "LEGACY"
+      )
+  - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Cognito::UserPoolClient")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::Cognito::UserPoolClient").all(
+      properties['PreventUserExistenceErrors'] != "LEGACY"
+      )
+
+  - uid: mondoo-aws-security-kms-key-no-public-access
+    title: Ensure KMS key policies do not grant access to wildcard principals
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-kms-key-no-public-access-aws
+        tags:
+          mondoo.com/filter-title: AWS KMS Key
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-kms-key-no-public-access-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kms-key-no-public-access-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kms-key-no-public-access-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-kms-key-no-public-access-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that KMS key policies do not contain `Allow` statements whose `Principal` is the wildcard value `"*"` or `{"AWS": "*"}`. A wildcard principal in a key policy grants cryptographic operations to any AWS principal, undermining the key as an access-control boundary.
+
+        **Why this matters**
+
+        - **Universal decrypt:** A key that any principal can use to `Decrypt` neutralizes the protection of every resource encrypted under it.
+        - **Blast radius:** KMS keys often protect many services (S3, EBS, RDS, Secrets Manager); a public key policy exposes all of them at once.
+        - **Bypasses resource controls:** Key-policy grants are evaluated independently of the encrypted resource's own IAM controls.
+
+        **Risk mitigation**
+
+        - **Scoped principals:** Granting key operations only to specific account, role, or service principals preserves the key as a control boundary.
+        - **Least privilege:** Explicit principals with conditions keep cryptographic operations limited to intended workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [KMS Console](https://console.aws.amazon.com/kms/) and select a customer-managed key.
+        2. Choose the **Key policy** tab (switch to policy view).
+        3. Review for any `Allow` statement whose `Principal` is `"*"` or `{"AWS": "*"}` without a restricting condition.
+
+        A passing key has no wildcard-principal `Allow` statement. A failing key grants access to `"*"`.
+
+        ### Audit via CLI
+
+        1. Retrieve the key policy and inspect the principals:
+
+        ```bash
+        aws kms get-key-policy --key-id <key-id> --policy-name default \
+          --query 'Policy' --output text
+        ```
+
+        A passing key has no wildcard principal in an `Allow` statement. A failing key grants access to `"*"`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the KMS console and select the key.
+            2. Open the **Key policy** tab and edit the policy.
+            3. Replace any `"Principal": "*"` in an `Allow` statement with specific account/role/service principals, or add a restricting condition.
+        - id: cli
+          desc: |
+            Replace the key policy with one scoped to specific principals:
+
+            ```bash
+            aws kms put-key-policy \
+              --key-id <key-id> \
+              --policy-name default \
+              --policy file://scoped-key-policy.json
+            ```
+        - id: terraform
+          desc: |
+            Build the key policy with `aws_iam_policy_document` scoped to explicit principals:
+
+            ```hcl
+            data "aws_iam_policy_document" "key" {
+              statement {
+                effect    = "Allow"
+                actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+                resources = ["*"]
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:role/AppRole"]
+                }
+              }
+            }
+
+            resource "aws_kms_key" "example" {
+              description = "example"
+              policy      = data.aws_iam_policy_document.key.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            Scope every `Allow` statement in the `KeyPolicy` to specific principals:
+
+            ```yaml
+            Resources:
+              Key:
+                Type: AWS::KMS::Key
+                Properties:
+                  KeyPolicy:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Effect: Allow
+                        Principal:
+                          AWS: arn:aws:iam::111122223333:role/AppRole
+                        Action: ["kms:Decrypt", "kms:GenerateDataKey"]
+                        Resource: "*"
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+        title: AWS Documentation - Key policies in AWS KMS
+
+  - uid: mondoo-aws-security-kms-key-no-public-access-aws
+    filters: asset.platform == "aws-kms-key"
+    mql: |
+      aws.kms.key.policyStatements.where(effect == "Allow").none(hasPublicPrincipal)
+  - uid: mondoo-aws-security-kms-key-no-public-access-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kms_key")
+    mql: |
+      terraform.resources("aws_kms_key").all(
+        arguments.policy == empty ||
+        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-kms-key-no-public-access-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_kms_key")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_kms_key").all(
+        change.after["policy"] == empty ||
+        change.after["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-kms-key-no-public-access-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_kms_key")
+    mql: |
+      terraform.state.resources.where(type == "aws_kms_key").all(
+        values["policy"] == empty ||
+        values["policy"]["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        )
+      )
+  - uid: mondoo-aws-security-kms-key-no-public-access-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::KMS::Key")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::KMS::Key").all(
+      properties['KeyPolicy'] == empty ||
+      properties['KeyPolicy']['Statement'].where(_["Effect"] == "Allow").none(
+        _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+      )
+      )
+
+  - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals
+    title: Ensure Lake Formation default permissions exclude IAM_ALLOWED_PRINCIPALS
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-1-7
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Lake Formation `CreateDatabaseDefaultPermissions` and `CreateTableDefaultPermissions` do not grant permissions to the `IAM_ALLOWED_PRINCIPALS` group. That group makes Lake Formation defer to coarse IAM permissions instead of enforcing its own fine-grained grants.
+
+        **Why this matters**
+
+        - **Fine-grained control bypass:** With `IAM_ALLOWED_PRINCIPALS` on default permissions, any principal with basic Glue/Lake Formation IAM access can read new databases and tables, bypassing column- and row-level controls.
+        - **Silent over-exposure:** New tables inherit the default grant, so data governance gaps appear automatically as the data lake grows.
+        - **Undermines the model:** Lake Formation's value is centralized, least-privilege data access; this default negates it.
+
+        **Risk mitigation**
+
+        - **Explicit grants:** Removing `IAM_ALLOWED_PRINCIPALS` forces access to flow through named Lake Formation grants.
+        - **Least privilege:** Fine-grained grants ensure principals see only the databases, tables, and columns they are entitled to.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Lake Formation Console](https://console.aws.amazon.com/lakeformation/) and choose **Administrative roles and tasks** / **Data catalog settings**.
+        2. Review **Default permissions for newly created databases and tables**.
+        3. Confirm **Use only IAM access control** options are cleared (no `IAM_ALLOWED_PRINCIPALS`).
+
+        A passing account has no default `IAM_ALLOWED_PRINCIPALS` grant. A failing account grants it by default.
+
+        ### Audit via CLI
+
+        1. Inspect the data lake default permissions:
+
+        ```bash
+        aws lakeformation get-data-lake-settings \
+          --query 'DataLakeSettings.{DB:CreateDatabaseDefaultPermissions,TBL:CreateTableDefaultPermissions}'
+        ```
+
+        A passing account returns empty default-permission lists. A failing account lists a principal of `IAM_ALLOWED_PRINCIPALS`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Lake Formation console and choose **Data catalog settings**.
+            2. Clear both **Use only IAM access control for new databases** and **for new tables**.
+            3. Save; then grant access explicitly through Lake Formation permissions.
+        - id: cli
+          desc: |
+            Remove the default `IAM_ALLOWED_PRINCIPALS` grants:
+
+            ```bash
+            aws lakeformation put-data-lake-settings \
+              --data-lake-settings 'CreateDatabaseDefaultPermissions=[],CreateTableDefaultPermissions=[]'
+            ```
+        - id: terraform
+          desc: |
+            Set empty default permissions on `aws_lakeformation_data_lake_settings` so new databases and tables do not grant `IAM_ALLOWED_PRINCIPALS`:
+
+            ```hcl
+            resource "aws_lakeformation_data_lake_settings" "example" {
+              admins = [aws_iam_role.lf_admin.arn]
+
+              create_database_default_permissions {}
+              create_table_default_permissions {}
+            }
+            ```
+        # No Terraform plan/state variants: the default-permission principal is expressed as a nested block that is
+        # frequently absent in plan/state output; the HCL variant covers Terraform source and the runtime check
+        # covers live settings.
+    refs:
+      - url: https://docs.aws.amazon.com/lake-formation/latest/dg/change-settings.html
+        title: AWS Documentation - Changing the default security settings for your data lake
+
+  # No Terraform plan/state variants: default-permission principals are nested blocks frequently absent in
+  # plan/state output; HCL covers source and the runtime check covers live settings.
+  - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.lakeformation.dataLakeSettings.createTableDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
+      aws.lakeformation.dataLakeSettings.createDatabaseDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
+  - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lakeformation_data_lake_settings")
+    mql: |
+      terraform.resources("aws_lakeformation_data_lake_settings").all(
+        blocks.where(type == "create_table_default_permissions").all(arguments.principal != "IAM_ALLOWED_PRINCIPALS") &&
+        blocks.where(type == "create_database_default_permissions").all(arguments.principal != "IAM_ALLOWED_PRINCIPALS")
+      )
+
+  - uid: mondoo-aws-security-dsql-cluster-cmk-encryption
+    title: Ensure Aurora DSQL clusters are encrypted with a customer-managed key
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-dsql-cluster-cmk-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon Aurora DSQL clusters are encrypted with a customer-managed KMS key rather than an AWS-owned key. A customer-managed key gives the account control over the key policy, rotation, and the ability to revoke access.
+
+        **Why this matters**
+
+        - **Key governance:** A customer-managed key lets the account define who may use the key and audit its use through CloudTrail.
+        - **Revocation and rotation:** Only a customer-managed key can be disabled or rotated on the account's own schedule to cut off access to the data.
+        - **Separation of duties:** Controlling the key independently from the database enforces a second boundary around the data.
+
+        **Risk mitigation**
+
+        - **Account-controlled encryption:** A customer-managed key ensures the data cannot be read without a key the account governs.
+        - **Auditable access:** Key usage is logged and can be alerted on for anomalous decryption.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Aurora DSQL Console](https://console.aws.amazon.com/dsql/) and select a cluster.
+        2. Review the cluster's **Encryption** settings.
+        3. Confirm encryption uses a customer-managed KMS key.
+
+        A passing cluster uses a customer-managed key. A failing cluster uses the AWS-owned default key.
+
+        ### Audit via CLI
+
+        1. Inspect the cluster encryption type:
+
+        ```bash
+        aws dsql get-cluster --identifier <cluster-id> \
+          --query 'encryptionDetails.encryptionType' --output text
+        ```
+
+        A passing cluster returns `CUSTOMER_MANAGED_KMS_KEY`. A failing cluster returns `AWS_OWNED_KMS_KEY`.
+      remediation:
+        - id: console
+          desc: |
+            The encryption key is set at cluster creation. Recreate the cluster with a customer-managed key:
+
+            1. Open the Aurora DSQL console and create a new cluster.
+            2. Under **Encryption**, choose a customer-managed KMS key.
+            3. Migrate data and delete the old cluster.
+        - id: cli
+          desc: |
+            Create a replacement cluster encrypted with a customer-managed key, then migrate:
+
+            ```bash
+            aws dsql create-cluster \
+              --kms-encryption-key <kms-key-arn>
+            ```
+        # No Terraform variants: Aurora DSQL cluster encryption is fixed at creation and evaluated from live
+        # cluster state; the runtime check reads the resolved encryption type.
+        # No CloudFormation remediation: the resolved encryption type is evaluated at runtime; set the
+        # KmsEncryptionKey at creation and use the console or CLI above to migrate existing clusters.
+    refs:
+      - url: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/encryption-at-rest.html
+        title: AWS Documentation - Encryption at rest for Aurora DSQL
+
+  # No Terraform variants: Aurora DSQL cluster encryption is fixed at creation and read from live state.
+  - uid: mondoo-aws-security-dsql-cluster-cmk-encryption-aws
+    filters: asset.platform == "aws"
+    mql: aws.dsql.clusters.all(encryptionType == "CUSTOMER_MANAGED_KMS_KEY")
+
+  - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption
+    title: Ensure Storage Gateway file shares are encrypted with a KMS key
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that AWS Storage Gateway file shares enable KMS encryption for the objects stored in their backing S3 bucket. Without KMS encryption enabled, objects fall back to S3-managed encryption without a customer-controlled key.
+
+        **Why this matters**
+
+        - **Customer-controlled key:** KMS encryption places file-share data under a key whose policy, rotation, and revocation the account controls.
+        - **On-premises data bridge:** File gateways front on-premises data into S3; that data inherits only the protection configured on the share.
+        - **Auditable access:** KMS key usage is logged, providing visibility into access to the stored objects.
+
+        **Risk mitigation**
+
+        - **Managed encryption:** Enabling KMS encryption ensures a customer-governed key protects file-share objects at rest.
+        - **Revocable access:** Access to the data can be cut off by disabling the key.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Storage Gateway Console](https://console.aws.amazon.com/storagegateway/) and choose **File shares**.
+        2. Select a file share and review its **Encryption** settings.
+        3. Confirm **KMS encryption** is enabled with a KMS key.
+
+        A passing file share has KMS encryption enabled. A failing file share does not.
+
+        ### Audit via CLI
+
+        1. Inspect the KMS encryption flag for an NFS file share (use `describe-smbfile-shares` for SMB):
+
+        ```bash
+        aws storagegateway describe-nfs-file-shares \
+          --file-share-arn-list <file-share-arn> \
+          --query 'NFSFileShareInfoList[*].{Share:FileShareId,KMS:KMSEncrypted}'
+        ```
+
+        A passing file share returns `true` for KMS encryption. A failing file share returns `false`.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Storage Gateway console and choose **File shares**.
+            2. Select the file share and choose **Edit**.
+            3. Enable **KMS encryption** and select a KMS key, then save.
+        - id: cli
+          desc: |
+            Enable KMS encryption on the file share (use `update-smbfile-share` for SMB):
+
+            ```bash
+            aws storagegateway update-nfs-file-share \
+              --file-share-arn <file-share-arn> \
+              --kms-encrypted \
+              --kms-key <kms-key-arn>
+            ```
+        - id: terraform
+          desc: |
+            Set `kms_encrypted = true` and a `kms_key_arn` on the file share:
+
+            ```hcl
+            resource "aws_storagegateway_nfs_file_share" "example" {
+              gateway_arn   = aws_storagegateway_gateway.example.arn
+              location_arn  = aws_s3_bucket.example.arn
+              role_arn      = aws_iam_role.example.arn
+              kms_encrypted = true
+              kms_key_arn   = aws_kms_key.example.arn
+            }
+            ```
+        # No Terraform plan/state variants: the NFS and SMB file-share resources are covered by the HCL variant;
+        # plan/state coverage is omitted to avoid duplicating the two-resource fanout, and the runtime check
+        # covers live shares.
+        # No CloudFormation remediation: there is no CloudFormation resource for Storage Gateway file shares; use
+        # the console, CLI, or Terraform examples above.
+    refs:
+      - url: https://docs.aws.amazon.com/filegateway/latest/files3/encryption.html
+        title: AWS Documentation - Encrypting file share data with AWS KMS
+
+  # No Terraform plan/state variants: NFS and SMB file shares are covered by the HCL variant; the runtime check
+  # covers live shares.
+  - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption-aws
+    filters: asset.platform == "aws"
+    mql: aws.storagegateway.gateways.all(fileShares.all(kmsEncrypted == true))
+  - uid: mondoo-aws-security-storagegateway-fileshare-kms-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_storagegateway_nfs_file_share" || nameLabel == "aws_storagegateway_smb_file_share")
+    mql: |
+      terraform.resources.where(nameLabel == "aws_storagegateway_nfs_file_share" || nameLabel == "aws_storagegateway_smb_file_share").all(
+        arguments.kms_encrypted == true
+      )
+
+  - uid: mondoo-aws-security-bedrock-agentcore-runtime-no-plaintext-secrets
+    title: Ensure Bedrock AgentCore runtimes do not store secrets in env vars
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-6-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    variants:
+      - uid: mondoo-aws-security-bedrock-agentcore-runtime-no-plaintext-secrets-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that Amazon Bedrock AgentCore runtimes do not carry secrets in plaintext environment variables. Environment-variable names such as `password`, `secret`, `token`, `api_key`, or `credential` indicate credentials embedded directly in the runtime configuration.
+
+        **Why this matters**
+
+        - **Exposed credentials:** Plaintext environment variables are readable by anyone with describe access to the runtime and are easy to leak through logs or backups.
+        - **Static, long-lived secrets:** Embedded credentials are rarely rotated and often grant broad access to downstream systems the agent calls.
+        - **Blast radius:** An agent runtime frequently holds credentials for multiple tools and APIs, so one exposure can compromise several systems.
+
+        **Risk mitigation**
+
+        - **Managed secret stores:** Referencing AWS Secrets Manager or SSM Parameter Store keeps secrets out of the runtime configuration.
+        - **Rotation and audit:** Managed stores support automatic rotation and access logging that embedded variables cannot.
+      audit: |
+        ### Audit via Console
+
+        1. Open the [Amazon Bedrock Console](https://console.aws.amazon.com/bedrock/) and choose **AgentCore** → **Runtimes**.
+        2. Select a runtime and review its **Environment variables**.
+        3. Confirm no variable name suggests a secret (for example `PASSWORD`, `API_KEY`, `TOKEN`, `SECRET`, `CREDENTIAL`).
+
+        A passing runtime references secrets from a managed store. A failing runtime defines secret-like environment variables inline.
+
+        ### Audit via CLI
+
+        1. Inspect the runtime environment variables:
+
+        ```bash
+        aws bedrock-agentcore-control get-agent-runtime --agent-runtime-id <runtime-id> \
+          --query 'environmentVariables' --output json
+        ```
+
+        A passing runtime has no secret-like variable names. A failing runtime lists names such as `API_KEY` or `PASSWORD` with inline values.
+      remediation:
+        - id: console
+          desc: |
+            1. Open the Bedrock console and choose **AgentCore** → **Runtimes**.
+            2. Edit the runtime and remove secret-like environment variables.
+            3. Grant the runtime role access to AWS Secrets Manager and fetch the secret at runtime instead.
+        - id: cli
+          desc: |
+            Update the runtime to drop inline secrets and resolve them from Secrets Manager at run time:
+
+            ```bash
+            aws bedrock-agentcore-control update-agent-runtime \
+              --agent-runtime-id <runtime-id> \
+              --environment-variables '{}'
+            ```
+        # No Terraform variants: Bedrock AgentCore runtimes have no stable Terraform resource; the runtime check
+        # inspects the resolved environment-variable names.
+        # No CloudFormation remediation: there is no CloudFormation resource for AgentCore runtimes; use the
+        # console or CLI above.
+    refs:
+      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
+        title: AWS Documentation - What is AWS Secrets Manager?
+
+  # No Terraform variants: Bedrock AgentCore runtimes have no stable Terraform resource; runtime state only.
+  - uid: mondoo-aws-security-bedrock-agentcore-runtime-no-plaintext-secrets-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.bedrock.agentCore.runtimes.all(
+        environmentVariables.keys.none(_ == /(?i)(password|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|credential)/)
+      )


### PR DESCRIPTION
## Summary

Adds **19 new security checks** to `mondoo-aws-security` targeting newer services with no prior coverage and internet-exposure gaps on assets already scanned. Every check is security-focused (no best-practice/deletion-prevention checks) and ships with runtime + IaC variants, full docs, and verified compliance mappings across all 13 frameworks the policy tags.

### Public / anonymous exposure
- RDS & DocumentDB snapshots not shared publicly
- Neptune Analytics graphs without public connectivity
- AWS Backup vault & EFS file-system policies deny wildcard/anonymous principals
- CodeBuild projects not `PUBLIC_READ`
- App Runner services not publicly accessible
- AppSync GraphQL APIs use `PRIVATE` visibility
- EMR account-level block-public-access enabled
- Q Business applications not `ANONYMOUS`

### Authentication
- Bedrock AgentCore gateways require an authorizer (not `NONE`)
- AppSync APIs do not use `API_KEY` as the sole auth type
- Cognito app clients disable `USER_PASSWORD_AUTH`

### Least privilege
- KMS key policies deny wildcard principals (distinct from existing grant checks)
- Lake Formation default permissions exclude `IAM_ALLOWED_PRINCIPALS`

### Enumeration / encryption / secrets
- Cognito app clients prevent user-existence errors
- Aurora DSQL clusters use a customer-managed KMS key
- Storage Gateway file shares use KMS encryption
- Bedrock AgentCore runtimes carry no plaintext secrets in env vars

## Impact anchoring
- Public-data-exposure checks at **90** anchor to `mondoo-aws-security-s3-bucket-policy-no-public-principal` (100) and the `*-public-access-check` family.
- CMK-encryption checks at **70** anchor to `mondoo-aws-security-backup-vault-encrypted` (70).

## Compliance
All 19 checks carry the full 13-framework tag set, each mapped by reading the control text in `cnspec-enterprise-policies/frameworks/` (verified control UIDs or the `false` boolean where no control genuinely fits — e.g. the enumeration check maps only to `nist-sp-800-53-rev5-si-11`).

## Verification
- `cnspec policy lint content/mondoo-aws-security.mql.yaml` → **valid** (only the 2 pre-existing `terraform.resources` warnings)
- `validate_remediation_commands.py aws` → **0 FAIL / 884 PASS**

## Reviewer notes
- **App Runner (#8) and AppSync visibility (#9)** are "ensure not public" checks in the spirit of the existing `ec2-instance-no-public-ip` / `elb-not-internet-reachable` — they will flag intentionally-public services; descriptions state internal services are the target and public ones should be scoped out.
- Variants follow the repo's "correct skip beats wrong variant" rule: full `terraform`/`cloudformation` fanouts where a clean IaC analog exists; new services and imperative/operational state (snapshot sharing, AgentCore, DSQL, EMR account BPA) are runtime-only with justified `# No Terraform variants:` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)