### PR TITLE
📝 querypacks: refocus pack descriptions on the data you get

### DIFF
--- a/content/querypacks/mondoo-asset-count.mql.yaml
+++ b/content/querypacks/mondoo-asset-count.mql.yaml
@@ -21,10 +21,13 @@ packs:
       desc: |
         Counts resources across AWS, Azure, GCP, VMware vSphere, Microsoft 365, GitLab, Kubernetes, and Windows Active Directory, giving you a fast way to size an environment and see where your assets live.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically count assets across your connected integrations, or scan a target manually with cnspec:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically count assets across your connected integrations, or scan a target manually with cnspec. Point cnspec at whichever platform you want to count; AWS is just one example:
 
         ```bash
         cnspec scan aws -f mondoo-asset-count.mql.yaml
+        cnspec scan azure -f mondoo-asset-count.mql.yaml
+        cnspec scan gcp -f mondoo-asset-count.mql.yaml
+        cnspec scan k8s -f mondoo-asset-count.mql.yaml
         ```
     groups:
       - title: ESXi asset counts

--- a/content/querypacks/mondoo-asset-count.mql.yaml
+++ b/content/querypacks/mondoo-asset-count.mql.yaml
@@ -19,28 +19,12 @@ packs:
     summary: Count resources across cloud and on-prem platforms
     docs:
       desc: |
-        ### Overview
+        Counts resources across AWS, Azure, GCP, VMware vSphere, Microsoft 365, GitLab, Kubernetes, and Windows Active Directory, giving you a fast way to size an environment and see where your assets live.
 
-        Counts resources across AWS, Azure, GCP, vSphere, Microsoft 365, GitLab, Kubernetes, and Windows Active Directory to size and inventory an environment.
-
-        ### Run query pack
-
-        To run this query pack against AWS:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically count assets across your connected integrations, or scan a target manually with cnspec:
 
         ```bash
         cnspec scan aws -f mondoo-asset-count.mql.yaml
-        ```
-
-        To run against Azure:
-
-        ```bash
-        cnspec scan azure --subscription <subscription_id> -f mondoo-asset-count.mql.yaml
-        ```
-
-        To run against GCP:
-
-        ```bash
-        cnspec scan gcp project <project_id> -f mondoo-asset-count.mql.yaml
         ```
     groups:
       - title: ESXi asset counts

--- a/content/querypacks/mondoo-aws-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-aws-incident-response.mql.yaml
@@ -17,13 +17,9 @@ packs:
     summary: Gather AWS evidence for security incident response
     docs:
       desc: |
-        ### Overview
-
         Collects AWS evidence for incident investigation: account identity, enabled regions, IAM users and their access, identities holding administrative or full-access policies, internet-facing EC2 instances, and publicly accessible S3 buckets.
 
