### PR TITLE
✨ gcp: add terraform-hcl variant for 1 check

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -39511,6 +39511,10 @@ queries:
         tags:
           mondoo.com/filter-title: GCP Cloud Run Job
           mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-cloud-run-job-no-plaintext-secrets-in-env-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Cloud Run job containers do not have environment variables whose names suggest they contain credentials, API keys, or other secrets with non-empty plaintext values. Storing secrets in environment variables exposes them in job configuration, Cloud Run metadata APIs, and any tooling that inspects container specs.
@@ -39578,6 +39582,21 @@ queries:
     mql: |
       gcp.project.cloudRunService.job.template.template.containers.all(
         env.none(_['name'] == /(?i)(password|secret|api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|credentials|connection[_-]?string)/ && _['value'] != empty)
+      )
+  - uid: mondoo-gcp-security-cloud-run-job-no-plaintext-secrets-in-env-terraform-hcl
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_cloud_run_v2_job')
+    mql: |
+      terraform.resources('google_cloud_run_v2_job').all(
+        blocks.where(type == 'template').all(
+          blocks.where(type == 'template').all(
+            blocks.where(type == 'containers').all(
+              blocks.where(type == 'env').none(
+                arguments['name'] == /(?i)(password|secret|api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|credentials|connection[_-]?string)/ && arguments['value'] != empty
+              )
+            )
+          )
+        )
       )
 # No Terraform variants: Vertex AI custom jobs are short-lived imperative API resources with no Terraform analog.
   - uid: mondoo-gcp-security-vertexai-custom-job-cmek-encryption


### PR DESCRIPTION
## Summary

Adds a `-terraform-hcl` variant for one GCP Cloud Run check so it is evaluated against Terraform HCL configurations in addition to the live GCP resource.

| Check | Target resource |
| --- | --- |
| `mondoo-gcp-security-cloud-run-job-no-plaintext-secrets-in-env` | `google_cloud_run_v2_job` |

The variant walks the nested `template > template > containers > env` blocks and fails any env whose name matches a credential pattern and has a non-empty plaintext `value`.

## Validation

- `cnspec policy lint ./content/mondoo-gcp-security.mql.yaml` → valid policy bundle (only pre-existing deprecation warnings unrelated to this change).
- Validated with a local per-check pass/fail Terraform fixture harness (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)