### PR TITLE
✨ digitalocean/hetzner: add SSH-key, function-auth, storage-box, and certificate checks

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.2.0
+    version: 2.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -46,6 +46,9 @@ policies:
           - uid: mondoo-digitalocean-security-droplet-in-vpc
           - uid: mondoo-digitalocean-security-droplet-firewall-coverage
           - uid: mondoo-digitalocean-security-droplet-not-internet-reachable
+      - title: Images
+        checks:
+          - uid: mondoo-digitalocean-security-image-not-public
       - title: Cloud Firewalls
         checks:
           - uid: mondoo-digitalocean-security-firewall-no-unrestricted-ssh
@@ -64,6 +67,7 @@ policies:
           - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
           - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy
           - uid: mondoo-digitalocean-security-lb-in-vpc
+          - uid: mondoo-digitalocean-security-lb-firewall-allowlist-not-open
       - title: Kubernetes (DOKS)
         checks:
           - uid: mondoo-digitalocean-security-doks-auto-upgrade-enabled
@@ -97,6 +101,7 @@ policies:
       - title: Functions
         checks:
           - uid: mondoo-digitalocean-security-function-requires-api-key
+          - uid: mondoo-digitalocean-security-function-access-key-not-stale
       - title: Security Scanning
         checks:
           - uid: mondoo-digitalocean-security-scan-no-critical-findings
@@ -4350,3 +4355,251 @@ queries:
     refs:
       - url: https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/
         title: Add SSH keys to DigitalOcean
