### PR TITLE
🐛 aws: fix 6 Terraform/CloudFormation checks that missed real misconfigurations

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2801,7 +2801,8 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_default_security_group")
     mql: |
       terraform.resources("aws_default_security_group").all(
-        arguments.ingress == empty && arguments.egress == empty
+        arguments.ingress == empty && arguments.egress == empty &&
+        blocks.where(type == "ingress") == empty && blocks.where(type == "egress") == empty
       )
   - uid: mondoo-aws-security-vpc-default-security-group-closed-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_default_security_group")
@@ -12833,7 +12834,7 @@ queries:
     mql: |
       aws.s3.bucket.website == empty
   - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket_website_configuration")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_bucket")
     mql: |
       terraform.resources("aws_s3_bucket_website_configuration").length == 0
   - uid: mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-plan
@@ -17030,6 +17031,7 @@ queries:
       )
       cloudformation.template.resources.where(type == "AWS::CodeBuild::Project").all(
       properties['Environment'] == empty ||
+      properties['Environment']['EnvironmentVariables'] == empty ||
       properties['Environment']['EnvironmentVariables'].where(_['Type'] == "PLAINTEXT").none(
       _['Name'] == /(?i)(PASSWORD|SECRET|KEY|TOKEN|CREDENTIAL)/
       )
@@ -47244,7 +47246,12 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sqs_queue_policy")
     mql: |
       terraform.resources("aws_sqs_queue_policy").all(
-      arguments.policy == empty || arguments.policy != /"Principal"\s*:\s*"\*"/
+        arguments.policy.first != null &&
+        arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
+          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+        ) ||
+        arguments.policy.first == null &&
+        arguments.policy != /"Principal"\s*:\s*"\*"/
       )
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sqs_queue_policy")
@@ -47262,7 +47269,13 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::SQS::QueuePolicy")
     mql: |
       cloudformation.template.resources.where(type == "AWS::SQS::QueuePolicy").all(
-      properties['PolicyDocument'].string != /"Principal"\s*:\s*"\*"/
+        properties['PolicyDocument'] == null ||
+        properties['PolicyDocument']['Statement'] == null ||
+        properties['PolicyDocument']['Statement'].where(_['Effect'] == "Allow").none(
+          _['Principal'] == "*" ||
+          _['Principal']['AWS'] == "*" ||
+          _['Principal']['AWS'] != null && _['Principal']['AWS'].contains("*")
+        )
       )
   # No Terraform variants: `aws_ecs_task_definition.container_definitions` is a JSON-encoded string in HCL — extracting and pattern-matching environment-variable names/values would require a JSON-walking variant pass that is not currently supported in the same shape as the runtime check.
   - uid: mondoo-aws-security-ecs-task-definition-no-plaintext-secrets
