### PR TITLE
♻️ cloud: simplify native MQL checks onto typed provider fields

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3363,11 +3363,10 @@ queries:
   - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-bucket
     filters: asset.platform == "aws-s3-bucket"
     mql: |
-      aws.s3.bucket.publicAccessBlock != empty
-      aws.s3.bucket.publicAccessBlock.BlockPublicAcls == true
-      aws.s3.bucket.publicAccessBlock.BlockPublicPolicy == true
-      aws.s3.bucket.publicAccessBlock.IgnorePublicAcls == true
-      aws.s3.bucket.publicAccessBlock.RestrictPublicBuckets == true
+      aws.s3.bucket.blockPublicAcls == true
+      aws.s3.bucket.blockPublicPolicy == true
+      aws.s3.bucket.ignorePublicAcls == true
+      aws.s3.bucket.restrictPublicBuckets == true
   - uid: mondoo-aws-security-s3-bucket-level-public-access-prohibited-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains( nameLabel == "aws_s3_bucket_public_access_block" )
     mql: |
@@ -41200,7 +41199,7 @@ queries:
   - uid: mondoo-aws-security-dynamodb-pitr-enabled-aws
     filters: asset.platform == "aws-dynamodb-table"
     mql: |
-      aws.dynamodb.table.continuousBackups["PointInTimeRecoveryDescription"]["PointInTimeRecoveryStatus"] == "ENABLED"
+      aws.dynamodb.table.pointInTimeRecoveryEnabled == true
   - uid: mondoo-aws-security-dynamodb-pitr-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dynamodb_table")
     mql: |
@@ -69792,7 +69791,7 @@ queries:
     mql: |
       aws.dynamodb.table.sseType == "KMS"
       aws.dynamodb.table.sseKmsKey { metadata["KeyManager"] == "CUSTOMER" }
-      aws.dynamodb.table.continuousBackups["PointInTimeRecoveryDescription"]["PointInTimeRecoveryStatus"] == "ENABLED"
+      aws.dynamodb.table.pointInTimeRecoveryEnabled == true
   - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_dynamodb_table")
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -12142,9 +12142,7 @@ queries:
     filters: |
       asset.platform == "azure-app-service-webapp"
     mql: |
-      azure.subscription.webService.appsite.configuration.properties["cors"] == null ||
-      azure.subscription.webService.appsite.configuration.properties["cors"]["allowedOrigins"] == null ||
-      azure.subscription.webService.appsite.configuration.properties["cors"]["allowedOrigins"].none(_ == "*")
+      azure.subscription.webService.appsite.configuration.corsAllowedOrigins.none(_ == "*")
   - uid: mondoo-azure-security-app-service-cors-no-wildcard-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_web_app/)
     mql: |
@@ -12333,7 +12331,7 @@ queries:
       asset.platform == "azure-app-service-webapp" &&
       azure.subscription.webService.appsite.kind == /functionapp/
     mql: |
-      azure.subscription.webService.appsite.authenticationSettings.properties["enabled"] == true
+      azure.subscription.webService.appsite.authenticationSettings.enabled == true
   - uid: mondoo-azure-security-function-app-authentication-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -16233,7 +16231,7 @@ queries:
     filters: |
       asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDbService.account.properties["networkAclBypass"] == "None"
+      azure.subscription.cosmosDbService.account.networkAclBypass == "None"
   - uid: mondoo-azure-security-cosmosdb-network-acl-bypass-none-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cosmosdb_account")
     mql: |
@@ -16673,7 +16671,7 @@ queries:
     filters: |
       asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDbService.account.properties["privateEndpointConnections"].length > 0
+      azure.subscription.cosmosDbService.account.privateEndpointConnections.length > 0
   - uid: mondoo-azure-security-cosmosdb-cors-no-wildcard
     title: Ensure Azure Cosmos DB accounts do not allow wildcard CORS origins
     impact: 50
@@ -17264,7 +17262,7 @@ queries:
     filters: |
       asset.platform == "azure-cosmosdb"
     mql: |
-      azure.subscription.cosmosDbService.account.properties["consistencyPolicy"]["defaultConsistencyLevel"].in(["Strong", "BoundedStaleness"])
+      azure.subscription.cosmosDbService.account.defaultConsistencyLevel.in(["Strong", "BoundedStaleness"])
   - uid: mondoo-azure-security-cosmosdb-strong-consistency-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cosmosdb_account")
     mql: |
@@ -17934,8 +17932,7 @@ queries:
       asset.platform == "azure-firewall" &&
       azure.subscription.networkService.firewall.policy != empty
     mql: |
-      azure.subscription.networkService.firewall.policy.properties["intrusionDetection"] != null &&
-      azure.subscription.networkService.firewall.policy.properties["intrusionDetection"]["mode"] == "Deny"
+      azure.subscription.networkService.firewall.policy.intrusionDetectionMode == "Deny"
   - uid: mondoo-azure-security-firewall-idps-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall_policy")
     mql: |
