### PR TITLE
🐛 aws: fix lakeformation IAM_ALLOWED_PRINCIPALS check erroring on every scan

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -76002,8 +76002,10 @@ queries:
   - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-aws
     filters: asset.platform == "aws"
     mql: |
-      aws.lakeformation.dataLakeSettings.createTableDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
-      aws.lakeformation.dataLakeSettings.createDatabaseDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
+      aws.lakeformation.settings.all(
+        createTableDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS") &&
+        createDatabaseDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
+      )
   - uid: mondoo-aws-security-lakeformation-no-iam-allowed-principals-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lakeformation_data_lake_settings")
     mql: |


### PR DESCRIPTION
## Summary

Fixes the AWS runtime variant of **`mondoo-aws-security-lakeformation-no-iam-allowed-principals`**, which errored on **every** AWS scan (regardless of whether Lake Formation was in use) with:

```
region required to fetch aws lakeformation data lake settings
```

Because the query errored, the check scored `error` (value 0) instead of pass/fail, leaving the control effectively dead for all AWS accounts.

## Root cause

The query referenced `aws.lakeformation.dataLakeSettings` as a **bare, region-less singleton**. In the AWS provider that resource is genuinely per-region and `private`, reachable only as the `settings` collection or by naming a region explicitly. A bare type reference takes the resource-instantiation path (`NewResource` → `init`), and the provider's `init` requires a `region` arg — with none supplied it errors **before any AWS API call**, which is why it failed on every scan.

This is **not** a provider bug: Lake Formation settings have no account-wide singleton (they're per `(account, region)`), so the per-region collection model and the `init` guard are both correct. The query was written against the wrong accessor.

## Fix

Iterate the per-region collection via the `settings` field read and assert with `.all(...)`:

```mql
aws.lakeformation.settings.all(
  createTableDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS") &&
  createDatabaseDefaultPermissions.none(_['principal'] == "IAM_ALLOWED_PRINCIPALS")
)
```

- `settings` is a field read on the `aws.lakeformation` singleton (getter path, `CreateResource`), so the provider's Go loop supplies the region per element and the `region required` guard is never reached.
- `.all(...)` asserts no region grants `IAM_ALLOWED_PRINCIPALS`, matching the control objective.
- If no region uses Lake Formation, `settings` is empty and `.all(...)` passes vacuously — correct, nothing is over-exposed.

The `terraform-hcl` variant was unaffected and is unchanged.

## Verification

- `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` → valid policy bundle.
- Ran the corrected MQL against a live AWS account: it now **evaluates** (previously errored) and correctly flags a region where `IAM_ALLOWED_PRINCIPALS` is granted `ALL`.

Fixes mondoohq/cnspec-enterprise-policies#2980