@@ -64565,7 +64578,7 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_workspacesweb_ip_access_settings")
     mql: |
       terraform.resources("aws_workspacesweb_ip_access_settings").all(
-        blocks.where(type == "ip_rules").all(
+        blocks.where(type == "ip_rule").all(
           arguments["ip_range"] != "0.0.0.0/0" && arguments["ip_range"] != "::/0"
         )
       )
@@ -64573,15 +64586,15 @@ queries:
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_workspacesweb_ip_access_settings")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_workspacesweb_ip_access_settings").all(
-        change.after["ip_rules"] == null ||
-        change.after["ip_rules"].all(_["ip_range"] != "0.0.0.0/0" && _["ip_range"] != "::/0")
+        change.after["ip_rule"] == null ||
+        change.after["ip_rule"].all(_["ip_range"] != "0.0.0.0/0" && _["ip_range"] != "::/0")
       )
   - uid: mondoo-aws-security-workspaces-web-ip-access-no-public-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_workspacesweb_ip_access_settings")
     mql: |
       terraform.state.resources.where(type == "aws_workspacesweb_ip_access_settings").all(
-        values["ip_rules"] == null ||
-        values["ip_rules"].all(_["ip_range"] != "0.0.0.0/0" && _["ip_range"] != "::/0")
+        values["ip_rule"] == null ||
+        values["ip_rule"].all(_["ip_range"] != "0.0.0.0/0" && _["ip_range"] != "::/0")
       )
   # No Terraform variants: certificate expiry is operational telemetry on the ACM certificate behind the origin mTLS reference, not a configuration argument on `aws_cloudfront_distribution`.
   - uid: mondoo-aws-security-cloudfront-origin-mtls-cert-not-expired

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -47248,22 +47248,29 @@ queries:
       terraform.resources("aws_sqs_queue_policy").all(
         arguments.policy.first != null &&
         arguments.policy.first["Statement"].where(_["Effect"] == "Allow").none(
-          _["Principal"] == "*" || _["Principal"]["AWS"] == "*"
+          _["Principal"] == "*" ||
+          _["Principal"]["AWS"] == "*" ||
+          _["Principal"]["AWS"] != null && _["Principal"]["AWS"].contains("*")
         ) ||
         arguments.policy.first == null &&
-        arguments.policy != /"Principal"\s*:\s*"\*"/
+        arguments.policy != /"Principal"\s*:\s*"\*"/ &&
+        arguments.policy != /"AWS"\s*:\s*\[?\s*"\*"/
       )
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_sqs_queue_policy")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_sqs_queue_policy").all(
-      change.after.policy == empty || change.after.policy != /"Principal"\s*:\s*"\*"/
+        change.after.policy == empty ||
+        change.after.policy != /"Principal"\s*:\s*"\*"/ &&
+        change.after.policy != /"AWS"\s*:\s*\[?\s*"\*"/
       )
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_sqs_queue_policy")
     mql: |
       terraform.state.resources.where(type == "aws_sqs_queue_policy").all(
-      values.policy == empty || values.policy != /"Principal"\s*:\s*"\*"/
+        values.policy == empty ||
+        values.policy != /"Principal"\s*:\s*"\*"/ &&
+        values.policy != /"AWS"\s*:\s*\[?\s*"\*"/
       )
   - uid: mondoo-aws-security-sqs-no-wildcard-policy-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::SQS::QueuePolicy")
@@ -47273,7 +47280,6 @@ queries:
         properties['PolicyDocument']['Statement'] == null ||
         properties['PolicyDocument']['Statement'].where(_['Effect'] == "Allow").none(
           _['Principal'] == "*" ||
-          _['Principal']['AWS'] == "*" ||
           _['Principal']['AWS'] != null && _['Principal']['AWS'].contains("*")
         )
       )


### PR DESCRIPTION
## Summary

Six checks in `mondoo-aws-security` silently passed real misconfigurations (or failed compliant infrastructure) because their MQL did not match the actual Terraform/CloudFormation shape. Each fix was proven with a local per-check pass/fail test harness that turns a realistic broken fixture from RED to GREEN with no regression of the previously-passing scenarios (the harness itself is not committed).

## Checks fixed

### `vpc-default-security-group-closed-terraform-hcl`
- **Broke on:** a default SG using idiomatic nested blocks, e.g. `ingress { ... }` / `egress { ... }`.
- **Root cause:** the query only inspected the attribute-list form (`arguments.ingress`/`arguments.egress`). Nested blocks land under `blocks.where(type=="ingress"/"egress")` and were never checked, so the SG wrongly passed.
- **Fix:** also require `blocks.where(type == "ingress") == empty && blocks.where(type == "egress") == empty`.

### `workspaces-web-ip-access-no-public` (terraform-hcl, terraform-plan, terraform-state)
- **Broke on:** an `aws_workspacesweb_ip_access_settings` allowlisting `0.0.0.0/0` or `::/0`.
- **Root cause:** the query used the name `ip_rules`, but the resource names the block/attribute `ip_rule` (singular). The mismatch made `.all()` vacuous, so a public allowlist wrongly passed.
- **Fix:** corrected the field name `ip_rules` → `ip_rule` in all three variants.

### `s3-bucket-static-website-hosting-disabled-terraform-hcl`
- **Broke on:** a compliant bucket with no website configuration — it was never scored.
- **Root cause:** contradictory filter/mql. The filter required an `aws_s3_bucket_website_configuration` resource to be present, while the mql only passed when zero such resources existed, so the check could never pass when it ran.
- **Fix:** broadened the filter to select on `aws_s3_bucket` (keeping the `length == 0` mql), so a compliant bucket is in scope and passes.

### `sqs-no-wildcard-policy-terraform-hcl`
- **Broke on:** `policy = jsonencode({ Statement = [{ Principal = "*", ... }] })`.
- **Root cause:** the policy was read as a string and regex-matched, so the structured `jsonencode` form slipped past.
- **Fix:** traverse the policy structurally (mirroring the working `s3-bucket-policy-no-public-principal-terraform-hcl` sibling) via `arguments.policy.first["Statement"]`, while retaining the regex path for heredoc/string policies.

### `sqs-no-wildcard-policy-cloudformation`
- **Broke on:** a `AWS::SQS::QueuePolicy` with `"Principal": "*"` (or `{"AWS": "*"}`).
- **Root cause:** `properties['PolicyDocument'].string` was regex-matched, but a CloudFormation `PolicyDocument` is a structured dict, so wildcard policies wrongly passed.
- **Fix:** traverse `PolicyDocument.Statement` structurally (mirroring `s3-bucket-policy-no-public-principal-cloudformation`), null-guarding absent PolicyDocument/Statement.

### `codebuild-no-plaintext-credentials-cloudformation`
- **Broke on:** a compliant service-role template with no `EnvironmentVariables` — it wrongly failed.
- **Root cause:** missing null guard on an absent `EnvironmentVariables` list.
- **Fix:** added `properties['Environment']['EnvironmentVariables'] == empty ||` so absent/empty is compliant, while a PLAINTEXT credential env var still fails.

## Verification

Each check's fixtures (both the RED fixture and all previously-green scenarios) pass under the local per-check Terraform/CloudFormation variant harness. `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` reports a valid bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)