### PR TITLE
🔧 aws: run codebuild/cognito/memorydb/transfer checks per-resource asset

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -16750,8 +16750,8 @@ queries:
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/security.html
         title: AWS Documentation - Security in AWS CodeBuild
   - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
-    filters: asset.platform == "aws"
-    mql: aws.codebuild.projects.all(environment["privilegedMode"] != true)
+    filters: asset.platform == "aws-codebuild-project"
+    mql: aws.codebuild.project.environment["privilegedMode"] != true
   - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -16964,17 +16964,13 @@ queries:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
         title: AWS Documentation - What is AWS Secrets Manager
   - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-codebuild-project"
     mql: |
-      aws.codebuild.projects.all(
-        environment["environmentVariables"]
-          .where(_["type"] == "PLAINTEXT")
-          .none(_["name"] == /(?i)(PASSWORD|SECRET|KEY|TOKEN|CREDENTIAL)/)
-      )
-      aws.codebuild.projects.all(
-        environment["imagePullCredentialsType"] == "CODEBUILD" ||
-        environment["imagePullCredentialsType"] == "SERVICE_ROLE"
-      )
+      aws.codebuild.project.environment["environmentVariables"]
+        .where(_["type"] == "PLAINTEXT")
+        .none(_["name"] == /(?i)(PASSWORD|SECRET|KEY|TOKEN|CREDENTIAL)/)
+      aws.codebuild.project.environment["imagePullCredentialsType"] == "CODEBUILD" ||
+      aws.codebuild.project.environment["imagePullCredentialsType"] == "SERVICE_ROLE"
   - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -23047,8 +23043,8 @@ queries:
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-source-version.html
         title: AWS Documentation - Source version sample
   - uid: mondoo-aws-security-codebuild-source-ssl-verification-aws
-    filters: asset.platform == "aws"
-    mql: aws.codebuild.projects.all(source["insecureSsl"] != true)
+    filters: asset.platform == "aws-codebuild-project"
+    mql: aws.codebuild.project.source["insecureSsl"] != true
   - uid: mondoo-aws-security-codebuild-source-ssl-verification-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -27272,8 +27268,8 @@ queries:
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/security.html
         title: AWS Documentation - Security in AWS CodeBuild
   - uid: mondoo-aws-security-codebuild-encryption-key-configured-aws
-    filters: asset.platform == "aws"
-    mql: aws.codebuild.projects.all(encryptionKey.metadata["KeyManager"] == "CUSTOMER")
+    filters: asset.platform == "aws-codebuild-project"
+    mql: aws.codebuild.project.encryptionKey.metadata["KeyManager"] == "CUSTOMER"
   - uid: mondoo-aws-security-codebuild-encryption-key-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -30694,8 +30690,8 @@ queries:
       - url: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html
         title: Adding MFA to a user pool
   - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-aws
-    filters: asset.platform == "aws"
-    mql: aws.cognito.userPools.all(mfaConfiguration == "ON")
+    filters: asset.platform == "aws-cognito-userpool"
+    mql: aws.cognito.userPool.mfaConfiguration == "ON"
   - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool")
     mql: |
@@ -30864,8 +30860,8 @@ queries:
       - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html
         title: Adding advanced security to a user pool
   - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-aws
-    filters: asset.platform == "aws"
-    mql: aws.cognito.userPools.all(advancedSecurityMode == "ENFORCED")
+    filters: asset.platform == "aws-cognito-userpool"
+    mql: aws.cognito.userPool.advancedSecurityMode == "ENFORCED"
   - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool")
     mql: |
@@ -30896,9 +30892,9 @@ queries:
   - uid: mondoo-aws-security-cognito-domain-min-tls-1-2
     title: Ensure Cognito custom domains enforce TLS 1.2 or higher
     impact: 70
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cognito-userpool"
     mql: |
-      aws.cognito.userPools.all( domain == null || domain.tlsSecurityPolicy == "" || domain.tlsSecurityPolicy != "TLS_V1" )
+      aws.cognito.userPool.domain == null || aws.cognito.userPool.domain.tlsSecurityPolicy == "" || aws.cognito.userPool.domain.tlsSecurityPolicy != "TLS_V1"
     docs:
       desc: |
         This check ensures that Cognito custom domains enforce a minimum TLS version of 1.2. The hosted-UI login endpoint for a custom domain carries a configurable TLS security policy; setting it to `TLS_V1` allows clients to negotiate TLS 1.0, an obsolete protocol with known weaknesses. A custom domain should enforce `TLS_V1_2_2021` or higher so that all sign-in traffic uses modern transport encryption.
