### PR TITLE
✨ querypacks: expand OCI inventory + add DigitalOcean, Hetzner, STACKIT, Proxmox, OpenStack & Nutanix packs

### DIFF
--- a/content/querypacks/mondoo-digitalocean-inventory.mql.yaml
+++ b/content/querypacks/mondoo-digitalocean-inventory.mql.yaml
@@ -1,0 +1,408 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-digitalocean
+    name: DigitalOcean Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: digitalocean
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: digitalocean,cloud
+      mondoo.com/category: best-practices
+    summary: Inventory DigitalOcean droplets, databases, networking, and storage
+    docs:
+      desc: |
+        Collects a DigitalOcean account inventory: account and billing metadata, droplets and images, Kubernetes clusters, managed databases, networking (VPCs, load balancers, firewalls, domains), storage (volumes, Spaces buckets), the container registry, serverless apps and functions, security assets, and monitoring resources.
+
+        ## Scan a DigitalOcean account
+
+        ```bash
+        cnspec scan digitalocean
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-digitalocean-account-group
+        title: Account
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-account
+          - uid: mondoo-asset-inventory-digitalocean-billing
+          - uid: mondoo-asset-inventory-digitalocean-projects
+      - uid: mondoo-asset-inventory-digitalocean-compute-group
+        title: Compute
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-droplets
+          - uid: mondoo-asset-inventory-digitalocean-images
+          - uid: mondoo-asset-inventory-digitalocean-snapshots
+          - uid: mondoo-asset-inventory-digitalocean-droplet-autoscale-pools
+      - uid: mondoo-asset-inventory-digitalocean-kubernetes-group
+        title: Kubernetes
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-kubernetes-clusters
+      - uid: mondoo-asset-inventory-digitalocean-databases-group
+        title: Databases
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-databases
+          - uid: mondoo-asset-inventory-digitalocean-vector-databases
+      - uid: mondoo-asset-inventory-digitalocean-networking-group
+        title: Networking
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-vpcs
+          - uid: mondoo-asset-inventory-digitalocean-load-balancers
+          - uid: mondoo-asset-inventory-digitalocean-firewalls
+          - uid: mondoo-asset-inventory-digitalocean-domains
+          - uid: mondoo-asset-inventory-digitalocean-reserved-ips
+          - uid: mondoo-asset-inventory-digitalocean-reserved-ipv6s
+          - uid: mondoo-asset-inventory-digitalocean-cdn-endpoints
+          - uid: mondoo-asset-inventory-digitalocean-vpc-nat-gateways
+          - uid: mondoo-asset-inventory-digitalocean-vpc-peerings
+      - uid: mondoo-asset-inventory-digitalocean-storage-group
+        title: Storage
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-volumes
+          - uid: mondoo-asset-inventory-digitalocean-spaces-buckets
+          - uid: mondoo-asset-inventory-digitalocean-nfs-shares
+      - uid: mondoo-asset-inventory-digitalocean-registry-group
+        title: Container Registry
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-registry-repositories
+      - uid: mondoo-asset-inventory-digitalocean-serverless-group
+        title: Serverless
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-function-namespaces
+          - uid: mondoo-asset-inventory-digitalocean-apps
+      - uid: mondoo-asset-inventory-digitalocean-security-group
+        title: Security
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-ssh-keys
+          - uid: mondoo-asset-inventory-digitalocean-certificates
+          - uid: mondoo-asset-inventory-digitalocean-secrets
+          - uid: mondoo-asset-inventory-digitalocean-spaces-keys
+      - uid: mondoo-asset-inventory-digitalocean-monitoring-group
+        title: Monitoring
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-alert-policies
+          - uid: mondoo-asset-inventory-digitalocean-uptime-checks
+      - uid: mondoo-asset-inventory-digitalocean-ai-group
+        title: AI
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-gradientai-agents
+          - uid: mondoo-asset-inventory-digitalocean-gradientai-knowledge-bases
+          - uid: mondoo-asset-inventory-digitalocean-gradientai-models
+      - uid: mondoo-asset-inventory-digitalocean-tags-group
+        title: Tags
+        filters: asset.runtime == "digitalocean"
+        queries:
+          - uid: mondoo-asset-inventory-digitalocean-tags
+queries:
+  - uid: mondoo-asset-inventory-digitalocean-account
+    title: DigitalOcean account information
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Returns core account metadata: UUID, email, team, status, and resource limits.
+    mql: |
+      digitalocean.account {
+        uuid
+        email
+        emailVerified
+        status
+        statusMessage
+        teamName
+        teamUuid
+        dropletLimit
+        floatingIpLimit
+        volumeLimit
+      }
+
+  - uid: mondoo-asset-inventory-digitalocean-billing
+    title: DigitalOcean billing information
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Returns account balance and month-to-date usage and balance.
+    mql: |
+      digitalocean.billing {
+        accountBalance
+        monthToDateBalance
+        monthToDateUsage
+        generatedAt
+      }
+
+  - uid: mondoo-asset-inventory-digitalocean-projects
+    title: DigitalOcean projects
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every project in the account.
+    mql: digitalocean.projects
+
+  - uid: mondoo-asset-inventory-digitalocean-droplets
+    title: DigitalOcean droplets
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every droplet in the account.
+    mql: digitalocean.droplets
+
+  - uid: mondoo-asset-inventory-digitalocean-images
+    title: DigitalOcean images
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every image available in the account.
+    mql: digitalocean.images
+
+  - uid: mondoo-asset-inventory-digitalocean-snapshots
+    title: DigitalOcean snapshots
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every droplet and volume snapshot in the account.
+    mql: digitalocean.snapshots
+
+  - uid: mondoo-asset-inventory-digitalocean-droplet-autoscale-pools
+    title: DigitalOcean droplet autoscale pools
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every droplet autoscale pool in the account.
+    mql: digitalocean.dropletAutoscalePools
+
+  - uid: mondoo-asset-inventory-digitalocean-kubernetes-clusters
+    title: DigitalOcean Kubernetes clusters
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every DigitalOcean Kubernetes (DOKS) cluster in the account.
+    mql: digitalocean.kubernetesClusters
+
+  - uid: mondoo-asset-inventory-digitalocean-databases
+    title: DigitalOcean managed databases
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every managed database cluster in the account.
+    mql: digitalocean.databases
+
+  - uid: mondoo-asset-inventory-digitalocean-vector-databases
+    title: DigitalOcean vector databases
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every managed vector database in the account.
+    mql: digitalocean.vectorDatabases
+
+  - uid: mondoo-asset-inventory-digitalocean-vpcs
+    title: DigitalOcean VPCs
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every VPC network in the account.
+    mql: digitalocean.vpcs
+
+  - uid: mondoo-asset-inventory-digitalocean-load-balancers
+    title: DigitalOcean load balancers
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every load balancer in the account.
+    mql: digitalocean.loadBalancers
+
+  - uid: mondoo-asset-inventory-digitalocean-firewalls
+    title: DigitalOcean firewalls
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every cloud firewall in the account.
+    mql: digitalocean.firewalls
+
+  - uid: mondoo-asset-inventory-digitalocean-domains
+    title: DigitalOcean domains
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every DNS domain managed in the account.
+    mql: digitalocean.domains
+
+  - uid: mondoo-asset-inventory-digitalocean-reserved-ips
+    title: DigitalOcean reserved IPs
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every reserved IPv4 address in the account.
+    mql: digitalocean.reservedIPs
+
+  - uid: mondoo-asset-inventory-digitalocean-reserved-ipv6s
+    title: DigitalOcean reserved IPv6 addresses
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every reserved IPv6 address in the account.
+    mql: digitalocean.reservedIPv6s
+
+  - uid: mondoo-asset-inventory-digitalocean-cdn-endpoints
+    title: DigitalOcean CDN endpoints
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every CDN endpoint in the account.
+    mql: digitalocean.cdnEndpoints
+
+  - uid: mondoo-asset-inventory-digitalocean-vpc-nat-gateways
+    title: DigitalOcean VPC NAT gateways
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every VPC NAT gateway in the account.
+    mql: digitalocean.vpcNatGateways
+
+  - uid: mondoo-asset-inventory-digitalocean-vpc-peerings
+    title: DigitalOcean VPC peerings
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every VPC peering connection in the account.
+    mql: digitalocean.vpcPeerings
+
+  - uid: mondoo-asset-inventory-digitalocean-volumes
+    title: DigitalOcean block storage volumes
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every block storage volume in the account.
+    mql: digitalocean.volumes
+
+  - uid: mondoo-asset-inventory-digitalocean-spaces-buckets
+    title: DigitalOcean Spaces buckets
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every Spaces object storage bucket in the account.
+    mql: digitalocean.spacesBuckets
+
+  - uid: mondoo-asset-inventory-digitalocean-nfs-shares
+    title: DigitalOcean NFS shares
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every NFS share in the account.
+    mql: digitalocean.nfsShares
+
+  - uid: mondoo-asset-inventory-digitalocean-registry-repositories
+    title: DigitalOcean container registry repositories
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every repository in the container registry.
+    mql: digitalocean.registryRepositories
+
+  - uid: mondoo-asset-inventory-digitalocean-function-namespaces
+    title: DigitalOcean function namespaces
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every serverless function namespace in the account.
+    mql: digitalocean.functionNamespaces
+
+  - uid: mondoo-asset-inventory-digitalocean-apps
+    title: DigitalOcean App Platform apps
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every App Platform app in the account.
+    mql: digitalocean.apps
+
+  - uid: mondoo-asset-inventory-digitalocean-ssh-keys
+    title: DigitalOcean SSH keys
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every SSH key registered in the account.
+    mql: digitalocean.sshKeys
+
+  - uid: mondoo-asset-inventory-digitalocean-certificates
+    title: DigitalOcean certificates
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every TLS certificate managed in the account.
+    mql: digitalocean.certificates
+
+  - uid: mondoo-asset-inventory-digitalocean-secrets
+    title: DigitalOcean secrets
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every secret managed in the account.
+    mql: digitalocean.secrets
+
+  - uid: mondoo-asset-inventory-digitalocean-spaces-keys
+    title: DigitalOcean Spaces access keys
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every Spaces access key in the account.
+    mql: digitalocean.spacesKeys
+
+  - uid: mondoo-asset-inventory-digitalocean-alert-policies
+    title: DigitalOcean alert policies
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every monitoring alert policy in the account.
+    mql: digitalocean.alertPolicies
+
+  - uid: mondoo-asset-inventory-digitalocean-uptime-checks
+    title: DigitalOcean uptime checks
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every uptime check configured in the account.
+    mql: digitalocean.uptimeChecks
+
+  - uid: mondoo-asset-inventory-digitalocean-tags
+    title: DigitalOcean tags
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every tag defined in the account.
+    mql: digitalocean.tags
+
+  - uid: mondoo-asset-inventory-digitalocean-gradientai-agents
+    title: GradientAI agents
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists every GradientAI agent in the account.
+    mql: digitalocean.gradientai.agents
+
+  - uid: mondoo-asset-inventory-digitalocean-gradientai-knowledge-bases
+    title: GradientAI knowledge bases
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists the GradientAI knowledge bases that back retrieval-augmented agents.
+    mql: digitalocean.gradientai.knowledgeBases
+
+  - uid: mondoo-asset-inventory-digitalocean-gradientai-models
+    title: GradientAI models
+    filters: asset.platform == "digitalocean"
+    docs:
+      desc: |
+        Lists the GradientAI models available in the account.
+    mql: digitalocean.gradientai.models

--- a/content/querypacks/mondoo-hetzner-inventory.mql.yaml
+++ b/content/querypacks/mondoo-hetzner-inventory.mql.yaml
@@ -1,0 +1,360 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-hetzner
+    name: Hetzner Cloud Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: hetzner
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: hetzner,cloud
+      mondoo.com/category: best-practices
+    summary: Inventory Hetzner Cloud servers, networking, storage, and account resources
+    docs:
+      desc: |
+        Collects a Hetzner Cloud project inventory: servers, images, and placement groups; networks, IPs, load balancers, firewalls, and certificates; block storage volumes and Storage Boxes; SSH keys; datacenters and locations; and the server, load balancer, and Storage Box type catalogs.
+
+        ## Scan a Hetzner Cloud project
+
+        ```bash
+        cnspec scan hetzner
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-hetzner-compute-group
+        title: Compute
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-servers-count
+          - uid: mondoo-asset-inventory-hetzner-servers-data
+          - uid: mondoo-asset-inventory-hetzner-images
+          - uid: mondoo-asset-inventory-hetzner-isos
+          - uid: mondoo-asset-inventory-hetzner-placement-groups
+      - uid: mondoo-asset-inventory-hetzner-networking-group
+        title: Networking
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-networks
+          - uid: mondoo-asset-inventory-hetzner-floating-ips
+          - uid: mondoo-asset-inventory-hetzner-primary-ips
+          - uid: mondoo-asset-inventory-hetzner-load-balancers
+          - uid: mondoo-asset-inventory-hetzner-firewalls
+          - uid: mondoo-asset-inventory-hetzner-certificates
+      - uid: mondoo-asset-inventory-hetzner-dns-group
+        title: DNS
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-dns-zones
+      - uid: mondoo-asset-inventory-hetzner-storage-group
+        title: Storage
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-volumes
+          - uid: mondoo-asset-inventory-hetzner-storage-boxes
+      - uid: mondoo-asset-inventory-hetzner-access-group
+        title: Access
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-ssh-keys
+      - uid: mondoo-asset-inventory-hetzner-infrastructure-group
+        title: Infrastructure
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-datacenters
+          - uid: mondoo-asset-inventory-hetzner-locations
+      - uid: mondoo-asset-inventory-hetzner-catalog-group
+        title: Catalog
+        filters: asset.runtime == "hetzner"
+        queries:
+          - uid: mondoo-asset-inventory-hetzner-server-types
+          - uid: mondoo-asset-inventory-hetzner-load-balancer-types
+          - uid: mondoo-asset-inventory-hetzner-storage-box-types
+queries:
+  - uid: mondoo-asset-inventory-hetzner-servers-count
+    title: Hetzner Cloud servers count
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Counts the cloud servers (virtual machines) in the project.
+    mql: hetzner.servers.length
+
+  - uid: mondoo-asset-inventory-hetzner-servers-data
+    title: Hetzner Cloud servers
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each cloud server with its type, status, datacenter, and network configuration.
+    mql: |
+      hetzner.servers {
+        id
+        name
+        status
+        serverType
+        datacenter
+        image
+        publicIpv4
+        publicIpv6
+        firewalls
+        labels
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-images
+    title: Hetzner Cloud images and snapshots
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the OS images, snapshots, backups, and app images available in the project.
+    mql: |
+      hetzner.images {
+        id
+        name
+        type
+        osFlavor
+        osVersion
+        architecture
+        status
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-isos
+    title: Hetzner Cloud ISOs
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the ISO images available for boot in the project.
+    mql: hetzner.isos
+
+  - uid: mondoo-asset-inventory-hetzner-placement-groups
+    title: Hetzner Cloud placement groups
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the placement groups and the servers assigned to each.
+    mql: hetzner.placementGroups
+
+  - uid: mondoo-asset-inventory-hetzner-networks
+    title: Hetzner Cloud networks
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each private network (VPC) with its IP range, subnets, and routes.
+    mql: |
+      hetzner.networks {
+        id
+        name
+        ipRange
+        subnets
+        routes
+        servers
+        labels
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-floating-ips
+    title: Hetzner Cloud floating IPs
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the floating IPs and the servers they are assigned to.
+    mql: hetzner.floatingIps
+
+  - uid: mondoo-asset-inventory-hetzner-primary-ips
+    title: Hetzner Cloud primary IPs
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the primary IPs and their assignees.
+    mql: hetzner.primaryIps
+
+  - uid: mondoo-asset-inventory-hetzner-load-balancers
+    title: Hetzner Cloud load balancers
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each load balancer with its algorithm, type, location, and public network configuration.
+    mql: |
+      hetzner.loadBalancers {
+        id
+        name
+        algorithm
+        loadBalancerType
+        location
+        publicNet
+        services
+        labels
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-firewalls
+    title: Hetzner Cloud firewalls
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each firewall with its rules and the servers it is applied to.
+    mql: |
+      hetzner.firewalls {
+        id
+        name
+        rules
+        servers
+        labelSelectors
+        labels
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-certificates
+    title: Hetzner Cloud TLS certificates
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each managed or uploaded TLS certificate with its domains and validity window.
+    mql: |
+      hetzner.certificates {
+        id
+        name
+        type
+        domainNames
+        notValidBefore
+        notValidAfter
+        fingerprint
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-volumes
+    title: Hetzner Cloud block storage volumes
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each block storage volume with its size, format, location, and attached server.
+    mql: |
+      hetzner.volumes {
+        id
+        name
+        size
+        format
+        location
+        server
+        status
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-storage-boxes
+    title: Hetzner Cloud Storage Boxes
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Returns each Storage Box with its type, location, size, and enabled access protocols.
+    mql: |
+      hetzner.storageBoxes {
+        id
+        name
+        status
+        storageBoxType
+        location
+        size
+        sambaEnabled
+        sshEnabled
+        webdavEnabled
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-ssh-keys
+    title: Hetzner Cloud SSH keys
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the project SSH keys with their algorithm, key size, and fingerprint.
+    mql: |
+      hetzner.sshKeys {
+        id
+        name
+        algorithm
+        bits
+        fingerprint
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-datacenters
+    title: Hetzner Cloud datacenters
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the datacenters and their parent locations.
+    mql: hetzner.datacenters
+
+  - uid: mondoo-asset-inventory-hetzner-locations
+    title: Hetzner Cloud locations
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the Hetzner Cloud locations (regions) with their city, country, and network zone.
+    mql: |
+      hetzner.locations {
+        id
+        name
+        city
+        country
+        networkZone
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-server-types
+    title: Hetzner Cloud server types
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the available server types (VM sizes) with their CPU, memory, and disk specifications.
+    mql: |
+      hetzner.serverTypes {
+        id
+        name
+        cores
+        memory
+        disk
+        cpuType
+        architecture
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-load-balancer-types
+    title: Hetzner Cloud load balancer types
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the available load balancer types with their connection, service, and target limits.
+    mql: |
+      hetzner.loadBalancerTypes {
+        id
+        name
+        maxConnections
+        maxServices
+        maxTargets
+        maxAssignedCertificates
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-storage-box-types
+    title: Hetzner Cloud Storage Box types
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the available Storage Box types (storage tiers) with their capacity and snapshot limits.
+    mql: |
+      hetzner.storageBoxTypes {
+        id
+        name
+        size
+        snapshotLimit
+        subaccountsLimit
+      }
+
+  - uid: mondoo-asset-inventory-hetzner-dns-zones
+    title: Hetzner managed DNS zones
+    filters: asset.platform == "hetzner-project"
+    docs:
+      desc: |
+        Lists the managed DNS zones with their mode, delegation status, record count, and nameservers.
+    mql: |
+      hetzner.zones {
+        id
+        name
+        mode
+        status
+        recordCount
+        ttl
+        delegationStatus
+        assignedNameservers
+      }

--- a/content/querypacks/mondoo-nutanix-inventory.mql.yaml
+++ b/content/querypacks/mondoo-nutanix-inventory.mql.yaml
@@ -1,0 +1,217 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-nutanix
+    name: Nutanix Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: nutanix
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: nutanix
+      mondoo.com/category: best-practices
+    summary: Inventory Nutanix clusters, hosts, virtual machines, storage, networking, and identity
+    docs:
+      desc: |
+        Collects a Nutanix Prism Central inventory: registered clusters and their hypervisor hosts, virtual machines, storage containers and volume groups, subnets, VPCs and floating IPs, disk images, and IAM users, groups, roles, directory services, authorization policies, and SAML identity providers.
+
+        ## Scan a Nutanix Prism Central
+
+        ```bash
+        cnspec scan nutanix
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-nutanix-clusters-group
+        title: Clusters
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-clusters-count
+          - uid: mondoo-asset-inventory-nutanix-clusters
+          - uid: mondoo-asset-inventory-nutanix-hosts
+          - uid: mondoo-asset-inventory-nutanix-cluster-nodes
+      - uid: mondoo-asset-inventory-nutanix-vms-group
+        title: Virtual Machines
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-vms-count
+          - uid: mondoo-asset-inventory-nutanix-vms
+      - uid: mondoo-asset-inventory-nutanix-storage-group
+        title: Storage
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-storage-containers
+          - uid: mondoo-asset-inventory-nutanix-volume-groups
+      - uid: mondoo-asset-inventory-nutanix-networking-group
+        title: Networking
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-subnets
+          - uid: mondoo-asset-inventory-nutanix-vpcs
+          - uid: mondoo-asset-inventory-nutanix-floating-ips
+      - uid: mondoo-asset-inventory-nutanix-iam-group
+        title: Identity & Access
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-iam-users
+          - uid: mondoo-asset-inventory-nutanix-iam-groups
+          - uid: mondoo-asset-inventory-nutanix-iam-roles
+          - uid: mondoo-asset-inventory-nutanix-iam-directory-services
+          - uid: mondoo-asset-inventory-nutanix-iam-authorization-policies
+          - uid: mondoo-asset-inventory-nutanix-iam-saml-identity-providers
+      - uid: mondoo-asset-inventory-nutanix-images-group
+        title: Images
+        filters: asset.runtime == "nutanix"
+        queries:
+          - uid: mondoo-asset-inventory-nutanix-images
+queries:
+  - uid: mondoo-asset-inventory-nutanix-clusters-count
+    title: Nutanix clusters count
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Counts the clusters registered with this Prism Central instance.
+    mql: nutanix.clusters.length
+
+  - uid: mondoo-asset-inventory-nutanix-clusters
+    title: Nutanix clusters
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns each registered cluster with its software version, hypervisor types, node and VM counts, redundancy, encryption posture, and support settings.
+    mql: nutanix.clusters
+
+  - uid: mondoo-asset-inventory-nutanix-hosts
+    title: Nutanix hypervisor hosts
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every hypervisor host across all registered clusters with its hardware model, CPU and memory capacity, hypervisor type, and boot and maintenance state.
+    mql: nutanix.hosts
+
+  - uid: mondoo-asset-inventory-nutanix-cluster-nodes
+    title: Nutanix cluster nodes
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Lists the nodes that make up each registered cluster with their host and controller-VM IP addresses.
+    mql: |
+      nutanix.clusters {
+        name
+        nodes
+      }
+
+  - uid: mondoo-asset-inventory-nutanix-vms-count
+    title: Nutanix virtual machines count
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Counts the virtual machines across all registered clusters.
+    mql: nutanix.vms.length
+
+  - uid: mondoo-asset-inventory-nutanix-vms
+    title: Nutanix virtual machines
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every virtual machine with its power state, vCPU topology, memory size, feature flags, and the cluster and host it runs on.
+    mql: nutanix.vms
+
+  - uid: mondoo-asset-inventory-nutanix-storage-containers
+    title: Nutanix storage containers
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every storage container with its replication factor, encryption state, compression and deduplication settings, and capacity.
+    mql: nutanix.storageContainers
+
+  - uid: mondoo-asset-inventory-nutanix-volume-groups
+    title: Nutanix volume groups
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every volume group with its protocol, sharing status, enabled authentication methods, and attachment type.
+    mql: nutanix.volumeGroups
+
+  - uid: mondoo-asset-inventory-nutanix-subnets
+    title: Nutanix subnets
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every subnet with its type, IP prefix, hypervisor type, NAT and external-network settings, and IP address usage.
+    mql: nutanix.subnets
+
+  - uid: mondoo-asset-inventory-nutanix-vpcs
+    title: Nutanix VPCs
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every virtual private cloud with its type, externally routable prefixes, SNAT IP addresses, and external routing domain reference.
+    mql: nutanix.vpcs
+
+  - uid: mondoo-asset-inventory-nutanix-floating-ips
+    title: Nutanix floating IP addresses
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every floating IP address with its value, association status, external subnet, and any associated private IP or VM NIC reference.
+    mql: nutanix.floatingIps
+
+  - uid: mondoo-asset-inventory-nutanix-iam-users
+    title: Nutanix IAM users
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every IAM identity with its username, user type, status, directory linkage, contact details, and last login time.
+    mql: nutanix.users
+
+  - uid: mondoo-asset-inventory-nutanix-iam-groups
+    title: Nutanix IAM user groups
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every IAM user group with its type, directory linkage, and distinguished name.
+    mql: nutanix.userGroups
+
+  - uid: mondoo-asset-inventory-nutanix-iam-roles
+    title: Nutanix IAM roles
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every IAM role with whether it is system-defined, the operations it grants, the entity types it covers, and how many identities are assigned.
+    mql: nutanix.roles
+
+  - uid: mondoo-asset-inventory-nutanix-iam-directory-services
+    title: Nutanix directory services
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every configured directory service (Active Directory or LDAP) with its type, domain, server URLs, group-search behavior, and bind service account.
+    mql: nutanix.directoryServices
+
+  - uid: mondoo-asset-inventory-nutanix-iam-authorization-policies
+    title: Nutanix IAM authorization policies
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every authorization policy with its type, the role it grants, whether it is system-defined, and how many users and groups are assigned.
+    mql: nutanix.authorizationPolicies
+
+  - uid: mondoo-asset-inventory-nutanix-iam-saml-identity-providers
+    title: Nutanix SAML identity providers
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every SAML identity provider with its issuer, assertion attribute mappings, metadata source, and whether signed authn requests are enforced.
+    mql: nutanix.samlIdentityProviders
+
+  - uid: mondoo-asset-inventory-nutanix-images
+    title: Nutanix disk images
+    filters: asset.platform == "nutanix-prism-central"
+    docs:
+      desc: |
+        Returns every disk image available for creating virtual machines with its name, type, size, and creation time.
+    mql: nutanix.images

--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -61,6 +61,94 @@ packs:
         queries:
           - uid: mondoo-asset-inventory-oci-network-vcns
           - uid: mondoo-asset-inventory-oci-network-security-lists
+          - uid: mondoo-asset-inventory-oci-network-subnets
+          - uid: mondoo-asset-inventory-oci-network-route-tables
+          - uid: mondoo-asset-inventory-oci-network-internet-gateways
+          - uid: mondoo-asset-inventory-oci-network-nat-gateways
+          - uid: mondoo-asset-inventory-oci-network-security-groups
+          - uid: mondoo-asset-inventory-oci-network-drgs
+      - uid: mondoo-asset-inventory-oci-database-group
+        title: Database
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-database-autonomous
+          - uid: mondoo-asset-inventory-oci-database-db-systems
+          - uid: mondoo-asset-inventory-oci-database-backups
+          - uid: mondoo-asset-inventory-oci-database-autonomous-backups
+      - uid: mondoo-asset-inventory-oci-load-balancing-group
+        title: Load Balancing
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-load-balancers
+      - uid: mondoo-asset-inventory-oci-kms-vault-group
+        title: Key Management and Vault
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-kms-vaults
+          - uid: mondoo-asset-inventory-oci-vault-secrets
+          - uid: mondoo-asset-inventory-oci-certificates
+          - uid: mondoo-asset-inventory-oci-certificate-authorities
+      - uid: mondoo-asset-inventory-oci-oke-group
+        title: Kubernetes (OKE)
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-oke-clusters
+      - uid: mondoo-asset-inventory-oci-functions-containers-group
+        title: Functions and Containers
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-functions-applications
+          - uid: mondoo-asset-inventory-oci-container-instances
+      - uid: mondoo-asset-inventory-oci-file-storage-group
+        title: File Storage
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-file-systems
+      - uid: mondoo-asset-inventory-oci-bastion-group
+        title: Bastion
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-bastions
+      - uid: mondoo-asset-inventory-oci-logging-monitoring-group
+        title: Logging and Monitoring
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-log-groups
+          - uid: mondoo-asset-inventory-oci-monitoring-alarms
+          - uid: mondoo-asset-inventory-oci-events-rules
+          - uid: mondoo-asset-inventory-oci-ons-topics
+      - uid: mondoo-asset-inventory-oci-security-posture-group
+        title: Security Posture
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-cloud-guard-targets
+          - uid: mondoo-asset-inventory-oci-vss-host-scan-recipes
+          - uid: mondoo-asset-inventory-oci-vss-container-scan-recipes
+          - uid: mondoo-asset-inventory-oci-data-safe-security-assessments
+          - uid: mondoo-asset-inventory-oci-data-safe-user-assessments
+          - uid: mondoo-asset-inventory-oci-data-safe-target-databases
+      - uid: mondoo-asset-inventory-oci-web-security-group
+        title: Web Security
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-waf-policies
+          - uid: mondoo-asset-inventory-oci-waf-firewalls
+          - uid: mondoo-asset-inventory-oci-network-firewalls
+          - uid: mondoo-asset-inventory-oci-network-firewall-policies
+          - uid: mondoo-asset-inventory-oci-apigateway-gateways
+          - uid: mondoo-asset-inventory-oci-apigateway-deployments
+      - uid: mondoo-asset-inventory-oci-redis-group
+        title: Redis
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-redis-clusters
+      - uid: mondoo-asset-inventory-oci-ai-group
+        title: AI Services
+        filters: asset.runtime == "oci"
+        queries:
+          - uid: mondoo-asset-inventory-oci-ai-generative-endpoints
+          - uid: mondoo-asset-inventory-oci-ai-generative-models
+          - uid: mondoo-asset-inventory-oci-ai-data-science-projects
 
 queries:
   # --- General ---
@@ -255,5 +343,711 @@ queries:
         vcn { id }
         ingressSecurityRules
         egressSecurityRules
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-subnets
+    title: VCN subnets
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the VCN subnets with their CIDR block, availability domain, and public-IP restrictions.
+    mql: |
+      oci.network.subnets {
+        id
+        name
+        state
+        cidrBlock
+        availabilityDomain
+        prohibitPublicIpOnVnic
+        prohibitInternetIngress
+        dnsLabel
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-route-tables
+    title: VCN route tables
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the VCN route tables with their route rules.
+    mql: |
+      oci.network.routeTables {
+        id
+        name
+        state
+        routeRules
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-internet-gateways
+    title: Internet gateways
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the VCN internet gateways and whether each is enabled.
+    mql: |
+      oci.network.internetGateways {
+        id
+        name
+        state
+        isEnabled
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-nat-gateways
+    title: NAT gateways
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the VCN NAT gateways with their public NAT IP and traffic-block status.
+    mql: |
+      oci.network.natGateways {
+        id
+        name
+        state
+        blockTraffic
+        natIp
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-security-groups
+    title: Network security groups
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the network security groups (NSGs) with their ingress and egress rules.
+    mql: |
+      oci.network.networkSecurityGroups {
+        id
+        name
+        state
+        hasStatelessRules
+        ingressSecurityRules
+        egressSecurityRules
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-drgs
+    title: Dynamic routing gateways
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the dynamic routing gateways (DRGs) with their state and creation time.
+    mql: |
+      oci.network.drgs {
+        id
+        name
+        state
+        created
+      }
+
+  # --- Database ---
+  - uid: mondoo-asset-inventory-oci-database-autonomous
+    title: Autonomous databases
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Autonomous Database instances with their workload type, version, CPU count, and license model.
+    mql: |
+      oci.database.autonomousDatabases {
+        id
+        name
+        state
+        dbName
+        dbVersion
+        dbWorkload
+        cpuCoreCount
+        licenseModel
+        isDedicated
+        isFreeTier
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-database-db-systems
+    title: DB systems
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the VM and bare-metal DB systems with their shape, database edition, version, and node count.
+    mql: |
+      oci.database.dbSystems {
+        id
+        name
+        state
+        shape
+        databaseEdition
+        version
+        cpuCoreCount
+        nodeCount
+        licenseModel
+        availabilityDomain
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-database-backups
+    title: Database backups
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the database backups with their type, database edition, size, and timing.
+    mql: |
+      oci.database.backups {
+        id
+        name
+        state
+        type
+        databaseEdition
+        databaseSizeInGBs
+        timeStarted
+        timeEnded
+      }
+
+  - uid: mondoo-asset-inventory-oci-database-autonomous-backups
+    title: Autonomous database backups
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Autonomous Database backups with their type, size, and whether each is automatic.
+    mql: |
+      oci.database.autonomousDatabaseBackups {
+        id
+        name
+        state
+        type
+        isAutomatic
+        sizeInTBs
+        timeStarted
+        timeEnded
+      }
+
+  # --- Load Balancing ---
+  - uid: mondoo-asset-inventory-oci-load-balancers
+    title: Load balancers
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the load balancers with their shape, IP addresses, private flag, and delete-protection status.
+    mql: |
+      oci.loadBalancer.loadBalancers {
+        id
+        name
+        state
+        shape
+        isPrivate
+        ipAddresses
+        isDeleteProtectionEnabled
+        created
+      }
+
+  # --- Key Management and Vault ---
+  - uid: mondoo-asset-inventory-oci-kms-vaults
+    title: KMS vaults
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Key Management vaults with their type and management endpoint. Encryption keys are exposed as the `keys` field of each vault.
+    mql: |
+      oci.kms.vaults {
+        id
+        name
+        state
+        vaultType
+        managementEndpoint
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-vault-secrets
+    title: Vault secrets
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Vault secrets with their rotation configuration and status.
+    mql: |
+      oci.vault.secrets {
+        id
+        name
+        state
+        description
+        isAutoGenerationEnabled
+        isScheduledRotationEnabled
+        rotationStatus
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-certificates
+    title: Certificates
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the managed certificates with their configuration type, key and signature algorithms, subject, and validity window.
+    mql: |
+      oci.certificates.certificates {
+        id
+        name
+        state
+        configType
+        keyAlgorithm
+        signatureAlgorithm
+        subject
+        autoRenewalEnabled
+        validityNotAfter
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-certificate-authorities
+    title: Certificate authorities
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the certificate authorities (CAs) with their configuration type, kind, signing algorithm, subject, and validity window.
+    mql: |
+      oci.certificates.certificateAuthorities {
+        id
+        name
+        state
+        configType
+        kind
+        signingAlgorithm
+        subject
+        validityNotAfter
+        created
+      }
+
+  # --- Kubernetes (OKE) ---
+  - uid: mondoo-asset-inventory-oci-oke-clusters
+    title: OKE clusters
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Kubernetes Engine (OKE) clusters with their version, endpoint exposure, and policy settings. Node pools are exposed as the `nodePools` field of each cluster.
+    mql: |
+      oci.oke.clusters {
+        id
+        name
+        state
+        kubernetesVersion
+        type
+        isPublicEndpointEnabled
+        isPodSecurityPolicyEnabled
+        isImagePolicyEnabled
+        created
+      }
+
+  # --- Functions and Containers ---
+  - uid: mondoo-asset-inventory-oci-functions-applications
+    title: Functions applications
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Functions applications with their shape and syslog URL. Individual functions are exposed as the `functions` field of each application.
+    mql: |
+      oci.functions.applications {
+        id
+        name
+        state
+        shape
+        syslogUrl
+        created
+        timeUpdated
+      }
+
+  - uid: mondoo-asset-inventory-oci-container-instances
+    title: Container instances
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the container instances with their shape, availability and fault domain, container count, and restart policy.
+    mql: |
+      oci.containerInstances.instances {
+        id
+        name
+        state
+        shape
+        availabilityDomain
+        faultDomain
+        containerCount
+        containerRestartPolicy
+        created
+      }
+
+  # --- File Storage ---
+  - uid: mondoo-asset-inventory-oci-file-systems
+    title: File systems
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the File Storage file systems with their availability domain, metered size, and clone-parent flag.
+    mql: |
+      oci.fileStorage.fileSystems {
+        id
+        name
+        state
+        availabilityDomain
+        meteredBytes
+        isCloneParent
+        created
+      }
+
+  # --- Bastion ---
+  - uid: mondoo-asset-inventory-oci-bastions
+    title: Bastions
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the bastions with their type and DNS proxy status.
+    mql: |
+      oci.bastion.bastions {
+        id
+        name
+        state
+        bastionType
+        dnsProxyStatus
+        created
+      }
+
+  # --- Logging and Monitoring ---
+  - uid: mondoo-asset-inventory-oci-log-groups
+    title: Log groups
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the logging log groups with their description and state. Individual logs are exposed as the `logs` field of each log group.
+    mql: |
+      oci.logging.logGroups {
+        id
+        name
+        state
+        description
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-monitoring-alarms
+    title: Monitoring alarms
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the monitoring alarms with their metric namespace, severity, query, and enabled status.
+    mql: |
+      oci.monitoring.alarms {
+        id
+        name
+        state
+        namespace
+        severity
+        isEnabled
+        query
+      }
+
+  - uid: mondoo-asset-inventory-oci-events-rules
+    title: Events rules
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Events service rules with their condition and enabled status.
+    mql: |
+      oci.events.rules {
+        id
+        name
+        state
+        description
+        isEnabled
+        condition
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-ons-topics
+    title: Notification topics
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Notifications service (ONS) topics with their description and state.
+    mql: |
+      oci.ons.topics {
+        id
+        name
+        state
+        description
+        created
+      }
+
+  # --- Security Posture ---
+  - uid: mondoo-asset-inventory-oci-cloud-guard-targets
+    title: Cloud Guard targets
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Cloud Guard targets with their target resource type, resource ID, and attached recipe count.
+    mql: |
+      oci.cloudGuard.targets {
+        id
+        name
+        state
+        targetResourceType
+        targetResourceId
+        recipeCount
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-vss-host-scan-recipes
+    title: Host scan recipes
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Vulnerability Scanning host scan recipes with their agent, port, CIS benchmark, and application scan configuration.
+    mql: |
+      oci.vulnerabilityScanning.hostScanRecipes {
+        id
+        name
+        state
+        agentScanLevel
+        portScanLevel
+        cisBenchmarkScanLevel
+        applicationScanEnabled
+        scheduleType
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-vss-container-scan-recipes
+    title: Container scan recipes
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Vulnerability Scanning container scan recipes with their scan level and image count.
+    mql: |
+      oci.vulnerabilityScanning.containerScanRecipes {
+        id
+        name
+        state
+        scanLevel
+        imageCount
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-data-safe-security-assessments
+    title: Data Safe security assessments
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Data Safe security assessments with their type, baseline status, and region.
+    mql: |
+      oci.dataSafe.securityAssessments {
+        id
+        displayName
+        lifecycleState
+        type
+        isBaseline
+        isDeviatedFromBaseline
+        region
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-data-safe-user-assessments
+    title: Data Safe user assessments
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Data Safe user assessments with their type, baseline status, and region.
+    mql: |
+      oci.dataSafe.userAssessments {
+        id
+        displayName
+        lifecycleState
+        type
+        isBaseline
+        isDeviatedFromBaseline
+        region
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-data-safe-target-databases
+    title: Data Safe target databases
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Data Safe target databases with their database type, infrastructure type, and region.
+    mql: |
+      oci.dataSafe.targetDatabases {
+        id
+        displayName
+        lifecycleState
+        databaseType
+        infrastructureType
+        region
+        created
+      }
+
+  # --- Web Security ---
+  - uid: mondoo-asset-inventory-oci-waf-policies
+    title: WAF policies
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Web Application Firewall (WAF) policies with their state and last-update time.
+    mql: |
+      oci.waf.policies {
+        id
+        name
+        state
+        created
+        timeUpdated
+      }
+
+  - uid: mondoo-asset-inventory-oci-waf-firewalls
+    title: WAF firewalls
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Web Application Firewall (WAF) firewalls with their state and last-update time.
+    mql: |
+      oci.waf.firewalls {
+        id
+        name
+        state
+        created
+        timeUpdated
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-firewalls
+    title: Network firewalls
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the network firewalls with their shape, IPv4 and IPv6 addresses, and health status.
+    mql: |
+      oci.networkFirewall.firewalls {
+        id
+        name
+        state
+        shape
+        ipv4Address
+        ipv6Address
+        healthStatus
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-network-firewall-policies
+    title: Network firewall policies
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the network firewall policies with their description and attached firewall count.
+    mql: |
+      oci.networkFirewall.policies {
+        id
+        name
+        state
+        description
+        attachedFirewallCount
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-apigateway-gateways
+    title: API gateways
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the API gateways with their endpoint type, hostname, IP mode, and response-cache status.
+    mql: |
+      oci.apigateway.gateways {
+        id
+        name
+        state
+        endpointType
+        hostname
+        ipMode
+        hasResponseCache
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-apigateway-deployments
+    title: API gateway deployments
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the API gateway deployments with their path prefix, endpoint, authentication type, and anonymous-access setting.
+    mql: |
+      oci.apigateway.deployments {
+        id
+        name
+        state
+        pathPrefix
+        endpoint
+        authenticationType
+        isAnonymousAccessAllowed
+        created
+      }
+
+  # --- Redis ---
+  - uid: mondoo-asset-inventory-oci-redis-clusters
+    title: Redis clusters
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Redis clusters with their software version, node count and memory, shard count, and cluster mode.
+    mql: |
+      oci.redis.clusters {
+        id
+        name
+        state
+        softwareVersion
+        nodeCount
+        nodeMemoryInGBs
+        shardCount
+        clusterMode
+        created
+      }
+
+  # --- AI Services ---
+  - uid: mondoo-asset-inventory-oci-ai-generative-endpoints
+    title: Generative AI endpoints
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Generative AI endpoints with their backing model and content-moderation, PII-detection, and prompt-injection settings.
+    mql: |
+      oci.ai.generativeAi.endpoints {
+        id
+        name
+        state
+        modelID
+        contentModerationEnabled
+        piiDetectionEnabled
+        promptInjectionEnabled
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-ai-generative-models
+    title: Generative AI models
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Generative AI models with their type, vendor, version, and capabilities.
+    mql: |
+      oci.ai.generativeAi.models {
+        id
+        name
+        state
+        type
+        vendor
+        version
+        capabilities
+        isLongTermSupported
+        created
+      }
+
+  - uid: mondoo-asset-inventory-oci-ai-data-science-projects
+    title: Data Science projects
+    filters: asset.platform == "oci"
+    docs:
+      desc: |
+        Lists the Data Science projects with their description and creator.
+    mql: |
+      oci.ai.dataScience.projects {
+        id
+        name
+        state
+        description
+        createdBy
         created
       }

--- a/content/querypacks/mondoo-openstack-inventory.mql.yaml
+++ b/content/querypacks/mondoo-openstack-inventory.mql.yaml
@@ -1,0 +1,381 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-openstack
+    name: OpenStack Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: openstack
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: openstack,cloud
+      mondoo.com/category: best-practices
+    summary: Inventory OpenStack identity, compute, storage, networking, and platform service resources
+    docs:
+      desc: |
+        Collects an OpenStack project inventory across Keystone identity, Nova compute, Cinder block storage, Neutron networking, Octavia load balancing, Glance images, Swift object storage, Barbican secrets, Heat orchestration, Trove databases, Magnum clusters, Manila shares, VPNaaS, Ironic bare metal, and Designate DNS.
+
+        ## Scan an OpenStack project
+
+        ```bash
+        cnspec scan openstack
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-openstack-identity-group
+        title: Identity
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-users
+          - uid: mondoo-asset-inventory-openstack-groups
+          - uid: mondoo-asset-inventory-openstack-projects
+          - uid: mondoo-asset-inventory-openstack-roles
+          - uid: mondoo-asset-inventory-openstack-domains
+      - uid: mondoo-asset-inventory-openstack-compute-group
+        title: Compute
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-servers
+          - uid: mondoo-asset-inventory-openstack-flavors
+          - uid: mondoo-asset-inventory-openstack-keypairs
+          - uid: mondoo-asset-inventory-openstack-server-groups
+      - uid: mondoo-asset-inventory-openstack-block-storage-group
+        title: Block Storage
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-volumes
+          - uid: mondoo-asset-inventory-openstack-snapshots
+          - uid: mondoo-asset-inventory-openstack-backups
+          - uid: mondoo-asset-inventory-openstack-volume-types
+      - uid: mondoo-asset-inventory-openstack-networking-group
+        title: Networking
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-networks
+          - uid: mondoo-asset-inventory-openstack-subnets
+          - uid: mondoo-asset-inventory-openstack-routers
+          - uid: mondoo-asset-inventory-openstack-ports
+          - uid: mondoo-asset-inventory-openstack-floating-ips
+          - uid: mondoo-asset-inventory-openstack-security-groups
+          - uid: mondoo-asset-inventory-openstack-firewall-groups
+      - uid: mondoo-asset-inventory-openstack-load-balancing-group
+        title: Load Balancing
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-load-balancers
+      - uid: mondoo-asset-inventory-openstack-images-group
+        title: Images
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-images
+      - uid: mondoo-asset-inventory-openstack-object-storage-group
+        title: Object Storage
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-object-storage-containers
+      - uid: mondoo-asset-inventory-openstack-key-management-group
+        title: Key Management
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-secrets
+      - uid: mondoo-asset-inventory-openstack-orchestration-group
+        title: Orchestration
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-stacks
+      - uid: mondoo-asset-inventory-openstack-database-group
+        title: Database
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-database-instances
+      - uid: mondoo-asset-inventory-openstack-container-infrastructure-group
+        title: Container Infrastructure
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-clusters
+      - uid: mondoo-asset-inventory-openstack-shared-file-systems-group
+        title: Shared File Systems
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-shares
+      - uid: mondoo-asset-inventory-openstack-vpn-group
+        title: VPN
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-vpn-services
+      - uid: mondoo-asset-inventory-openstack-bare-metal-group
+        title: Bare Metal
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-baremetal-nodes
+      - uid: mondoo-asset-inventory-openstack-dns-group
+        title: DNS
+        filters: asset.runtime == "openstack"
+        queries:
+          - uid: mondoo-asset-inventory-openstack-dns-zones
+queries:
+  # Identity
+  - uid: mondoo-asset-inventory-openstack-users
+    title: OpenStack Keystone users
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Keystone users visible to the scoped project.
+    mql: openstack.users
+
+  - uid: mondoo-asset-inventory-openstack-groups
+    title: OpenStack Keystone groups
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Keystone groups visible to the scoped project.
+    mql: openstack.groups
+
+  - uid: mondoo-asset-inventory-openstack-projects
+    title: OpenStack Keystone projects
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Keystone projects visible to the authenticated user.
+    mql: openstack.projects
+
+  - uid: mondoo-asset-inventory-openstack-roles
+    title: OpenStack Keystone roles
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Keystone roles defined in the cloud.
+    mql: openstack.roles
+
+  - uid: mondoo-asset-inventory-openstack-domains
+    title: OpenStack Keystone domains
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Keystone domains defined in the cloud.
+    mql: openstack.domains
+
+  # Compute
+  - uid: mondoo-asset-inventory-openstack-servers
+    title: OpenStack Nova compute servers
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Nova compute servers (instances) in the scoped project.
+    mql: openstack.servers
+
+  - uid: mondoo-asset-inventory-openstack-flavors
+    title: OpenStack Nova flavors
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Nova flavors (VM sizes) available to the scoped project.
+    mql: openstack.flavors
+
+  - uid: mondoo-asset-inventory-openstack-keypairs
+    title: OpenStack Nova keypairs
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Nova SSH keypairs registered in the scoped project.
+    mql: openstack.keypairs
+
+  - uid: mondoo-asset-inventory-openstack-server-groups
+    title: OpenStack Nova server groups
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Nova server groups (affinity and anti-affinity policies) in the scoped project.
+    mql: openstack.serverGroups
+
+  # Block Storage
+  - uid: mondoo-asset-inventory-openstack-volumes
+    title: OpenStack Cinder volumes
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Cinder block-storage volumes in the scoped project.
+    mql: openstack.volumes
+
+  - uid: mondoo-asset-inventory-openstack-snapshots
+    title: OpenStack Cinder volume snapshots
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Cinder volume snapshots in the scoped project.
+    mql: openstack.snapshots
+
+  - uid: mondoo-asset-inventory-openstack-backups
+    title: OpenStack Cinder volume backups
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Cinder volume backups in the scoped project.
+    mql: openstack.backups
+
+  - uid: mondoo-asset-inventory-openstack-volume-types
+    title: OpenStack Cinder volume types
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Cinder volume types (storage classes) visible to the scoped project.
+    mql: openstack.volumeTypes
+
+  # Networking
+  - uid: mondoo-asset-inventory-openstack-networks
+    title: OpenStack Neutron networks
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron networks in the scoped project.
+    mql: openstack.networks
+
+  - uid: mondoo-asset-inventory-openstack-subnets
+    title: OpenStack Neutron subnets
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron subnets in the scoped project.
+    mql: openstack.subnets
+
+  - uid: mondoo-asset-inventory-openstack-routers
+    title: OpenStack Neutron routers
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron routers in the scoped project.
+    mql: openstack.routers
+
+  - uid: mondoo-asset-inventory-openstack-ports
+    title: OpenStack Neutron ports
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron ports in the scoped project.
+    mql: openstack.ports
+
+  - uid: mondoo-asset-inventory-openstack-floating-ips
+    title: OpenStack Neutron floating IPs
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron floating IPs in the scoped project.
+    mql: openstack.floatingIps
+
+  - uid: mondoo-asset-inventory-openstack-security-groups
+    title: OpenStack Neutron security groups
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron security groups (with embedded rules) in the scoped project.
+    mql: openstack.securityGroups
+
+  - uid: mondoo-asset-inventory-openstack-firewall-groups
+    title: OpenStack Neutron firewall groups
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron FWaaS v2 firewall groups in the scoped project.
+    mql: openstack.firewallGroups
+
+  # Load Balancing
+  - uid: mondoo-asset-inventory-openstack-load-balancers
+    title: OpenStack Octavia load balancers
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Octavia load balancers in the scoped project.
+    mql: openstack.loadBalancers
+
+  # Images
+  - uid: mondoo-asset-inventory-openstack-images
+    title: OpenStack Glance images
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Glance images visible to the scoped project.
+    mql: openstack.images
+
+  # Object Storage
+  - uid: mondoo-asset-inventory-openstack-object-storage-containers
+    title: OpenStack Swift object storage containers
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Swift object-storage containers in the scoped project.
+    mql: openstack.objectStorageContainers
+
+  # Key Management
+  - uid: mondoo-asset-inventory-openstack-secrets
+    title: OpenStack Barbican secrets
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Barbican secrets in the scoped project.
+    mql: openstack.secrets
+
+  # Orchestration
+  - uid: mondoo-asset-inventory-openstack-stacks
+    title: OpenStack Heat orchestration stacks
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Heat orchestration stacks in the scoped project.
+    mql: openstack.stacks
+
+  # Database
+  - uid: mondoo-asset-inventory-openstack-database-instances
+    title: OpenStack Trove database instances
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Trove managed database instances in the scoped project.
+    mql: openstack.databaseInstances
+
+  # Container Infrastructure
+  - uid: mondoo-asset-inventory-openstack-clusters
+    title: OpenStack Magnum clusters
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Magnum container-orchestration clusters in the scoped project.
+    mql: openstack.clusters
+
+  # Shared File Systems
+  - uid: mondoo-asset-inventory-openstack-shares
+    title: OpenStack Manila shares
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Manila shared file systems in the scoped project.
+    mql: openstack.shares
+
+  # VPN
+  - uid: mondoo-asset-inventory-openstack-vpn-services
+    title: OpenStack VPN services
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Neutron VPNaaS v2 IPsec VPN services in the scoped project.
+    mql: openstack.vpnServices
+
+  # Bare Metal
+  - uid: mondoo-asset-inventory-openstack-baremetal-nodes
+    title: OpenStack Ironic bare metal nodes
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Ironic bare-metal nodes in the scoped project.
+    mql: openstack.baremetalNodes
+
+  # DNS
+  - uid: mondoo-asset-inventory-openstack-dns-zones
+    title: OpenStack Designate DNS zones
+    filters: asset.platform == "openstack-project"
+    docs:
+      desc: |
+        Lists the Designate DNS zones visible to the scoped project.
+    mql: openstack.dnsZones

--- a/content/querypacks/mondoo-proxmox-inventory.mql.yaml
+++ b/content/querypacks/mondoo-proxmox-inventory.mql.yaml
@@ -1,0 +1,482 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-proxmox
+    name: Proxmox VE Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: proxmox
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: proxmox
+      mondoo.com/category: best-practices
+    summary: Inventory Proxmox VE nodes, VMs, containers, storage, networking, and access control
+    docs:
+      desc: |
+        Collects a Proxmox VE inventory: cluster and node metadata, virtual machines, containers,
+        storage, networking, firewall and SDN configuration, users, groups, roles, realms, tokens,
+        ACLs, replication jobs, repositories, subscription status, and services.
+
+        ## Scan a Proxmox VE cluster
+
+        ```bash
+        cnspec scan proxmox
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-proxmox-cluster-group
+        title: Cluster
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-cluster-info
+          - uid: mondoo-asset-inventory-proxmox-nodes-count
+          - uid: mondoo-asset-inventory-proxmox-nodes
+          - uid: mondoo-asset-inventory-proxmox-pools
+      - uid: mondoo-asset-inventory-proxmox-vms-group
+        title: Virtual Machines
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-vms-count
+          - uid: mondoo-asset-inventory-proxmox-vms
+      - uid: mondoo-asset-inventory-proxmox-containers-group
+        title: Containers
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-containers-count
+          - uid: mondoo-asset-inventory-proxmox-containers
+      - uid: mondoo-asset-inventory-proxmox-storage-group
+        title: Storage
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-storage-count
+          - uid: mondoo-asset-inventory-proxmox-storage
+          - uid: mondoo-asset-inventory-proxmox-backup-jobs
+          - uid: mondoo-asset-inventory-proxmox-zfs-pools
+          - uid: mondoo-asset-inventory-proxmox-lvm-volumes
+      - uid: mondoo-asset-inventory-proxmox-networking-group
+        title: Networking
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-node-networks
+          - uid: mondoo-asset-inventory-proxmox-sdn-zones
+          - uid: mondoo-asset-inventory-proxmox-sdn-vnets
+          - uid: mondoo-asset-inventory-proxmox-firewall-rules
+      - uid: mondoo-asset-inventory-proxmox-access-control-group
+        title: Access Control
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-users
+          - uid: mondoo-asset-inventory-proxmox-groups
+          - uid: mondoo-asset-inventory-proxmox-roles
+          - uid: mondoo-asset-inventory-proxmox-realms
+          - uid: mondoo-asset-inventory-proxmox-tokens
+          - uid: mondoo-asset-inventory-proxmox-acls
+      - uid: mondoo-asset-inventory-proxmox-data-protection-group
+        title: Data Protection
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-replication-jobs
+      - uid: mondoo-asset-inventory-proxmox-maintenance-group
+        title: Maintenance
+        filters: asset.runtime == "proxmox"
+        queries:
+          - uid: mondoo-asset-inventory-proxmox-repositories
+          - uid: mondoo-asset-inventory-proxmox-subscription
+          - uid: mondoo-asset-inventory-proxmox-services
+queries:
+  - uid: mondoo-asset-inventory-proxmox-cluster-info
+    title: Proxmox VE cluster information
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns cluster metadata: name, version, quorum state, node count, and migration settings.
+    mql: |
+      proxmox.cluster {
+        name
+        version
+        quorate
+        nodeCount
+        migrationNetwork
+        migrationPolicy
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-nodes-count
+    title: Proxmox VE nodes count
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Counts the nodes in the Proxmox VE cluster.
+    mql: proxmox.nodes.length
+
+  - uid: mondoo-asset-inventory-proxmox-nodes
+    title: Proxmox VE nodes
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each node's status, versions, CPU and memory details, uptime, and boot state.
+    mql: |
+      proxmox.nodes {
+        name
+        status
+        pveVersion
+        kernelVersion
+        cpuModel
+        cpuCores
+        cpuSockets
+        memTotal
+        uptime
+        pendingReboot
+        secureBoot
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-pools
+    title: Proxmox VE resource pools
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the resource pools defined in the cluster.
+    mql: |
+      proxmox.pools {
+        id
+        comment
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-vms-count
+    title: Proxmox VE running virtual machines count
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Counts the running virtual machines in the cluster.
+    mql: proxmox.vms.where( status == "running" ).length
+
+  - uid: mondoo-asset-inventory-proxmox-vms
+    title: Proxmox VE virtual machines
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each virtual machine's identity, host node, status, resource limits, and tags.
+    mql: |
+      proxmox.vms {
+        id
+        name
+        node
+        status
+        template
+        protection
+        maxcpu
+        maxmem
+        maxdisk
+        osType
+        tags
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-containers-count
+    title: Proxmox VE containers count
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Counts the LXC containers in the cluster.
+    mql: proxmox.containers.length
+
+  - uid: mondoo-asset-inventory-proxmox-containers
+    title: Proxmox VE containers
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each LXC container's identity, host node, status, privilege mode, and resource limits.
+    mql: |
+      proxmox.containers {
+        id
+        name
+        node
+        status
+        template
+        unprivileged
+        protection
+        maxcpu
+        maxmem
+        maxdisk
+        osType
+        tags
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-storage-count
+    title: Proxmox VE storage count
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Counts the configured storage backends in the cluster.
+    mql: proxmox.storages.length
+
+  - uid: mondoo-asset-inventory-proxmox-storage
+    title: Proxmox VE storage
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each storage backend's type, content, capacity, and encryption and sharing flags.
+    mql: |
+      proxmox.storages {
+        id
+        type
+        content
+        enabled
+        shared
+        encrypted
+        total
+        used
+        available
+        usagePercent
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-backup-jobs
+    title: Proxmox VE backup jobs
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each scheduled backup job's target storage, schedule, mode, and notification settings.
+    mql: |
+      proxmox.backupJobs {
+        id
+        enabled
+        schedule
+        mode
+        storage
+        compress
+        mailto
+        vmids
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-zfs-pools
+    title: Proxmox VE ZFS pools
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the ZFS pools present on each node.
+    mql: |
+      proxmox.nodes {
+        name
+        zfsPools
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-lvm-volumes
+    title: Proxmox VE LVM volume groups and thin pools
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the LVM volume groups and thin pools present on each node.
+    mql: |
+      proxmox.nodes {
+        name
+        volumeGroups
+        thinPools
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-node-networks
+    title: Proxmox VE node network interfaces
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the network interfaces configured on each node.
+    mql: |
+      proxmox.nodes {
+        name
+        networks
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-sdn-zones
+    title: Proxmox VE SDN zones
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the software-defined networking zones and their type, IPAM, and MTU settings.
+    mql: |
+      proxmox.sdnZones {
+        zone
+        type
+        ipam
+        mtu
+        nodes
+        state
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-sdn-vnets
+    title: Proxmox VE SDN VNets
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the software-defined networking VNets and their zone, VLAN tag, and VLAN-aware flag.
+    mql: |
+      proxmox.sdnVnets {
+        vnet
+        zone
+        type
+        tag
+        vlanAware
+        alias
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-firewall-rules
+    title: Proxmox VE cluster firewall rules
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the datacenter-level firewall rules, including action, protocol, ports, and public-ingress flag.
+    mql: |
+      proxmox.cluster.firewallRules {
+        pos
+        action
+        type
+        proto
+        dport
+        source
+        dest
+        enable
+        allowsPublicIngress
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-users
+    title: Proxmox VE users
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each user's realm, enablement, contact details, group memberships, and MFA factors.
+    mql: |
+      proxmox.users {
+        id
+        realm
+        realmType
+        enable
+        email
+        firstname
+        lastname
+        groupRefs
+        expire
+        tfaFactors
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-groups
+    title: Proxmox VE groups
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the groups and their member user IDs.
+    mql: |
+      proxmox.groups {
+        id
+        comment
+        memberIds
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-roles
+    title: Proxmox VE roles
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each role and the privileges it grants.
+    mql: |
+      proxmox.roles {
+        id
+        special
+        privs
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-realms
+    title: Proxmox VE authentication realms
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the authentication realms and their type, default flag, and MFA type.
+    mql: |
+      proxmox.realms {
+        realm
+        type
+        default
+        tfaType
+        comment
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-tokens
+    title: Proxmox VE API tokens
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the API tokens owned by each user.
+    mql: |
+      proxmox.users {
+        id
+        tokens
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-acls
+    title: Proxmox VE access control entries
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the ACL entries binding a path and role to a user, group, or token.
+    mql: |
+      proxmox.acl {
+        path
+        roleId
+        type
+        ugid
+        propagate
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-replication-jobs
+    title: Proxmox VE replication jobs
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns each storage replication job's source, target, schedule, and disabled state.
+    mql: |
+      proxmox.replicationJobs {
+        id
+        type
+        source
+        target
+        schedule
+        disabled
+        rate
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-repositories
+    title: Proxmox VE package repositories
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the APT package repositories configured on each node.
+    mql: |
+      proxmox.nodes {
+        name
+        repositories
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-subscription
+    title: Proxmox VE subscription
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Returns the subscription status, level, product name, and next due date.
+    mql: |
+      proxmox.subscription {
+        status
+        level
+        productName
+        serverId
+        nextDueDate
+      }
+
+  - uid: mondoo-asset-inventory-proxmox-services
+    title: Proxmox VE node services
+    filters: asset.platform == "proxmox"
+    docs:
+      desc: |
+        Lists the system services and their state on each node.
+    mql: |
+      proxmox.nodes {
+        name
+        services
+      }

--- a/content/querypacks/mondoo-stackit-inventory.mql.yaml
+++ b/content/querypacks/mondoo-stackit-inventory.mql.yaml
@@ -1,0 +1,368 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+packs:
+  - uid: mondoo-asset-inventory-stackit
+    name: STACKIT Asset Inventory Pack
+    version: 1.0.0
+    license: BUSL-1.1
+    require:
+      - provider: stackit
+    authors:
+      - name: Mondoo, Inc
+        email: hello@mondoo.com
+    tags:
+      mondoo.com/platform: stackit,cloud
+      mondoo.com/category: best-practices
+    summary: Inventory STACKIT projects, compute, databases, networking, and storage
+    docs:
+      desc: |
+        Collects STACKIT project inventory: project metadata, IAM members and roles, compute servers, SKE clusters, managed databases, networking, object storage, keys, observability, and model serving.
+
+        ## Scan a STACKIT project
+
+        ```bash
+        cnspec scan stackit
+        ```
+    groups:
+      - uid: mondoo-asset-inventory-stackit-project-iam-group
+        title: Project & IAM
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-project-info
+          - uid: mondoo-asset-inventory-stackit-iam-members
+          - uid: mondoo-asset-inventory-stackit-iam-roles
+          - uid: mondoo-asset-inventory-stackit-service-accounts
+      - uid: mondoo-asset-inventory-stackit-compute-group
+        title: Compute
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-servers
+          - uid: mondoo-asset-inventory-stackit-images
+          - uid: mondoo-asset-inventory-stackit-key-pairs
+          - uid: mondoo-asset-inventory-stackit-snapshots
+          - uid: mondoo-asset-inventory-stackit-volumes
+      - uid: mondoo-asset-inventory-stackit-kubernetes-group
+        title: Kubernetes
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-ske-clusters
+      - uid: mondoo-asset-inventory-stackit-databases-group
+        title: Databases
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-postgresflex-instances
+          - uid: mondoo-asset-inventory-stackit-mariadb-instances
+          - uid: mondoo-asset-inventory-stackit-mongodbflex-instances
+          - uid: mondoo-asset-inventory-stackit-sqlserverflex-instances
+          - uid: mondoo-asset-inventory-stackit-redis-instances
+          - uid: mondoo-asset-inventory-stackit-rabbitmq-instances
+          - uid: mondoo-asset-inventory-stackit-opensearch-instances
+          - uid: mondoo-asset-inventory-stackit-logme-instances
+      - uid: mondoo-asset-inventory-stackit-networking-group
+        title: Networking
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-networks
+          - uid: mondoo-asset-inventory-stackit-load-balancers
+          - uid: mondoo-asset-inventory-stackit-application-load-balancers
+          - uid: mondoo-asset-inventory-stackit-security-groups
+          - uid: mondoo-asset-inventory-stackit-public-ips
+          - uid: mondoo-asset-inventory-stackit-dns-zones
+      - uid: mondoo-asset-inventory-stackit-storage-group
+        title: Storage
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-object-storage-buckets
+          - uid: mondoo-asset-inventory-stackit-sfs-resource-pools
+      - uid: mondoo-asset-inventory-stackit-security-keys-group
+        title: Security & Keys
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-kms-key-rings
+          - uid: mondoo-asset-inventory-stackit-kms-keys
+          - uid: mondoo-asset-inventory-stackit-certificates
+          - uid: mondoo-asset-inventory-stackit-secrets-manager-instances
+      - uid: mondoo-asset-inventory-stackit-observability-telemetry-group
+        title: Observability & Telemetry
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-observability-instances
+          - uid: mondoo-asset-inventory-stackit-telemetry-routers
+      - uid: mondoo-asset-inventory-stackit-ai-group
+        title: AI
+        filters: asset.runtime == "stackit"
+        queries:
+          - uid: mondoo-asset-inventory-stackit-model-serving-models
+queries:
+  - uid: mondoo-asset-inventory-stackit-project-info
+    title: STACKIT project information
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Returns core project metadata: name, ID, lifecycle state, parent, labels, and creation time.
+    mql: |
+      stackit.project {
+        name
+        id
+        lifecycleState
+        parent
+        labels
+        creationTime
+      }
+
+  - uid: mondoo-asset-inventory-stackit-iam-members
+    title: STACKIT IAM members
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the IAM members with access to the project.
+    mql: stackit.iam.members
+
+  - uid: mondoo-asset-inventory-stackit-iam-roles
+    title: STACKIT IAM roles
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the IAM roles defined for the project.
+    mql: stackit.iam.roles
+
+  - uid: mondoo-asset-inventory-stackit-service-accounts
+    title: STACKIT service accounts
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the service accounts in the project.
+    mql: stackit.serviceAccounts
+
+  - uid: mondoo-asset-inventory-stackit-servers
+    title: STACKIT compute servers
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the compute servers in the project.
+    mql: stackit.servers
+
+  - uid: mondoo-asset-inventory-stackit-images
+    title: STACKIT compute images
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the machine images available in the project.
+    mql: stackit.images
+
+  - uid: mondoo-asset-inventory-stackit-key-pairs
+    title: STACKIT SSH key pairs
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the SSH key pairs registered in the project.
+    mql: stackit.keyPairs
+
+  - uid: mondoo-asset-inventory-stackit-snapshots
+    title: STACKIT volume snapshots
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the volume snapshots in the project.
+    mql: stackit.snapshots
+
+  - uid: mondoo-asset-inventory-stackit-volumes
+    title: STACKIT block volumes
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the block storage volumes in the project.
+    mql: stackit.volumes
+
+  - uid: mondoo-asset-inventory-stackit-ske-clusters
+    title: STACKIT Kubernetes Engine clusters
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the STACKIT Kubernetes Engine (SKE) clusters in the project.
+    mql: stackit.ske.clusters
+
+  - uid: mondoo-asset-inventory-stackit-postgresflex-instances
+    title: STACKIT PostgreSQL Flex instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the PostgreSQL Flex database instances in the project.
+    mql: stackit.postgresFlex.instances
+
+  - uid: mondoo-asset-inventory-stackit-mariadb-instances
+    title: STACKIT MariaDB instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the MariaDB database instances in the project.
+    mql: stackit.mariaDb.instances
+
+  - uid: mondoo-asset-inventory-stackit-mongodbflex-instances
+    title: STACKIT MongoDB Flex instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the MongoDB Flex database instances in the project.
+    mql: stackit.mongoDbFlex.instances
+
+  - uid: mondoo-asset-inventory-stackit-sqlserverflex-instances
+    title: STACKIT SQL Server Flex instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the SQL Server Flex database instances in the project.
+    mql: stackit.sqlServerFlex.instances
+
+  - uid: mondoo-asset-inventory-stackit-redis-instances
+    title: STACKIT Redis instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Redis database instances in the project.
+    mql: stackit.redis.instances
+
+  - uid: mondoo-asset-inventory-stackit-rabbitmq-instances
+    title: STACKIT RabbitMQ instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the RabbitMQ messaging instances in the project.
+    mql: stackit.rabbitMq.instances
+
+  - uid: mondoo-asset-inventory-stackit-opensearch-instances
+    title: STACKIT OpenSearch instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the OpenSearch instances in the project.
+    mql: stackit.openSearch.instances
+
+  - uid: mondoo-asset-inventory-stackit-logme-instances
+    title: STACKIT LogMe instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the LogMe logging instances in the project.
+    mql: stackit.logMe.instances
+
+  - uid: mondoo-asset-inventory-stackit-networks
+    title: STACKIT networks
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the networks configured in the project.
+    mql: stackit.networks
+
+  - uid: mondoo-asset-inventory-stackit-load-balancers
+    title: STACKIT load balancers
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the load balancers in the project.
+    mql: stackit.loadBalancers
+
+  - uid: mondoo-asset-inventory-stackit-application-load-balancers
+    title: STACKIT application load balancers
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the application load balancers in the project.
+    mql: stackit.albLoadBalancers
+
+  - uid: mondoo-asset-inventory-stackit-security-groups
+    title: STACKIT security groups
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the security groups in the project.
+    mql: stackit.securityGroups
+
+  - uid: mondoo-asset-inventory-stackit-public-ips
+    title: STACKIT public IP addresses
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the public IP addresses allocated in the project.
+    mql: stackit.publicIps
+
+  - uid: mondoo-asset-inventory-stackit-dns-zones
+    title: STACKIT DNS zones
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the DNS zones in the project.
+    mql: stackit.dns.zones
+
+  - uid: mondoo-asset-inventory-stackit-object-storage-buckets
+    title: STACKIT Object Storage buckets
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Object Storage buckets in the project.
+    mql: stackit.objectStorage.buckets
+
+  - uid: mondoo-asset-inventory-stackit-sfs-resource-pools
+    title: STACKIT Shared File System resource pools
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Shared File System (SFS) resource pools in the project.
+    mql: stackit.sfs.resourcePools
+
+  - uid: mondoo-asset-inventory-stackit-kms-key-rings
+    title: STACKIT KMS key rings
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Key Management Service (KMS) key rings in the project.
+    mql: stackit.kms.keyRings
+
+  - uid: mondoo-asset-inventory-stackit-kms-keys
+    title: STACKIT KMS keys
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Key Management Service (KMS) keys in the project.
+    mql: stackit.kms.keys
+
+  - uid: mondoo-asset-inventory-stackit-certificates
+    title: STACKIT certificates
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the certificates in the project.
+    mql: stackit.certificates
+
+  - uid: mondoo-asset-inventory-stackit-secrets-manager-instances
+    title: STACKIT Secrets Manager instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Secrets Manager instances in the project.
+    mql: stackit.secretsManager.instances
+
+  - uid: mondoo-asset-inventory-stackit-observability-instances
+    title: STACKIT Observability instances
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Observability instances in the project.
+    mql: stackit.observability.instances
+
+  - uid: mondoo-asset-inventory-stackit-telemetry-routers
+    title: STACKIT telemetry routers
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the telemetry routers in the project.
+    mql: stackit.telemetry.routers
+
+  - uid: mondoo-asset-inventory-stackit-model-serving-models
+    title: STACKIT Model Serving models
+    filters: asset.platform == "stackit-project"
+    docs:
+      desc: |
+        Lists the Model Serving models in the project.
+    mql: stackit.modelServing.models


### PR DESCRIPTION
## What

Two things the inventory query packs were missing:

1. **The OCI pack only covered a fraction of the OCI services we support.** Expanded it from 5 groups / 12 queries to **17 groups / 52 queries**, covering every major OCI service namespace.
2. **Six supported providers had no inventory pack at all.** Added one for each.

| Pack | Groups | Queries | Notable coverage |
|------|-------:|--------:|------------------|
| `mondoo-oci-inventory` (expanded) | 17 | 52 | + Database, KMS/Vault, Load Balancing, OKE, Functions/Containers, File Storage, Bastion, Logging & Monitoring, Security Posture (Cloud Guard, Vuln Scanning, Data Safe), Web Security (WAF, Network Firewall, API Gateway), Redis, AI, expanded Networking |
| `mondoo-digitalocean-inventory` (new) | 12 | 35 | Compute, Kubernetes, Databases, Networking, Storage/Spaces, Registry, Serverless/Apps, Security, Monitoring, GradientAI, Tags |
| `mondoo-hetzner-inventory` (new) | 7 | 20 | Compute, Networking, DNS, Storage, Access, Infrastructure, Catalog |
| `mondoo-stackit-inventory` (new) | 9 | 33 | Project & IAM, Compute, SKE, Databases (8 engines), Networking, Storage, Security & Keys, Observability, AI |
| `mondoo-proxmox-inventory` (new) | 8 | 27 | Cluster, VMs, Containers, Storage, Networking, Access Control, Data Protection, Maintenance |
| `mondoo-openstack-inventory` (new) | 15 | 31 | Identity, Compute, Block Storage, Networking, Octavia LB, Images, Swift, Barbican, Heat, Trove, Magnum, Manila, VPNaaS, Ironic, Designate |
| `mondoo-nutanix-inventory` (new) | 6 | 18 | Clusters, VMs, Storage, Networking, IAM, Images |

## How

Each pack follows the established inventory-pack convention (`mondoo-oci-inventory` / `mondoo-aws-inventory`): service-family `groups:` filtered by `asset.runtime`, and data-collection `queries:` filtered by the provider's account/project `asset.platform`. Note the root asset platform is provider-specific — `hetzner-project`, `stackit-project`, `openstack-project`, `nutanix-prism-central` — while the group runtime is the bare provider name.

Every query was authored against the **installed provider schema** (`~/.config/mondoo/providers/<p>/<p>.resources.json`), not guessed — list accessors and every selected field were confirmed to exist, and where a resource is only reachable via a parent (e.g. OCI `oci.kms.vault.keys`, Proxmox per-node `zfsPools`) the query was routed accordingly rather than referencing a non-existent root accessor.

## Verification

`cnspec policy lint ./content/querypacks` → `valid policy bundle(s)` (compiles every query's MQL against the provider schemas). Live scans were not run (no cloud credentials in this environment); lint is the correctness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)