### PR TITLE
🐛 fix: guard against divide-by-zero in weighted and decayed score calculators

### DIFF
--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -314,7 +314,10 @@ func (c *weightedScoreCalculator) Calculate() *Score {
 		res.Type = ScoreType_Result
 		res.ScoreCompletion = c.scoreCompletion / c.scoreTotal
 		res.Weight = c.weight
-		res.Value = c.value / c.scoreCnt
+		// scoreCnt can be 0 when all contributors have zero weight; guard.
+		if c.scoreCnt != 0 {
+			res.Value = c.value / c.scoreCnt
+		}
 	} else if c.hasErrors {
 		res.Type = ScoreType_Error
 	}
@@ -746,9 +749,12 @@ func (c *decayedScoreCalculator) Calculate() *Score {
 	if c.hasResults {
 		res.Type = ScoreType_Result
 		relGravity := float64(c.weight) / gravity
-		xscaled := c.x / c.xmax * (relGravity)
-		floor := math.Exp(-relGravity)
-		res.Value = uint32(math.Floor(100 * (math.Exp(-xscaled) - floor) / (1 - floor)))
+		// xmax can be 0 when all contributors have zero weight; guard.
+		if c.xmax != 0 {
+			xscaled := c.x / c.xmax * (relGravity)
+			floor := math.Exp(-relGravity)
+			res.Value = uint32(math.Floor(100 * (math.Exp(-xscaled) - floor) / (1 - floor)))
+		}
 		res.ScoreCompletion = c.scoreCompletion / c.scoreTotal
 		res.Weight = c.weight
 	} else if c.hasErrors {

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -145,6 +145,13 @@ func TestWeightedScores(t *testing.T) {
 			},
 			out: &Score{ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Type: ScoreType_Error},
 		},
+		{
+			// zero-weight result must not divide by zero
+			in: []*Score{
+				{Value: 50, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 0, Type: ScoreType_Result},
+			},
+			out: &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 0, Type: ScoreType_Result},
+		},
 	})
 }
 
@@ -323,6 +330,16 @@ func TestDecayedScores(t *testing.T) {
 				{Action: Action_IGNORE},
 			},
 			out: &Score{Value: 61, ScoreCompletion: 100, DataCompletion: 66, Weight: 10, Type: ScoreType_Result},
+		},
+		{
+			// zero-weight result must not divide by zero
+			in: []*Score{
+				{Value: 50, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 0, Type: ScoreType_Result},
+			},
+			impacts: []*Impact{
+				{Value: &ImpactValue{Value: 100}},
+			},
+			out: &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 0, Type: ScoreType_Result},
 		},
 	})
 }


### PR DESCRIPTION
## What

The `weightedScoreCalculator` and `decayedScoreCalculator` divide by an accumulator (`scoreCnt` / `xmax`) that is only incremented for scores with **non-zero completion and weight** (`if score.ScoreCompletion != 0 && score.Weight != 0`), while `hasResults` is set for **any** result. A scoring group whose only contributors have zero weight therefore reaches the division with a zero divisor:

- **`weightedScoreCalculator`** (`res.Value = c.value / c.scoreCnt`): integer divide-by-zero → **panic, crashing the scan**.
- **`decayedScoreCalculator`** (`c.x / c.xmax`): `0.0 / 0.0 = NaN` → `uint32(NaN)` → **garbage score, silently**.

`averageScoreCalculator` already guards this exact case with `if c.scoreCnt != 0`. This PR applies the same guard to the other two calculators (leaving `res.Value` at 0, matching the average calculator's behavior).

## Testing

- Added a zero-weight regression case to both `TestWeightedScores` and `TestDecayedScores`.
- Verified the weighted case panics with `integer divide by zero` without the guard, and passes with it.
- Full `policy` package test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)