@@ -31890,8 +31886,8 @@ queries:
       - url: https://docs.aws.amazon.com/memorydb/latest/devguide/in-transit-encryption.html
         title: MemoryDB encryption in transit
   - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-aws
-    filters: asset.platform == "aws"
-    mql: aws.memorydb.clusters.all(tlsEnabled == true)
+    filters: asset.platform == "aws-memorydb-cluster"
+    mql: aws.memorydb.cluster.tlsEnabled == true
   - uid: mondoo-aws-security-memorydb-cluster-tls-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_memorydb_cluster")
     mql: |
@@ -32063,8 +32059,8 @@ queries:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk
         title: AWS KMS Customer Managed Keys
   - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.memorydb.clusters.all(kmsKey { metadata.KeyManager == "CUSTOMER" })
+    filters: asset.platform == "aws-memorydb-cluster"
+    mql: aws.memorydb.cluster.kmsKey { metadata.KeyManager == "CUSTOMER" }
   - uid: mondoo-aws-security-memorydb-cluster-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_memorydb_cluster")
     mql: |
@@ -32229,8 +32225,8 @@ queries:
       - url: https://docs.aws.amazon.com/memorydb/latest/devguide/engine-versions.html
         title: MemoryDB engine versions
   - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-aws
-    filters: asset.platform == "aws"
-    mql: aws.memorydb.clusters.all(autoMinorVersionUpgrade == true)
+    filters: asset.platform == "aws-memorydb-cluster"
+    mql: aws.memorydb.cluster.autoMinorVersionUpgrade == true
   - uid: mondoo-aws-security-memorydb-cluster-auto-minor-version-upgrade-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_memorydb_cluster")
     mql: |
@@ -57706,9 +57702,9 @@ queries:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/create-server.html
         title: AWS Documentation - Creating a Transfer Family server
   - uid: mondoo-aws-security-transfer-no-ftp-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-transfer-server"
     mql: |
-      aws.transfer.servers.all(protocols.none(_ == "FTP"))
+      aws.transfer.server.protocols.none(_ == "FTP")
   - uid: mondoo-aws-security-transfer-no-ftp-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
     mql: |
@@ -57874,9 +57870,9 @@ queries:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/create-server-in-vpc.html
         title: AWS Documentation - Creating a server in a VPC
   - uid: mondoo-aws-security-transfer-vpc-endpoint-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-transfer-server"
     mql: |
-      aws.transfer.servers.all(endpointType == "VPC" || endpointType == "VPC_ENDPOINT")
+      aws.transfer.server.endpointType == "VPC" || aws.transfer.server.endpointType == "VPC_ENDPOINT"
   - uid: mondoo-aws-security-transfer-vpc-endpoint-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
     mql: |
@@ -58039,9 +58035,9 @@ queries:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/structured-logging.html
         title: AWS Documentation - Transfer Family logging
   - uid: mondoo-aws-security-transfer-logging-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-transfer-server"
     mql: |
-      aws.transfer.servers.all(loggingRole != empty)
+      aws.transfer.server.loggingRole != empty
   - uid: mondoo-aws-security-transfer-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
     mql: |
@@ -58192,9 +58188,9 @@ queries:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/security-policies.html
         title: AWS Documentation - Transfer Family security policies
   - uid: mondoo-aws-security-transfer-security-policy-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-transfer-server"
     mql: |
-      aws.transfer.servers.all(securityPolicyName != "TransferSecurityPolicy-2018-11")
+      aws.transfer.server.securityPolicyName != "TransferSecurityPolicy-2018-11"
   - uid: mondoo-aws-security-transfer-security-policy-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
     mql: |
@@ -58345,9 +58341,9 @@ queries:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/custom-identity-provider-users.html
         title: AWS Documentation - Using custom identity providers
   - uid: mondoo-aws-security-transfer-identity-provider-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-transfer-server"
     mql: |
