### PR TITLE
🐛 aws: fix terraform-hcl secgroup/NACL checks blind to valid HCL forms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -10104,8 +10104,22 @@ queries:
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
   - uid: mondoo-aws-security-secgroup-restricted-ssh-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains( nameLabel == "aws_security_group")
-    mql: terraform.resources("aws_security_group").where(blocks.where( type == "ingress").contains( arguments.to_port == 22 )).none( blocks.where( type == "ingress" ) { arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.cidr_blocks.contains("::/0") })
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources("aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 22 && arguments.to_port >= 22).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 22 && _["to_port"] >= 22).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 22 && arguments.to_port >= 22).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-ssh-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( type == "aws_security_group")
     mql: terraform.plan.resourceChanges.where( type == "aws_security_group" && change.after.ingress.contains( to_port == 22 )).none( change.after.ingress.where(to_port == 22).any(cidr_blocks.contains("0.0.0.0/0") || cidr_blocks.contains("::/0")))
@@ -10280,15 +10294,22 @@ queries:
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
         )
   - uid: mondoo-aws-security-secgroup-restricted-vnc-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_security_group")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
     mql: |
-      terraform.resources("aws_security_group").where(blocks.where(type == "ingress").contains(
-          arguments.from_port <= 5900 && arguments.to_port >= 5903 && arguments.to_port != 0)
-        ).none(
-          blocks.where(type == "ingress") {
-            arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.cidr_blocks.contains("::/0")
-          }
+      terraform.resources("aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 5900 && arguments.to_port >= 5903).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
         )
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 5900 && _["to_port"] >= 5903).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 5900 && arguments.to_port >= 5903).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-vnc-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_security_group")
     mql: |
@@ -10490,8 +10511,22 @@ queries:
           ipRanges.contains("0.0.0.0/0") || ipRanges.contains("::/0")
           )
   - uid: mondoo-aws-security-secgroup-restricted-rdp-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains( nameLabel == "aws_security_group")
-    mql: terraform.resources("aws_security_group").where(blocks.where( type == "ingress").contains( arguments.to_port == 3389 )).none( blocks.where( type == "ingress" ) { arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.cidr_blocks.contains("::/0") })
+    filters: asset.platform == "terraform-hcl" && terraform.resources.where(nameLabel == "aws_security_group" || nameLabel == "aws_vpc_security_group_ingress_rule") != empty
+    mql: |
+      terraform.resources("aws_security_group").all(
+        blocks.where(type == "ingress" && arguments.from_port <= 3389 && arguments.to_port >= 3389).none(
+          arguments.cidr_blocks.contains("0.0.0.0/0") || arguments.ipv6_cidr_blocks.contains("::/0")
+        )
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 3389 && _["to_port"] >= 3389).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
+      ) &&
+      terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 3389 && arguments.to_port >= 3389).all(
+        arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      )
   - uid: mondoo-aws-security-secgroup-restricted-rdp-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains( type == "aws_security_group")
     mql: terraform.plan.resourceChanges.where( type == "aws_security_group" && change.after.ingress.contains( to_port == 3389 )).none( change.after.ingress.where(to_port == 3389).any(cidr_blocks.contains("0.0.0.0/0") || cidr_blocks.contains("::/0")))
@@ -24966,7 +25001,8 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_default_network_acl")
     mql: |
       terraform.resources("aws_default_network_acl").all(
-      arguments.ingress == empty && arguments.egress == empty
+      arguments.ingress == empty && arguments.egress == empty &&
+      blocks.none( type == "ingress" ) && blocks.none( type == "egress" )
       )
   - uid: mondoo-aws-security-default-nacl-restrictive-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_default_network_acl")
@@ -44596,6 +44632,7 @@ queries:
   - uid: mondoo-aws-security-secgroup-no-unrestricted-egress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_security_group" || nameLabel == "aws_security_group_rule" || nameLabel == "aws_vpc_security_group_egress_rule")
     mql: |