-        ### Run query pack
-
-        To run this query pack against an AWS account:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your AWS accounts, or scan an account manually with cnspec:
 
         ```bash
         cnspec scan aws -f mondoo-aws-incident-response.mql.yaml

--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -17,7 +17,13 @@ packs:
     summary: Inventory AWS accounts, EC2, S3, IAM, and more
     docs:
       desc: |
-        Collects AWS account inventory: IAM users, groups, roles, and policies; VPCs and subnets; EC2, EBS, RDS, S3, EKS, and Lambda resources; load balancers, Elastic IPs, ACM certificates, CloudTrail trails, and WAF web ACLs.
+        Inventories an AWS account: IAM users, groups, roles, and policies; VPCs and subnets; EC2, EBS, RDS, S3, EKS, and Lambda resources; and load balancers, Elastic IPs, ACM certificates, CloudTrail trails, and WAF web ACLs.
+
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your AWS accounts, or scan an account manually with cnspec:
+
+        ```bash
+        cnspec scan aws -f mondoo-aws-inventory.mql.yaml
+        ```
     groups:
       - uid: mondoo-asset-inventory-aws-general-group
         title: AWS General

--- a/content/querypacks/mondoo-azure-inventory.mql.yaml
+++ b/content/querypacks/mondoo-azure-inventory.mql.yaml
@@ -17,7 +17,13 @@ packs:
     summary: Inventory Azure subscriptions, VMs, and resources
     docs:
       desc: |
-        Collects Azure subscription inventory: IAM role definitions, activity and diagnostic logs, Microsoft Defender for Cloud settings, storage accounts, SQL/PostgreSQL/MySQL servers, key vaults, network resources, virtual machines, disks, web apps, and Cosmos DB accounts.
+        Inventories an Azure subscription: IAM role definitions, activity and diagnostic logs, Microsoft Defender for Cloud settings, storage accounts, SQL/PostgreSQL/MySQL servers, key vaults, network resources, virtual machines, disks, web apps, and Cosmos DB accounts.
+
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your Azure subscriptions, or scan a subscription manually with cnspec:
+
+        ```bash
+        cnspec scan azure -f mondoo-azure-inventory.mql.yaml
+        ```
     groups:
       - uid: mondoo-asset-inventory-azure-subscription-group
         title: Azure Subscription

--- a/content/querypacks/mondoo-dns-inventory.mql.yaml
+++ b/content/querypacks/mondoo-dns-inventory.mql.yaml
@@ -17,17 +17,9 @@ packs:
     summary: Inventory DNS records and configurations
     docs:
       desc: |
-        ### Overview
+        Inventories a domain's DNS records: the full record set and the mail exchanger (MX) records.
 
-        Collects a domain's DNS records: the full record set and the mail exchanger (MX) records.
-
-        ### Prerequisites
-
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
-
-        ### Run query pack
-
-        To run this query pack against a Domain:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your domains, or scan a domain manually with cnspec:
 
         ```bash
         cnspec scan host <domain> -f mondoo-dns-inventory.mql.yaml

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -17,20 +17,12 @@ packs:
     summary: Inventory email authentication configurations
     docs:
       desc: |
-        ### Overview
+        Inventories a domain's email authentication DNS records: SPF, DKIM, DMARC, and the reverse-DNS PTR record.
 
-        Collects a domain's email authentication DNS records: SPF, DKIM, DMARC, and the reverse-DNS PTR record.
-
-        ### Prerequisites
-
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
-
-        ### Run query pack
-
-        To run this query pack against a Domain:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your domains, or scan a domain manually with cnspec:
 
         ```bash
-        cnspec scan host <domain> -f mondoo-mail-inventory.mql.yaml
+        cnspec scan host <domain> -f mondoo-email-inventory.mql.yaml
         ```
     filters: asset.family.contains('network')
     queries:

--- a/content/querypacks/mondoo-gcp-inventory.mql.yaml
+++ b/content/querypacks/mondoo-gcp-inventory.mql.yaml
@@ -17,7 +17,13 @@ packs:
     summary: Inventory GCP projects, compute, and resources
     docs:
       desc: |
-        Collects GCP project inventory: project metadata, enabled services, IAM bindings, GKE clusters, Compute Engine instances, and VPC networks.
+        Inventories a GCP project: project metadata, enabled services, IAM bindings, GKE clusters, Compute Engine instances, and VPC networks.
+
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GCP projects, or scan a project manually with cnspec:
+
+        ```bash
+        cnspec scan gcp project <project_id> -f mondoo-gcp-inventory.mql.yaml
+        ```
     groups:
       - uid: mondoo-asset-inventory-gcp-general-group
         title: GCP General

--- a/content/querypacks/mondoo-github-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-github-incident-response.mql.yaml
@@ -17,21 +17,13 @@ packs:
     summary: Gather GitHub evidence for security incident response
     docs:
       desc: |
-        ### Overview
-
         Gathers evidence from a GitHub organization during a security incident: organization settings, MFA enforcement, owners, members, teams, repositories, and published packages.
 
