### PR TITLE
🐛 fix: don't lock transient nil property values into check execution

### DIFF
--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -47,7 +47,11 @@ type executionManager struct {
 
 type runQueueItem struct {
 	codeBundle *llx.CodeBundle
-	props      map[string]*llx.Result
+	// props returns the query's property values. It is invoked when the item
+	// is dequeued (not when it is queued), so a transient nil property that
+	// was upgraded to its real value while waiting in the queue is picked up.
+	// It may be nil for queries without properties.
+	props func() map[string]*llx.Result
 }
 
 func newExecutionManager(runtime llx.Runtime, runQueue chan runQueueItem,
@@ -84,7 +88,11 @@ func (em *executionManager) Start() {
 				}
 				props := make(map[string]*llx.Primitive)
 				errMsg := ""
-				for k, r := range item.props {
+				var itemProps map[string]*llx.Result
+				if item.props != nil {
+					itemProps = item.props()
+				}
+				for k, r := range itemProps {
 					if r.Error != "" {
 						// This case is tricky to handle. If we cannot run the query at
 						// all, it's unclear what to report for the datapoint. If we

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13/cli/progress"
@@ -77,15 +78,30 @@ type executionQueryProperty struct {
 	checksum string
 	value    *llx.Result
 	resolved bool
-}
-
-func (p *executionQueryProperty) Resolve(value *llx.Result) {
-	p.value = value
-	p.resolved = true
+	// resolvedNil is true when the property resolved to a nil value with no
+	// error. Short-circuit evaluation (e.g. &&, ||) reports nil for
+	// unevaluated branches; a query sharing the property's checksum can
+	// therefore deliver a transient nil BEFORE the real value arrives. Such a
+	// nil may still be upgraded to real data later (see isNilResult /
+	// hasRealData on the datapoint consumers).
+	resolvedNil bool
 }
 
 func (p *executionQueryProperty) IsResolved() bool {
 	return p.resolved
+}
+
+// isNilResultProto returns true if the proto result carries a nil value and
+// no error. This is the proto counterpart of isNilResult.
+func isNilResultProto(res *llx.Result) bool {
+	if res == nil || res.Error != "" {
+		return false
+	}
+	data := res.Data
+	if data == nil {
+		return true
+	}
+	return types.Type(data.Type) == types.Nil
 }
 
 type DataResult struct {
@@ -107,7 +123,11 @@ type ExecutionQueryNodeData struct {
 	queryID    string
 	codeBundle *llx.CodeBundle
 
-	invalidated        bool
+	invalidated bool
+	// propsLock guards requiredProperties value/resolved state. Values are
+	// written by the graph loop and read by the execution manager goroutine
+	// when a queued query materializes its properties.
+	propsLock          sync.Mutex
 	requiredProperties map[string]*executionQueryProperty
 	runState           queryRunState
 	runQueue           chan<- runQueueItem
@@ -122,24 +142,46 @@ func (nodeData *ExecutionQueryNodeData) initialize() {
 
 // consume saves any received data that matches any the required properties
 func (nodeData *ExecutionQueryNodeData) consume(from NodeID, data *envelope) {
-	if nodeData.runState == executedQueryRunState {
-		// Nothing can change once the query has been marked as executed
+	if len(nodeData.requiredProperties) == 0 {
+		if nodeData.runState != executedQueryRunState {
+			nodeData.invalidated = true
+		}
 		return
 	}
 
-	if len(nodeData.requiredProperties) == 0 {
-		nodeData.invalidated = true
+	if data.res == nil {
+		return
 	}
 
-	if data.res != nil {
-		for _, p := range nodeData.requiredProperties {
-			// Find the property with the matching checksum
-			if p.checksum == data.res.CodeID {
-				// Save the value of the property
-				p.Resolve(data.res.Result())
-				// invalidate the node for recalculation
+	nodeData.propsLock.Lock()
+	defer nodeData.propsLock.Unlock()
+
+	for _, p := range nodeData.requiredProperties {
+		// Find the property with the matching checksum
+		if p.checksum != data.res.CodeID {
+			continue
+		}
+
+		if !p.resolved {
+			// First result for this property. A nil (no value, no error) may
+			// come from short-circuit evaluation and may be followed by the
+			// real value. Accept it so execution is not blocked (a property
+			// can legitimately be null), but remember that it may be upgraded.
+			p.value = data.res.Result()
+			p.resolved = true
+			p.resolvedNil = isNilResultProto(p.value)
+			if nodeData.runState != executedQueryRunState {
 				nodeData.invalidated = true
 			}
+			continue
+		}
+
+		// Already resolved: only allow a real result (value or error) to
+		// replace a previously-reported transient nil. This mirrors the
+		// nil-override semantics of DatapointNodeData/ReportingQueryNodeData.
+		if p.resolvedNil && hasRealData(data.res) {
+			p.value = data.res.Result()
+			p.resolvedNil = false
 		}
 	}
 }
@@ -174,27 +216,36 @@ func (nodeData *ExecutionQueryNodeData) recalculate() *envelope {
 // this should only be called when the query is runnable (
 // all properties needed are available)
 func (nodeData *ExecutionQueryNodeData) run() {
-	var props map[string]*llx.Result
-
-	if len(nodeData.requiredProperties) > 0 {
-		props = make(map[string]*llx.Result)
-		for _, p := range nodeData.requiredProperties {
-			props[p.name] = p.value
-		}
-	}
-
 	nodeData.runState = executedQueryRunState
 
 	nodeData.runQueue <- runQueueItem{
 		codeBundle: nodeData.codeBundle,
-		props:      props,
+		props:      nodeData.materializeProps,
 	}
+}
+
+// materializeProps snapshots the current property values. It is called by the
+// execution manager when the query is dequeued, NOT when it is queued: if a
+// transient nil property was upgraded to its real value while the query was
+// waiting in the run queue, the query executes with the real value.
+func (nodeData *ExecutionQueryNodeData) materializeProps() map[string]*llx.Result {
+	nodeData.propsLock.Lock()
+	defer nodeData.propsLock.Unlock()
+
+	if len(nodeData.requiredProperties) == 0 {
+		return nil
+	}
+	props := make(map[string]*llx.Result, len(nodeData.requiredProperties))
+	for _, p := range nodeData.requiredProperties {
+		props[p.name] = p.value
+	}
+	return props
 }
 
 // updateRunState sets the query to runnable if all the
 // required properties needed have been received
 func (d *ExecutionQueryNodeData) updateRunState() {
-	if d.runState == readyQueryRunState {
+	if d.runState == readyQueryRunState || d.runState == executedQueryRunState {
 		return
 	}
 

--- a/policy/executor/internal/nodes_nilprop_test.go
+++ b/policy/executor/internal/nodes_nilprop_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package internal

--- a/policy/executor/internal/nodes_nilprop_test.go
+++ b/policy/executor/internal/nodes_nilprop_test.go
@@ -1,0 +1,147 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func nilPropNode(t *testing.T) (*ExecutionQueryNodeData, chan runQueueItem) {
+	t.Helper()
+	q := make(chan runQueueItem, 1)
+	nodeData := &ExecutionQueryNodeData{
+		queryID:  "checkquery",
+		runQueue: q,
+		codeBundle: &llx.CodeBundle{
+			CodeV2: &llx.CodeV2{Id: "checkquery"},
+		},
+		requiredProperties: map[string]*executionQueryProperty{
+			"prop1": {
+				name:     "prop1",
+				checksum: "prop-checksum",
+			},
+		},
+	}
+	nodeData.initialize()
+	require.Nil(t, nodeData.recalculate())
+	return nodeData, q
+}
+
+func nilRes(checksum string) *llx.RawResult {
+	return &llx.RawResult{
+		CodeID: checksum,
+		Data:   &llx.RawData{Type: types.String, Value: nil, Error: nil},
+	}
+}
+
+// A transient nil (short-circuit evaluation reports nil for unevaluated
+// branches; see isNilResult) can arrive for a property checksum BEFORE the
+// real value. The query must execute with the real value, not the nil.
+// Otherwise every comparison against the property evaluates to false and the
+// check reports a false FAIL with correct-looking data.
+func TestExecutionQueryNode_NilPropUpgradedBeforeDequeue(t *testing.T) {
+	nodeData, q := nilPropNode(t)
+
+	// 1. transient nil arrives first: query becomes runnable and is queued
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: nilRes("prop-checksum")})
+	nodeData.recalculate()
+
+	// 2. real value arrives while the item waits in the run queue
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: &llx.RawResult{
+		CodeID: "prop-checksum",
+		Data:   llx.StringData("Success and Failure"),
+	}})
+	nodeData.recalculate()
+
+	select {
+	case item := <-q:
+		props := item.props()
+		got := props["prop1"]
+		require.NotNil(t, got)
+		require.Empty(t, got.Error)
+		require.NotNil(t, got.Data)
+		assert.Equal(t, llx.StringPrimitive("Success and Failure").Value, got.Data.Value,
+			"query must execute with the real value, not the transient nil")
+	default:
+		t.Fatal("query never queued")
+	}
+
+	// the nil->real upgrade must not queue the query a second time
+	select {
+	case <-q:
+		t.Fatal("query queued twice")
+	default:
+	}
+}
+
+// A property may legitimately resolve to null (e.g. a missing map key).
+// If no real value ever arrives, the query still runs with the null value.
+func TestExecutionQueryNode_LegitimateNullPropStillRuns(t *testing.T) {
+	nodeData, q := nilPropNode(t)
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: nilRes("prop-checksum")})
+	nodeData.recalculate()
+
+	select {
+	case item := <-q:
+		props := item.props()
+		got := props["prop1"]
+		require.NotNil(t, got)
+		assert.Equal(t, types.Type(got.Data.Type), types.Nil, "null property value is preserved")
+	default:
+		t.Fatal("query never queued")
+	}
+}
+
+// A real value must never be downgraded by a later nil for the same checksum.
+func TestExecutionQueryNode_RealPropNotDowngradedByNil(t *testing.T) {
+	nodeData, q := nilPropNode(t)
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: &llx.RawResult{
+		CodeID: "prop-checksum",
+		Data:   llx.StringData("Success"),
+	}})
+	nodeData.recalculate()
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: nilRes("prop-checksum")})
+	nodeData.recalculate()
+
+	select {
+	case item := <-q:
+		got := item.props()["prop1"]
+		require.NotNil(t, got)
+		assert.Equal(t, llx.StringPrimitive("Success").Value, got.Data.Value)
+	default:
+		t.Fatal("query never queued")
+	}
+}
+
+// An error result is real data: it must resolve the property (and win over a
+// transient nil), so the execution manager can surface the property error.
+func TestExecutionQueryNode_ErrorPropOverridesNil(t *testing.T) {
+	nodeData, q := nilPropNode(t)
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: nilRes("prop-checksum")})
+	nodeData.recalculate()
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: &llx.RawResult{
+		CodeID: "prop-checksum",
+		Data:   &llx.RawData{Error: assert.AnError},
+	}})
+	nodeData.recalculate()
+
+	select {
+	case item := <-q:
+		got := item.props()["prop1"]
+		require.NotNil(t, got)
+		assert.NotEmpty(t, got.Error)
+	default:
+		t.Fatal("query never queued")
+	}
+}

--- a/policy/executor/internal/nodes_test.go
+++ b/policy/executor/internal/nodes_test.go
@@ -489,7 +489,7 @@ func TestExecutionQueryNode(t *testing.T) {
 			case item := <-q:
 				require.NotNil(t, item.codeBundle)
 				assert.Equal(t, "testqueryid", item.codeBundle.CodeV2.Id)
-				assert.Contains(t, item.props, "prop1")
+				assert.Contains(t, item.props(), "prop1")
 			default:
 				assert.Fail(t, "expected something to be executed")
 			}


### PR DESCRIPTION
Fixes #2971

## Problem

`ExecutionQueryNodeData.consume` resolves a required property with the **first** result that arrives for its checksum and then locks (`executedQueryRunState`). Short-circuit evaluation reports transient nil results for unevaluated branches (#2209); when such a nil lands on a property checksum before the real value, the check executes with a **null prop**. Null comparisons are defined `false` (`nonNilDataOpV2`), so e.g. `.all(field == props.X)` fails for every entry → **false FAIL with correct-looking assessment data**, because the display consumers (patched in #2209) do accept the later real value.

#2209 added `isNilResult`/`hasRealData` tolerance to `DatapointNodeData`, `ReportingQueryNodeData` and `ReportingJobNodeData` — but not to `ExecutionQueryNodeData`, the consumer that feeds `props` into execution. Since prop queries are deduplicated by CodeID across policies, one nil-first race poisons every check consuming that prop in the scan.

## Fix

- `ExecutionQueryNodeData.consume`: track properties resolved to nil-without-error (`resolvedNil`); allow a later **real** result (value or error) to upgrade them. Real values are never downgraded by a later nil. Mirrors the #2209 semantics.
- `runQueueItem.props` is now a closure (`materializeProps`) invoked when the execution manager **dequeues** the item instead of a map snapshotted when the query is queued — upgrades that land while the item waits in the run queue take effect.
- Property state is mutex-guarded (graph loop writes; execution manager goroutine reads).
- `updateRunState` can no longer leave `executedQueryRunState` (prevents re-queue on post-execution consume).

A legitimately-null property (no real value ever arrives) still resolves and executes with null — nothing deadlocks, and `TestExecutionQueryNode_LegitimateNullPropStillRuns` pins that behavior.

## Tests

- `TestExecutionQueryNode_NilPropUpgradedBeforeDequeue` — the regression: nil-then-real must execute with the real value, and must not queue twice (fails on `main`)
- `TestExecutionQueryNode_LegitimateNullPropStillRuns` — null props still run
- `TestExecutionQueryNode_RealPropNotDowngradedByNil` — no downgrade
- `TestExecutionQueryNode_ErrorPropOverridesNil` — errors are real data and win over transient nils
- `go test -race ./policy/executor/internal/` clean; `./policy/executor/... ./policy/` green

## Limitation / follow-up

If the real value arrives only **after** the query was dequeued and executed, the consumer side cannot help — the producer (llx short-circuit nil caching) still needs a fix to stop emitting transient nils for callback points that later produce real values. Tracked in #2971.