+
+  # No Terraform variants: DigitalOcean Functions have no digitalocean Terraform
+  # resource, and lastUsedAt/createdAt are runtime observations of credential
+  # activity that no Terraform source expresses.
+  - uid: mondoo-digitalocean-security-function-access-key-not-stale
+    title: Ensure Functions namespace access keys are not stale
+    impact: 70
+    filters: asset.platform == "digitalocean"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-2-2
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      digitalocean.functionNamespaces.all(accessKeys.all(lastUsedAt != empty && lastUsedAt > time.now - 90 * time.day || lastUsedAt == empty && createdAt > time.now - 90 * time.day))
+    docs:
+      desc: |
+        This check ensures that every Functions namespace API access key has been used within the last 90 days (keys created within the window are exempt while they wait to be used first). An access key that has sat unused for months is almost always a forgotten credential — still valid, still able to deploy and invoke functions, but no longer watched by anyone.
+
+        **Why this matters**
+
+        - **Forgotten standing credentials:** A key nobody uses is a key nobody notices being abused. Dormant credentials are a favorite foothold because their misuse blends into the absence of legitimate activity.
+        - **Larger credential inventory:** Every live key is an independent secret that can leak from a laptop, CI system, or backup. Retiring unused keys shrinks the set of secrets that must be protected and rotated.
+        - **No expiration by default:** Namespace keys do not expire on their own, so without periodic cleanup they accumulate indefinitely.
+
+        **Risk mitigation**
+
+        - **Credential leakage:** Removing keys that are no longer in active use eliminates secrets whose compromise would otherwise go undetected.
+        - **Least standing access:** Pruning dormant keys keeps the namespace's authorized credentials aligned with what is actually in use.
+
+        Delete keys that are no longer needed, and rotate the keys that remain on a regular schedule.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Functions** and open each namespace's settings.
+        3. Review the access keys and their last-used dates.
+
+        A passing key has been used within the last 90 days or was created recently. A failing key has gone unused for more than 90 days.
+
+        ### Audit via CLI
+
+        1. Connect to the namespace and list its API access keys:
+
+        ```bash
+        doctl serverless connect
+        doctl serverless namespaces list
+        ```
+
+        Review each key's last-used timestamp. A passing key was used within the last 90 days; a failing key has been idle longer.
+      remediation:
+        - id: console
+          desc: |
+            To remove stale Functions namespace access keys in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Functions** and open the namespace's settings.
+            2. Identify access keys that have not been used in over 90 days and confirm they are no longer needed.
+            3. Delete the unused keys, and rotate the keys that remain.
+        - id: cli
+          desc: |
+            Manage a namespace's access keys with the `doctl serverless` command group. After confirming a key is unused, delete it:
+
+            ```bash
+            doctl serverless connect
+            doctl serverless namespaces list
+            ```
+
+            Remove the stale key through the namespace's key management, then rotate the remaining keys on a regular schedule.
+        # No Terraform remediation: Functions namespace access keys have no
+        # digitalocean Terraform resource; they are managed only through doctl and
+        # the control panel.
+    refs:
+      - url: https://docs.digitalocean.com/products/functions/how-to/manage-namespaces/
+        title: Manage Functions namespaces
+
+  # No Terraform variants: image visibility is not an argument on
+  # digitalocean_custom_image; publishing or unpublishing an image is a separate
+  # imperative action, so the public flag cannot be evaluated from Terraform.
+  - uid: mondoo-digitalocean-security-image-not-public
+    title: Ensure custom images are not publicly shared
+    impact: 80
+    filters: asset.platform == "digitalocean"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      digitalocean.images.all(public == false)
+    docs:
+      desc: |
+        This check ensures that no custom image, snapshot, or backup owned by the account is publicly shared. A public image can be listed and used by any DigitalOcean user, and disk images frequently carry embedded secrets, credentials, application source, and configuration baked in at build time.
+
+        **Why this matters**
+
+        - **Embedded secrets:** Golden images and snapshots routinely contain SSH keys, API tokens, database credentials, and application code that were present on the source system when the image was captured.
+        - **Intellectual property exposure:** A public custom image exposes proprietary software, configuration, and architecture to anyone who launches it.
+        - **Unintended distribution:** Once an image is public it can be copied by others, so the exposure persists even after the image is later made private.
+
+        **Risk mitigation**
+
+        - **Data leakage:** Keeping images private ensures their contents are reachable only by the account and the team members it authorizes.
+        - **Supply-chain integrity:** Private images cannot be enumerated and used as an untrusted base by unrelated parties.
+
+        Keep custom images private and share them explicitly with named accounts only when required. Rebuild any image that was public to rotate secrets it may have exposed.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Images** and review the **Custom Images** and **Snapshots** tabs.
+        3. Check the visibility of each image.
+
+        A passing image is private to the account. A failing image is marked public.
+
+        ### Audit via CLI
+
+        1. List the images owned by the account and review the **Public** column:
+
+        ```bash
+        doctl compute image list-user --format ID,Name,Public
+        ```
+
+        A passing image shows `Public` as `false`. A failing image shows `Public` as `true`.
+      remediation:
+        - id: console
+          desc: |
+            To stop sharing a custom image publicly in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Images** and locate the public custom image or snapshot.
+            2. Remove its public sharing so it is private to the account.
+            3. If the image was public, rebuild it and rotate any secrets it may have contained, then delete the exposed image.
+        - id: cli
+          desc: |
+            Custom image visibility cannot be toggled from the CLI. Review the account's images and delete an exposed image once a private replacement exists:
+
+            ```bash
+            doctl compute image list-user --format ID,Name,Public
+            doctl compute image delete <image-id>
+            ```
+
+            Rebuild the image as private and rotate any secrets it may have exposed before deleting the public copy.
+        # No Terraform remediation: image visibility is not a digitalocean_custom_image
+        # argument; publishing and unpublishing are imperative actions outside Terraform.
+    refs:
+      - url: https://docs.digitalocean.com/products/images/custom-images/
+        title: DigitalOcean custom images
+
+  # No Terraform variants: the load balancer firewall is a nested block whose
+  # allow entries are encoded with cidr:/ip: prefixes; the runtime check inspects
+  # the normalized source list, and expressing the any-address refinement across
+  # terraform-hcl/plan/state adds fragility for a narrow refinement.
+  - uid: mondoo-digitalocean-security-lb-firewall-allowlist-not-open
+    title: Ensure load balancer firewall allowlists are not open to all
+    impact: 70
+    filters: asset.platform == "digitalocean-loadbalancer"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      digitalocean.loadBalancer.firewallAllow == empty || digitalocean.loadBalancer.firewallAllow.all(_.contains("0.0.0.0/0") == false && _.contains("::/0") == false)
+    docs:
+      desc: |
+        This check ensures that when a DigitalOcean load balancer defines a source-IP firewall allowlist, that allowlist does not include an any-address entry (`0.0.0.0/0` or `::/0`). A load balancer firewall allowlist is meant to restrict which source addresses can reach the balancer; an any-address entry defeats that purpose while giving the false impression that access is controlled.
+
+        **Why this matters**
+
+        - **False sense of restriction:** An allowlist containing `0.0.0.0/0` looks like a control in the console and in code review, but admits every host on the internet just as if no allowlist existed.
+        - **Silent scope creep:** A specific allowlist that later has an any-address entry added — often as a temporary troubleshooting step — quietly reopens the load balancer to the world.
+        - **Bypassed segmentation:** Load balancers front application backends; an unrestricted allowlist exposes those backends to internet-wide scanning and attack.
+
+        **Risk mitigation**
+
+        - **Attack surface:** Restricting the allowlist to the specific source ranges that need access removes the load balancer from opportunistic internet scanning.
+        - **Auditable intent:** An allowlist without an any-address entry accurately reflects who is permitted to reach the balancer.
+
+        Replace any-address entries with the specific administrative, client, or CDN source ranges that legitimately need to reach the load balancer. A load balancer that is intentionally public simply omits the allowlist rather than allowlisting `0.0.0.0/0`.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Networking** > **Load Balancers** and open each load balancer.
+        3. On the **Settings** tab, review the firewall (allow/deny) rules.
+
+        A passing load balancer either has no allow rules or lists only specific source ranges. A failing load balancer has an allow rule of `0.0.0.0/0` or `::/0`.
+
+        ### Audit via CLI
+
+        1. List the load balancers and inspect each one's firewall rules:
+
+        ```bash
+        doctl compute load-balancer list --format ID,Name,IP
+        doctl compute load-balancer get <load-balancer-id>
+        ```
+
+        A passing load balancer's allow list is empty or contains only specific ranges. A failing load balancer's allow list contains `cidr:0.0.0.0/0` or `cidr:::/0`.
+      remediation:
+        - id: console
+          desc: |
+            To tighten a load balancer firewall allowlist in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Networking** > **Load Balancers** and open the affected load balancer.
+            2. On the **Settings** tab, edit the firewall rules and remove the `0.0.0.0/0` / `::/0` allow entry.
+            3. Add the specific source ranges that need access, or remove the allowlist entirely if the load balancer is meant to be public.
+        - id: cli
+          desc: |
+            To replace an any-address allowlist with specific source ranges using the `doctl` CLI:
+
+            ```bash
+            doctl compute load-balancer update <load-balancer-id> \
+              --allow-list cidr:203.0.113.0/24,ip:198.51.100.10
+            ```
+
+            Provide the trusted source ranges that need access. Omit the allowlist entirely if the load balancer is intentionally public.
+        # No Terraform remediation: the load balancer firewall is a nested block on
+        # digitalocean_loadbalancer using cidr:/ip: encoded entries; fix it by editing
+        # the firewall.allow list in that block to remove any-address entries.
+    refs:
+      - url: https://docs.digitalocean.com/products/networking/load-balancers/how-to/manage/
+        title: Manage DigitalOcean load balancers

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -38,6 +38,9 @@ policies:
       - title: Account
         checks:
           - uid: mondoo-digitalocean-security-account-email-verified
