### PR TITLE
🧹 aws: rework six services' checks to per-resource asset platforms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -30388,7 +30388,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS AppStream Fleet"
           mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-terraform-hcl
         tags:
@@ -30513,9 +30513,9 @@ queries:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/internet-access.html
         title: Internet access for Amazon AppStream 2.0
   - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-appstream-fleet"
     mql: |
-      aws.appstream.fleets.all(enableDefaultInternetAccess == false)
+      aws.appstream.fleet.enableDefaultInternetAccess == false
   - uid: mondoo-aws-security-appstream-fleet-no-default-internet-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appstream_fleet")
     mql: |
@@ -30560,7 +30560,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS AppStream Fleet"
           mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-hcl
         tags:
@@ -30664,9 +30664,9 @@ queries:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/fleets-and-stacks.html
         title: Amazon AppStream 2.0 fleets and stacks
   - uid: mondoo-aws-security-appstream-fleet-max-session-duration-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-appstream-fleet"
     mql: |
-      aws.appstream.fleets.all(maxUserDurationInSeconds <= 36000)
+      aws.appstream.fleet.maxUserDurationInSeconds <= 36000
   - uid: mondoo-aws-security-appstream-fleet-max-session-duration-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appstream_fleet")
     mql: |
@@ -30711,7 +30711,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS AppStream Fleet"
           mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-terraform-hcl
         tags:
@@ -30817,11 +30817,9 @@ queries:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/fleets-and-stacks.html
         title: Amazon AppStream 2.0 fleets and stacks
   - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-appstream-fleet"
     mql: |
-      aws.appstream.fleets.all(
-        idleDisconnectTimeoutInSeconds > 0 && idleDisconnectTimeoutInSeconds <= 900
-      )
+      aws.appstream.fleet.idleDisconnectTimeoutInSeconds > 0 && aws.appstream.fleet.idleDisconnectTimeoutInSeconds <= 900
   - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_appstream_fleet")
     mql: |
@@ -31140,7 +31138,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-directoryservice-os-version-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Directory Service Directory"
           mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-directoryservice-os-version-terraform-hcl
         tags:
@@ -31255,11 +31253,11 @@ queries:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_directory_maintenance.html
         title: AWS Managed Microsoft AD directory maintenance
   - uid: mondoo-aws-security-directoryservice-os-version-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-directoryservice-directory"
     mql: |
-      aws.directoryservice.directories.where(stage == "Active" && type == "MicrosoftAD").all(
-        osVersion != "SERVER_2012"
-      )
+      aws.directoryservice.directory.stage != "Active" ||
+      aws.directoryservice.directory.type != "MicrosoftAD" ||
+      aws.directoryservice.directory.osVersion != "SERVER_2012"
   - uid: mondoo-aws-security-directoryservice-os-version-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_directory_service_directory")
     mql: |
@@ -31299,7 +31297,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-directoryservice-sso-enabled-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Directory Service Directory"
           mondoo.com/filter-icon: "aws"
     docs:
       desc: |
@@ -31373,11 +31371,11 @@ queries:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_single_sign_on.html
         title: Single sign-on for AWS Managed Microsoft AD
   - uid: mondoo-aws-security-directoryservice-sso-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-directoryservice-directory"
     mql: |
-      aws.directoryservice.directories.where(stage == "Active" && type != "ADConnector").all(
-        ssoEnabled == true
-      )
+      aws.directoryservice.directory.stage != "Active" ||
+      aws.directoryservice.directory.type == "ADConnector" ||
+      aws.directoryservice.directory.ssoEnabled == true
   # No Terraform variants: RADIUS MFA is enabled via the `EnableRadius` API and the `aws_directory_service_directory` resource exposes no `radius_*` arguments. There is no Terraform analog for this configuration.
   - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled
     title: Ensure Directory Service Managed AD has RADIUS MFA enabled
@@ -31399,7 +31397,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS Directory Service Directory"
           mondoo.com/filter-icon: "aws"
     docs:
       desc: |
@@ -31502,11 +31500,11 @@ queries:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_mfa.html
         title: Enable multi-factor authentication for AWS Managed Microsoft AD
   - uid: mondoo-aws-security-directoryservice-radius-mfa-enabled-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-directoryservice-directory"
     mql: |
-      aws.directoryservice.directories.where(stage == "Active" && type == "MicrosoftAD").all(
-        radiusStatus == "Completed"
-      )
+      aws.directoryservice.directory.stage != "Active" ||
+      aws.directoryservice.directory.type != "MicrosoftAD" ||
+      aws.directoryservice.directory.radiusStatus == "Completed"
   - uid: mondoo-aws-security-documentdb-cluster-encrypted
     title: Ensure DocumentDB clusters are encrypted at rest
     impact: 90