-      aws.transfer.servers.all(identityProviderType != "SERVICE_MANAGED")
+      aws.transfer.server.identityProviderType != "SERVICE_MANAGED"
   - uid: mondoo-aws-security-transfer-identity-provider-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_transfer_server")
     mql: |
@@ -73007,8 +73003,8 @@ queries:
         title: AWS Documentation - Public build projects in AWS CodeBuild
 
   - uid: mondoo-aws-security-codebuild-not-public-aws
-    filters: asset.platform == "aws"
-    mql: aws.codebuild.projects.all(projectVisibility != "PUBLIC_READ")
+    filters: asset.platform == "aws-codebuild-project"
+    mql: aws.codebuild.project.projectVisibility != "PUBLIC_READ"
   - uid: mondoo-aws-security-codebuild-not-public-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -73769,12 +73765,10 @@ queries:
         title: AWS Documentation - User pool authentication flow
 
   - uid: mondoo-aws-security-cognito-client-no-user-password-auth-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cognito-userpool"
     mql: |
-      aws.cognito.userPools.all(
-        clients.all(
-          explicitAuthFlows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
-        )
+      aws.cognito.userPool.clients.all(
+        explicitAuthFlows.none(_ == "ALLOW_USER_PASSWORD_AUTH" || _ == "USER_PASSWORD_AUTH")
       )
   - uid: mondoo-aws-security-cognito-client-no-user-password-auth-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool_client")
@@ -73920,11 +73914,9 @@ queries:
         title: AWS Documentation - Managing error responses for user existence
 
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-cognito-userpool"
     mql: |
-      aws.cognito.userPools.all(
-        clients.all(preventUserExistenceErrors == "ENABLED")
-      )
+      aws.cognito.userPool.clients.all(preventUserExistenceErrors == "ENABLED")
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_cognito_user_pool_client")
     mql: |


### PR DESCRIPTION
## What

[mql PR #8915](https://github.com/mondoohq/mql/pull/8915) promotes four AWS resources to independently discoverable/scannable assets, each with its own platform string and ARN-based init:

| Service | New platform | Singular resource |
|---|---|---|
| CodeBuild | `aws-codebuild-project` | `aws.codebuild.project` |
| Cognito | `aws-cognito-userpool` | `aws.cognito.userPool` |
| MemoryDB | `aws-memorydb-cluster` | `aws.memorydb.cluster` |
| Transfer | `aws-transfer-server` | `aws.transfer.server` |

This retargets the **18 runtime variants** in `mondoo-aws-security` that scan these resources from the account-wide form:

```yaml
filters: asset.platform == "aws"
mql: aws.memorydb.clusters.all(tlsEnabled == true)
```

to the per-resource-platform form, evaluating **per asset** against the singular resource:

```yaml
filters: asset.platform == "aws-memorydb-cluster"
mql: aws.memorydb.cluster.tlsEnabled == true
```

This matches the convention already used ~40 times in this file (`aws-elasticache-cluster`, `aws-s3-bucket`, `aws-rds-dbinstance`, …).

## Scope

- **CodeBuild (5):** no-privileged-mode, no-plaintext-credentials, source-ssl-verification, encryption-key-configured, not-public
- **Cognito (5):** user-pool-mfa-enforced, advanced-security-enforced, domain-min-tls-1-2, client-no-user-password-auth, client-prevent-user-existence-errors
- **MemoryDB (3):** cluster-tls-enabled, cluster-cmk-encryption, cluster-auto-minor-version-upgrade
- **Transfer (5):** no-ftp, vpc-endpoint, logging-enabled, security-policy, identity-provider

Runtime variant UIDs are **unchanged** — only `filters:` and `mql:` are repointed in place. Terraform/CloudFormation variants are untouched.

## Out of scope

Checks on resources PR #8915 does **not** promote stay on `asset.platform == "aws"`: Cognito identity pools, MemoryDB snapshots/ACLs, and Transfer connectors/web-apps/workflows.

## Verification

All four singular resources already exist in the installed AWS provider schema, so the rewritten MQL compiles locally without building the PR branch:

```
cnspec policy lint content/mondoo-aws-security.mql.yaml
→ valid policy bundle(s)
```

(The two `terraform.resources` WHERE-clause warnings are pre-existing on `main` and unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)