### PR TITLE
🐛 aws: index jsonencode policies with .first in terraform-hcl policy checks

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -49753,7 +49753,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ecr_repository_policy")
     mql: |
       terraform.resources("aws_ecr_repository_policy").all(
-        arguments.policy["Statement"].none(
+        arguments.policy.first["Statement"].none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -59131,7 +59131,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_secretsmanager_secret_policy")
     mql: |
       terraform.resources("aws_secretsmanager_secret_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -60219,7 +60219,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")
     mql: |
       terraform.resources("aws_sns_topic_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -63496,7 +63496,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
     mql: |
       terraform.resources("aws_s3_bucket_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -63704,7 +63704,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_policy")
     mql: |
       terraform.resources("aws_s3_bucket_policy").all(
-        arguments.policy["Statement"].any(
+        arguments.policy.first["Statement"].any(
           _["Effect"] == "Deny" &&
           _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
           _["Effect"] == "Deny" &&
@@ -69008,7 +69008,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cloudwatch_event_bus_policy")
     mql: |
       terraform.resources("aws_cloudwatch_event_bus_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").all(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").all(
           _["Principal"] != "*" && _["Principal"]["AWS"] != "*" ||
           _["Condition"] != null
         )
@@ -71022,7 +71022,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue_policy")
     mql: |
       terraform.resources("aws_sqs_queue_policy").all(
-        arguments.policy["Statement"].any(
+        arguments.policy.first["Statement"].any(
           _["Effect"] == "Deny" &&
           _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
           _["Effect"] == "Deny" &&
@@ -71236,7 +71236,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sns_topic_policy")
     mql: |
       terraform.resources("aws_sns_topic_policy").all(
-        arguments.policy["Statement"].any(
+        arguments.policy.first["Statement"].any(
           _["Effect"] == "Deny" &&
           _["Condition"]["Bool"]["aws:SecureTransport"] == "false" ||
           _["Effect"] == "Deny" &&
@@ -72723,7 +72723,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_backup_vault_policy")
     mql: |
       terraform.resources("aws_backup_vault_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -72861,7 +72861,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_efs_file_system_policy")
     mql: |
       terraform.resources("aws_efs_file_system_policy").all(
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )
@@ -74079,7 +74079,7 @@ queries:
     mql: |
       terraform.resources("aws_kms_key").all(
         arguments.policy == empty ||
-        arguments.policy["Statement"].where(_["Effect"] == "Allow").none(
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
           _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
         )
       )


### PR DESCRIPTION
## Problem

Several AWS `terraform-hcl` policy-document checks read `arguments.policy["Statement"]`, treating the `policy` attribute as a map. But the idiomatic Terraform form is:

```hcl
policy = jsonencode({ Version = "2012-10-17", Statement = [ { ... } ] })
```

which the terraform provider evaluates to a **list-wrapped map** — `[ { Version = ..., Statement = [...] } ]`. Indexing that list with the string key `"Statement"` yields null, so the downstream `.where(...)/.none(...)/.all(...)` silently mis-evaluated: compliant policies were flagged and/or public (`Principal: "*"`) policies were not detected.

## Fix

Select the wrapped object first — `arguments.policy.first["Statement"]` — across the affected checks (kms-key-no-public-access, the two s3-bucket-policy checks, eventbridge-bus-policy, backup-vault, secretsmanager-no-public-policy, ecr-no-public-access, efs-filesystem-no-public-access, and the other policy-document checks using this pattern).

Verified against realistic `jsonencode({...})` fixtures: compliant scoped-principal policies pass, `Principal:"*"` / `Principal.AWS:"*"` policies fail. `cnspec policy lint` passes.

> Note: policies whose JSON references another resource (e.g. `Resource = aws_x.this.arn`) can still evaluate to an empty value because the provider can't statically resolve the reference — that's a separate provider-level limitation, tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)