@@ -31876,7 +31874,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS DocumentDB Instance
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-terraform-hcl
         tags:
@@ -31989,8 +31987,8 @@ queries:
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-modify.html
         title: Modifying an Amazon DocumentDB Instance
   - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-aws
-    filters: asset.platform == "aws"
-    mql: aws.documentdb.instances.all(autoMinorVersionUpgrade == true)
+    filters: asset.platform == "aws-documentdb-instance"
+    mql: aws.documentdb.instance.autoMinorVersionUpgrade == true
   - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster_instance")
     mql: |
@@ -32035,7 +32033,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS DocumentDB Instance
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-hcl
         tags:
@@ -32187,8 +32185,8 @@ queries:
       - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/docdb/modify-db-instance.html
         title: AWS CLI Command Reference - docdb modify-db-instance
   - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
-    filters: asset.platform == "aws"
-    mql: aws.documentdb.instances.all(publiclyAccessible == false)
+    filters: asset.platform == "aws-documentdb-instance"
+    mql: aws.documentdb.instance.publiclyAccessible == false
   - uid: mondoo-aws-security-documentdb-instance-public-access-check-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_docdb_cluster_instance")
     mql: |
@@ -32218,9 +32216,9 @@ queries:
   - uid: mondoo-aws-security-documentdb-instance-not-internet-reachable
     title: Ensure DocumentDB instances are not reachable from the internet
     impact: 85
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-documentdb-instance"
     mql: |
-      aws.documentdb.instances.all( exposure.internetReachable == false )
+      aws.documentdb.instance.exposure.internetReachable == false
     docs:
       desc: |
         This check ensures that Amazon DocumentDB instances are not directly reachable from the internet. The `internetReachable` verdict combines the instance's publicly-accessible flag with the ingress rules of its attached security groups, so an instance is flagged only when AWS resolves its endpoint to a public address *and* a security group permits inbound traffic from the internet. This surfaces databases that are genuinely accessible from arbitrary hosts, rather than every instance that merely carries the public-access flag behind a closed security group.
@@ -34592,7 +34590,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Athena Workgroup
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-terraform-hcl
         tags:
@@ -34708,11 +34706,10 @@ queries:
       - url: https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html
         title: Workgroup settings override client-side settings
   - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-athena-workgroup"
     mql: |
-      aws.athena.workgroups.where(state == "ENABLED").all(
-        enforceWorkGroupConfiguration == true
-      )
+      aws.athena.workgroup.state != "ENABLED" ||
+      aws.athena.workgroup.enforceWorkGroupConfiguration == true
   - uid: mondoo-aws-security-athena-workgroup-enforce-configuration-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_athena_workgroup")
     mql: |
@@ -34760,7 +34757,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Athena Workgroup
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-hcl
         tags:
@@ -34896,9 +34893,10 @@ queries:
       - url: https://docs.aws.amazon.com/athena/latest/ug/encrypting-query-results-stored-in-s3.html
         title: Encrypting Athena query results stored in Amazon S3
   - uid: mondoo-aws-security-athena-workgroup-results-encrypted-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-athena-workgroup"
     mql: |
-      aws.athena.workgroups.where(state == "ENABLED").all(encrypted == true)
+      aws.athena.workgroup.state != "ENABLED" ||
+      aws.athena.workgroup.encrypted == true
   - uid: mondoo-aws-security-athena-workgroup-results-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_athena_workgroup")
     mql: |
@@ -67865,7 +67863,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-batch-no-privileged-containers-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Batch Job Definition
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-batch-no-privileged-containers-cloudformation
         tags:
@@ -67986,12 +67984,11 @@ queries:
       - url: https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html
         title: Batch job definition parameters
   - uid: mondoo-aws-security-batch-no-privileged-containers-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-batch-jobdefinition"
     mql: |
-      aws.batch.jobDefinitions.where(status == "ACTIVE").none(
-        container.privileged == true ||
-        nodeRangeProperties.any(container.privileged == true)
-      )
+      aws.batch.jobDefinition.status != "ACTIVE" ||
+      aws.batch.jobDefinition.container.privileged != true &&
+      aws.batch.jobDefinition.nodeRangeProperties.any(container.privileged == true) == false
   - uid: mondoo-aws-security-batch-no-privileged-containers-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Batch::JobDefinition")
     mql: |
