### PR TITLE
🐛 fix: stop query-run error broadcasts from poisoning shared datapoints

### DIFF
--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -4,12 +4,12 @@
 package internal
 
 import (
-	"errors"
 	"os"
 	goruntime "runtime"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13"
 	"go.mondoo.com/mql/v13/llx"
@@ -174,14 +174,20 @@ func (em *executionManager) executeCodeBundle(codeBundle *llx.CodeBundle, props 
 			// is not guaranteed to happen in a single thread
 			wg.Add(checksum)
 			if errMsg != "" {
-				// TODO: this is not entirely correct when looking at things as a whole.
-				// Its possible that another query executing will produce a non error.
-				// However, datapoint nodes take the first data that was reported. This
-				// issue exists in general for any query that errors
+				// The query cannot run; broadcast a typed placeholder for
+				// every codepoint so downstream consumers don't wait forever.
+				// Datapoint checksums are content-addressed and shared across
+				// queries, so a healthy query may still report a real result
+				// for the same checksum. Consumers let executed results
+				// override these placeholders and never let a placeholder
+				// override an executed result (see queryRunError).
 				sendResult(&llx.RawResult{
 					CodeID: checksum,
 					Data: &llx.RawData{
-						Error: errors.New(errMsg),
+						Error: &queryRunError{
+							originCodeID: codeBundle.CodeV2.GetId(),
+							err:          errors.New(errMsg),
+						},
 					},
 				})
 			}

--- a/policy/executor/internal/nodes.go
+++ b/policy/executor/internal/nodes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13/cli/progress"
 	"go.mondoo.com/cnspec/v13/policy"
@@ -26,6 +27,63 @@ func isNilResult(res *llx.RawResult) bool {
 func hasRealData(res *llx.RawResult) bool {
 	return res != nil && res.Data != nil &&
 		(res.Data.Value != nil || res.Data.Error != nil)
+}
+
+// queryRunError marks a result that was broadcast for a query that could not
+// be executed at all (e.g. one of its properties errored). Such results are
+// placeholders: they exist so that datapoint consumers do not wait forever
+// for results that will never arrive. They are NOT produced by evaluating the
+// statement they are reported for. Datapoint checksums are content-addressed
+// and shared across queries, so a placeholder may land on a checksum that a
+// different, healthy query will still report a real result for. Consumers
+// therefore let any executed result (value, nil, or error) override a
+// placeholder, and never let a placeholder override anything.
+type queryRunError struct {
+	// originCodeID is the CodeV2.Id of the query that failed to run
+	originCodeID string
+	err          error
+}
+
+func (e *queryRunError) Error() string { return e.err.Error() }
+func (e *queryRunError) Unwrap() error { return e.err }
+
+// isPlaceholderResult returns true if the result is a broadcast placeholder
+// for a query that never ran (see queryRunError).
+func isPlaceholderResult(res *llx.RawResult) bool {
+	if res == nil || res.Data == nil || res.Data.Error == nil {
+		return false
+	}
+	var qre *queryRunError
+	return errors.As(res.Data.Error, &qre)
+}
+
+// placeholderOrigin returns the CodeID of the query whose failure produced
+// this placeholder result, or "" if the result is not a placeholder.
+func placeholderOrigin(res *llx.RawResult) string {
+	if res == nil || res.Data == nil || res.Data.Error == nil {
+		return ""
+	}
+	var qre *queryRunError
+	if errors.As(res.Data.Error, &qre) {
+		return qre.originCodeID
+	}
+	return ""
+}
+
+// resultUpgrades returns true if next should replace prev:
+//   - an executed result (real data, error, or evaluated nil) replaces a
+//     placeholder
+//   - real data replaces an evaluated nil (short-circuit case)
+//
+// A placeholder never replaces anything.
+func resultUpgrades(prev, next *llx.RawResult) bool {
+	if isPlaceholderResult(next) {
+		return false
+	}
+	if isPlaceholderResult(prev) {
+		return true
+	}
+	return isNilResult(prev) && hasRealData(next)
 }
 
 const (
@@ -85,6 +143,10 @@ type executionQueryProperty struct {
 	// nil may still be upgraded to real data later (see isNilResult /
 	// hasRealData on the datapoint consumers).
 	resolvedNil bool
+	// resolvedPlaceholder is true when the property resolved from a broadcast
+	// placeholder (queryRunError) of a query that never ran. An executed
+	// result may upgrade it.
+	resolvedPlaceholder bool
 }
 
 func (p *executionQueryProperty) IsResolved() bool {
@@ -93,6 +155,15 @@ func (p *executionQueryProperty) IsResolved() bool {
 
 // isNilResultProto returns true if the proto result carries a nil value and
 // no error. This is the proto counterpart of isNilResult.
+//
+// It relies on RawData.Result() normalizing nil values to types.Nil in the
+// proto representation: raw2primitive returns NilPrimitive for any nil value
+// regardless of the declared type (llx/data_conversions.go), so a typed nil
+// (e.g. RawData{Type: types.String, Value: nil}) arrives here with
+// Data.Type == types.Nil. Do NOT additionally test Data.Value == nil:
+// falsy real values encode as empty/zero byte slices (e.g. "" -> []byte{}),
+// which proto round-trips can deliver as nil slices — such a check would
+// misclassify real values as nil.
 func isNilResultProto(res *llx.Result) bool {
 	if res == nil || res.Error != "" {
 		return false
@@ -170,16 +241,23 @@ func (nodeData *ExecutionQueryNodeData) consume(from NodeID, data *envelope) {
 			p.value = data.res.Result()
 			p.resolved = true
 			p.resolvedNil = isNilResultProto(p.value)
+			p.resolvedPlaceholder = isPlaceholderResult(data.res)
 			if nodeData.runState != executedQueryRunState {
 				nodeData.invalidated = true
 			}
 			continue
 		}
 
-		// Already resolved: only allow a real result (value or error) to
-		// replace a previously-reported transient nil. This mirrors the
-		// nil-override semantics of DatapointNodeData/ReportingQueryNodeData.
-		if p.resolvedNil && hasRealData(data.res) {
+		// Already resolved: allow an executed result to replace a broadcast
+		// placeholder, and a real result to replace a transient nil. This
+		// mirrors the upgrade semantics of the datapoint consumers.
+		if p.resolvedPlaceholder && !isPlaceholderResult(data.res) {
+			p.value = data.res.Result()
+			p.resolvedPlaceholder = false
+			p.resolvedNil = isNilResultProto(p.value)
+			continue
+		}
+		if p.resolvedNil && hasRealData(data.res) && !isPlaceholderResult(data.res) {
 			p.value = data.res.Result()
 			p.resolvedNil = false
 		}
@@ -285,10 +363,11 @@ func (nodeData *DatapointNodeData) consume(from NodeID, data *envelope) {
 		return
 	}
 	if nodeData.isReported {
-		// Allow a real result to override a nil one. This handles the case
-		// where short-circuit evaluation (e.g. &&) reports nil for an
-		// unevaluated branch, and a later query reports the actual value.
-		if isNilResult(nodeData.res) && hasRealData(data.res) {
+		// Allow upgrades only:
+		// - an executed result overrides a broadcast placeholder from a query
+		//   that never ran (see queryRunError)
+		// - a real result overrides a nil one from short-circuit evaluation
+		if resultUpgrades(nodeData.res, data.res) {
 			nodeData.set(data.res)
 		}
 		return
@@ -350,8 +429,9 @@ func (nodeData *ReportingQueryNodeData) consume(from NodeID, data *envelope) {
 		return
 	}
 	if dr.resolved {
-		// Allow a real result to override a nil one (short-circuit case)
-		if isNilResult(dr.value) && hasRealData(data.res) {
+		// Allow upgrades only: executed results override broadcast
+		// placeholders, real results override short-circuit nils.
+		if resultUpgrades(dr.value, data.res) {
 			dr.value = data.res
 			nodeData.invalidated = true
 		}
@@ -390,7 +470,13 @@ func (nodeData *ReportingQueryNodeData) score() *policy.Score {
 	var scoreFound *llx.RawData
 	var scoreValue int
 
+	// Errors are aggregated in two buckets. Placeholder errors broadcast by
+	// OTHER queries that could not run (see queryRunError) land on shared
+	// datapoint checksums; their messages describe a different query's
+	// failure and must not leak into this query's message if this query has
+	// errors of its own.
 	var err multierr.Errors
+	var foreignErr multierr.Errors
 	for _, dr := range nodeData.results {
 		cur := dr.value
 		if cur == nil {
@@ -407,7 +493,11 @@ func (nodeData *ReportingQueryNodeData) score() *policy.Score {
 				foundError = true
 			}
 
-			err.Add(cur.Data.Error)
+			if origin := placeholderOrigin(cur); origin != "" && origin != nodeData.queryID {
+				foreignErr.Add(cur.Data.Error)
+			} else {
+				err.Add(cur.Data.Error)
+			}
 			continue
 		}
 
@@ -429,6 +519,13 @@ func (nodeData *ReportingQueryNodeData) score() *policy.Score {
 		if valid {
 			allSkipped = false
 		}
+	}
+
+	// Prefer this query's own errors for the message; fall back to foreign
+	// placeholder errors only when they are all we have (e.g. this query's
+	// shared statement was poisoned and nothing else errored).
+	if len(err.Errors) == 0 {
+		err = foreignErr
 	}
 
 	if allFound {
@@ -570,10 +667,19 @@ func (nodeData *ReportingJobNodeData) consume(from NodeID, data *envelope) {
 		if !ok {
 			panic("invalid datapoint report")
 		}
-		// If the previously-reported result was nil (from short-circuit) and
-		// we're now getting real data, reset completed so the score can be
-		// recalculated with the actual data.
-		if nodeData.completed && isNilResult(dp.res) && hasRealData(data.res) {
+		// A broadcast placeholder (queryRunError) never replaces an executed
+		// result, and any non-upgrade write (duplicate, downgrade) is
+		// dropped — mirroring DatapointNodeData/ReportingQueryNodeData.
+		// Upgrades (executed result over placeholder, real data over
+		// short-circuit nil) reopen a completed job so the score is
+		// recalculated with the better data.
+		if dp.res != nil && isPlaceholderResult(data.res) && !isPlaceholderResult(dp.res) {
+			return
+		}
+		if dp.res != nil && !resultUpgrades(dp.res, data.res) {
+			return
+		}
+		if nodeData.completed {
 			nodeData.completed = false
 		}
 		dp.res = data.res

--- a/policy/executor/internal/nodes_placeholder_test.go
+++ b/policy/executor/internal/nodes_placeholder_test.go
@@ -1,0 +1,208 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package internal
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func placeholderRes(checksum, origin, msg string) *llx.RawResult {
+	return &llx.RawResult{
+		CodeID: checksum,
+		Data: &llx.RawData{
+			Error: &queryRunError{originCodeID: origin, err: errors.New(msg)},
+		},
+	}
+}
+
+func realBoolRes(checksum string, v bool) *llx.RawResult {
+	return &llx.RawResult{CodeID: checksum, Data: llx.BoolData(v)}
+}
+
+func executedNilRes(checksum string) *llx.RawResult {
+	return &llx.RawResult{
+		CodeID: checksum,
+		Data:   &llx.RawData{Type: types.String, Value: nil, Error: nil},
+	}
+}
+
+// A broadcast placeholder from a query that never ran must not survive on a
+// shared datapoint once a healthy query reports an executed result.
+func TestDatapointNode_PlaceholderUpgradedByExecutedResult(t *testing.T) {
+	t.Run("real value overrides placeholder", func(t *testing.T) {
+		nodeData := &DatapointNodeData{}
+		nodeData.initialize()
+		nodeData.consume("", &envelope{res: placeholderRes("cs", "otherquery", "property p errored")})
+		nodeData.consume("", &envelope{res: realBoolRes("cs", true)})
+		require.NotNil(t, nodeData.res)
+		require.Nil(t, nodeData.res.Data.Error)
+		assert.Equal(t, true, nodeData.res.Data.Value)
+	})
+
+	t.Run("executed nil overrides placeholder", func(t *testing.T) {
+		nodeData := &DatapointNodeData{}
+		nodeData.initialize()
+		nodeData.consume("", &envelope{res: placeholderRes("cs", "otherquery", "property p errored")})
+		nodeData.consume("", &envelope{res: executedNilRes("cs")})
+		require.NotNil(t, nodeData.res)
+		assert.Nil(t, nodeData.res.Data.Error)
+	})
+
+	t.Run("placeholder never overrides executed result", func(t *testing.T) {
+		nodeData := &DatapointNodeData{}
+		nodeData.initialize()
+		nodeData.consume("", &envelope{res: realBoolRes("cs", true)})
+		nodeData.consume("", &envelope{res: placeholderRes("cs", "otherquery", "property p errored")})
+		require.Nil(t, nodeData.res.Data.Error)
+		assert.Equal(t, true, nodeData.res.Data.Value)
+	})
+
+	t.Run("real executed error is kept (not a placeholder)", func(t *testing.T) {
+		nodeData := &DatapointNodeData{}
+		nodeData.initialize()
+		nodeData.consume("", &envelope{res: &llx.RawResult{
+			CodeID: "cs",
+			Data:   &llx.RawData{Error: errors.New("real execution error")},
+		}})
+		nodeData.consume("", &envelope{res: realBoolRes("cs", true)})
+		// a genuinely executed error is real data; it is not upgraded away
+		require.NotNil(t, nodeData.res.Data.Error)
+	})
+}
+
+// A healthy query whose shared statement checksum was poisoned by another
+// query's broadcast placeholder must score from its own executed results.
+func TestReportingQueryNode_PoisonedSharedChecksumRecovers(t *testing.T) {
+	nodeData := &ReportingQueryNodeData{
+		queryID: "healthyquery",
+		results: map[string]*DataResult{
+			"shared-cs": {checksum: "shared-cs"},
+		},
+	}
+	nodeData.initialize()
+
+	// another query that could not run broadcasts its placeholder first
+	nodeData.consume(NodeID("shared-cs"), &envelope{res: placeholderRes("shared-cs", "brokenquery", "property p errored")})
+	s := nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Error, s.Type, "before the upgrade the poisoned score is an error")
+
+	// the healthy query executes and reports the real result
+	nodeData.consume(NodeID("shared-cs"), &envelope{res: realBoolRes("shared-cs", true)})
+	nodeData.invalidated = true
+	s = nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Result, s.Type, "executed result must override the placeholder")
+	assert.Equal(t, uint32(100), s.Value)
+	assert.Empty(t, s.Message)
+}
+
+// An erroring query must report its OWN property error, not the error of a
+// different query that happened to poison a shared statement checksum first.
+func TestReportingQueryNode_OwnErrorPreferredOverForeign(t *testing.T) {
+	nodeData := &ReportingQueryNodeData{
+		queryID: "queryA",
+		results: map[string]*DataResult{
+			"shared-cs": {checksum: "shared-cs"},
+			"own-cs":    {checksum: "own-cs"},
+		},
+	}
+	nodeData.initialize()
+
+	// queryB failed first and poisoned the shared checksum
+	nodeData.consume(NodeID("shared-cs"), &envelope{res: placeholderRes("shared-cs", "queryB", "property propB errored: bad B")})
+	// queryA's own broadcast for its exclusive checksum
+	nodeData.consume(NodeID("own-cs"), &envelope{res: placeholderRes("own-cs", "queryA", "property propA errored: bad A")})
+
+	s := nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Error, s.Type)
+	assert.Contains(t, s.Message, "propA", "own error must be reported")
+	assert.NotContains(t, s.Message, "propB", "foreign query's error must not leak into this query's message")
+}
+
+// If the only errors available are foreign placeholders, they are still used
+// as the message (better than an empty error).
+func TestReportingQueryNode_ForeignErrorFallback(t *testing.T) {
+	nodeData := &ReportingQueryNodeData{
+		queryID: "queryA",
+		results: map[string]*DataResult{
+			"shared-cs": {checksum: "shared-cs"},
+		},
+	}
+	nodeData.initialize()
+	nodeData.consume(NodeID("shared-cs"), &envelope{res: placeholderRes("shared-cs", "queryB", "property propB errored: bad B")})
+
+	s := nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Error, s.Type)
+	assert.True(t, strings.Contains(s.Message, "propB"), "fallback to the only available message")
+}
+
+// A completed reporting job must reopen when a poisoned datapoint is upgraded
+// with the executed result, and a placeholder must never clobber an executed
+// result.
+func TestReportingJobNode_PlaceholderUpgradeReopens(t *testing.T) {
+	newJob := func() *ReportingJobNodeData {
+		return &ReportingJobNodeData{
+			queryID:      "job",
+			forwardScore: true,
+			childScores:  map[NodeID]*reportingJobResult{},
+			datapoints: map[NodeID]*reportingJobDatapoint{
+				"cs": {},
+			},
+		}
+	}
+
+	t.Run("real result reopens completed job", func(t *testing.T) {
+		nodeData := newJob()
+		nodeData.consume(NodeID("cs"), &envelope{res: placeholderRes("cs", "otherquery", "property p errored")})
+		nodeData.completed = true
+
+		nodeData.consume(NodeID("cs"), &envelope{res: realBoolRes("cs", true)})
+		assert.False(t, nodeData.completed, "upgrade must reopen the job for rescoring")
+		require.NotNil(t, nodeData.datapoints[NodeID("cs")].res)
+		assert.Nil(t, nodeData.datapoints[NodeID("cs")].res.Data.Error)
+	})
+
+	t.Run("placeholder does not clobber executed result", func(t *testing.T) {
+		nodeData := newJob()
+		nodeData.consume(NodeID("cs"), &envelope{res: realBoolRes("cs", true)})
+		nodeData.consume(NodeID("cs"), &envelope{res: placeholderRes("cs", "otherquery", "property p errored")})
+		require.NotNil(t, nodeData.datapoints[NodeID("cs")].res)
+		assert.Nil(t, nodeData.datapoints[NodeID("cs")].res.Data.Error)
+	})
+}
+
+// A property fed by a poisoned datapoint must pick up the executed value.
+func TestExecutionQueryNode_PlaceholderPropUpgraded(t *testing.T) {
+	nodeData, q := nilPropNode(t)
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: placeholderRes("prop-checksum", "otherquery", "property p errored")})
+	nodeData.recalculate()
+
+	nodeData.consume(NodeID("prop-checksum"), &envelope{res: &llx.RawResult{
+		CodeID: "prop-checksum",
+		Data:   llx.StringData("Success and Failure"),
+	}})
+	nodeData.recalculate()
+
+	select {
+	case item := <-q:
+		got := item.props()["prop1"]
+		require.NotNil(t, got)
+		require.Empty(t, got.Error, "placeholder error must be upgraded by the real value")
+		assert.Equal(t, llx.StringPrimitive("Success and Failure").Value, got.Data.Value)
+	default:
+		t.Fatal("query never queued")
+	}
+}


### PR DESCRIPTION
Fixes #2973

> **Note:** stacked on #2972 (includes its commits — the property-materialization plumbing this fix builds on). Merge #2972 first; this PR then reduces to the placeholder changes.

## Problem

When a query cannot run (e.g. one of its properties errored), `executeCodeBundle` broadcasts the error as the result for **every codepoint checksum of the bundle** — acknowledged as incorrect by the existing TODO. Datapoint checksums are content-addressed and shared across queries with identical (sub)statements, and datapoint nodes keep the **first** reported result. Two failure modes:

1. **Score poisoning** — a healthy query sharing a statement checksum with a failing one is scored ERROR if the failing query's broadcast lands first.
2. **Message contamination** — an erroring query's message shows a *different* query's property error. Reproducible deterministically with two checks sharing `users.where(uid == 0).list != []`, each with its own erroring prop:

```
! Error:  A - prop hard-errors at runtime
  Message:    2 errors occurred:
        * property errprop2 errored: ...
        * property swerrprop2 errored: ...   <-- belongs to check B
```

## Fix

The broadcast results become **typed placeholders** — `queryRunError{originCodeID, err}` — distinguishable from results produced by actually executing a statement, and carrying which query's failure produced them. Consumers get upgrade semantics mirroring the #2209 nil-override handling (`resultUpgrades`):

- an **executed** result (value, evaluated nil, or genuine error) overrides a placeholder; a **placeholder never overrides anything** — applied to `DatapointNodeData`, `ReportingQueryNodeData`, `ReportingJobNodeData`, and `ExecutionQueryNodeData` (props)
- `ReportingJobNodeData` reopens a completed job when a poisoned datapoint is upgraded, so the score is recalculated with real data
- `ReportingQueryNodeData.score` aggregates errors **origin-aware**: the query's own errors are preferred for the message; foreign placeholder errors are used only as a fallback when nothing else errored

The erroring query itself still scores ERROR through its own placeholders — no behavior change for genuinely broken queries.

## Verification

- New: `nodes_placeholder_test.go` — placeholder-vs-real precedence on all four consumers, poisoned-shared-checksum recovery (ERROR→Result), own-vs-foreign message preference, foreign-message fallback, completed-job reopen
- E2E: the two-check repro above now reports `1 error occurred: * property errprop2 …` for A and `1 error occurred: * property swerrprop2 …` for B (was: both messages on both checks)
- `go test -race ./policy/executor/internal/` clean; `./policy/executor/... ./policy/` green