### PR TITLE
🐛 aws: fix cloudformation checks that mis-evaluate template properties

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -23900,7 +23900,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::DMS::ReplicationInstance")
     mql: |
       cloudformation.template.resources.where(type == "AWS::DMS::ReplicationInstance").all(
-      properties['PubliclyAccessible'] != true
+      properties['PubliclyAccessible'] == false
       )
   - uid: mondoo-aws-security-dms-replication-encrypted
     title: Ensure DMS replication instances use encryption
@@ -27292,7 +27292,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::CodeBuild::Project")
     mql: |
       cloudformation.template.resources.where(type == "AWS::CodeBuild::Project").all(
-      properties['EncryptionKey'] != ""
+      properties['EncryptionKey'] != empty
       )
   - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted
     title: Ensure Neptune DB cluster snapshots are encrypted at rest
@@ -41431,7 +41431,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("UnauthorizedOperation") || properties['FilterPattern'].string.contains("AccessDenied")
+      properties['FilterPattern'].contains("UnauthorizedOperation") || properties['FilterPattern'].contains("AccessDenied")
       )
   - uid: mondoo-aws-security-cloudwatch-no-mfa-login-alarm
     title: Ensure log metric filter exists for console sign-in without MFA
@@ -41643,7 +41643,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("ConsoleLogin") && properties['FilterPattern'].string.contains("MFAUsed")
+      properties['FilterPattern'].contains("ConsoleLogin") && properties['FilterPattern'].contains("MFAUsed")
       )
   - uid: mondoo-aws-security-cloudwatch-root-usage-alarm
     title: Ensure log metric filter exists for root account usage
@@ -41856,7 +41856,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("Root") && properties['FilterPattern'].string.contains("userIdentity")
+      properties['FilterPattern'].contains("Root") && properties['FilterPattern'].contains("userIdentity")
       )
   - uid: mondoo-aws-security-cloudwatch-iam-policy-change-alarm
     title: Ensure log metric filter exists for IAM policy changes
@@ -42070,7 +42070,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreatePolicy") || properties['FilterPattern'].string.contains("DeletePolicy") || properties['FilterPattern'].string.contains("AttachRolePolicy")
+      properties['FilterPattern'].contains("CreatePolicy") || properties['FilterPattern'].contains("DeletePolicy") || properties['FilterPattern'].contains("AttachRolePolicy")
       )
   - uid: mondoo-aws-security-cloudwatch-cloudtrail-config-alarm
     title: Ensure log metric filter exists for CloudTrail config changes
@@ -42283,7 +42283,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreateTrail") || properties['FilterPattern'].string.contains("UpdateTrail") || properties['FilterPattern'].string.contains("DeleteTrail") || properties['FilterPattern'].string.contains("StartLogging") || properties['FilterPattern'].string.contains("StopLogging")
+      properties['FilterPattern'].contains("CreateTrail") || properties['FilterPattern'].contains("UpdateTrail") || properties['FilterPattern'].contains("DeleteTrail") || properties['FilterPattern'].contains("StartLogging") || properties['FilterPattern'].contains("StopLogging")
       )
   - uid: mondoo-aws-security-cloudwatch-console-auth-failure-alarm
     title: Ensure log metric filter exists for console auth failures
@@ -42496,7 +42496,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("ConsoleLogin") && properties['FilterPattern'].string.contains("Failed")
+      properties['FilterPattern'].contains("ConsoleLogin") && properties['FilterPattern'].contains("Failed")
       )
   - uid: mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm
     title: Ensure log metric filter exists for CMK disable or deletion
@@ -42709,7 +42709,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("DisableKey") || properties['FilterPattern'].string.contains("ScheduleKeyDeletion")
+      properties['FilterPattern'].contains("DisableKey") || properties['FilterPattern'].contains("ScheduleKeyDeletion")
       )
   - uid: mondoo-aws-security-cloudwatch-s3-policy-change-alarm
     title: Ensure log metric filter exists for S3 bucket policy changes
@@ -42922,7 +42922,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("PutBucketPolicy") || properties['FilterPattern'].string.contains("DeleteBucketPolicy")
+      properties['FilterPattern'].contains("PutBucketPolicy") || properties['FilterPattern'].contains("DeleteBucketPolicy")
       )
   - uid: mondoo-aws-security-cloudwatch-config-change-alarm
     title: Ensure log metric filter exists for AWS Config changes
