### PR TITLE
🧹 aws: rework six more checks to per-resource asset platforms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -10074,9 +10074,9 @@ queries:
   - uid: mondoo-aws-security-elb-not-internet-reachable
     title: Ensure load balancers are not unexpectedly internet-reachable
     impact: 80
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
-      aws.elb.loadBalancers.all( exposure.internetReachable == false )
+      aws.elb.loadbalancer.exposure.internetReachable == false
     docs:
       desc: |
         This check ensures that load balancers are not reachable from the internet unless intentionally designed to be. The `internetReachable` verdict combines the load balancer's scheme (internet-facing versus internal) with the ingress rules of its attached security groups, so a balancer is flagged only when its scheme is internet-facing *and* a security group permits inbound traffic from the internet.
@@ -27069,9 +27069,9 @@ queries:
   - uid: mondoo-aws-security-eks-control-plane-egress-customer-routed
     title: Ensure EKS control-plane egress is customer-routed
     impact: 60
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-eks-cluster"
     mql: |
-      aws.eks.clusters.all( controlPlaneEgressMode == "CUSTOMER_ROUTED" )
+      aws.eks.cluster.controlPlaneEgressMode == "CUSTOMER_ROUTED"
     docs:
       desc: |
         This check ensures that EKS clusters route control-plane egress through your own VPC subnets rather than letting Amazon EKS manage the egress path. With `CUSTOMER_ROUTED`, the control plane's outbound traffic to endpoints such as webhook servers and OIDC providers flows through subnets you control, so it can be filtered, inspected, and logged with your existing network controls. With `AWS_MANAGED`, Amazon EKS handles egress and you have no control point on that traffic.
@@ -30865,7 +30865,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-appstream-fleet-imdsv2-aws
         tags:
-          mondoo.com/filter-title: "AWS Account"
+          mondoo.com/filter-title: "AWS AppStream Fleet"
           mondoo.com/filter-icon: "aws"
       - uid: mondoo-aws-security-appstream-fleet-imdsv2-cloudformation
         tags:
@@ -30946,9 +30946,9 @@ queries:
       - url: https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html
         title: Amazon AppStream 2.0 CreateFleet API reference
   - uid: mondoo-aws-security-appstream-fleet-imdsv2-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-appstream-fleet"
     mql: |
-      aws.appstream.fleets.all(disableIMDSV1 == true)
+      aws.appstream.fleet.disableIMDSV1 == true
   - uid: mondoo-aws-security-appstream-fleet-imdsv2-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::AppStream::Fleet")
     mql: |
@@ -49241,7 +49241,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-no-default-vpc-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS EC2 VPC
           mondoo.com/filter-icon: aws
     docs:
       desc: |
@@ -49329,8 +49329,8 @@ queries:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
         title: AWS Documentation - Default VPCs
   - uid: mondoo-aws-security-no-default-vpc-aws
-    filters: asset.platform == "aws"
-    mql: aws.vpcs.none(isDefault == true)
+    filters: asset.platform == "aws-vpc"
+    mql: aws.vpc.isDefault == false
   - uid: mondoo-aws-security-emr-local-disk-encryption
     title: Ensure EMR clusters have local disk encryption enabled
     impact: 80
@@ -74562,7 +74562,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-efs-filesystem-no-public-access-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS EFS File System
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-hcl
         tags:
@@ -74653,8 +74653,8 @@ queries:
         title: AWS Documentation - Using IAM to control file system data access
 
   - uid: mondoo-aws-security-efs-filesystem-no-public-access-aws
-    filters: asset.platform == "aws"
-    mql: aws.efs.filesystems.all(isPublic == false)
+    filters: asset.platform == "aws-efs-filesystem"
+    mql: aws.efs.filesystem.isPublic == false
   - uid: mondoo-aws-security-efs-filesystem-no-public-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_efs_file_system_policy")
     mql: |
@@ -76311,7 +76311,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-aws
         tags:
-          mondoo.com/filter-title: AWS VPC
+          mondoo.com/filter-title: AWS EC2 VPC
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl
         tags:
@@ -76412,9 +76412,10 @@ queries:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/encryption-in-transit.html
         title: AWS Documentation - Encryption in transit for your VPC
   - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-vpc"
     mql: |
-      aws.vpcs.all(encryptionControl != empty && encryptionControl.mode == "enforce")
+      aws.vpc.encryptionControl != empty
+      aws.vpc.encryptionControl.mode == "enforce"
   - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_encryption_control")
     mql: |


### PR DESCRIPTION
## Summary

Continues the per-resource asset-platform rework from #3038. Six checks that still filtered on the broad `aws` account platform (iterating a whole collection with `.all()`/`.none()`) are moved onto the dedicated singular asset platforms mql already exposes, so they score per-resource instead of once per account.

| Check | New platform | MQL after |
|---|---|---|
| `elb-not-internet-reachable` | `aws-elb-loadbalancer` | `aws.elb.loadbalancer.exposure.internetReachable == false` |
| `eks-control-plane-egress-customer-routed` | `aws-eks-cluster` | `aws.eks.cluster.controlPlaneEgressMode == "CUSTOMER_ROUTED"` |
| `appstream-fleet-imdsv2` | `aws-appstream-fleet` | `aws.appstream.fleet.disableIMDSV1 == true` |
| `efs-filesystem-no-public-access` | `aws-efs-filesystem` | `aws.efs.filesystem.isPublic == false` |
| `no-default-vpc` | `aws-vpc` | `aws.vpc.isDefault == false` |
| `vpc-encryption-in-transit-enforced` | `aws-vpc` | `aws.vpc.encryptionControl != empty` / `.mode == "enforce"` |

## Notes

- `.none(isDefault == true)` → `isDefault == false` preserves the original "no default VPC" semantics per-resource.
- The multi-field VPC encryption predicate repeats the full singular path per field (newline-as-AND), following the `aws.secretsmanager.secret.*` precedent.
- Variant `mondoo.com/filter-title` values updated from "AWS Account" to the resource-specific titles already used by sibling checks on each platform (`AWS EC2 VPC`, `AWS EFS File System`, `AWS AppStream Fleet`).
- The 15 CloudWatch `.any()` alarm checks and IAM/EC2/SSM account- and host-scoped checks were intentionally **left on `aws`** — `.any()` is an account-level existence assertion that per-resource scoping would break.

## Verification

`cnspec policy lint ./content/mondoo-aws-security.mql.yaml` → valid policy bundle (the two `terraform.resources` WHERE warnings are pre-existing and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)