### PR TITLE
♻️ azure: migrate app service & function identity checks to typed fields

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -2593,8 +2593,8 @@ queries:
     filters: |
       asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.webService.appsite.identity.type != empty
-      azure.subscription.webService.appsite.identity.principalId != empty
+      azure.subscription.webService.appsite.identityType != empty
+      azure.subscription.webService.appsite.principalId != empty
   - uid: mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_web_app/)
     mql: |
@@ -38137,7 +38137,7 @@ queries:
   - uid: mondoo-azure-security-function-app-managed-identity-azure
     filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functionsService.functionApp.managedServiceIdentityId != empty
+      azure.subscription.functionsService.functionApp.principalId != empty
   - uid: mondoo-azure-security-function-app-managed-identity-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |


### PR DESCRIPTION
## What

Follow-up to #2988. Migrates two more runtime checks off deprecated fields flagged by `cnspec policy lint`, onto the typed scalar accessors the azure provider now exposes.

| Check | Before | After |
|---|---|---|
| `mondoo-azure-security-ensure-register-with-ad-is-enabled-on-app-service-azure` | `appsite.identity.type` / `appsite.identity.principalId` (dict navigation on the deprecated `identity` block) | `appsite.identityType` / `appsite.principalId` |
| `mondoo-azure-security-function-app-managed-identity-azure` | `functionApp.managedServiceIdentityId` (deprecated) | `functionApp.principalId` |

## Why

Both are **pure typed-scalar swaps**: no behavior change, no new resource resolution, and they clear the `query-deprecated-symbol` lint warnings. `identityType`/`principalId` are the typed extractions of the same values the deprecated `identity` dict and `managedServiceIdentityId` string carried (the system-assigned principal ID).

## Validation

`cnspec policy lint` passes (`valid policy bundle(s)`); the two corresponding deprecation warnings are gone. Terraform variants unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)