### PR TITLE
✨ junit: add opt-in `detailed` output with rich failure detail

### DIFF
--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -161,7 +161,7 @@ func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollectio
 		return err
 	case FormatJUnit:
 		writer := iox.IOWriter{Writer: r.out}
-		return ConvertToJunit(data, &writer)
+		return ConvertToJunit(data, &writer, r.Conf.detailed)
 	case FormatSarif:
 		writer := iox.IOWriter{Writer: r.out}
 		return ConvertToSarif(data, &writer)

--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -274,7 +274,10 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 	// The assessment (expected vs actual) is only available for assertion checks
 	// that executed. Guard exactly like the SARIF reporter: GetCodeBundle panics
 	// when ExecutionJob is nil, and returns nil when the query has no code bundle.
-	if resolved != nil && resolved.ExecutionJob != nil {
+	// report is guaranteed non-nil by the caller (assetPolicyTests ranges over
+	// report.Scores) but is guarded here too, since Query2Assessment dereferences
+	// it via report.Scores / report.Data.
+	if report != nil && resolved != nil && resolved.ExecutionJob != nil {
 		if cb := resolved.GetCodeBundle(query); cb != nil {
 			if assessment := policy.Query2Assessment(cb, report); assessment != nil {
 				if text := strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(cb, assessment)); text != "" {

--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -7,15 +7,22 @@ import (
 	"encoding/xml"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
 	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/cli/printer"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/utils/iox"
+	"go.mondoo.com/mql/v13/utils/stringx"
 )
 
-// ConvertToJunit maps the ReportCollection to Junit. Each asset becomes its own Suite
-func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper) error {
+// ConvertToJunit maps the ReportCollection to Junit. Each asset becomes its own Suite.
+// When detailed is true, failed and errored check testcases carry a rich body
+// (description, query, assessment, remediation, references) in their <failure>/<error>
+// element; passing and skipped checks stay lean regardless.
+func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper, detailed bool) error {
 	noXMLHeader := false
 
 	suites := junit.Testsuites{}
@@ -57,7 +64,7 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper) error {
 		// iterate over asset mrns
 		for assetMrn, assetObj := range r.Assets {
 			// add check results
-			ts := assetPolicyTests(r, assetMrn, assetObj, queries)
+			ts := assetPolicyTests(r, assetMrn, assetObj, queries, detailed)
 			suites.Suites = append(suites.Suites, ts)
 
 			vulnerabilityTests := assetMvdTests(r, assetMrn, assetObj)
@@ -84,7 +91,7 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper) error {
 }
 
 // assetPolicyTests converts asset scoring queries to Junit test cases
-func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inventory.Asset, queries map[string]*policy.Mquery) junit.Testsuite {
+func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inventory.Asset, queries map[string]*policy.Mquery, detailed bool) junit.Testsuite {
 	ts := junit.Testsuite{
 		Time:      "",
 		Testcases: []junit.Testcase{},
@@ -103,8 +110,10 @@ func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inv
 		return ts
 	}
 
-	// jUnit is not able to handle meta information of policies and also does not support
-	// data query results.
+	// Data queries have no score and are not represented here. When detailed is set,
+	// failed/errored checks carry their meta information (description, query, assessment,
+	// remediation, references) in the failure body below.
+	platformKeys := platformRemediationKeys(assetObj.Platform)
 	for id, score := range report.Scores {
 		_, ok := resolved.CollectorJob.ReportingQueries[id]
 		if !ok {
@@ -141,6 +150,9 @@ func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inv
 				testCase.Failure = &junit.Result{
 					Type: "error",
 				}
+				if detailed {
+					testCase.Failure.Data = detailedCheckBody(resolved, report, query, score, platformKeys)
+				}
 				ts.Failures++
 			}
 
@@ -148,6 +160,12 @@ func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inv
 				testCase.Failure = &junit.Result{
 					Message: "results do not match",
 					Type:    "fail",
+				}
+				if detailed {
+					if line := score.MessageLine(); line != "" {
+						testCase.Failure.Message = line
+					}
+					testCase.Failure.Data = detailedCheckBody(resolved, report, query, score, platformKeys)
 				}
 				ts.Failures++
 			}
@@ -234,6 +252,180 @@ func assetMvdTests(r *policy.ReportCollection, assetMrn string, assetObj *invent
 	}
 
 	return ts
+}
+
+// detailedCheckBody renders rich, human-readable detail for a failed or errored
+// check into the CDATA body of a JUnit <failure>/<error> element. Most JUnit
+// consumers (including GitLab) surface this body only for failing tests, so it is
+// only built for failures. It uses the no-color printer so no ANSI escape
+// sequences leak into the XML.
+func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, query *policy.Mquery, score *policy.Score, platformKeys map[string]bool) string {
+	var b strings.Builder
+
+	if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+		b.WriteString(desc)
+		b.WriteString("\n")
+	}
+
+	if mql := queryMql(query); mql != "" {
+		writeJunitSection(&b, "Query", mql)
+	}
+
+	// The assessment (expected vs actual) is only available for assertion checks
+	// that executed. Guard exactly like the SARIF reporter: GetCodeBundle panics
+	// when ExecutionJob is nil, and returns nil when the query has no code bundle.
+	if resolved != nil && resolved.ExecutionJob != nil {
+		if cb := resolved.GetCodeBundle(query); cb != nil {
+			if assessment := policy.Query2Assessment(cb, report); assessment != nil {
+				if text := strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(cb, assessment)); text != "" {
+					writeJunitSection(&b, "Result", text)
+				}
+				if locs := failingResourceLocations(cb, assessment); locs != "" {
+					writeJunitSection(&b, "Failing resources", locs)
+				}
+			}
+		}
+	}
+
+	// For errored checks the score message carries the failure reason.
+	if score != nil && score.Type == policy.ScoreType_Error {
+		if msg := score.MessageLine(); msg != "" {
+			writeJunitSection(&b, "Error", msg)
+		}
+	}
+
+	if rem := queryRemediation(query, platformKeys); rem != "" {
+		writeJunitSection(&b, "Remediation", rem)
+	}
+
+	if refs := queryReferences(query); refs != "" {
+		writeJunitSection(&b, "References", refs)
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+// writeJunitSection appends an indented "Title:\n  body" section to b.
+func writeJunitSection(b *strings.Builder, title, body string) {
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString(title)
+	b.WriteString(":\n")
+	b.WriteString(stringx.Indent(2, strings.TrimSpace(body)))
+	b.WriteString("\n")
+}
+
+// queryMql returns the MQL source for a query, preferring the current field and
+// falling back to the deprecated one (which the compact reporter still reads).
+func queryMql(query *policy.Mquery) string {
+	if query.Mql != "" {
+		return query.Mql
+	}
+	return query.Query
+}
+
+// platformRemediationKeys returns the set of remediation ids relevant to an
+// asset's platform: the platform name, its family entries (e.g. "terraform" for
+// the "terraform-hcl" platform), and the platform-agnostic "default"/"" ids. It
+// is used to filter remediation down to the platform being scanned so a Terraform
+// scan shows Terraform remediation rather than every IaC/tool variant.
+func platformRemediationKeys(platform *inventory.Platform) map[string]bool {
+	keys := map[string]bool{"": true, "default": true}
+	if platform != nil {
+		if platform.Name != "" {
+			keys[strings.ToLower(platform.Name)] = true
+		}
+		for _, f := range platform.Family {
+			if f != "" {
+				keys[strings.ToLower(f)] = true
+			}
+		}
+	}
+	return keys
+}
+
+// queryRemediation renders the remediation for a query, labeling each item with
+// its platform/tool id (e.g. "[terraform]") when present. Items are filtered to
+// those matching the asset's platform (name/family) or that are platform-agnostic;
+// if none match, all items are shown so remediation is never dropped entirely.
+func queryRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
+	if query.Docs == nil || query.Docs.Remediation == nil {
+		return ""
+	}
+
+	// Collect non-empty items, splitting into platform matches and the rest.
+	var matched, all []*policy.TypedDoc
+	for _, item := range query.Docs.Remediation.Items {
+		if item == nil || strings.TrimSpace(item.Desc) == "" {
+			continue
+		}
+		all = append(all, item)
+		if platformKeys[strings.ToLower(item.Id)] {
+			matched = append(matched, item)
+		}
+	}
+
+	items := matched
+	if len(items) == 0 {
+		items = all // fallback: no platform-specific match, show everything
+	}
+
+	var b strings.Builder
+	for _, item := range items {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		if item.Id != "" && item.Id != "default" {
+			b.WriteString("[" + item.Id + "] ")
+		}
+		b.WriteString(strings.TrimSpace(item.Desc))
+	}
+	return b.String()
+}
+
+// queryReferences renders a query's references as "Title: URL" lines. It prefers
+// docs.refs (the canonical location) and falls back to the deprecated refs field.
+func queryReferences(query *policy.Mquery) string {
+	refs := query.Refs
+	if query.Docs != nil && len(query.Docs.Refs) > 0 {
+		refs = query.Docs.Refs
+	}
+	var b strings.Builder
+	for _, ref := range refs {
+		if ref == nil || ref.Url == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		if ref.Title != "" {
+			b.WriteString(ref.Title + ": ")
+		}
+		b.WriteString(ref.Url)
+	}
+	return b.String()
+}
+
+// failingResourceLocations lists the source locations (path:line) of the resources
+// that caused a check to fail. It is populated for resources that carry source
+// context (e.g. Terraform/HCL) and empty for scalar checks.
+func failingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) string {
+	var b strings.Builder
+	for _, sc := range cb.FailingResourceContexts(assessment) {
+		if sc.Path == "" {
+			continue
+		}
+		loc := sc.Path
+		if startLine, _, _, _, _, ok := sc.Range.Bounds(); ok && startLine >= 1 {
+			loc += ":" + strconv.FormatInt(int64(startLine), 10)
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(loc)
+	}
+	return b.String()
 }
 
 func iota32(i int32) string {

--- a/cli/reporter/junit_test.go
+++ b/cli/reporter/junit_test.go
@@ -5,6 +5,8 @@ package reporter
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,7 +117,7 @@ func TestJunitConverter(t *testing.T) {
 	yr := sampleReportCollection()
 	buf := bytes.Buffer{}
 	writer := iox.IOWriter{Writer: &buf}
-	err := ConvertToJunit(yr, &writer)
+	err := ConvertToJunit(yr, &writer, false)
 	require.NoError(t, err)
 
 	junitReport := buf.String()
@@ -135,8 +137,148 @@ func TestJunitNilReport(t *testing.T) {
 
 	buf := bytes.Buffer{}
 	writer := iox.IOWriter{Writer: &buf}
-	err := ConvertToJunit(yr, &writer)
+	err := ConvertToJunit(yr, &writer, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites></testsuites>\n", buf.String())
+}
+
+// detailedReportCollection builds a minimal collection with a single failing
+// check that carries a description, MQL, remediation, and references. It has no
+// ExecutionJob, so the assessment section is intentionally absent here (that path
+// is covered by TestJunitConverterDetailedAssessment).
+func detailedReportCollection() *policy.ReportCollection {
+	assetMrn := "//assets.api.mondoo.app/spaces/test/assets/abc"
+	codeID := "abc123=="
+	return &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			assetMrn: {
+				Name:     "X1",
+				Platform: &inventory.Platform{Name: "terraform-hcl", Family: []string{"terraform"}},
+			},
+		},
+		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
+			assetMrn: {
+				CollectorJob: &policy.CollectorJob{
+					ReportingQueries: map[string]*policy.StringArray{
+						codeID: nil,
+					},
+				},
+			},
+		},
+		Bundle: &policy.Bundle{
+			Queries: []*policy.Mquery{
+				{
+					Mrn:    "//policy.api.mondoo.app/queries/test-check",
+					CodeId: codeID,
+					Title:  "Ensure the thing is configured",
+					Mql:    "sshd.config.params['PermitRootLogin'] == \"no\"",
+					Docs: &policy.MqueryDocs{
+						Desc: "Root login over SSH should be disabled.",
+						Remediation: &policy.Remediation{
+							Items: []*policy.TypedDoc{
+								{Id: "console", Desc: "Use the AWS console to fix it."},
+								{Id: "terraform", Desc: "Set PermitRootLogin to no in your TF config."},
+								{Id: "cloudformation", Desc: "Use CloudFormation to fix it."},
+							},
+						},
+						Refs: []*policy.MqueryRef{
+							{Title: "CIS Benchmark", Url: "https://example.com/cis"},
+						},
+					},
+				},
+			},
+		},
+		Reports: map[string]*policy.Report{
+			assetMrn: {
+				ScoringMrn: assetMrn,
+				EntityMrn:  assetMrn,
+				Scores: map[string]*policy.Score{
+					codeID: {Type: policy.ScoreType_Result, Value: 0},
+				},
+			},
+		},
+	}
+}
+
+func TestJunitConverterDetailed(t *testing.T) {
+	yr := detailedReportCollection()
+
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	require.NoError(t, ConvertToJunit(yr, &writer, true))
+	out := buf.String()
+
+	// the failed check testcase carries a rich body
+	assert.Contains(t, out, "name=\"Ensure the thing is configured\"")
+	assert.Contains(t, out, "Root login over SSH should be disabled.")
+	assert.Contains(t, out, "Query:")
+	assert.Contains(t, out, "PermitRootLogin")
+	assert.Contains(t, out, "Remediation:")
+	// remediation is filtered to the terraform platform (family match); the
+	// console/cloudformation variants are dropped as noise
+	assert.Contains(t, out, "[terraform] Set PermitRootLogin to no in your TF config.")
+	assert.NotContains(t, out, "Use the AWS console to fix it.")
+	assert.NotContains(t, out, "Use CloudFormation to fix it.")
+	assert.Contains(t, out, "References:")
+	assert.Contains(t, out, "CIS Benchmark: https://example.com/cis")
+
+	// the default (lean) output must be unchanged: no body, generic message
+	leanBuf := bytes.Buffer{}
+	leanWriter := iox.IOWriter{Writer: &leanBuf}
+	require.NoError(t, ConvertToJunit(yr, &leanWriter, false))
+	lean := leanBuf.String()
+	assert.NotContains(t, lean, "Root login over SSH should be disabled.")
+	assert.NotContains(t, lean, "Remediation:")
+	assert.Contains(t, lean, "message=\"results do not match\"")
+}
+
+// TestJunitConverterDetailedAssessment exercises the GetCodeBundle ->
+// Query2Assessment -> Assessment path against a real report fixture that carries
+// a compiled execution job and failing assertion checks.
+func TestJunitConverterDetailedAssessment(t *testing.T) {
+	raw, err := os.ReadFile("./testdata/report-ubuntu.json")
+	require.NoError(t, err)
+	yr := &policy.ReportCollection{}
+	require.NoError(t, json.Unmarshal(raw, yr))
+
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	require.NoError(t, ConvertToJunit(yr, &writer, true))
+	out := buf.String()
+
+	// failing checks render the query and the expected-vs-actual assessment
+	assert.Contains(t, out, "Query:")
+	assert.Contains(t, out, "Result:")
+	// no ANSI color escapes should leak into the XML
+	assert.NotContains(t, out, "\x1b[")
+}
+
+func TestQueryRemediationPlatformFilter(t *testing.T) {
+	mkQuery := func(items ...*policy.TypedDoc) *policy.Mquery {
+		return &policy.Mquery{Docs: &policy.MqueryDocs{Remediation: &policy.Remediation{Items: items}}}
+	}
+	console := &policy.TypedDoc{Id: "console", Desc: "console fix"}
+	tf := &policy.TypedDoc{Id: "terraform", Desc: "terraform fix"}
+	def := &policy.TypedDoc{Id: "default", Desc: "generic fix"}
+
+	tfKeys := platformRemediationKeys(&inventory.Platform{Name: "terraform-hcl", Family: []string{"terraform"}})
+
+	// family match ("terraform" via terraform-hcl) keeps only the terraform item
+	out := queryRemediation(mkQuery(console, tf), tfKeys)
+	assert.Contains(t, out, "[terraform] terraform fix")
+	assert.NotContains(t, out, "console fix")
+
+	// no platform-specific match -> fall back to all items (never drop remediation)
+	out = queryRemediation(mkQuery(console), tfKeys)
+	assert.Contains(t, out, "[console] console fix")
+
+	// platform-agnostic "default" is kept and shown without a label
+	out = queryRemediation(mkQuery(def, console), tfKeys)
+	assert.Contains(t, out, "generic fix")
+	assert.NotContains(t, out, "[default]")
+	assert.NotContains(t, out, "console fix")
+
+	// nil docs / nil remediation are safe
+	assert.Equal(t, "", queryRemediation(&policy.Mquery{}, tfKeys))
 }

--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -23,6 +23,9 @@ type PrintConfig struct {
 	printData            bool
 	printRisks           bool
 	printVulnerabilities bool
+	// detailed enables rich per-check output (description, query, assessment,
+	// remediation, references). Currently consumed by the JUnit reporter.
+	detailed bool
 }
 
 func defaultPrintConfig() *PrintConfig {
@@ -43,6 +46,7 @@ const (
 	OptionPrintData     = "data"
 	OptionPrintRisks    = "risks"
 	OptionPrintVulns    = "vulns"
+	OptionDetailed      = "detailed"
 )
 
 func ParseConfig[T string | Format](raw T) (*PrintConfig, error) {
@@ -83,6 +87,10 @@ func ParseConfig[T string | Format](raw T) (*PrintConfig, error) {
 			res.printRisks = false
 		case "no" + OptionPrintVulns, "novuln":
 			res.printVulnerabilities = false
+		case OptionDetailed:
+			res.detailed = true
+		case "no" + OptionDetailed:
+			res.detailed = false
 		default:
 			unknown = append(unknown, cur)
 		}
@@ -177,7 +185,8 @@ func AllOptions() string {
 		"[no]" + OptionPrintControls + ", " +
 		"[no]" + OptionPrintData + ", " +
 		"[no]" + OptionPrintRisks + ", " +
-		"[no]" + OptionPrintVulns
+		"[no]" + OptionPrintVulns + ", " +
+		"[no]" + OptionDetailed + " (junit)"
 }
 
 func (r *Reporter) scoreColored(rating policy.ScoreRating, s string) string {


### PR DESCRIPTION
The JUnit reporter previously emitted only pass/fail/skip with a generic "results do not match" message. In a GitLab pipeline — the only findings surface available without a GitLab Ultimate license (SARIF ingestion is Ultimate-only) — that leaves failed checks in the Tests tab with no actionable detail.

Add an opt-in `detailed` option (`--output junit,detailed`) that enriches the <failure>/<error> body of failed and errored checks with the check description, the MQL query, the expected-vs-actual assessment (including failing-resource file:line for Terraform/HCL), remediation, and references. The rich content rides in the failure CDATA body — the one place GitLab reliably renders — so passing and skipped checks stay lean and the default (non-detailed) output is byte-for-byte unchanged.

Remediation is filtered to the scanned asset's platform via the platform name and family (e.g. "terraform" for the terraform-hcl platform), falling back to all items when nothing matches so a fix is never dropped. The no-color printer is used so no ANSI escapes leak into the XML, and the SARIF reporter's assessment helpers are reused.

- cli/reporter/print.go: add `detailed` PrintConfig field and `detailed` option
- cli/reporter/cli_reporter.go: pass Conf.detailed to ConvertToJunit
- cli/reporter/junit.go: build the detailed failure body + helpers
- cli/reporter/junit_test.go: cover detailed output, the assessment path, and platform-filtered remediation