### PR TITLE
🧹 windows: migrate deprecated auditpol resource to windows.auditPolicy

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -851,8 +851,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9217-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.where(guid == "0CCE9217-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9217-69AE-11D9-BED3-505054503030").all(failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -951,8 +951,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9239-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9239-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9239-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9239-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/win32/secauthz/authorization-manager-model
@@ -1052,8 +1052,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE922F-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE922F-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE922F-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE922F-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1150,8 +1150,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9230-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9230-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9230-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9230-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1250,8 +1250,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9231-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9231-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9231-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9231-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1344,8 +1344,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE923F-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE923F-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE923F-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE923F-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1437,8 +1437,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9244-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9244-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.where(guid == "0CCE9244-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9244-69AE-11D9-BED3-505054503030").all(failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1527,8 +1527,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9224-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9224-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9224-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9224-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1717,8 +1717,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9249-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9249-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9249-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9249-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1808,8 +1808,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9213-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9213-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9213-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9213-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1908,8 +1908,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9216-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9216-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9216-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9216-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1999,8 +1999,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9215-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9215-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9215-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9215-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2092,8 +2092,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9232-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9232-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9232-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9232-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2196,8 +2196,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE921C-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE921C-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE921C-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE921C-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2295,8 +2295,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9227-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9227-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9227-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9227-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2397,8 +2397,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9234-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9234-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.where(guid == "0CCE9234-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9234-69AE-11D9-BED3-505054503030").all(failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2495,8 +2495,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9214-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9214-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9214-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9214-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2597,8 +2597,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9248-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9248-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9248-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9248-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2688,8 +2688,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE922B-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE922B-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE922B-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE922B-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2782,8 +2782,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9245-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9245-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9245-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9245-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2873,8 +2873,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9237-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9237-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9237-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9237-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2978,8 +2978,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9210-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9210-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9210-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9210-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3071,8 +3071,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9211-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9211-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE9211-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9211-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3165,8 +3165,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9228-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9228-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9228-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9228-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3369,8 +3369,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE921B-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE921B-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.where(guid == "0CCE921B-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE921B-69AE-11D9-BED3-505054503030").all(success)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3459,8 +3459,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9212-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9212-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9212-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9212-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3558,8 +3558,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      auditpol.where(subcategoryguid == "0CCE9235-69AE-11D9-BED3-505054503030").list != []
-      auditpol.where(subcategoryguid == "0CCE9235-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.where(guid == "0CCE9235-69AE-11D9-BED3-505054503030").list != []
+      windows.auditPolicy.where(guid == "0CCE9235-69AE-11D9-BED3-505054503030").all(success && failure)
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -851,8 +851,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9217-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9217-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.subcategory(name: "Account Lockout").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -951,8 +950,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9239-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9239-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Application Group Management").success
+      windows.auditPolicy.subcategory(name: "Application Group Management").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/win32/secauthz/authorization-manager-model
@@ -1052,8 +1051,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE922F-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE922F-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Audit Policy Change").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1150,8 +1148,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9230-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9230-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Authentication Policy Change").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1250,8 +1247,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9231-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9231-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Authorization Policy Change").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1344,8 +1340,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE923F-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE923F-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Credential Validation").success
+      windows.auditPolicy.subcategory(name: "Credential Validation").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1437,8 +1433,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9244-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9244-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.subcategory(name: "Detailed File Share").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1527,8 +1522,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9224-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9224-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "File Share").success
+      windows.auditPolicy.subcategory(name: "File Share").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1717,8 +1712,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9249-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9249-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Group Membership").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1808,8 +1802,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9213-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9213-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "IPsec Driver").success
+      windows.auditPolicy.subcategory(name: "IPsec Driver").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1908,8 +1902,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9216-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9216-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Logoff").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -1999,8 +1992,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9215-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9215-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Logon").success
+      windows.auditPolicy.subcategory(name: "Logon").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2092,8 +2085,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9232-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9232-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "MPSSVC Rule-Level Policy Change").success
+      windows.auditPolicy.subcategory(name: "MPSSVC Rule-Level Policy Change").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2196,8 +2189,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE921C-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE921C-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Other Logon/Logoff Events").success
+      windows.auditPolicy.subcategory(name: "Other Logon/Logoff Events").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2295,8 +2288,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9227-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9227-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Other Object Access Events").success
+      windows.auditPolicy.subcategory(name: "Other Object Access Events").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2397,8 +2390,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9234-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9234-69AE-11D9-BED3-505054503030").all(failure)
+      windows.auditPolicy.subcategory(name: "Other Policy Change Events").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2495,8 +2487,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9214-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9214-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Other System Events").success
+      windows.auditPolicy.subcategory(name: "Other System Events").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2597,8 +2589,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9248-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9248-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Plug and Play Events").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2688,8 +2679,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE922B-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE922B-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Process Creation").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2782,8 +2772,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9245-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9245-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Removable Storage").success
+      windows.auditPolicy.subcategory(name: "Removable Storage").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2873,8 +2863,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9237-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9237-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Security Group Management").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -2978,8 +2967,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9210-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9210-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Security State Change").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3071,8 +3059,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9211-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9211-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Security System Extension").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3165,8 +3152,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9228-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9228-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "Sensitive Privilege Use").success
+      windows.auditPolicy.subcategory(name: "Sensitive Privilege Use").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3369,8 +3356,7 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE921B-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE921B-69AE-11D9-BED3-505054503030").all(success)
+      windows.auditPolicy.subcategory(name: "Special Logon").success
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3459,8 +3445,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9212-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9212-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "System Integrity").success
+      windows.auditPolicy.subcategory(name: "System Integrity").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies
@@ -3558,8 +3544,8 @@ queries:
     filters: |
       asset.platform == "windows"
     mql: |
