### PR TITLE
🐛 Guard over-broad terraform filters in GCP/AWS security policies

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -1080,7 +1080,7 @@ queries:
       eksPlan.all(_['endpoint_private_access'] == true)
       eksPlan.all(_['endpoint_public_access'] == false)
   - uid: mondoo-aws-security-eks-cluster-private-controlplane-terraform-state
-    filters: asset.platform == "terraform-state"
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
     mql: |
       eksState = terraform.state.resources.where(type == "aws_eks_cluster").map(values.vpc_config).flat
       eksState.all(_['endpoint_private_access'] == true)
@@ -1251,17 +1251,17 @@ queries:
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(accessKey1Active == false)
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(accessKey2Active == false)
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-hcl
-    filters: asset.platform == "terraform-hcl"
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
     mql: |
       terraform.resources("aws_iam_access_key").all(arguments["user"] != "root")
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-plan
-    filters: asset.platform == "terraform-plan"
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
     mql: |
       policyPlan = terraform.plan.resourceChanges.where(type == "aws_iam_policy").map(change.after.policy).first
       policyPlan.contains('Action') && policyPlan.contains('iam:CreateAccessKey')
       policyPlan.contains('Effect') && policyPlan.contains('Deny')
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-state
-    filters: asset.platform == "terraform-state"
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
     mql: |
       policyState = terraform.state.resources.where(type == "aws_iam_policy").map(values.policy).first
       policyState.contains('Action') && policyState.contains('iam:CreateAccessKey')
@@ -1430,7 +1430,7 @@ queries:
     filters: asset.platform == "aws"
     mql: aws.iam.credentialReport.where(properties.user == "<root_account>").all(mfaActive == true)
   - uid: mondoo-aws-security-root-account-mfa-enabled-terraform-hcl
-    filters: asset.platform == "terraform-hcl"
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
     mql: |
       terraform.resources("aws_iam_policy").where(arguments["policy"].first["Statement"] != null).any(arguments["policy"].first["Statement"].any(_["Effect"] == "Deny" && _["Condition"].toString().contains("MultiFactorAuthPresent")))
   - uid: mondoo-aws-security-root-account-mfa-enabled-terraform-plan
@@ -2025,7 +2025,7 @@ queries:
         )
       )
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-plan
-    filters: asset.platform == "terraform-plan"
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_iam_policy").any(
         change.after.policy.contains('Deny') &&
@@ -2033,7 +2033,7 @@ queries:
         change.after.policy.contains('false')
       )
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-state
-    filters: asset.platform == "terraform-state"
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
     mql: |
       terraform.state.resources.where(type == "aws_iam_policy").any(
         values.policy.contains('Deny') &&
@@ -58806,13 +58806,13 @@ queries:
     mql: |
       aws.identitycenter.instances.all(permissionSets.all(inlinePolicy == "" || inlinePolicy == empty))
   - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-hcl
-    filters: asset.platform == "terraform-hcl"
+    filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
     mql: terraform.resources("aws_ssoadmin_permission_set_inline_policy") == empty
   - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-plan
-    filters: asset.platform == "terraform-plan"
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
     mql: terraform.plan.resourceChanges.where(type == "aws_ssoadmin_permission_set_inline_policy") == empty
   - uid: mondoo-aws-security-identitycenter-no-inline-policy-terraform-state
-    filters: asset.platform == "terraform-state"
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
     mql: terraform.state.resources.where(type == "aws_ssoadmin_permission_set_inline_policy") == empty
   - uid: mondoo-aws-security-identitycenter-group-assignments
     title: Ensure Identity Center uses group-based assignments

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -10514,17 +10514,20 @@ queries:
       gcp.project.iam.serviceAccount.keys.where(keyType == "USER_MANAGED").length == 0
   - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl'
+      asset.platform == 'terraform-hcl' &&
+        terraform.providers.any(nameLabel == 'google')
     mql: |
       terraform.resources('google_service_account_key').length == 0
   - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-plan
     filters: |
-      asset.platform == 'terraform-plan'
+      asset.platform == 'terraform-plan' &&
+        terraform.plan.resourceChanges.contains(type == /^google_/)
     mql: |
       terraform.plan.resourceChanges.where(type == 'google_service_account_key').length == 0
   - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-terraform-state
     filters: |
-      asset.platform == 'terraform-state'
+      asset.platform == 'terraform-state' &&
+        terraform.state.resources.contains(type == /^google_/)
     mql: |
       terraform.state.resources.where(type == 'google_service_account_key').length == 0
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled
@@ -11620,15 +11623,15 @@ queries:
     mql: |
       gcp.project.loggingservice.sinks().where(id != "_Required" && id != "_Default").length > 0
   - uid: mondoo-gcp-security-logging-sinks-configured-terraform-hcl
-    filters: asset.platform == 'terraform-hcl'
+    filters: asset.platform == 'terraform-hcl' && terraform.providers.any(nameLabel == 'google')
     mql: |
       terraform.resources('google_logging_project_sink').length > 0
   - uid: mondoo-gcp-security-logging-sinks-configured-terraform-plan
-    filters: asset.platform == 'terraform-plan'
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == /^google_/)
     mql: |
       terraform.plan.resourceChanges.where(type == 'google_logging_project_sink').length > 0
   - uid: mondoo-gcp-security-logging-sinks-configured-terraform-state
