### PR TITLE
🧹 azure: rework Managed HSM and IoT hub checks to per-resource platforms

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.4.0
+    version: 9.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -34494,7 +34494,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-managed-hsm-soft-delete-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-managed-hsm-soft-delete-terraform-hcl
         tags:
@@ -34596,12 +34596,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/soft-delete-overview
         title: Managed HSM soft delete overview
   - uid: mondoo-azure-security-managed-hsm-soft-delete-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-keyvault-managedhsm"
     mql: |
-      azure.subscription.keyVault.managedHsms.all(
-        enableSoftDelete == true
-      )
+      azure.subscription.keyVaultService.managedHsm.enableSoftDelete == true
   - uid: mondoo-azure-security-managed-hsm-soft-delete-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module")
     mql: |
@@ -34646,7 +34643,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-managed-hsm-purge-protection-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-managed-hsm-purge-protection-terraform-hcl
         tags:
@@ -34755,12 +34752,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/soft-delete-overview
         title: Managed HSM soft delete and purge protection
   - uid: mondoo-azure-security-managed-hsm-purge-protection-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-keyvault-managedhsm"
     mql: |
-      azure.subscription.keyVault.managedHsms.all(
-        enablePurgeProtection == true
-      )
+      azure.subscription.keyVaultService.managedHsm.enablePurgeProtection == true
   - uid: mondoo-azure-security-managed-hsm-purge-protection-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module")
     mql: |
@@ -34805,7 +34799,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-managed-hsm-public-access-disabled-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-managed-hsm-public-access-disabled-terraform-hcl
         tags:
@@ -34906,12 +34900,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/private-link
         title: Integrate Managed HSM with Azure Private Link
   - uid: mondoo-azure-security-managed-hsm-public-access-disabled-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-keyvault-managedhsm"
     mql: |
-      azure.subscription.keyVault.managedHsms.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.keyVaultService.managedHsm.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-managed-hsm-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module")
     mql: |
@@ -34956,7 +34947,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-managed-hsm-private-endpoints-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-managed-hsm-private-endpoints-terraform-hcl
         tags:
@@ -35083,12 +35074,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/private-link
         title: Integrate Managed HSM with Azure Private Link
   - uid: mondoo-azure-security-managed-hsm-private-endpoints-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-keyvault-managedhsm"
     mql: |
-      azure.subscription.keyVault.managedHsms.all(
-        privateEndpointConnections.length > 0
-      )
+      azure.subscription.keyVaultService.managedHsm.privateEndpointConnections.length > 0
   - uid: mondoo-azure-security-managed-hsm-private-endpoints-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_private_endpoint")
     mql: |
@@ -42841,12 +42829,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/iot-hub/authenticate-authorize-azure-ad
         title: Control access to IoT Hub by using Microsoft Entra ID
   - uid: mondoo-azure-security-iot-hub-local-auth-disabled-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-iot-iothub"
     mql: |
-      azure.subscription.iot.iotHubs.all(
-        disableLocalAuth == true
-      )
+      azure.subscription.iotService.iotHub.disableLocalAuth == true
   - uid: mondoo-azure-security-iot-hub-local-auth-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
     mql: |
@@ -42993,12 +42978,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-public-network-access
         title: Manage public network access for your IoT hub
   - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-iot-iothub"
     mql: |
-      azure.subscription.iot.iotHubs.all(
-        publicNetworkAccess == "Disabled"
-      )
+      azure.subscription.iotService.iotHub.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-iot-hub-public-network-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
     mql: |
@@ -43147,10 +43129,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-tls-support
         title: Transport Layer Security (TLS) support in Azure IoT Hub
   - uid: mondoo-azure-security-iot-hub-min-tls-1-2-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-iot-iothub"
     mql: |
-      azure.subscription.iot.iotHubs.all(minTlsVersion == "1.2")
+      azure.subscription.iotService.iotHub.minTlsVersion == "1.2"
   - uid: mondoo-azure-security-iot-hub-min-tls-1-2-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
     mql: |
@@ -43308,10 +43289,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/iot-hub/monitor-iot-hub
         title: Monitor Azure IoT Hub
   - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled-azure
-    filters: |
-      asset.platform == "azure"
+    filters: asset.platform == "azure-iot-iothub"
     mql: |
-      azure.subscription.iot.iotHubs.all(diagnosticSettings != empty)
+      azure.subscription.iotService.iotHub.diagnosticSettings != empty
   # No Terraform variant: the Azure check requires every IoT hub to have a diagnostic
   # setting (iotHubs.all(diagnosticSettings != empty)). In HCL a diagnostic setting is a
   # separate azurerm_monitor_diagnostic_setting resource linked to a hub only by an opaque


### PR DESCRIPTION
## What

Reworks the runtime (`-azure`) variants of the Azure Managed HSM and IoT hub checks to use the new per-resource asset platforms introduced in [mondoohq/mql#9011](https://github.com/mondoohq/mql/pull/9011):

- `azure-keyvault-managedhsm` → `azure.subscription.keyVaultService.managedHsm`
- `azure-iot-iothub` → `azure.subscription.iotService.iotHub`

Previously these variants filtered on the broad `asset.platform == "azure"` and iterated `azure.subscription.keyVault.managedHsms` / `azure.subscription.iot.iotHubs` with `.all(...)`. Now each Managed HSM and each IoT hub is discovered as its own asset, so the variant filters on the specific platform and queries the singular resource directly. The `.all(pred)` over the collection collapses to `pred` on the single resource.

## Checks reworked (8 runtime variants)

**Managed HSM** (`azure-keyvault-managedhsm`)
- `managed-hsm-soft-delete` → `...managedHsm.enableSoftDelete == true`
- `managed-hsm-purge-protection` → `...managedHsm.enablePurgeProtection == true`
- `managed-hsm-public-access-disabled` → `...managedHsm.publicNetworkAccess == "Disabled"`
- `managed-hsm-private-endpoints` → `...managedHsm.privateEndpointConnections.length > 0`

**IoT hub** (`azure-iot-iothub`)
- `iot-hub-local-auth-disabled` → `...iotHub.disableLocalAuth == true`
- `iot-hub-public-network-access-disabled` → `...iotHub.publicNetworkAccess == "Disabled"`
- `iot-hub-min-tls-1-2` → `...iotHub.minTlsVersion == "1.2"`
- `iot-hub-diagnostic-settings-enabled` → `...iotHub.diagnosticSettings != empty`

Only the `-azure` runtime variants change. The Terraform HCL/plan/state and Bicep variants are untouched. The four Managed HSM variants' `mondoo.com/filter-title` tags were corrected from the generic "Azure Subscription" to "Azure Key Vault Managed HSM" (the IoT variants already used "Azure IoT Hub"). Policy version bumped 9.4.0 → 9.5.0.

## Testing

- `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` — valid (only pre-existing, unrelated deprecated-field warnings on batch/datafactory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)