@@ -43135,7 +43135,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("StopConfigurationRecorder") || properties['FilterPattern'].string.contains("DeleteDeliveryChannel")
+      properties['FilterPattern'].contains("StopConfigurationRecorder") || properties['FilterPattern'].contains("DeleteDeliveryChannel")
       )
   - uid: mondoo-aws-security-cloudwatch-security-group-change-alarm
     title: Ensure log metric filter exists for security group changes
@@ -43348,7 +43348,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("AuthorizeSecurityGroupIngress") || properties['FilterPattern'].string.contains("RevokeSecurityGroupIngress")
+      properties['FilterPattern'].contains("AuthorizeSecurityGroupIngress") || properties['FilterPattern'].contains("RevokeSecurityGroupIngress")
       )
   - uid: mondoo-aws-security-cloudwatch-nacl-change-alarm
     title: Ensure log metric filter exists for NACL changes
@@ -43561,7 +43561,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreateNetworkAcl") || properties['FilterPattern'].string.contains("DeleteNetworkAcl")
+      properties['FilterPattern'].contains("CreateNetworkAcl") || properties['FilterPattern'].contains("DeleteNetworkAcl")
       )
   - uid: mondoo-aws-security-cloudwatch-network-gw-change-alarm
     title: Ensure log metric filter exists for network gateway changes
@@ -43774,7 +43774,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreateCustomerGateway") || properties['FilterPattern'].string.contains("AttachInternetGateway")
+      properties['FilterPattern'].contains("CreateCustomerGateway") || properties['FilterPattern'].contains("AttachInternetGateway")
       )
   - uid: mondoo-aws-security-cloudwatch-route-table-change-alarm
     title: Ensure log metric filter exists for route table changes
@@ -43987,7 +43987,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreateRoute") || properties['FilterPattern'].string.contains("DeleteRoute")
+      properties['FilterPattern'].contains("CreateRoute") || properties['FilterPattern'].contains("DeleteRoute")
       )
   - uid: mondoo-aws-security-cloudwatch-vpc-change-alarm
     title: Ensure log metric filter exists for VPC changes
@@ -44200,7 +44200,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("CreateVpc") || properties['FilterPattern'].string.contains("DeleteVpc")
+      properties['FilterPattern'].contains("CreateVpc") || properties['FilterPattern'].contains("DeleteVpc")
       )
   - uid: mondoo-aws-security-cloudwatch-org-change-alarm
     title: Ensure log metric filter exists for organization changes
@@ -44413,7 +44413,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Logs::MetricFilter")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Logs::MetricFilter").any(
-      properties['FilterPattern'].string.contains("organizations.amazonaws.com")
+      properties['FilterPattern'].contains("organizations.amazonaws.com")
       )
   - uid: mondoo-aws-security-secgroup-no-unrestricted-egress
     title: Ensure security groups do not allow unrestricted egress


### PR DESCRIPTION
Found by per-variant pass/fail CloudFormation template testing (realistic templates in, MQL fixed when a compliant one failed or a non-compliant one passed).

## Systemic: CloudWatch MetricFilter alarm checks (15 checks)
The mql called `properties['FilterPattern'].string.contains(...)`. In the cloudformation provider `properties['X']` is already a scalar-string value, and the intermediate **`.string` accessor errors** on it, so `.string.contains(...)` was **never true** — every compliant `AWS::Logs::MetricFilter` template failed the check. Dropping `.string` (calling `.contains(...)` directly) fixes all of them.

Affected: `cloudwatch-{unauthorized-api,no-mfa-login,root-usage,config-change,cloudtrail-config,cmk-disable-delete,console-auth-failure,iam-policy-change,nacl-change,network-gw-change,org-change,route-table-change,s3-policy-change,security-group-change,vpc-change}-alarm-cloudformation`.

## Null-safety / defaults
- **codebuild-encryption-key-configured** — `properties['EncryptionKey'] != ""` isn't null-safe; an omitted key (the real misconfig — CodeBuild falls back to the default S3 key, not a CMK) is null and `null != ""` is true → wrongly passed. → `!= empty`.
- **dms-replication-not-public** — `properties['PubliclyAccessible'] != true` treated an absent property as compliant, but an `AWS::DMS::ReplicationInstance` **defaults to PubliclyAccessible=true**. → require explicit `== false`.

`cnspec policy lint` passes. Verified against realistic pass/fail CloudFormation templates for each check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)