@@ -21380,7 +21377,7 @@ queries:
     filters: |
       asset.platform == "azure-aks-cluster"
     mql: |
-      azure.subscription.aksService.cluster.storageProfile["diskCSIDriver"]["enabled"] == true
+      azure.subscription.aksService.cluster.diskCsiDriverEnabled == true
   - uid: mondoo-azure-security-aks-disk-encryption-set-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_kubernetes_cluster")
     mql: |
@@ -21862,9 +21859,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.databricks.workspaces.all(
-        properties["publicNetworkAccess"] == "Disabled"
-      )
+      azure.subscription.databricks.workspaces.all(publicNetworkAccess == "Disabled")
   - uid: mondoo-azure-security-databricks-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_databricks_workspace")
     mql: |
@@ -24873,8 +24868,7 @@ queries:
     filters: |
       asset.platform == "azure-mysql-flexible-server"
     mql: |
-      azure.subscription.mySql.flexibleServer.properties["dataEncryption"] != null &&
-      azure.subscription.mySql.flexibleServer.properties["dataEncryption"]["type"] == "AzureKeyVault"
+      azure.subscription.mySql.flexibleServer.dataEncryptionType == "AzureKeyVault"
   - uid: mondoo-azure-security-mysql-flexible-server-infrastructure-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mysql_flexible_server")
     mql: |
@@ -28660,7 +28654,7 @@ queries:
     filters: |
       asset.platform == "azure-compute-vm-api"
     mql: |
