### PR TITLE
🐛 oci: fix vcn ingress port checks reading a nonexistent tcp_options block

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -6816,21 +6816,19 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
-      # A 0.0.0.0/0 TCP ingress rule with no tcp_options block opens every TCP port (including the DB ports below), so require the block to exist before scoping the port range.
+      # A 0.0.0.0/0 TCP ingress rule with no tcp_options block opens every TCP port (including the DB ports below); tcp_options exposes the port range through flat min/max arguments.
       terraform.resources("oci_core_security_list").all(
-        blocks.where(type == "ingress_security_rules" && arguments.source == "0.0.0.0/0" && arguments.protocol == "6").all(
-          blocks.where(type == "tcp_options") != empty &&
-          blocks.where(type == "tcp_options").all(
-            blocks.where(type == "destination_port_range").none(
-              arguments['min'] <= 1521 && arguments['max'] >= 1521 ||
-              arguments['min'] <= 1522 && arguments['max'] >= 1522 ||
-              arguments['min'] <= 1433 && arguments['max'] >= 1433 ||
-              arguments['min'] <= 3306 && arguments['max'] >= 3306 ||
-              arguments['min'] <= 5432 && arguments['max'] >= 5432 ||
-              arguments['min'] <= 6379 && arguments['max'] >= 6379 ||
-              arguments['min'] <= 9200 && arguments['max'] >= 9200 ||
-              arguments['min'] <= 27017 && arguments['max'] >= 27017
-            )
+        blocks.where(type == "ingress_security_rules" && arguments.source == "0.0.0.0/0" && arguments.protocol == "6").none(
+          blocks.where(type == "tcp_options") == empty ||
+          blocks.where(type == "tcp_options").any(
+            arguments.min <= 1521 && arguments.max >= 1521 ||
+            arguments.min <= 1522 && arguments.max >= 1522 ||
+            arguments.min <= 1433 && arguments.max >= 1433 ||
+            arguments.min <= 3306 && arguments.max >= 3306 ||
+            arguments.min <= 5432 && arguments.max >= 5432 ||
+            arguments.min <= 6379 && arguments.max >= 6379 ||
+            arguments.min <= 9200 && arguments.max >= 9200 ||
+            arguments.min <= 27017 && arguments.max >= 27017
           )
         )
       )
@@ -7000,20 +6998,18 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
-      # A 0.0.0.0/0 TCP ingress rule with no tcp_options block opens every TCP port (including the legacy admin ports below), so require the block to exist before scoping the port range.
+      # A 0.0.0.0/0 TCP ingress rule with no tcp_options block opens every TCP port (including the legacy admin ports below); tcp_options exposes the port range through flat min/max arguments.
       terraform.resources("oci_core_security_list").all(
-        blocks.where(type == "ingress_security_rules" && arguments.source == "0.0.0.0/0" && arguments.protocol == "6").all(
-          blocks.where(type == "tcp_options") != empty &&
-          blocks.where(type == "tcp_options").all(
-            blocks.where(type == "destination_port_range").none(
-              arguments['min'] <= 21 && arguments['max'] >= 21 ||
-              arguments['min'] <= 23 && arguments['max'] >= 23 ||
-              arguments['min'] <= 135 && arguments['max'] >= 135 ||
-              arguments['min'] <= 137 && arguments['max'] >= 137 ||
-              arguments['min'] <= 138 && arguments['max'] >= 138 ||
-              arguments['min'] <= 139 && arguments['max'] >= 139 ||
-              arguments['min'] <= 445 && arguments['max'] >= 445
-            )
+        blocks.where(type == "ingress_security_rules" && arguments.source == "0.0.0.0/0" && arguments.protocol == "6").none(
+          blocks.where(type == "tcp_options") == empty ||
+          blocks.where(type == "tcp_options").any(
+            arguments.min <= 21 && arguments.max >= 21 ||
+            arguments.min <= 23 && arguments.max >= 23 ||
+            arguments.min <= 135 && arguments.max >= 135 ||
+            arguments.min <= 137 && arguments.max >= 137 ||
+            arguments.min <= 138 && arguments.max >= 138 ||
+            arguments.min <= 139 && arguments.max >= 139 ||
+            arguments.min <= 445 && arguments.max >= 445
           )
         )
       )
@@ -7351,13 +7347,11 @@ queries:
         )
       )
       terraform.resources("oci_core_security_list").all(
-        blocks.where(type == "ingress_security_rules" && arguments.source == "::/0" && arguments.protocol == "6").all(
-          blocks.where(type == "tcp_options") != empty &&
-          blocks.where(type == "tcp_options").all(
-            blocks.where(type == "destination_port_range").none(
-              arguments['min'] <= 22 && arguments['max'] >= 22 ||
-              arguments['min'] <= 3389 && arguments['max'] >= 3389
-            )
+        blocks.where(type == "ingress_security_rules" && arguments.source == "::/0" && arguments.protocol == "6").none(
+          blocks.where(type == "tcp_options") == empty ||
+          blocks.where(type == "tcp_options").any(
+            arguments.min <= 22 && arguments.max >= 22 ||
+            arguments.min <= 3389 && arguments.max >= 3389
           )
         )
       )


### PR DESCRIPTION
## Problem

Three Terraform HCL variants of the OCI VCN unrestricted-ingress checks scoped their port match against a `destination_port_range` block nested inside `tcp_options`. That block does not exist in the `oci_core_security_list` schema — the OCI Terraform provider exposes the port range as flat `min`/`max` arguments directly on the `tcp_options` block. Because the nested `destination_port_range` block never matched, an internet-exposed database, legacy-admin, or IPv6 port was never flagged. The checks silently passed on real misconfigurations.

## Fix

Each affected check is rewritten to mirror the already-working `vcn-no-unrestricted-ssh-ingress` / `-rdp-ingress` HCL siblings: read the flat `tcp_options` `min`/`max`, and treat a `0.0.0.0/0` (or `::/0`) TCP rule with **no** `tcp_options` block as unrestricted.

| Check (`-terraform-hcl`) | Broken HCL form | Ports preserved |
|---|---|---|
| `vcn-no-unrestricted-ingress-db-ports` | `tcp_options { min = 1521 max = 1521 }` never matched `destination_port_range` | 1521, 1522, 1433, 3306, 5432, 6379, 9200, 27017 |
| `vcn-no-unrestricted-ingress-legacy-admin-ports` | same, e.g. `min = 445` (SMB), `min = 23` (Telnet) | 21, 23, 135, 137, 138, 139, 445 |
| `vcn-no-unrestricted-ipv6-ingress` | `::/0` TCP datapoint used the same nonexistent nested block | 22, 3389 (all-protocol + UDP datapoints unchanged) |

Ranges are expressed with the sibling's `min <= port && max >= port` style.

## Verification

Proven with a local per-check pass/fail Terraform fixture harness (not committed). The previously-RED fixtures now fail as intended and every existing pass fixture stays green:

- `fail/oracle-1521`, `fail/no-tcp-options` (db-ports)
- `fail/smb-445`, `fail/telnet-23`, `fail/no-tcp-options` (legacy-admin-ports)
- `fail/tcp-ssh-22`, `fail/tcp-no-options`, `fail/udp-no-options`, `fail/all-protocols` (ipv6)
- all `pass/*` scenarios green

`cnspec policy lint ./content/mondoo-oci-security.mql.yaml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)