### PR TITLE
🧹 googleworkspace: migrate policies off deprecated report.usage dict fields

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-google-workspace-security
     name: Mondoo Google Workspace Security
-    version: 1.2.3
+    version: 1.2.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -147,7 +147,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).length <= 4
+    mql: googleworkspace.report.users.where(isSuperAdmin == true).length <= 4
     docs:
       desc: |
         This check ensures that the Google Workspace organization is configured to keep no more than four users with super admin permissions. Super admin accounts have unrestricted access to all organizational data and settings, so each one is a high-value target.
@@ -217,7 +217,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).length > 1
+    mql: googleworkspace.report.users.where(isSuperAdmin == true).length > 1
     docs:
       desc: |
         This check ensures that the Google Workspace organization is configured to keep more than one user with super admin permissions. A single super admin creates a single point of failure for all administrative access.
@@ -287,7 +287,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: googleworkspace.report.users.all(security["isLessSecureAppsAccessAllowed"] == false)
+    mql: googleworkspace.report.users.all(isLessSecureAppsAccessAllowed == false)
     docs:
       desc: |
         This check ensures that the Google Workspace organization is configured to block users from granting access to less secure apps that use legacy authentication without OAuth. Less secure apps bypass modern authentication controls and create a significant vulnerability.
@@ -357,7 +357,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-4-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true).all(security["numSecurityKeys"] >= 1)
+    mql: googleworkspace.report.users.where(isSuperAdmin == true).all(numSecurityKeys >= 1)
     docs:
       desc: |
         This check ensures that every super admin account is configured with at least one hardware security key registered for 2-step verification. Super admins control the entire organization and need the strongest available authentication.

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-googleworkspace-incident-response
     name: Google Workspace Incident Response Pack
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     require:
       - provider: google-workspace
@@ -78,7 +78,7 @@ packs:
         title: Google Workspace super admins
         docs:
           desc: Lists all users with super admin privileges to identify privileged accounts.
-        mql: googleworkspace.report.users.where( security["isSuperAdmin"] == true) { userEmail  }
+        mql: googleworkspace.report.users.where(isSuperAdmin == true) { userEmail }
       - uid: mondoo-googleworkspace-incident-response-super-admins-without-2FA-enrolled
         title: Google Workspace super admins who are not enrolled in 2FA
         docs:
@@ -93,7 +93,7 @@ packs:
         title: Super admin accounts that do not use hardware-based security keys
         docs:
           desc: Identifies super admin accounts without hardware security keys, which provide stronger protection than software-based 2FA.
-        mql: googleworkspace.report.users.where(security["isSuperAdmin"] == true && security["numSecurityKeys"] <= 0 ) {account['adminSetName'] security['numSecurityKeys']}
+        mql: googleworkspace.report.users.where(isSuperAdmin == true && numSecurityKeys <= 0 ) {userEmail numSecurityKeys}
       - uid: mondoo-googleworkspace-incident-response-config-drift-recovery-email
         title: Primary and recovery email accounts of all Google Workspace users
         docs:


### PR DESCRIPTION
## What

Resolves the `query-deprecated-symbol` lint warnings on the two Google Workspace policies by moving off the deprecated raw-dict fields on `googleworkspace.report.usage` (`security[...]`, `account[...]`) to the provider's typed scalar fields.

The provider deprecated `googleworkspace.report.usage.security` and `googleworkspace.report.usage.account` (both raw `dict` fields) in favor of typed fields like `isSuperAdmin`, `numSecurityKeys`, `isLessSecureAppsAccessAllowed`, and `userEmail`. Typed fields are validated at lint time and carry a real type, whereas dict-key access silently returns `null` on a typo.

## Changes

**`content/mondoo-google-workspace-security.mql.yaml`** (`1.2.3` → `1.2.4`)
- `limit-super-admins`, `minimum-super-admins`: `security["isSuperAdmin"]` → `isSuperAdmin`
- `less-secure-app-access-should-not-be-allowed`: `security["isLessSecureAppsAccessAllowed"]` → `isLessSecureAppsAccessAllowed`
- `super-admins-should-use-hardware-based-2fa`: `security["isSuperAdmin"]` → `isSuperAdmin`, `security["numSecurityKeys"]` → `numSecurityKeys`

**`content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml`** (`1.1.0` → `1.1.1`)
- `super-admins`: `security["isSuperAdmin"]` → `isSuperAdmin`
- `super-admins-without-hardware-based-2fa`: typed field migration; output field changed from `account['adminSetName']` to `userEmail` — the deprecated `account` dict's `adminSetName` has no typed equivalent, and `userEmail` is the typed field for identifying the account.

## Verification

`cnspec policy lint` on both files → `valid policy bundle(s)`, zero `query-deprecated-symbol` warnings, no remaining `security["..."]`/`account[...]` accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)