-    filters: asset.platform == 'terraform-state'
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == /^google_/)
     mql: |
       terraform.state.resources.where(type == 'google_logging_project_sink').length > 0
   - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption


### PR DESCRIPTION
## Problem

Sixteen check variants in `mondoo-gcp-security` and `mondoo-aws-security` filter on a bare
`asset.platform == "terraform-hcl"` (plus the `terraform-plan` / `terraform-state` siblings)
with **no guard on the cloud provider actually in use**.

That filter is true for *every* terraform asset. Scanning Azure Terraform therefore attaches the
Mondoo GCP Security and Mondoo AWS Security policies to it. The checks then evaluate against an
empty resource set and produce false findings:

| Policy | Check | Result on Azure Terraform |
|---|---|---|
| GCP | Ensure Cloud Logging has at least one sink configured (`… .length > 0`) | ✕ MEDIUM (60) |
| AWS | Ensure MFA is enabled for the "root user" account | ✕ CRITICAL (90) |

`mondoo-azure-security` was already fully guarded — it is the model, and is unchanged here.

## Fix

Guard each variant by the provider actually in use, mirroring the idiom already used in
`mondoo-aws-security` (L10827) and `mondoo-okta-security` (L284):

```yaml
# terraform-hcl
filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
# terraform-plan
filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
# terraform-state
filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
```

Guarding on each check's *own* resource type would make these checks vacuous — they assert either
that a resource is absent, or that a required one is present. So the guard is deliberately
provider-level rather than resource-level.

## Verification

Scanned real terraform fixtures with `cnspec scan terraform <dir> -f content/<bundle>.mql.yaml --incognito`.

**Before** — GCP policy against Azure-only HCL:
```
Passing:  ✓ Ensure user-managed service account keys are not created
Failing:  ✕ MEDIUM (60): Ensure Cloud Logging has at least one sink configured for log export
```

**After** — GCP policy against the same Azure HCL: no longer attaches
(`asset doesn't support any policies`, as this scan supplied only that one bundle).

**After** — GCP policy against GCP HCL, i.e. no coverage lost:
```
Passing:  ✓ Ensure user-managed service account keys are not created
Failing:  ✕ MEDIUM (60): Ensure Cloud Logging has at least one sink configured for log export
```
The sink check still legitimately fails when the GCP terraform declares no sink.

The same before/after holds for AWS: the CRITICAL root-MFA false positive disappears on Azure HCL,
and all three guarded AWS checks still evaluate on AWS HCL.

`cnspec policy lint` passes on both bundles with no new warnings (the two pre-existing
"standalone function in a WHERE clause" warnings are present on `main` as well).

## Note for reviewers

A naive grep over-counts the offenders. In a `filters: |` block, consecutive lines are ANDed, so
most `asset.platform == 'terraform-plan'` lines already carry their guard on the following line.
Only 16 filters are genuinely unguarded; those are the only ones touched.