-      windows.auditPolicy.where(guid == "0CCE9235-69AE-11D9-BED3-505054503030").list != []
-      windows.auditPolicy.where(guid == "0CCE9235-69AE-11D9-BED3-505054503030").all(success && failure)
+      windows.auditPolicy.subcategory(name: "User Account Management").success
+      windows.auditPolicy.subcategory(name: "User Account Management").failure
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-security-audit-policies

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -228,7 +228,7 @@ packs:
         title: Windows audit policies
         docs:
           desc: Returns configured Windows audit policies for security event logging.
-        mql: auditpol { exclusionsetting machinename policytarget subcategory inclusionsetting subcategoryguid }
+        mql: windows.auditPolicy { name category guid inclusionSetting exclusionSetting success failure }
       - uid: mondoo-windows-windows-system-access-policy
         title: Windows local System Access security policy
         docs:


### PR DESCRIPTION
## Summary

Resolves the `query-deprecated-symbol` lint warnings for the `auditpol` / `auditpol.entry` MQL resources in the Windows content, then refactors the migrated checks to drop the opaque GUIDs entirely.

Both old resources are deprecated in favor of `windows.auditPolicy` / `windows.auditPolicy.subcategory`, which report subcategory names and categories in **English regardless of the OS display language** and support single-subcategory lookup by name or GUID.

## Changes

**Commit 1 — migrate off the deprecated resource:**
- `mondoo-windows-security.mql.yaml` — 27 advanced-audit-policy checks: `auditpol.where(subcategoryguid == "<GUID>")` → `windows.auditPolicy.where(guid == "<GUID>")`.
- `content/querypacks/mondoo-windows-inventory.mql.yaml` — the audit-policy inventory query now targets `windows.auditPolicy` with the new field names.

**Commit 2 — select subcategories by name instead of GUID:**
- Each check's `.where(guid == "0CCE9...").list != []` + `.all(...)` pair becomes the single-subcategory accessor keyed by the English subcategory name, e.g. `windows.auditPolicy.subcategory(name: "Credential Validation").success`.
- An absent subcategory reports `success`/`failure` as `false` (not null-erroring), so the accessor **fails** rather than errors when the subcategory is missing — this folds the old `.list != []` existence guard into the assertion, so pass/fail semantics are preserved.
- "Success and Failure" checks become two newline-AND'd datapoints (`.success` then `.failure`) so each condition surfaces independently in scan output.

The subcategory names come from the provider's canonical GUID→name table (`providers/os/resources/windows/auditpol.go`) and were cross-checked against every check's UID. They're matched case-insensitively against the English name, GUID, or localized name, so the checks stay correct on localized Windows installs.

## Notes

- The `auditpol.exe` CLI command in `audit:`/`remediation:` prose (e.g. `auditpol /get /subcategory:{...}`) is the Windows tool, **not** the deprecated MQL resource, and is intentionally left untouched.
- `cnspec policy lint` passes clean on both files with no remaining deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)