### PR TITLE
✨ azure: add 18 security checks for new services (AI, Event Grid, Kusto, and more)

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -46933,6 +46933,7 @@ queries:
       terraform.state.resources.where(type == "azurerm_automation_account").all(
         values['public_network_access_enabled'] == false
       )
+  # publicNetworkAccess is a bool for Microsoft.Automation/automationAccounts (ARM: "publicNetworkAccess": bool), unlike most Azure resources that use the string enum "Enabled"/"Disabled". Compare to boolean false, not "Disabled".
   - uid: mondoo-azure-security-automation-account-public-network-access-disabled-bicep
     filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Automation/automationAccounts")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -45095,6 +45095,7 @@ queries:
       terraform.state.resources.where(type == "azurerm_cognitive_account").all(
         values['identity'] != null
       )
+  # Uses body["identity"] rather than properties[...] because a managed identity is a top-level Bicep resource field (identity: { ... }), not nested under properties.
   - uid: mondoo-azure-security-cognitive-services-managed-identity-bicep
     filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
     mql: |
@@ -45821,6 +45822,7 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/event-grid/transport-layer-security-configure-minimum-version
         title: Configure the minimum TLS version for an Event Grid resource
+  # Exact match on "1.2" is intentional: the ARM minimumTlsVersionAllowed enum is a closed set of "1.0", "1.1", and "1.2", so equality is precise. Revisit if Azure introduces a higher value.
   - uid: mondoo-azure-security-eventgrid-minimum-tls-1-2-bicep
     filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventGrid/topics")
     mql: |
@@ -46775,24 +46777,28 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/automation/shared-resources/variables
         title: Manage variables in Azure Automation
+  # Covers all four azurerm automation variable resource types; each all() is vacuously true when that type is absent, so a config using only some types is still fully checked.
   - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_automation_variable_string")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.any(nameLabel == "azurerm_automation_variable_string" || nameLabel == "azurerm_automation_variable_int" || nameLabel == "azurerm_automation_variable_bool" || nameLabel == "azurerm_automation_variable_datetime")
     mql: |
-      terraform.resources("azurerm_automation_variable_string").all(
-        arguments['encrypted'] == true
-      )
+      terraform.resources("azurerm_automation_variable_string").all(arguments['encrypted'] == true)
+      terraform.resources("azurerm_automation_variable_int").all(arguments['encrypted'] == true)
+      terraform.resources("azurerm_automation_variable_bool").all(arguments['encrypted'] == true)
+      terraform.resources("azurerm_automation_variable_datetime").all(arguments['encrypted'] == true)
   - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_automation_variable_string")
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.any(type == "azurerm_automation_variable_string" || type == "azurerm_automation_variable_int" || type == "azurerm_automation_variable_bool" || type == "azurerm_automation_variable_datetime")
     mql: |
-      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_string").all(
-        change.after['encrypted'] == true
-      )
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_string").all(change.after['encrypted'] == true)
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_int").all(change.after['encrypted'] == true)
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_bool").all(change.after['encrypted'] == true)
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_datetime").all(change.after['encrypted'] == true)
   - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_automation_variable_string")
+    filters: asset.platform == "terraform-state" && terraform.state.resources.any(type == "azurerm_automation_variable_string" || type == "azurerm_automation_variable_int" || type == "azurerm_automation_variable_bool" || type == "azurerm_automation_variable_datetime")
     mql: |
-      terraform.state.resources.where(type == "azurerm_automation_variable_string").all(
-        values['encrypted'] == true
-      )
+      terraform.state.resources.where(type == "azurerm_automation_variable_string").all(values['encrypted'] == true)
+      terraform.state.resources.where(type == "azurerm_automation_variable_int").all(values['encrypted'] == true)
+      terraform.state.resources.where(type == "azurerm_automation_variable_bool").all(values['encrypted'] == true)
+      terraform.state.resources.where(type == "azurerm_automation_variable_datetime").all(values['encrypted'] == true)
   - uid: mondoo-azure-security-automation-account-variables-encrypted-bicep
     filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Automation/automationAccounts/variables")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -376,6 +376,40 @@ policies:
       - title: Azure Cognitive Services
         checks:
           - uid: mondoo-azure-security-cognitive-services-public-network-access-disabled
+          - uid: mondoo-azure-security-cognitive-services-local-auth-disabled
+          - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny
+          - uid: mondoo-azure-security-cognitive-services-managed-identity
+      - title: Azure Machine Learning
+        checks:
+          - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled
+          - uid: mondoo-azure-security-ml-compute-no-public-ip
+          - uid: mondoo-azure-security-ml-online-endpoint-key-auth-disabled
+      - title: Azure Event Grid
+        checks:
+          - uid: mondoo-azure-security-eventgrid-local-auth-disabled
+          - uid: mondoo-azure-security-eventgrid-public-network-access-disabled
+          - uid: mondoo-azure-security-eventgrid-minimum-tls-1-2
+      - title: Azure Logic Apps
+        checks:
+          - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted
+      - title: Azure SignalR
+        checks:
+          - uid: mondoo-azure-security-signalr-local-auth-disabled
+          - uid: mondoo-azure-security-signalr-public-network-access-disabled
+      - title: Azure Web PubSub
+        checks:
+          - uid: mondoo-azure-security-webpubsub-public-network-access-disabled
+      - title: Azure Data Explorer
+        checks:
+          - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled
+          - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled
+      - title: Azure Automation
+        checks:
+          - uid: mondoo-azure-security-automation-account-variables-encrypted
+          - uid: mondoo-azure-security-automation-account-public-network-access-disabled
+      - title: Microsoft Purview
+        checks:
+          - uid: mondoo-azure-security-purview-account-public-network-access-disabled
       - title: Azure DNS
         checks:
           - uid: mondoo-azure-security-private-dns-no-auto-registration
