### PR TITLE
✨ azure: add Virtual Network Manager security admin deny rule check

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -174,6 +174,7 @@ policies:
           - uid: mondoo-azure-security-nsg-no-unrestricted-egress
           - uid: mondoo-azure-security-network-interface-ip-forwarding-disabled
           - uid: mondoo-azure-security-nsg-sensitive-ports-restricted
+          - uid: mondoo-azure-security-network-manager-security-admin-deny-rule
       - title: Azure Subscription
         checks:
           - uid: mondoo-azure-security-diagnostic-settings-essential-categories
@@ -47114,3 +47115,131 @@ queries:
       bicep.resources.where(type == "Microsoft.Purview/accounts").all(
         properties["publicNetworkAccess"] == "Disabled"
       )
+  # No Terraform variants: the scoring assertion is an existence check (at least one Deny security admin rule exists across the network manager's configurations). The repo's terraform.resources(...).all(...) variant idiom cannot express "at least one Deny rule exists" without either passing vacuously when no rules are defined or wrongly requiring every admin rule to be Deny (legitimate Allow rules exist). Remediation still documents the Terraform and Bicep paths for creating a Deny rule.
+  - uid: mondoo-azure-security-network-manager-security-admin-deny-rule
+    title: Ensure Virtual Network Manager enforces a security admin deny rule
+    impact: 70
+    filters: asset.platform == "azure"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    docs:
+      desc: |
+        This check ensures that every deployed Azure Virtual Network Manager enforces at least one security admin *deny* rule. Security admin rules are high-priority, centrally managed rules that apply across the virtual networks in the manager's network groups and take precedence over network security group rules; a network manager configured only for connectivity, or with security admin rules that never deny, provides no centralized guardrail.
+
+        **Why this matters**
+
+        - **Centralized enforcement:** Security admin deny rules apply organization-wide and cannot be overridden by individual resource owners' NSG rules, closing gaps left by inconsistent per-subnet configuration.
+        - **Baseline guardrails:** A deny rule blocking high-risk traffic (for example inbound management ports or known-bad ports) enforces a floor of protection that every managed virtual network inherits.
+        - **Defense against drift:** As teams create new subnets and NSGs, a centrally enforced deny rule keeps risky traffic blocked without depending on each team applying the control correctly.
+
+        **Risk mitigation**
+
+        - **Consistent segmentation:** One centrally managed rule set governs traffic across all managed virtual networks rather than a patchwork of local rules.
+        - **Reduced lateral movement:** Enforced deny rules limit the paths an attacker can use to move between managed virtual networks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Azure portal and open **Network Manager**.
+        2. Select the network manager, then open **Configurations**, **Security admin configurations**.
+        3. Open each configuration's rule collections and confirm at least one rule has **Action** set to **Deny**.
+        4. Repeat for every network manager.
+
+        A passing network manager has at least one security admin rule with the `Deny` action. A failing network manager has no security admin configuration, no rules, or only `Allow`/`AlwaysAllow` rules.
+
+        ### Audit via CLI
+
+        1. List the security admin rules for a configuration and inspect their action:
+
+        ```bash
+        az network manager security-admin-config rule-collection rule list \
+          --network-manager-name <network-manager-name> \
+          --resource-group <resource-group> \
+          --configuration-name <config-name> \
+          --rule-collection-name <rule-collection-name> \
+          --query '[].{Name:name,Access:access}' \
+          --output table
+        ```
+
+        A passing configuration returns at least one rule with `Deny`. A failing configuration returns none.
+      remediation:
+        - id: portal
+          desc: |
+            To enforce a security admin deny rule using the Azure portal:
+
+            1. Open **Network Manager** and select the network manager.
+            2. Open **Configurations**, **Security admin configurations**, and create or select a configuration.
+            3. Add a rule collection that applies to your network groups, then add a rule with **Action** set to **Deny** for the traffic you want to block.
+            4. **Deploy** the security admin configuration to the target regions.
+        - id: cli
+          desc: |
+            To create a security admin deny rule using the Azure CLI, submit the rule with `access` set to `Deny` via `az rest`:
+
+            ```bash
+            az rest --method put \
+              --url "https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Network/networkManagers/<network-manager-name>/securityAdminConfigurations/<config-name>/ruleCollections/<rule-collection-name>/rules/<rule-name>?api-version=2024-05-01" \
+              --body '{"kind":"Custom","properties":{"access":"Deny","direction":"Inbound","priority":100,"protocol":"Tcp","destinationPortRanges":["3389"]}}'
+            ```
+        - id: terraform
+          desc: |
+            To enforce a security admin deny rule using Terraform, set `action` to `Deny` on the admin rule:
+
+            ```hcl
+            resource "azurerm_network_manager_admin_rule" "example" {
+              name                     = "deny-rdp"
+              admin_rule_collection_id = azurerm_network_manager_security_admin_configuration_rule_collection.example.id
+              action                   = "Deny"
+              direction                = "Inbound"
+              priority                 = 100
+              protocol                 = "Tcp"
+              source_port_ranges       = ["0-65535"]
+              destination_port_ranges  = ["3389"]
+
+              source {
+                address_prefix_type = "IPPrefix"
+                address_prefix      = "*"
+              }
+              destination {
+                address_prefix_type = "IPPrefix"
+                address_prefix      = "*"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enforce a security admin deny rule using Bicep, set `properties.access` to `Deny` on a `Custom` rule:
+
+            ```bicep
+            resource denyRule 'Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections/rules@2024-05-01' = {
+              parent: ruleCollection
+              name: 'deny-rdp'
+              kind: 'Custom'
+              properties: {
+                access: 'Deny'
+                direction: 'Inbound'
+                priority: 100
+                protocol: 'Tcp'
+                destinationPortRanges: [
+                  '3389'
+                ]
+              }
+            }
+            ```
+    mql: |
+      azure.subscription.network.networkManagers.all(
+        securityAdminConfigurations.any(ruleCollections.any(rules.any(access == "Deny")))
+      )
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-network-manager/concept-security-admins
+        title: Microsoft Learn - Security admin rules in Azure Virtual Network Manager


### PR DESCRIPTION
## What

Adds one Azure check that uses the **Azure Virtual Network Manager (AVNM)** resources introduced in **azure-13.26.0** (mql [#8964](https://github.com/mondoohq/mql/pull/8964), now merged). This is the AVNM follow-up deferred from #3016.

| UID | Asserts | Impact |
|-----|---------|--------|
| `mondoo-azure-security-network-manager-security-admin-deny-rule` | every deployed network manager enforces ≥1 security admin **Deny** rule | 70 |

```mql
azure.subscription.network.networkManagers.all(
  securityAdminConfigurations.any(ruleCollections.any(rules.any(access == "Deny")))
)
```

Security admin rules are high-priority, centrally managed rules that apply across the VNets in a manager's network groups and take precedence over NSG rules. A network manager configured only for connectivity — or whose security admin rules never deny — provides no centralized guardrail. The check passes vacuously where AVNM is not deployed, so it targets the specific misconfiguration rather than penalizing non-AVNM environments.

## Runtime-only (no IaC scoring variants)

The control objective is *"at least one Deny rule exists"* — an existence/ANY assertion. The repo's `terraform.resources(...).all(...)` variant idiom can't express that without either passing vacuously (config defines no rules) or wrongly requiring **every** admin rule to be `Deny` (legitimate `Allow`/`AlwaysAllow` rules exist). This is documented with a `# No Terraform variants:` comment. Remediation still documents the Terraform and Bicep paths for creating a Deny rule (portal, CLI, Terraform, Bicep all covered).

## Compliance tags

Mirrors the network-segmentation mapping used by `nsg-sensitive-ports-restricted` / the NSP check: NIST SC-7 (Boundary Protection), ISO A.8.22 (Segregation of networks), CSA IVS-03, PCI 1.3.1, etc. All 13 framework UIDs verified to exist in `cnspec-enterprise-policies/frameworks/`.

## Verification

- ✅ `cnspec policy lint ./content` — valid (query compiles against azure-13.26.0 `networkManagers` → `securityAdminConfigurations` → `ruleCollections` → `rules.access`)
- ✅ `validate_remediation_commands.py azure` — 369 passed, 0 failed
- ✅ title 66 chars (≤75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)