@@ -68019,7 +68016,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-batch-approved-image-registry-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Batch Job Definition
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-batch-approved-image-registry-cloudformation
         tags:
@@ -68142,13 +68139,12 @@ queries:
       - url: https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html
         title: AWS Batch job definitions
   - uid: mondoo-aws-security-batch-approved-image-registry-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-batch-jobdefinition"
     mql: |
-      aws.batch.jobDefinitions.where(status == "ACTIVE").none(
-        images.any(_['registry'] == "docker.io" ||
-                   _['registry'] == "registry.hub.docker.com" ||
-                   _['registry'] == "public.ecr.aws")
-      )
+      aws.batch.jobDefinition.status != "ACTIVE" ||
+      aws.batch.jobDefinition.images.any(_['registry'] == "docker.io" ||
+        _['registry'] == "registry.hub.docker.com" ||
+        _['registry'] == "public.ecr.aws") == false
   - uid: mondoo-aws-security-batch-approved-image-registry-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Batch::JobDefinition")
     mql: |
@@ -68318,7 +68314,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-batch-job-role-no-wildcards-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Batch Job Definition
           mondoo.com/filter-icon: aws
     docs:
       desc: |
@@ -68459,16 +68455,17 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html
         title: IAM security best practices
   - uid: mondoo-aws-security-batch-job-role-no-wildcards-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-batch-jobdefinition"
     mql: |
