### PR TITLE
🐛 aws: fix false positives/negatives in terraform-hcl checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2634,7 +2634,8 @@ queries:
   - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iam_user")
     mql: |
-      terraform.resources("aws_iam_user_policy") == empty
+      terraform.resources("aws_iam_user_policy") == empty &&
+      terraform.resources("aws_iam_user").all(blocks.where(type == "inline_policy") == empty)
   - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_iam_user")
     mql: |
@@ -6658,8 +6659,8 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_instance")
     mql: |
       terraform.resources("aws_instance").all(
-        blocks.none(type == "root_block_device" && arguments.delete_on_termination != true) &&
-        blocks.none(type == "ebs_block_device" && arguments.delete_on_termination != true)
+        blocks.none(type == "root_block_device" && arguments.delete_on_termination == false) &&
+        blocks.none(type == "ebs_block_device" && arguments.delete_on_termination == false)
       )
   - uid: mondoo-aws-security-ec2-volume-inuse-check-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_instance")
@@ -16979,6 +16980,7 @@ queries:
     mql: |
       terraform.resources("aws_codebuild_project").all(
         blocks.where(type == "environment").all(
+          arguments["image_pull_credentials_type"] == null ||
           arguments.image_pull_credentials_type == "CODEBUILD" ||
           arguments.image_pull_credentials_type == "SERVICE_ROLE"
         )
@@ -25955,7 +25957,7 @@ queries:
     mql: |
       terraform.resources("aws_ecs_cluster").all(
       blocks.where(type == "setting") != empty &&
-      blocks.where(type == "setting").any(arguments.name == "containerInsights" && arguments.value == "enabled")
+      blocks.where(type == "setting").any(arguments.name == "containerInsights" && arguments.value != "disabled")
       )
   - uid: mondoo-aws-security-ecs-cluster-container-insights-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ecs_cluster")
@@ -28981,7 +28983,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appstream_fleet")
     mql: |
       terraform.resources("aws_appstream_fleet").all(
-      arguments.max_user_duration_in_seconds <= 36000
+      arguments["max_user_duration_in_seconds"] == null || arguments.max_user_duration_in_seconds <= 36000
       )
   - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_appstream_fleet")
@@ -32567,7 +32569,8 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_kinesis_stream")
     mql: |
       terraform.resources("aws_kinesis_stream").all(
-      arguments.encryption_type == "KMS" && arguments.kms_key_id != empty
+      arguments.encryption_type == "KMS" && arguments.kms_key_id != empty &&
+      arguments.kms_key_id.contains("alias/aws/kinesis") == false
       )
   - uid: mondoo-aws-security-kinesis-stream-cmk-encryption-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_kinesis_stream")
@@ -46258,7 +46261,7 @@ queries:
     mql: |
       terraform.resources("aws_elasticsearch_domain").all(
       blocks.where(type == "log_publishing_options") != empty &&
-      blocks.where(type == "log_publishing_options").all(arguments.log_type == "AUDIT_LOGS")
+      blocks.where(type == "log_publishing_options").any(arguments.log_type == "AUDIT_LOGS")
       )
   - uid: mondoo-aws-security-elasticsearch-audit-logging-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_elasticsearch_domain")
@@ -54306,7 +54309,8 @@ queries:
     mql: |
       terraform.resources("aws_kinesis_stream").all(
         arguments['encryption_type'] == "KMS" &&
-        arguments['kms_key_id'] != empty
+        arguments['kms_key_id'] != empty &&
+        arguments['kms_key_id'].contains("alias/aws/kinesis") == false
       )
   - uid: mondoo-aws-security-kinesis-cmk-typed-key-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_kinesis_stream")


### PR DESCRIPTION
Fixes eight AWS `terraform-hcl` checks that returned the wrong verdict on realistic, idiomatic Terraform. Each was found by a per-variant pass/fail test that exercises the real HCL forms.

## False positives (compliant config wrongly flagged)
- **elasticsearch-audit-logging** — `.all(log_type=="AUDIT_LOGS")` over `log_publishing_options` blocks fails a domain that *also* ships slow logs (a sibling block), even with audit logging on. → `.any()`.
- **ec2-volume-inuse-check** — `delete_on_termination != true` is `null` when the attribute is omitted (AWS default `true` = compliant); `null != true` is null, which `none()` treats as a match. → `== false`.
- **appstream-fleet-max-session-duration** — `max_user_duration_in_seconds <= 36000` is null when omitted (default 960s = compliant). → guard `== null ||`.
- **codebuild-no-plaintext-credentials** — `image_pull_credentials_type` is null when omitted (default `CODEBUILD` = compliant). → guard `== null ||`.

## False negatives (misconfig wrongly passed)
- **ecs-cluster-container-insights** — required `value == "enabled"`, rejecting the valid `"enhanced"` mode. → `value != "disabled"`.
- **kinesis-stream-cmk-encryption** / **kinesis-cmk-typed-key** — only asserted `kms_key_id != empty`, so the AWS-managed `alias/aws/kinesis` key passed despite the checks requiring a customer-managed CMK. → also reject `alias/aws/kinesis`.
- **iam-user-no-inline-policies-check** — only looked for `aws_iam_user_policy` resources, missing the idiomatic `inline_policy { }` block on `aws_iam_user`. → add a clause for it.

`cnspec policy lint` passes. Policy-only change; no behavior change for already-correctly-classified configs.

> Note: the `-terraform-plan` / `-terraform-state` siblings of some of these (notably the two kinesis CMK checks) share the same gap; those will follow once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)