-      if (azure.subscription.compute.vm.properties['storageProfile']['osDisk']['osType'] != "Linux") {
+      if (azure.subscription.compute.vm.osType != "Linux") {
         return true
       }
       azure.subscription.compute.vm.properties['osProfile']['linuxConfiguration']['disablePasswordAuthentication'] == true
@@ -40253,7 +40247,7 @@ queries:
   - uid: mondoo-azure-security-function-app-public-network-access-disabled-azure
     filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functionsService.functionApp.properties["publicNetworkAccess"] == "Disabled"
+      azure.subscription.functionsService.functionApp.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-function-app-public-network-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -41017,9 +41011,7 @@ queries:
   - uid: mondoo-azure-security-application-gateway-no-public-frontend-azure
     filters: asset.platform == "azure-application-gateway"
     mql: |
-      azure.subscription.networkService.applicationGateway.properties["frontendIPConfigurations"].any(
-        _["properties"]["subnet"] != null
-      )
+      azure.subscription.networkService.applicationGateway.frontendIpConfigs.any(subnet != null)
   - uid: mondoo-azure-security-application-gateway-no-public-frontend-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
     mql: |
@@ -41843,8 +41835,7 @@ queries:
   - uid: mondoo-azure-security-function-app-cmk-encryption-azure
     filters: asset.platform == "azure-function-app"
     mql: |
-      azure.subscription.functionsService.functionApp.properties["keyVaultReferenceIdentity"] != null &&
-      azure.subscription.functionsService.functionApp.properties["keyVaultReferenceIdentity"] != ""
+      azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity != empty
   - uid: mondoo-azure-security-function-app-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -1610,7 +1610,7 @@ queries:
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-gcp
     filters: asset.platform == 'gcp-storage-bucket'
-    mql: gcp.storage.bucket.encryption['defaultKmsKeyName'] != empty
+    mql: gcp.storage.bucket.defaultEncryptionEnabled
   - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -8386,7 +8386,7 @@ queries:
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
-    mql: gcp.project.gkeService.cluster.legacyAbac['enabled'] != true
+    mql: gcp.project.gkeService.cluster.legacyAbacEnabled != true
   - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
@@ -9060,8 +9060,7 @@ queries:
   - uid: mondoo-gcp-security-gke-workload-identity-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
-      gcp.project.gkeService.cluster.workloadIdentityConfig['workloadPool'] != empty
-      gcp.project.gkeService.cluster.workloadIdentityConfig['workloadPool'] != ""
+      gcp.project.gkeService.cluster.workloadIdentityEnabled
   - uid: mondoo-gcp-security-gke-workload-identity-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_container_cluster')
@@ -9338,7 +9337,7 @@ queries:
   - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
-      gcp.project.gkeService.cluster.shieldedNodesConfig['enabled'] == true
+      gcp.project.gkeService.cluster.shieldedNodesEnabled == true
   - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_container_cluster')
@@ -16889,8 +16888,7 @@ queries:
   - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
     filters: asset.platform == 'gcp-compute-disk'
     mql: |
-      gcp.compute.disk.diskEncryptionKey != empty
-      gcp.compute.disk.diskEncryptionKey['kmsKeyName'] != empty
+      gcp.compute.disk.kmsKey != empty
   - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_disk')
@@ -17674,7 +17672,7 @@ queries:
   - uid: mondoo-gcp-security-gke-database-encryption-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
-      gcp.project.gkeService.cluster.databaseEncryption['state'] == "ENCRYPTED"
+      gcp.project.gkeService.cluster.databaseEncryptionState == "ENCRYPTED"
   - uid: mondoo-gcp-security-gke-database-encryption-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_container_cluster')
@@ -23245,7 +23243,7 @@ queries:
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
       gcp.project.gkeService.cluster.nodePools.all(
-        management["autoUpgrade"] == true
+        autoUpgrade == true
       )
   - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-terraform-hcl
     filters: |
@@ -23381,7 +23379,7 @@ queries:
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
       gcp.project.gkeService.cluster.nodePools.all(
-        management["autoRepair"] == true
+        autoRepair == true
       )
   - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-terraform-hcl
     filters: |
@@ -37554,10 +37552,7 @@ queries:
   - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
     filters: asset.platform == 'gcp'
     mql: |
-      gcp.project.computeService.snapshots.all(
-        snapshotEncryptionKey != empty &&
-        snapshotEncryptionKey['kmsKeyName'] != empty
-      )
+      gcp.project.computeService.snapshots.all(kmsKey != empty)
   - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_snapshot')
@@ -37694,8 +37689,7 @@ queries:
   - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
     filters: asset.platform == 'gcp-compute-image'
     mql: |
-      gcp.project.computeService.image.imageEncryptionKey != empty &&
-      gcp.project.computeService.image.imageEncryptionKey['kmsKeyName'] != empty
+      gcp.project.computeService.image.kmsKey != empty
   - uid: mondoo-gcp-security-compute-image-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_image')

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -5380,8 +5380,8 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       oci.database.dbSystems.all(
-        subnet.routeTable.routeRules.none(
-          _['destination'] == "0.0.0.0/0" && _['networkEntityId'].contains("internetgateway")
+        subnet.routeTable.routes.none(
+          destination == "0.0.0.0/0" && internetGateway != null
         )
       )
     docs:


### PR DESCRIPTION
## What

Migrates **27 native aws/azure/gcp/oci runtime checks** off dict-index and string-status workarounds onto typed provider fields that were added to the mql providers in recent releases. This continues the pattern started in #2988 / #2989 (typed encryption/TLS/identity fields).

**Behavior is preserved** — every change is a *representation* swap (same underlying data, cleaner accessor), not a logic change. Terraform/HCL/Bicep variants are untouched. All four bundles lint clean.

## How it was found

Each field in the installed provider schema is tagged with `min_provider_version`, so "what typed fields are new?" is a precise query. A per-cloud pass cross-referenced native checks using workaround patterns (`x['Key']['Sub']`, `== "ENABLED"`, `parse.json`, deep digs) against typed fields that now exist, confirming each field (and that it is **not** deprecated) before proposing a swap.

## Changes

**aws (3)**
- s3 bucket-level public-access: `publicAccessBlock.*` digs + `!= empty` guard → typed `blockPublicAcls`/`blockPublicPolicy`/`ignorePublicAcls`/`restrictPublicBuckets`
- dynamodb PITR (enabled + cmk-encryption): `continuousBackups[...][...] == "ENABLED"` → `pointInTimeRecoveryEnabled == true`

**azure (13)**
- app-service CORS, function-app easy-auth, cosmosdb (networkAclBypass / consistency / private endpoints), firewall IDPS, aks disk-CSI, databricks public-access, mysql data-encryption, vm OS guard, function-app public-network-access, application-gateway frontend, function-app CMK

**gcp (10)**
- storage/disk/snapshot/image CMEK → `defaultEncryptionEnabled` / `kmsKey`
- gke workload-identity / shielded-nodes / legacy-abac / node auto-upgrade / node auto-repair / database-encryption → typed bools + `databaseEncryptionState`

**oci (1)**
- db-system subnet no-internet-gateway: raw `routeRules` dig → typed `routes` with `internetGateway != null`

## Deliberately deferred (need live-cloud verification)

These involve a *logic* change (provider computes the result), not just representation, so equivalence can't be proven from the schema alone — worth a follow-up validated against real assets:
- aws lambda/ecr/sns/secretsmanager `isPublic` (condition-aware public-access rollups; the lambda one collapses 23 lines → 1)
- azure cosmos/batch `encryptionKey` CMK rollups, cosmos CORS comma-split
- gcp dataflow `workerIpConfiguration`/`kmsKey`, cloud-sql `internetReachable`, kms `primaryState`

One candidate (gcp gke `privateNodesEnabled`) was dropped: the typed field is already **deprecated**, so the original dict access is retained.

## Verification

`cnspec policy lint` passes on all four bundles with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)