### PR TITLE
🐛 Apply server-activated features before asset discovery

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -347,6 +347,66 @@ func (s *LocalScanner) stampScanSource(job *Job) {
 	job.Inventory.ApplyLabels(map[string]string{LabelScanSource: s.scanSource})
 }
 
+// withServerFeatures layers the named server-activated mql features onto ctx.
+// Server features are layered on top of features already set by local config —
+// we never replace or disable what the user asked for. Unknown names are logged
+// and skipped. It is a no-op for an empty list.
+func withServerFeatures(ctx context.Context, featureNames []string) context.Context {
+	if len(featureNames) == 0 {
+		return ctx
+	}
+	log.Info().Strs("features", featureNames).Msg("server activated features")
+	for _, name := range featureNames {
+		f, ok := mql.FeaturesValue[name]
+		if !ok {
+			log.Warn().Str("feature", name).Msg("unknown server feature, ignoring")
+			continue
+		}
+		ctx = mql.WithFeature(ctx, f)
+	}
+	return ctx
+}
+
+// resolveServerScanParameters fetches server-controlled scan parameters and
+// layers any server-activated features onto ctx. It returns the enriched ctx
+// plus the resolved remote services and space MRN, which the scan pipeline
+// reuses.
+//
+// This MUST run before asset discovery. Connection-level features (e.g.
+// TerraformResolveVars, read at provider Connect time) only take effect if they
+// are present on the context when the provider connects, and discovery connects
+// the root asset. Fetching scan parameters after discovery — as this code used
+// to — left those features inactive on the root connection. For incognito or
+// credential-less scans it is a no-op that returns ctx unchanged with nil
+// services.
+func (s *LocalScanner) resolveServerScanParameters(ctx context.Context, upstreamConfig *upstream.UpstreamConfig) (context.Context, *policy.Services, string, error) {
+	if upstreamConfig == nil || upstreamConfig.ApiEndpoint == "" || upstreamConfig.Incognito {
+		return ctx, nil, "", nil
+	}
+
+	client, err := upstreamConfig.InitClient(ctx)
+	if err != nil {
+		return ctx, nil, "", err
+	}
+	spaceMrn := client.SpaceMrn
+
+	services, err := policy.NewRemoteServices(client.ApiEndpoint, client.Plugins, client.HttpClient)
+	if err != nil {
+		return ctx, nil, "", err
+	}
+
+	resp, err := services.GetScanParameters(ctx, &policy.GetScanParametersReq{ScopeMrn: spaceMrn})
+	if err != nil {
+		// A failed scan-parameters call must not abort the scan; proceed without
+		// server-activated features.
+		log.Warn().Err(err).Msg("could not get server scan parameters")
+		return ctx, services, spaceMrn, nil
+	}
+
+	ctx = withServerFeatures(ctx, resp.GetEnabledFeatures())
+	return ctx, services, spaceMrn, nil
+}
+
 func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *upstream.UpstreamConfig) (*ScanResult, error) {
 	// Stamp the scan source (interactive vs. service) onto every asset so it can
 	// be aggregated upstream. This is the single chokepoint for Run/RunIncognito
@@ -377,6 +437,14 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			}
 			conf.Options[plugin.OptionStagedDiscovery] = ""
 		}
+	}
+
+	// Fetch server-controlled scan parameters and layer any server-activated
+	// features onto ctx BEFORE discovery, so connection-level features (e.g.
+	// TerraformResolveVars) are present when discovery connects the root asset.
+	ctx, services, spaceMrn, err := s.resolveServerScanParameters(ctx, upstream)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Info().Msgf("discover related assets for %d asset(s)", len(job.Inventory.Spec.Assets))
@@ -418,39 +486,6 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	// Make sure the progress bar is closed when we exit early. Calling this multiple times
 	// is safe
 	defer multiprogress.Close()
