### PR TITLE
📝 openstack: list all covered services in policy description

### DIFF
--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.5.0
+    version: 1.5.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -13,16 +13,17 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure OpenStack projects across Keystone, Nova, Neutron, Cinder, Glance, Swift, Octavia, Manila, Magnum, and Trove
+    summary: Secure OpenStack projects across Keystone, Nova, Neutron, VPNaaS, Cinder, Glance, Swift, Octavia, Manila, Magnum, and Trove
     docs:
       desc: |
         The Mondoo OpenStack Security policy identifies critical misconfigurations that could leave your OpenStack project exposed to attackers. The policy focuses on security-relevant controls and helps organizations harden against unauthorized network access, weak credentials, unencrypted data, and accidental exposure of project-owned assets.
 
         This policy provides security checks across the following OpenStack services:
 
-        - Keystone (identity, users, application credentials, trusts)
+        - Keystone (identity, users, application credentials, trusts, service catalog endpoints)
         - Nova (compute servers and keypairs)
         - Neutron (networks, ports, security groups)
+        - Neutron VPNaaS (IKE/IPsec site-to-site VPN policies)
         - Cinder (block-storage volumes)
         - Glance (images)
         - Swift (object-storage containers)


### PR DESCRIPTION
Follow-up to #3024 (merged). Brings the OpenStack policy description in sync with the services it now covers:

- Adds **Neutron VPNaaS (IKE/IPsec site-to-site VPN policies)** to the service list — the VPN group added in #3024 was not reflected in the description.
- Notes **service catalog endpoints** under Keystone (the `endpoints-use-https` check).
- Adds VPNaaS to the one-line `summary`.
- Patch-bumps the policy to **1.5.1**.

Description/summary only — no check logic changes. Passes `cnspec policy lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)