### PR TITLE
🧹 oci: rework Generative AI endpoint checks to per-resource platform

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.2.0
+    version: 4.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -11497,11 +11497,9 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    filters: asset.platform == "oci"
+    filters: asset.platform == "oci-ai-generativeai-endpoint"
     mql: |
-      oci.ai.generativeAi.endpoints.all(
-        promptInjectionEnabled == true
-      )
+      oci.ai.generativeAi.endpoint.promptInjectionEnabled == true
     docs:
       desc: |
         This check ensures that every OCI Generative AI endpoint has prompt injection detection enabled. Prompt injection detection inspects incoming prompts for adversarial instructions that attempt to override the model's guardrails, exfiltrate system prompts, or coerce the model into unintended actions. Without it, an endpoint processes crafted prompts with no defense against instruction-hijacking attacks.
@@ -11574,11 +11572,9 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    filters: asset.platform == "oci"
+    filters: asset.platform == "oci-ai-generativeai-endpoint"
     mql: |
-      oci.ai.generativeAi.endpoints.all(
-        piiDetectionEnabled == true
-      )
+      oci.ai.generativeAi.endpoint.piiDetectionEnabled == true
     docs:
       desc: |
         This check ensures that every OCI Generative AI endpoint has personally identifiable information detection enabled. PII detection inspects prompts and responses for sensitive personal data such as names, government identifiers, and financial details. Without it, an endpoint can echo or leak sensitive data supplied in prompts or produced by the model into logs and downstream systems.
@@ -11651,11 +11647,9 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    filters: asset.platform == "oci"
+    filters: asset.platform == "oci-ai-generativeai-endpoint"
     mql: |
-      oci.ai.generativeAi.endpoints.all(
-        contentModerationEnabled == true
-      )
+      oci.ai.generativeAi.endpoint.contentModerationEnabled == true
     docs:
       desc: |
         This check ensures that every OCI Generative AI endpoint has content moderation enabled. Content moderation screens prompts and responses for harmful, abusive, or policy-violating content. Without it, an endpoint can be driven to generate disallowed output or be abused to produce harmful material at scale.
@@ -11728,11 +11722,9 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    filters: asset.platform == "oci"
+    filters: asset.platform == "oci-ai-generativeai-endpoint"
     mql: |
-      oci.ai.generativeAi.endpoints.all(
-        generativeAiPrivateEndpointID != empty
-      )
+      oci.ai.generativeAi.endpoint.generativeAiPrivateEndpointID != empty
     docs:
       desc: |
         This check ensures that every OCI Generative AI endpoint is reached through a Generative AI private endpoint. A private endpoint keeps inference traffic on the customer's private network rather than traversing the public internet. Without one, prompts and responses, which frequently contain sensitive business data, travel over public paths and the endpoint is reachable from outside the private network.


### PR DESCRIPTION
## What

Reworks the four OCI Generative AI endpoint checks to use the new per-resource `oci-ai-generativeai-endpoint` asset platform introduced in [mondoohq/mql#9010](https://github.com/mondoohq/mql/pull/9010).

Previously these checks filtered on the broad `asset.platform == "oci"` and iterated `oci.ai.generativeAi.endpoints` with `.all(...)`. Now each endpoint is discovered as its own asset, so the checks filter on `asset.platform == "oci-ai-generativeai-endpoint"` and query the singular `oci.ai.generativeAi.endpoint` resource directly. The `.all(pred)` over the collection collapses to `pred` on the single endpoint.

## Checks reworked

All four are standalone checks (each already carries a `# No Terraform variants:` comment), so only their `filters:` and `mql:` change:

- `genai-endpoint-prompt-injection-detection` → `oci.ai.generativeAi.endpoint.promptInjectionEnabled == true`
- `genai-endpoint-pii-detection` → `oci.ai.generativeAi.endpoint.piiDetectionEnabled == true`
- `genai-endpoint-content-moderation` → `oci.ai.generativeAi.endpoint.contentModerationEnabled == true`
- `genai-endpoint-private-endpoint` → `oci.ai.generativeAi.endpoint.generativeAiPrivateEndpointID != empty`

Policy version bumped 4.2.0 → 4.3.0.

## Testing

- `cnspec policy lint ./content/mondoo-oci-security.mql.yaml` — valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)