-        ### Prerequisites
-
-        To run this query pack, you will need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access to the GitHub organization you are scanning.
-
-        ### Run query pack
-
-        To run this query pack against a GitHub Organization:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
-        cnspec scan github org <org_name> -f mondoo-github-org-incident-response.mql.yaml
+        cnspec scan github org <org_name> -f mondoo-github-incident-response.mql.yaml
         ```
     groups:
       - uid: mondoo-incident-response-github-profile-group

--- a/content/querypacks/mondoo-github-inventory.mql.yaml
+++ b/content/querypacks/mondoo-github-inventory.mql.yaml
@@ -17,17 +17,9 @@ packs:
     summary: Inventory GitHub organizations and repositories
     docs:
       desc: |
-        ### Overview
+        Inventories a GitHub organization: profile identity, contact and social links, repository count, and creation and update timestamps.
 
-        Collects GitHub organization inventory: profile identity, contact and social links, repository count, and creation and update timestamps.
-
-        ### Prerequisites
-
-        To run this query pack, you will need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access to the GitHub organization you are scanning.
-
-        ### Run query pack
-
-        To run this query pack against a GitHub organization:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
@@ -114,17 +106,9 @@ packs:
     summary: Inventory GitHub user profiles and settings
     docs:
       desc: |
-        ### Overview
+        Inventories a GitHub user: profile identity, contact and social links, repository count, and account timestamps.
 
-        Collects GitHub user inventory: profile identity, contact and social links, repository count, and account timestamps.
-
-        ### Prerequisites
-
-        To run this query pack, you will need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access to the GitHub organization you are scanning.
-
-        ### Run query pack
-
-        To run this query pack against a GitHub user:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory GitHub users, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
@@ -211,17 +195,9 @@ packs:
     summary: Inventory GitHub repository configurations
     docs:
       desc: |
-        ### Overview
+        Inventories a GitHub repository: identity and description, popularity metrics, license and language, enabled features, clone URLs, visibility, and lifecycle timestamps.
 
-        Collects GitHub repository inventory: identity and description, popularity metrics, license and language, enabled features, clone URLs, visibility, and lifecycle timestamps.
-
-        ### Prerequisites
-
-        To run this query pack, you will need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access to the GitHub organization you are scanning.
-
-        ### Run query pack
-
-        To run this query pack against a GitHub repository:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub repositories, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -17,50 +17,13 @@ packs:
     summary: Gather Google Workspace evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Collects Google Workspace evidence for incident investigation: configured domains, user 2-Step Verification enrollment, super admin accounts, hardware security key usage, and account recovery email addresses.
 
-        ### Prerequisites
-
-        1. Create/Select a GCP project
-        2. Navigate to the [Google API Console](https://console.cloud.google.com/apis/dashboard). 
-        3. Select "Enable APIs and Services" and enable the following APIs:
-          - Admin SDK API 
-          - Cloud Identity API 
-          - Google Calendar API
-          - Google Drive API
-          - Gmail API
-          - Google People API
-        4. Create a service account for [Google Workspace](https://support.google.com/a/answer/7378726?product_name=UnuFlow&hl=en&visit_id=638041387835615758-4147680582&rd=1&src=supportwidget0&hl=en)
-        5. Create credentials for the service account and download the json file
-        6. Enter the following scopes in Security -> Access and data controls -> API controls, and select [Domain-wide Delegation](https://developers.google.com/workspace/guides/create-credentials#delegate_domain-wide_authority_to_your_service_account) 
-
-          - https://www.googleapis.com/auth/admin.chrome.printers.readonly
-          - https://www.googleapis.com/auth/admin.directory.customer.readonly
-          - https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly
-          - https://www.googleapis.com/auth/admin.directory.device.mobile.readonly
-          - https://www.googleapis.com/auth/admin.directory.domain.readonly
-          - https://www.googleapis.com/auth/admin.directory.group.member.readonly
-          - https://www.googleapis.com/auth/admin.directory.group.readonly
-          - https://www.googleapis.com/auth/admin.directory.orgunit.readonly
-          - https://www.googleapis.com/auth/admin.directory.resource.calendar.readonly
-          - https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.alias.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.readonly
-          - https://www.googleapis.com/auth/admin.directory.userschema.readonly
-          - https://www.googleapis.com/auth/admin.reports.audit.readonly
-          - https://www.googleapis.com/auth/admin.reports.usage.readonly
-          - https://www.googleapis.com/auth/admin.directory.user.security
-          - https://www.googleapis.com/auth/cloud-identity.groups.readonly
-
-        ### Run query pack
-
-        To run this query pack against a Google Workspace customer:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Google Workspace account, or scan it manually with cnspec. Manual scans need a service account with domain-wide delegation and the required admin read scopes; see the [Google Workspace setup guide](https://mondoo.com/docs/cnspec/saas/google-workspace):
 
         ```bash
