### PR TITLE
📝 Require policy summary field with a 130-character limit

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -9,6 +9,7 @@ policies:
   - uid: example-policy
     name: Example Policy
     version: 1.0.0
+    summary: Secure the example service configuration and access controls
     groups:
       - title: Security Checks
         filters: asset.platform == "linux"
@@ -25,6 +26,7 @@ policies:
 **Key concepts**:
 
 - **uid**: Unique identifier for policies, checks, queries.
+- **summary**: Required one-line policy description (≤130 chars). See Formatting requirements.
 - **filters**: MQL expressions that determine applicability.
 - **impact**: Risk score 0-100 for prioritization.
 - **checks**: Scoring queries (pass/fail).
@@ -33,6 +35,7 @@ policies:
 
 ## Formatting requirements
 
+- Every policy must have a `summary:` field — the one-line description shown in policy listings and the marketplace. It is **required** and must be **130 characters or fewer**. Write it verb-first (`Secure`, `Enforce`, `Validate`, `Detect`, `Harden`) followed by the concrete scope, matching the existing policies. Do **not** use em-dashes (`—`, `–`) or `--` in the summary; restructure the sentence instead.
 - All `desc` and `remediation` fields must be valid Markdown (rendered in the UI). Use proper headings, lists, code blocks, links.
 - Check `title` fields must be 75 characters or fewer.
 - Check `title` must match the action enforced by the `mql` query and described in `desc`. If the title says "Ensure X is enabled" the query must assert X is enabled and the description must explain X — don't let titles drift from what the check actually does (e.g., a title about "encryption at rest" paired with a query that inspects TLS settings).

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -1,7 +1,7 @@
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
-  - summary: Harden a Portainer container-management control plane — regular-user container privileges, authentication, RBAC, Edge trust, Kubernetes console, and connection security
+  - summary: Secure Portainer authentication, RBAC, user privileges, Edge trust, and connection settings
     uid: mondoo-portainer-security
     name: Mondoo Portainer Security
     version: 1.0.0

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -13,6 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc
         email: hello@mondoo.com
+    summary: Detect open ports and known vulnerabilities on Shodan-scanned hosts and domains
     docs:
       desc: |-
         The Mondoo Shodan Security policy provides security guidelines for hosts, networks, and IP addresses that are scanned by Shodan, a search engine for internet-connected devices. It confirms Shodan membership status and checks Shodan findings for vulnerabilities and open ports.

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -13,6 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
+    summary: Secure VMware ESXi hosts across access, logging, storage, and networking
     docs:
       desc: |-
         The Mondoo VMware vSphere ESXi Security policy provides security guidelines for VMware ESXi hosts. It covers installation, communication, logging, access control, console, storage, and network configurations to ensure ESXi hosts are hardened against unauthorized access and misconfiguration.

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -13,6 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
+    summary: Secure VMware vSphere virtual machine communication, devices, and logging
     docs:
       desc: |-
         The Mondoo VMware vSphere Security Baseline policy provides security guidelines for virtual machines running on VMware vSphere. It covers communication, device, monitor, and logging configurations to ensure VMs are hardened against unauthorized access and information leakage.


### PR DESCRIPTION
## What

Documents the policy-level `summary:` field in `content/CLAUDE.md` and brings every existing policy into compliance.

### Documentation (`content/CLAUDE.md`)
- New Formatting-requirements rule: `summary:` is **required**, must be **≤130 characters**, written verb-first (`Secure`, `Enforce`, `Validate`, `Detect`, `Harden`), and must **not** use em-dashes (`—`, `–`, `--`).
- Added `summary` to the bundle-structure example and the key-concepts list for discoverability.

### Policy fixes
| Policy | Fix |
|---|---|
| `mondoo-shodan` | added missing summary |
| `mondoo-vmware-vsphere-esxi` | added missing summary |
| `mondoo-vmware-vsphere` | added missing summary |
| `mondoo-portainer-security` | rewrote summary (was 168 chars **and** used an em-dash) |

## Verification
- Full YAML audit across all 63 policies: `missing=0 toolong=0 dash=0`.
- `cnspec policy lint` passes on all four edited bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)