+      terraform.resources("aws_security_group").all(blocks.where(type == "egress").none(arguments["cidr_blocks"] != null && arguments["cidr_blocks"].contains("0.0.0.0/0") || arguments["ipv6_cidr_blocks"] != null && arguments["ipv6_cidr_blocks"].contains("::/0")))
       terraform.resources("aws_security_group").all(arguments["egress"] == empty || arguments["egress"].none(_["cidr_blocks"] != null && _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"] != null && _["ipv6_cidr_blocks"].contains("::/0")))
       terraform.resources("aws_security_group_rule").where(arguments["type"] == "egress").none(arguments["cidr_blocks"] != null && arguments["cidr_blocks"].contains("0.0.0.0/0") || arguments["ipv6_cidr_blocks"] != null && arguments["ipv6_cidr_blocks"].contains("::/0"))
       terraform.resources("aws_vpc_security_group_egress_rule").none(arguments["cidr_ipv4"] == "0.0.0.0/0" || arguments["cidr_ipv6"] == "::/0")
@@ -60992,6 +61029,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 5432 && arguments.to_port >= 5432).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 5432 && _["to_port"] >= 5432).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-postgresql-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -61158,6 +61201,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 3306 && arguments.to_port >= 3306).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 3306 && _["to_port"] >= 3306).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-mysql-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -61324,6 +61373,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 1433 && arguments.to_port >= 1433).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 1433 && _["to_port"] >= 1433).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-mssql-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -61496,6 +61551,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 1521 && arguments.to_port >= 1521).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 1521 && _["to_port"] >= 1521).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-oracle-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -61668,6 +61729,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 27017 && arguments.to_port >= 27017).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 27017 && _["to_port"] >= 27017).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-mongodb-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -61840,6 +61907,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 6379 && arguments.to_port >= 6379).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 6379 && _["to_port"] >= 6379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-redis-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62016,6 +62089,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 11211 && arguments.to_port >= 11211).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 11211 && _["to_port"] >= 11211).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-memcached-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62188,6 +62267,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 9300 && arguments.to_port >= 9200).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 9300 && _["to_port"] >= 9200).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62360,6 +62445,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 5986 && arguments.to_port >= 5985).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 5986 && _["to_port"] >= 5985).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-winrm-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62534,6 +62625,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 2376 && arguments.to_port >= 2375).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 2376 && _["to_port"] >= 2375).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-docker-daemon-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62708,6 +62805,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 6443 && arguments.to_port >= 6443).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 6443 && _["to_port"] >= 6443).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-kubernetes-api-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -62879,6 +62982,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 10255 && arguments.to_port >= 10250).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 10255 && _["to_port"] >= 10250).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-kubelet-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty
@@ -63049,6 +63158,12 @@ queries:
       ) &&
       terraform.resources("aws_vpc_security_group_ingress_rule").where(arguments.from_port <= 2380 && arguments.to_port >= 2379).all(
         arguments.cidr_ipv4 != "0.0.0.0/0" && arguments.cidr_ipv6 != "::/0"
+      ) &&
+      terraform.resources("aws_security_group").all(
+        arguments["ingress"] == empty ||
+        arguments["ingress"].where(_["from_port"] <= 2380 && _["to_port"] >= 2379).none(
+          _["cidr_blocks"].contains("0.0.0.0/0") || _["ipv6_cidr_blocks"].contains("::/0")
+        )
       )
   - uid: mondoo-aws-security-secgroup-restricted-etcd-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.where(type == "aws_security_group" || type == "aws_vpc_security_group_ingress_rule") != empty


### PR DESCRIPTION
## Problem

Several `terraform-hcl` variants only inspected a *subset* of the valid HCL forms a security-group ingress/egress rule (or a default-NACL rule) can be written in. Terraform accepts multiple equivalent forms, and the provider surfaces them differently:

- nested block `ingress { ... }` → `blocks.where(type=="ingress")`
- attribute-list `ingress = [{ ... }]` → `arguments.ingress` (with `blocks == []`)
- standalone `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule`

Because the checks only looked at one form, a rule opened to `0.0.0.0/0` (or `::/0`) written in an unhandled form made the `.none()`/`.all()` **vacuously true**, so the check **silently passed a world-open port**. This was found by a per-variant pass/fail test harness exercising each valid HCL form.

## Fix (all verified against realistic pass/fail fixtures for every form)

- **`secgroup-restricted-*`** (memcached, mongodb, mssql, mysql, oracle, postgresql, redis, ssh, rdp, vnc, winrm, docker-daemon, etcd, kubelet, kubernetes-api, elasticsearch): now also check the attribute-list form and `aws_vpc_security_group_ingress_rule`.
- **`ssh` & `rdp`**: additionally were matching `to_port == P` *exactly* (missing a wide-open range like `0-65535`) and had no standalone-rule coverage — rewritten to `from_port <= P && to_port >= P` and to select the standalone rule resource.
- **`secgroup-no-unrestricted-egress`**: handled attribute-list, `aws_security_group_rule`, and `aws_vpc_security_group_egress_rule`, but not the nested `egress { }` block — added the block-form clause.
- **`default-nacl-restrictive`**: only checked `arguments.ingress/egress == empty`; a permissive default NACL written with `ingress { }` blocks passed — added `blocks.none(type=="ingress"/"egress")`.

No behavior change for compliant configurations; the checks now additionally flag the previously-missed open-rule forms.

## Notes
- `cnspec policy lint` passes (the two pre-existing `standalone function in a WHERE clause` warnings are unrelated and present on `main`).
- The test harness that surfaced these will land separately; this PR is the policy fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)