@@ -44639,4 +44673,2401 @@ queries:
     mql: |
       bicep.resources.where(type == "Microsoft.Databricks/workspaces").all(
         properties["parameters"]["enableNoPublicIp"]["value"] == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-local-auth-disabled
+    title: Ensure Cognitive Services accounts disable local authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Cognitive Services (Azure AI Services) accounts have local authentication disabled, so callers must present a Microsoft Entra ID token instead of a static account key. By default local authentication is enabled and every account exposes two long-lived keys that grant full data-plane access.
+
+        **Why this matters**
+
+        - **Key theft**: A leaked account key grants complete access to models, prompts, and embeddings with no user context, no expiry, and no conditional access. Disabling local auth removes that bearer-token risk entirely.
+        - **Attribution**: Microsoft Entra ID authentication ties every call to a specific identity, which makes misuse auditable and enables least-privilege role assignments that shared keys cannot express.
+        - **Centralized revocation**: Access granted through Entra ID can be revoked instantly by removing a role assignment or disabling an identity, whereas a compromised key stays valid until it is manually rotated.
+
+        **Risk mitigation**
+
+        - Set the account to reject key-based authentication and require Microsoft Entra ID tokens for all data-plane calls.
+        - Assign least-privilege Azure roles to the identities that need access instead of distributing shared keys.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure AI services** in the Azure Portal.
+        2. Select an account.
+        3. Open **Resource Management** and select **Identity and access** or **Keys and Endpoint**.
+        4. Verify that key-based access is disabled and Microsoft Entra ID authentication is required.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --query "properties.disableLocalAuth"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable local authentication on a Cognitive Services account using the Azure Portal:
+
+            1. Navigate to **Azure AI services** in the Azure Portal.
+            2. Select the account.
+            3. Under **Resource Management**, review the authentication settings and disable key-based access.
+            4. Assign the appropriate Azure roles to the identities that require data-plane access.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable local authentication on a Cognitive Services account using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --set properties.disableLocalAuth=true
+            ```
+        - id: terraform
+          desc: |
+            To disable local authentication on a Cognitive Services account in Terraform:
+
+            ```hcl
+            resource "azurerm_cognitive_account" "example" {
+              name                = "example-cognitive"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              kind                = "OpenAI"
+              sku_name            = "S0"
+              local_auth_enabled  = false
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable local authentication on a Cognitive Services account in Bicep:
+
+            ```bicep
+            resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+              name: 'example-cognitive'
+              location: resourceGroup().location
+              kind: 'OpenAI'
+              sku: {
+                name: 'S0'
+              }
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                disableLocalAuth: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/ai-services/authentication
+        title: Authenticate requests to Azure AI services
+  - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
+    mql: |
+      terraform.resources("azurerm_cognitive_account").all(
+        arguments['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_cognitive_account").all(
+        change.after['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_cognitive_account").all(
+        values['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-cognitive-services-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.CognitiveServices/accounts").all(
+        properties["disableLocalAuth"] == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny
+    title: Ensure Cognitive Services accounts set network ACLs to deny by default
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Cognitive Services (Azure AI Services) accounts configure their network ACLs with a default action of deny, so only explicitly allowed virtual networks and IP ranges can reach the account. A default action of allow leaves the account open to every source that is not otherwise blocked, even when specific rules are present.
+
+        **Why this matters**
+
+        - **Implicit exposure**: With a default action of allow, adding a few permitted IPs does not restrict anyone else. Only a default deny turns the allow list into an actual boundary.
+        - **Sensitive workloads**: Cognitive Services accounts process customer documents, prompts, and transcribed audio. A deny-by-default posture keeps that traffic on approved networks.
+        - **Defense in depth**: Network ACLs complement Microsoft Entra ID authentication and private endpoints by rejecting connection attempts from unapproved networks before authentication is even attempted.
+
+        **Risk mitigation**
+
+        - Set the account network ACL default action to **Deny** and enumerate only the virtual networks and IP ranges that require access.
+        - Combine deny-by-default ACLs with private endpoints so that authorized traffic stays on the Azure backbone.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure AI services** in the Azure Portal.
+        2. Select an account.
+        3. Open **Networking** under **Resource Management**.
+        4. On the **Firewalls and virtual networks** tab, verify that the selected access mode denies traffic by default and lists only approved networks.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --query "properties.networkAcls.defaultAction"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To set network ACLs to deny by default on a Cognitive Services account using the Azure Portal:
+
+            1. Navigate to **Azure AI services** in the Azure Portal.
+            2. Select the account.
+            3. Under **Resource Management**, select **Networking**.
+            4. On the **Firewalls and virtual networks** tab, choose the option that denies access by default and add only the approved networks.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To set network ACLs to deny by default on a Cognitive Services account using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --set properties.networkAcls.defaultAction=Deny
+            ```
+        - id: terraform
+          desc: |
+            To set network ACLs to deny by default on a Cognitive Services account in Terraform:
+
+            ```hcl
+            resource "azurerm_cognitive_account" "example" {
+              name                = "example-cognitive"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              kind                = "OpenAI"
+              sku_name            = "S0"
+
+              network_acls {
+                default_action = "Deny"
+                ip_rules       = ["203.0.113.0/24"]
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set network ACLs to deny by default on a Cognitive Services account in Bicep:
+
+            ```bicep
+            resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+              name: 'example-cognitive'
+              location: resourceGroup().location
+              kind: 'OpenAI'
+              sku: {
+                name: 'S0'
+              }
+              properties: {
+                networkAcls: {
+                  defaultAction: 'Deny'
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-virtual-networks
+        title: Configure Azure AI services virtual networks
+  - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
+    mql: |
+      terraform.resources("azurerm_cognitive_account").all(
+        arguments['network_acls'] != null &&
+        arguments['network_acls'][0]['default_action'] == "Deny"
+      )
+  - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_cognitive_account").all(
+        change.after['network_acls'] != null &&
+        change.after['network_acls'][0]['default_action'] == "Deny"
+      )
+  - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_cognitive_account").all(
+        values['network_acls'] != null &&
+        values['network_acls'][0]['default_action'] == "Deny"
+      )
+  - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.CognitiveServices/accounts").all(
+        properties["networkAcls"]["defaultAction"] == "Deny"
+      )
+  - uid: mondoo-azure-security-cognitive-services-managed-identity
+    title: Ensure Cognitive Services accounts use a managed identity
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-managed-identity-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Cognitive Services (Azure AI Services) accounts have a managed identity assigned, so the account authenticates to downstream Azure resources such as Key Vault and Storage with a rotating Microsoft Entra ID credential instead of stored keys or connection strings. An account with no managed identity must fall back to embedding long-lived secrets in its configuration.
+
+        **Why this matters**
+
+        - **Secret sprawl**: Without a managed identity, connections to storage and key vaults rely on account keys or SAS tokens that live in configuration and get copied between environments. A managed identity removes those static secrets.
+        - **Automatic rotation**: Managed identity credentials are issued and rotated by the platform, so there is no key for an operator to leak or forget to rotate.
+        - **Least privilege**: A managed identity can be granted narrowly scoped Azure roles on exactly the resources it needs, which is not possible with a shared account key.
+
+        **Risk mitigation**
+
+        - Assign a system-assigned or user-assigned managed identity to the account and grant it least-privilege roles on the resources it consumes.
+        - Remove stored keys and connection strings from the account configuration once the managed identity is in place.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure AI services** in the Azure Portal.
+        2. Select an account.
+        3. Open **Identity** under **Resource Management**.
+        4. Verify that a system-assigned or user-assigned managed identity is enabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --query "identity.type"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To assign a managed identity to a Cognitive Services account using the Azure Portal:
+
+            1. Navigate to **Azure AI services** in the Azure Portal.
+            2. Select the account.
+            3. Under **Resource Management**, select **Identity**.
+            4. Enable a system-assigned identity or add a user-assigned identity.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To assign a system-assigned managed identity to a Cognitive Services account using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.CognitiveServices/accounts --resource-group <ResourceGroupName> --name <AccountName> --set identity.type=SystemAssigned
+            ```
+        - id: terraform
+          desc: |
+            To assign a managed identity to a Cognitive Services account in Terraform:
+
+            ```hcl
+            resource "azurerm_cognitive_account" "example" {
+              name                = "example-cognitive"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              kind                = "OpenAI"
+              sku_name            = "S0"
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To assign a managed identity to a Cognitive Services account in Bicep:
+
+            ```bicep
+            resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+              name: 'example-cognitive'
+              location: resourceGroup().location
+              kind: 'OpenAI'
+              sku: {
+                name: 'S0'
+              }
+              identity: {
+                type: 'SystemAssigned'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/ai-services/authentication
+        title: Authenticate requests to Azure AI services
+  - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
+    mql: |
+      terraform.resources("azurerm_cognitive_account").all(
+        arguments['identity'] != null
+      )
+  - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_cognitive_account").all(
+        change.after['identity'] != null
+      )
+  - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_cognitive_account").all(
+        values['identity'] != null
+      )
+  - uid: mondoo-azure-security-cognitive-services-managed-identity-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.CognitiveServices/accounts").all(
+        body["identity"] != empty
+      )
+  - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled
+    title: Ensure Machine Learning workspaces disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Machine Learning workspaces have public network access disabled, so notebooks, datastores, registered models, and the workspace API are reachable only through private endpoints inside an authorized virtual network. By default a workspace accepts connections from the public internet.
+
+        **Why this matters**
+
+        - **Training data and model theft**: A workspace exposes datastores, registered models, and experiment outputs. Public exposure puts proprietary training data and model artifacts within reach of anyone who obtains a credential.
+        - **Network isolation**: Disabling public access forces workspace and compute traffic through Private Link, which keeps the workspace unreachable from outside the perimeter even when a token or key is leaked.
+        - **Defense in depth**: Microsoft Entra ID authentication and role-based access control are most effective when combined with network-level isolation that blocks direct internet probing of the workspace endpoint.
+
+        **Risk mitigation**
+
+        - Set the workspace public network access to disabled and configure private endpoints for each authorized virtual network.
+        - Route compute and studio access through the private endpoint rather than the public workspace URL.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Machine Learning** in the Azure Portal.
+        2. Select a workspace.
+        3. Open **Networking** under **Settings**.
+        4. On the **Public access** tab, verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.MachineLearningServices/workspaces --resource-group <ResourceGroupName> --name <WorkspaceName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on a Machine Learning workspace using the Azure Portal:
+
+            1. Navigate to **Azure Machine Learning** in the Azure Portal.
+            2. Select the workspace.
+            3. Under **Settings**, select **Networking**.
+            4. On the **Public access** tab, set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on a Machine Learning workspace using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.MachineLearningServices/workspaces --resource-group <ResourceGroupName> --name <WorkspaceName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on a Machine Learning workspace in Terraform:
+
+            ```hcl
+            resource "azurerm_machine_learning_workspace" "example" {
+              name                          = "example-mlw"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              application_insights_id       = azurerm_application_insights.example.id
+              key_vault_id                  = azurerm_key_vault.example.id
+              storage_account_id            = azurerm_storage_account.example.id
+              public_network_access_enabled = false
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on a Machine Learning workspace in Bicep:
+
+            ```bicep
+            resource mlWorkspace 'Microsoft.MachineLearningServices/workspaces@2024-04-01' = {
+              name: 'example-mlw'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-configure-private-link
+        title: Configure a private endpoint for an Azure Machine Learning workspace
+  - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.resources("azurerm_machine_learning_workspace").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_machine_learning_workspace").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_machine_learning_workspace").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.MachineLearningServices/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  - uid: mondoo-azure-security-ml-compute-no-public-ip
+    title: Ensure Machine Learning compute clusters have no public IP
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-compute-no-public-ip-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Machine Learning compute clusters are provisioned without a public IP on their nodes, so training and job nodes are reachable only from within the virtual network. By default a compute cluster assigns public IPs to its nodes, which places managed compute directly on the internet.
+
+        **Why this matters**
+
+        - **Exposed compute**: Machine Learning compute nodes run training jobs with access to datastores and credentials. A node with a public IP is an internet-facing host that becomes a target for exploitation and lateral movement.
+        - **Network isolation**: Deploying compute without public IPs keeps job traffic on the virtual network and forces access through private, controlled paths.
+        - **Reduced attack surface**: No public IP means there is no directly reachable management or SSH surface for an attacker to probe.
+
+        **Risk mitigation**
+
+        - Create compute clusters with node public IP disabled and place them in a subnet of an authorized virtual network.
+        - Access compute through the virtual network rather than over the public internet.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Machine Learning** in the Azure Portal.
+        2. Select a workspace and open **Compute**.
+        3. Select a compute cluster and review its networking configuration.
+        4. Verify that **No public IP** is enabled for the cluster nodes.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.MachineLearningServices/workspaces/computes --resource-group <ResourceGroupName> --name <WorkspaceName>/<ComputeName> --query "properties.properties.enableNodePublicIp"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To provision a Machine Learning compute cluster without a public IP using the Azure Portal:
+
+            1. Navigate to **Azure Machine Learning** in the Azure Portal.
+            2. Select the workspace and open **Compute**.
+            3. Create a new compute cluster.
+            4. Under the networking options, select a virtual network subnet and enable **No public IP**.
+            5. Create the cluster. Existing clusters must be recreated because this setting is fixed at creation.
+        - id: cli
+          desc: |
+            To provision a Machine Learning compute cluster without a public IP using the Azure CLI, create the cluster with node public IP disabled. This setting is fixed at creation, so existing clusters must be recreated:
+
+            ```bash
+            az ml compute create --name <ComputeName> --resource-group-name <ResourceGroupName> --workspace-name <WorkspaceName> --type AmlCompute --enable-node-public-ip false --vnet-name <VNetName> --subnet <SubnetName>
+            ```
+        - id: terraform
+          desc: |
+            To provision a Machine Learning compute cluster without a public IP in Terraform:
+
+            ```hcl
+            resource "azurerm_machine_learning_compute_cluster" "example" {
+              name                          = "example-cluster"
+              location                      = azurerm_resource_group.example.location
+              machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+              vm_priority                   = "Dedicated"
+              vm_size                       = "Standard_DS2_v2"
+              subnet_resource_id            = azurerm_subnet.example.id
+              node_public_ip_enabled        = false
+
+              scale_settings {
+                min_node_count = 0
+                max_node_count = 4
+                scale_down_nodes_after_idle_duration = "PT30S"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To provision a Machine Learning compute cluster without a public IP in Bicep:
+
+            ```bicep
+            resource mlCompute 'Microsoft.MachineLearningServices/workspaces/computes@2024-04-01' = {
+              parent: mlWorkspace
+              name: 'example-cluster'
+              location: resourceGroup().location
+              properties: {
+                computeType: 'AmlCompute'
+                properties: {
+                  enableNodePublicIp: false
+                  subnet: {
+                    id: subnet.id
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-secure-training-vnet
+        title: Secure an Azure Machine Learning training environment with virtual networks
+  - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_machine_learning_compute_cluster")
+    mql: |
+      terraform.resources("azurerm_machine_learning_compute_cluster").all(
+        arguments['node_public_ip_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_machine_learning_compute_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_machine_learning_compute_cluster").all(
+        change.after['node_public_ip_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-compute-no-public-ip-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_machine_learning_compute_cluster")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_machine_learning_compute_cluster").all(
+        values['node_public_ip_enabled'] == false
+      )
+  - uid: mondoo-azure-security-ml-compute-no-public-ip-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.MachineLearningServices/workspaces/computes")
+    mql: |
+      bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces/computes").all(
+        properties["properties"]["enableNodePublicIp"] == false
+      )
+  # No Terraform variants: the azurerm provider exposes no Machine Learning online endpoint resource with an auth-mode argument, so this control can only be verified against ARM/Bicep templates. Revisit if azurerm adds an online endpoint resource.
+  - uid: mondoo-azure-security-ml-online-endpoint-key-auth-disabled
+    title: Ensure Machine Learning online endpoints disable key authentication
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-ml-online-endpoint-key-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Machine Learning managed online endpoints do not use static key authentication, requiring Microsoft Entra ID tokens or Azure Machine Learning tokens instead. Key authentication issues long-lived keys that grant full access to invoke the inference endpoint with no user context or expiry.
+
+        **Why this matters**
+
+        - **Model abuse**: An online endpoint serves a deployed model for inference. A leaked static key lets anyone invoke the model, run up cost, and extract behavior with no attribution.
+        - **Token-based access**: Microsoft Entra ID and Azure Machine Learning tokens are short-lived and tied to an identity, which makes access revocable and auditable.
+        - **No key rotation gap**: Removing key authentication eliminates the risk of a compromised key remaining valid until someone remembers to rotate it.
+
+        **Risk mitigation**
+
+        - Configure online endpoints with token-based authentication rather than key-based authentication.
+        - Grant least-privilege roles to the identities that invoke the endpoint.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Machine Learning** in the Azure Portal.
+        2. Select a workspace and open **Endpoints**.
+        3. Select an online endpoint and review its authentication settings.
+        4. Verify that the authentication mode is token-based rather than key-based.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az ml online-endpoint show --name <EndpointName> --resource-group-name <ResourceGroupName> --workspace-name <WorkspaceName> --query "auth_mode"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To require token authentication on a Machine Learning online endpoint using the Azure Portal:
+
+            1. Navigate to **Azure Machine Learning** in the Azure Portal.
+            2. Select the workspace and open **Endpoints**.
+            3. Create the online endpoint with a token-based authentication mode. The authentication mode is fixed at creation, so an existing key-based endpoint must be recreated.
+        - id: cli
+          desc: |
+            To require token authentication on a Machine Learning online endpoint using the Azure CLI, create the endpoint with a token-based auth mode. The auth mode is fixed at creation, so an existing key-based endpoint must be recreated:
+
+            ```bash
+            az ml online-endpoint create --name <EndpointName> --resource-group-name <ResourceGroupName> --workspace-name <WorkspaceName> --auth-mode aad_token
+            ```
+        # No Terraform remediation: the azurerm provider exposes no Machine Learning online endpoint resource, so there is no Terraform argument to set.
+        - id: bicep
+          desc: |
+            To require token authentication on a Machine Learning online endpoint in Bicep:
+
+            ```bicep
+            resource onlineEndpoint 'Microsoft.MachineLearningServices/workspaces/onlineEndpoints@2024-04-01' = {
+              parent: mlWorkspace
+              name: 'example-endpoint'
+              location: resourceGroup().location
+              properties: {
+                authMode: 'AADToken'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-authenticate-online-endpoint
+        title: Authenticate clients for online endpoints
+  - uid: mondoo-azure-security-ml-online-endpoint-key-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.MachineLearningServices/workspaces/onlineEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces/onlineEndpoints").all(
+        properties["authMode"] != "Key"
+      )
+  - uid: mondoo-azure-security-eventgrid-local-auth-disabled
+    title: Ensure Event Grid topics disable local authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Event Grid topics have local authentication disabled, so publishers must present a Microsoft Entra ID token instead of a shared access key or SAS token. By default local authentication is enabled and any holder of a topic key can publish events.
+
+        **Why this matters**
+
+        - **Forged events**: Event Grid topics feed downstream automation, functions, and workflows. A leaked access key lets an attacker inject arbitrary events that trigger privileged downstream actions.
+        - **Attribution**: Microsoft Entra ID authentication ties each publish operation to an identity, making misuse auditable and enabling least-privilege role assignments.
+        - **Revocable access**: Access granted through Entra ID is revoked by removing a role assignment, whereas a leaked key stays valid until it is manually rotated.
+
+        **Risk mitigation**
+
+        - Disable local authentication on the topic and require Microsoft Entra ID tokens for publishing.
+        - Grant least-privilege roles to the identities that publish events.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Event Grid Topics** in the Azure Portal.
+        2. Select a topic.
+        3. Open **Access control (IAM)** and the topic configuration.
+        4. Verify that local (key-based) authentication is disabled and Microsoft Entra ID authentication is required.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --query "properties.disableLocalAuth"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable local authentication on an Event Grid topic using the Azure Portal:
+
+            1. Navigate to **Event Grid Topics** in the Azure Portal.
+            2. Select the topic.
+            3. Open the topic configuration and disable local (key-based) authentication.
+            4. Assign the appropriate roles to the identities that publish events.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable local authentication on an Event Grid topic using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --set properties.disableLocalAuth=true
+            ```
+        - id: terraform
+          desc: |
+            To disable local authentication on an Event Grid topic in Terraform:
+
+            ```hcl
+            resource "azurerm_eventgrid_topic" "example" {
+              name                = "example-topic"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              local_auth_enabled  = false
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable local authentication on an Event Grid topic in Bicep:
+
+            ```bicep
+            resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
+              name: 'example-topic'
+              location: resourceGroup().location
+              properties: {
+                disableLocalAuth: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/event-grid/authenticate-with-microsoft-entra-id
+        title: Authenticate Event Grid publishing clients using Microsoft Entra ID
+  - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.resources("azurerm_eventgrid_topic").all(
+        arguments['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_eventgrid_topic").all(
+        change.after['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-local-auth-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_eventgrid_topic").all(
+        values['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventGrid/topics")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventGrid/topics").all(
+        properties["disableLocalAuth"] == true
+      )
+  - uid: mondoo-azure-security-eventgrid-public-network-access-disabled
+    title: Ensure Event Grid topics disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Event Grid topics have public network access disabled, so events are published only through private endpoints inside an authorized virtual network. By default a topic accepts publish requests from the public internet.
+
+        **Why this matters**
+
+        - **Exposed ingestion**: A publicly reachable topic endpoint is an internet-facing ingestion point that attackers can probe and, with a leaked key, publish to directly.
+        - **Network isolation**: Disabling public access forces publishing traffic through Private Link, which keeps the topic unreachable from outside the perimeter.
+        - **Defense in depth**: Network isolation complements Microsoft Entra ID authentication by rejecting connections from unapproved networks before authentication is attempted.
+
+        **Risk mitigation**
+
+        - Set the topic public network access to disabled and configure private endpoints for authorized virtual networks.
+        - Restrict any remaining access with inbound IP rules.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Event Grid Topics** in the Azure Portal.
+        2. Select a topic.
+        3. Open **Networking** under **Settings**.
+        4. Verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on an Event Grid topic using the Azure Portal:
+
+            1. Navigate to **Event Grid Topics** in the Azure Portal.
+            2. Select the topic.
+            3. Under **Settings**, select **Networking**.
+            4. Set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on an Event Grid topic using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on an Event Grid topic in Terraform:
+
+            ```hcl
+            resource "azurerm_eventgrid_topic" "example" {
+              name                          = "example-topic"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              public_network_access_enabled = false
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on an Event Grid topic in Bicep:
+
+            ```bicep
+            resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
+              name: 'example-topic'
+              location: resourceGroup().location
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints
+        title: Configure private endpoints for Azure Event Grid topics
+  - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.resources("azurerm_eventgrid_topic").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_eventgrid_topic").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_eventgrid_topic")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_eventgrid_topic").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-eventgrid-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventGrid/topics")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventGrid/topics").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  # No Terraform variants: the azurerm azurerm_eventgrid_topic resource exposes no minimum TLS version argument, so this control can only be verified against ARM/Bicep templates. Revisit if azurerm adds a minimum_tls_version_allowed argument.
+  - uid: mondoo-azure-security-eventgrid-minimum-tls-1-2
+    title: Ensure Event Grid topics require a minimum of TLS 1.2
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-eventgrid-minimum-tls-1-2-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Event Grid topics require a minimum TLS version of 1.2 for publishers, so clients cannot negotiate the deprecated TLS 1.0 or 1.1 protocols. Older TLS versions contain known cryptographic weaknesses that expose event data in transit.
+
+        **Why this matters**
+
+        - **Data in transit**: Events published to a topic can carry sensitive payloads. TLS 1.0 and 1.1 are vulnerable to known attacks that can expose that data during transport.
+        - **Downgrade protection**: Enforcing a minimum of TLS 1.2 prevents a client or attacker from negotiating a weaker protocol version.
+        - **Compliance**: Modern security baselines require TLS 1.2 or higher for data in transit.
+
+        **Risk mitigation**
+
+        - Set the topic minimum TLS version to 1.2 so weaker protocols are rejected at the handshake.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Event Grid Topics** in the Azure Portal.
+        2. Select a topic.
+        3. Open the topic configuration under **Settings**.
+        4. Verify that the minimum TLS version is set to **1.2**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --query "properties.minimumTlsVersionAllowed"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To require a minimum of TLS 1.2 on an Event Grid topic using the Azure Portal:
+
+            1. Navigate to **Event Grid Topics** in the Azure Portal.
+            2. Select the topic.
+            3. Open the topic configuration under **Settings**.
+            4. Set the minimum TLS version to **1.2**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To require a minimum of TLS 1.2 on an Event Grid topic using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.EventGrid/topics --resource-group <ResourceGroupName> --name <TopicName> --set properties.minimumTlsVersionAllowed=1.2
+            ```
+        # No Terraform remediation: the azurerm azurerm_eventgrid_topic resource exposes no minimum TLS version argument, so there is no Terraform argument to set.
+        - id: bicep
+          desc: |
+            To require a minimum of TLS 1.2 on an Event Grid topic in Bicep:
+
+            ```bicep
+            resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
+              name: 'example-topic'
+              location: resourceGroup().location
+              properties: {
+                minimumTlsVersionAllowed: '1.2'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/event-grid/transport-layer-security-configure-minimum-version
+        title: Configure the minimum TLS version for an Event Grid resource
+  - uid: mondoo-azure-security-eventgrid-minimum-tls-1-2-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.EventGrid/topics")
+    mql: |
+      bicep.resources.where(type == "Microsoft.EventGrid/topics").all(
+        properties["minimumTlsVersionAllowed"] == "1.2"
+      )
+  - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted
+    title: Ensure Logic App workflows restrict trigger caller IP ranges
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Logic App workflows restrict which caller IP address ranges can invoke their triggers, so an HTTP-request trigger is not reachable from the entire internet. Without an allowed caller IP range, a request trigger accepts calls from any source.
+
+        **Why this matters**
+
+        - **Unauthenticated invocation surface**: A Logic App HTTP trigger runs privileged connector actions. Left open, it is an internet-facing endpoint that anyone who learns the callback URL can invoke.
+        - **Blast radius**: Workflows often move data between systems and call other services with stored connections. Restricting caller IPs limits who can set those actions in motion.
+        - **Defense in depth**: IP range restrictions complement the shared access signature on the callback URL by rejecting calls from unapproved networks before they reach the workflow.
+
+        **Risk mitigation**
+
+        - Configure the workflow access control to allow trigger calls only from known IP address ranges.
+        - Combine IP restrictions with a private networking design where possible.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Logic apps** in the Azure Portal.
+        2. Select a workflow.
+        3. Open **Workflow settings** under **Settings**.
+        4. Under **Access control configuration**, verify that trigger access is limited to specific IP address ranges.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.Logic/workflows --resource-group <ResourceGroupName> --name <WorkflowName> --query "properties.accessControl.triggers.allowedCallerIpAddresses"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To restrict trigger caller IP ranges on a Logic App workflow using the Azure Portal:
+
+            1. Navigate to **Logic apps** in the Azure Portal.
+            2. Select the workflow.
+            3. Under **Settings**, open **Workflow settings**.
+            4. Under **Access control configuration**, set the allowed inbound IP addresses for triggers to specific ranges.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To restrict trigger caller IP ranges on a Logic App workflow using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.Logic/workflows --resource-group <ResourceGroupName> --name <WorkflowName> --set properties.accessControl.triggers.allowedCallerIpAddresses='[{"addressRange":"203.0.113.0/24"}]'
+            ```
+        - id: terraform
+          desc: |
+            To restrict trigger caller IP ranges on a Logic App workflow in Terraform:
+
+            ```hcl
+            resource "azurerm_logic_app_workflow" "example" {
+              name                = "example-workflow"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+
+              access_control {
+                trigger {
+                  allowed_caller_ip_address_range = ["203.0.113.0/24"]
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To restrict trigger caller IP ranges on a Logic App workflow in Bicep:
+
+            ```bicep
+            resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
+              name: 'example-workflow'
+              location: resourceGroup().location
+              properties: {
+                accessControl: {
+                  triggers: {
+                    allowedCallerIpAddresses: [
+                      {
+                        addressRange: '203.0.113.0/24'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-securing-a-logic-app
+        title: Secure access and data in Azure Logic Apps
+  - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_logic_app_workflow")
+    mql: |
+      terraform.resources("azurerm_logic_app_workflow").all(
+        arguments['access_control'] != null &&
+        arguments['access_control'][0]['trigger'] != null &&
+        arguments['access_control'][0]['trigger'][0]['allowed_caller_ip_address_range'] != empty
+      )
+  - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_logic_app_workflow")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_logic_app_workflow").all(
+        change.after['access_control'] != null &&
+        change.after['access_control'][0]['trigger'] != null &&
+        change.after['access_control'][0]['trigger'][0]['allowed_caller_ip_address_range'] != empty
+      )
+  - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_logic_app_workflow")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_logic_app_workflow").all(
+        values['access_control'] != null &&
+        values['access_control'][0]['trigger'] != null &&
+        values['access_control'][0]['trigger'][0]['allowed_caller_ip_address_range'] != empty
+      )
+  - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Logic/workflows")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Logic/workflows").all(
+        properties["accessControl"]["triggers"]["allowedCallerIpAddresses"] != empty
+      )
+  - uid: mondoo-azure-security-signalr-local-auth-disabled
+    title: Ensure SignalR services disable local authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-local-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure SignalR services have local authentication disabled, so clients authenticate with Microsoft Entra ID tokens instead of the service access key. By default local authentication with the access key is enabled, and that key grants full control of the SignalR resource.
+
+        **Why this matters**
+
+        - **Key theft**: The SignalR access key allows a holder to connect and send messages to every client. Disabling local auth removes that long-lived bearer credential.
+        - **Attribution**: Microsoft Entra ID authentication ties connections to an identity, which makes access auditable and revocable.
+        - **Centralized control**: Access granted through Entra ID can be revoked by removing a role assignment, whereas a leaked key stays valid until rotated.
+
+        **Risk mitigation**
+
+        - Disable local authentication on the SignalR resource and require Microsoft Entra ID tokens.
+        - Assign least-privilege roles to the identities that connect to the service.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **SignalR** in the Azure Portal.
+        2. Select a SignalR resource.
+        3. Open **Keys** or the authentication settings under **Settings**.
+        4. Verify that access-key (local) authentication is disabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.SignalRService/signalR --resource-group <ResourceGroupName> --name <ResourceName> --query "properties.disableLocalAuth"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable local authentication on a SignalR service using the Azure Portal:
+
+            1. Navigate to **SignalR** in the Azure Portal.
+            2. Select the resource.
+            3. Under **Settings**, open the authentication or keys configuration and disable access-key authentication.
+            4. Assign the appropriate roles to the identities that connect.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable local authentication on a SignalR service using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.SignalRService/signalR --resource-group <ResourceGroupName> --name <ResourceName> --set properties.disableLocalAuth=true
+            ```
+        - id: terraform
+          desc: |
+            To disable local authentication on a SignalR service in Terraform:
+
+            ```hcl
+            resource "azurerm_signalr_service" "example" {
+              name                = "example-signalr"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+              local_auth_enabled  = false
+
+              sku {
+                name     = "Standard_S1"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable local authentication on a SignalR service in Bicep:
+
+            ```bicep
+            resource signalr 'Microsoft.SignalRService/signalR@2024-03-01' = {
+              name: 'example-signalr'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_S1'
+                capacity: 1
+              }
+              properties: {
+                disableLocalAuth: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-concept-authenticate-azure-active-directory
+        title: Authenticate with Microsoft Entra ID for Azure SignalR Service
+  - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_signalr_service")
+    mql: |
+      terraform.resources("azurerm_signalr_service").all(
+        arguments['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_signalr_service")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_signalr_service").all(
+        change.after['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_signalr_service")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_signalr_service").all(
+        values['local_auth_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-local-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.SignalRService/signalR")
+    mql: |
+      bicep.resources.where(type == "Microsoft.SignalRService/signalR").all(
+        properties["disableLocalAuth"] == true
+      )
+  - uid: mondoo-azure-security-signalr-public-network-access-disabled
+    title: Ensure SignalR services disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-signalr-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure SignalR services have public network access disabled, so clients connect only through private endpoints inside an authorized virtual network. By default a SignalR resource accepts connections from the public internet.
+
+        **Why this matters**
+
+        - **Exposed real-time endpoint**: A publicly reachable SignalR endpoint is an internet-facing service that attackers can probe and, with a leaked key, connect to directly.
+        - **Network isolation**: Disabling public access forces client and management traffic through Private Link, which keeps the resource unreachable from outside the perimeter.
+        - **Defense in depth**: Network isolation complements Microsoft Entra ID authentication by rejecting connections from unapproved networks before authentication is attempted.
+
+        **Risk mitigation**
+
+        - Set the SignalR resource public network access to disabled and configure private endpoints for authorized virtual networks.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **SignalR** in the Azure Portal.
+        2. Select a SignalR resource.
+        3. Open **Networking** under **Settings**.
+        4. Verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.SignalRService/signalR --resource-group <ResourceGroupName> --name <ResourceName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on a SignalR service using the Azure Portal:
+
+            1. Navigate to **SignalR** in the Azure Portal.
+            2. Select the resource.
+            3. Under **Settings**, select **Networking**.
+            4. Set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on a SignalR service using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.SignalRService/signalR --resource-group <ResourceGroupName> --name <ResourceName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on a SignalR service in Terraform:
+
+            ```hcl
+            resource "azurerm_signalr_service" "example" {
+              name                          = "example-signalr"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              public_network_access_enabled = false
+
+              sku {
+                name     = "Standard_S1"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on a SignalR service in Bicep:
+
+            ```bicep
+            resource signalr 'Microsoft.SignalRService/signalR@2024-03-01' = {
+              name: 'example-signalr'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_S1'
+                capacity: 1
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-signalr/howto-private-endpoints
+        title: Use private endpoints for Azure SignalR Service
+  - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_signalr_service")
+    mql: |
+      terraform.resources("azurerm_signalr_service").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_signalr_service")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_signalr_service").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_signalr_service")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_signalr_service").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-signalr-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.SignalRService/signalR")
+    mql: |
+      bicep.resources.where(type == "Microsoft.SignalRService/signalR").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  - uid: mondoo-azure-security-webpubsub-public-network-access-disabled
+    title: Ensure Web PubSub services disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Web PubSub services have public network access disabled, so clients connect only through private endpoints inside an authorized virtual network. By default a Web PubSub resource accepts connections from the public internet.
+
+        **Why this matters**
+
+        - **Exposed real-time endpoint**: A publicly reachable Web PubSub endpoint is an internet-facing service that attackers can probe and, with a leaked key, connect to directly.
+        - **Network isolation**: Disabling public access forces client and management traffic through Private Link, which keeps the resource unreachable from outside the perimeter.
+        - **Defense in depth**: Network isolation complements Microsoft Entra ID authentication by rejecting connections from unapproved networks before authentication is attempted.
+
+        **Risk mitigation**
+
+        - Set the Web PubSub resource public network access to disabled and configure private endpoints for authorized virtual networks.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Web PubSub** in the Azure Portal.
+        2. Select a Web PubSub resource.
+        3. Open **Networking** under **Settings**.
+        4. Verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.SignalRService/webPubSub --resource-group <ResourceGroupName> --name <ResourceName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on a Web PubSub service using the Azure Portal:
+
+            1. Navigate to **Web PubSub** in the Azure Portal.
+            2. Select the resource.
+            3. Under **Settings**, select **Networking**.
+            4. Set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on a Web PubSub service using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.SignalRService/webPubSub --resource-group <ResourceGroupName> --name <ResourceName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on a Web PubSub service in Terraform:
+
+            ```hcl
+            resource "azurerm_web_pubsub" "example" {
+              name                          = "example-webpubsub"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              sku                           = "Standard_S1"
+              capacity                      = 1
+              public_network_access_enabled = false
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on a Web PubSub service in Bicep:
+
+            ```bicep
+            resource webPubSub 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
+              name: 'example-webpubsub'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_S1'
+                capacity: 1
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/azure-web-pubsub/howto-secure-private-endpoints
+        title: Use private endpoints for Azure Web PubSub Service
+  - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_web_pubsub")
+    mql: |
+      terraform.resources("azurerm_web_pubsub").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_web_pubsub")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_web_pubsub").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_web_pubsub")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_web_pubsub").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-webpubsub-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.SignalRService/webPubSub")
+    mql: |
+      bicep.resources.where(type == "Microsoft.SignalRService/webPubSub").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled
+    title: Ensure Data Explorer clusters disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Data Explorer (Kusto) clusters have public network access disabled, so the cluster is reachable only through private endpoints inside an authorized virtual network. By default a cluster accepts connections from the public internet.
+
+        **Why this matters**
+
+        - **Bulk data exfiltration**: Data Explorer clusters hold large analytical datasets. A publicly reachable cluster is an internet-facing target for bulk data theft if a credential is compromised.
+        - **Network isolation**: Disabling public access forces query and ingestion traffic through Private Link, which keeps the cluster unreachable from outside the perimeter.
+        - **Defense in depth**: Network isolation complements Microsoft Entra ID authentication by rejecting connections from unapproved networks before authentication is attempted.
+
+        **Risk mitigation**
+
+        - Set the cluster public network access to disabled and configure private endpoints for authorized virtual networks.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Data Explorer Clusters** in the Azure Portal.
+        2. Select a cluster.
+        3. Open **Networking** under **Settings**.
+        4. Verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.Kusto/clusters --resource-group <ResourceGroupName> --name <ClusterName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on a Data Explorer cluster using the Azure Portal:
+
+            1. Navigate to **Azure Data Explorer Clusters** in the Azure Portal.
+            2. Select the cluster.
+            3. Under **Settings**, select **Networking**.
+            4. Set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on a Data Explorer cluster using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.Kusto/clusters --resource-group <ResourceGroupName> --name <ClusterName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on a Data Explorer cluster in Terraform:
+
+            ```hcl
+            resource "azurerm_kusto_cluster" "example" {
+              name                          = "examplekusto"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              public_network_access_enabled = false
+
+              sku {
+                name     = "Dev(No SLA)_Standard_D11_v2"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on a Data Explorer cluster in Bicep:
+
+            ```bicep
+            resource cluster 'Microsoft.Kusto/clusters@2024-04-13' = {
+              name: 'examplekusto'
+              location: resourceGroup().location
+              sku: {
+                name: 'Dev(No SLA)_Standard_D11_v2'
+                tier: 'Basic'
+                capacity: 1
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/data-explorer/security-network-private-endpoint
+        title: Create a private endpoint for Azure Data Explorer
+  - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_kusto_cluster")
+    mql: |
+      terraform.resources("azurerm_kusto_cluster").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_kusto_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_kusto_cluster").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_kusto_cluster")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_kusto_cluster").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-kusto-cluster-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Kusto/clusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Kusto/clusters").all(
+        properties["publicNetworkAccess"] == "Disabled"
+      )
+  - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled
+    title: Ensure Data Explorer clusters enable disk encryption
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Data Explorer (Kusto) clusters have disk encryption enabled, so the cluster's underlying data disks are encrypted at rest. By default disk encryption is disabled, leaving cluster disks unencrypted beyond the platform baseline.
+
+        **Why this matters**
+
+        - **Data at rest**: Data Explorer clusters store large analytical datasets on managed disks. Disk encryption protects that data if the underlying storage is accessed outside the normal control plane.
+        - **Decommissioning and media theft**: Encrypted disks yield no readable data when hardware is retired or improperly disposed of.
+        - **Compliance**: Encryption at rest is a baseline requirement in most security and regulatory frameworks.
+
+        **Risk mitigation**
+
+        - Enable disk encryption on the cluster so its data disks are encrypted at rest.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Azure Data Explorer Clusters** in the Azure Portal.
+        2. Select a cluster.
+        3. Open the **Security** or configuration settings under **Settings**.
+        4. Verify that disk encryption is enabled.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.Kusto/clusters --resource-group <ResourceGroupName> --name <ClusterName> --query "properties.enableDiskEncryption"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To enable disk encryption on a Data Explorer cluster using the Azure Portal:
+
+            1. Navigate to **Azure Data Explorer Clusters** in the Azure Portal.
+            2. Select the cluster.
+            3. Under **Settings**, open the security or configuration settings.
+            4. Enable disk encryption.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To enable disk encryption on a Data Explorer cluster using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.Kusto/clusters --resource-group <ResourceGroupName> --name <ClusterName> --set properties.enableDiskEncryption=true
+            ```
+        - id: terraform
+          desc: |
+            To enable disk encryption on a Data Explorer cluster in Terraform:
+
+            ```hcl
+            resource "azurerm_kusto_cluster" "example" {
+              name                    = "examplekusto"
+              location                = azurerm_resource_group.example.location
+              resource_group_name     = azurerm_resource_group.example.name
+              disk_encryption_enabled = true
+
+              sku {
+                name     = "Dev(No SLA)_Standard_D11_v2"
+                capacity = 1
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable disk encryption on a Data Explorer cluster in Bicep:
+
+            ```bicep
+            resource cluster 'Microsoft.Kusto/clusters@2024-04-13' = {
+              name: 'examplekusto'
+              location: resourceGroup().location
+              sku: {
+                name: 'Dev(No SLA)_Standard_D11_v2'
+                tier: 'Basic'
+                capacity: 1
+              }
+              properties: {
+                enableDiskEncryption: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/data-explorer/security
+        title: Secure your Azure Data Explorer cluster
+  - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_kusto_cluster")
+    mql: |
+      terraform.resources("azurerm_kusto_cluster").all(
+        arguments['disk_encryption_enabled'] == true
+      )
+  - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_kusto_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_kusto_cluster").all(
+        change.after['disk_encryption_enabled'] == true
+      )
+  - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_kusto_cluster")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_kusto_cluster").all(
+        values['disk_encryption_enabled'] == true
+      )
+  - uid: mondoo-azure-security-kusto-cluster-disk-encryption-enabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Kusto/clusters")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Kusto/clusters").all(
+        properties["enableDiskEncryption"] == true
+      )
+  - uid: mondoo-azure-security-automation-account-variables-encrypted
+    title: Ensure Automation account variables are encrypted
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-variables-encrypted-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Automation account string variables are stored encrypted, so secrets such as credentials and connection strings are not readable in plaintext. By default a variable is created unencrypted, and an unencrypted variable value is returned in clear text to anyone with read access to the account.
+
+        **Why this matters**
+
+        - **Plaintext secret exposure**: Automation variables routinely hold connection strings, tokens, and credentials used by runbooks. An unencrypted variable exposes those secrets to any principal with reader access to the account.
+        - **Read access is broad**: Reader-level roles are commonly granted for monitoring and troubleshooting, so plaintext variables leak secrets far beyond their intended audience.
+        - **Encrypted values are protected**: An encrypted variable cannot be read back in plaintext, which prevents casual and accidental secret disclosure.
+
+        **Risk mitigation**
+
+        - Mark every Automation variable that holds a secret as encrypted so its value cannot be read back in plaintext.
+        - Prefer referencing secrets from Key Vault over storing them as Automation variables where possible.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Automation Accounts** in the Azure Portal.
+        2. Select an account.
+        3. Open **Variables** under **Shared Resources**.
+        4. Verify that each variable holding a secret is marked as **Encrypted**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource list --resource-type Microsoft.Automation/automationAccounts/variables --resource-group <ResourceGroupName> --query "[].{Name:name, Encrypted:properties.isEncrypted}"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To store Automation account variables encrypted using the Azure Portal:
+
+            1. Navigate to **Automation Accounts** in the Azure Portal.
+            2. Select the account and open **Variables** under **Shared Resources**.
+            3. Create the variable with **Encrypted** set to **Yes**. An existing unencrypted variable must be recreated as encrypted because the setting is fixed at creation.
+        - id: cli
+          desc: |
+            To store an Automation account variable encrypted using the Azure CLI, create it with encryption enabled. An existing unencrypted variable must be recreated because the setting is fixed at creation:
+
+            ```bash
+            az resource create --resource-type Microsoft.Automation/automationAccounts/variables --resource-group-name <ResourceGroupName> --resource-name <AccountName>/<VariableName> --api-version 2023-11-01 --properties "{\"isEncrypted\": true, \"value\": \"<SecretValue>\"}"
+            ```
+        - id: terraform
+          desc: |
+            To store an Automation account variable encrypted in Terraform:
+
+            ```hcl
+            resource "azurerm_automation_variable_string" "example" {
+              name                    = "example-secret"
+              resource_group_name     = azurerm_resource_group.example.name
+              automation_account_name = azurerm_automation_account.example.name
+              value                   = "sensitive-value"
+              encrypted               = true
+            }
+            ```
+        - id: bicep
+          desc: |
+            To store an Automation account variable encrypted in Bicep:
+
+            ```bicep
+            resource variable 'Microsoft.Automation/automationAccounts/variables@2023-11-01' = {
+              parent: automationAccount
+              name: 'example-secret'
+              properties: {
+                isEncrypted: true
+                value: '"sensitive-value"'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/automation/shared-resources/variables
+        title: Manage variables in Azure Automation
+  - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_automation_variable_string")
+    mql: |
+      terraform.resources("azurerm_automation_variable_string").all(
+        arguments['encrypted'] == true
+      )
+  - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_automation_variable_string")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_variable_string").all(
+        change.after['encrypted'] == true
+      )
+  - uid: mondoo-azure-security-automation-account-variables-encrypted-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_automation_variable_string")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_automation_variable_string").all(
+        values['encrypted'] == true
+      )
+  - uid: mondoo-azure-security-automation-account-variables-encrypted-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Automation/automationAccounts/variables")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Automation/automationAccounts/variables").all(
+        properties["isEncrypted"] == true
+      )
+  - uid: mondoo-azure-security-automation-account-public-network-access-disabled
+    title: Ensure Automation accounts disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-automation-account-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Automation accounts have public network access disabled, so runbook webhooks, DSC, and hybrid worker traffic reach the account only through private endpoints inside an authorized virtual network. By default the account's non-ARM endpoints are reachable from the public internet.
+
+        **Why this matters**
+
+        - **Remote execution surface**: Automation accounts run runbooks that can manage infrastructure and hold credentials. A publicly reachable webhook or agent endpoint is an internet-facing execution surface.
+        - **Network isolation**: Disabling public access forces webhook and agent traffic through Private Link, which keeps the account unreachable from outside the perimeter.
+        - **Defense in depth**: Network isolation complements Microsoft Entra ID authentication by rejecting connections from unapproved networks before authentication is attempted.
+
+        **Risk mitigation**
+
+        - Set the Automation account public network access to disabled and configure private endpoints for authorized virtual networks.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Automation Accounts** in the Azure Portal.
+        2. Select an account.
+        3. Open **Networking** under **Account Settings**.
+        4. Verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.Automation/automationAccounts --resource-group <ResourceGroupName> --name <AccountName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on an Automation account using the Azure Portal:
+
+            1. Navigate to **Automation Accounts** in the Azure Portal.
+            2. Select the account.
+            3. Under **Account Settings**, select **Networking**.
+            4. Set public network access to **Disabled**.
+            5. Configure private endpoints for the authorized virtual networks.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on an Automation account using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.Automation/automationAccounts --resource-group <ResourceGroupName> --name <AccountName> --set properties.publicNetworkAccess=false
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on an Automation account in Terraform:
+
+            ```hcl
+            resource "azurerm_automation_account" "example" {
+              name                          = "example-automation"
+              location                      = azurerm_resource_group.example.location
+              resource_group_name           = azurerm_resource_group.example.name
+              sku_name                      = "Basic"
+              public_network_access_enabled = false
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on an Automation account in Bicep:
+
+            ```bicep
+            resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = {
+              name: 'example-automation'
+              location: resourceGroup().location
+              properties: {
+                publicNetworkAccess: false
+                sku: {
+                  name: 'Basic'
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/automation/how-to/private-link-security
+        title: Use Azure Private Link to securely connect to Azure Automation
+  - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_automation_account")
+    mql: |
+      terraform.resources("azurerm_automation_account").all(
+        arguments['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_automation_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_automation_account").all(
+        change.after['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-automation-account-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_automation_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_automation_account").all(
+        values['public_network_access_enabled'] == false
+      )
+  - uid: mondoo-azure-security-automation-account-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Automation/automationAccounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Automation/automationAccounts").all(
+        properties["publicNetworkAccess"] == false
+      )
+  - uid: mondoo-azure-security-purview-account-public-network-access-disabled
+    title: Ensure Microsoft Purview accounts disable public network access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-purview-account-public-network-access-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Microsoft Purview accounts have public network access disabled, so the data-catalog map of scanned data sources, classifications, and lineage is reachable only through private endpoints inside an authorized virtual network. By default a Purview account accepts connections from the public internet.
+
+        **Why this matters**
+
+        - **Estate reconnaissance exposure**: A Purview account holds a catalog of the entire data estate, including source names, schemas, classifications, and sensitivity labels. Exposing its endpoint to the public internet gives an attacker who obtains a token a map of exactly where the crown-jewel data lives.
+        - **Network isolation**: Disabling public access forces catalog and scanning traffic through Private Link, which keeps the account unreachable from outside the perimeter even when a credential is leaked.
+        - **Defense in depth**: Microsoft Entra ID authentication and role-based collection permissions are most effective when combined with network-level isolation that blocks direct internet probing of the account endpoint.
+
+        **Risk mitigation**
+
+        - Set the Purview account public network access to disabled and configure private endpoints for the account, portal, and ingestion sub-resources in each authorized virtual network.
+        - Restrict catalog and collection access with Microsoft Entra ID authentication and least-privilege role assignments.
+      audit: |
+        **Manual Audit via Azure Portal:**
+
+        1. Navigate to **Microsoft Purview accounts** in the Azure Portal.
+        2. Select an account.
+        3. Open **Networking** under **Settings**.
+        4. On the **Public access** tab, verify that public network access is set to **Disabled**.
+
+        **Automated Audit with Azure CLI:**
+
+        ```bash
+        az resource show --resource-type Microsoft.Purview/accounts --resource-group <ResourceGroupName> --name <AccountName> --query "properties.publicNetworkAccess"
+        ```
+      remediation:
+        - id: portal
+          desc: |
+            To disable public network access on a Microsoft Purview account using the Azure Portal:
+
+            1. Navigate to **Microsoft Purview accounts** in the Azure Portal.
+            2. Select the account.
+            3. Under **Settings**, select **Networking**.
+            4. On the **Public access** tab, set public network access to **Disabled**.
+            5. Configure private endpoints for the account, portal, and ingestion sub-resources in the authorized subnets.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To disable public network access on a Microsoft Purview account using the Azure CLI:
+
+            ```bash
+            az resource update --resource-type Microsoft.Purview/accounts --resource-group <ResourceGroupName> --name <AccountName> --set properties.publicNetworkAccess=Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable public network access on a Microsoft Purview account in Terraform:
+
+            ```hcl
+            resource "azurerm_purview_account" "example" {
+              name                   = "example-purview"
+              resource_group_name    = azurerm_resource_group.example.name
+              location               = azurerm_resource_group.example.location
+              public_network_enabled = false
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable public network access on a Microsoft Purview account in Bicep:
+
+            ```bicep
+            resource purviewAccount 'Microsoft.Purview/accounts@2021-12-01' = {
+              name: 'example-purview'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/purview/catalog-private-link
+        title: Use private endpoints for your Microsoft Purview account
+  - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_purview_account")
+    mql: |
+      terraform.resources("azurerm_purview_account").all(
+        arguments['public_network_enabled'] == false
+      )
+  - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_purview_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_purview_account").all(
+        change.after['public_network_enabled'] == false
+      )
+  - uid: mondoo-azure-security-purview-account-public-network-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_purview_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_purview_account").all(
+        values['public_network_enabled'] == false
+      )
+  - uid: mondoo-azure-security-purview-account-public-network-access-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Purview/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Purview/accounts").all(
+        properties["publicNetworkAccess"] == "Disabled"
       )


### PR DESCRIPTION
## Summary

Adds **18 new security checks** to `mondoo-azure-security` for Azure services the provider supports but the policy did not yet cover, plus hardening of the Cognitive Services (Azure AI) surface. Each check ships **Terraform (HCL / plan / state) + Bicep** variants with full `desc` / `audit` / `remediation` docs and verified compliance tags.

These services have no fine-grained runtime platform yet, so — matching the existing `cognitive-services-public-network-access-disabled` sibling — the checks are authored against IaC assets only (no `-azure` runtime variant). Runtime variants can follow once per-asset platforms land.

## Checks

| Service | Check |
|---|---|
| Cognitive Services (Azure AI) | disable local auth · network ACL default deny · require managed identity |
| Machine Learning | workspace public network access disabled · compute no public IP · online-endpoint key auth disabled¹ |
| Event Grid | local auth disabled · public network access disabled · minimum TLS 1.2² |
| Logic Apps | HTTP trigger caller IP ranges restricted |
| SignalR | local auth disabled · public network access disabled |
| Web PubSub | public network access disabled |
| Azure Data Explorer (Kusto) | public network access disabled · disk encryption enabled³ |
| Automation | account variables encrypted · public network access disabled |
| Microsoft Purview | public network access disabled |

Two originally-proposed controls were substituted where Azure exposes no matching setting, and one was made Bicep-only:
- ¹ **ML online-endpoint key auth** — Bicep-only; the `azurerm` provider has no ML online-endpoint resource (`# No Terraform variants` comment included).
- ² **Event Grid min-TLS** — Bicep-only; `azurerm_eventgrid_topic` has no minimum-TLS argument (ARM does).
- ³ **Kusto disk encryption** — substituted for the requested "disable local auth"; Kusto is always Entra ID authenticated and has no local-auth knob, so disk encryption (`enableDiskEncryption`, default off) is the real security control.
- **Web PubSub public access** — substituted for the requested "SignalR min-TLS"; SignalR enforces TLS 1.2 by default with no knob to assert.

## Field verification

Every `azurerm` argument and Bicep/ARM property was verified against the Terraform Registry provider docs and Microsoft Learn ARM template reference before use (e.g. Purview uses `public_network_enabled`, not `public_network_access_enabled`; Automation `publicNetworkAccess` is a **bool**, not a string enum).

## Compliance tags

Tags reuse two verified in-repo clusters, applied strictly by control objective (no blind copying from adjacent checks):
- **Network boundary** (`sc-7`, …) — from `cognitive-services-public-network-access-disabled`, used for public-network / network-ACL / no-public-IP / IP-restriction checks.
- **Crypto / auth** (`sc-28`, …) — from `eventhubs-local-auth-disabled` and `servicebus-namespace-min-tls-1-2`, used for local-auth / TLS / managed-identity / encrypted-variable checks.

Impact anchored to those siblings: 80 for exposure/auth controls, 70 for TLS / managed-identity / encryption-at-rest.

## Validation

- `cnspec policy lint content/mondoo-azure-security.mql.yaml` → **valid policy bundle** (only pre-existing deprecated-field warnings remain, on unrelated checks).
- `python3 content/validation/validate_remediation_commands.py azure` → **368 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)