### PR TITLE
🐛 nextdns: remove block-bypass check that fails to compile

### DIFF
--- a/content/mondoo-nextdns-security.mql.yaml
+++ b/content/mondoo-nextdns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-nextdns-security
     name: Mondoo NextDNS Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -43,10 +43,6 @@ policies:
           - uid: mondoo-nextdns-security-nrd-blocking-enabled
           - uid: mondoo-nextdns-security-csam-blocking-enabled
           - uid: mondoo-nextdns-security-parked-domain-blocking-enabled
-      - title: Filtering Integrity
-        filters: asset.platform == "nextdns-profile"
-        checks:
-          - uid: mondoo-nextdns-security-block-bypass-methods-blocked
       - title: Logging and Visibility
         filters: asset.platform == "nextdns-profile"
         checks:
@@ -755,79 +751,6 @@ queries:
     refs:
       - url: https://nextdns.github.io/api/#security
         title: NextDNS API — Security
-
-  # ==========================================
-  # Filtering Integrity
-  # ==========================================
-  - uid: mondoo-nextdns-security-block-bypass-methods-blocked
-    title: Ensure NextDNS blocks filtering bypass methods
-    impact: 80
-    tags:
-      compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
-      compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
-      compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-pt-3
-      compliance/nist-csf-2: nist-csf-2-pr-ps-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
-      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
-      compliance/pci-dss-4: false
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-3
-    mql: |
-      nextdns.profile.parentalControl.blockBypass == true
-    docs:
-      desc: |
-        This check verifies that NextDNS blocks bypass methods on the profile. With this setting enabled, NextDNS blocks the VPNs, proxies, Tor nodes, and encrypted DNS providers that users employ to circumvent DNS-layer filtering.
-
-        **Why this matters**
-
-        - **Policy enforcement:** Without bypass blocking, a user can switch to a public resolver or VPN and defeat every other protection in the profile.
-        - **Consistent coverage:** Bypass blocking keeps clients on the filtered resolver so threat and content controls actually apply.
-        - **Shadow IT containment:** Blocking circumvention tools reduces unsanctioned tunneling out of the managed network.
-
-        **Risk mitigation**
-
-        - **Closes the escape hatch:** Preventing use of alternate resolvers and tunnels ensures the rest of the profile's controls cannot be trivially sidestepped.
-        - **Uniform protection:** All clients remain subject to the same filtering regardless of user attempts to opt out.
-      audit: |
-        To verify that bypass-method blocking is enabled from the NextDNS dashboard:
-
-        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
-        2. Open the **Parental Control** tab.
-        3. Inspect the **Block Bypass Methods** toggle.
-
-        If the toggle is on, the check passes. If it is off, the check fails.
-
-        To verify via the NextDNS API, inspect `blockBypass` under parentalControl:
-
-        ```bash
-        curl -s https://api.nextdns.io/profiles/<profile-id>/parentalControl \
-          -H "X-Api-Key: $NEXTDNS_API_KEY"
-        ```
-      remediation:
-        - id: console
-          desc: |
-            To block bypass methods from the NextDNS dashboard:
-
-            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
-            2. Open the **Parental Control** tab.
-            3. Turn on **Block Bypass Methods**.
-        - id: api
-          desc: |
-            To block bypass methods using the NextDNS API:
-
-            ```bash
-            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/parentalControl \
-              -H "X-Api-Key: $NEXTDNS_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d '{"blockBypass": true}'
-            ```
-    refs:
-      - url: https://nextdns.github.io/api/#parentalcontrol
-        title: NextDNS API — Parental Control
 
   # ==========================================
   # Logging and Visibility


### PR DESCRIPTION
## What

Removes the `mondoo-nextdns-security-block-bypass-methods-blocked` check from the NextDNS security policy. It is **blocking prod policy-bundle deployment** in downstream consumers.

## Why

The prod deployment fails to load the policy bundle because the check's MQL field does not exist in the prod NextDNS provider:

```
failed to compile query 'nextdns.profile.settings.blockBypassMethods == true':
cannot find field 'blockBypassMethods' in nextdns.profileSettings
```

#2983 repointed this check from `settings.blockBypassMethods` to `parentalControl.blockBypass`, but that field is **also** unavailable in the prod build, so the bundle still fails to compile. To unblock deployments we remove the check entirely for now — mirroring how #2983 removed the redundant `end-user-block-bypass-disabled` check.

## Changes

- Drop the check definition and its now-empty **Filtering Integrity** group.
- Bump policy version **1.0.1 → 1.0.2**.

## Testing

- `cnspec policy lint ./content/mondoo-nextdns-security.mql.yaml` → **valid policy bundle**
- No remaining references to the check UID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)