### PR TITLE
🧹 digitalocean: rework GradientAI agent checks to per-resource platform

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.3.0
+    version: 2.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -3958,7 +3958,7 @@ queries:
   # GradientAI agent or its deployment visibility, so there is nothing to assert in HCL,
   # plan, or state.
   - uid: mondoo-digitalocean-security-gradientai-agent-not-publicly-deployed
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-gradientai-agent"
     title: Ensure GradientAI agents are not deployed with public visibility
     impact: 80
     tags:
@@ -3976,7 +3976,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      digitalocean.gradientai.agents.all(deploymentVisibility != "VISIBILITY_PUBLIC")
+      digitalocean.gradientai.agent.deploymentVisibility != "VISIBILITY_PUBLIC"
     docs:
       desc: |
         This check ensures that no GradientAI agent is deployed with public visibility. An agent deployed with `VISIBILITY_PUBLIC` exposes its chat endpoint to anyone with the URL, with no authentication, allowing unauthenticated users to interact with the agent and the data and tools it can reach.
@@ -4036,7 +4036,7 @@ queries:
   # panel; the digitalocean Terraform provider has no resource representing an agent or its
   # attached guardrails, so there is nothing to assert in HCL, plan, or state.
   - uid: mondoo-digitalocean-security-gradientai-agent-has-guardrails
-    filters: asset.platform == "digitalocean"
+    filters: asset.platform == "digitalocean-gradientai-agent"
     title: Ensure GradientAI agents have a content guardrail attached
     impact: 60
     tags:
@@ -4054,7 +4054,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
     mql: |
-      digitalocean.gradientai.agents.all(guardrails.where(isAttached == true).length > 0)
+      digitalocean.gradientai.agent.guardrails.where(isAttached == true).length > 0
     docs:
       desc: |
         This check ensures that every GradientAI agent has at least one content guardrail attached. Guardrails inspect the prompts an agent receives and the responses it returns, blocking content that violates the configured policy and returning a canned response instead. An agent with no attached guardrail applies no content filtering to its inputs or outputs.


### PR DESCRIPTION
## What

Reworks the two DigitalOcean GradientAI agent checks to use the new per-resource `digitalocean-gradientai-agent` asset platform introduced in [mondoohq/mql#9014](https://github.com/mondoohq/mql/pull/9014).

Previously these checks filtered on the broad `asset.platform == "digitalocean"` and iterated `digitalocean.gradientai.agents` with `.all(...)`. Now each agent is discovered as its own asset, so the checks filter on `asset.platform == "digitalocean-gradientai-agent"` and query the singular `digitalocean.gradientai.agent` resource directly. The `.all(pred)` over the collection collapses to `pred` on the single agent.

## Checks reworked

| Check | Before | After |
|---|---|---|
| `gradientai-agent-not-publicly-deployed` | `digitalocean.gradientai.agents.all(deploymentVisibility != "VISIBILITY_PUBLIC")` | `digitalocean.gradientai.agent.deploymentVisibility != "VISIBILITY_PUBLIC"` |
| `gradientai-agent-has-guardrails` | `digitalocean.gradientai.agents.all(guardrails.where(isAttached == true).length > 0)` | `digitalocean.gradientai.agent.guardrails.where(isAttached == true).length > 0` |

Both are standalone checks (no `variants:` block), so only their `filters:` and `mql:` change. Policy version bumped 2.3.0 → 2.4.0.

## Testing

- `cnspec policy lint ./content/mondoo-digitalocean-security.mql.yaml` — valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)