-        export GOOGLEWORKSPACE_CREDENTIALS=$PWD/my-project-123456-1234ea722b12.json
-        cnspec scan google-workspace --customer-id <CUSTOMERID> --impersonated-user-email <EMAIL>
+        export GOOGLEWORKSPACE_CREDENTIALS=$PWD/service-account.json
+        cnspec scan google-workspace --customer-id <customer_id> --impersonated-user-email <admin_email> -f mondoo-googleworkplace-incident-response.mql.yaml
         ```
     filters: asset.platform == "googleworkspace" || asset.platform == "google-workspace"
     queries:

--- a/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-incident-response.mql.yaml
@@ -17,22 +17,12 @@ packs:
     summary: Gather Kubernetes evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Collects Kubernetes evidence for incident investigation: the cluster server version, RoleBindings and ClusterRoleBindings that grant cluster-admin, container security contexts, and container image sources across pods, deployments, cronjobs, jobs, daemonsets, statefulsets, and replicasets.
 
-        ### Run query pack
-
-        To run this query pack against a Kubernetes cluster:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your clusters, or scan a cluster manually with cnspec:
 
         ```bash
         cnspec scan k8s -f mondoo-kubernetes-incident-response.mql.yaml
-        ```
-
-        To run against a specific namespace:
-
-        ```bash
-        cnspec scan k8s --namespace <namespace> -f mondoo-kubernetes-incident-response.mql.yaml
         ```
     groups:
       - title: Cluster Incident Response

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -17,18 +17,13 @@ packs:
     summary: Inventory Kubernetes cluster resources and workloads
     docs:
       desc: |
-        Collects Kubernetes cluster inventory: server version, namespaces, nodes, RBAC roles and bindings, quotas, limit ranges, storage, autoscalers, and workload resources such as pods, deployments, jobs, and ingresses.
+        Inventories a Kubernetes cluster: server version, namespaces, nodes, RBAC roles and bindings, quotas, limit ranges, storage, autoscalers, and workload resources such as pods, deployments, jobs, and ingresses.
 
-        To run this pack for a Kubernetes Cluster:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your clusters, or scan a cluster manually with cnspec:
 
         ```bash
         cnspec scan k8s -f mondoo-kubernetes-inventory.mql.yaml
         ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - title: Cluster inventory
         filters: asset.platform == "k8s-cluster"

--- a/content/querypacks/mondoo-linux-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-linux-incident-response.mql.yaml
@@ -17,22 +17,12 @@ packs:
     summary: Gather Linux host evidence for incident response
     docs:
       desc: |
-        ### Overview
+        Gathers forensic evidence from a Linux host during a security incident: kernel details, running processes, mounted devices, listening ports, installed packages, and running services.
 
-        Gathers forensic evidence from Linux hosts during a security incident: kernel details, running processes, mounted devices, listening ports, installed packages, and running services.
-
-        ### Run query pack
-
-        To run this query pack locally on a Linux host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Linux hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-linux-incident-response.mql.yaml
-        ```
-
-        To run against a remote Linux host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -f mondoo-linux-incident-response.mql.yaml
         ```
     groups:
       - uid: mondoo-linux-incident-response-system-group

--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -17,26 +17,13 @@ packs:
     summary: Inventory Linux host OS, packages, and configuration
     docs:
       desc: |
-        Inventories Linux hosts: OS and platform details, users and groups, kernel and modules, packages and services, network and firewall configuration, hardware and SMBIOS, and disk encryption.
+        Inventories a Linux host: OS and platform details, users and groups, kernel and modules, packages and services, network and firewall configuration, hardware and SMBIOS, and disk encryption.
 
-        ## Local scan
-        To run this pack locally on a Linux host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your Linux hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-linux-inventory.mql.yaml
         ```
-
-        ## Remote scan
-        To run this pack against a remote Linux host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -i <identity_file> -f mondoo-linux-inventory.mql.yaml
-        ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - uid: mondoo-linux-inventory-system-group
         title: System

--- a/content/querypacks/mondoo-m365-inventory.mql.yaml
+++ b/content/querypacks/mondoo-m365-inventory.mql.yaml
@@ -17,18 +17,13 @@ packs:
     summary: Inventory Microsoft 365 users, groups, and resources
     docs:
       desc: |
-        Collects Microsoft 365 tenant inventory: organization and subscription details, users, groups, applications, service principals, directory roles, domains, Intune device management, identity policies, and Secure Score.
+        Inventories a Microsoft 365 tenant: organization and subscription details, users, groups, applications, service principals, directory roles, domains, Intune device management, identity policies, and Secure Score.
 
-        To run this pack for an Microsoft 365 Tenant:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your Microsoft 365 tenant, or scan it manually with cnspec. Manual scans need app registration credentials; see the [Microsoft 365 setup guide](https://mondoo.com/docs/cnspec/saas/m365):
 
         ```bash