-      aws.batch.jobDefinitions.where(status == "ACTIVE" && container != null && container.jobRole != null).all(
-        container.jobRole.inlinePolicies.length == 0 &&
-        container.jobRole.attachedPolicies.all(
-          defaultVersion.document['Statement'].all(
-            _['Effect'].upcase == "DENY" ||
-            [_['Resource']].flat.none(_ == "*") &&
-            [_['Action']].flat.none(_ == "*")
-          )
+      aws.batch.jobDefinition.status != "ACTIVE" ||
+      aws.batch.jobDefinition.container == null ||
+      aws.batch.jobDefinition.container.jobRole == null ||
+      aws.batch.jobDefinition.container.jobRole.inlinePolicies.length == 0 &&
+      aws.batch.jobDefinition.container.jobRole.attachedPolicies.all(
+        defaultVersion.document['Statement'].all(
+          _['Effect'].upcase == "DENY" ||
+          [_['Resource']].flat.none(_ == "*") &&
+          [_['Action']].flat.none(_ == "*")
         )
       )
   # No Terraform variants: this check follows state-machine references into the IAM role and inspects attached managed-policy documents; that cross-resource correlation against arbitrary aws_iam_role / aws_iam_role_policy / aws_iam_policy resources cannot be replicated structurally.
@@ -69348,7 +69345,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-apigatewayv2-routes-require-authorizer-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS API Gateway v2 API
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-apigatewayv2-routes-require-authorizer-terraform-hcl
         tags:
@@ -69462,12 +69459,10 @@ queries:
       - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-jwt-authorizer.html
         title: API Gateway v2 JWT authorizers
   - uid: mondoo-aws-security-apigatewayv2-routes-require-authorizer-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-apigatewayv2-api"
     mql: |
-      aws.apigatewayv2.apis.all(
-        routes.where(routeKey != /^OPTIONS /).all(
-          authorizationType != "NONE"
-        )
+      aws.apigatewayv2.api.routes.where(routeKey != /^OPTIONS /).all(
+        authorizationType != "NONE"
       )
   - uid: mondoo-aws-security-apigatewayv2-routes-require-authorizer-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_apigatewayv2_route")
@@ -70075,7 +70070,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS Athena Workgroup
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-terraform-hcl
         tags:
@@ -70194,12 +70189,11 @@ queries:
       - url: https://docs.aws.amazon.com/athena/latest/ug/encryption.html
         title: Encrypting Athena query results
   - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-athena-workgroup"
     mql: |
-      aws.athena.workgroups.where(state == "ENABLED").all(
-        resultEncryptionOption == /^(SSE|CSE)_KMS$/ &&
-        kmsKey != null
-      )
+      aws.athena.workgroup.state != "ENABLED" ||
+      aws.athena.workgroup.resultEncryptionOption == /^(SSE|CSE)_KMS$/ &&
+      aws.athena.workgroup.kmsKey != null
   - uid: mondoo-aws-security-athena-workgroup-results-cmk-encrypted-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_athena_workgroup")
     mql: |
@@ -70424,7 +70418,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS API Gateway v2 API
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl
         tags:
@@ -70516,13 +70510,12 @@ queries:
       - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html
         title: Configuring CORS for an HTTP API
   - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-apigatewayv2-api"
     mql: |
-      aws.apigatewayv2.apis.where(corsConfiguration != null).all(
-        corsConfiguration["AllowCredentials"] != true ||
-        corsConfiguration["AllowOrigins"] == null ||
-        corsConfiguration["AllowOrigins"].contains("*") == false
-      )
+      aws.apigatewayv2.api.corsConfiguration == null ||
+      aws.apigatewayv2.api.corsConfiguration["AllowCredentials"] != true ||
+      aws.apigatewayv2.api.corsConfiguration["AllowOrigins"] == null ||
+      aws.apigatewayv2.api.corsConfiguration["AllowOrigins"].contains("*") == false
   - uid: mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_apigatewayv2_api")
     mql: |
@@ -70578,11 +70571,10 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-apigatewayv2-api"
     mql: |
-      aws.apigatewayv2.apis.where(protocolType == "WEBSOCKET").all(
-        routes.all(authorizationType != "NONE")
-      )
+      aws.apigatewayv2.api.protocolType != "WEBSOCKET" ||
+      aws.apigatewayv2.api.routes.all(authorizationType != "NONE")
     docs:
       desc: |
         This check ensures that every route on an API Gateway v2 WebSocket API has an authorization type other than `NONE`. WebSocket APIs establish long-lived, bidirectional connections, and an unauthenticated route allows any internet client to open a persistent channel to the backend integration without presenting any credentials.


### PR DESCRIPTION
## What

Reworks the runtime (`-aws`) variants of 18 checks across six AWS services to use the new per-resource asset platforms introduced in [mondoohq/mql#9013](https://github.com/mondoohq/mql/pull/9013). Each check now filters on the specific platform and queries the singular resource directly, instead of filtering the broad `asset.platform == "aws"` and iterating the plural collection.

| Platform | Singular resource | Checks |
|---|---|---|
| `aws-apigatewayv2-api` | `aws.apigatewayv2.api` | routes-require-authorizer, cors-not-wildcard-with-credentials, websocket-route-auth-required |
| `aws-athena-workgroup` | `aws.athena.workgroup` | enforce-configuration, results-encrypted, results-cmk-encrypted |
| `aws-appstream-fleet` | `aws.appstream.fleet` | no-default-internet-access, max-session-duration, idle-disconnect |
| `aws-batch-jobdefinition` | `aws.batch.jobDefinition` | no-privileged-containers, approved-image-registry, job-role-no-wildcards |
| `aws-directoryservice-directory` | `aws.directoryservice.directory` | os-version, sso-enabled, radius-mfa-enabled |
| `aws-documentdb-instance` | `aws.documentdb.instance` | auto-minor-version-upgrade, public-access-check, not-internet-reachable |

## Translation semantics

- Bare `.all(pred)` collapses to `pred` on the single resource; multi-field predicates repeat the singular path (matching the existing `aws-secretsmanager-secret` checks).
- `.where(P).all(Q)` → guard **`!P || Q`**; `.where(P).none(Q)` → **`!P || Q == false`** (comparing the inner `.any(...)` result to `false` preserves the exact original sub-evaluation and null behavior). This keeps the `.where()` predicate's scope — e.g. Athena checks still only assert on `ENABLED` workgroups, Batch checks only on `ACTIVE` job definitions.
- De Morgan is applied without parens (MQL forbids paren grouping and binds `&&` tighter than `||`), e.g. `.where(stage == "Active" && type == "MicrosoftAD")` → `stage != "Active" || type != "MicrosoftAD" || <assertion>`.
- Nested `.all()` over fields that are still collections on the single resource (`routes`, `document['Statement']`, `attachedPolicies`) is kept unchanged.

## Scope

Only the `-aws` runtime variants change (16 are variant sub-queries; `documentdb-instance-not-internet-reachable` and `apigatewayv2-websocket-route-auth-required` are standalone checks). The Terraform HCL/plan/state and CloudFormation variants are untouched. The 16 variant checks' `mondoo.com/filter-title` tags were made resource-specific (e.g. "AWS Athena Workgroup").

Checks on resource types **not** promoted to their own platform are intentionally left on the broad `aws` platform: `aws.documentdb.cluster`/`snapshots`, `aws.appstream.stacks`/`imageBuilders`/`images`, `aws.batch.jobQueues`, and `aws.apigatewayv2.domainNames`.

Policy version bumped 12.4.0 → 12.5.0.

## Testing

- `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` — valid (the two `terraform.resources` WHERE-clause warnings are pre-existing on untouched Terraform variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)