### PR TITLE
🧹 gcp: migrate policy off deprecated typed-ref fields

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.4.0
+    version: 9.4.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -18174,7 +18174,7 @@ queries:
   - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-gcp
     filters: asset.platform == 'gcp-cloud-function'
     mql: |
-      gcp.project.cloudFunction.dockerRepository != empty
+      gcp.project.cloudFunction.dockerRepositoryRef != null
   - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_cloudfunctions2_function')
@@ -27220,7 +27220,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      gcp.project.vertexaiService.customJob.serviceAccount != empty
+      gcp.project.vertexaiService.customJob.serviceAccountRef != null
     docs:
       desc: |
         This check ensures that every running, pending, or queued Vertex AI custom job has an explicit service account configured in its job specification. Without an explicit service account, custom jobs inherit the project's default Compute Engine service account, which carries broad project-level permissions far beyond what any individual training job actually needs.
@@ -34818,8 +34818,8 @@ queries:
       asset.platform == 'gcp-vertexai-job' &&
       gcp.project.vertexaiService.customJob.state.in(["JOB_STATE_RUNNING", "JOB_STATE_PENDING", "JOB_STATE_QUEUED"])
     mql: |
-      gcp.project.vertexaiService.customJob.serviceAccount != empty &&
-      gcp.project.vertexaiService.customJob.serviceAccount != /^\d+-compute@developer\.gserviceaccount\.com$/
+      gcp.project.vertexaiService.customJob.serviceAccountRef != null &&
+      gcp.project.vertexaiService.customJob.serviceAccountRef.email != /^\d+-compute@developer\.gserviceaccount\.com$/
     docs:
       desc: |
         This check ensures that Vertex AI custom training jobs are configured to use a dedicated service account rather than the project's default Compute Engine service account. By default, jobs that omit an explicit service account identity run as the default Compute Engine SA, which carries the Editor role and is shared across all workloads in the project.
@@ -39744,7 +39744,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      gcp.project.vertexaiService.customJob.network != empty
+      gcp.project.vertexaiService.customJob.networkRef != null
     docs:
       desc: |
         This check ensures that active Vertex AI custom jobs specify a VPC network in their job specification so that training workers run on a private network rather than the default public internet path. Without a network configuration, worker-to-worker traffic and access to internal services traverse the public internet, bypassing the organization's network controls.
@@ -41455,7 +41455,7 @@ queries:
     filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudSchedulerService.jobs.where(targetType == "httpTarget").all(
-        oidcServiceAccountEmail != "" || oauthServiceAccountEmail != ""
+        oidcServiceAccount != null || oauthServiceAccount != null
       )
     tags:
       compliance/bsi-sys-1-5: false
@@ -41547,9 +41547,11 @@ queries:
     impact: 80
     filters: asset.platform == 'gcp-project'
     mql: |
-      gcp.project.cloudSchedulerService.jobs.all(
-        oidcServiceAccountEmail != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
-        oauthServiceAccountEmail != /^\d+-compute@developer\.gserviceaccount\.com$/
+      gcp.project.cloudSchedulerService.jobs.where(oidcServiceAccount != null).all(
+        oidcServiceAccount.email != /^\d+-compute@developer\.gserviceaccount\.com$/
+      )
+      gcp.project.cloudSchedulerService.jobs.where(oauthServiceAccount != null).all(
+        oauthServiceAccount.email != /^\d+-compute@developer\.gserviceaccount\.com$/
       )
     tags:
       compliance/bsi-sys-1-5: false


### PR DESCRIPTION
## What

Clears the `query-deprecated-symbol` lint warnings on `mondoo-gcp-security.mql.yaml` by moving six checks off deprecated string fields to the provider's typed-resource replacements.

| Deprecated field | Replacement |
|---|---|
| `gcp.project.cloudFunction.dockerRepository` | `dockerRepositoryRef` (typed `artifactRegistryService.repository`) |
| `gcp.project.vertexaiService.customJob.serviceAccount` | `serviceAccountRef` (typed `iamService.serviceAccount`, `.email`) |
| `gcp.project.vertexaiService.customJob.network` | `networkRef` (typed `computeService.network`) |
| `gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail` | `oidcServiceAccount` (typed IAM SA, `.email`) |
| `gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail` | `oauthServiceAccount` (typed IAM SA, `.email`) |

## Why this isn't a find-replace

The deprecated fields were **strings** (empty `""` when unset); the typed replacements are **resources** (`null` when unset). This flips absent-case semantics, so the migration is behavior-preserving only with care:

- **Presence checks** (`docker-repository-configured`, `has-explicit-service-account`, `private-network`, `http-target-authentication`) use `!= null` — an absent typed resource is null, matching the old "must be set" intent (absent → fail).
- **No-default-SA checks** compare a regex against `.email`. Verified in MQL that `null != /regex/` evaluates to **null**, not `true` — so a naive swap would break the absent case. The Vertex AI custom-job check follows the repo's existing typed-ref idiom already shipping in `mondoo-gcp-security-vertexai-pipeline-job-no-default-service-account-gcp` (guard `serviceAccountRef != null &&` then compare `.email`).
- **Cloud Scheduler no-default-SA** carries **two** mutually exclusive SA fields (a job sets oauth *or* oidc, the other is null). Guarding both inline would need parenthesized grouping, which MQL does not support, so it is restructured to `.where(sa != null).all(sa.email != /default/)` — `.where` yields a list (never null) and `.all` on `[]` passes vacuously, so jobs without that SA are correctly excluded rather than erroring.

## Verification

`cnspec policy lint content/mondoo-gcp-security.mql.yaml` → `valid policy bundle(s)`, zero `query-deprecated-symbol` warnings, no remaining deprecated field references. Policy version bumped `9.4.0` → `9.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)