-
-	spaceMrn := ""
-	var services *policy.Services
-	if upstream != nil && upstream.ApiEndpoint != "" && !upstream.Incognito {
-		client, err := upstream.InitClient(ctx)
-		if err != nil {
-			return nil, err
-		}
-		spaceMrn = client.SpaceMrn
-
-		services, err = policy.NewRemoteServices(client.ApiEndpoint, client.Plugins, client.HttpClient)
-		if err != nil {
-			return nil, err
-		}
-
-		// Fetch server-controlled scan parameters before scanning. Server-enabled
-		// features are layered on top of any features already set on the context
-		// by local config — we never replace or disable what the user asked for.
-		resp, err := services.GetScanParameters(ctx, &policy.GetScanParametersReq{ScopeMrn: spaceMrn})
-		if err != nil {
-			log.Warn().Err(err).Msg("could not get server scan parameters")
-		} else if len(resp.EnabledFeatures) > 0 {
-			log.Info().Strs("features", resp.EnabledFeatures).Msg("server activated features")
-			for _, name := range resp.EnabledFeatures {
-				f, ok := mql.FeaturesValue[name]
-				if !ok {
-					log.Warn().Str("feature", name).Msg("unknown server feature, ignoring")
-					continue
-				}
-				ctx = mql.WithFeature(ctx, f)
-			}
-		}
-	}
 
 	parallelism := int(job.Parallelism)
 	if parallelism < 1 {

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -82,6 +82,52 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
+func TestWithServerFeatures(t *testing.T) {
+	t.Run("activates known server features on the context", func(t *testing.T) {
+		ctx := mql.SetFeatures(context.Background(), mql.DefaultFeatures)
+		ctx = withServerFeatures(ctx, []string{"TerraformResolveVars"})
+		require.True(t, mql.GetFeatures(ctx).IsActive(mql.TerraformResolveVars))
+	})
+
+	t.Run("skips unknown features but keeps known ones", func(t *testing.T) {
+		ctx := mql.SetFeatures(context.Background(), mql.DefaultFeatures)
+		ctx = withServerFeatures(ctx, []string{"NotARealFeature", "TerraformResolveVars"})
+		require.True(t, mql.GetFeatures(ctx).IsActive(mql.TerraformResolveVars))
+	})
+
+	t.Run("empty list returns the context unchanged", func(t *testing.T) {
+		base := mql.SetFeatures(context.Background(), mql.DefaultFeatures)
+		require.Equal(t, base, withServerFeatures(base, nil))
+	})
+}
+
+// TestResolveServerScanParameters_NoUpstream verifies the pre-discovery hook is
+// a no-op (context unchanged, nil services) for incognito / credential-less
+// scans, so it can be safely called before asset discovery in every scan.
+func TestResolveServerScanParameters_NoUpstream(t *testing.T) {
+	s := NewLocalScanner()
+	base := mql.SetFeatures(context.Background(), mql.DefaultFeatures)
+
+	t.Run("nil upstream", func(t *testing.T) {
+		ctx, services, spaceMrn, err := s.resolveServerScanParameters(base, nil)
+		require.NoError(t, err)
+		require.Equal(t, base, ctx)
+		require.Nil(t, services)
+		require.Empty(t, spaceMrn)
+	})
+
+	t.Run("incognito upstream", func(t *testing.T) {
+		ctx, services, spaceMrn, err := s.resolveServerScanParameters(base, &upstream.UpstreamConfig{
+			ApiEndpoint: "https://example.com",
+			Incognito:   true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, base, ctx)
+		require.Nil(t, services)
+		require.Empty(t, spaceMrn)
+	})
+}
+
 type LocalScannerSuite struct {
 	suite.Suite
 	ctx  context.Context


### PR DESCRIPTION
## Problem

Server-controlled scan parameters (`GetScanParameters`) were fetched **after** `NewAssetExplorer` had already connected the root asset. Connection-level mql features are read at provider **Connect** time, so any feature the server activated (e.g. `TerraformResolveVars`) was layered onto the context *too late* to reach the root connection.

For an authenticated (service-account) Terraform scan this meant `var.*`/`local.*` references could not be resolved even when the platform enabled `TerraformResolveVars` — so a bad value hidden behind a variable (with a `.tfvars` override) was silently missed. See mondoohq/mql#8753.

```
distributeJob():
  NewAssetExplorer(ctx, ...)   ← connects the ROOT asset (features captured here)
  GetScanParameters(...)       ← server features merged into ctx (TOO LATE)
```

## Fix

- Extract the scan-parameters fetch + feature merge into `resolveServerScanParameters` and call it **before** discovery, so server-activated features are on the context when the provider connects.
- Extract `withServerFeatures` for the merge (unit-tested: activates known features, skips unknown ones, no-op on empty).
- Incognito / credential-less scans remain a no-op. Local `MONDOO_FEATURES` behavior is unchanged.

## Tests

- `TestWithServerFeatures` — merge logic + unknown-feature skip.
- `TestResolveServerScanParameters_NoUpstream` — no-op contract for nil/incognito upstream.
- Full `policy/scan` suite passes; verified locally that an authenticated Terraform scan with local `MONDOO_FEATURES=TerraformResolveVars` still resolves variables (CRITICAL) after the reorder.

Fixes the client half of mondoohq/mql#8753.