### PR TITLE
🩹 ai-security: surface failing tool details and tighten regexes

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-ai-security
     name: Mondoo AI Security
-    version: 2.0.2
+    version: 2.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -115,9 +115,9 @@ queries:
           return /(?i)(copilot|claude)/
     mql: |
       processes.where(
-        executable == /(?i)(ollama|llama|lmstudio|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|zed|chatgpt)/ &&
+        executable == /(?i)\b(ollama|llama|lmstudio|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|zed|chatgpt)\b/ &&
         executable != props.mondooAiSecurityApprovedProcesses
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Unapproved AI coding agents and local LLM runtimes running as live processes can transmit proprietary source code, customer data, or secrets to untrusted model providers. Only AI tools reviewed and approved by the security team should be permitted to execute on corporate endpoints. The `mondooAiSecurityApprovedProcesses` property defines the allow-list and can be customized for your environment.
@@ -248,9 +248,9 @@ queries:
           return /(?i)(copilot|claude)/
     mql: |
       packages.where(
-        name == /(?i)(ollama|llama-cpp|llama\.cpp|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|chatgpt)/ &&
+        name == /(?i)\b(ollama|llama-cpp|llama\.cpp|lm-studio|localai|gpt4all|cursor|windsurf|codeium|tabby|codex|goose|chatgpt)\b/ &&
         name != props.mondooAiSecurityApprovedPackages
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Unapproved AI tools installed through system package managers such as apt, dnf, rpm, or the Windows uninstall registry remain available even when not actively running. Only AI tools reviewed and approved by the security team should be present on corporate endpoints. The `mondooAiSecurityApprovedPackages` property defines the allow-list and can be customized for your environment.
@@ -354,9 +354,9 @@ queries:
           return /(?i)(copilot|claude)/
     mql: |
       homebrew.packages.where(
-        name == /(?i)(ollama|llama|llama-cpp|lm-studio|localai|gpt4all|cursor|windsurf|codex|chatgpt|goose|codeium|tabby)/ &&
+        name == /(?i)\b(ollama|llama|llama-cpp|lm-studio|localai|gpt4all|cursor|windsurf|codex|chatgpt|goose|codeium|tabby)\b/ &&
         name != props.mondooAiSecurityApprovedHomebrewPackages
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Homebrew is a common installation path for desktop AI applications on macOS, and packages installed this way persist outside the approved software set. Only AI tools reviewed and approved by the security team should be present on corporate endpoints. The `mondooAiSecurityApprovedHomebrewPackages` property defines the allow-list and can be customized for your environment.
@@ -431,7 +431,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      cursor.skills.length == 0 && cursor.mcpServers.length == 0 && cursor.rules.length == 0
+      cursor.skills.none()
+      cursor.mcpServers.none()
+      cursor.rules.none()
     docs:
       desc: |
         Cursor is an AI-native code editor that sends code to cloud AI models for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
@@ -525,7 +527,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      windsurf.skills.length == 0 && windsurf.mcpServers.length == 0 && windsurf.rules.length == 0
+      windsurf.skills.none()
+      windsurf.mcpServers.none()
+      windsurf.rules.none()
     docs:
       desc: |
         Windsurf is an AI-native code editor from Codeium that sends code to cloud AI models for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
@@ -619,7 +623,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      goose.skills.length == 0 && goose.extensions.length == 0
+      goose.skills.none()
+      goose.extensions.none()
     docs:
       desc: |
         Goose is an open-source AI agent from Block that connects to multiple model providers and executes code with full system access through extensions. When it is configured on an endpoint, it can act autonomously on local files and systems. Endpoints should carry only the AI agents approved by the security team.
@@ -701,7 +706,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      zed.extensions.length == 0
+      zed.extensions.none()
     docs:
       desc: |
         Zed is a code editor with built-in AI assistant features that send code to cloud model providers for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
@@ -786,7 +791,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      cline.skills.length == 0
+      cline.skills.none()
     docs:
       desc: |
         Cline is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -874,7 +879,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      roo.skills.length == 0
+      roo.skills.none()
     docs:
       desc: |
         Roo Code is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -959,7 +964,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      continuedev.skills.length == 0
+      continuedev.skills.none()
     docs:
       desc: |
         Continue is an open-source AI coding assistant that connects to a range of cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1044,7 +1049,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      trae.skills.length == 0
+      trae.skills.none()
     docs:
       desc: |
         Trae is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1123,7 +1128,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      opencode.skills.length == 0
+      opencode.skills.none()
     docs:
       desc: |
         OpenCode is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1202,7 +1207,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      kiro.skills.length == 0
+      kiro.skills.none()
     docs:
       desc: |
         Kiro is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1281,7 +1286,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      pi.skills.length == 0
+      pi.skills.none()
     docs:
       desc: |
         Pi is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1358,7 +1363,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      mistral.vibe.skills.length == 0
+      mistral.vibe.skills.none()
     docs:
       desc: |
         Mistral Vibe is an AI coding agent from Mistral that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1435,7 +1440,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      antigravity.skills.length == 0
+      antigravity.skills.none()
     docs:
       desc: |
         Antigravity is an AI coding agent from Google that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1514,7 +1519,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      ibm.bob.skills.length == 0
+      ibm.bob.skills.none()
     docs:
       desc: |
         IBM Bob is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1591,7 +1596,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      openclaw.skills.length == 0
+      openclaw.skills.none()
     docs:
       desc: |
         OpenClaw is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1668,7 +1673,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      snowflake.cortex.skills.length == 0
+      snowflake.cortex.skills.none()
     docs:
       desc: |
         Snowflake Cortex Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1745,7 +1750,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      junie.skills.length == 0
+      junie.skills.none()
     docs:
       desc: |
         Junie is an AI coding agent from JetBrains that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1822,7 +1827,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      augment.skills.length == 0
+      augment.skills.none()
     docs:
       desc: |
         Augment is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -1899,7 +1904,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      warp.skills.length == 0
+      warp.skills.none()
     docs:
       desc: |
         Warp is an AI-powered terminal that sends command history and context to cloud model providers for its AI features. When it is configured on an endpoint, command output and code context can be transmitted to third-party services. Endpoints should carry only the terminals approved by the security team.
@@ -1984,7 +1989,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      kilocode.skills.length == 0
+      kilocode.skills.none()
     docs:
       desc: |
         Kilo Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -2069,7 +2074,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      openhands.skills.length == 0
+      openhands.skills.none()
     docs:
       desc: |
         OpenHands is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -2146,7 +2151,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: false
     mql: |
-      qwen.code.skills.length == 0
+      qwen.code.skills.none()
     docs:
       desc: |
         Qwen Code is an AI coding agent from Alibaba that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
@@ -2232,7 +2237,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)codeium\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Codeium AI coding extensions installed in VS Code-compatible editors transmit source code to cloud AI models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2316,7 +2321,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)tabnine\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Tabnine AI coding extensions installed in VS Code-compatible editors can transmit source code to cloud AI models for completion depending on configuration. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2400,7 +2405,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)supermaven\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Supermaven AI coding extensions installed in VS Code-compatible editors transmit source code to cloud AI models for completion. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2484,7 +2489,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)continue\.continue/
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Continue is an open-source AI coding assistant that connects to a range of LLM providers. When its extension is installed in a VS Code-compatible editor, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2568,7 +2573,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)saoudrizwan\.claude-dev|cline\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Cline, formerly Claude Dev, is an autonomous AI agent that runs as a VS Code extension and can execute code and modify files. When its extension is installed in a VS Code-compatible editor, it can act on local files and send code context to a cloud model provider. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2652,7 +2657,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)sourcegraph\.cody/
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Sourcegraph Cody is an AI coding extension that transmits source code to cloud AI models for completion and chat. When its extension is installed in a VS Code-compatible editor, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2736,7 +2741,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)openai\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Extensions from the OpenAI publisher installed in VS Code-compatible editors, such as the Codex extension `openai.chatgpt`, transmit source code to OpenAI's cloud models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2820,7 +2825,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)anthropic\.claude/
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Anthropic Claude extensions installed in VS Code-compatible editors transmit source code to Anthropic's cloud models for completion and chat. Even where Claude tooling is approved elsewhere, an editor extension that has not been reviewed represents an uninventoried path for code to leave the endpoint. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2904,7 +2909,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)(cursor|anysphere)\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Cursor-specific AI extensions installed in VS Code-compatible editors bring Cursor's AI completion and chat features into editors where they have not been reviewed. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
@@ -2991,7 +2996,7 @@ queries:
     mql: |
       vscode.extensions.where(
         identifier == /(?i)rooveterinaryinc\.roo-cline|roocode\./
-      ).length == 0
+      ).none()
     docs:
       desc: |
         Roo Code is an autonomous AI agent forked from Cline that runs as a VS Code extension and can execute code and modify files. When its extension is installed in a VS Code-compatible editor, it can act on local files and send code context to a cloud model provider. Only AI extensions reviewed and approved by the security team should be installed.