-        cnspec scan ms365 --certificate-path certificate.combo.pem --tenant-id YOUR-TENANT-ID --client-id YOUR-CLIENT-ID --policy-bundle mondoo-m365-inventory.mql.yaml
+        cnspec scan ms365 --certificate-path certificate.pem --tenant-id <tenant_id> --client-id <client_id> -f mondoo-m365-inventory.mql.yaml
         ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - title: Organization
         filters: asset.platform == "microsoft365" || asset.runtime == "ms-graph"

--- a/content/querypacks/mondoo-macos-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-macos-incident-response.mql.yaml
@@ -17,22 +17,12 @@ packs:
     summary: Gather macOS host evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Collects macOS host evidence for incident investigation: platform and version details, user accounts, kernel version and extensions, running processes and services, mounted devices, installed packages, uptime and timezone, firewall exceptions, FileVault and Gatekeeper status, and pending software updates.
 
-        ### Run query pack
-
-        To run this query pack locally on a macOS host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your macOS hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-macos-incident-response.mql.yaml
-        ```
-
-        To run against a remote macOS host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -f mondoo-macos-incident-response.mql.yaml
         ```
     groups:
       - uid: mondoo-macos-incident-response-system-group

--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -17,26 +17,13 @@ packs:
     summary: Inventory macOS host OS, packages, and configuration
     docs:
       desc: |
-        Collects macOS host inventory: hardware and OS details, installed packages, running services and processes, network configuration, and security posture including FileVault, Gatekeeper, and MDM enrollment.
+        Inventories a macOS host: hardware and OS details, installed packages, running services and processes, network configuration, and security posture including FileVault, Gatekeeper, and MDM enrollment.
 
-        ## Local scan
-        To run this pack locally on a macOS host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your macOS hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-macos-inventory.mql.yaml
         ```
-
-        ## Remote scan
-        To run this pack against a remote macOS host using SSH (requires Remote Management is activated in System Preferences):
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -i <identity_file> -f mondoo-macos-inventory.mql.yaml
-        ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - uid: mondoo-macos-inventory-system-group
         title: System

--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -17,16 +17,12 @@ packs:
     summary: Inventory OCI tenancies, compute, networking, and storage
     docs:
       desc: |
-        Collects Oracle Cloud Infrastructure (OCI) tenancy inventory: regions and compartments, identity and access management, compute instances and images, virtual cloud networks, and object storage.
+        Inventories an Oracle Cloud Infrastructure (OCI) tenancy: regions and compartments, identity and access management, compute instances and images, virtual cloud networks, and object storage.
 
-        ## Authentication
-
-        Scanning OCI requires API key authentication configured in your OCI CLI config file (`~/.oci/config`).
-
-        ## Scan an OCI tenancy
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your OCI tenancy, or scan it manually with cnspec. Manual scans use the API key configured in your OCI CLI config file at `~/.oci/config`:
 
         ```bash
-        cnspec scan oci
+        cnspec scan oci -f mondoo-oci-inventory.mql.yaml
         ```
     groups:
       - uid: mondoo-asset-inventory-oci-general-group

--- a/content/querypacks/mondoo-okta-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-okta-incident-response.mql.yaml
@@ -17,24 +17,13 @@ packs:
     summary: Gather Okta configuration evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Collects Okta configuration evidence for incident investigation: the org's user accounts and integrated applications.
 
-        ### Prerequisites
-
-        To run this query pack, you will need access to the Okta API:
-
-        1. Create an Okta [API token](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/) by going to https:/DOMAIN.okta.com/admin/access/api/tokens
-        2. Note your Okta domain https://DOMAIN.okta.com
-
-        ### Run query pack
-
-        To run this query pack against an Okta domain:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Okta org, or scan it manually with cnspec. Manual scans need an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/):
 
         ```bash
