### PR TITLE
🧹 gcp: rework Model Armor and Datastream checks to per-resource platforms

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.7.0
+    version: 9.7.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -27778,7 +27778,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-terraform-hcl
         tags:
@@ -27868,11 +27868,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        filterConfig['piAndJailbreakFilterSettings']['filterEnforcement'] == "ENABLED"
-      )
+      gcp.project.modelArmorService.template.filterConfig['piAndJailbreakFilterSettings']['filterEnforcement'] == "ENABLED"
   - uid: mondoo-gcp-security-model-armor-pi-jailbreak-filter-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -27923,7 +27921,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-terraform-hcl
         tags:
@@ -28010,11 +28008,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        filterConfig['maliciousUriFilterSettings']['filterEnforcement'] == "ENABLED"
-      )
+      gcp.project.modelArmorService.template.filterConfig['maliciousUriFilterSettings']['filterEnforcement'] == "ENABLED"
   - uid: mondoo-gcp-security-model-armor-malicious-uri-filter-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -28065,7 +28061,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-filters-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-rai-filters-terraform-hcl
         tags:
@@ -28171,11 +28167,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-rai-filters-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        filterConfig['raiSettings']['raiFilters'] != empty
-      )
+      gcp.project.modelArmorService.template.filterConfig['raiSettings']['raiFilters'] != empty
   - uid: mondoo-gcp-security-model-armor-rai-filters-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -28228,7 +28222,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-sdp-enabled-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-sdp-enabled-terraform-hcl
         tags:
@@ -28326,11 +28320,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-sdp-enabled-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        filterConfig['sdpSettings'] != empty
-      )
+      gcp.project.modelArmorService.template.filterConfig['sdpSettings'] != empty
   - uid: mondoo-gcp-security-model-armor-sdp-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -28374,7 +28366,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-blocking-mode-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-blocking-mode-terraform-hcl
         tags:
@@ -28463,11 +28455,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-blocking-mode-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        templateMetadata['enforcementType'] != "INSPECT_ONLY"
-      )
+      gcp.project.modelArmorService.template.templateMetadata['enforcementType'] != "INSPECT_ONLY"
   - uid: mondoo-gcp-security-model-armor-blocking-mode-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -28508,7 +28498,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-sanitize-logging-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-sanitize-logging-terraform-hcl
         tags:
@@ -28593,11 +28583,9 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-sanitize-logging-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        templateMetadata['logSanitizeOperations'] == true
-      )
+      gcp.project.modelArmorService.template.templateMetadata['logSanitizeOperations'] == true
   - uid: mondoo-gcp-security-model-armor-sanitize-logging-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
     mql: |
@@ -28639,7 +28627,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-model-armor-rai-confidence-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Model Armor Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-model-armor-rai-confidence-terraform-hcl
         tags:
@@ -28746,12 +28734,10 @@ queries:
       - url: https://cloud.google.com/security/products/model-armor
         title: Google Cloud Model Armor overview
   - uid: mondoo-gcp-security-model-armor-rai-confidence-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-modelarmor-template'
     mql: |
-      gcp.project.modelArmor.templates.all(
-        filterConfig['raiSettings']['raiFilters'].all(
-          _['confidenceLevel'] != "HIGH"
-        )
+      gcp.project.modelArmorService.template.filterConfig['raiSettings']['raiFilters'].all(
+        _['confidenceLevel'] != "HIGH"
       )
   - uid: mondoo-gcp-security-model-armor-rai-confidence-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "google_model_armor_template")
@@ -31332,7 +31318,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Datastream Connection Profile
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-terraform-hcl
         tags:
@@ -31433,9 +31419,9 @@ queries:
       - url: https://cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-datastream-connectionprofile'
     mql: |
-      gcp.datastream.connectionProfiles.all(connectivityType != "staticServiceIp")
+      gcp.project.datastreamService.connectionProfile.connectivityType != "staticServiceIp"
   - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_datastream_connection_profile')
@@ -31479,7 +31465,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Datastream Connection Profile
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-terraform-hcl
         tags:
@@ -31567,9 +31553,9 @@ queries:
       - url: https://cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-datastream-connectionprofile'
     mql: |
-      gcp.datastream.connectionProfiles.all(connectivityType != "forwardSsh")
+      gcp.project.datastreamService.connectionProfile.connectivityType != "forwardSsh"
   - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_datastream_connection_profile')
@@ -31613,7 +31599,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
         tags:
-          mondoo.com/filter-title: GCP Project
+          mondoo.com/filter-title: GCP Datastream Connection Profile
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-terraform-hcl
         tags:
@@ -31723,14 +31709,14 @@ queries:
       - url: https://cloud.google.com/datastream/docs/configure-your-source-database
         title: Configure your Datastream source database (Secret Manager)
   - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-datastream-connectionprofile'
     mql: |
-      gcp.datastream.connectionProfiles.where(
-        profileType == "mysql" || profileType == "postgresql" || profileType == "sqlserver" || profileType == "oracle"
-      ).all(
-        profile["secretManagerStoredPassword"] != null &&
-        profile["secretManagerStoredPassword"] != ""
-      )
+      gcp.project.datastreamService.connectionProfile.profileType != "mysql" &&
+      gcp.project.datastreamService.connectionProfile.profileType != "postgresql" &&
+      gcp.project.datastreamService.connectionProfile.profileType != "sqlserver" &&
+      gcp.project.datastreamService.connectionProfile.profileType != "oracle" ||
+      gcp.project.datastreamService.connectionProfile.profile["secretManagerStoredPassword"] != null &&
+      gcp.project.datastreamService.connectionProfile.profile["secretManagerStoredPassword"] != ""
   - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_datastream_connection_profile')
@@ -31979,13 +31965,12 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-datastream-connectionprofile'
     mql: |
-      gcp.datastream.connectionProfiles.where(profileType == "gcs").all(
-        bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
-        bucket.iamConfiguration["publicAccessPrevention"] == "enforced" &&
-        bucket.defaultKmsKey != null
-      )
+      gcp.project.datastreamService.connectionProfile.profileType != "gcs" ||
+      gcp.project.datastreamService.connectionProfile.bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
+      gcp.project.datastreamService.connectionProfile.bucket.iamConfiguration["publicAccessPrevention"] == "enforced" &&
+      gcp.project.datastreamService.connectionProfile.bucket.defaultKmsKey != null
     docs:
       desc: |
         This check ensures that Cloud Storage buckets used as Datastream GCS destinations have three controls in place: uniform bucket-level access enabled, public access prevention enforced, and CMEK configured. A Datastream GCS destination receives a continuously-updated mirror of the source database, so a bucket that is weaker than the source database's own controls undermines the overall data protection posture.


### PR DESCRIPTION
## What

Reworks the runtime (`-gcp`) variants of the GCP Model Armor and Datastream connection-profile checks to use the new per-resource asset platforms introduced in [mondoohq/mql#9012](https://github.com/mondoohq/mql/pull/9012):

- `gcp-modelarmor-template` → `gcp.project.modelArmorService.template`
- `gcp-datastream-connectionprofile` → `gcp.project.datastreamService.connectionProfile`

Previously these variants filtered on the broad `gcp` / `gcp-project` platform and iterated `gcp.project.modelArmor.templates` / `gcp.datastream.connectionProfiles` with `.all(...)` / `.where(...).all(...)`. Now each template and each connection profile is discovered as its own asset, so the variant filters on the specific platform and queries the singular resource directly.

## Translation semantics

- Bare `.all(pred)` collapses to `pred` on the single resource.
- `.where(P).all(Q)` collapses to the guard form **`!P || Q`** so the `.where()` predicate's scope is preserved (e.g. `datastream-gcs-destination-bucket-hardened` only asserts on `gcs` profiles: `connectionProfile.profileType != "gcs" || <hardening>`). MQL binds `&&` tighter than `||`, so no parens are needed (and MQL forbids paren grouping).
- The nested inner `.all()` in `model-armor-rai-confidence` (over the `raiFilters` field) stays as-is — that field is still a collection on the single template.

## Checks reworked (11 runtime variants)

**Model Armor** (`gcp-modelarmor-template`): pi-jailbreak-filter, malicious-uri-filter, rai-filters, sdp-enabled, blocking-mode, sanitize-logging, rai-confidence

**Datastream** (`gcp-datastream-connectionprofile`): no-static-service-ip-connectivity, no-forward-ssh-connectivity, source-uses-secret-manager-password, gcs-destination-bucket-hardened

Only the runtime variants change; the Terraform HCL/plan/state variants are untouched. The variants' `mondoo.com/filter-title` tags were made resource-specific ("GCP Model Armor Template" / "GCP Datastream Connection Profile"). Policy version bumped 9.7.0 → 9.7.1.

## Testing

- `cnspec policy lint ./content/mondoo-gcp-security.mql.yaml` — valid policy bundle, no warnings.
- Rebased onto current `main`. The conflicts were this PR's own retargeting against #3128/#3137, which had since repointed these same checks from the bare `gcp` platform to `gcp-project`; resolved in favour of the per-resource platforms, leaving the 11 runtime variants split 7 Model Armor / 4 Datastream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