@@ -3081,11 +3086,11 @@ queries:
         mql: |
           return /(?i)^$/
     mql: |
-      claude.code.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
-      openai.codex.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
-      cursor.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
-      github.copilot.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
-      windsurf.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers) &&
+      claude.code.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
+      openai.codex.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
+      cursor.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
+      github.copilot.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
+      windsurf.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
       gemini.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
     docs:
       desc: |
@@ -3182,8 +3187,8 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       processes.where(
-        executable == /(?i)(ollama|llama|lmstudio|lm-studio|localai|gpt4all)/
-      ).length == 0
+        executable == /(?i)\b(ollama|llama|lmstudio|lm-studio|localai|gpt4all)\b/
+      ).none()
     docs:
       desc: |
         Local LLM inference runtimes such as Ollama, LM Studio, llama.cpp, LocalAI, GPT4All, and Jan run model inference directly on the endpoint. While they keep prompts off remote APIs, they still allow data to be processed outside approved channels and can carry licensing exposure from the model weights they load. Endpoints should run only the LLM runtimes approved by the security team.


### PR DESCRIPTION
## What

Improves the `mondoo-ai-security` policy so that **failing checks report which AI tools caused the failure**, not just a count. Also tightens the aggregate regexes to remove substring false positives.

## Why

