### PR TITLE
🐛 aws: fix terraform-hcl logging/NACL checks that missed real misconfigs

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -24646,7 +24646,9 @@ queries:
     mql: |
       terraform.resources("aws_timestreaminfluxdb_db_instance").all(
       blocks.where(type == "log_delivery_configuration") != empty &&
-      blocks.where(type == "log_delivery_configuration").all(arguments != empty)
+      blocks.where(type == "log_delivery_configuration").all(
+        blocks.where(type == "s3_configuration").any(arguments.enabled == true)
+      )
       )
   - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_timestreaminfluxdb_db_instance")
@@ -24823,10 +24825,12 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_network_acl_rule")
     mql: |
       terraform.resources("aws_network_acl_rule").where(arguments.egress != true && arguments.rule_action == "allow").none(
-      arguments.from_port == 22 && arguments.cidr_block == "0.0.0.0/0" ||
-      arguments.from_port == 22 && arguments.ipv6_cidr_block == "::/0" ||
-      arguments.from_port == 3389 && arguments.cidr_block == "0.0.0.0/0" ||
-      arguments.from_port == 3389 && arguments.ipv6_cidr_block == "::/0"
+      arguments.cidr_block == "0.0.0.0/0" && arguments.protocol == "-1" ||
+      arguments.ipv6_cidr_block == "::/0" && arguments.protocol == "-1" ||
+      arguments.cidr_block == "0.0.0.0/0" && arguments.from_port <= 22 && arguments.to_port >= 22 ||
+      arguments.ipv6_cidr_block == "::/0" && arguments.from_port <= 22 && arguments.to_port >= 22 ||
+      arguments.cidr_block == "0.0.0.0/0" && arguments.from_port <= 3389 && arguments.to_port >= 3389 ||
+      arguments.ipv6_cidr_block == "::/0" && arguments.from_port <= 3389 && arguments.to_port >= 3389
       )
   - uid: mondoo-aws-security-nacl-no-unrestricted-ssh-rdp-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_network_acl_rule")
@@ -40643,7 +40647,14 @@ queries:
     mql: |
       terraform.resources("aws_msk_cluster").all(
       blocks.where(type == "logging_info") != empty &&
-      blocks.where(type == "logging_info").all(blocks.where(type == "broker_logs") != empty)
+      blocks.where(type == "logging_info").all(
+        blocks.where(type == "broker_logs") != empty &&
+        blocks.where(type == "broker_logs").all(
+          blocks.where(type == "cloudwatch_logs").any(arguments.enabled == true) ||
+          blocks.where(type == "firehose").any(arguments.enabled == true) ||
+          blocks.where(type == "s3").any(arguments.enabled == true)
+        )
+      )
       )
   - uid: mondoo-aws-security-msk-logging-enabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_msk_cluster")


### PR DESCRIPTION
Three AWS `terraform-hcl` checks passed genuinely non-compliant configurations. Found by per-variant pass/fail testing across realistic HCL forms.

- **nacl-no-unrestricted-ssh-rdp** — only matched `from_port == 22` / `== 3389` *exactly*. A NACL allow rule that is all-traffic (`protocol = "-1"`) or spans a wide port range (e.g. `0-65535`) while open to `0.0.0.0/0`/`::/0` exposes SSH and RDP but was **not flagged**. Now also flags `protocol == "-1"` and any range where `from_port <= P && to_port >= P` for P ∈ {22, 3389}. (MQL has no parenthesized grouping, so the `open && (all-traffic || covers-port)` condition is written distributed.)
- **msk-logging-enabled** — only asserted the `broker_logs` block *exists*; a `broker_logs` block whose only sink has `enabled = false` ships nothing yet passed. Now requires at least one enabled `cloudwatch_logs` / `firehose` / `s3` sink.
- **timestream-influxdb-logging-enabled** — asserted `arguments != empty` on the `log_delivery_configuration` block, which has no scalar attributes (only a nested `s3_configuration` block), so a fully-configured logging setup could **never pass**. Now drills into `s3_configuration` and requires `enabled == true`.

`cnspec policy lint` passes. Verified against realistic pass/fail fixtures for each new case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)