### PR TITLE
🐛 nextdns: fix bypass check and correct remediation UI labels

### DIFF
--- a/content/mondoo-nextdns-security.mql.yaml
+++ b/content/mondoo-nextdns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-nextdns-security
     name: Mondoo NextDNS Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -47,7 +47,6 @@ policies:
         filters: asset.platform == "nextdns-profile"
         checks:
           - uid: mondoo-nextdns-security-block-bypass-methods-blocked
-          - uid: mondoo-nextdns-security-end-user-block-bypass-disabled
       - title: Logging and Visibility
         filters: asset.platform == "nextdns-profile"
         checks:
@@ -95,7 +94,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Threat Intelligence Feeds** toggle.
+        3. Inspect the **Use Threat Intelligence Feeds** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -112,7 +111,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Threat Intelligence Feeds**.
+            3. Turn on **Use Threat Intelligence Feeds**.
         - id: api
           desc: |
             To enable threat intelligence feeds using the NextDNS API:
@@ -165,7 +164,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block DNS Rebinding** toggle.
+        3. Inspect the **Enable DNS Rebinding Protection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -182,7 +181,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block DNS Rebinding**.
+            3. Turn on **Enable DNS Rebinding Protection**.
         - id: api
           desc: |
             To enable DNS rebinding protection using the NextDNS API:
@@ -235,7 +234,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **AI-Driven Threat Detection** toggle.
+        3. Inspect the **Enable AI-Driven Threat Detection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -252,7 +251,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **AI-Driven Threat Detection**.
+            3. Turn on **Enable AI-Driven Threat Detection**.
         - id: api
           desc: |
             To enable AI-driven threat detection using the NextDNS API:
@@ -305,7 +304,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block Cryptojacking** toggle.
+        3. Inspect the **Enable Cryptojacking Protection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -322,7 +321,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block Cryptojacking**.
+            3. Turn on **Enable Cryptojacking Protection**.
         - id: api
           desc: |
             To enable cryptojacking protection using the NextDNS API:
@@ -375,7 +374,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block Domain Generation Algorithms** toggle.
+        3. Inspect the **Enable DGA Protection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -392,7 +391,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block Domain Generation Algorithms**.
+            3. Turn on **Enable DGA Protection**.
         - id: api
           desc: |
             To enable DGA protection using the NextDNS API:
@@ -445,7 +444,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block IDN Homograph Attacks** toggle.
+        3. Inspect the **Enable Homograph Attacks Protection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -462,7 +461,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block IDN Homograph Attacks**.
+            3. Turn on **Enable Homograph Attacks Protection**.
         - id: api
           desc: |
             To enable IDN homograph protection using the NextDNS API:
@@ -515,7 +514,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block Typosquatting** toggle.
+        3. Inspect the **Enable Typosquatting Protection** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -532,7 +531,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block Typosquatting**.
+            3. Turn on **Enable Typosquatting Protection**.
         - id: api
           desc: |
             To enable typosquatting protection using the NextDNS API:
@@ -585,7 +584,7 @@ queries:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
         2. Open the **Security** tab.
-        3. Inspect the **Block Newly Registered Domains** toggle.
+        3. Inspect the **Block Newly Registered Domains (NRDs)** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
 
@@ -602,7 +601,7 @@ queries:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Security** tab.
-            3. Turn on **Block Newly Registered Domains**.
+            3. Turn on **Block Newly Registered Domains (NRDs)**.
         - id: api
           desc: |
             To enable newly registered domain blocking using the NextDNS API:
@@ -778,10 +777,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-3
     mql: |
-      nextdns.profile.settings.blockBypassMethods == true
+      nextdns.profile.parentalControl.blockBypass == true
     docs:
       desc: |
-        This check verifies that NextDNS blocks bypass methods on the profile. With this setting enabled, NextDNS blocks the VPNs, proxies, Tor nodes, and public DNS resolvers that users employ to circumvent DNS-layer filtering.
+        This check verifies that NextDNS blocks bypass methods on the profile. With this setting enabled, NextDNS blocks the VPNs, proxies, Tor nodes, and encrypted DNS providers that users employ to circumvent DNS-layer filtering.
 
         **Why this matters**
 
@@ -797,80 +796,10 @@ queries:
         To verify that bypass-method blocking is enabled from the NextDNS dashboard:
 
         1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
-        2. Open the **Security** tab.
+        2. Open the **Parental Control** tab.
         3. Inspect the **Block Bypass Methods** toggle.
 
         If the toggle is on, the check passes. If it is off, the check fails.
