### PR TITLE
📝 querypacks: rework all pack and query descriptions

### DIFF
--- a/content/querypacks/mondoo-asset-count.mql.yaml
+++ b/content/querypacks/mondoo-asset-count.mql.yaml
@@ -21,7 +21,7 @@ packs:
       desc: |
         ### Overview
 
-        The Asset Count Query Pack by Mondoo retrieves resource counts across cloud providers and platforms including AWS, Azure, GCP, vSphere, Microsoft 365, GitLab, Kubernetes, and Windows Active Directory.
+        Counts resources across AWS, Azure, GCP, vSphere, Microsoft 365, GitLab, Kubernetes, and Windows Active Directory to size and inventory an environment.
 
         ### Run query pack
 
@@ -49,13 +49,13 @@ packs:
           - uid: mondoo-asset-count-on-vsphere-cluster-esxi
             title: ESXi hosts
             docs:
-              desc: Returns the number of ESXi hosts in each vSphere datacenter.
+              desc: Counts ESXi hosts in each vSphere datacenter.
             mql: |
               vsphere.datacenters { hosts.length }
           - uid: mondoo-asset-count-on-vsphere-cluster-vms
             title: VMs in vSphere cluster
             docs:
-              desc: Returns the number of virtual machines in each vSphere datacenter.
+              desc: Counts virtual machines in each vSphere datacenter.
             mql: |
               vsphere.datacenters { vms.length }
       - title: Microsoft 365 asset counts
@@ -162,176 +162,176 @@ queries:
   - uid: mondoo-asset-count-azure-resource-groups
     title: Azure Resource Groups count
     docs:
-      desc: Returns the number of resource groups in the Azure subscription.
+      desc: Counts resource groups in the subscription.
     mql: |
       azure.subscription.resourceGroups.length
 
   - uid: mondoo-asset-count-azure-vms
     title: Azure virtual machine count
     docs:
-      desc: Returns the number of virtual machines in the Azure subscription.
+      desc: Counts virtual machines in the subscription.
     mql: |
       azure.subscription.computeService.vms.length
 
   - uid: mondoo-asset-count-azure-subscription-name
     title: Azure subscription name
     docs:
-      desc: Returns the name of the Azure subscription for identification.
+      desc: Reports the Azure subscription name for identification.
     mql: |
       azure.subscription.name
 
   - uid: mondoo-asset-count-azure-cosmosdb-accounts
     title: Azure Cosmos DB accounts
     docs:
-      desc: Returns the number of Cosmos DB accounts in the Azure subscription.
+      desc: Counts Cosmos DB accounts in the subscription.
     mql: |
       azure.subscription.cosmosDb.accounts.length
 
   - uid: mondoo-asset-count-azure-vaults
     title: Azure key vaults
     docs:
-      desc: Returns the number of Key Vaults in the Azure subscription.
+      desc: Counts Key Vaults in the subscription.
     mql: |
       azure.subscription.keyVault.vaults.length
 
   - uid: mondoo-asset-count-azure-mySql-servers
     title: Azure MySQL servers
     docs:
-      desc: Returns the number of MySQL servers in the Azure subscription.
+      desc: Counts MySQL servers in the subscription.
     mql: |
       azure.subscription.mySql.servers.length
 
   - uid: mondoo-asset-count-azure-postgreSql-servers
     title: Azure PostgreSQL servers
     docs:
-      desc: Returns the number of PostgreSQL servers in the Azure subscription.
+      desc: Counts PostgreSQL servers in the subscription.
     mql: |
       azure.subscription.postgreSql.servers.length
 
   - uid: mondoo-asset-count-azure-application-gateways
     title: Azure Application Gateways
     docs:
-      desc: Returns the number of Application Gateways in the Azure subscription.
+      desc: Counts Application Gateways in the subscription.
     mql: |
       azure.subscription.network.applicationGateways.length
 
   - uid: mondoo-asset-count-azure-bastion-hosts
     title: Azure Bastion Hosts
     docs:
-      desc: Returns the number of Bastion Hosts in the Azure subscription.
+      desc: Counts Bastion hosts in the subscription.
     mql: |
       azure.subscription.network.bastionHosts.length
 
   - uid: mondoo-asset-count-azure-firewalls
     title: Azure Firewalls
     docs:
-      desc: Returns the number of Azure Firewalls in the subscription.
+      desc: Counts Azure Firewalls in the subscription.
     mql: |
       azure.subscription.network.firewalls.length
 
   - uid: mondoo-asset-count-azure-loadbalancers
     title: Azure Load Balancers
     docs:
-      desc: Returns the number of Load Balancers in the Azure subscription.
+      desc: Counts load balancers in the subscription.
     mql: |
       azure.subscription.network.loadBalancers.length
 
   - uid: mondoo-asset-count-azure-natgateways
     title: Azure NAT Gateways
     docs:
-      desc: Returns the number of NAT Gateways in the Azure subscription.
+      desc: Counts NAT gateways in the subscription.
     mql: |
       azure.subscription.network.natGateways.length
 
   - uid: mondoo-asset-count-azure-public-addresses
     title: Azure Public Addresses
     docs:
-      desc: Returns the number of public IP addresses in the Azure subscription.
+      desc: Counts public IP addresses in the subscription.
     mql: |
       azure.subscription.network.publicIpAddresses.length
 
   - uid: mondoo-asset-count-azure-security-groups
     title: Azure Security Groups
     docs:
-      desc: Returns the number of Network Security Groups in the Azure subscription.
+      desc: Counts network security groups in the subscription.
     mql: |
       azure.subscription.network.securityGroups.length
 
   - uid: mondoo-asset-count-azure-virtual-network-gateways
     title: Azure Virtual Network Gateways
     docs:
-      desc: Returns the number of Virtual Network Gateways in the Azure subscription.
+      desc: Counts virtual network gateways in the subscription.
     mql: |
       azure.subscription.network.virtualNetworkGateways.length
 
   - uid: mondoo-asset-count-azure-virtual-networks
     title: Azure virtual Networks
     docs:
-      desc: Returns the number of Virtual Networks in the Azure subscription.
+      desc: Counts virtual networks in the subscription.
     mql: |
       azure.subscription.network.virtualNetworks.length
 
   - uid: mondoo-asset-count-azure-aks-clusters
     title: Azure AKS Clusters
     docs:
-      desc: Returns the number of Azure Kubernetes Service clusters in the subscription.
+      desc: Counts Azure Kubernetes Service clusters in the subscription.
     mql: |
       azure.subscription.aks.clusters.length
 
   - uid: mondoo-asset-count-azure-aks-agent-pools
     title: Azure AKS Cluster Agent Pool Count
     docs:
-      desc: Returns the number of agent pools for each AKS cluster in the subscription.
+      desc: Counts node pools for each AKS cluster in the subscription.
     mql: |
       azure.subscription.aks.clusters { nodePools.length }
 
   - uid: mondoo-count-users-in-entra-id
     title: Entra ID user count
     docs:
-      desc: Returns the number of users in Microsoft Entra ID (formerly Azure AD).
+      desc: Counts users in Microsoft Entra ID (formerly Azure AD).
     mql: |
       microsoft.users.length
 
   - uid: mondoo-asset-count-aws-account-id
     title: AWS account ID
     docs:
-      desc: Returns the AWS account ID for identification.
+      desc: Reports the AWS account ID for identification.
     mql: aws.account.id
 
   - uid: mondoo-asset-count-aws-acm-certificates
     title: AWS ACM Certificates
     docs:
-      desc: Returns the number of ACM certificates in the AWS account.
+      desc: Counts ACM certificates in the account.
     mql: aws.acm.certificates.length
 
   - uid: mondoo-asset-count-aws-api-gateways
     title: AWS API Gateways
     docs:
-      desc: Returns the number of API Gateway REST APIs in the AWS account.
+      desc: Counts API Gateway REST APIs in the account.
     mql: aws.apigateway.restApis.length
 
   - uid: mondoo-asset-count-aws-autoscaling-groups
     title: AWS Autoscaling Groups (not created by Mondoo)
     docs:
-      desc: Returns the number of Auto Scaling groups excluding Mondoo-created groups.
+      desc: Counts Auto Scaling groups, excluding the Mondoo scanning group.
     mql: aws.autoscaling.groups.where( name != "mondoo-scanning-asg" ).length
 
   - uid: mondoo-asset-count-aws-iam-users
     title: AWS IAM users
     docs:
-      desc: Returns the number of IAM users in the AWS account.
+      desc: Counts IAM users in the account.
     mql: aws.iam.users.length
 
   - uid: mondoo-asset-count-aws-iam-groups
     title: AWS IAM groups
     docs:
-      desc: Returns the number of IAM groups in the AWS account.
+      desc: Counts IAM groups in the account.
     mql: aws.iam.groups.length
 
   - uid: mondoo-asset-count-aws-iam-policies
     title: AWS IAM custom policies
     docs:
-      desc: Returns the number of customer-managed IAM policies in the AWS account.
+      desc: Counts customer-managed IAM policies in the account.
     mql: |
       aws_account = aws.account.id
       aws.iam.policies.where( arn.contains(aws_account)).length
@@ -339,318 +339,318 @@ queries:
   - uid: mondoo-asset-count-aws-active-regions
     title: AWS Regions Active
     docs:
-      desc: Returns the number of active AWS regions.
+      desc: Counts active AWS regions.
     mql: aws.regions.length
 
   - uid: mondoo-asset-count-aws-ec2-instances
     title: AWS EC2 Instances
     docs:
-      desc: Returns the number of EC2 instances in the AWS account.
+      desc: Counts EC2 instances in the account.
     mql: aws.ec2.instances.length
 
   - uid: mondoo-asset-count-aws-s3-buckets
     title: AWS S3 Buckets
     docs:
-      desc: Returns the number of S3 buckets in the AWS account.
+      desc: Counts S3 buckets in the account.
     mql: aws.s3.buckets.length
 
   - uid: mondoo-asset-count-aws-vpcs
     title: AWS VPCs
     docs:
-      desc: Returns the number of VPCs in the AWS account.
+      desc: Counts VPCs in the account.
     mql: aws.vpcs.length
 
   - uid: mondoo-asset-count-aws-security-groups
     title: AWS Security Groups
     docs:
-      desc: Returns the number of EC2 security groups in the AWS account.
+      desc: Counts EC2 security groups in the account.
     mql: aws.ec2.securityGroups.length
 
   - uid: mondoo-asset-count-aws-eks-clusters
     title: AWS Elastic Kubernetes Clusters (EKS)
     docs:
-      desc: Returns the number of EKS clusters in the AWS account.
+      desc: Counts EKS clusters in the account.
     mql: aws.eks.clusters.length
 
   - uid: mondoo-asset-count-aws-private-ecr-container-registries
     title: AWS Private Elastic Container Registries (ECR)
     docs:
-      desc: Returns the number of private ECR repositories in the AWS account.
+      desc: Counts private ECR repositories in the account.
     mql: aws.ecr.privateRepositories.length
 
   - uid: mondoo-asset-count-aws-public-ecr-container-registries
     title: AWS Public Elastic Container Registries (ECR)
     docs:
-      desc: Returns the number of public ECR repositories in the AWS account.
+      desc: Counts public ECR repositories in the account.
     mql: aws.ecr.publicRepositories.length
 
   - uid: mondoo-asset-count-aws-ecr-container-images
     title: AWS Elastic Container Images (ECR)
     docs:
-      desc: Returns the number of container images in ECR repositories.
+      desc: Counts container images across ECR repositories.
     mql: aws.ecr.images.length
 
   - uid: mondoo-asset-count-aws-rds-dbclusters
     title: AWS RDS Database Clusters
     docs:
-      desc: Returns the number of RDS database clusters in the AWS account.
+      desc: Counts RDS database clusters in the account.
     mql: aws.rds.clusters.length
 
   - uid: mondoo-asset-count-aws-cloudtrails
     title: AWS CloudTrails
     docs:
-      desc: Returns the number of CloudTrail trails in the AWS account.
+      desc: Counts CloudTrail trails in the account.
     mql: aws.cloudtrail.trails.length
 
   - uid: mondoo-asset-count-aws-dynamodb-tables
     title: AWS DynamoDB Tables
     docs:
-      desc: Returns the number of DynamoDB tables in the AWS account.
+      desc: Counts DynamoDB tables in the account.
     mql: aws.dynamodb.tables.length
 
   - uid: mondoo-asset-count-aws-dynamodb-global-tables
     title: AWS DynamoDB Global Tables
     docs:
-      desc: Returns the number of DynamoDB global tables in the AWS account.
+      desc: Counts DynamoDB global tables in the account.
     mql: aws.dynamodb.globalTables.length
 
   - uid: mondoo-asset-count-aws-ecs-clusters
     title: AWS ECS Clusters
     docs:
-      desc: Returns the number of ECS clusters in the AWS account.
+      desc: Counts ECS clusters in the account.
     mql: aws.ecs.clusters.length
 
   - uid: mondoo-asset-count-aws-ecs-container-instances
     title: AWS ECS Container Instances
     docs:
-      desc: Returns the number of ECS container instances in the AWS account.
+      desc: Counts ECS container instances in the account.
     mql: aws.ecs.containerInstances.length
 
   - uid: mondoo-asset-count-aws-ecs-containers
     title: AWS ECS Containers
     docs:
-      desc: Returns the number of ECS containers in the AWS account.
+      desc: Counts ECS containers in the account.
     mql: aws.ecs.containers.length
 
   - uid: mondoo-asset-count-aws-efs-filesystems
     title: AWS EFS Filesystems
     docs:
-      desc: Returns the number of EFS file systems in the AWS account.
+      desc: Counts EFS file systems in the account.
     mql: aws.efs.filesystems.length
 
   - uid: mondoo-asset-count-aws-elasticache-cache-clusters
     title: AWS ElastiCache Cache Clusters
     docs:
-      desc: Returns the number of ElastiCache clusters in the AWS account.
+      desc: Counts ElastiCache clusters in the account.
     mql: aws.elasticache.cacheClusters.length
 
   - uid: mondoo-asset-count-aws-elb-application
     title: AWS Elastic Application Load Balancers
     docs:
-      desc: Returns the number of Application Load Balancers in the AWS account.
+      desc: Counts Application Load Balancers in the account.
     mql: aws.elb.loadBalancers.length
 
   - uid: mondoo-asset-count-aws-elb-classic
     title: AWS Elastic Classic Load Balancers
     docs:
-      desc: Returns the number of Classic Load Balancers in the AWS account.
+      desc: Counts Classic Load Balancers in the account.
     mql: aws.elb.classicLoadBalancers.length
 
   - uid: mondoo-asset-count-aws-emr-clusters
     title: AWS Elastic Map Reduce Clusters
     docs:
-      desc: Returns the number of EMR clusters in the AWS account.
+      desc: Counts EMR clusters in the account.
     mql: aws.emr.clusters.length
 
   - uid: mondoo-asset-count-aws-es-domains
     title: AWS Elasticsearch Service Domain
     docs:
-      desc: Returns the number of Elasticsearch domains in the AWS account.
+      desc: Counts Elasticsearch Service domains in the account.
     mql: aws.es.domains.length
 
   - uid: mondoo-asset-count-aws-guardduty-detectors
     title: AWS Guard Duty Detectors
     docs:
-      desc: Returns the number of GuardDuty detectors in the AWS account.
+      desc: Counts GuardDuty detectors in the account.
     mql: aws.guardduty.detectors.length
 
   - uid: mondoo-asset-count-aws-kms-keys
     title: AWS KMS Keys
     docs:
-      desc: Returns the number of KMS keys in the AWS account.
+      desc: Counts KMS keys in the account.
     mql: aws.kms.keys.length
 
   - uid: mondoo-asset-count-aws-redshift-clusters
     title: AWS Redshift Clusters
     docs:
-      desc: Returns the number of Redshift clusters in the AWS account.
+      desc: Counts Redshift clusters in the account.
     mql: aws.redshift.clusters.length
 
   - uid: mondoo-asset-count-aws-sagemaker-endpoints
     title: AWS SageMaker Endpoints
     docs:
-      desc: Returns the number of SageMaker endpoints in the AWS account.
+      desc: Counts SageMaker endpoints in the account.
     mql: aws.sagemaker.endpoints.length
 
   - uid: mondoo-asset-count-aws-sagemaker-notebook-instances
     title: AWS SageMaker Notebook Instances
     docs:
-      desc: Returns the number of SageMaker notebook instances in the AWS account.
+      desc: Counts SageMaker notebook instances in the account.
     mql: aws.sagemaker.notebookInstances.length
 
   - uid: mondoo-asset-count-aws-secrets-manager-secrets
     title: AWS Secrets Manager Secrets
     docs:
-      desc: Returns the number of secrets in Secrets Manager.
+      desc: Counts secrets in Secrets Manager.
     mql: aws.secretsmanager.secrets.length
 
   - uid: mondoo-asset-count-aws-security-hub
     title: AWS Security Hub
     docs:
-      desc: Returns the number of Security Hub instances in the AWS account.
+      desc: Counts Security Hub instances in the account.
     mql: aws.securityhub.hubs.length
 
   - uid: mondoo-asset-count-aws-sns-topics
     title: AWS SNS Topics
     docs:
-      desc: Returns the number of SNS topics in the AWS account.
+      desc: Counts SNS topics in the account.
     mql: aws.sns.topics.length
 
   - uid: mondoo-asset-count-in-windows-domain
     title: All computer objects in the Windows domain
     docs:
-      desc: Returns all Active Directory computer objects that have logged in within the last 180 days.
+      desc: Lists Active Directory computer objects that logged on in the last 180 days, with name, enabled state, operating system, version, and last logon date. Requires domain access.
     mql: |
       parse.json(content: powershell('$time = (Get-Date).Adddays(-(180));Get-ADComputer -Filter {LastLogonTimeStamp -ge $time} -properties * | select Name,Enabled,OperatingSystem,OperatingSystemVersion,LastLogonDate | ConvertTo-Json').stdout).params
 
   - uid: mondoo-asset-count-gcp-storage-buckets
     title: GCP Project Storage Buckets
     docs:
-      desc: Returns the number of Cloud Storage buckets in the GCP project.
+      desc: Counts Cloud Storage buckets in the project.
     mql: gcp.project.storage.buckets.length
 
   - uid: mondoo-asset-count-gcp-compute-instances
     title: GCP Project Compute Instances
     docs:
-      desc: Returns the number of Compute Engine instances in the GCP project.
+      desc: Counts Compute Engine instances in the project.
     mql: gcp.project.compute.instances.length
 
   - uid: mondoo-asset-count-gcp-service-accounts
     title: GCP Project Service Accounts
     docs:
-      desc: Returns the number of service accounts in the GCP project.
+      desc: Counts service accounts in the project.
     mql: gcp.project.iam.serviceAccounts.length
 
   - uid: mondoo-asset-count-gcp-gke-clusters
     title: GCP Project GKE Clusters
     docs:
