### PR TITLE
🐛 azure: fix broken Terraform HCL checks producing false results

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -898,7 +898,7 @@ queries:
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Tcp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == "22"
         )
       )
@@ -911,7 +911,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "22"
         )
       )
@@ -924,7 +924,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "22"
         )
       )
@@ -936,7 +936,7 @@ queries:
           _["properties"]["direction"] == "Inbound" &&
           _["properties"]["access"] == "Allow" &&
           _["properties"]["protocol"] == /Tcp|\*/i &&
-          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["sourceAddressPrefix"] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _["properties"]["destinationPortRange"] == "22"
         )
       )
@@ -1131,7 +1131,7 @@ queries:
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Tcp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == "3389"
         )
       )
@@ -1144,7 +1144,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "3389"
         )
       )
@@ -1157,7 +1157,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "3389"
         )
       )
@@ -1169,7 +1169,7 @@ queries:
           _["properties"]["direction"] == "Inbound" &&
           _["properties"]["access"] == "Allow" &&
           _["properties"]["protocol"] == /Tcp|\*/i &&
-          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["sourceAddressPrefix"] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _["properties"]["destinationPortRange"] == "3389"
         )
       )
@@ -1364,7 +1364,7 @@ queries:
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Tcp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == /^590[0-3]$/
         )
       )
@@ -1377,7 +1377,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^590[0-3]$/
         )
       )
@@ -1390,7 +1390,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^590[0-3]$/
         )
       )
@@ -1402,7 +1402,7 @@ queries:
           _["properties"]["direction"] == "Inbound" &&
           _["properties"]["access"] == "Allow" &&
           _["properties"]["protocol"] == /Tcp|\*/i &&
-          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["sourceAddressPrefix"] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _["properties"]["destinationPortRange"] == /590[0-3]/
         )
       )
@@ -5373,14 +5373,14 @@ queries:
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Udp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == "*"
         ) &&
         blocks.where(type == "security_rule").none(
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Udp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == /^(53|123|161|389|1900)$/
         )
       )
@@ -5393,7 +5393,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Udp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "*"
         )
       )
@@ -5403,7 +5403,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Udp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^(53|123|161|389|1900)$/
         )
       )
@@ -5416,7 +5416,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Udp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == "*"
         )
       )
@@ -5426,7 +5426,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Udp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^(53|123|161|389|1900)$/
         )
       )
@@ -5438,7 +5438,7 @@ queries:
           _["properties"]["direction"] == "Inbound" &&
           _["properties"]["access"] == "Allow" &&
           _["properties"]["protocol"] == /Udp|\*/i &&
-          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["sourceAddressPrefix"] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _["properties"]["destinationPortRange"] == /^(\*|53|123|161|389|1900)$/
         )
       )
@@ -5572,7 +5572,9 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_account")
     mql: |
       terraform.resources("azurerm_storage_account").all(
+        blocks.where(type == "blob_properties") != empty &&
         blocks.where(type == "blob_properties").all(
+          blocks.where(type == "delete_retention_policy") != empty &&
           blocks.where(type == "delete_retention_policy").all(
             arguments['days'] > 0
           )
@@ -5726,7 +5728,9 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_account")
     mql: |
       terraform.resources("azurerm_storage_account").all(
+        blocks.where(type == "blob_properties") != empty &&
         blocks.where(type == "blob_properties").all(
+          blocks.where(type == "container_delete_retention_policy") != empty &&
           blocks.where(type == "container_delete_retention_policy").all(
             arguments['days'] > 0
           )
@@ -9312,6 +9316,7 @@ queries:
     mql: |
       terraform.resources("azapi_update_resource").
         where(arguments['type'] == /Microsoft.Web\/sites\/basicPublishingCredentialsPolicies/).any(
+          arguments['body'].first['properties']['allow'] == false ||
           arguments['body'].properties.allow == false
         )
   - uid: mondoo-azure-security-app-service-scm-disabled-terraform-plan
@@ -14637,7 +14642,7 @@ queries:
           arguments['direction'] == "Inbound" &&
           arguments['access'] == "Allow" &&
           arguments['protocol'] == /Tcp|\*/i &&
-          arguments['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          arguments['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           arguments['destination_port_range'] == /^(1433|3306|5432|27017)$/
         )
       )
@@ -14650,7 +14655,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^(1433|3306|5432|27017)$/
         )
       )
@@ -14663,7 +14668,7 @@ queries:
           _['direction'] == "Inbound" &&
           _['access'] == "Allow" &&
           _['protocol'] == /Tcp|\*/i &&
-          _['source_address_prefix'] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _['source_address_prefix'] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _['destination_port_range'] == /^(1433|3306|5432|27017)$/
         )
       )
