### PR TITLE
🐛 recover panics during policy query execution instead of crashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f
-	go.mondoo.com/mql/v13 v13.27.4
+	go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f
-	go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70
+	go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.18.1
 	go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f
-	go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4
+	go.mondoo.com/mql/v13 v13.27.5-0.20260706105452-a03e1a2a88ee
 	go.mondoo.com/ranger-rpc v0.8.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f h1:iqu3c+zoWBcfcCvmik7YCF+93LezrHHZ8YDGaJQC4T8=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4 h1:nc/46M+ISkxYe38fbS9K3/gJkDVCz6q7/TEErIB+k0g=
-go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
+go.mondoo.com/mql/v13 v13.27.5-0.20260706105452-a03e1a2a88ee h1:bFJhbHyVvK+S4e16TDot5ffEm2hwjAHDfYE4y1KftSM=
+go.mondoo.com/mql/v13 v13.27.5-0.20260706105452-a03e1a2a88ee/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f h1:iqu3c+zoWBcfcCvmik7YCF+93LezrHHZ8YDGaJQC4T8=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.27.4 h1:f8smL+xechWTlt1lmKW78uZPogpqAYm8IStDmUiYBvc=
-go.mondoo.com/mql/v13 v13.27.4/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
+go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70 h1:RUiIhzaLLC67LZ9YhFTq/30Z8hhcGcn3EGUoa+iJ7dU=
+go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f h1:iqu3c+zoWBcfcCvmik7YCF+93LezrHHZ8YDGaJQC4T8=
 go.mondoo.com/mondoo-go v0.0.0-20260701003351-dac3d802a80f/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70 h1:RUiIhzaLLC67LZ9YhFTq/30Z8hhcGcn3EGUoa+iJ7dU=
-go.mondoo.com/mql/v13 v13.27.5-0.20260704105616-771c16979e70/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
+go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4 h1:nc/46M+ISkxYe38fbS9K3/gJkDVCz6q7/TEErIB+k0g=
+go.mondoo.com/mql/v13 v13.27.5-0.20260706085915-658186ff9bc4/go.mod h1:U4eWXP4Ef21KPnxeQ88QhiIhZpJ7XCF749GyByo9SCU=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=
 go.mondoo.com/ranger-rpc v0.8.0/go.mod h1:JbxC6J5d0pQwVGZ9efmq7amMzasEETKH80zPd0TcBug=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -4,8 +4,10 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	goruntime "runtime"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -73,17 +75,31 @@ func (em *executionManager) Start() {
 	go func() {
 		defer em.wg.Done()
 		// current is the code bundle being executed; the deferred panic
-		// reporter snapshots it at crash time so the report carries WHICH
+		// handler snapshots it at crash time so the report carries WHICH
 		// query was running, not just where the engine died. The recover
-		// stays at the goroutine top — recovering closer to the query and
-		// re-panicking would truncate the stacktrace.
+		// stays at the goroutine top so the stacktrace points at the
+		// panic site. Instead of crashing the process, the panic is
+		// reported upstream and surfaced as an unrecoverable execution
+		// error, mirroring the executeCodeBundle error path below.
 		var current *llx.CodeBundle
-		defer health.ReportPanicWithTags("cnspec", cnspec.Version, cnspec.Build, func() map[string]string {
-			if current == nil {
-				return nil
+		defer func() {
+			r := recover()
+			if r == nil {
+				return
 			}
-			return health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
-		})
+			var tags map[string]string
+			if current != nil {
+				tags = health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
+			}
+			health.ReportRecoveredPanic("cnspec", cnspec.Version, cnspec.Build, r, tags)
+			log.Error().
+				Str("stacktrace", string(debug.Stack())).
+				Msgf("recovered from panic during query execution: %v", r)
+			select {
+			case em.errChan <- fmt.Errorf("panic during query execution: %v", r):
+			default:
+			}
+		}()
 		for {
 			// Prioritize stopChan
 			select {

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -91,9 +91,10 @@ func (em *executionManager) Start() {
 			if current != nil {
 				tags = health.QueryPanicTags(current.CodeV2.GetId(), current.Source)
 			}
-			health.ReportRecoveredPanic("cnspec", cnspec.Version, cnspec.Build, r, tags)
+			stack := debug.Stack()
+			health.ReportRecoveredPanic("cnspec", cnspec.Version, cnspec.Build, r, stack, tags)
 			log.Error().
-				Str("stacktrace", string(debug.Stack())).
+				Str("stacktrace", string(stack)).
 				Msgf("recovered from panic during query execution: %v", r)
 			select {
 			case em.errChan <- fmt.Errorf("panic during query execution: %v", r):

--- a/policy/executor/internal/execution_manager.go
+++ b/policy/executor/internal/execution_manager.go
@@ -81,6 +81,10 @@ func (em *executionManager) Start() {
 		// panic site. Instead of crashing the process, the panic is
 		// reported upstream and surfaced as an unrecoverable execution
 		// error, mirroring the executeCodeBundle error path below.
+		// Like that path, the goroutine deliberately exits and takes the
+		// whole pipeline for this scan with it: after a panic the runtime
+		// state can't be trusted, so we don't keep executing the remaining
+		// queries.
 		var current *llx.CodeBundle
 		defer func() {
 			r := recover()

--- a/policy/executor/internal/execution_manager_test.go
+++ b/policy/executor/internal/execution_manager_test.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestExecutionManagerRecoversPanic(t *testing.T) {
+	runQueue := make(chan runQueueItem, 1)
+	resultChan := make(chan *llx.RawResult, 1)
+	em := newExecutionManager(nil, runQueue, resultChan, time.Second, false)
+	em.Start()
+
+	// A nil code bundle panics inside executeCodeBundle. The manager must
+	// recover and surface it as an unrecoverable error instead of crashing.
+	runQueue <- runQueueItem{}
+
+	select {
+	case err := <-em.Err():
+		require.ErrorContains(t, err, "panic during query execution")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the execution manager to report the panic as an error")
+	}
+
+	em.Stop()
+}


### PR DESCRIPTION
## Problem

Same issue as mondoohq/mql#8934, in cnspec's policy executor: a panic during query execution was reported to the platform (via `health.ReportPanicWithTags`) but then **re-panicked**, killing the whole process. One bad query could take down an entire policy scan.

## Change

`policy/executor/internal/execution_manager.go` — the executor goroutine now owns the `recover()`. On panic it:
1. reports upstream with the crash-time query tags (code ID + source), same as before,
2. logs the panic locally with its stacktrace,
3. surfaces it as an unrecoverable execution error on `errChan`, mirroring the existing `executeCodeBundle` error path — the graph executor returns the error and the process survives.

This is a 1:1 port of the mql change, using the `health.ReportRecoveredPanic` helper introduced there.

## Dependency

⚠️ **Depends on mondoohq/mql#8934.** `go.mod` currently pins mql to a pseudo-version of that PR's branch commit (`v13.27.5-0.20260704105616-771c16979e70`) so CI compiles. Before merging, swap to a tagged mql release containing `health.ReportRecoveredPanic`.

Once this merges, `health.ReportPanicWithTags`/`PanicTagsFn` have no callers left and can be removed from mql's providers-sdk in a breaking cleanup.

## Testing

- New `TestExecutionManagerRecoversPanic`: pushes a nil code bundle through the run queue (panics inside `executeCodeBundle`) and asserts the manager surfaces it on `Err()` instead of crashing.
- `go test ./policy/executor/...` passes with `GOWORK=off` against the pinned pseudo-version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)