-      desc: Returns the number of GKE clusters in the GCP project.
+      desc: Counts GKE clusters in the project.
     mql: gcp.project.gke.clusters.length
 
   - uid: mondoo-asset-count-gcp-bigquery-datasets
     title: GCP Project BigQuery Datasets
     docs:
-      desc: Returns the number of BigQuery datasets in the GCP project.
+      desc: Counts BigQuery datasets in the project.
     mql: gcp.project.bigquery.datasets.length
 
   - uid: mondoo-asset-count-gcp-cloudfunctions
     title: GCP Project CloudFunctions
     docs:
-      desc: Returns the number of Cloud Functions in the GCP project.
+      desc: Counts Cloud Functions in the project.
     mql: gcp.project.cloudFunctions.length
 
   - uid: mondoo-asset-count-gcp-cloudrun-jobs
     title: GCP Project Cloud Run Jobs
     docs:
-      desc: Returns the number of Cloud Run jobs in the GCP project.
+      desc: Counts Cloud Run jobs in the project.
     mql: gcp.project.cloudRun.jobs.length
 
   - uid: mondoo-asset-count-gcp-cloudrun-services
     title: GCP Project Cloud Run Services
     docs:
-      desc: Returns the number of Cloud Run services in the GCP project.
+      desc: Counts Cloud Run services in the project.
     mql: gcp.project.cloudRun.services.length
 
   - uid: mondoo-asset-count-gcp-cloudrun-operations
     title: GCP Project Cloud Run Operations
     docs:
-      desc: Returns the number of Cloud Run operations in the GCP project.
+      desc: Counts Cloud Run operations in the project.
     mql: gcp.project.cloudRun.operations.length
 
   - uid: mondoo-asset-count-gcp-dns-managed-zones
     title: GCP Project DNS Managed Zones
     docs:
-      desc: Returns the number of Cloud DNS managed zones in the GCP project.
+      desc: Counts Cloud DNS managed zones in the project.
     mql: gcp.project.dns.managedZones.length
 
   - uid: mondoo-asset-count-gcp-iam-policies
     title: GCP Project IAM Policies
     docs:
-      desc: Returns the number of IAM policy bindings in the GCP project.
+      desc: Counts IAM policy bindings in the project.
     mql: gcp.project.iamPolicy.length
 
   - uid: mondoo-asset-count-gcp-kms-keyrings
     title: GCP Project KMS Keyrings
     docs:
-      desc: Returns the number of Cloud KMS key rings in the GCP project.
+      desc: Counts Cloud KMS key rings in the project.
     mql: gcp.project.kms.keyrings.length
 
   - uid: mondoo-asset-count-gcp-sql-instances
     title: GCP Project SQL Instances
     docs:
-      desc: Returns the number of Cloud SQL instances in the GCP project.
+      desc: Counts Cloud SQL instances in the project.
     mql: gcp.project.sql.instances.length
 
   - uid: mondoo-asset-count-gcp-services
     title: GCP Project Services Enabled
     docs:
-      desc: Returns the number of enabled APIs and services in the GCP project.
+      desc: Counts enabled APIs and services in the project.
     mql: gcp.project.services.where( enabled ).length
 
   - uid: mondoo-asset-count-gitlab-group-projects
     title: GitLab Group Projects
     docs:
-      desc: Returns the number of projects in the GitLab group.
+      desc: Counts projects in the GitLab group.
     mql: gitlab.group.projects.length
 
   - uid: mondoo-asset-count-k8s-nodes
     title: K8s Nodes count
     docs:
-      desc: Returns the number of nodes in the Kubernetes cluster.
+      desc: Counts nodes in the cluster.
     mql: k8s.nodes.length
 
   - uid: mondoo-asset-count-k8s-daemonsets
     title: K8s Daemon Sets count
     docs:
-      desc: Returns the number of DaemonSets in the Kubernetes cluster.
+      desc: Counts DaemonSets in the cluster.
     mql: k8s.daemonsets.length
 
   - uid: mondoo-asset-count-k8s-cronjobs
     title: K8s Cronjobs count
     docs:
-      desc: Returns the number of CronJobs in the Kubernetes cluster.
+      desc: Counts CronJobs in the cluster.
     mql: k8s.cronjobs.length
 
   - uid: mondoo-asset-count-k8s-jobs
     title: K8s Jobs count
     docs:
-      desc: Returns the number of Jobs in the Kubernetes cluster.
+      desc: Counts Jobs in the cluster.
     mql: k8s.jobs.length
 
   - uid: mondoo-asset-count-k8s-deployments
     title: K8s Deployments count
     docs:
-      desc: Returns the number of Deployments in the Kubernetes cluster.
+      desc: Counts Deployments in the cluster.
     mql: k8s.deployments.length
 
   - uid: mondoo-asset-count-k8s-replicasets
     title: K8s Replicasets count
     docs:
-      desc: Returns the number of ReplicaSets in the Kubernetes cluster.
+      desc: Counts ReplicaSets in the cluster.
     mql: k8s.replicasets.length
 
   - uid: mondoo-asset-count-k8s-pods
     title: K8s PODs count
     docs:
-      desc: Returns the number of Pods in the Kubernetes cluster.
+      desc: Counts Pods in the cluster.
     mql: k8s.pods.length

--- a/content/querypacks/mondoo-aws-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-aws-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The AWS Incident Response Pack by Mondoo query pack retrieves data about AWS services and resources for investigation during a security incident.
+        Collects AWS evidence for incident investigation: account identity, enabled regions, IAM users and their access, identities holding administrative or full-access policies, internet-facing EC2 instances, and publicly accessible S3 buckets.
 
         ### Run query pack
 
@@ -67,7 +67,7 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves all AWS regions enabled in the account
+        Lists every region enabled in the account, showing where an attacker could have stood up resources.
     mql: |
       aws { regions }
 
@@ -76,7 +76,7 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves data for users with console access. The following fields are retrieved:
+        Users with console sign-in enabled, showing when each password was last used and last changed and whether MFA is active. Reveals which human identities an attacker could abuse and which lack MFA:
 
         ```
         properties['user']
@@ -98,7 +98,7 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves all of the IAM users that have API access along with the following fields:
+        IAM users with at least one active access key, showing each key's last-used date, last-used service, and last rotation. Helps spot stale or abused programmatic credentials:
 
         ```
         properties['user']
@@ -129,7 +129,7 @@ queries:
     title: IAM users, groups, and roles to which the AdministratorAccess policy is attached
     docs:
       desc: |
-        This query retrieves all IAM users, groups, and roles with the `AdministratorAccess` role attached.
+        IAM users, groups, and roles that have the `AdministratorAccess` policy attached, exposing which identities hold full administrative control.
     variants:
       - uid: mondoo-incident-response-aws-iam-administrator-access-all
       - uid: mondoo-incident-response-aws-iam-administrator-access-user
