### PR TITLE
🧹 azure/gcp: replace deprecated MQL fields with typed resource refs

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -18429,7 +18429,7 @@ queries:
     filters: |
       asset.platform == "azure-batch-account"
     mql: |
-      azure.subscription.batchService.account.encryption["keySource"] == "Microsoft.KeyVault"
+      azure.subscription.batchService.account.encryptionKey != null
   - uid: mondoo-azure-security-batch-encryption-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_batch_account")
     mql: |
@@ -31336,7 +31336,7 @@ queries:
     filters: |
       asset.platform == "azure-datafactory"
     mql: |
-      azure.subscription.dataFactory.factory.cmkKeyName != empty
+      azure.subscription.dataFactory.factory.cmkKey != null
   - uid: mondoo-azure-security-datafactory-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_data_factory")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -4009,7 +4009,7 @@ queries:
       asset.platform == 'gcp-compute-instance'
       gcp.compute.instance.name != /^gke-/
     mql: |
-      gcp.compute.instance.networkInterfaces.all(accessConfigs == empty)
+      gcp.compute.instance.nics.all(accessConfigs == empty)
   - uid: mondoo-gcp-security-compute-instances-no-public-ip-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" &&
@@ -18174,7 +18174,7 @@ queries:
   - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-gcp
     filters: asset.platform == 'gcp-cloud-function'
     mql: |
-      gcp.project.cloudFunction.dockerRepository != empty
+      gcp.project.cloudFunction.dockerRepositoryRef != null
   - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_cloudfunctions2_function')
@@ -27220,7 +27220,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      gcp.project.vertexaiService.customJob.serviceAccount != empty
+      gcp.project.vertexaiService.customJob.serviceAccountRef != null
     docs:
       desc: |
         This check ensures that every running, pending, or queued Vertex AI custom job has an explicit service account configured in its job specification. Without an explicit service account, custom jobs inherit the project's default Compute Engine service account, which carries broad project-level permissions far beyond what any individual training job actually needs.
@@ -34818,8 +34818,8 @@ queries:
       asset.platform == 'gcp-vertexai-job' &&
       gcp.project.vertexaiService.customJob.state.in(["JOB_STATE_RUNNING", "JOB_STATE_PENDING", "JOB_STATE_QUEUED"])
     mql: |
-      gcp.project.vertexaiService.customJob.serviceAccount != empty &&
-      gcp.project.vertexaiService.customJob.serviceAccount != /^\d+-compute@developer\.gserviceaccount\.com$/
+      gcp.project.vertexaiService.customJob.serviceAccountRef != null &&
+      gcp.project.vertexaiService.customJob.serviceAccountRef.email != /^\d+-compute@developer\.gserviceaccount\.com$/
     docs:
       desc: |
         This check ensures that Vertex AI custom training jobs are configured to use a dedicated service account rather than the project's default Compute Engine service account. By default, jobs that omit an explicit service account identity run as the default Compute Engine SA, which carries the Editor role and is shared across all workloads in the project.
@@ -39744,7 +39744,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      gcp.project.vertexaiService.customJob.network != empty
+      gcp.project.vertexaiService.customJob.networkRef != null
     docs:
       desc: |
         This check ensures that active Vertex AI custom jobs specify a VPC network in their job specification so that training workers run on a private network rather than the default public internet path. Without a network configuration, worker-to-worker traffic and access to internal services traverse the public internet, bypassing the organization's network controls.
@@ -41455,7 +41455,7 @@ queries:
     filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudSchedulerService.jobs.where(targetType == "httpTarget").all(
-        oidcServiceAccountEmail != "" || oauthServiceAccountEmail != ""
+        oidcServiceAccount != null || oauthServiceAccount != null
       )
     tags:
       compliance/bsi-sys-1-5: false
@@ -41548,8 +41548,8 @@ queries:
     filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudSchedulerService.jobs.all(
-        oidcServiceAccountEmail != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
-        oauthServiceAccountEmail != /^\d+-compute@developer\.gserviceaccount\.com$/
+        oidcServiceAccount.email != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
+        oauthServiceAccount.email != /^\d+-compute@developer\.gserviceaccount\.com$/
       )
     tags:
       compliance/bsi-sys-1-5: false


### PR DESCRIPTION
## What

Fixes the `query-deprecated-symbol` lint warnings in `mondoo-azure-security.mql.yaml` and `mondoo-gcp-security.mql.yaml`. Each deprecated field was migrated to the replacement the current provider exposes.

| Deprecated field | Replacement | Notes |
|---|---|---|
| `batchService.account.encryption["keySource"] == "Microsoft.KeyVault"` | `encryptionKey != null` | CMK key resolves to a Key Vault key resource; `null` for platform-managed |
| `dataFactory.factory.cmkKeyName != empty` | `cmkKey != null` | Resolved key resource; `null` for platform-managed |
| `compute.instance.networkInterfaces` | `nics` | Typed `networkInterface` resource (same as querypack migration in #3020) |
| `cloudFunction.dockerRepository != empty` | `dockerRepositoryRef != null` | Resolved Artifact Registry repository |
| `vertexaiService.customJob.serviceAccount` | `serviceAccountRef` | Typed IAM service account |
| `vertexaiService.customJob.network` | `networkRef` | Typed compute network |
| `cloudSchedulerService.job.oauthServiceAccountEmail` | `oauthServiceAccount` | Typed IAM service account |
| `cloudSchedulerService.job.oidcServiceAccountEmail` | `oidcServiceAccount` | Typed IAM service account |

## Semantics preserved

The deprecated scalars used empty-string / empty-dict sentinels; the typed refs are `null` when absent, so `!= empty` / `!= ""` become `!= null`.

Where the old query matched an email string against the default-SA regex (Vertex AI *no-default-SA* and Cloud Scheduler *no-default-SA* checks), it now reads `.email` off the resolved service account resource. MQL field access on a `null` ref returns `null`, and `null != /regex/` evaluates `true` — verified with `mql run` — so the original pass/fail behavior is preserved without adding null guards.

Only the runtime (`-gcp` / `-azure`) variants used these fields; the Terraform HCL/plan/state siblings were already on their own resource shapes and are untouched.

## Testing

`cnspec policy lint` passes on both bundles with no remaining `query-deprecated-symbol` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)