-
-        To verify via the NextDNS API, inspect `bav` under settings:
-
-        ```bash
-        curl -s https://api.nextdns.io/profiles/<profile-id>/settings \
-          -H "X-Api-Key: $NEXTDNS_API_KEY"
-        ```
-      remediation:
-        - id: console
-          desc: |
-            To block bypass methods from the NextDNS dashboard:
-
-            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
-            2. Open the **Security** tab.
-            3. Turn on **Block Bypass Methods**.
-        - id: api
-          desc: |
-            To block bypass methods using the NextDNS API:
-
-            ```bash
-            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/settings \
-              -H "X-Api-Key: $NEXTDNS_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{"bav": true}'
-            ```
-    refs:
-      - url: https://nextdns.github.io/api/#settings
-        title: NextDNS API — Settings
-
-  - uid: mondoo-nextdns-security-end-user-block-bypass-disabled
-    title: Ensure NextDNS end-user block bypass is disabled
-    impact: 65
-    tags:
-      compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
-      compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
-      compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-3
-    mql: |
-      nextdns.profile.parentalControl.blockBypass == false
-    docs:
-      desc: |
-        This check verifies that end-user block bypass is disabled on the profile. When block bypass is allowed, users can dismiss the block page and proceed to a blocked destination, undermining the profile's parental-control and security blocks.
-
-        **Why this matters**
-
-        - **Override removal:** Allowing bypass turns every block into a suggestion that a user can click through.
-        - **Weakened enforcement:** A control that the end user can disable on demand provides little assurance.
-        - **Audit gaps:** Self-service bypass makes it harder to reason about what was actually blocked versus allowed.
-
-        **Risk mitigation**
-
-        - **Hard enforcement:** Disabling bypass ensures blocked destinations stay blocked for end users.
-        - **Predictable posture:** Administrators retain control over exceptions instead of delegating them to users.
-      audit: |
-        To verify that end-user block bypass is disabled from the NextDNS dashboard:
-
-        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
-        2. Open the **Parental Control** tab.
-        3. Inspect the **Allow users to bypass blocked pages** option.
-
-        If the option is off, the check passes. If it is on, the check fails.
 
         To verify via the NextDNS API, inspect `blockBypass` under parentalControl:
 
@@ -881,20 +810,20 @@ queries:
       remediation:
         - id: console
           desc: |
-            To disable end-user block bypass from the NextDNS dashboard:
+            To block bypass methods from the NextDNS dashboard:
 
             1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
             2. Open the **Parental Control** tab.
-            3. Turn off **Allow users to bypass blocked pages**.
+            3. Turn on **Block Bypass Methods**.
         - id: api
           desc: |
-            To disable end-user block bypass using the NextDNS API:
+            To block bypass methods using the NextDNS API:
 
             ```bash
             curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/parentalControl \
               -H "X-Api-Key: $NEXTDNS_API_KEY" \
               -H "Content-Type: application/json" \
-              -d '{"blockBypass": false}'
+              -d '{"blockBypass": true}'
             ```
     refs:
       - url: https://nextdns.github.io/api/#parentalcontrol


### PR DESCRIPTION
## What

Fixes the NextDNS policy's bypass check and corrects the dashboard UI labels referenced in the audit/remediation steps so they match the current NextDNS console.

### The bypass fix

The **Block Bypass Methods** feature lives under the **Parental Control** tab and maps to `parentalControl.blockBypass` (secure when `true`). Two checks were confused about this:

- `mondoo-nextdns-security-block-bypass-methods-blocked` queried `settings.blockBypassMethods` — the API's `settings.bav`, which no longer exists — so the check could **never pass**.
- `mondoo-nextdns-security-end-user-block-bypass-disabled` used the correct field but asserted the **insecure** state (`blockBypass == false`), with a fabricated "dismiss the block page" description and a nonexistent "Allow users to bypass blocked pages" UI option.

Resolution: repoint `block-bypass-methods-blocked` to `nextdns.profile.parentalControl.blockBypass == true`, move its audit/remediation to the **Parental Control** tab and the `/parentalControl` API path, and **delete** the duplicate `end-user-block-bypass-disabled` check.

### Security-tab label corrections

Corrected the toggle labels in audit + remediation steps to match the dashboard:

| Check | Old | New |
|---|---|---|
| Threat intelligence | Threat Intelligence Feeds | Use Threat Intelligence Feeds |
| DNS rebinding | Block DNS Rebinding | Enable DNS Rebinding Protection |
| AI detection | AI-Driven Threat Detection | Enable AI-Driven Threat Detection |
| Cryptojacking | Block Cryptojacking | Enable Cryptojacking Protection |
| DGA | Block Domain Generation Algorithms | Enable DGA Protection |
| IDN homograph | Block IDN Homograph Attacks | Enable Homograph Attacks Protection |
| Typosquatting | Block Typosquatting | Enable Typosquatting Protection |
| NRD | Block Newly Registered Domains | Block Newly Registered Domains (NRDs) |

CSAM and Parked Domains already matched — untouched.

## Version

Policy bumped `1.0.0` → `1.0.1`.

## Testing

`cnspec policy lint ./content/mondoo-nextdns-security.mql.yaml` → `valid policy bundle(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)