+      - title: SSH Keys
+        checks:
+          - uid: mondoo-digitalocean-security-ssh-key-no-dsa
       - title: Droplets
         checks:
           - uid: mondoo-digitalocean-security-droplet-in-vpc
@@ -91,6 +94,9 @@ policies:
       - title: App Platform
         checks:
           - uid: mondoo-digitalocean-security-app-platform-https
+      - title: Functions
+        checks:
+          - uid: mondoo-digitalocean-security-function-requires-api-key
       - title: Security Scanning
         checks:
           - uid: mondoo-digitalocean-security-scan-no-critical-findings
@@ -4162,3 +4168,185 @@ queries:
     refs:
       - url: https://docs.digitalocean.com/products/gradientai-platform/
         title: DigitalOcean GradientAI platform
+
+  # No Terraform variants: DigitalOcean Functions are deployed imperatively via
+  # `doctl serverless deploy` and a project.yml manifest; there is no digitalocean
+  # Terraform resource for a serverless function, so the web-export and API-key
+  # annotations cannot be evaluated from Terraform HCL, plan, or state.
+  - uid: mondoo-digitalocean-security-function-requires-api-key
+    title: Ensure web-invokable Functions require an API key
+    impact: 85
+    filters: asset.platform == "digitalocean"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      digitalocean.functionNamespaces.all(functions.where(webExported == true).all(requiresApiKey == true))
+    docs:
+      desc: |
+        This check ensures that every DigitalOcean Function published as a web-invokable HTTP endpoint requires an API key. A function marked web-invokable is reachable over the internet at its namespace URL; unless it also requires an API key, anyone who learns or guesses the URL can invoke it without credentials.
+
+        **Why this matters**
+
+        - **Unauthenticated invocation:** A web-invokable function without an API key runs its code for any anonymous caller, exposing whatever data access, downstream services, and secrets the function holds.
+        - **Abuse and cost:** Open endpoints are targets for automated abuse — scraping, data injection, and invocation floods that run up compute charges.
+        - **Bypassed access controls:** Functions frequently sit in front of databases, object storage, or third-party APIs. An unauthenticated function becomes an open proxy to those backends.
+
+        **Risk mitigation**
+
+        - **Anonymous access:** Requiring an API key ensures only callers presenting a valid credential can execute the function.
+        - **Attack surface:** Endpoints that reject unauthenticated requests are not usable by opportunistic internet scanners probing for open functions.
+
+        Functions that are intentionally public, such as a health check that returns no sensitive data, should be reviewed and documented as exceptions rather than left unauthenticated by default.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Functions** and open each namespace.
+        3. For each function, review whether it is web-invokable and whether it requires authentication.
+
+        A passing function is either not web-invokable or requires an API key. A failing function is web-invokable and allows unauthenticated access.
+
+        ### Audit via CLI
+
+        1. List the functions in the namespace and inspect each function's metadata:
+
+        ```bash
+        doctl serverless functions list
+        doctl serverless functions get <function-name>
+        ```
+
+        A passing web-invokable function shows that an API key (secured web access) is required. A failing function shows web access enabled with no authentication requirement.
+      remediation:
+        - id: console
+          desc: |
+            To require authentication on a web-invokable function in the DigitalOcean Cloud Control Panel:
+
+            1. Navigate to **Functions** and open the affected function.
+            2. Under the function's web settings, enable the option that requires an API key for web invocation (secured web access), or disable web invocation entirely if the function does not need to be reachable over HTTP.
+            3. Save the change and confirm that legitimate callers now present the API key.
+        - id: cli
+          desc: |
+            DigitalOcean Functions are deployed from a `project.yml` manifest. Mark the function as requiring authenticated web access and redeploy it with the `doctl` CLI.
+
+            In `project.yml`, secure the function's web access:
+
+            ```yaml
+            packages:
+              - name: default
+                functions:
+                  - name: my-function
+                    web: true
+                    webSecure: true
+            ```
+
+            Then redeploy the project:
+
+            ```bash
+            doctl serverless deploy <project-directory>
+            ```
+
+            Setting `webSecure: true` requires callers to present the function's API key. Set `web: false` instead if the function does not need to be reachable over HTTP.
+        # No Terraform remediation: DigitalOcean Functions have no digitalocean
+        # Terraform resource; they are managed only through project.yml and doctl.
+    refs:
+      - url: https://docs.digitalocean.com/products/functions/how-to/create-functions/
+        title: DigitalOcean Functions overview
+      - url: https://docs.digitalocean.com/products/functions/reference/project-configuration/
+        title: Functions project configuration reference
+
+  # No Terraform variants: the key algorithm is parsed from the SSH public-key
+  # material. In Terraform, digitalocean_ssh_key.public_key is almost always a
+  # file() or variable reference rather than a literal, so the algorithm cannot be
+  # read from the source, and a weak key is remediated by generating a new key
+  # pair — not by changing a Terraform argument.
+  - uid: mondoo-digitalocean-security-ssh-key-no-dsa
+    title: Ensure SSH keys do not use the deprecated DSA algorithm
+    impact: 70
+    filters: asset.platform == "digitalocean"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      digitalocean.sshKeys.none(publicKey.split(" ")[0] == "ssh-dss")
+    docs:
+      desc: |
+        This check ensures that no SSH key registered on the DigitalOcean account uses the DSA (`ssh-dss`) algorithm. DSA keys are capped at 1024 bits, rely on a signing scheme that is fragile to poor random-number generation, and have been disabled by default in OpenSSH since version 7.0.
+
+        **Why this matters**
+
+        - **Weak by construction:** DSA SSH keys are limited to 1024-bit strength, which is below the cryptographic strength recommended for authentication credentials.
+        - **Fragile signing:** DSA signatures can leak the private key if the per-signature nonce is ever reused or predictable, a failure mode that has compromised real keys.
+        - **Deprecated everywhere:** Modern SSH clients and servers reject `ssh-dss` by default, so a DSA key is both insecure and increasingly unusable.
+
+        **Risk mitigation**
+
+        - **Credential compromise:** Replacing DSA keys with Ed25519 or RSA (2048-bit or larger) keys removes a class of key that is realistically forgeable.
+        - **Access continuity:** Migrating off deprecated algorithms avoids sudden lockout when a client or server drops `ssh-dss` support.
+
+        Replace any DSA key with an Ed25519 key (preferred) or an RSA key of at least 2048 bits.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
+        2. Navigate to **Settings** > **Security** and review the **SSH keys** list.
+        3. Inspect each stored public key.
+
+        A passing key begins with `ssh-ed25519`, `ssh-rsa`, or `ecdsa-sha2-*`. A failing key begins with `ssh-dss`.
+
+        ### Audit via CLI
+
+        1. List the SSH keys on the account and inspect each key's public-key material:
+
+        ```bash
+        doctl compute ssh-key list
+        ```
+
+        A passing key's public key begins with `ssh-ed25519`, `ssh-rsa`, or `ecdsa-sha2-*`. A failing key's public key begins with `ssh-dss`.
+      remediation:
+        - id: console
+          desc: |
+            To replace a DSA SSH key in the DigitalOcean Cloud Control Panel:
+
+            1. Generate a new key locally, for example `ssh-keygen -t ed25519 -C "you@example.com"`.
+            2. Navigate to **Settings** > **Security** > **SSH keys** and add the new public key.
+            3. Update your Droplets and automation to trust the new key, then delete the `ssh-dss` key.
+        - id: cli
+          desc: |
+            To replace a DSA SSH key using the `doctl` CLI:
+
+            ```bash
+            ssh-keygen -t ed25519 -f ~/.ssh/do_ed25519 -C "you@example.com"
+            doctl compute ssh-key import my-ed25519-key --public-key-file ~/.ssh/do_ed25519.pub
+            doctl compute ssh-key delete <dsa-key-id>
+            ```
+
+            Import the new key before deleting the old one so you do not lose access to Droplets that reference it.
+        # No Terraform remediation: the key algorithm is a property of the key
+        # material generated with ssh-keygen, not a digitalocean_ssh_key argument;
+        # the fix is to generate and register a new key pair.
+    refs:
+      - url: https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/
+        title: Add SSH keys to DigitalOcean

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure DigitalOcean Droplets, Databases, Load Balancers, DOKS, Spaces, and App Platform
+    summary: Secure DigitalOcean Droplets, Databases, Load Balancers, DOKS, Spaces, Functions, GenAI, and App Platform
     docs:
       desc: |
         The Mondoo DigitalOcean Security policy identifies critical misconfigurations that could leave your DigitalOcean cloud infrastructure vulnerable to attackers. This policy focuses on security-relevant controls and helps organizations harden against unauthorized access, data exposure, weak cryptography, credential misuse, and exposure to known CVEs through end-of-life software.