Previously every check reduced to a count or a bare boolean, so a failing scan gave no actionable detail:

- `processes.where(...).length == 0` → `expected: == 0, actual: 45` (just a number)
- `cursor.skills.length == 0 && cursor.mcpServers.length == 0 && ...` → `[failed] false && false` (nothing)
- The 6-agent MCP check `A && B && ... && F` → collapsed to `false && false...`, hiding which agent had the unapproved server

## Changes

**Surface failing details** (semantics unchanged — a check passes exactly when it did before; only the rendered detail on failure improves):

1. **Filtered-list checks** (processes, packages, homebrew, 10× vscode extensions, local LLM runtimes): `.where(...).length == 0` → `.where(...).none()`. On failure cnspec dumps the matching resources with their curated default fields (e.g. extension `editor`/`name`/`identifier`/`version`, process `executable`/`pid`).
2. **Editor/agent-config checks** (cursor, windsurf, goose + ~25 single-list agents): compound `&&` chains split into newline-AND statements, each `.none()`, so each list surfaces its offending entries as a separate datapoint.
3. **MCP governance check**: the 6-way `&&` split into six per-agent `.none(predicate)` lines. A failing scan now attributes the offending servers to the responsible agent (e.g. `claude.code`) while the others report `[ok]`.

**Tighten regexes**: anchored the four aggregate name/executable regexes with word boundaries (`\b...\b`). This drops substring false positives such as `libxcursor` matching `cursor` and `mongoose` matching `goose`, while still matching real tools and hyphenated variants (`ollama-app`, `lm-studio`, `llama.cpp`).

Policy version bumped `2.0.2` → `2.1.0`.

## Testing

- `cnspec policy lint ./content/mondoo-ai-security.mql.yaml` passes.
- Verified against a live `cnspec scan local` that failing checks now render the offending tool list (confirmed with real `vscode.extensions` and `claude.code.mcpServers` on the endpoint).
- Confirmed the Homebrew check no longer flags `libxcursor`, and that `\b`-anchored regexes still match real tool names / variants and reject collateral (`mongoose`, `libxcursor`, `xcursor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)