### PR TITLE
♻️ Migrate encryption/TLS checks to typed provider fields

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -12529,7 +12529,7 @@ queries:
   - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-aws
     filters: asset.platform == "aws-s3-bucket"
     mql: |
-      aws.s3.bucket.encryption['Rules'] != empty
+      aws.s3.bucket.encrypted == true
   - uid: mondoo-aws-security-s3-bucket-server-side-encryption-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_server_side_encryption_configuration")
     mql: |
@@ -33096,10 +33096,7 @@ queries:
   - uid: mondoo-aws-security-athena-workgroup-results-encrypted-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.athena.workgroups.where(state == "ENABLED").all(
-        resultConfiguration['EncryptionConfiguration'] != null &&
-        resultConfiguration['EncryptionConfiguration']['EncryptionOption'] != null
-      )
+      aws.athena.workgroups.where(state == "ENABLED").all(encrypted == true)
   - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_athena_workgroup")
     mql: |
@@ -47043,7 +47040,7 @@ queries:
         title: AWS Security Hub - DynamoDB controls reference
   - uid: mondoo-aws-security-dax-encryption-at-rest-aws
     filters: asset.platform == "aws"
-    mql: aws.dynamodb.daxClusters.all(sseStatus == "ENABLED")
+    mql: aws.dynamodb.daxClusters.all(encrypted == true)
   - uid: mondoo-aws-security-dax-encryption-at-rest-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dax_cluster")
     mql: |
@@ -68390,10 +68387,8 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.athena.workgroups.where(state == "ENABLED").all(
-        resultConfiguration['EncryptionConfiguration'] != null &&
-        resultConfiguration['EncryptionConfiguration']['EncryptionOption'] == /^(SSE|CSE)_KMS$/ &&
-        resultConfiguration['EncryptionConfiguration']['KmsKey'] != null &&
-        resultConfiguration['EncryptionConfiguration']['KmsKey'] != ""
+        resultEncryptionOption == /^(SSE|CSE)_KMS$/ &&
+        kmsKey != null
       )
   - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_athena_workgroup")

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -42441,10 +42441,10 @@ queries:
       asset.platform == "azure"
     mql: |
       azure.subscription.apiManagement.services.all(
-        customProperties["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"] != "True" &&
-        customProperties["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11"] != "True" &&
-        customProperties["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10"] != "True" &&
-        customProperties["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11"] != "True"
+        tls10Enabled != true &&
+        tls11Enabled != true &&
+        backendTls10Enabled != true &&
+        backendTls11Enabled != true
       )
   - uid: mondoo-azure-security-api-management-gateway-min-tls-1-2-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_api_management")


### PR DESCRIPTION
## What

Refactors 5 runtime security checks off deprecated dict/string accessors and onto the typed fields recently added to the **aws** and **azure** providers. The provider authors marked the old accessors `@maturity("deprecated")`, so this migrates the policies to the intended path.

## Checks refactored

| File | Check | Before | After |
|---|---|---|---|
| aws | `s3-bucket-server-side-encryption-enabled-aws` | `encryption['Rules'] != empty` | `encrypted == true` |
| aws | `athena-workgroup-results-encrypted-aws` | `resultConfiguration['EncryptionConfiguration']['EncryptionOption'] != null` | `encrypted == true` |
| aws | `athena-workgroup-results-cmk-encrypted-aws` | `resultConfiguration[...]['EncryptionOption'] == /KMS/ && [...]['KmsKey'] != ""` | `resultEncryptionOption == /^(SSE\|CSE)_KMS$/ && kmsKey != null` |
| aws | `dax-encryption-at-rest-aws` | `sseStatus == "ENABLED"` | `encrypted == true` |
| azure | `api-management-gateway-min-tls-1-2-azure` | 4× `customProperties["...Tls1x"] != "True"` | typed `tls10Enabled/tls11Enabled/backendTls10Enabled/backendTls11Enabled != true` |

## Notes

- **Behavior preserved.** The APIM check uses `!= true` (not `== false`) so it keeps the original null-tolerant semantics: a service that does not report a protocol setting still passes.
- **Runtime variants only.** Terraform/HCL/Bicep sibling variants are untouched.
- `kmsKey` on the Athena workgroup is now a resolved `aws.kms.key` resource, so `kmsKey != null` replaces the previous ARN-string presence check.

## Validation

`cnspec policy lint` passes on both bundles (`valid policy bundle(s)`). No new lint warnings introduced — the Azure check no longer appears under `query-deprecated-symbol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)