-        export OKTA_TOKEN=<TOKEN>
-        mql shell okta --organization DOMAIN.okta.com --token $OKTA_TOKEN 
+        export OKTA_TOKEN=<your api token>
+        cnspec scan okta --organization <your_domain>.okta.com --token $OKTA_TOKEN -f mondoo-okta-incident-response.mql.yaml
         ```
     filters: asset.platform == "okta" || asset.platform == "okta-org"
     queries:

--- a/content/querypacks/mondoo-openssl-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-openssl-incident-response.mql.yaml
@@ -17,22 +17,12 @@ packs:
     summary: Gather OpenSSL library evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Gathers SSL/TLS library evidence from a Linux host during a security incident: platform details, installed SSL packages, and listening ports that may be serving SSL/TLS.
 
-        ### Run query pack
-
-        To run this query pack locally on a Linux host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Linux hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-openssl-incident-response.mql.yaml
-        ```
-
-        To run against a remote Linux host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -f mondoo-openssl-incident-response.mql.yaml
         ```
     filters: asset.family.contains("linux")
     queries:

--- a/content/querypacks/mondoo-shodan-inventory.mql.yaml
+++ b/content/querypacks/mondoo-shodan-inventory.mql.yaml
@@ -19,18 +19,12 @@ packs:
       desc: |
         Collects Shodan intelligence for hosts and domains: hostnames, ASN, ISP, organization, open ports, detected OS, known CVEs, subdomains, and DNS records.
 
-        ## Local scan
-        To run this pack locally:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically enrich your assets with Shodan data, or scan a network manually with cnspec. Manual scans need a [Shodan API token](https://account.shodan.io/):
 
         ```bash
-        export SHODAN_TOKEN="XXX"
+        export SHODAN_TOKEN=<your api token>
         cnspec scan shodan --networks "1.1.1.1/28" --discover hosts -f mondoo-shodan-inventory.mql.yaml
         ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - uid: mondoo-shodan-inventory-host-group
         title: Host

--- a/content/querypacks/mondoo-slack-inventory.mql.yaml
+++ b/content/querypacks/mondoo-slack-inventory.mql.yaml
@@ -17,46 +17,13 @@ packs:
     summary: Inventory Slack teams, channels, and users
     docs:
       desc: |
-        ### Overview
-
         Inventories a Slack workspace: team domain and ID, users with their MFA status, owners and admins, and externally shared channels.
 