@@ -21,15 +21,20 @@ policies:
         This policy provides security checks across key DigitalOcean services, uncovering misconfigurations that could put critical resources at risk:
 
         - Account identity
+        - SSH keys
         - Droplets (virtual machines)
+        - Custom images and snapshots
         - Cloud Firewalls
         - Managed Databases
         - Load Balancers
         - Kubernetes (DOKS)
         - TLS Certificates
         - Content Delivery Network (CDN)
-        - Spaces (object storage) access keys
+        - Spaces (object storage) buckets and access keys
         - App Platform
+        - Functions (serverless)
+        - Security scanning
+        - GenAI (GradientAI) agents and knowledge bases
 
         Learn more about scanning DigitalOcean in the [cnspec DigitalOcean documentation](https://mondoo.com/docs/cnspec/cloud/digitalocean).
 

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -4543,10 +4543,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      digitalocean.loadBalancer.firewallAllow == empty || digitalocean.loadBalancer.firewallAllow.all(_.contains("0.0.0.0/0") == false && _.contains("::/0") == false)
+      digitalocean.loadBalancer.firewallAllow == empty || digitalocean.loadBalancer.firewallAllow.all(_.contains("/0") == false)
     docs:
       desc: |
-        This check ensures that when a DigitalOcean load balancer defines a source-IP firewall allowlist, that allowlist does not include an any-address entry (`0.0.0.0/0` or `::/0`). A load balancer firewall allowlist is meant to restrict which source addresses can reach the balancer; an any-address entry defeats that purpose while giving the false impression that access is controlled.
+        This check ensures that when a DigitalOcean load balancer defines a source-IP firewall allowlist, that allowlist does not include an any-address entry with a `/0` mask such as `0.0.0.0/0` or `::/0`. A load balancer firewall allowlist is meant to restrict which source addresses can reach the balancer; an any-address entry defeats that purpose while giving the false impression that access is controlled.
 
         **Why this matters**
 

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -4174,7 +4174,7 @@ queries:
   # Terraform resource for a serverless function, so the web-export and API-key
   # annotations cannot be evaluated from Terraform HCL, plan, or state.
   - uid: mondoo-digitalocean-security-function-requires-api-key
-    title: Ensure web-invokable Functions require an API key
+    title: Ensure web-accessible Functions require an API key
     impact: 85
     filters: asset.platform == "digitalocean"
     tags:
@@ -4195,11 +4195,11 @@ queries:
       digitalocean.functionNamespaces.all(functions.where(webExported == true).all(requiresApiKey == true))
     docs:
       desc: |
-        This check ensures that every DigitalOcean Function published as a web-invokable HTTP endpoint requires an API key. A function marked web-invokable is reachable over the internet at its namespace URL; unless it also requires an API key, anyone who learns or guesses the URL can invoke it without credentials.
+        This check ensures that every DigitalOcean Function published as a web-accessible HTTP endpoint requires an API key. A function marked web-accessible is reachable over the internet at its namespace URL; unless it also requires an API key, anyone who learns or guesses the URL can invoke it without credentials.
 
         **Why this matters**
 
-        - **Unauthenticated invocation:** A web-invokable function without an API key runs its code for any anonymous caller, exposing whatever data access, downstream services, and secrets the function holds.
+        - **Unauthenticated invocation:** A web-accessible function without an API key runs its code for any anonymous caller, exposing whatever data access, downstream services, and secrets the function holds.
         - **Abuse and cost:** Open endpoints are targets for automated abuse — scraping, data injection, and invocation floods that run up compute charges.
         - **Bypassed access controls:** Functions frequently sit in front of databases, object storage, or third-party APIs. An unauthenticated function becomes an open proxy to those backends.
 
@@ -4214,9 +4214,9 @@ queries:
 
         1. Sign in to the DigitalOcean [Cloud Control Panel](https://cloud.digitalocean.com/).
         2. Navigate to **Functions** and open each namespace.
-        3. For each function, review whether it is web-invokable and whether it requires authentication.
+        3. For each function, review whether it is web-accessible and whether it requires authentication.
 
-        A passing function is either not web-invokable or requires an API key. A failing function is web-invokable and allows unauthenticated access.
+        A passing function is either not web-accessible or requires an API key. A failing function is web-accessible and allows unauthenticated access.
 
         ### Audit via CLI
 
@@ -4227,11 +4227,11 @@ queries:
         doctl serverless functions get <function-name>
         ```
 
-        A passing web-invokable function shows that an API key (secured web access) is required. A failing function shows web access enabled with no authentication requirement.
+        A passing web-accessible function shows that an API key (secured web access) is required. A failing function shows web access enabled with no authentication requirement.
       remediation:
         - id: console
           desc: |
-            To require authentication on a web-invokable function in the DigitalOcean Cloud Control Panel:
+            To require authentication on a web-accessible function in the DigitalOcean Cloud Control Panel:
 
             1. Navigate to **Functions** and open the affected function.
             2. Under the function's web settings, enable the option that requires an API key for web invocation (secured web access), or disable web invocation entirely if the function does not need to be reachable over HTTP.

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -36,6 +36,9 @@ policies:
           - uid: mondoo-hetzner-security-server-has-firewall
           - uid: mondoo-hetzner-security-server-image-not-deprecated
           - uid: mondoo-hetzner-security-server-not-internet-reachable
+      - title: SSH Keys
+        checks:
+          - uid: mondoo-hetzner-security-ssh-key-strong-algorithm
       - title: Firewalls
         checks:
           - uid: mondoo-hetzner-security-firewall-no-unrestricted-ssh
@@ -52,6 +55,10 @@ policies:
       - title: TLS Certificates
         checks:
           - uid: mondoo-hetzner-security-cert-not-expired
+          - uid: mondoo-hetzner-security-cert-not-self-signed
+      - title: Storage Boxes
+        checks:
+          - uid: mondoo-hetzner-security-storage-box-not-externally-reachable
       - title: IP Addresses
         checks:
           - uid: mondoo-hetzner-security-floating-ip-not-blocked
@@ -2084,3 +2091,278 @@ queries:
     refs:
       - url: https://docs.hetzner.com/cloud/primary-ips/overview/
         title: Hetzner Cloud Primary IPs overview
+
+  # No Terraform variants: the key algorithm and size are parsed from the SSH
+  # public-key material. In Terraform, hcloud_ssh_key.public_key is almost always
+  # a file() or variable reference rather than a literal, so the algorithm and bit
+  # length cannot be read from the source, and a weak key is remediated by
+  # generating a new key pair — not by changing a Terraform argument.
+  - uid: mondoo-hetzner-security-ssh-key-strong-algorithm
+    title: Ensure SSH keys use strong algorithms and key sizes
+    impact: 70
+    filters: asset.platform == "hetzner-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      hetzner.sshKeys.none(algorithm == "ssh-dss")
+      hetzner.sshKeys.where(algorithm == "ssh-rsa").all(bits >= 2048)
+    docs:
+      desc: |
+        This check ensures that SSH keys uploaded to Hetzner Cloud use strong cryptography: it rejects DSA (`ssh-dss`) keys outright and requires RSA keys to be at least 2048 bits. DSA keys are capped at 1024 bits and use a fragile signing scheme; RSA keys below 2048 bits no longer meet accepted strength for authentication credentials.
+
+        **Why this matters**
+
+        - **Weak DSA keys:** `ssh-dss` keys are limited to 1024 bits and leak the private key if the per-signature nonce is ever reused or predictable — they are disabled by default in modern OpenSSH.
+        - **Undersized RSA keys:** RSA keys shorter than 2048 bits are within reach of factoring attacks and fall below current baselines for authentication key strength.
+        - **Keys are standing credentials:** An SSH key authorizes interactive and automated access to servers; a weak key is a durable, high-value target that outlives most passwords.
+
+        **Risk mitigation**
+
+        - **Credential compromise:** Enforcing Ed25519, ECDSA, or RSA ≥ 2048-bit keys removes classes of key that are realistically forgeable or brute-forceable.
+        - **Access continuity:** Migrating off deprecated algorithms avoids sudden lockout when a client or server drops `ssh-dss` support.
+
+        Prefer Ed25519 keys for new access; where RSA is required, generate keys of at least 2048 bits (3072 or 4096 recommended).
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Security** > **SSH Keys**.
+        3. Review the algorithm of each stored key.
+
+        A passing key is Ed25519, ECDSA, or RSA with at least 2048 bits. A failing key is DSA (`ssh-dss`) or an RSA key smaller than 2048 bits.
+
+        ### Audit via CLI
+
+        1. List the SSH keys in the project and inspect each key's fingerprint and public key:
+
+        ```bash
+        hcloud ssh-key list
+        ```
+
+        A passing key's public key begins with `ssh-ed25519`, `ecdsa-sha2-*`, or `ssh-rsa` with a 2048-bit-or-larger modulus. A failing key begins with `ssh-dss` or is a shorter RSA key.
+      remediation:
+        - id: console
+          desc: |
+            To replace a weak SSH key in the Hetzner Cloud Console:
+
+            1. Generate a new key locally, for example `ssh-keygen -t ed25519 -C "you@example.com"`.
+            2. Navigate to **Security** > **SSH Keys** and add the new public key.
+            3. Update the servers and automation that reference the old key, then delete the weak key.
+        - id: cli
+          desc: |
+            To replace a weak SSH key using the `hcloud` CLI:
+
+            ```bash
+            ssh-keygen -t ed25519 -f ~/.ssh/hetzner_ed25519 -C "you@example.com"
+            hcloud ssh-key create --name my-ed25519-key --public-key-from-file ~/.ssh/hetzner_ed25519.pub
+            hcloud ssh-key delete <weak-key-name>
+            ```
+
+            Create the new key before deleting the old one so servers that reference it do not lose their authorized key.
+        # No Terraform remediation: the key algorithm and size are properties of the
+        # key material generated with ssh-keygen, not an hcloud_ssh_key argument; the
+        # fix is to generate and register a new key pair.
+    refs:
+      - url: https://docs.hetzner.com/cloud/servers/getting-started/connecting-via-ssh/
+        title: Hetzner Cloud SSH keys
+
+  # No Terraform variants: selfSigned and signatureAlgorithm are derived by parsing
+  # the certificate PEM at runtime. Terraform sources carry the certificate as an
+  # opaque string (commonly a file() reference), and MQL cannot parse the signature
+  # algorithm or self-signed status from it on terraform-hcl/plan/state assets.
+  - uid: mondoo-hetzner-security-cert-not-self-signed
+    title: Ensure TLS certificates are not self-signed or weakly signed
+    impact: 70
+    filters: asset.platform == "hetzner-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-11
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      hetzner.certificates.all(selfSigned == false)
+      hetzner.certificates.none(signatureAlgorithm.downcase.contains("sha1"))
+      hetzner.certificates.none(signatureAlgorithm.downcase.contains("md5"))
+    docs:
+      desc: |
+        This check ensures that no TLS certificate managed in Hetzner Cloud is self-signed or signed with a weak algorithm (SHA-1 or MD5). A self-signed certificate is not anchored to a trusted certificate authority, and a SHA-1 or MD5 signature can be forged through collision attacks, so both undermine the trust that TLS is supposed to provide.
+
+        **Why this matters**
+
+        - **No trust anchor:** A self-signed certificate is trusted by no default root store, so clients cannot distinguish it from an attacker-supplied certificate and either fail or are trained to click through warnings.
+        - **Forgeable signatures:** SHA-1 and MD5 are broken against collision attacks, allowing an adversary to craft a certificate that appears validly signed.
+        - **Downgraded protection:** A weak or untrusted certificate leaves connections open to interception and man-in-the-middle attacks even though TLS appears to be in use.
+
+        **Risk mitigation**
+
+        - **Man-in-the-middle:** CA-issued certificates with SHA-256-or-stronger signatures let clients verify server identity and reject impostors.
+        - **Warning fatigue:** Trusted certificates remove the persistent browser warnings that condition users to ignore certificate errors.
+
+        Use Hetzner-managed certificates (issued by Let's Encrypt) or upload certificates issued by a trusted CA with a SHA-256-or-stronger signature.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Certificates**.
+        3. Review the type and issuer of each certificate.
+
+        A passing certificate is CA-issued (for example a managed Let's Encrypt certificate) and uses a SHA-256-or-stronger signature. A failing certificate is self-signed or uses a SHA-1 or MD5 signature.
+
+        ### Audit via CLI
+
+        1. List all certificates and inspect each certificate's details:
+
+        ```bash
+        hcloud certificate list
+        hcloud certificate describe <certificate>
+        ```
+
+        A passing certificate shows a recognized issuer distinct from its subject and a strong signature algorithm. A failing certificate shows the subject and issuer as identical (self-signed) or a SHA-1/MD5 signature algorithm.
+      remediation:
+        - id: console
+          desc: |
+            To replace a self-signed or weakly signed certificate in the Hetzner Cloud Console:
+
+            1. Navigate to **Certificates**.
+            2. Create a managed certificate (issued and auto-renewed by Let's Encrypt) for the domain, or upload a certificate issued by a trusted CA with a SHA-256-or-stronger signature.
+            3. Update any load balancers referencing the old certificate to use the new one, then delete the self-signed or weak certificate.
+        - id: cli
+          desc: |
+            Create a managed certificate so Hetzner issues a CA-signed, strongly signed certificate via Let's Encrypt:
+
+            ```bash
+            hcloud certificate create --type managed --name <new-name> --domain <domain>
+            ```
+
+            To upload a CA-issued certificate instead:
+
+            ```bash
+            hcloud certificate create --type uploaded --name <new-name> --cert-file cert.pem --key-file key.pem
+            ```
+        - id: terraform
+          desc: |
+            Prefer `hcloud_managed_certificate` so Hetzner issues and renews a CA-signed certificate with a strong signature, rather than uploading a self-signed one:
+
+            ```hcl
+            resource "hcloud_managed_certificate" "example" {
+              name         = "example"
+              domain_names = ["example.com", "*.example.com"]
+            }
+            ```
+
+            If you must upload a certificate, ensure it is issued by a trusted CA with a SHA-256-or-stronger signature:
+
+            ```hcl
+            resource "hcloud_uploaded_certificate" "example" {
+              name        = "example"
+              certificate = file("${path.module}/cert.pem")
+              private_key = file("${path.module}/key.pem")
+            }
+            ```
+    refs:
+      - url: https://docs.hetzner.com/cloud/certificates/overview/
+        title: Hetzner Cloud Certificates overview
+
+  # No Terraform variants: Hetzner Storage Boxes are not managed by the hcloud
+  # Terraform provider; reachableExternally is an access setting of the Storage Box
+  # surfaced only through the live Hetzner API, with no Terraform resource to
+  # evaluate on terraform-hcl/plan/state assets.
+  - uid: mondoo-hetzner-security-storage-box-not-externally-reachable
+    title: Ensure Storage Boxes are not reachable from the public internet
+    impact: 85
+    filters: asset.platform == "hetzner-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-22
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      hetzner.storageBoxes.all(reachableExternally == false)
+    docs:
+      desc: |
+        This check ensures that no Hetzner Storage Box is reachable from outside the Hetzner network. A Storage Box holds backups and file data; when it is reachable externally, its enabled protocols (Samba/CIFS, WebDAV, SSH/SFTP) are exposed to the public internet rather than being restricted to hosts inside the Hetzner network.
+
+        **Why this matters**
+
+        - **Backup data exposure:** Storage Boxes typically hold backups and archives — exactly the data an attacker wants — so exposing them to the internet puts the most sensitive copies of data within reach of remote attackers.
+        - **Broad protocol attack surface:** External reachability opens the box's file-sharing protocols to internet-wide scanning and credential attacks against SMB, WebDAV, and SSH.
+        - **Ransomware target:** Internet-reachable backup stores are a primary target for ransomware operators seeking to destroy or encrypt recovery data before triggering their payload.
+
+        **Risk mitigation**
+
+        - **Data exfiltration and tampering:** Restricting the Storage Box to the internal network removes the direct network path an attacker would use to read or overwrite backups.
+        - **Internet-wide scanning:** A box that is not externally reachable is not discoverable by mass scanners probing for exposed file-sharing services.
+
+        Access the Storage Box from servers within the Hetzner network. If external access is genuinely required, restrict it tightly and disable the protocols that are not in use.
+      audit: |
+        ### Audit via Console
+
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        2. Navigate to **Storage Boxes** and open each Storage Box.
+        3. Review the access settings for external reachability.
+
+        A passing Storage Box has external reachability disabled. A failing Storage Box is reachable from outside the Hetzner network.
+
+        ### Audit via CLI
+
+        1. List the Storage Boxes and inspect each box's access settings:
+
+        ```bash
+        hcloud storage-box list
+        hcloud storage-box describe <storage-box>
+        ```
+
+        A passing Storage Box reports external reachability as disabled. A failing Storage Box reports it as enabled.
+      remediation:
+        - id: console
+          desc: |
+            To disable external reachability in the Hetzner Cloud Console:
+
+            1. Navigate to **Storage Boxes** and open the affected box.
+            2. In the access settings, disable **Reachable externally** (and disable any file-sharing protocols the box does not need).
+            3. Confirm that your backup jobs and clients reach the box over the internal Hetzner network.
+        - id: cli
+          desc: |
+            To disable external reachability using the `hcloud` CLI:
+
+            ```bash
+            hcloud storage-box update-access-settings <storage-box> --reachable-externally false
+            ```
+
+            Verify that internal clients can still reach the box afterward.
+        # No Terraform remediation: Hetzner Storage Boxes are not managed by the
+        # hcloud Terraform provider; external reachability can only be changed through
+        # the Hetzner Cloud Console or the hcloud CLI.
+    refs:
+      - url: https://docs.hetzner.com/storage/storage-box/general/
+        title: Hetzner Storage Box overview

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 2.2.1
+    version: 2.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure Hetzner Cloud servers, firewalls, load balancers, certificates, and IP addresses
+    summary: Secure Hetzner Cloud servers, SSH keys, firewalls, load balancers, certificates, Storage Boxes, and IP addresses
     docs:
       desc: |
         The Mondoo Hetzner Cloud Security policy identifies critical misconfigurations that could leave your Hetzner Cloud project vulnerable to attackers. This policy focuses on security-relevant controls and helps organizations harden against unauthorized network access, data exposure in transit, weak cryptography, and exposure to known CVEs through end-of-life software.
@@ -21,9 +21,11 @@ policies:
         This policy provides security checks across key Hetzner Cloud resources:
 
         - Cloud Servers
+        - SSH keys
         - Firewalls
         - Load Balancers
         - TLS Certificates
+        - Storage Boxes
         - Floating IPs and Primary IPs
 
         Learn more about scanning Hetzner Cloud in the [cnspec Hetzner Cloud documentation](https://mondoo.com/docs/cnspec/cloud/hetzner).


### PR DESCRIPTION
## What

Adds eight new security checks across the DigitalOcean and Hetzner policies, and minor-bumps both to **2.3.0**. Each check ships with compliance mappings verified against the framework text for all 13 frameworks these policies tag, full `docs:` (desc/audit/remediation), and a documented reason it is runtime-only (no Terraform analog).

### DigitalOcean
| UID | Impact | Enforces |
|-----|--------|----------|
| `function-requires-api-key` | 85 | Web-accessible Functions (`webExported`) must require an API key — prevents unauthenticated public HTTP endpoints. |
| `function-access-key-not-stale` | 70 | Namespace API access keys must have been used within 90 days (recently-created keys exempt). |
| `image-not-public` | 80 | Custom images/snapshots must not be publicly shared (they routinely carry embedded secrets/source). |
| `ssh-key-no-dsa` | 70 | Reject deprecated DSA (`ssh-dss`) account keys. |
| `lb-firewall-allowlist-not-open` | 70 | When a load balancer defines a source-IP allowlist, it must not contain `0.0.0.0/0`/`::/0` (a wide-open allowlist that only *looks* like a control). Public LBs simply omit the allowlist. |

### Hetzner
| UID | Impact | Enforces |
|-----|--------|----------|
| `ssh-key-strong-algorithm` | 70 | Reject DSA keys; require RSA ≥ 2048 bits (uses parsed `algorithm`/`bits`). |
| `cert-not-self-signed` | 70 | Reject self-signed certs and SHA-1/MD5 signatures. |
| `storage-box-not-externally-reachable` | 85 | Storage Boxes (backup data) must not be reachable from the public internet. |

## Design notes
- **`lb-firewall-allowlist-not-open`** is scoped to "allowlist not wide open" rather than "firewall must be configured" — a blanket "must restrict" would fail every legitimately public load balancer. `firewallAllow` keeps godo's `cidr:`/`ip:` prefixes and a `/0` mask is open regardless of base, so the match is on the `0.0.0.0/0`/`::/0` substring with a null-safe guard.
- **`function-access-key-not-stale`** asserts staleness only, not a mandatory expiry date — DO keys default to no expiry, so mandating one would fail near-universally (noise, not signal).
- **Dropped from the original proposal**: a DOKS control-plane-allowlist check — `doks-control-plane-firewall-enabled` already asserts `controlPlaneFirewallAllowedAddresses.containsNone(["0.0.0.0/0","::/0"])`.

## Compliance mappings (highlights, verified against framework text)
- **SSH-key strength** → `nist-sp-800-53-rev5-ia-5`, `iso-27001-2022-a-8-24`, `csa cek-10`; `hipaa`/`pci-dss-4` = `false` (no control governs auth-key crypto strength).
- **Cert self-signed/weak-sig** → `sc-17` (PKI Certificates), `pcidss-requirement-4-2-1` (explicitly rejects self-signed), `nist-sp-800-171--3-13-11`.
- **Function auth** → `ac-3`, `pcidss-requirement-8-3-1`, `soc2-control-cc6-1-4`.
- **Stale keys** → `ia-5`, `nist-sp-800-171--3-5-6` (disable inactive identifiers), `soc2-control-cc6-2-2`.
- **Public image** → `iso-27001-2022-a-8-3` (info access restriction), `pcidss-requirement-7-2-1`, `soc2-control-cc6-1-3`.
- **Storage-box / LB exposure** → `sc-7` (Boundary Protection), `pcidss-requirement-1-3-1`.
- `bsi-sys-1-5` = `false` on all (framework scoped to the SYS.1.5 virtualization module).

## Verification
- `cnspec policy lint` passes on both policies.
- Remediation CLI validators pass: **digitalocean 63/0**, **hetzner 67/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)