### PR TITLE
✨ aws: add 6 security checks across 5 per-resource platforms

### DIFF
--- a/content/validation/validators/aws.py
+++ b/content/validation/validators/aws.py
@@ -237,6 +237,29 @@ AWS_CLI_CUSTOM_SUBCOMMANDS = {
     "wait",
 }
 
+# Service-scoped subcommands the AWS CLI synthesizes on top of the botocore
+# model. They are real CLI surface but have no service-2.json operation, so the
+# generated database never contains them. Each maps to the flags the CLI
+# exposes for that customization.
+AWS_CLI_CUSTOM_SERVICE_SUBCOMMANDS = {
+    "emr": {
+        # `modify-cluster-attributes` wraps SetVisibleToAllUsers /
+        # SetTerminationProtection / etc.; it replaces the removed
+        # set-visible-to-all-users command in CLI v2.
+        "modify-cluster-attributes": [
+            "--cluster-id",
+            "--visible-to-all-users",
+            "--no-visible-to-all-users",
+            "--termination-protected",
+            "--no-termination-protected",
+            "--unhealthy-node-replacement",
+            "--no-unhealthy-node-replacement",
+            "--auto-terminate",
+            "--no-auto-terminate",
+        ],
+    },
+}
+
 AWS_CLI_CUSTOM_FLAGS = {
     # CLI customization that writes the seed material to a local file.
     "iam create-virtual-mfa-device": ["--outfile", "--bootstrap-method"],
@@ -270,6 +293,14 @@ def validate_aws_command(
 
     if subcommand in AWS_CLI_CUSTOM_SUBCOMMANDS:
         return True, []
+
+    custom_subcommands = AWS_CLI_CUSTOM_SERVICE_SUBCOMMANDS.get(service, {})
+    if subcommand in custom_subcommands:
+        valid_flags = set(custom_subcommands[subcommand])
+        for flag in flags:
+            if flag not in valid_flags:
+                errors.append(f"unknown flag '{flag}' for '{service} {subcommand}'")
+        return len(errors) == 0, errors
 
     valid_subcommands = commands_db[service]
     if subcommand not in valid_subcommands:


### PR DESCRIPTION
## Summary

Adds six new security checks across five per-resource AWS asset platforms. Continues the per-resource pattern from #3061–#3065.

| Platform | Check | Impact | Variants |
|---|---|---:|---|
| `aws-elasticache-cluster` | Redis clusters disallow plaintext connections (transit mode = `required`) | 70 | runtime-only |
| `aws-elasticache-cluster` | Clusters enable automatic minor version upgrades | 60 | runtime-only |
| `aws-emr-cluster` | Clusters restrict visibility to the creating IAM principal | 60 | runtime-only |
| `aws-ecr-repository` | Repositories use continuous (enhanced) vulnerability scanning | 70 | runtime-only |
| `aws-kms-key` | Customer-managed keys rotate at least every 365 days | 70 | aws + tf-hcl/plan/state + cfn |
| `aws-sns-topic` | Topics have a data protection policy configured | 60 | runtime-only |

## Design notes

- **ElastiCache transit mode (`required` vs `preferred`)** — the existing in-transit check only asserts encryption is *enabled*; in `preferred` mode a cluster still accepts plaintext fallback connections. This check closes that gap. Gated on `engine == "redis"` in the filter, mirroring the existing ElastiCache in-transit check.
- **Runtime-only rationale** (5 of 6), each documented in a `# No Terraform variants:` comment:
  - ElastiCache (both) and EMR follow the runtime-only pattern of every existing check on those platforms; TF/CFN remediation still documented.
  - **ECR continuous scanning** — scan frequency comes from *registry-level* enhanced-scanning rules (`aws_ecr_registry_scanning_configuration`), not a repository attribute, so there is no faithful per-repository IaC variant.
  - **SNS data protection policy** — applied via the separate `aws_sns_topic_data_protection_policy` resource, not an attribute of `aws_sns_topic`.
- **KMS rotation period** gets full variants (`rotation_period_in_days` is a clean attribute on `aws_kms_key`, and the KMS siblings carry variants). Filter mirrors the existing CMK-rotation check (enabled + symmetric + customer-managed). Asserts `keyRotationEnabled == false || rotationPeriodInDays <= 365` so it never double-flags keys the rotation-enabled check already covers.
- **Dropped from the requested set:** the Batch "non-root user" check — the provider's `aws.batch.jobDefinition.containerProperties` resource exposes `privileged`/`readonlyRootFilesystem`/`linuxParameters` but **no container `user` field**, so it can't be authored without an mql provider change. Happy to add the field upstream if wanted.

## Validator change

The EMR remediation uses `aws emr modify-cluster-attributes --no-visible-to-all-users`. That is the real AWS CLI v2 command, but it's a **CLI customization absent from the botocore model** the remediation validator builds its DB from (the botocore-known `set-visible-to-all-users` was removed from CLI v2). Rather than ship a dead command to pass CI, this adds a small **service-scoped custom-subcommand registry** (`AWS_CLI_CUSTOM_SERVICE_SUBCOMMANDS`) to `validators/aws.py` — the same mechanism already used for the `iam`/`ec2` flag customizations — so the real command validates.

## Compliance tags

Three checks **reuse verified same-objective sibling blocks** (ElastiCache transit → the in-transit block; KMS rotation period → the CMK-rotation block; ElastiCache auto-minor → the patch-management block). Three (EMR visibility → access enforcement, ECR → vulnerability management, SNS → data-leakage prevention) came from per-check framework research. **All non-`false` control UIDs were verified to exist** in the `cnspec-enterprise-policies` framework files. SNS honestly maps `nis-2`/`pci-dss-4`/`soc2-2017` to `false` (no strict content-based DLP control).

## Verification

- `cnspec policy lint content/mondoo-aws-security.mql.yaml` → valid (only the 2 pre-existing WHERE-clause warnings)
- `python3 content/validation/validate_remediation_commands.py aws` → 975 passed, 0 failed
- `typos content/mondoo-aws-security.mql.yaml` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)