@@ -192,7 +192,7 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves all IAM users, groups, and roles with an AWS FullAccess role attached.
+        AWS policies whose name contains `FullAccess` and that are attached to at least one identity, with the users, groups, and roles bound to each. Surfaces broad service-level privileges an attacker could exploit.
     mql: |
       aws.iam.policies.
         where( name == /FullAccess/i && attachmentCount != 0) {
@@ -208,7 +208,7 @@ queries:
     title: EC2 instances that have a public IP address
     docs:
       desc: |
-        This query retrieves all EC2 instances that have a public IP address attached along with the following fields:
+        EC2 instances with a public IP address, along with their VPC, key pair, security groups, and inbound rules. Identifies internet-reachable hosts an attacker could target or may have already reached:
 
         ```
         arn
@@ -275,7 +275,7 @@ queries:
     title: EC2 instances that do not have tags configured
     docs:
       desc: |
-        This query retrieves all EC2 instances that do not have tags configured, along with the following fields:
+        EC2 instances with no tags, along with their region, key pair, image, and state. Untagged hosts often escape ownership and inventory tracking, making them easy to overlook during response:
         ```mql
         instanceId
         region
@@ -317,7 +317,7 @@ queries:
     title: S3 buckets that are public
     docs:
       desc: |
-        This query retrieves all S3 buckets that are configured with public access and returns the following fields:
+        S3 buckets configured for public access, with their location, public access block settings, encryption rules, tags, and bucket policy. Pinpoints potential data-exposure paths:
         ```mql
         arn
         name

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory AWS accounts, EC2, S3, IAM, and more
     docs:
       desc: |
-        The AWS Asset Inventory Pack retrieves information about AWS accounts for asset inventory.
+        Collects AWS account inventory: IAM users, groups, roles, and policies; VPCs and subnets; EC2, EBS, RDS, S3, EKS, and Lambda resources; load balancers, Elastic IPs, ACM certificates, CloudTrail trails, and WAF web ACLs.
     groups:
       - uid: mondoo-asset-inventory-aws-general-group
         title: AWS General
@@ -110,7 +110,7 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves all AWS regions enabled in the account
+        Lists the AWS regions enabled in the account.
     mql: |
       aws { regions }
 
@@ -118,7 +118,7 @@ queries:
     title: VPCs
     docs:
       desc: |
-        This query retrieves all of the configuration data for AWS VPCs
+        Returns configuration data for the account's VPCs.
     variants:
       - uid: mondoo-asset-inventory-aws-vpcs-all
       - uid: mondoo-asset-inventory-aws-vpcs-single
@@ -174,7 +174,7 @@ queries:
     title: IAM users
     docs:
       desc: |
-        This query retrieves data for all IAM users
+        Lists the account's IAM users.
     variants:
       - uid: mondoo-asset-inventory-aws-iam-users-all
       - uid: mondoo-asset-inventory-aws-iam-users-single
@@ -191,7 +191,7 @@ queries:
     title: IAM groups
     docs:
       desc: |
-        This query retrieves all of the IAM groups.
+        Lists the account's IAM groups.
     variants:
       - uid: mondoo-asset-inventory-aws-iam-groups-all
       - uid: mondoo-asset-inventory-aws-iam-groups-single
@@ -208,7 +208,7 @@ queries:
     title: IAM roles
     docs:
       desc: |
-        This query retrieves all IAM Roles
+        Lists the account's IAM roles.
     variants:
       - uid: mondoo-asset-inventory-aws-iam-roles-all
   - uid: mondoo-asset-inventory-aws-iam-roles-all
@@ -221,14 +221,14 @@ queries:
     filters: asset.platform == "aws"
     docs:
       desc: |
-        This query retrieves all IAM policies attached to a user, group, or role.
+        Lists IAM policies currently attached to a user, group, or role.
     mql: aws.iam.policies.where( attachmentCount > 0 )
 
   - uid: mondoo-asset-inventory-aws-ec2-security-groups
     title: EC2 Security Groups
     docs:
       desc: |
-        This query retrieves all AWS EC2 Security Groups
+        Lists the account's EC2 security groups.
     variants:
       - uid: mondoo-asset-inventory-aws-ec2-security-groups-all
       - uid: mondoo-asset-inventory-aws-ec2-security-groups-single
@@ -245,7 +245,7 @@ queries:
     title: EBS volumes
     docs:
       desc: |
-        This query retrieves all AWS EBS volumes
+        Lists the account's EBS volumes.
     variants:
       - uid: mondoo-asset-inventory-aws-ec2-volumes-all
       - uid: mondoo-asset-inventory-aws-ec2-volumes-single
@@ -286,9 +286,9 @@ queries:
         public IP, whether it sits in a public subnet, the security-group ingress
         rules that open it, and any internet-facing load balancers that front it.
 
-        Scoped to the AWS account scan (no `-single` variant): the exposure
-        analysis is account-wide — `internetFacingLoadBalancers` requires
-        enumerating the account's load balancers and target groups.
+        Scoped to the AWS account scan, with no `-single` variant, because the
+        `internetFacingLoadBalancers` field requires enumerating the account's
+        load balancers and target groups.
     variants:
       - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
   - uid: mondoo-asset-inventory-aws-ec2-instances-exposure-all
@@ -317,12 +317,12 @@ queries:
     title: Elastic IP addresses
     docs:
       desc: |
-        Lists Elastic IP addresses and the instance / network interface they are
-        associated with, mapping externally routable public IPs to resources.
+        Lists Elastic IP addresses and the instance or network interface they
+        are associated with, mapping externally routable public IPs to resources.
 
-        Elastic IPs are enumerated only at the account level — there is no
-        standalone `aws-eip` asset platform — so this query has no `-single`
-        variant (same pattern as the ACM and Access Analyzer queries above).
+        Elastic IPs are enumerated only at the account level, since there is no
+        standalone `aws-eip` asset platform, so this query has no `-single`
+        variant, matching the ACM and Access Analyzer queries above.
     variants:
       - uid: mondoo-asset-inventory-aws-eips-all
   - uid: mondoo-asset-inventory-aws-eips-all

--- a/content/querypacks/mondoo-azure-inventory.mql.yaml
+++ b/content/querypacks/mondoo-azure-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Azure subscriptions, VMs, and resources
     docs:
       desc: |
-        The Azure Asset Inventory by Mondoo query pack retrieves information about Azure subscriptions and resources for asset inventory.
+        Collects Azure subscription inventory: IAM role definitions, activity and diagnostic logs, Microsoft Defender for Cloud settings, storage accounts, SQL/PostgreSQL/MySQL servers, key vaults, network resources, virtual machines, disks, web apps, and Cosmos DB accounts.
     groups:
       - uid: mondoo-asset-inventory-azure-subscription-group
         title: Azure Subscription
@@ -93,7 +93,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all role definitions in the subscription
+        Lists the IAM role definitions available in the subscription.
     mql: azure.subscription.iam.roles
 
   - uid: mondoo-asset-inventory-azure-cloudDefender
@@ -101,14 +101,14 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for Microsoft Defender for Cloud
+        Reports Microsoft Defender for Cloud coverage for servers and containers, plus the security contacts and their notification sources.
     mql: azure.subscription.cloudDefender { forServers forContainers securityContacts { name notificationSources }  }
 
   - uid: mondoo-asset-inventory-azure-storageAccounts
     title: Azure Storage accounts
     docs:
       desc: |
-        This query retrieves data for all storage accounts
+        Lists the storage accounts in the subscription.
     variants:
       - uid: mondoo-asset-inventory-azure-storageAccounts-single
       - uid: mondoo-asset-inventory-azure-storageAccounts-api
@@ -123,7 +123,7 @@ queries:
     title: Azure Storage account containers
     docs:
       desc: |
-        This query retrieves data for all containers in storage accounts
+        Lists the blob containers within each storage account.
     variants:
       - uid: mondoo-asset-inventory-azure-storageAccounts-containers-single
       - uid: mondoo-asset-inventory-azure-storageAccounts-containers-api
@@ -138,7 +138,7 @@ queries:
     title: Azure storage accounts blobs
     docs:
       desc: |
-        This query retrieves data for all blobs in storage accounts
+        Shows the blob service properties configured on each storage account.
     variants:
       - uid: mondoo-asset-inventory-azure-storageAccounts-blobs-single
       - uid: mondoo-asset-inventory-azure-storageAccounts-blobs-api
@@ -153,7 +153,7 @@ queries:
     title: Azure Storage accounts tables
     docs:
       desc: |
-        This query retrieves data for all tables in storage accounts
+        Shows the table service properties configured on each storage account.
     variants:
       - uid: mondoo-asset-inventory-azure-storageAccounts-tables-single
       - uid: mondoo-asset-inventory-azure-storageAccounts-tables-api
@@ -168,7 +168,7 @@ queries:
     title: Azure SQL Database servers
     docs:
       desc: |
-        This query retrieves data for all Azure SQL Database servers
+        Lists the Azure SQL Database servers in the subscription.
     variants:
       - uid: mondoo-asset-inventory-azure-sqlServers-single
       - uid: mondoo-asset-inventory-azure-sqlServers-api
@@ -183,7 +183,7 @@ queries:
     title: Azure SQL Database server firewall rules
     docs:
       desc: |
-        This query retrieves data for all firewall rules in Azure SQL Database servers
+        Lists the firewall rules configured on each Azure SQL Database server.
     variants:
       - uid: mondoo-asset-inventory-azure-sqlServers-firewallrules-single
       - uid: mondoo-asset-inventory-azure-sqlServers-firewallrules-api
@@ -198,7 +198,7 @@ queries:
     title: Azure SQL Database server databases
     docs:
       desc: |
-        This query retrieves data for all databases in Azure SQL Database servers
+        Lists the databases hosted on each Azure SQL Database server.
     variants:
       - uid: mondoo-asset-inventory-azure-sqlServers-databases-single
       - uid: mondoo-asset-inventory-azure-sqlServers-databases-api
@@ -213,7 +213,7 @@ queries:
     title: Azure PostgreSQL servers
     docs:
       desc: |
-        This query retrieves data for all PostgreSQL servers
+        Lists both single-server and flexible-server Azure Database for PostgreSQL instances.
     variants:
       - uid: mondoo-asset-inventory-azure-postgresql-all
       - uid: mondoo-asset-inventory-azure-postgresql-legacy
@@ -234,7 +234,7 @@ queries:
     title: Azure PostgreSQL server firewall rules
     docs:
       desc: |
-        This query retrieves data for all firewall rules in Azure PostgreSQL servers
+        Lists the firewall rules on Azure Database for PostgreSQL single and flexible servers.
     variants:
       - uid: mondoo-asset-inventory-azure-postgresql-firewallrules-all
       - uid: mondoo-asset-inventory-azure-postgresql-firewallrules-legacy
@@ -255,7 +255,7 @@ queries:
     title: Azure MySQL server firewall rules
     docs:
       desc: |
-        This query retrieves data for all firewall rules in Azure MySQL servers
+        Lists the firewall rules on Azure Database for MySQL single and flexible servers.
     variants:
       - uid: mondoo-asset-inventory-azure-mysql-firewallrules-all
       - uid: mondoo-asset-inventory-azure-mysql-firewallrules-legacy
@@ -276,7 +276,7 @@ queries:
     title: Azure MySQL servers
     docs:
       desc: |
-        This query retrieves data for all Azure MySQL servers
+        Lists both single-server and flexible-server Azure Database for MySQL instances.
     variants:
       - uid: mondoo-asset-inventory-azure-mysql-all
       - uid: mondoo-asset-inventory-azure-mysql-legacy
@@ -298,14 +298,14 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all diagnostic settings
+        Lists the Azure Monitor diagnostic settings for the subscription.
     mql: azure.subscription.monitor.diagnosticSettings
 
   - uid: mondoo-asset-inventory-azure-keyVaults
     title: Azure Key Vault vaults
     docs:
       desc: |
-        This query retrieves data for all Azure Key Vault vaults
+        Lists the Azure Key Vault vaults in the subscription.
     variants:
       - uid: mondoo-asset-inventory-azure-keyVaults-single
       - uid: mondoo-asset-inventory-azure-keyVaults-api
@@ -320,7 +320,7 @@ queries:
     title: Azure Key Vault vault keys
     docs:
       desc: |
-        This query retrieves data for all keys in Key Vaults
+        Lists the keys stored in each key vault.
     variants:
       - uid: mondoo-asset-inventory-azure-keyVaults-keys-api
       - uid: mondoo-asset-inventory-azure-keyVaults-keys-single
@@ -335,7 +335,7 @@ queries:
     title: Azure Key Vault vault secrets
     docs:
       desc: |
-        This query retrieves data for all secrets in Key Vaults
+        Lists the secrets stored in each key vault.
     variants:
       - uid: mondoo-asset-inventory-azure-keyVaults-secrets-api
       - uid: mondoo-asset-inventory-azure-keyVaults-secrets-single
@@ -350,7 +350,7 @@ queries:
     title: Azure Key Vault vault certificates
     docs:
       desc: |
-        This query retrieves data for all certificates in Key Vaults
+        Lists the certificates stored in each key vault.
     variants:
       - uid: mondoo-asset-inventory-azure-keyVaults-certificates-api
       - uid: mondoo-asset-inventory-azure-keyVaults-certificates-single
@@ -366,14 +366,14 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all activity logs
+        Returns the Azure Monitor activity log for the subscription.
     mql: azure.subscription.monitor.activityLog
 
   - uid: mondoo-asset-inventory-azure-networkSecurityGroups
     title: Azure network security groups
     docs:
       desc: |
-        This query retrieves data for all network security groups
+        Lists the network security groups in the subscription.
     variants:
       - uid: mondoo-asset-inventory-azure-networkSecurityGroups-api
       - uid: mondoo-asset-inventory-azure-networkSecurityGroups-single
@@ -389,14 +389,14 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves all public IP addresses in your subscription
+        Lists the public IP addresses in the subscription with their name, location, and assigned address.
     mql: azure.subscription.networkService.publicIpAddresses{ name location ipAddress }
 
   - uid: mondoo-asset-inventory-azure-virtualmachines
     title: Azure virtual machines
     docs:
       desc: |
-        This query retrieves data for all virtual machines
+        Lists the virtual machines in the subscription.
     variants:
       - uid: mondoo-asset-inventory-azure-virtualmachines-api
       - uid: mondoo-asset-inventory-azure-virtualmachines-single
@@ -411,7 +411,7 @@ queries:
     title: Azure virtual machines with managed disks
     docs:
       desc: |
-        This query retrieves data for all virtual machines with managed disks
+        Identifies the virtual machines whose OS disk is a managed disk.
     variants:
       - uid: mondoo-asset-inventory-azure-virtualmachines-managedDisk-api
       - uid: mondoo-asset-inventory-azure-virtualmachines-managedDisk-single
@@ -427,7 +427,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all web apps
+        Lists the App Service web apps in the subscription.
     mql: azure.subscription.web.apps
 
   - uid: mondoo-asset-inventory-azure-cosmosDb
@@ -435,7 +435,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all Cosmos DB accounts
+        Lists the Azure Cosmos DB accounts in the subscription.
     mql: azure.subscription.cosmosDb.accounts
 
   - uid: mondoo-asset-inventory-azure-applicationInsight
@@ -443,7 +443,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all Application Insights
+        Lists the Application Insights components monitored by Azure Monitor.
     mql: azure.subscription.monitor.applicationInsights
 
   - uid: mondoo-asset-inventory-azure-networkWatcher
@@ -451,7 +451,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for Azure Network Watchers
+        Lists the Network Watcher instances in the subscription.
     mql: azure.subscription.network.watchers
 
   - uid: mondoo-asset-inventory-azure-bastionHosts
@@ -459,7 +459,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all Bastion hosts
+        Lists the Azure Bastion hosts in the subscription.
     mql: azure.subscription.network.bastionHosts
 
   - uid: mondoo-asset-inventory-azure-compute-disks
@@ -467,7 +467,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all compute disks available in the subscription
+        Lists the managed compute disks in the subscription.
     mql: azure.subscription.compute.disks
 
   - uid: mondoo-asset-inventory-azure-network-interfaces
@@ -475,7 +475,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all network interfaces
+        Lists the network interfaces with their name, location, NIC type, MAC address, and attached virtual machine.
     mql: azure.subscription.network.interfaces{ name location properties['nicType'] properties['nicType'] properties['macAddress'] properties['virtualMachine']['id'] }
 
   - uid: mondoo-asset-inventory-azure-resourcegroups
@@ -483,7 +483,7 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all resource groups inside the subscription
+        Lists the resource groups in the subscription.
     mql: azure.subscription.resourceGroups
 
   - uid: mondoo-asset-inventory-azure-resources
@@ -491,5 +491,5 @@ queries:
     filters: asset.platform == "azure"
     docs:
       desc: |
-        This query retrieves data for all resources inside the subscription
+        Lists every resource in the subscription across all resource groups.
     mql: azure.subscription.resources

--- a/content/querypacks/mondoo-dns-inventory.mql.yaml
+++ b/content/querypacks/mondoo-dns-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The DNS Inventory Pack by Mondoo query pack retrieves information about DNS entries.
+        Collects a domain's DNS records: the full record set and the mail exchanger (MX) records.
 
         ### Prerequisites
 
@@ -37,11 +37,11 @@ packs:
       - uid: mondoo-dns-inventory-dns-records
         title: Retrieve information about DNS records
         docs:
-          desc: Returns all DNS records (A, AAAA, CNAME, MX, TXT, etc.) for the domain.
+          desc: Returns every DNS record for the domain, including A, AAAA, CNAME, MX, and TXT.
         mql: dns.params
       - uid: mondoo-dns-inventory-dns-mx-records
         title: Retrieve information about the MX records
         docs:
-          desc: Returns mail exchanger (MX) records with their domain names and preferences for email routing.
+          desc: Returns the mail exchanger (MX) records with each host's domain name and preference value.
         filters: dns.params.MX.name != empty
         mql: dns.mx { domainName preference }

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Email Inventory Pack by Mondoo query pack retrieves information about Email entries.
+        Collects a domain's email authentication DNS records: SPF, DKIM, DMARC, and the reverse-DNS PTR record.
 
         ### Prerequisites
 
@@ -37,23 +37,23 @@ packs:
       - uid: mondoo-email-inventory-mail-records
         title: Retrieve reverse IP Lookup PTR record
         docs:
-          desc: Performs reverse DNS lookup on the domain's IP address to verify PTR record configuration.
+          desc: Resolves the domain's IP address back to its PTR record via reverse DNS.
         mql: |
           dns.reverse
       - uid: mondoo-email-inventory-spf-record
         title: Retrieve SPF record
         docs:
-          desc: Returns TXT records which include SPF (Sender Policy Framework) configuration for email authentication.
+          desc: Returns the domain's TXT records, which carry the SPF (Sender Policy Framework) policy used for email authentication.
         mql: dns.params.TXT
       - uid: mondoo-email-inventory-dmarc-entry
         title: Retrieve DMARC DNS entry
         docs:
-          desc: Returns the DMARC (Domain-based Message Authentication) record for email policy enforcement.
+          desc: Returns the TXT record at the _dmarc subdomain, which defines the domain's DMARC (Domain-based Message Authentication) policy.
         mql: dns("_dmarc."+domainName.fqdn).params.TXT
       - uid: mondoo-email-inventory-dkim-configuration
         title: Retrieve DKIM entry
         docs:
-          desc: Checks for DKIM (DomainKeys Identified Mail) records using common selectors for email signing verification.
+          desc: Queries a list of common selectors under _domainkey to find published DKIM (DomainKeys Identified Mail) signing keys.
         props:
           - uid: mondooEmailSecurityDkimSelectors
             title: Define a list of valid DKIM selectors

--- a/content/querypacks/mondoo-gcp-inventory.mql.yaml
+++ b/content/querypacks/mondoo-gcp-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory GCP projects, compute, and resources
     docs:
       desc: |
-        The GCP Asset Inventory by Mondoo query pack retrieves information about GCP projects for asset inventory.
+        Collects GCP project inventory: project metadata, enabled services, IAM bindings, GKE clusters, Compute Engine instances, and VPC networks.
     groups:
       - uid: mondoo-asset-inventory-gcp-general-group
         title: GCP General
@@ -57,7 +57,7 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        Returns basic GCP project information including name, ID, state, and labels.
+        Returns core project metadata: name, ID, lifecycle state, and labels.
     mql: |
       gcp.project {
         name
@@ -71,7 +71,7 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves data for all owners of the GCP project
+        Lists the IAM members bound to the project owner role.
     mql: |
       gcp.project.iamPolicy.where( role == "roles/owner" ) {
         id
@@ -83,7 +83,7 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves data for all editors of the GCP project
+        Lists the IAM members bound to the project editor role.
     mql: |
       gcp.project.iamPolicy.where( role == "roles/editors" ) {
         id
@@ -95,7 +95,7 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves all roles defined for a GCP project
+        Lists every IAM role defined in the project's IAM policy.
     mql: gcp.project.iamPolicy { role }
 
   - uid: mondoo-asset-inventory-gcp-enabled-services
@@ -103,7 +103,7 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves all services enabled in the GCP Project
+        Lists the enabled Google Cloud APIs and services for the project.
     mql: gcp.project.services.where( enabled == true )
 
   - uid: mondoo-asset-inventory-gcp-gke-clusters-count
@@ -111,14 +111,14 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves a count of GKE clusters running in a GCP project
+        Counts the GKE clusters in the project.
     mql: gcp.project.gke.clusters.length
 
   - uid: mondoo-asset-inventory-gcp-gke-clusters-data
     title: GKE clusters configuration
     docs:
       desc: |
-        This query retrieves all of the configuration data for GKE clusters within a project
+        Returns the full configuration for each GKE cluster in the project.
     variants:
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data-all
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data-single
@@ -136,14 +136,14 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves a count of running GCP compute instances in a GCP project
+        Counts running Compute Engine instances.
     mql: gcp.compute.instances.where( status == "RUNNING" ).length
 
   - uid: mondoo-asset-inventory-gcp-compute-instances-data
     title: GCP compute instances
     docs:
       desc: |
-        This query retrieves the data for all running GCP compute instances in a GCP project
+        Returns the full configuration for every running Compute Engine instance.
     variants:
       - uid: mondoo-asset-inventory-gcp-compute-instances-data-all
       - uid: mondoo-asset-inventory-gcp-compute-instances-data-single
@@ -162,7 +162,7 @@ queries:
     title: GCP Compute Engine instances
     docs:
       desc: |
-        This query retrieves the data for all GCP Compute Engine instances that have been configured with an external IP address.
+        Lists Compute Engine instances that have an external NAT IP address, exposing them directly to the internet.
     variants:
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
@@ -182,14 +182,14 @@ queries:
     filters: asset.platform == "gcp-project"
     docs:
       desc: |
-        This query retrieves a count of GCP Compute Engine networks configured in a GCP project
+        Counts the VPC networks configured in the project.
     mql: gcp.compute.networks.length
 
   - uid: mondoo-asset-inventory-gcp-compute-networks-data
     title: GCP Compute Engine networks
     docs:
       desc: |
-        This query retrieves the data for all GCP Compute Engine networks configured in a GCP project.
+        Returns the configuration for every VPC network in the project.
     variants:
       - uid: mondoo-asset-inventory-gcp-compute-networks-data-all
       - uid: mondoo-asset-inventory-gcp-compute-networks-data-single

--- a/content/querypacks/mondoo-github-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-github-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Incident Response Pack by Mondoo query pack retrieves configuration data about GitHub organizations and the repositories within them for investigation during a security incident.
+        Gathers evidence from a GitHub organization during a security incident: organization settings, MFA enforcement, owners, members, teams, repositories, and published packages.
 
         ### Prerequisites
 
@@ -60,14 +60,14 @@ packs:
         title: GitHub Organization MFA status
         docs:
           desc: |
-            This query retrieves whether multi-factor authentication is required for users of the organization. A null value means the API token used to query the information doesn't have sufficient permissions in the organization. The API token must have owner permissions in the organization to access this data.
+            Reports whether the organization requires multi-factor authentication for its members. A null value means the API token lacks the owner permissions needed to read this setting.
         mql: |
           github.organization.twoFactorRequirementEnabled
       - uid: mondoo-incident-response-github-org-owners
         title: GitHub Organization Owners
         docs:
           desc: |
-            This query retrieves all GitHub organization owners.
+            Lists the organization's owners with their name, email, and login, plus a total count. Owners hold full administrative control.
         mql: |
           github.organization.owners.length
           github.organization {
@@ -81,7 +81,7 @@ packs:
         title: GitHub Organization Members
         docs:
           desc: |
-            This query retrieves all of the members of the GitHub organization.
+            Lists all organization members with their name, login, and email, plus a total count.
         mql: |
           github.organization.members.length
           github.organization {
@@ -95,7 +95,7 @@ packs:
         title: GitHub Organization Teams
         docs:
           desc: |
-            This query retrieves all GitHub organization teams.
+            Lists the organization's teams with each team's slug, privacy, default repository permission, and member roster.
         mql: |
           github.organization {
             teams {
@@ -113,7 +113,7 @@ packs:
         title: GitHub Organization private repositories
         docs:
           desc: |
-            This query retrieves all of the public repositories within the GitHub organization. The query returns the repo's name and whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules.
+            Lists the organization's public repositories, reporting whether each repo's default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) by branch protection rules.
         mql: |
           github.organization.repositories.
             where( private == false ) {
@@ -127,7 +127,7 @@ packs:
         title: GitHub Organization private repositories
         docs:
           desc: |
-            This query retrieves the packages published to GHCR.io.
+            Lists the packages the organization has published, with each package's visibility, type, and owner.
         mql: |
           github.organization {
             packages {

--- a/content/querypacks/mondoo-github-inventory.mql.yaml
+++ b/content/querypacks/mondoo-github-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Inventory Pack by Mondoo query pack retrieves configuration data about GitHub organizations.
+        Collects GitHub organization inventory: profile identity, contact and social links, repository count, and creation and update timestamps.
 
         ### Prerequisites
 
@@ -38,67 +38,67 @@ packs:
       - uid: mondoo-github-inventory-org-login
         title: GitHub organization login
         docs:
-          desc: Returns the login handle (URL slug) of the GitHub organization.
+          desc: Returns the organization login handle, the slug used in its URL.
         mql: github.organization.login
       - uid: mondoo-github-inventory-org-id
         title: GitHub organization ID
         docs:
-          desc: Returns the unique numeric identifier of the GitHub organization.
+          desc: Returns the organization's unique numeric ID.
         mql: github.organization.id
       - uid: mondoo-github-inventory-org-profile-photo
         title: GitHub organization profile photo
         docs:
-          desc: Returns the URL of the organization's avatar/profile photo.
+          desc: Returns the URL of the organization's avatar image.
         mql: github.organization.avatarUrl
       - uid: mondoo-github-inventory-org-email
         title: GitHub organization email
         docs:
-          desc: Returns the public email address configured for the organization.
+          desc: Returns the public contact email set for the organization.
         mql: github.organization.email
       - uid: mondoo-github-inventory-org-desc
         title: GitHub organization description
         docs:
-          desc: Returns the description configured for the GitHub organization.
+          desc: Returns the organization's profile description.
         mql: github.organization.description
       - uid: mondoo-github-inventory-org-blog
         title: GitHub organization blog
         docs:
-          desc: Returns the blog/website URL configured for the organization.
+          desc: Returns the website or blog URL set on the organization profile.
         mql: github.organization.blog
       - uid: mondoo-github-inventory-org-location
         title: GitHub organization location
         docs:
-          desc: Returns the location configured for the organization profile.
+          desc: Returns the location listed on the organization profile.
         mql: github.organization.location
       - uid: mondoo-github-inventory-org-followers
         title: GitHub organization followers
         docs:
-          desc: Returns the number of users following the organization.
+          desc: Returns the count of users following the organization.
         mql: github.organization.followers
       - uid: mondoo-github-inventory-org-following
         title: GitHub organization following
         docs:
-          desc: Returns the number of users the organization is following.
+          desc: Returns the count of users the organization follows.
         mql: github.organization.following
       - uid: mondoo-github-inventory-org-twitter
         title: GitHub organization twitter handle
         docs:
-          desc: Returns the Twitter/X username configured for the organization.
+          desc: Returns the X (Twitter) handle set on the organization profile.
         mql: github.organization.twitterUsername
       - uid: mondoo-github-inventory-org-number-repositories
         title: GitHub organization repositories
         docs:
-          desc: Returns the total number of repositories in the organization.
+          desc: Counts the repositories in the organization.
         mql: github.organization.repositories.length
       - uid: mondoo-github-inventory-org-created
         title: GitHub organization created
         docs:
-          desc: Returns the timestamp when the organization was created.
+          desc: Returns the organization's creation timestamp.
         mql: github.organization.createdAt
       - uid: mondoo-github-inventory-org-updated
         title: GitHub organization updated
         docs:
-          desc: Returns the timestamp when the organization was last updated.
+          desc: Returns the timestamp of the organization's last update.
         mql: github.organization.updatedAt
   - uid: mondoo-github-inventory-user
     name: GitHub User Inventory Pack
@@ -116,7 +116,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub User Inventory query pack retrieves configuration data about GitHub users.
+        Collects GitHub user inventory: profile identity, contact and social links, repository count, and account timestamps.
 
         ### Prerequisites
 
@@ -135,67 +135,67 @@ packs:
       - uid: mondoo-github-inventory-user-login
         title: GitHub user login
         docs:
-          desc: Returns the login/username of the GitHub user.
+          desc: Returns the user's login name.
         mql: github.user.login
       - uid: mondoo-github-inventory-user-id
         title: GitHub user ID
         docs:
-          desc: Returns the unique numeric identifier of the GitHub user.
+          desc: Returns the user's unique numeric ID.
         mql: github.user.id
       - uid: mondoo-github-inventory-user-profile-photo
         title: GitHub user profile photo
         docs:
-          desc: Returns the URL of the user's avatar/profile photo.
+          desc: Returns the URL of the user's avatar image.
         mql: github.user.avatarUrl
       - uid: mondoo-github-inventory-user-email
         title: GitHub user email
         docs:
-          desc: Returns the public email address of the GitHub user.
+          desc: Returns the user's public email address.
         mql: github.user.email
       - uid: mondoo-github-inventory-user-bio
         title: GitHub user bio
         docs:
-          desc: Returns the biography text from the user's profile.
+          desc: Returns the bio text from the user's profile.
         mql: github.user.bio
       - uid: mondoo-github-inventory-user-blog
         title: GitHub user blog
         docs:
-          desc: Returns the blog/website URL from the user's profile.
+          desc: Returns the website or blog URL from the user's profile.
         mql: github.user.blog
       - uid: mondoo-github-inventory-user-location
         title: GitHub user location
         docs:
-          desc: Returns the location from the user's profile.
+          desc: Returns the location listed on the user's profile.
         mql: github.user.location
       - uid: mondoo-github-inventory-user-followers
         title: GitHub user followers
         docs:
-          desc: Returns the number of users following this user.
+          desc: Returns the count of users following this user.
         mql: github.user.followers
       - uid: mondoo-github-inventory-user-following
         title: GitHub user following
         docs:
-          desc: Returns the number of users this user is following.
+          desc: Returns the count of users this user follows.
         mql: github.user.following
       - uid: mondoo-github-inventory-user-twitter
         title: GitHub user twitter handle
         docs:
-          desc: Returns the Twitter/X username from the user's profile.
+          desc: Returns the X (Twitter) handle from the user's profile.
         mql: github.user.twitterUsername
       - uid: mondoo-github-inventory-user-number-repositories
         title: GitHub user repositories
         docs:
-          desc: Returns the total number of repositories owned by the user.
+          desc: Counts the repositories owned by the user.
         mql: github.user.repositories.length
       - uid: mondoo-github-inventory-user-created
         title: GitHub user created
         docs:
-          desc: Returns the timestamp when the user account was created.
+          desc: Returns the account creation timestamp.
         mql: github.user.createdAt
       - uid: mondoo-github-inventory-user-updated
         title: GitHub user updated
         docs:
-          desc: Returns the timestamp when the user profile was last updated.
+          desc: Returns the timestamp of the profile's last update.
         mql: github.user.updatedAt
   - uid: mondoo-github-inventory-repo
     name: GitHub Repository Inventory Pack
@@ -213,7 +213,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub Repository Inventory query pack retrieves configuration data about GitHub repositories.
+        Collects GitHub repository inventory: identity and description, popularity metrics, license and language, enabled features, clone URLs, visibility, and lifecycle timestamps.
 
         ### Prerequisites
 
@@ -232,130 +232,130 @@ packs:
       - uid: mondoo-github-inventory-repo-id
         title: GitHub repository ID
         docs:
-          desc: Returns the unique numeric identifier of the repository.
+          desc: Returns the repository's unique numeric ID.
         mql: github.repository.id
       - uid: mondoo-github-inventory-repo-description
         title: GitHub repository description
         docs:
-          desc: Returns the description text of the repository.
+          desc: Returns the repository's description text.
         mql: github.repository.description
       - uid: mondoo-github-inventory-repo-forks
         title: Number GitHub repository forks
         docs:
-          desc: Returns the number of times this repository has been forked.
+          desc: Counts how many times the repository has been forked.
         mql: github.repository.forksCount
       - uid: mondoo-github-inventory-repo-stargazers
         title: Number GitHub repository stargazers
         docs:
-          desc: Returns the number of users who have starred the repository.
+          desc: Counts the users who have starred the repository.
         mql: github.repository.stargazersCount
       - uid: mondoo-github-inventory-repo-watchers
         title: Number GitHub repository watchers
         docs:
-          desc: Returns the number of users watching the repository for notifications.
+          desc: Counts the users watching the repository for notifications.
         mql: github.repository.watchersCount
       - uid: mondoo-github-inventory-repo-license
         title: GitHub repository license
         docs:
-          desc: Returns the SPDX identifier of the repository's license.
+          desc: Returns the SPDX identifier of the repository's declared license.
         mql: github.repository.license.spdxId
       - uid: mondoo-github-inventory-repo-default-branch
         title: GitHub repo default branch
         docs:
-          desc: Returns the name of the repository's default branch.
+          desc: Returns the name of the repository's default branch, typically main or master.
         mql: github.repository.defaultBranchName
       - uid: mondoo-github-inventory-repo-visibility
         title: GitHub repository visibility
         docs:
-          desc: Returns the visibility setting (public, private, internal) of the repository.
+          desc: "Returns the repository's visibility: public, private, or internal."
         mql: github.repository.visibility
       - uid: mondoo-github-inventory-repo-languages
         title: GitHub repository languages
         docs:
-          desc: Returns the primary programming language of the repository.
+          desc: Returns the repository's primary programming language.
         mql: github.repository.language
       - uid: mondoo-github-inventory-repo-open-issues
         title: GitHub repository open issues
         docs:
-          desc: Returns the count of open issues and pull requests in the repository.
+          desc: Counts open issues and pull requests in the repository.
         mql: github.repository.openIssuesCount
       - uid: mondoo-github-inventory-repo-topics
         title: GitHub repository topics
         docs:
-          desc: Returns the topic tags assigned to the repository.
+          desc: Lists the topic tags applied to the repository.
         mql: github.repository.topics
       - uid: mondoo-github-inventory-repo-homepage
         title: GitHub repository homepage
         docs:
-          desc: Returns the homepage URL configured for the repository.
+          desc: Returns the homepage URL set for the repository.
         mql: github.repository.homepage
       - uid: mondoo-github-inventory-repo-clone-url
         title: GitHub repository Clone URL
         docs:
-          desc: Returns the HTTPS URL for cloning the repository.
+          desc: Returns the HTTPS clone URL for the repository.
         mql: github.repository.cloneUrl
       - uid: mondoo-github-inventory-repo-ssl-url
         title: GitHub repository SSH URL
         docs:
-          desc: Returns the SSH URL for cloning the repository.
+          desc: Returns the SSH clone URL for the repository.
         mql: github.repository.sshUrl
       - uid: mondoo-github-inventory-repo-is-fork
         title: Is fork
         docs:
-          desc: Returns whether the repository is a fork of another repository.
+          desc: Reports whether the repository is a fork of another repository.
         mql: github.repository.isFork
       - uid: mondoo-github-inventory-repo-is-forkable
         title: Is forkable
         docs:
-          desc: Returns whether forking is allowed for the repository.
+          desc: Reports whether forking is allowed for the repository.
         mql: github.repository.allowForking
       - uid: mondoo-github-inventory-repo-is-private
         title: Is private
         docs:
-          desc: Returns whether the repository is private.
+          desc: Reports whether the repository is private.
         mql: github.repository.private
       - uid: mondoo-github-inventory-repo-is-archived
         title: Is archived
         docs:
-          desc: Returns whether the repository has been archived.
+          desc: Reports whether the repository is archived.
         mql: github.repository.archived
       - uid: mondoo-github-inventory-repo-has-downloads
         title: Has downloads
         docs:
-          desc: Returns whether downloads are enabled for the repository.
+          desc: Reports whether downloads are enabled for the repository.
         mql: github.repository.hasDownloads
       - uid: mondoo-github-inventory-repo-has-issues
         title: Has issues
         docs:
-          desc: Returns whether the issues feature is enabled for the repository.
+          desc: Reports whether the issues feature is enabled for the repository.
         mql: github.repository.hasIssues
       - uid: mondoo-github-inventory-repo-has-pages
         title: Has pages
         docs:
-          desc: Returns whether GitHub Pages is enabled for the repository.
+          desc: Reports whether GitHub Pages is enabled for the repository.
         mql: github.repository.hasPages
       - uid: mondoo-github-inventory-repo-has-projects
         title: Has projects
         docs:
-          desc: Returns whether projects feature is enabled for the repository.
+          desc: Reports whether the projects feature is enabled for the repository.
         mql: github.repository.hasProjects
       - uid: mondoo-github-inventory-repo-has-wiki
         title: Has wiki
         docs:
-          desc: Returns whether the wiki feature is enabled for the repository.
+          desc: Reports whether the wiki feature is enabled for the repository.
         mql: github.repository.hasWiki
       - uid: mondoo-github-inventory-repo-pushed-at
         title: Pushed at
         docs:
-          desc: Returns the timestamp of the last push to the repository.
+          desc: Returns the timestamp of the most recent push to the repository.
         mql: github.repository.pushedAt
       - uid: mondoo-github-inventory-repo-created-at
         title: Created at
         docs:
-          desc: Returns the timestamp when the repository was created.
+          desc: Returns the repository's creation timestamp.
         mql: github.repository.createdAt
       - uid: mondoo-github-inventory-repo-updated-at
         title: Updated at
         docs:
-          desc: Returns the timestamp when the repository was last updated.
+          desc: Returns the timestamp of the repository's last update.
         mql: github.repository.updatedAt

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Google Workspace Incident Response query pack retrieves configuration data about your Google Workspace configuration during a security incident.
+        Collects Google Workspace evidence for incident investigation: configured domains, user 2-Step Verification enrollment, super admin accounts, hardware security key usage, and account recovery email addresses.
 
         ### Prerequisites
 
@@ -67,35 +67,35 @@ packs:
       - uid: mondoo-googleworkspace-incident-response-domain
         title: Google Workspace domains
         docs:
-          desc: Lists all domains configured in Google Workspace with their primary and verification status.
+          desc: Lists the tenant's configured domains with their primary designation and verification status, establishing the legitimate identity boundary.
         mql: googleworkspace.domains { domainName isPrimary verified }
       - uid: mondoo-googleworkspace-incident-response-user-mfa-status
         title: Google Workspace users' MFA status
         docs:
-          desc: Lists all users with their email and 2-Step Verification enforcement status.
+          desc: Lists every user with their email and whether 2-Step Verification is enforced, showing where account-takeover protection is missing.
         mql: googleworkspace.users { primaryEmail isEnforcedIn2Sv }
       - uid: mondoo-googleworkspace-incident-response-super-admins
         title: Google Workspace super admins
         docs:
-          desc: Lists all users with super admin privileges to identify privileged accounts.
+          desc: Lists the accounts holding super admin privileges, the highest-value targets in the tenant.
         mql: googleworkspace.report.users.where(isSuperAdmin == true) { userEmail }
       - uid: mondoo-googleworkspace-incident-response-super-admins-without-2FA-enrolled
         title: Google Workspace super admins who are not enrolled in 2FA
         docs:
-          desc: Identifies super admin accounts that have not enrolled in 2-Step Verification, representing a security risk.
+          desc: Identifies admin accounts that have not enrolled in 2-Step Verification, a high-risk gap an attacker could exploit for privileged access.
         mql: googleworkspace.users.where(isEnrolledIn2Sv != true && isAdmin == true) {primaryEmail isEnrolledIn2Sv isAdmin}
       - uid: mondoo-googleworkspace-incident-response-users-without-2FA-enrolled
         title: Google Workspace user accounts that are not enrolled in 2FA
         docs:
-          desc: Identifies all user accounts not enrolled in 2-Step Verification for security assessment.
+          desc: Identifies all accounts not enrolled in 2-Step Verification, the identities most exposed to credential-based takeover.
         mql: googleworkspace.users.where(isEnrolledIn2Sv != true) {primaryEmail isEnrolledIn2Sv isAdmin}
       - uid: mondoo-googleworkspace-incident-response-super-admins-without-hardware-based-2fa
         title: Super admin accounts that do not use hardware-based security keys
         docs:
-          desc: Identifies super admin accounts without hardware security keys, which provide stronger protection than software-based 2FA.
+          desc: Identifies super admin accounts with no hardware security key registered, leaving them reliant on weaker second factors.
         mql: googleworkspace.report.users.where(isSuperAdmin == true && numSecurityKeys <= 0 ) {userEmail numSecurityKeys}
       - uid: mondoo-googleworkspace-incident-response-config-drift-recovery-email
         title: Primary and recovery email accounts of all Google Workspace users
         docs:
-          desc: Lists primary and recovery email addresses to identify potential account recovery attack vectors.
+          desc: Lists each user's primary and recovery email addresses, exposing recovery paths an attacker could hijack to seize an account.
         mql: googleworkspace.users {primaryEmail recoveryEmail}

--- a/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Kubernetes Incident Response Pack by Mondoo retrieves security-related configuration data from Kubernetes clusters for investigation during a security incident. This includes cluster version, role bindings with cluster-admin permissions, pod security contexts, and container image information across various workload types.
+        Collects Kubernetes evidence for incident investigation: the cluster server version, RoleBindings and ClusterRoleBindings that grant cluster-admin, container security contexts, and container image sources across pods, deployments, cronjobs, jobs, daemonsets, statefulsets, and replicasets.
 
         ### Run query pack
 
@@ -41,13 +41,13 @@ packs:
           - uid: mondoo-kubernetes-incident-response-cluster-version
             title: Kubernetes Cluster Version
             docs:
-              desc: Returns the Kubernetes cluster version to identify potential vulnerabilities in the control plane.
+              desc: Returns the cluster's Kubernetes server version, revealing control-plane components that may carry known vulnerabilities.
             mql: |
               k8s.serverVersion
           - uid: mondoo-kubernetes-incident-response-role-bindings-with-cluster-admin-permissions
             title: Role bindings with cluster-admin permissions
             docs:
-              desc: Lists namespace-scoped RoleBindings that grant cluster-admin privileges to identify accounts with excessive permissions.
+              desc: Lists namespace-scoped RoleBindings bound to the cluster-admin ClusterRole, with their subjects, exposing accounts granted excessive privileges.
             mql: |
               k8s.rolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
                 name
@@ -58,7 +58,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-clusterrole-bindings-with-cluster-admin-permissions
             title: ClusterRoleBindings with cluster-admin permissions
             docs:
-              desc: Lists cluster-wide ClusterRoleBindings that grant cluster-admin privileges to identify accounts with full cluster access.
+              desc: Lists cluster-wide ClusterRoleBindings bound to the cluster-admin ClusterRole, with their subjects, exposing accounts that hold full control of the cluster.
             mql: |
               k8s.clusterrolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
                 name
@@ -71,7 +71,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-pod-security-context
             title: Pod Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the pod to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the pod's init, ephemeral, and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.pod {
                 ephemeralContainers {
@@ -87,7 +87,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-pod-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry, along with the node the pod runs on, to trace where the running images originated.
             mql: |
               k8s.pod {
                 name
@@ -136,7 +136,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-deployment-security-context
             title: Deployment Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the deployment to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the deployment's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.deployment {
                 initContainers {
@@ -149,7 +149,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-deployment-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.deployment {
                 name
@@ -185,7 +185,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-cronjob-security-context
             title: CronJob Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the cronjob to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the cronjob's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.cronjob {
                 initContainers {
@@ -198,7 +198,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-cronjob-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.cronjob {
                 name
@@ -234,7 +234,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-job-security-context
             title: Job Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the job to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the job's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.job {
                 initContainers {
@@ -247,7 +247,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-job-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.job {
                 name
@@ -283,7 +283,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-daemonset-security-context
             title: DaemonSet Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the daemonset to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the daemonset's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.daemonset {
                 initContainers {
@@ -296,7 +296,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-daemonset-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.daemonset {
                 name
@@ -332,7 +332,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-statefulset-security-context
             title: StatefulSet Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the statefulset to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the statefulset's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.statefulset {
                 initContainers {
@@ -345,7 +345,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-statefulset-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.statefulset {
                 name
@@ -381,7 +381,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-replicaset-security-context
             title: ReplicaSet Security Context
             docs:
-              desc: Retrieves security context settings for all containers in the replicaset to identify privileged containers or insecure configurations.
+              desc: Shows the security context of the replicaset's init and application containers, revealing privileged or otherwise insecure container settings.
             mql: |
               k8s.replicaset {
                 initContainers {
@@ -394,7 +394,7 @@ packs:
           - uid: mondoo-kubernetes-incident-response-replicaset-container
             title: Container image information
             docs:
-              desc: Retrieves container image details including registry and image identifiers to trace the source of container images.
+              desc: Lists each container's image name, identifier, and source registry to trace where the running images originated.
             mql: |
               k8s.replicaset {
                 name

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Kubernetes cluster resources and workloads
     docs:
       desc: |
-        The Kubernetes Inventory Pack by Mondoo retrieves data about a Kubernetes Cluster for asset inventory.
+        Collects Kubernetes cluster inventory: server version, namespaces, nodes, RBAC roles and bindings, quotas, limit ranges, storage, autoscalers, and workload resources such as pods, deployments, jobs, and ingresses.
 
         To run this pack for a Kubernetes Cluster:
 
@@ -36,7 +36,7 @@ packs:
           - uid: k8s-cluster-version
             title: Kubernetes cluster version
             docs:
-              desc: Returns the Kubernetes server version for cluster identification.
+              desc: Reports the Kubernetes API server version for cluster identification.
             mql: |
               k8s.serverVersion
           - uid: k8s-cluster-namespaces
@@ -55,18 +55,18 @@ packs:
             title: Cluster node cloud provider IDs
             docs:
               desc: |
-                Maps each node to its cloud provider ID (for AWS, providerID is
-                "aws:///<az>/<instance-id>"), bridging Kubernetes nodes to the
-                underlying EC2 instances for internet-exposure attribution.
+                Maps each node name to its cloud provider ID, linking Kubernetes
+                nodes to the underlying cloud instances for internet-exposure
+                attribution.
             mql: |
               k8s.nodes { name providerID }
           - uid: k8s-cluster-pod-nodes
             title: Pod-to-node placement
             docs:
               desc: |
-                Maps each pod to the node it runs on, so workloads fronted by an
-                internet-facing ingress/load balancer can be traced down to the
-                specific node (and, via the node provider ID, the EC2 instance).
+                Maps each pod to the node it runs on, tracing workloads behind an
+                internet-facing ingress or load balancer down to a specific node
+                and, via the node provider ID, the underlying cloud instance.
             mql: |
               k8s.pods { namespace name nodeName }
           - uid: k8s-cluster-clusterroles
@@ -123,7 +123,7 @@ packs:
           - uid: k8s-pod
             title: Pod information
             docs:
-              desc: Returns detailed information about the pod including spec and status.
+              desc: Returns the pod's full spec and status.
             mql: |
               k8s.pod
           - uid: k8s-pod-container
@@ -138,7 +138,7 @@ packs:
           - uid: k8s-deployment
             title: Deployment information
             docs:
-              desc: Returns detailed information about deployments in the cluster.
+              desc: Returns each deployment's spec and status.
             mql: |
               k8s.deployments
           - uid: k8s-deployment-container
@@ -153,7 +153,7 @@ packs:
           - uid: k8s-cronjob
             title: CronJob information
             docs:
-              desc: Returns detailed information about the CronJob including schedule and job template.
+              desc: Returns the CronJob's schedule, job template, spec, and status.
             mql: |
               k8s.cronjob { * }
           - uid: k8s-cronjob-container
@@ -168,7 +168,7 @@ packs:
           - uid: k8s-job
             title: Job information
             docs:
-              desc: Returns detailed information about the Job including spec and status.
+              desc: Returns the Job's spec and status.
             mql: |
               k8s.job { * }
           - uid: k8s-job-container
@@ -183,7 +183,7 @@ packs:
           - uid: k8s-daemonset
             title: DaemonSet information
             docs:
-              desc: Returns detailed information about the DaemonSet including spec and status.
+              desc: Returns the DaemonSet's spec and status.
             mql: |
               k8s.daemonset { * }
           - uid: k8s-daemonset-container
@@ -198,7 +198,7 @@ packs:
           - uid: k8s-statefulset
             title: StatefulSet information
             docs:
-              desc: Returns detailed information about the StatefulSet including spec and status.
+              desc: Returns the StatefulSet's spec and status.
             mql: |
               k8s.statefulset { * }
           - uid: k8s-statefulset-container
@@ -213,7 +213,7 @@ packs:
           - uid: k8s-replicaset
             title: ReplicaSet information
             docs:
-              desc: Returns detailed information about the ReplicaSet including spec and status.
+              desc: Returns the ReplicaSet's spec and status.
             mql: |
               k8s.replicaset { * }
           - uid: k8s-replicaset-container
@@ -228,6 +228,6 @@ packs:
           - uid: k8s-ingress
             title: Ingress information
             docs:
-              desc: Returns detailed information about the Ingress including rules and backend configuration.
+              desc: Returns the Ingress rules and backend service configuration.
             mql: |
               k8s.ingress { * }

--- a/content/querypacks/mondoo-linux-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-linux-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Linux Incident Response Pack by Mondoo retrieves configuration data from Linux hosts for investigation during a security incident. This includes kernel information, running processes, mounted devices, listening ports, installed packages, and running services.
+        Gathers forensic evidence from Linux hosts during a security incident: kernel details, running processes, mounted devices, listening ports, installed packages, and running services.
 
         ### Run query pack
 
@@ -39,61 +39,61 @@ packs:
       - uid: mondoo-linux-incident-response-installed-kernel
         title: Installed kernels
         docs:
-          desc: Lists all installed kernel versions to identify available kernels and verify if security patches have been applied.
+          desc: Lists all installed kernel versions, showing which kernels can boot and whether security patches have been applied.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.installed
       - uid: mondoo-linux-incident-response-kernel-info
         title: Running kernel version
         docs:
-          desc: Returns information about the currently running kernel to identify the active kernel version and potential vulnerabilities.
+          desc: Reports the currently running kernel version, helping spot an outdated or vulnerable active kernel.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.info
       - uid: mondoo-linux-incident-response-kernel-modules
         title: Kernel modules
         docs:
-          desc: Lists all kernel modules with their load status to identify potentially malicious or unauthorized kernel extensions.
+          desc: Lists kernel modules and their load status, surfacing unauthorized or malicious kernel extensions.
         mql: kernel.modules { name loaded }
       - uid: mondoo-linux-incident-response-processes
         title: Running processes
         docs:
-          desc: Lists all running processes with their PID and command to identify suspicious or malicious processes.
+          desc: Lists running processes with their PID and command line, helping spot suspicious or malicious activity.
         filters: mondoo.capabilities.contains("run-command")
         mql: processes { pid  command }
       - uid: mondoo-linux-incident-response-mounts
         title: Mounted devices
         docs:
-          desc: Lists all mounted filesystems with their paths, types, devices, and mount options to identify unusual mounts or insecure configurations.
+          desc: Lists mounted filesystems with their paths, types, devices, and options, revealing unusual mounts or insecure settings.
         mql: mount.list { path fstype device options size used available }
       - uid: mondoo-linux-incident-response-listening-ports
         title: Listening ports
         docs:
-          desc: Lists all listening network ports to identify services exposed to the network and potential unauthorized access points.
+          desc: Lists listening network ports, exposing network-facing services and possible unauthorized access points.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports.listening
       - uid: mondoo-linux-incident-response-uptime
         title: Operating system uptime
         docs:
-          desc: Returns the system uptime to help determine when the system was last rebooted and establish incident timeline.
+          desc: Reports system uptime, helping pin down the last reboot and build the incident timeline.
         filters: mondoo.capabilities.contains("run-command")
         mql: os.uptime
       - uid: mondoo-linux-incident-response-installed-packages
         title: Installed packages
         docs:
-          desc: Lists all installed packages with version, architecture, and origin information to identify potentially vulnerable or malicious software.
+          desc: Lists installed packages with version, architecture, and origin, surfacing vulnerable or malicious software.
         mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-linux-incident-response-timezone
         title: System timezone
         docs:
-          desc: Returns the system timezone to help correlate log timestamps across systems during incident investigation.
+          desc: Reports the system timezone, needed to correlate log timestamps across hosts.
         mql: os.date.timezone
       - uid: mondoo-linux-incident-response-selinux-status
         title: SELinux status
         docs:
-          desc: Returns SELinux enforcement mode and configuration to identify whether mandatory access controls have been disabled, which is a common indicator of compromise or misconfiguration.
+          desc: Reports SELinux enforcement mode and configuration, revealing whether mandatory access controls were disabled, a common sign of compromise or misconfiguration.
         filters: asset.family.contains("redhat") || asset.platform == "amazonlinux"
         mql: selinux { installed mode configMode policyType }
       - uid: mondoo-linux-incident-response-running-services
         title: Running services
         docs:
-          desc: Lists all currently running services with their status to identify suspicious or unauthorized services that may indicate compromise.
+          desc: Lists currently running services and their status, surfacing unauthorized services that may indicate compromise.
         mql: services.where(running == true) { name running enabled masked type }

--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Linux host OS, packages, and configuration
     docs:
       desc: |
-        The Linux Inventory Pack by Mondoo retrieves data about Linux hosts for asset inventory.
+        Inventories Linux hosts: OS and platform details, users and groups, kernel and modules, packages and services, network and firewall configuration, hardware and SMBIOS, and disk encryption.
 
         ## Local scan
         To run this pack locally on a Linux host:
@@ -42,225 +42,225 @@ packs:
       - uid: mondoo-linux-asset-info
         title: Asset information
         docs:
-          desc: Returns basic asset information including platform, architecture, and version.
+          desc: "Returns core asset identity: kind, title, platform, name, architecture, runtime, and version."
         mql: asset { kind title platform name arch runtime version }
       - uid: mondoo-linux-hostname
         title: Hostname
         docs:
-          desc: Returns the system hostname.
+          desc: Returns the host's configured hostname.
         mql: os.hostname
       - uid: mondoo-linux-platform
         title: Platform
         docs:
-          desc: Returns the Linux distribution name (e.g., ubuntu, redhat, debian).
+          desc: Returns the Linux distribution identifier, such as ubuntu, redhat, or debian.
         mql: asset.platform
       - uid: mondoo-linux-users
         title: Regular users with shell access
         docs:
-          desc: Lists regular user accounts with shell access, including SSH keys and home directories.
+          desc: Lists regular accounts (non-root, UID 1000+) with login shells, showing UID, GID, shell, home directory, group, and SSH authorized keys.
         mql: users.where(shell != "/sbin/nologin" && uid >= 1000 && name != "root") { name sid uid gid shell authorizedkeys.list sshkeys home group }
       - uid: mondoo-linux-groups-wheel
         title: Members of the wheel group
         docs:
-          desc: Lists members of the wheel group who have sudo privileges.
+          desc: Lists members of the wheel group, which typically grants sudo access.
         mql: groups.where(name == "wheel") { members }
       - uid: mondoo-linux-installed-kernel
         title: Installed kernels
         docs:
-          desc: Lists all installed kernel versions.
+          desc: Lists all installed kernel packages and versions.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.installed
       - uid: mondoo-linux-kernel-info
         title: Running kernel versions
         docs:
-          desc: Returns information about the currently running kernel.
+          desc: Returns details about the currently running kernel.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.info
       - uid: mondoo-linux-kernel-modules
         title: Kernel modules
         docs:
-          desc: Lists all kernel modules with their load status.
+          desc: Lists kernel modules and whether each is currently loaded.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.modules { name loaded }
       - uid: mondoo-linux-kernel-parameters
         title: Kernel parameters
         docs:
-          desc: Returns kernel runtime parameters (sysctl values).
+          desc: Returns runtime kernel parameters (sysctl values).
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.parameters
       - uid: mondoo-linux-processes
         title: Running processes
         docs:
-          desc: Lists all running processes with their PID, command, and flags.
+          desc: Lists running processes with their PID, command, and flags.
         filters: mondoo.capabilities.contains("run-command")
         mql: processes { pid command flags }
       - uid: mondoo-linux-mounts
         title: Mounted devices
         docs:
-          desc: Lists all mounted filesystems with their paths, types, and mount options.
+          desc: Lists mounted filesystems with path, type, device, options, and total, used, and available space.
         filters: mondoo.capabilities.contains("run-command")
         mql: mount.list { path fstype device options size used available }
       - uid: mondoo-linux-listening-ports
         title: Listening ports
         docs:
-          desc: Lists all listening network ports with their associated processes.
+          desc: Lists listening network ports with their protocol, address, state, and owning process.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports.listening { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-linux-all-connections
         title: All network connections
         docs:
-          desc: Lists all retained network connections with their associated processes.
+          desc: Lists all retained network connections with their protocol, address, state, and owning process.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-linux-active-connections
         title: Active network connections
         docs:
-          desc: Lists all active network connections with their associated processes.
+          desc: Lists network connections that are not closed, with their protocol, address, state, and owning process.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-linux-uptime
         title: Operating system uptime
         docs:
-          desc: Returns how long the system has been running since last boot.
+          desc: Returns the time elapsed since the last boot.
         filters: mondoo.capabilities.contains("run-command")
         mql: os.uptime
       - uid: mondoo-linux-installed-packages
         title: Installed packages
         docs:
-          desc: Lists all installed packages with version, architecture, and origin information.
+          desc: Lists installed packages with version, architecture, origin, and package URL (purl).
         mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-linux-running-services
         title: Running services
         docs:
-          desc: Lists all currently running services (systemd units) with their status.
+          desc: Lists running services with their enabled, masked, and type status.
         filters: mondoo.capabilities.contains("run-command")
         mql: services.where(running == true) { name running enabled masked type }
       - uid: mondoo-linux-systemd-timers
         title: systemd timers
         docs:
-          desc: Lists all systemd timer units with their schedule and activation target.
+          desc: Lists systemd timers with their schedule and the unit each activates.
         filters: mondoo.capabilities.contains("run-command")
         mql: systemd.timers { name enabled running onCalendar activates }
       - uid: mondoo-linux-systemd-sockets
         title: systemd sockets
         docs:
-          desc: Lists all systemd socket units with their listen addresses and activation target.
+          desc: Lists systemd sockets with their listen addresses and the unit each activates.
         filters: mondoo.capabilities.contains("run-command")
         mql: systemd.sockets { name enabled running listenAddresses activates }
       - uid: mondoo-linux-interface-configuration
         title: Network interface configuration
         docs:
-          desc: Returns detailed network interface configuration for all interfaces, including MAC address and per-address CIDR and subnet.
+          desc: "Returns network interface configuration: MAC address, vendor, MTU, flags, and each assigned IP with its CIDR, subnet, broadcast, and gateway."
         mql: network.interfaces { name mac vendor mtu flags active virtual ips { ip cidr subnet broadcast gateway } }
       - uid: mondoo-linux-etc-hosts
         title: Static host entries
         docs:
-          desc: Returns the static hostname-to-IP mappings from /etc/hosts.
+          desc: Returns the static hostname-to-IP mappings defined in /etc/hosts.
         mql: |
           if (file("/etc/hosts").exists) { file("/etc/hosts").content }
       - uid: mondoo-linux-resolv-conf
         title: DNS resolver configuration
         docs:
-          desc: Returns the contents of /etc/resolv.conf (nameservers and search domains).
+          desc: Returns the contents of /etc/resolv.conf, including nameservers and search domains.
         mql: |
           if (file("/etc/resolv.conf").exists) { file("/etc/resolv.conf").content }
       - uid: mondoo-linux-systemd-resolved
         title: systemd-resolved DNS configuration
         docs:
-          desc: Returns the systemd-resolved global DNS configuration, including active and fallback servers and search domains.
+          desc: "Returns the systemd-resolved DNS configuration: active state, resolvers, current and fallback servers, and search domains."
         filters: mondoo.capabilities.contains("run-command")
         mql: systemd.resolved { active dns currentDnsServer fallbackDns domains }
       - uid: mondoo-linux-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
+          desc: "Returns cloud provider instance identity from the metadata service: public and private IPs and hostnames, plus the raw metadata carrying account or subscription, region, and instance type. On non-cloud hosts the provider resolves to \"Unknown\" and instance fields are unavailable."
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-linux-docker-containers
         title: Docker containers
         docs:
-          desc: Lists Docker containers with their image, names, state, labels, and host configuration (including published port bindings). Covers the system Docker daemon at the default /var/run/docker.sock; rootless Docker and Podman sockets under $XDG_RUNTIME_DIR are not inspected.
+          desc: Lists Docker containers with their image, names, state, labels, and host configuration including published port bindings. Covers only the system Docker daemon at /var/run/docker.sock; rootless Docker and Podman sockets are not inspected.
         filters: file("/var/run/docker.sock").exists
         mql: docker.containers { id image imageid command names state status labels hostConfig }
       - uid: mondoo-linux-iptables-input
         title: iptables INPUT chain (filter table)
         docs:
-          desc: Lists the filter-table INPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
+          desc: Lists the filter table INPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
         filters: mondoo.capabilities.contains("run-command")
         mql: iptables.input { lineNumber chain target protocol source destination dport dportRange dports in out packets bytes }
       - uid: mondoo-linux-iptables-output
         title: iptables OUTPUT chain (filter table)
         docs:
-          desc: Lists the filter-table OUTPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
+          desc: Lists the filter table OUTPUT chain rules. Requires root; returns empty on hosts using nftables natively or where access is denied.
         filters: mondoo.capabilities.contains("run-command")
         mql: iptables.output { lineNumber chain target protocol source destination dport dportRange dports in out packets bytes }
       - uid: mondoo-linux-nftables-ruleset
         title: nftables ruleset
         docs:
-          desc: Lists nftables chains with their family, table, hook, default policy, and rules. Complements the iptables queries on nftables-native distributions (e.g. RHEL 9+/10, recent Debian/Ubuntu) where the legacy iptables binary is absent. Requires root; returns empty on hosts that do not use nftables or where access is denied.
+          desc: Lists nftables chains with their family, table, hook, default policy, and rules. Complements the iptables queries on nftables-native distributions where the legacy iptables binary is absent. Requires root; returns empty on hosts that do not use nftables or where access is denied.
         filters: mondoo.capabilities.contains("run-command")
         mql: nftables.chains { family table name type hook policy isBaseChain rules { handle expr comment } }
       - uid: mondoo-linux-network-neighbors
         title: ARP/NDP neighbor cache
         docs:
-          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with their IP, MAC address, interface, and cache state.
+          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with IP, MAC address, interface, and cache state.
         filters: mondoo.capabilities.contains("run-command")
         mql: network.neighbors { ip mac interface state }
       - uid: mondoo-sshd-interface-configuration
         title: sshd configuration
         docs:
-          desc: Returns the SSH server configuration parameters.
+          desc: Returns the SSH server (sshd) configuration parameters.
         filters: package('openssh-server').installed || package('openssh').installed
         mql: sshd.config.params
       - uid: mondoo-linux-system-manufacturer
         title: System manufacturer
         docs:
-          desc: Returns the system/motherboard manufacturer from SMBIOS.
+          desc: Returns the motherboard manufacturer reported by SMBIOS.
         mql: machine.baseboard.manufacturer
       - uid: mondoo-linux-system-product-name
         title: System product name
         docs:
-          desc: Returns the system/motherboard product name from SMBIOS.
+          desc: Returns the motherboard product name reported by SMBIOS.
         mql: machine.baseboard.product
       - uid: mondoo-linux-cpu-type
         title: CPU type
         docs:
-          desc: Returns the CPU model name for hardware inventory.
+          desc: Returns the CPU model name.
         mql: machine.cpu.model
       - uid: mondoo-linux-root-volume
         title: Root volume size and filesystem type
         docs:
-          desc: Returns the root volume size and filesystem type.
+          desc: Returns the root volume's size and filesystem type.
         mql: mount.point("/") { size fstype }
       - uid: mondoo-linux-physical-memory
         title: Physical memory size
         docs:
-          desc: Returns the total installed physical memory.
+          desc: Returns the total installed physical memory (MemTotal from /proc/meminfo).
         mql: |
           file("/proc/meminfo").content.lines.where(_.contains("MemTotal")).first().split(":").last().trim()
       - uid: mondoo-linux-smbios-baseboard
         title: SMBIOS baseboard (or module) information
         docs:
-          desc: Returns SMBIOS baseboard/motherboard information for hardware inventory.
+          desc: "Returns SMBIOS baseboard details: manufacturer, version, serial, asset tag, and product."
         mql: machine.baseboard { manufacturer version serial assetTag product }
       - uid: mondoo-linux-smbios-bios
         title: SMBIOS BIOS information
         docs:
-          desc: Returns SMBIOS BIOS information including vendor and version.
+          desc: Returns the SMBIOS BIOS vendor, version, and release date.
         mql: machine.bios { vendor version releaseDate }
       - uid: mondoo-linux-smbios-system
         title: SMBIOS System information
         docs:
-          desc: Returns SMBIOS system information including manufacturer, model, and UUID.
+          desc: "Returns SMBIOS system details: SKU, serial, family, version, product, UUID, and manufacturer."
         mql: machine.system { sku serial family version product uuid manufacturer }
       - uid: mondoo-linux-smbios-chassis
         title: SMBIOS Chassis information
         docs:
-          desc: Returns SMBIOS chassis information for hardware inventory.
+          desc: Returns the SMBIOS chassis manufacturer, serial, version, and asset tag.
         mql: machine.chassis { manufacturer serial version assetTag }
       - uid: mondoo-linux-workstation-security-permissions-on-bootloader-config-metadata
         title: Bootloader configuration metadata
         docs:
-          desc: Returns bootloader configuration file permissions for security auditing.
+          desc: Returns the directory, filename, and permissions of GRUB bootloader configuration files.
         filters:
           - mql: asset.family.contains('linux')
           - mql: packages.where(name == /xorg|xserver|wayland/i).any(installed)
@@ -272,7 +272,7 @@ packs:
       - uid: mondoo-linux-workstation-security-secure-boot-is-enabled-metadata
         title: Secure Boot status
         docs:
-          desc: Returns whether UEFI Secure Boot is enabled on the system.
+          desc: "Returns UEFI Secure Boot status: EFI presence, whether it is enabled, and setup mode."
         filters:
           - mql: asset.family.contains('linux')
           - mql: packages.where(name == /xorg|xserver|wayland/i).any(installed)
@@ -281,7 +281,7 @@ packs:
       - uid: mondoo-linux-workstation-security-aes-encryption-algo-metadata
         title: Disk encryption cipher suite
         docs:
-          desc: Returns LUKS encryption metadata for encrypted volumes.
+          desc: Returns LUKS encryption parameters for crypt volumes, read from cryptsetup metadata.
         filters:
           - mql: asset.family.contains('linux')
           - mql: packages.where(name == /xorg|xserver|wayland/i).any(installed)
@@ -290,7 +290,7 @@ packs:
       - uid: mondoo-linux-workstation-security-disk-encryption-metadata
         title: Disk encryption metadata
         docs:
-          desc: Returns block device information including encryption status.
+          desc: Lists block devices with their label, UUID, filesystem type, and mount points.
         filters:
           - mql: asset.family.contains('linux')
           - mql: packages.where(name == /xorg|xserver|wayland/i).any(installed)
@@ -299,16 +299,16 @@ packs:
       - uid: mondoo-linux-timezone
         title: System timezone
         docs:
-          desc: Returns the configured timezone of the remote system.
+          desc: Returns the system's configured timezone.
         mql: os.date.timezone
       - uid: mondoo-linux-selinux-status
         title: SELinux status
         docs:
-          desc: Returns SELinux installation status, enforcement mode, configured mode, and policy type.
+          desc: "Returns SELinux status: whether installed, the current enforcement mode, configured mode, and policy type."
         filters: asset.family.contains("redhat") || asset.platform == "amazonlinux"
         mql: selinux { installed mode configMode policyType }
       - uid: mondoo-linux-logged-in-users
         title: Logged-in users
         docs:
-          desc: Lists currently logged-in users.
+          desc: Lists currently logged-in users, from the output of w.
         mql: command('w -h').stdout

--- a/content/querypacks/mondoo-m365-inventory.mql.yaml
+++ b/content/querypacks/mondoo-m365-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Microsoft 365 users, groups, and resources
     docs:
       desc: |
-        The Microsoft 365 Asset Inventory Pack by Mondoo retrieves data about Microsoft 365 resources for asset inventory.
+        Collects Microsoft 365 tenant inventory: organization and subscription details, users, groups, applications, service principals, directory roles, domains, Intune device management, identity policies, and Secure Score.
 
         To run this pack for an Microsoft 365 Tenant:
 
@@ -36,43 +36,43 @@ packs:
           - uid: mondoo-asset-inventory-m365-tenant-id
             title: Tenant ID
             docs:
-              desc: Returns the unique identifier of the Microsoft 365 tenant.
+              desc: Returns the tenant's unique identifier.
             mql: |
               microsoft.tenant.id
           - uid: mondoo-asset-inventory-m365-tenant-name
             title: Tenant Name
             docs:
-              desc: Returns the display name of the Microsoft 365 tenant.
+              desc: Returns the tenant's display name.
             mql: |
               microsoft.tenant.name
           - uid: mondoo-asset-inventory-m365-tenant-doamin-name
             title: Organization Tenant Domain Name
             docs:
-              desc: Returns the primary domain name of the Microsoft 365 tenant.
+              desc: Returns the tenant's primary domain name.
             mql: |
               microsoft.tenantDomainName
           - uid: mondoo-asset-inventory-m365-tenant-assigned-plans
             title: Tenant Assigned Plans
             docs:
-              desc: Lists all service plans assigned to the tenant.
+              desc: Lists the service plans assigned to the tenant.
             mql: |
               microsoft.tenant.assignedPlans
           - uid: mondoo-asset-inventory-m365-tenant-provisioned-plans
             title: Tenant Provisioned Plans
             docs:
-              desc: Lists all provisioned service plans for the tenant.
+              desc: Lists the provisioned service plans for the tenant.
             mql: |
               microsoft.tenant.provisionedPlans
           - uid: mondoo-asset-inventory-m365-tenant-created
             title: Tenant Created
             docs:
-              desc: Returns the timestamp when the tenant was created.
+              desc: Returns the tenant's creation timestamp.
             mql: |
               microsoft.tenant.createdAt
           - uid: mondoo-asset-inventory-m365-organization-subscriptions
             title: Organization Subscriptions
             docs:
-              desc: Lists all subscriptions associated with the tenant.
+              desc: Lists the subscriptions associated with the tenant.
             mql: |
               microsoft.tenant.subscriptions
 
@@ -82,19 +82,19 @@ packs:
           - uid: mondoo-asset-inventory-m365-groups
             title: Groups
             docs:
-              desc: Lists all Microsoft 365 groups in the organization.
+              desc: Lists the Microsoft 365 groups in the organization.
             mql: |
               microsoft.groups
           - uid: mondoo-asset-inventory-m365-groups-public
             title: Public Groups and their Members
             docs:
-              desc: Lists all public groups with their members for visibility assessment.
+              desc: Lists groups with Public visibility, showing each group's ID, display name, security-enabled flag, and members.
             mql: |
               microsoft.groups.where (visibility == "Public") {id displayName securityEnabled members}
           - uid: mondoo-asset-inventory-m365-groups-security-enabled
             title: Groups no Security enabled
             docs:
-              desc: Lists groups without security features enabled for security assessment.
+              desc: Lists groups that are not security-enabled, showing each group's ID, display name, and members.
             mql: |
               microsoft.groups.where (securityEnabled == false) {id displayName securityEnabled members}
 
@@ -104,19 +104,19 @@ packs:
           - uid: mondoo-asset-inventory-m365-applications
             title: Applications
             docs:
-              desc: Lists all applications registered in Microsoft Entra ID.
+              desc: Lists the applications registered in Microsoft Entra ID.
             mql: |
               microsoft.applications
           - uid: mondoo-asset-inventory-m365-applications-expired-credentials
             title: Applications with expired credentials
             docs:
-              desc: Identifies applications with expired credentials that may need credential rotation.
+              desc: Lists applications with expired credentials, showing app ID, name, owners, creation date, and service principal, so stale secrets can be rotated.
             mql: |
               microsoft.applications.where(hasExpiredCredentials == true) {appId name owners createdAt servicePrincipal}
           - uid: mondoo-asset-inventory-m365-enterprise-applications
             title: Enterprise Applications
             docs:
-              desc: Lists all enterprise applications (service principals) in the tenant.
+              desc: Lists the enterprise applications, the service principals, in the tenant.
             mql: |
               microsoft.enterpriseApplications
 
@@ -126,13 +126,13 @@ packs:
           - uid: mondoo-asset-inventory-m365-device-management-device-compliance-policy
             title: Device Compliance Policy
             docs:
-              desc: Lists all Intune device compliance policies configured in the tenant.
+              desc: Lists the Intune device compliance policies configured in the tenant.
             mql: |
               microsoft.devicemanagement.deviceCompliancePolicies
           - uid: mondoo-asset-inventory-m365-device-management-device-configurations
             title: Device Configurations
             docs:
-              desc: Lists all Intune device configuration profiles in the tenant.
+              desc: Lists the Intune device configuration profiles in the tenant.
             mql: |
               microsoft.devicemanagement.deviceConfigurations
 
@@ -142,7 +142,7 @@ packs:
           - uid: mondoo-asset-inventory-m365-domains
             title: Domains
             docs:
-              desc: Lists all domains configured in the Microsoft 365 tenant.
+              desc: Lists the domains configured in the tenant.
             mql: |
               microsoft.domains
 
@@ -152,19 +152,19 @@ packs:
           - uid: mondoo-asset-inventory-m365-users
             title: Users
             docs:
-              desc: Lists all users in the Microsoft 365 tenant.
+              desc: Lists the users in the tenant.
             mql: |
               microsoft.users
           - uid: mondoo-asset-inventory-m365-users-account-enabled
             title: Users account enabled
             docs:
-              desc: Lists all users with enabled accounts for active user inventory.
+              desc: Lists users whose accounts are enabled, showing given name, surname, and user principal name.
             mql: |
               microsoft.users.where(accountEnabled == true) {id givenName surname userPrincipalName}
           - uid: mondoo-asset-inventory-m365-users-mfa
             title: Users with no MFA enabled
             docs:
-              desc: Identifies users without MFA enabled for security assessment.
+              desc: Lists users without MFA enabled, showing given name, surname, and user principal name.
             mql: |
               microsoft.users.where(mfaEnabled == false) {id givenName surname userPrincipalName}
 
@@ -174,31 +174,31 @@ packs:
           - uid: mondoo-asset-inventory-m365-policies-admin-consent-request-policy
             title: Admin Consent Request Policy
             docs:
-              desc: Returns the admin consent request policy configuration for app permissions.
+              desc: Returns the admin consent request policy that governs how users request admin approval for app permissions.
             mql: |
               microsoft.policies.adminConsentRequestPolicy
           - uid: mondoo-asset-inventory-m365-policies-authorization-policy
             title: Authorization Policy
             docs:
-              desc: Returns the authorization policy configuration for the tenant.
+              desc: Returns the tenant authorization policy that controls default user permissions.
             mql: |
               microsoft.policies.authorizationPolicy
           - uid: mondoo-asset-inventory-m365-policies-consent-policy-settings
             title: Consent Policy Settings
             docs:
-              desc: Returns the consent policy settings for application permissions.
+              desc: Returns the consent policy settings that govern user consent to applications.
             mql: |
               microsoft.policies.consentPolicySettings
           - uid: mondoo-asset-inventory-m365-policies-identity-security-defaults-enforcement-policy
             title: Identity Security Defaults Enforcement Policy
             docs:
-              desc: Returns whether security defaults are enabled for the tenant.
+              desc: Reports whether Microsoft Entra security defaults are enforced for the tenant.
             mql: |
               microsoft.policies.identitySecurityDefaultsEnforcementPolicy
           - uid: mondoo-asset-inventory-m365-policies-permission-grant-policies
             title: Permission Grant Policies
             docs:
-              desc: Lists permission grant policies that control app consent.
+              desc: Lists the permission grant policies that control which app permissions users can consent to.
             mql: |
               microsoft.policies.permissionGrantPolicies
 
@@ -208,7 +208,7 @@ packs:
           - uid: mondoo-asset-inventory-m365-roles
             title: Roles
             docs:
-              desc: Lists all directory roles available in Microsoft Entra ID.
+              desc: Lists the directory roles available in Microsoft Entra ID.
             mql: |
               microsoft.roles
 
@@ -218,13 +218,13 @@ packs:
           - uid: mondoo-asset-inventory-m365-security-latest-secure-scores
             title: Latest Security Score
             docs:
-              desc: Returns the latest Microsoft Secure Score with comparative metrics.
+              desc: Returns the latest Microsoft Secure Score, including current and maximum score, active user count, and comparative scores against similar organizations.
             mql: |
               microsoft.security.latestSecureScores {maxScore currentScore azureTenantId vendorInformation averageComparativeScores activeUserCount}
           - uid: mondoo-asset-inventory-m365-security-risky-users
             title: Risky Users
             docs:
-              desc: Lists users flagged as risky by Microsoft Entra ID Identity Protection.
+              desc: Lists the users flagged as risky by Microsoft Entra ID Identity Protection.
             mql: |
               microsoft.security.riskyUsers
 
@@ -234,13 +234,13 @@ packs:
           - uid: mondoo-asset-inventory-m365-service-principals
             title: Service Principals
             docs:
-              desc: Lists all service principals (app identities) in the tenant.
+              desc: Lists the service principals, the app identities, in the tenant.
             mql: |
               microsoft.serviceprincipals
           - uid: mondoo-asset-inventory-m365-service-principals-enabled
             title: Enabled Service Principals
             docs:
-              desc: Lists enabled service principals with their permissions and assignments.
+              desc: Lists enabled service principals, showing name, service principal names, assignments, sign-in audience, and permissions.
             mql: |
               microsoft.serviceprincipals.where(enabled == true) {id name servicePrincipalNames assignments signInAudience permissions}
 
@@ -250,6 +250,6 @@ packs:
           - uid: mondoo-asset-inventory-m365-group-settings
             title: Group Settings
             docs:
-              desc: Returns the group settings configured for the tenant.
+              desc: Returns the directory-level group settings configured for the tenant.
             mql: |
               microsoft.groupSettings

--- a/content/querypacks/mondoo-macos-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-macos-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The macOS Incident Response Pack by Mondoo retrieves configuration data from macOS hosts for investigation during a security incident. This includes platform information, user accounts, kernel details, running processes, mounted devices, installed packages, running services, firewall exceptions, and pending software updates.
+        Collects macOS host evidence for incident investigation: platform and version details, user accounts, kernel version and extensions, running processes and services, mounted devices, installed packages, uptime and timezone, firewall exceptions, FileVault and Gatekeeper status, and pending software updates.
 
         ### Run query pack
 
@@ -39,70 +39,70 @@ packs:
       - uid: mondoo-macos-incident-response-platform-info
         title: Platform information
         docs:
-          desc: Retrieves the macOS platform, version, and architecture to identify the affected system.
+          desc: Returns the host's platform, title, version, and architecture to identify the affected system.
         mql: asset { platform title version arch }
       - uid: mondoo-macos-incident-response-regular-users
         title: Regular users
         docs:
-          desc: Lists regular user accounts (excluding system accounts) to identify potentially compromised or unauthorized user accounts.
+          desc: Lists interactive user accounts, filtering out system accounts, to surface potentially compromised or unauthorized logins.
         mql: users.where( name != /^_/ && shell != /\/usr\/bin\/false/ )
       - uid: mondoo-macos-incident-response-kernel-info
         title: Running macOS kernel
         docs:
-          desc: Returns the currently running kernel version to identify potential kernel-level vulnerabilities.
+          desc: Returns the running kernel version, revealing kernel-level vulnerabilities the host may be exposed to.
         mql: kernel.info.version
       - uid: mondoo-macos-incident-response-kernel-modules
         title: macOS kernel modules
         docs:
-          desc: Lists all kernel extensions with their load status to identify potentially malicious or unauthorized kernel extensions.
+          desc: Lists every kernel extension and whether it is loaded, surfacing unauthorized or malicious kexts.
         mql: kernel.modules { name loaded }
       - uid: mondoo-macos-incident-response-processes
         title: Running processes
         docs:
-          desc: Lists all running processes with their PID and command to identify suspicious or malicious processes.
+          desc: Lists every running process with its PID and command line, surfacing suspicious or malicious activity.
         mql: processes.list { pid  command }
       - uid: mondoo-macos-incident-response-mounts
         title: Mounted devices
         docs:
-          desc: Lists all mounted filesystems to identify unusual mounts or external storage devices.
+          desc: Lists mounted filesystems with their device, type, options, and capacity, surfacing unusual mounts or attached external storage.
         mql: mount.list { path fstype device options size used available }
       - uid: mondoo-macos-incident-response-uptime
         title: Operating system uptime
         docs:
-          desc: Returns the system uptime to help determine when the system was last rebooted and establish incident timeline.
+          desc: Returns system uptime, helping establish when the host last rebooted and anchor the incident timeline.
         mql: os.uptime
       - uid: mondoo-macos-incident-response-installed-packages
         title: Installed packages
         docs:
-          desc: Lists all installed packages to identify potentially vulnerable or malicious software.
+          desc: Lists installed packages, surfacing vulnerable or malicious software on the host.
         mql: packages
       - uid: mondoo-macos-incident-response-timezone
         title: System timezone
         docs:
-          desc: Returns the system timezone to help correlate log timestamps across systems during incident investigation.
+          desc: Returns the configured timezone, needed to correlate the host's log timestamps with other systems.
         mql: os.date.timezone
       - uid: mondoo-macos-incident-response-running-services
         title: Running services
         docs:
-          desc: Lists all currently running services with their status to identify suspicious or unauthorized services.
+          desc: Lists currently running services with their enabled, masked, and type attributes, surfacing suspicious or unauthorized services.
         mql: services.where(running == true) { name running enabled masked type }
       - uid: mondoo-macos-incident-response-alf-extensions
         title: Exceptions from the Application Layer Firewall
         docs:
-          desc: Lists applications with firewall exceptions to identify software allowed to bypass the macOS Application Layer Firewall.
+          desc: Lists applications granted exceptions to the macOS Application Layer Firewall, revealing software allowed to bypass it.
         mql: macos.alf.exceptions
       - uid: mondoo-macos-incident-response-filevault
         title: FileVault disk encryption status
         docs:
-          desc: Returns FileVault encryption state and recovery-key configuration to confirm whether disk contents were protected at the time of the incident.
+          desc: Returns FileVault encryption state, recovery-key configuration, and enabled users, confirming whether disk contents were protected at the time of the incident.
         mql: macos.filevault { enabled status hasPersonalRecoveryKey hasInstitutionalRecoveryKey users }
       - uid: mondoo-macos-incident-response-gatekeeper
         title: Gatekeeper assessment status
         docs:
-          desc: Returns Gatekeeper assessment state to confirm whether application-execution controls were enforced when the incident occurred.
+          desc: Returns Gatekeeper's enabled state and assessment status, confirming whether application-execution controls were enforced when the incident occurred.
         mql: macos.gatekeeper { enabled status }
       - uid: mondoo-macos-incident-response-check-recommended-updates
         title: Recommended OS and application updates
         docs:
-          desc: Lists pending software updates to identify missing security patches and system updates.
+          desc: Lists pending OS and application updates, revealing missing security patches on the host.
         mql: macos.softwareupdate.updates { label title version size recommended action }

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory macOS host OS, packages, and configuration
     docs:
       desc: |
-        The macOS Inventory Pack by Mondoo retrieves data about macOS hosts for asset inventory.
+        Collects macOS host inventory: hardware and OS details, installed packages, running services and processes, network configuration, and security posture including FileVault, Gatekeeper, and MDM enrollment.
 
         ## Local scan
         To run this pack locally on a macOS host:
@@ -42,19 +42,19 @@ packs:
       - uid: mondoo-macos-machine-model-identifier
         title: Machine model identifier
         docs:
-          desc: Returns the Mac hardware model identifier (e.g., MacBookPro18,1).
+          desc: Returns the Mac hardware model identifier, such as MacBookPro18,1.
         mql: |
           macos.hardware.machineModel
       - uid: mondoo-macos-machine-model-name
         title: Machine model name
         docs:
-          desc: Returns the human-readable Mac model name (e.g., MacBook Pro).
+          desc: Returns the human-readable Mac model name, such as MacBook Pro.
         mql: |
           macos.hardware.machineName
       - uid: mondoo-macos-model-part-number
         title: Model part number
         docs:
-          desc: Returns the Apple model/part number for the hardware.
+          desc: Returns the Apple model and part number for the hardware.
         mql: |
           macos.hardware.modelNumber
       - uid: mondoo-macos-serial-number
@@ -66,7 +66,7 @@ packs:
       - uid: mondoo-macos-cpu-type
         title: CPU type
         docs:
-          desc: Returns the processor chip type (e.g., Apple M1, Intel Core i7).
+          desc: Returns the processor chip type, such as Apple M1 or Intel Core i7.
         mql: |
           macos.hardware.chipType
       - uid: mondoo-macos-physical-memory
@@ -78,7 +78,7 @@ packs:
       - uid: mondoo-asset-info
         title: Asset information
         docs:
-          desc: Returns basic asset information including platform, architecture, and version.
+          desc: "Returns core asset attributes: kind, title, platform, name, architecture, runtime, and version."
         mql: asset { kind title platform name arch runtime version }
       - uid: mondoo-hostname
         title: Hostname
@@ -88,141 +88,141 @@ packs:
       - uid: mondoo-macos-uptime
         title: Operating system uptime
         docs:
-          desc: Returns how long the system has been running since last boot.
+          desc: Reports how long the system has run since its last boot.
         filters: mondoo.capabilities.contains("run-command")
         mql: os.uptime
       - uid: mondoo-macos-processes
         title: Running processes
         docs:
-          desc: Lists all running processes with their PID, command, and flags.
+          desc: Lists running processes with PID, command, and flags.
         filters: mondoo.capabilities.contains("run-command")
         mql: processes { pid command flags }
       - uid: mondoo-macos-kernel-modules
         title: Kernel modules
         docs:
-          desc: Lists loaded kernel extensions (kexts) with their load status.
+          desc: Lists kernel extensions (kexts) and whether each is loaded.
         filters: mondoo.capabilities.contains("run-command")
         mql: kernel.modules { name loaded }
       - uid: mondoo-macos-mounts
         title: Mounted devices
         docs:
-          desc: Lists all mounted filesystems with their paths, types, and mount options.
+          desc: Lists mounted filesystems with path, type, device, options, size, used, and available space.
         mql: mount.list { path fstype device options size used available }
       - uid: mondoo-macos-users
         title: Regular users
         docs:
-          desc: Lists regular user accounts (excluding system accounts starting with underscore).
+          desc: Lists regular user accounts, excluding root and system accounts whose names begin with an underscore.
         mql: users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root")
       - uid: mondoo-macos-packages
         title: Installed packages
         docs:
-          desc: Lists all installed packages with version, architecture, and origin information.
+          desc: Lists installed packages with name, version, architecture, install date, origin, and package URL.
         mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-macos-running-services
         title: Running services
         docs:
-          desc: Lists all currently running services (launchd jobs) with their status.
+          desc: Lists currently running launchd services with their enabled, masked, and type attributes.
         filters: mondoo.capabilities.contains("run-command")
         mql: services.where(running == true) { name running enabled masked type }
       - uid: mondoo-macos-ports-listening
         title: Listening ports
         docs:
-          desc: Lists all listening network ports with their associated processes.
+          desc: Lists network ports that are not closed, with the owning user, local address, protocol, and process.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-macos-active-connections
         title: Active network connections
         docs:
-          desc: Lists all active network connections with their associated processes.
+          desc: Lists active (non-closed) network connections with the owning user, local and remote endpoints, protocol, and process.
         filters: mondoo.capabilities.contains("run-command")
         mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-macos-interface-configuration
         title: Network interface configuration
         docs:
-          desc: Returns detailed network interface configuration for all interfaces, including MAC address and per-address CIDR and subnet.
+          desc: "Returns per-interface network configuration: MAC address, vendor, MTU, flags, and each assigned IP with its CIDR, subnet, broadcast, and gateway."
         mql: network.interfaces { name mac vendor mtu flags active virtual ips { ip cidr subnet broadcast gateway } }
       - uid: mondoo-macos-etc-hosts
         title: Static host entries
         docs:
-          desc: Returns the static hostname-to-IP mappings from /etc/hosts.
+          desc: Returns the contents of /etc/hosts, the static hostname-to-IP mappings, when the file exists.
         mql: |
           if (file("/etc/hosts").exists) { file("/etc/hosts").content }
       - uid: mondoo-macos-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
+          desc: "Returns cloud provider instance identity from the instance metadata service: public and private hostnames and IPs plus the raw instance metadata carrying account or subscription, region, and instance type. On non-cloud hosts the provider resolves to \"Unknown\" and the instance lookup reports an error."
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-macos-network-neighbors
         title: ARP/NDP neighbor cache
         docs:
-          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with their IP, MAC address, interface, and cache state.
+          desc: Lists ARP (IPv4) and NDP (IPv6) neighbor cache entries with IP, MAC address, interface, and cache state.
         filters: mondoo.capabilities.contains("run-command")
         mql: network.neighbors { ip mac interface state }
       - uid: mondoo-macos-sshd-interface-configuration
         title: sshd configuration
         docs:
-          desc: Returns the SSH server configuration parameters.
+          desc: Returns the SSH server configuration parameters from sshd_config.
         mql: sshd.config.params
       - uid: mondoo-macos-recommended-software-updates
         title: Recommended software updates
         docs:
-          desc: Lists pending macOS and application updates recommended by Apple.
+          desc: Lists pending macOS and application updates recommended by Apple, with version, size, and required action.
         mql: macos.softwareupdate.updates { label title version size recommended action }
       - uid: mondoo-macos-hardware-information
         title: Hardware information
         docs:
-          desc: Returns comprehensive hardware information including model, chip type, and memory.
+          desc: "Returns consolidated hardware details: model, name, part number, chip type, serial number, platform UUID, memory, and processor count."
         mql: macos.hardware{ machineModel machineName modelNumber chipType serialNumber platformUUID physicalMemory numberProcessors }
       - uid: mondoo-macos-storage
         title: Storage Data
         docs:
-          desc: Returns detailed storage information from system profiler.
+          desc: Returns storage volume details from macOS system_profiler.
         mql: |
           parse.json(content: command('system_profiler SPStorageDataType -json').stdout).params
       - uid: mondoo-macos-power
         title: Power Data
         docs:
-          desc: Returns power and battery information from system profiler.
+          desc: Returns power and battery details from macOS system_profiler.
         mql: |
           parse.json(content: command('system_profiler SPPowerDataType -json').stdout).params
       - uid: mondoo-macos-network
         title: Network Data
         docs:
-          desc: Returns network configuration from system profiler.
+          desc: Returns network configuration from macOS system_profiler.
         mql: |
           parse.json(content: command('system_profiler SPNetworkDataType -json').stdout).params
       - uid: mondoo-macos-mdm-enrollment
         title: MDM enrollment status
         docs:
-          desc: Returns Mobile Device Management enrollment details, including DEP and User Approved MDM status.
+          desc: "Returns MDM enrollment details: enrollment state, DEP status, User Approved MDM status, and management server URL."
         mql: macos.mdm { enrolled dep userApproved serverUrl }
       - uid: mondoo-macos-profile
         title: Configuration Profile Data
         docs:
-          desc: Returns installed Configuration Profiles, sourced from both MDM-delivered and manually installed payloads.
+          desc: Lists installed configuration profiles, both MDM-delivered and manually installed, with identifier, display name, organization, scope, and payloads.
         mql: macos.profiles.list { identifier uuid displayName description organization type removalDisallowed scope payloads }
       - uid: mondoo-macos-timezone
         title: System timezone
         docs:
-          desc: Returns the configured timezone of the remote system.
+          desc: Returns the configured system timezone.
         mql: os.date.timezone
       - uid: mondoo-macos-logged-in-users
         title: Logged-in users
         docs:
-          desc: Lists currently logged-in users.
+          desc: Lists currently logged-in users from the output of the w command.
         mql: command('w -h').stdout
       - uid: mondoo-macos-system-extensions
         title: macOS System Extensions
         docs:
-          desc: Lists installed system extensions with their activation status.
+          desc: Lists installed system extensions with identifier, version, and activation state.
         mql: macos.systemExtensions { active enabled identifier state version }
       - uid: mondoo-macos-filevault
         title: FileVault disk encryption status
         docs:
-          desc: Returns FileVault full-disk encryption state, status message, recovery key configuration, and the users authorized to unlock the encrypted volume.
+          desc: Returns FileVault full-disk encryption state, status message, personal and institutional recovery key configuration, and the users authorized to unlock the volume.
         mql: macos.filevault { enabled status hasPersonalRecoveryKey hasInstitutionalRecoveryKey users }
       - uid: mondoo-macos-gatekeeper
         title: Gatekeeper assessment status
         docs:
-          desc: Returns Gatekeeper application-assessment state and the underlying status message reported by `spctl`.
+          desc: Returns Gatekeeper application-assessment state and the status message reported by `spctl`.
         mql: macos.gatekeeper { enabled status }

--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory OCI tenancies, compute, networking, and storage
     docs:
       desc: |
-        The OCI Asset Inventory Pack by Mondoo retrieves information about Oracle Cloud Infrastructure (OCI) tenancies for asset inventory. It covers identity and access management, compute instances, networking, and object storage.
+        Collects Oracle Cloud Infrastructure (OCI) tenancy inventory: regions and compartments, identity and access management, compute instances and images, virtual cloud networks, and object storage.
 
         ## Authentication
 
@@ -69,7 +69,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns basic OCI tenancy information including name, ID, and description.
+        Returns the OCI tenancy name, ID, and description.
     mql: |
       oci.tenancy {
         id
@@ -82,7 +82,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all regions the tenancy is subscribed to with their status and home region indicator.
+        Lists the regions the tenancy subscribes to, with each region's status and home-region flag.
     mql: |
       oci.regions {
         id
@@ -96,7 +96,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all compartments in the tenancy for understanding the organizational structure.
+        Lists the tenancy compartments with their name, description, and state.
     mql: |
       oci.compartments {
         id
@@ -111,7 +111,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all IAM users in the tenancy with their state, MFA status, and email verification.
+        Lists the IAM users with their state, MFA activation, email verification, capabilities, and last login.
     mql: |
       oci.identity.users {
         id
@@ -130,7 +130,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all IAM groups in the tenancy.
+        Lists the IAM groups with their description, state, and creation time.
     mql: |
       oci.identity.groups {
         id
@@ -145,7 +145,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all IAM policies in the tenancy with their permission statements.
+        Lists the IAM policies with their permission statements.
     mql: |
       oci.identity.policies {
         id
@@ -161,7 +161,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all compute instances with their shape, state, and availability domain.
+        Lists the compute instances with their shape, state, availability and fault domain, and freeform tags.
     mql: |
       oci.compute.instances {
         id
@@ -179,7 +179,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all compute images available in the tenancy.
+        Lists the compute images with their operating system, version, and size.
     mql: |
       oci.compute.images {
         id
@@ -197,7 +197,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns the Object Storage namespace for the tenancy.
+        Returns the tenancy Object Storage namespace.
     mql: |
       oci.objectStorage.namespace
 
@@ -206,7 +206,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all Object Storage buckets with their access, versioning, and encryption configuration.
+        Lists the Object Storage buckets with their public access type, storage tier, versioning, KMS encryption key, and size.
     mql: |
       oci.objectStorage.buckets {
         name
@@ -229,7 +229,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all VCNs with their CIDR blocks and DNS configuration.
+        Lists the virtual cloud networks (VCNs) with their CIDR blocks and DNS configuration.
     mql: |
       oci.network.vcns {
         id
@@ -246,7 +246,7 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Returns all VCN security lists with their ingress and egress rules.
+        Lists the VCN security lists with their ingress and egress rules and parent VCN.
     mql: |
       oci.network.securityLists {
         id

--- a/content/querypacks/mondoo-okta-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-okta-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        During a security incident, the Okta Incident Response query pack retrieves configuration data about your Okta configuration.
+        Collects Okta configuration evidence for incident investigation: the org's user accounts and integrated applications.
 
         ### Prerequisites
 
@@ -41,10 +41,10 @@ packs:
       - uid: mondoo-okta-incident-response-users
         title: Users
         docs:
-          desc: Retrieves all Okta users to identify user accounts and their status during incident investigation.
+          desc: Lists all Okta users so an investigator can review accounts and their status.
         mql: okta.users
       - uid: mondoo-okta-incident-response-team-id
         title: Installed applications
         docs:
-          desc: Retrieves all applications integrated with Okta to identify potentially compromised OAuth apps or unauthorized integrations.
+          desc: Lists all applications integrated with Okta to surface compromised OAuth apps or unauthorized integrations.
         mql: okta.applications

--- a/content/querypacks/mondoo-openssl-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-openssl-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The OpenSSL Incident Response Pack by Mondoo retrieves SSL/TLS library information from Linux hosts for investigation during a security incident. This includes platform details, installed SSL libraries, and listening ports that may be using SSL/TLS.
+        Gathers SSL/TLS library evidence from a Linux host during a security incident: platform details, installed SSL packages, and listening ports that may be serving SSL/TLS.
 
         ### Run query pack
 
@@ -39,7 +39,7 @@ packs:
       - uid: mondoo-openssl-incident-response-platform
         title: Platform details
         docs:
-          desc: Retrieves the operating system platform, version, and architecture to identify the affected system.
+          desc: Returns the host's platform, version, and architecture to identify the affected system.
         mql: |
           asset {
             platform
@@ -49,12 +49,12 @@ packs:
       - uid: mondoo-openssl-incident-response-installed-version
         title: Installed ssl libraries
         docs:
-          desc: Lists all installed packages with 'ssl' in their name to identify OpenSSL and related library versions that may be affected by vulnerabilities.
+          desc: Lists installed packages whose name contains 'ssl' to pin down OpenSSL and related library versions affected by vulnerabilities.
         mql: packages.where(name == /ssl/)
       - uid: mondoo-openssl-incident-response-listening-ports
         title: Listening ports for running systems
         docs:
-          desc: Lists all listening network ports to identify services that may be using SSL/TLS and could be affected by OpenSSL vulnerabilities.
+          desc: Lists listening ports with protocol, address, and port to surface services that may be exposing SSL/TLS. Runs only where command execution is available.
         mql: |
           if ( mondoo.capabilities.contains('run-command') ) {
             ports.listening {

--- a/content/querypacks/mondoo-shodan-inventory.mql.yaml
+++ b/content/querypacks/mondoo-shodan-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Shodan host and service data
     docs:
       desc: |
-        The Shodan Inventory Pack by Mondoo retrieves data about shodan.io assets. 
+        Collects Shodan intelligence for hosts and domains: hostnames, ASN, ISP, organization, open ports, detected OS, known CVEs, subdomains, and DNS records.
 
         ## Local scan
         To run this pack locally:
@@ -36,84 +36,84 @@ packs:
       - uid: mondoo-shodan-inventory-hostnames
         title: Shodan info about Hostnames / DNS
         docs:
-          desc: Returns hostnames associated with the IP address from Shodan's database.
+          desc: Lists the hostnames Shodan associates with the host's IP address.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.hostnames
       - uid: mondoo-shodan-inventory-asn
         title: Shodan info about ASN
         docs:
-          desc: Returns the Autonomous System Number (ASN) for the host's IP address.
+          desc: Returns the Autonomous System Number (ASN) that routes the host's IP address.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.asn
       - uid: mondoo-shodan-inventory-tags
         title: Shodan info about Tags
         docs:
-          desc: Returns Shodan-assigned tags describing the host's characteristics and services.
+          desc: Returns the Shodan tags describing the host's characteristics and exposed services.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.tags
       - uid: mondoo-shodan-inventory-isp
         title: Shodan info about ISP
         docs:
-          desc: Returns the Internet Service Provider hosting the IP address.
+          desc: Returns the internet service provider that hosts the IP address.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.isp
       - uid: mondoo-shodan-inventory-org
         title: Shodan info about Org
         docs:
-          desc: Returns the organization associated with the IP address.
+          desc: Returns the organization that owns the IP address.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.org
       - uid: mondoo-shodan-inventory-ip
         title: Shodan info about IP
         docs:
-          desc: Returns the IP address of the scanned host.
+          desc: Returns the IP address of the queried host.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.ip
       - uid: mondoo-shodan-inventory-os
         title: Shodan info about OS
         docs:
-          desc: Returns the operating system detected by Shodan for the host.
+          desc: Returns the operating system Shodan detected for the host.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.os
       - uid: mondoo-shodan-inventory-ports
         title: Shodan info about Ports
         docs:
-          desc: Returns open ports discovered by Shodan on the host.
+          desc: Lists the open ports Shodan observed on the host.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.ports
       - uid: mondoo-shodan-inventory-vulns
         title: Shodan info about vulnerabilities
         docs:
-          desc: Returns known vulnerabilities (CVEs) associated with services on the host.
+          desc: Lists the known vulnerabilities (CVEs) Shodan associates with services on the host.
         filters: asset.platform == "shodan-host"
         mql: |
           shodan.host.vulns { * }
       - uid: mondoo-shodan-inventory-nsrecords
         title: Shodan info about DNS NS records
         docs:
-          desc: Returns nameserver (NS) records for the domain from Shodan.
+          desc: Lists the nameserver (NS) records Shodan has for the domain.
         filters: asset.platform == "shodan-domain"
         mql: |
           shodan.domain.nsrecords
       - uid: mondoo-shodan-inventory-subdomains
         title: Shodan info about Subdomains
         docs:
-          desc: Returns subdomains discovered by Shodan for the domain.
+          desc: Lists the subdomains Shodan discovered for the domain.
         filters: asset.platform == "shodan-domain"
         mql: |
           shodan.domain.subdomains
       - uid: mondoo-shodan-inventory-domain-tags
         title: Shodan info about Tags
         docs:
-          desc: Returns Shodan-assigned tags for the domain.
+          desc: Returns the Shodan tags assigned to the domain.
         filters: asset.platform == "shodan-domain"
         mql: |
           shodan.domain.tags

--- a/content/querypacks/mondoo-slack-inventory.mql.yaml
+++ b/content/querypacks/mondoo-slack-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Slack Inventory Pack retrieves information about Slack teams for asset inventory.
+        Inventories a Slack workspace: team domain and ID, users with their MFA status, owners and admins, and externally shared channels.
 
         ### Prerequisites
 
@@ -63,27 +63,27 @@ packs:
       - uid: mondoo-slack-inventory-team-domain
         title: Slack Team Domain
         docs:
-          desc: Returns the workspace domain name for the Slack team.
+          desc: Returns the Slack workspace domain name.
         mql: |
           slack.team.domain
       - uid: mondoo-slack-inventory-team-id
         title: Slack Team ID
         docs:
-          desc: Returns the unique identifier for the Slack workspace.
+          desc: Returns the Slack workspace's unique ID.
         mql: |
           slack.team.id
       - uid: mondoo-slack-inventory-mfa-status
         title: Slack Team MFA status
         docs:
           desc: |
-            This query retrieves the status of whether MFA is configured for all users.
+            Lists every user with their ID, name, email, bot flag, team ID, and two-factor status.
         mql: |
           slack.users { id name profile["email"] isBot teamId has2FA }
       - uid: mondoo-slack-inventory-owners
         title: Slack Team Owners
         docs:
           desc: |
-            This query retrieves the list of all users with the Owner privilege.
+            Counts users with the Owner privilege and lists each with their ID, name, email, bot flag, team ID, and two-factor status.
         mql: |
           slack.users.owners.length
           slack.users.owners { id name profile["email"] isBot teamId has2FA }
@@ -91,11 +91,11 @@ packs:
         title: Slack Admins
         docs:
           desc: |
-            This query retrieves the list of all users with the Admin privilege.
+            Lists users with the Admin privilege, with their ID and name.
         mql: slack.users.admins { id name }
       - uid: mondoo-slack-inventory-external-channels
         title: Externally shared channels
         docs:
           desc: |
-            This query retrieves the list of all channels that have been externally shared.
+            Lists channels shared with external workspaces, with their ID and name.
         mql: slack.conversations.where(isExtShared == true) { id name }

--- a/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The SSL/TLS Certificate Incident Response Pack by Mondoo query pack retrieves information about SSL/TLS certificates of a domain for investigation during a security incident.
+        Collects a domain's SSL/TLS certificate evidence for a security incident investigation: negotiated protocol versions, cipher suites, and per-certificate chain details.
 
         ### Prerequisites
 
@@ -37,25 +37,25 @@ packs:
       - uid: mondoo-ssl-tls-certificate-incident-response-domain-name
         title: Domain Name
         docs:
-          desc: Returns the domain name being scanned for TLS/SSL certificate information.
+          desc: Returns the domain name being inspected.
         mql: |
           tls.domainName
       - uid: mondoo-ssl-tls-certificate-incident-response-versions
         title: Supported SSL and TLS versions
         docs:
-          desc: Lists all SSL/TLS protocol versions supported by the server for security assessment.
+          desc: Lists the SSL/TLS protocol versions the server accepts, to flag outdated protocols.
         mql: |
           tls.versions
       - uid: mondoo-ssl-tls-certificate-incident-response-ciphers
         title: Supported SSl/TLS ciphers
         docs:
-          desc: Lists all cipher suites supported by the server for cryptographic strength assessment.
+          desc: Lists the cipher suites the server accepts, to spot weak cryptography.
         mql: |
           tls.ciphers
       - uid: mondoo-ssl-tls-certificate-incident-response-signing-algo
         title: Signature algorithm of all certificates in the certificate chain
         docs:
-          desc: Returns the signing algorithm and subject name for each certificate in the chain to identify weak algorithms.
+          desc: Returns the signing algorithm and common name of each certificate in the chain, to spot weak algorithms.
         mql: |
           tls.certificates {
             signingAlgorithm
@@ -64,7 +64,7 @@ packs:
       - uid: mondoo-ssl-tls-certificate-incident-response-is-revoked
         title: Revoked, verified, and CA status of all certificates in the certificate chain
         docs:
-          desc: Returns revocation status, verification status, and CA flag for each certificate to identify compromised certificates.
+          desc: Returns the revocation status, verification status, and CA flag of each certificate in the chain, to spot compromised certificates.
         mql: |
           tls.certificates {
             subject.commonName
@@ -75,7 +75,7 @@ packs:
       - uid: mondoo-ssl-tls-certificate-incident-response-when-expire
         title: Expiration dates for all certificates in the certificate chain
         docs:
-          desc: Returns validity period information for each certificate to identify expired or expiring certificates.
+          desc: Returns each certificate's validity window and time until expiry, to spot expired or expiring certificates.
         mql: |
           tls.certificates {
             subject.commonName

--- a/content/querypacks/mondoo-terraform-inventory.mql.yaml
+++ b/content/querypacks/mondoo-terraform-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Terraform HCL, plans, and state files
     docs:
       desc: |
-        The Terraform Asset Inventory Pack retrieves information about Terraform HCL, Terraform Plan, and Terraform State for asset inventory.
+        Inventories Terraform HCL, plan, and state files, cataloging the infrastructure resources they manage.
     groups:
       - title: Terraform State Asset inventory
         filters: asset.platform == "terraform-state"
@@ -29,13 +29,13 @@ queries:
     title: Terraform State Terraform Version
     docs:
       desc: |
-        This query gathers the version of Terraform that was used to execute a Terraform run.
+        Returns the Terraform version that produced the state file.
     mql: terraform.state.terraformVersion
   - uid: mondoo-asset-inventory-terraform-state-resources
     title: Terraform State resources
     docs:
       desc: |
-        This query gathers the resources stored in Terraform state files to provide an inventory of infrastructure managed by Terraform.
+        Inventories the resources recorded in Terraform state files, broken out by cloud provider.
     variants:
       - uid: mondoo-asset-inventory-terraform-state-aws-resources
       - uid: mondoo-asset-inventory-terraform-state-gcp-resources
@@ -44,17 +44,17 @@ queries:
     filters: asset.platform == "terraform-state" && terraform.state.resources.any( type == /^aws_/ )
     docs:
       desc: |
-        This query gathers the resources stored in Terraform state files that manage any AWS resources. The data is only gather if any of the resources match 'aws_' such as 'aws_s3_bucket'.
+        Lists AWS resources in the state file with their type, provider name, ARN, and owner ID. Runs only when a resource type matches 'aws_', such as 'aws_s3_bucket'.
     mql: terraform.state.resources { type providerName values['arn']  values['owner_id'] }
   - uid: mondoo-asset-inventory-terraform-state-gcp-resources
     filters: asset.platform == "terraform-state" && terraform.state.resources.any( type == /^google_/ )
     docs:
       desc: |
-        This query gathers the resources stored in Terraform state files that manage any Google Cloud resources. The data is only gather if any of the resources match 'google_' such as 'google_compute_instance'.
+        Lists Google Cloud resources in the state file with their type, provider name, project, and ID. Runs only when a resource type matches 'google_', such as 'google_compute_instance'.
     mql: terraform.state.resources { type providerName values['project'] values['id'] }
   - uid: mondoo-asset-inventory-terraform-state-azure-resources
     filters: asset.platform == "terraform-state" && terraform.state.resources.any( type == /^azurerm_/ )
     docs:
       desc: |
-        This query gathers the resources stored in Terraform state files that manage any Microsoft Azure resources. The data is only gather if any of the resources match 'azurerm_' such as 'azurerm_resource_group'.
+        Lists Microsoft Azure resources in the state file with their type, provider name, and ID. Runs only when a resource type matches 'azurerm_', such as 'azurerm_resource_group'.
     mql: terraform.state.resources { type providerName values['id'] }

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ## Overview
 
-        VMware vCenter Incident Response Pack by Mondoo retrieves data about vCenter and its ESXi hosts.
+        Gathers ESXi host evidence for a vCenter incident investigation: kernel modules, installed packages, services, host acceptance level, and NTP configuration.
 
         ### Run query pack
 
@@ -39,17 +39,17 @@ packs:
       - uid: mondoo-vmware-incident-response-kernel-modules
         title: Kernel modules
         docs:
-          desc: Lists all ESXi kernel modules to identify potentially malicious or unauthorized kernel extensions.
+          desc: Lists the ESXi host's kernel modules, to spot malicious or unauthorized kernel extensions.
         mql: vsphere.host.kernelModules
       - uid: mondoo-vmware-incident-response-installed-packages
         title: Installed packages
         docs:
-          desc: Lists all installed VIBs (vSphere Installation Bundles) to identify potentially vulnerable or unauthorized software.
+          desc: Lists installed VIBs (vSphere Installation Bundles), to spot vulnerable or unauthorized software.
         mql: vsphere.host.packages
       - uid: mondoo-vmware-incident-response-running-services
         title: All services
         docs:
-          desc: Lists all ESXi services to identify potentially vulnerable services like SLP that should be disabled.
+          desc: Lists the ESXi host's services, to spot risky services such as SLP that should be disabled.
         mql: vsphere.host.services
         refs:
           - title: VMSA-2021-0002
@@ -59,7 +59,7 @@ packs:
       - uid: mondoo-vmware-incident-response-acceptance-level
         title: Host acceptance level
         docs:
-          desc: The host acceptance level determines which VIBs can be installed on a host.
+          desc: Returns the host acceptance level, which governs the signing level of VIBs allowed on the host.
         mql: vsphere.host.acceptanceLevel
         refs:
           - title:
@@ -67,5 +67,5 @@ packs:
       - uid: mondoo-vmware-incident-response-ntp-servers
         title: Configured NTP servers
         docs:
-          desc: Lists configured NTP servers to verify time synchronization and detect potential time manipulation attacks.
+          desc: Lists the configured NTP servers, to verify time synchronization and detect time-manipulation tampering.
         mql: vsphere.host.ntp.server

--- a/content/querypacks/mondoo-vmware-inventory.mql.yaml
+++ b/content/querypacks/mondoo-vmware-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ## Overview
 
-        VMware vCenter Asset Inventory Pack by Mondoo retrieves data about vCenter and its ESXi hosts.
+        Collects VMware inventory: vCenter datacenters, clusters, and virtual machines, plus ESXi host packages, services, networking, firewall, and time configuration.
 
         ### Run query pack
 
@@ -39,91 +39,91 @@ packs:
       - uid: mondoo-vmware-asset-inventory-vcenter-datacenters
         title: VMware vSphere Datacenters
         docs:
-          desc: Lists all vSphere datacenters in the environment.
+          desc: Lists the vSphere datacenters that organize hosts, clusters, and VMs.
         filters: asset.platform == "vmware-vsphere"
         mql: |
           vsphere.datacenters { name }
       - uid: mondoo-vmware-asset-inventory-vcenter-clusters
         title: VMware vSphere Clusters per Datacenter
         docs:
-          desc: Lists all vSphere clusters within each datacenter.
+          desc: Lists the vSphere clusters within each datacenter.
         filters: asset.platform == "vmware-vsphere"
         mql: |
           vsphere.datacenters { clusters }
       - uid: mondoo-vmware-asset-inventory-vcenter-vms
         title: VMware vSphere VMs per Datacenters
         docs:
-          desc: Lists all virtual machines in each datacenter with their guest OS state and detailed guest info.
+          desc: Lists the virtual machines in each datacenter with guest OS state and detailed guest info.
         filters: asset.platform == "vmware-vsphere"
         mql: |
           vsphere.datacenters { vms { name advancedSettings["guestInfo.detailed.data"] properties["guest"]["guestState"] } }
       - uid: mondoo-vmware-asset-inventory-esxi-kernel-modules
         title: VMware ESXi Kernel modules
         docs:
-          desc: Lists all kernel modules loaded on the ESXi host.
+          desc: Lists the kernel modules loaded on the ESXi host.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.kernelModules
       - uid: mondoo-vmware-asset-inventory-esxi-installed-packages
         title: VMware ESXi Installed packages
         docs:
-          desc: Lists all VIBs (vSphere Installation Bundles) installed on the ESXi host.
+          desc: Lists the VIBs (vSphere Installation Bundles) installed on the ESXi host.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.packages
       - uid: mondoo-vmware-asset-inventory-esxi-services
         title: VMware ESXi Services
         docs:
-          desc: Lists all services configured on the ESXi host with their status.
+          desc: Lists the ESXi host services with their running status.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.services
       - uid: mondoo-vmware-asset-inventory-esxi-acceptance-level
         title: VMware ESXi Acceptance Level
         docs:
-          desc: Returns the host acceptance level that determines which VIBs can be installed.
+          desc: Returns the host acceptance level, which sets the signature trust required to install a VIB.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.acceptanceLevel
       - uid: mondoo-vmware-asset-inventory-esxi-ntp-server
         title: VMware ESXi NTP servers
         docs:
-          desc: Lists configured NTP servers for time synchronization.
+          desc: Lists the NTP servers the ESXi host uses for time synchronization.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.ntp.server
       - uid: mondoo-vmware-asset-inventory-esxi-ntp-config
         title: VMware ESXi NTP configuration
         docs:
-          desc: Returns the NTP client configuration settings.
+          desc: Returns the ESXi NTP client configuration.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.ntp.config
       - uid: mondoo-vmware-asset-inventory-esxi-fileSystemVolume
         title: VMware ESXi File System Volume
         docs:
-          desc: Returns configured file system volume.
+          desc: Returns the ESXi host file system volume configuration.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.properties.config.fileSystemVolume
       - uid: mondoo-vmware-asset-inventory-esxi-firewall
         title: VMware ESXi Firewall
         docs:
-          desc: Returns the ESXi firewall configuration and rules.
+          desc: Returns the ESXi host firewall configuration and rules.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.properties.config.firewall
       - uid: mondoo-vmware-asset-inventory-esxi-adapters
         title: VMware ESXi Physical Adapters
         docs:
-          desc: Lists physical network adapters installed in the ESXi host.
+          desc: Lists the physical network adapters installed in the ESXi host.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.adapters
       - uid: mondoo-vmware-asset-inventory-esxi-standardSwitch
         title: VMware ESXi Standard vSwitch
         docs:
-          desc: Lists standard virtual switches configured on the ESXi host.
+          desc: Lists the standard virtual switches configured on the ESXi host.
         filters: asset.platform == "vmware-esxi"
         mql: |
           vsphere.host.standardSwitch

--- a/content/querypacks/mondoo-windows-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-windows-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         ### Overview
 
-        The Windows Incident Response Pack by Mondoo retrieves configuration data from Windows hosts for investigation during a security incident. This includes installed hotfixes, system uptime, installed packages, computer information, and running services.
+        Collects Windows host evidence for incident investigation: installed hotfixes, system uptime and timezone, installed packages, computer and OS details, and running services.
 
         ### Run query pack
 
@@ -45,30 +45,30 @@ packs:
       - uid: mondoo-windows-incident-response-installed-hotfixes
         title: Installed hotfixes
         docs:
-          desc: Lists all installed Windows hotfixes with their ID and installation date to verify patch status and identify missing security updates.
+          desc: Lists installed hotfixes with their ID and installation date, revealing the host's patch level and any missing security updates an attacker could exploit.
         mql: windows.hotfixes { hotfixId installedOn }
       - uid: mondoo-windows-incident-response-uptime
         title: Operating system uptime
         docs:
-          desc: Returns the system uptime to help determine when the system was last rebooted and establish incident timeline.
+          desc: Returns system uptime, helping pin down the last reboot and anchor the incident timeline.
         mql: os.uptime
       - uid: mondoo-windows-incident-response-installed-packages
         title: Installed packages
         docs:
-          desc: Lists all installed software packages to identify potentially malicious or vulnerable applications.
+          desc: Lists installed software packages, helping spot malicious or vulnerable applications on the host.
         mql: packages
       - uid: mondoo-windows-incident-response-interface-configuration
         title: Windows Computer/System information
         docs:
-          desc: Retrieves detailed Windows system information including hardware and OS configuration for asset identification.
+          desc: Returns Windows computer and OS details, including hardware and configuration, for identifying the host under investigation.
         mql: windows.computerInfo
       - uid: mondoo-windows-incident-response-timezone
         title: System timezone
         docs:
-          desc: Returns the system timezone to help correlate log timestamps across systems during incident investigation.
+          desc: Returns the host's timezone, essential for correlating log timestamps across systems during investigation.
         mql: os.date.timezone
       - uid: mondoo-windows-incident-response-running-services
         title: Running services
         docs:
-          desc: Lists all currently running Windows services to identify suspicious or unauthorized services that may indicate compromise.
+          desc: Lists services currently running, helping surface suspicious or unauthorized services that may signal compromise.
         mql: services.where(running == true)

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Windows host OS, software, and configuration
     docs:
       desc: |
-        The Windows Asset Inventory Pack by Mondoo retrieves data about Windows hosts for asset inventory.
+        Collects Windows host inventory: OS and computer information, installed software and hotfixes, services, listening ports, network configuration, security products, and audit policy.
 
         ## Local scan
         To run this pack locally on a Windows host:
@@ -113,7 +113,7 @@ packs:
       - uid: mondoo-windows-cloud-instance
         title: Cloud instance metadata
         docs:
-          desc: Returns cloud provider instance identity (public and private IPs, hostnames, and the raw instance metadata dict carrying account/subscription, region, and instance type) from the instance metadata service. On non-cloud hosts the provider resolves to "Unknown" and the instance fields are unavailable (the instance lookup reports an error).
+          desc: "Returns cloud provider instance identity from the instance metadata service: public and private IPs, hostnames, and the raw metadata dict carrying account or subscription, region, and instance type. On non-cloud hosts the provider resolves to \"Unknown\" and the instance fields are unavailable."
         mql: cloud { provider instance { publicHostname privateHostname publicIpv4 { ip } privateIpv4 { ip } metadata } }
       - uid: mondoo-windows-network-neighbors
         title: ARP/NDP neighbor cache
@@ -162,14 +162,14 @@ packs:
             Shows where the computer sits in Active Directory, based on its location in the registry. No
             commands are run on the host. It reports:
 
-            - **OrganizationalUnit** – the organizational unit (OU) the computer is in
-            - **OUPath** – the full path of OUs it sits under (e.g. `Servers/Production`)
-            - **Domain** – the Active Directory domain (e.g. `corp.example.com`)
-            - **DistinguishedName** – the computer's full Active Directory location
-            - **PartOfDomain** – whether the computer is joined to a domain
+            - **OrganizationalUnit**: the organizational unit (OU) the computer is in
+            - **OUPath**: the full path of OUs it sits under (e.g. `Servers/Production`)
+            - **Domain**: the Active Directory domain (e.g. `corp.example.com`)
+            - **DistinguishedName**: the computer's full Active Directory location
+            - **PartOfDomain**: whether the computer is joined to a domain
 
             These are empty for computers that aren't joined to a domain, including cloud-only (Entra)
-            hosts. The value comes from Windows' own cached copy, so it can be slightly out of date — for
+            hosts. The value comes from Windows' own cached copy, so it can be slightly out of date, for
             example just after a computer is moved to a different OU or first joined to the domain.
         mql: |
           # The DN is parsed by splitting on raw ',' and '=' . AD escapes those characters inside an

--- a/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
@@ -17,7 +17,7 @@ packs:
     summary: Inventory Windows operational and monitoring data
     docs:
       desc: |-
-        The Windows Operational Inventory Pack by Mondoo retrieves monitoring data about Windows hosts.
+        Collects Windows host operational telemetry: memory, CPU, and disk utilization sampled from Windows performance counters.
 
         ## Local scan
         To run this pack locally on a Windows host:


### PR DESCRIPTION
## What

Reworks every pack-level overview and per-query description across all 29 query packs so they explain, in fewer words, **what data a query returns and why it is useful**.

## Why

Many descriptions were dead boilerplate (`This query retrieves data for all owners of the GCP project`) that spent words on the phrase "This query retrieves" instead of on the content. The best packs (windows/aws inventory) already used a tight, verb-first style; this brings the rest in line.

## Changes

- Replace `This query retrieves...` / `...by Mondoo query pack retrieves information about...` lead-ins with verb-first, concrete descriptions (`Lists` / `Counts` / `Returns` / `Reports`).
- Frame incident-response query descriptions around what an investigator learns from the data.
- Name the fields a query actually projects where that adds clarity, verified against each `mql:`.
- Remove emdashes, en-dashes, and double-hyphens from all description prose.

## Scope & safety

- **Only `desc:` values changed.** A YAML round-trip diff confirms `mql`, `uid`, `title`, `filters`, `tags`, `variants`, and `version` are byte-for-byte unchanged.
- `cnspec policy lint ./content/querypacks` passes.
- 29 files, ~490 descriptions reworked.

## Notes for reviewers (pre-existing content quirks surfaced, not changed here)

- `mondoo-github-incident-response`: the "private repositories" and "packages" queries have titles that don't match their MQL (`private == false`; `github.organization.packages`). Descriptions were written accurate to the MQL; titles left untouched.
- `mondoo-macos-inventory`: "Listening ports" and "Active network connections" share identical MQL (`ports.where(state != "close")`). Descriptions reflect the actual shared filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)