@@ -14675,7 +14680,7 @@ queries:
           _["properties"]["direction"] == "Inbound" &&
           _["properties"]["access"] == "Allow" &&
           _["properties"]["protocol"] == /Tcp|\*/i &&
-          _["properties"]["sourceAddressPrefix"] == /\*|0\.0\.0\.0|Internet|Any/i &&
+          _["properties"]["sourceAddressPrefix"] == /^(\*|0\.0\.0\.0\/0|Internet|Any)$/i &&
           _["properties"]["destinationPortRange"] == /^(1433|3306|5432|27017)$/
         )
       )
@@ -31151,7 +31156,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |
       terraform.resources("azurerm_data_factory").all(
-        arguments['public_network_access_enabled'] == false
+        arguments['public_network_enabled'] == false
       )
   - uid: mondoo-azure-security-datafactory-public-access-disabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_data_factory")
@@ -44939,8 +44944,9 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
     mql: |
       terraform.resources("azurerm_cognitive_account").all(
-        arguments['network_acls'] != null &&
-        arguments['network_acls'][0]['default_action'] == "Deny"
+        blocks.where(type == "network_acls").any(
+          arguments['default_action'] == "Deny"
+        )
       )
   - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
@@ -45081,7 +45087,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
     mql: |
       terraform.resources("azurerm_cognitive_account").all(
-        arguments['identity'] != null
+        blocks.any(type == "identity")
       )
   - uid: mondoo-azure-security-cognitive-services-managed-identity-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
@@ -45952,9 +45958,11 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_logic_app_workflow")
     mql: |
       terraform.resources("azurerm_logic_app_workflow").all(
-        arguments['access_control'] != null &&
-        arguments['access_control'][0]['trigger'] != null &&
-        arguments['access_control'][0]['trigger'][0]['allowed_caller_ip_address_range'] != empty
+        blocks.where(type == "access_control").any(
+          blocks.where(type == "trigger").any(
+            arguments['allowed_caller_ip_address_range'] != empty
+          )
+        )
       )
   - uid: mondoo-azure-security-logic-app-http-trigger-ip-restricted-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_logic_app_workflow")


### PR DESCRIPTION
## Summary

Eight Terraform HCL variant checks in `mondoo-azure-security` queried attributes or paths that never match the real HCL shape, so they returned the wrong verdict (false positives that failed compliant configs, or false negatives that passed insecure ones). Each fix was proven by a local per-check pass/fail harness: the realistic RED fixture now turns green and no previously-green scenario regressed. Only `content/mondoo-azure-security.mql.yaml` is changed (the harness and fixtures are not committed).

## Checks fixed

| Check (terraform-hcl variant) | Realistic HCL form that broke it | Fix |
|---|---|---|
| `datafactory-public-access-disabled` | `azurerm_data_factory` exposes `public_network_enabled`; query read `public_network_access_enabled` → always null → disabled config failed | query `arguments['public_network_enabled'] == false` |
| `cognitive-services-managed-identity` | `identity {}` is a nested block, not an argument; `arguments['identity'] != null` always null → compliant failed | `blocks.any(type == "identity")` |
| `cognitive-services-network-acl-default-deny` | `network_acls {}` is a nested block; `arguments['network_acls'][0]...` never matched | `blocks.where(type == "network_acls").any(arguments['default_action'] == "Deny")` |
| `logic-app-http-trigger-ip-restricted` | `access_control {}` / `trigger {}` are nested blocks; indexed access always null → every logic app flagged | traverse nested `access_control` → `trigger` blocks |
| `app-service-scm-disabled` | azapi v1 `body = jsonencode({...})` is list-wrapped → `body.properties` null → compliant resource failed | accept both list-wrapped (v1) `body.first['properties']['allow']` and plain-dict (v2) `body.properties.allow` |
| `storage-blob-soft-delete-enabled` | disabled state omits `delete_retention_policy` → nested `.all()` vacuously true → soft-delete-off passed | require `blob_properties` and `delete_retention_policy` blocks to exist |
| `storage-container-soft-delete-enabled` | same, for `container_delete_retention_policy` | analogous existence guard |
| NSG source-address regex (`disable-udp-virtualmachines`, `rdp`/`ssh`/`vnc-access-restricted-from-internet`, `nsg-sensitive-ports-restricted`) | unanchored `/\*\|0\.0\.0\.0\|Internet\|Any/i` matches any private CIDR containing substring `0.0.0.0` (e.g. `10.0.0.0/8`) → internal allow-rules false-flagged | anchored to `/^(\*\|0\.0\.0\.0\/0\|Internet\|Any)$/i` across all 23 occurrences |

## Verification

- `go test ./content -run 'TestTerraformVariants/mondoo-azure-security/...'` — full azure variant suite green.
- `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` — valid bundle (only pre-existing deprecated-symbol warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
