### PR TITLE
🧹 querypacks: fix deprecated MQL field warnings

### DIFF
--- a/content/querypacks/mondoo-aws-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-aws-incident-response.mql.yaml
@@ -163,7 +163,7 @@ queries:
         tags
         attachedPolicies
         createdAt
-        accessKeys
+        accessKeyDetails
         loginProfile
         groups
       }
@@ -323,7 +323,7 @@ queries:
         name
         location
         publicAccessBlock
-        encryption
+        encryptionRules
         tags
         policy
         ```
@@ -339,7 +339,7 @@ queries:
           name
           location
           publicAccessBlock
-          encryption
+          encryptionRules
           tags
           policy
         }
@@ -353,7 +353,7 @@ queries:
           name
           location
           publicAccessBlock
-          encryption
+          encryptionRules
           tags
           policy
         }

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -151,7 +151,7 @@ queries:
           mapPublicIpOnLaunch
           routeTable {
             id
-            routeEntries { destinationCidrBlock gatewayId natGatewayId state }
+            routeEntries { destinationCidrBlock gatewayId natGateway state }
           }
         }
       }
@@ -165,7 +165,7 @@ queries:
           mapPublicIpOnLaunch
           routeTable {
             id
-            routeEntries { destinationCidrBlock gatewayId natGatewayId state }
+            routeEntries { destinationCidrBlock gatewayId natGateway state }
           }
         }
       }

--- a/content/querypacks/mondoo-gcp-inventory.mql.yaml
+++ b/content/querypacks/mondoo-gcp-inventory.mql.yaml
@@ -169,11 +169,11 @@ queries:
   - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
     filters: asset.platform == "gcp-project"
     mql: |
-      gcp.compute.instances.where(networkInterfaces.where(_['accessConfigs'].where(_['name'] == "External NAT")))
+      gcp.compute.instances.where(nics.where(_.accessConfigs.where(_['name'] == "External NAT")))
   - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
     filters:
       - mql: asset.platform == "gcp-compute-instance"
-      - mql: gcp.compute.instance.networkInterfaces.any(_['accessConfigs'].where(_['name'] == "External NAT"))
+      - mql: gcp.compute.instance.nics.any(_.accessConfigs.where(_['name'] == "External NAT"))
     mql: |
       gcp.compute.instance
 


### PR DESCRIPTION
## What

Fixes the six `query-deprecated-symbol` lint warnings across three querypacks by migrating each query to the replacement field the current providers expose.

| File | Deprecated field | Replacement |
|------|------------------|-------------|
| `mondoo-aws-incident-response.mql.yaml` | `aws.iam.user.accessKeys` | `accessKeyDetails` (typed `aws.iam.user.accessKey`) |
| `mondoo-aws-incident-response.mql.yaml` | `aws.s3.bucket.encryption` (×2 queries + docs) | `encryptionRules` (typed `aws.s3.bucket.encryptionRule`) |
| `mondoo-aws-inventory.mql.yaml` | `aws.vpc.routetable.route.natGatewayId` (×2 queries) | `natGateway` (typed `aws.vpc.natgateway`) |
| `mondoo-gcp-inventory.mql.yaml` | `gcp…instance.networkInterfaces` | `nics` (typed `networkInterface`) |

## Notes

- These deprecations all follow the same theme: **stringly-typed ID fields → typed sub-resources**.
- The GCP change also switches dict indexing `_['accessConfigs']` to field access `_.accessConfigs`, because `nics` resolves to a typed resource rather than a `[]dict`.
- Also updated the GCP `-single` sibling filter that used the same deprecated field (not flagged by lint but kept consistent to avoid a future warning).
- The S3 docs `desc` field list was updated to match the new query output.

## Verification

`cnspec policy lint` reports `valid policy bundle(s)` with zero deprecation warnings for all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)