### PR TITLE
🐛 fix terraform-hcl false negatives in hetzner/vsphere-esxi/oci checks

### DIFF
--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -1525,7 +1525,7 @@ queries:
     mql: |
       terraform.resources("hcloud_load_balancer_service").all(
         arguments['protocol'] != "http" ||
-        blocks.where(type == "http").all(arguments['redirect_http'] == true)
+        blocks.where(type == "http").any(arguments['redirect_http'] == true)
       )
   - uid: mondoo-hetzner-security-lb-http-redirected-to-https-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "hcloud_load_balancer_service")

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -4024,7 +4024,7 @@ queries:
     mql: |
       # HTTPS / HTTP2 listeners must declare an ssl_configuration block whose protocols list excludes legacy TLS / SSL versions.
       terraform.resources('oci_load_balancer_listener')
-        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']))
+        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']) || blocks.where(type == "ssl_configuration") != empty)
         .all(
           blocks.where(type == 'ssl_configuration') != empty &&
           blocks.where(type == 'ssl_configuration').all(
@@ -4186,7 +4186,7 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'oci_load_balancer_listener')
     mql: |
       terraform.resources('oci_load_balancer_listener')
-        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']))
+        .where(arguments['protocol'].in(['HTTPS', 'HTTP2']) || blocks.where(type == "ssl_configuration") != empty)
         .all(
           blocks.where(type == 'ssl_configuration') != empty &&
           blocks.where(type == 'ssl_configuration').all(

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -2557,7 +2557,7 @@ queries:
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'vsphere_host_port_group')
     mql: |
       terraform.resources('vsphere_host_port_group').all(
-        arguments['vlan_id'] != 0 && arguments['vlan_id'] != 4095
+        arguments['vlan_id'] >= 1 && arguments['vlan_id'] <= 4094
       )
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-terraform-plan
     filters: |


### PR DESCRIPTION
Three policies' `terraform-hcl` checks silently passed real misconfigurations. Found by a per-variant Terraform pass/fail test harness.

- **hetzner `lb-http-redirected-to-https`** — used `.all()` over the `http` block set, which is vacuously true when the block is absent, so a plain HTTP listener with no `redirect_http` (the idiomatic default that does *not* redirect to HTTPS) passed. → `.any()` (mirrors the sibling `lb-https-service-has-certificate`).
- **vmware-vsphere-esxi `...vlan-4095-and-0`** — `vlan_id != 0 && vlan_id != 4095` isn't null-safe; an omitted `vlan_id` (provider default `0` = the native VLAN this control forbids) reads as null and passed. → `vlan_id >= 1 && vlan_id <= 4094` (permits VLAN 1, forbids 0/4095, flags absent).
- **oci `loadbalancer-no-weak-cipher-suites` & `loadbalancer-tls-minimum-1-2`** — filtered by `protocol.in(['HTTPS','HTTP2'])`, but OCI has no `HTTPS` listener protocol; TLS is terminated on an **HTTP-protocol listener with an `ssl_configuration` block**. Those listeners were skipped (vacuous `.all()`), so weak ciphers / TLSv1 passed. → also select listeners declaring `ssl_configuration`.

`cnspec policy lint` passes for all three. Verified against realistic pass/fail fixtures.

> Follow-up (not in this PR): the harness also found 3 oci `vcn-no-unrestricted-ingress-*` checks that read a nonexistent `destination_port_range` block on `oci_core_security_list` (it uses flat `min`/`max` on `tcp_options`), plus one m365/snowflake-style items — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)