-        ### Prerequisites
-
-        To run this query pack, you will need access to the Slack API. To get a token, you need to create an App for the Slack workspace 
-        and assign the appropriate permissions:
-
-        1. Sign in to [the Slack website](https://api.slack.com/apps/), and view "Your Apps"
-        2. Select "Create New App"
-        3. Select "From scratch"
-        4. Enter an "App Name" e.g. mql and select the workspace, then select "Create App"
-        5. In the section "Add features & functionality" select "Permissions"
-        6. Scroll to "Scopes" and then "User Token Scopes"
-
-        Note: Bots are very limited in their access; therefore we need to set the user scopes
-
-        7. Add the required permissions to "User Token Scopes"
-
-        | OAuth Scope  |
-        | ---- | 
-        | [channels:read](https://api.slack.com/scopes/channels:read) | 
-        | [groups:read](https://api.slack.com/scopes/groups:read) |
-        | [im:read](https://api.slack.com/scopes/im:read) |
-        | [mpim:read](https://api.slack.com/scopes/mpim:read) | 
-        | [team:read](https://api.slack.com/scopes/team:read) | 
-        | [usergroups:read](https://api.slack.com/scopes/usergroups:read) | 
-        | [users:read](https://api.slack.com/scopes/users:read) |
-
-        8. Scroll up to "OAuth Tokens for Your Workspace" and select "Install to Workspace"
-        9. Copy the provided "User OAuth Token", it will look like `xoxp-1234567890123-1234567890123-1234567890123-12345cea5ae0d3bed30dca43cb34c2d1`
-
-        ### Run query pack
-
-        To run this query pack against a Slack workspace:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your Slack workspace, or scan it manually with cnspec. Manual scans need a Slack user OAuth token with read scopes; see the [Slack setup guide](https://mondoo.com/docs/cnspec/saas/slack):
 
         ```bash
-        export SLACK_TOKEN=xoxp-TOKEN
-        cnspec scan slack --query-pack mondoo-slack-inventory
+        export SLACK_TOKEN=xoxp-<your token>
+        cnspec scan slack --token $SLACK_TOKEN -f mondoo-slack-inventory.mql.yaml
         ```
     filters: asset.platform == "slack" || asset.platform == "slack-team"
     queries:

--- a/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -17,17 +17,9 @@ packs:
     summary: Gather TLS certificate evidence for incident response
     docs:
       desc: |
-        ### Overview
+        Collects a domain's SSL/TLS certificate evidence for incident investigation: negotiated protocol versions, cipher suites, and per-certificate chain details.
 
-        Collects a domain's SSL/TLS certificate evidence for a security incident investigation: negotiated protocol versions, cipher suites, and per-certificate chain details.
-
-        ### Prerequisites
-
-        To run this query pack, you will need to install the mql binary ([Get Started with mql](https://mondoo.com/docs/mql)).
-
-        ### Run query pack
-
-        To run this query pack against a Domain:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your domains, or scan a domain manually with cnspec:
 
         ```bash
         cnspec scan host <domain> -f mondoo-ssl-tls-certificate-incident-response.mql.yaml

--- a/content/querypacks/mondoo-terraform-inventory.mql.yaml
+++ b/content/querypacks/mondoo-terraform-inventory.mql.yaml
@@ -18,6 +18,12 @@ packs:
     docs:
       desc: |
         Inventories Terraform HCL, plan, and state files, cataloging the infrastructure resources they manage.
+
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory Terraform in your repositories, or scan a directory of Terraform files manually with cnspec:
+
+        ```bash
+        cnspec scan terraform . -f mondoo-terraform-inventory.mql.yaml
+        ```
     groups:
       - title: Terraform State Asset inventory
         filters: asset.platform == "terraform-state"

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -17,23 +17,13 @@ packs:
     summary: Gather VMware vCenter evidence for incident response
     docs:
       desc: |
-        ## Overview
-
         Gathers ESXi host evidence for a vCenter incident investigation: kernel modules, installed packages, services, host acceptance level, and NTP configuration.
 
-        ### Run query pack
-
-        To run this query pack against VMware vCenter:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your vCenter, or scan it manually with cnspec:
 
         ```bash
-        cnspec scan vsphere user@domain.local@192.168.5.24 --ask-pass -f core/mondoo-vmware-incident-response.mql.yaml
+        cnspec scan vsphere <user>@<vcenter_host> --ask-pass -f mondoo-vmware-incident-response.mql.yaml
         ```
-
-        ## Join the community!
-
-        Our goal is to build policies that are simple to deploy, accurate, and actionable. 
-
-        If you have any suggestions for improving this policy, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters: asset.platform == "vmware-esxi"
     queries:
       - uid: mondoo-vmware-incident-response-kernel-modules

--- a/content/querypacks/mondoo-vmware-inventory.mql.yaml
+++ b/content/querypacks/mondoo-vmware-inventory.mql.yaml
@@ -17,23 +17,13 @@ packs:
     summary: Inventory VMware vCenter and ESXi hosts
     docs:
       desc: |
-        ## Overview
+        Inventories VMware vCenter and ESXi: vCenter datacenters, clusters, and virtual machines, plus ESXi host packages, services, networking, firewall, and time configuration.
 
-        Collects VMware inventory: vCenter datacenters, clusters, and virtual machines, plus ESXi host packages, services, networking, firewall, and time configuration.
-
-        ### Run query pack
-
-        To run this query pack against VMware vCenter:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your vCenter, or scan it manually with cnspec:
 
         ```bash
-        cnspec scan vsphere user@domain.local@192.168.5.24 --ask-pass -f core/mondoo-vmware-inventory.mql.yaml
+        cnspec scan vsphere <user>@<vcenter_host> --ask-pass -f mondoo-vmware-inventory.mql.yaml
         ```
-
-        ## Join the community!
-
-        Our goal is to build policies that are simple to deploy, accurate, and actionable.
-
-        If you have any suggestions for improving this policy, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - uid: mondoo-vmware-asset-inventory-vcenter-group
         title: vCenter and vSphere

--- a/content/querypacks/mondoo-windows-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-windows-incident-response.mql.yaml
@@ -17,28 +17,12 @@ packs:
     summary: Gather Windows host evidence for incident response
     docs:
       desc: |
-        ### Overview
-
         Collects Windows host evidence for incident investigation: installed hotfixes, system uptime and timezone, installed packages, computer and OS details, and running services.
 
-        ### Run query pack
-
-        To run this query pack locally on a Windows host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Windows hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-windows-incident-response.mql.yaml
-        ```
-
-        To run against a remote Windows host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -f mondoo-windows-incident-response.mql.yaml
-        ```
-
-        To run against a remote Windows host using WinRM:
-
-        ```bash
-        cnspec scan winrm <user>@<ip_address> -f mondoo-windows-incident-response.mql.yaml
         ```
     filters: asset.platform == "windows"
     queries:

--- a/content/querypacks/mondoo-windows-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-inventory.mql.yaml
@@ -17,26 +17,13 @@ packs:
     summary: Inventory Windows host OS, software, and configuration
     docs:
       desc: |
-        Collects Windows host inventory: OS and computer information, installed software and hotfixes, services, listening ports, network configuration, security products, and audit policy.
+        Inventories a Windows host: OS and computer information, installed software and hotfixes, services, listening ports, network configuration, security products, and audit policy.
 
-        ## Local scan
-        To run this pack locally on a Windows host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your Windows hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-windows-inventory.mql.yaml
         ```
-
-        ## Remote scan
-        To run this pack against a remote Windows host using WinRM:
-
-        ```bash
-        cnspec scan winrm <user>@<ip_address> -f mondoo-windows-inventory.mql.yaml
-        ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     groups:
       - uid: mondoo-windows-asset-inventory-system-group
         title: System

--- a/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
+++ b/content/querypacks/mondoo-windows-operational-inventory.mql.yaml
@@ -16,27 +16,14 @@ packs:
       mondoo.com/category: best-practices
     summary: Inventory Windows operational and monitoring data
     docs:
-      desc: |-
+      desc: |
         Collects Windows host operational telemetry: memory, CPU, and disk utilization sampled from Windows performance counters.
 
-        ## Local scan
-        To run this pack locally on a Windows host:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically collect this telemetry from your Windows hosts, or scan a host manually with cnspec:
 
         ```bash
         cnspec scan local -f mondoo-windows-operational-inventory.mql.yaml
         ```
-
-        ## Remote execution
-        To run this pack against a remote Windows host using SSH:
-
-        ```bash
-        cnspec scan ssh <user>@<ip_address> -f mondoo-windows-operational-inventory.mql.yaml
-        ```
-
-        ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
-
-        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters: asset.family.contains("windows")
     queries:
       - uid: mondoo-windows-operational-inventory-memory-usage


### PR DESCRIPTION
Reworks every query pack's pack-level `docs.desc` to focus on **what the pack gives you**, then how to run it. Follows up on #3039/#3040.

## What changed

Each pack description now follows one shape:

1. A one-paragraph summary of the data the pack collects.
2. A single line: enable the pack in [Mondoo Platform](https://mondoo.com/platform) for automatic scanning of the right assets, or run it manually with one `cnspec` command.

Removed across the board:
- **"Join the community" footers** — belong in the README, not every pack.
- **Complex remote-scan variants** — SSH/WinRM alternates and multi-cloud example lists that added noise.
- **Long prerequisite walls** (OAuth scope tables, API-enablement steps) — replaced with a self-contained manual command and a one-line pointer to the relevant setup guide for auth-gated providers (GitHub, Okta, Slack, Google Workspace, Microsoft 365, Shodan).

## Bug fixes (stale filenames in scan commands)

- Email pack referenced `mondoo-mail-inventory.mql.yaml` → `mondoo-email-inventory.mql.yaml`
- GitHub IR pack referenced `mondoo-github-org-incident-response.mql.yaml` → `mondoo-github-incident-response.mql.yaml`
- VMware packs carried a stray `core/` path prefix → removed

## Scope & validation

- Only pack `docs.desc` values changed. `mql`, `uid`, `title`, `filters`, `tags`, and `version` are untouched (verified via diff).
- All 31 packs across 29 files updated; YAML parses cleanly and `cnspec policy lint` passes on every pack.
- Net −281 lines of boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)