### PR TITLE
✨ ai-security: add NIST AI 100-1 compliance tags

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -101,6 +101,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -234,6 +235,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -340,6 +342,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -423,6 +426,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -519,6 +523,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -615,6 +620,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -698,6 +704,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -783,6 +790,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -871,6 +879,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -956,6 +965,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1041,6 +1051,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1120,6 +1131,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1199,6 +1211,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1278,6 +1291,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1355,6 +1369,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1432,6 +1447,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1511,6 +1527,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1588,6 +1605,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1665,6 +1683,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1742,6 +1761,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1819,6 +1839,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1896,6 +1917,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1981,6 +2003,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2066,6 +2089,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2143,6 +2167,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2227,6 +2252,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2311,6 +2337,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2395,6 +2422,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2479,6 +2507,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2563,6 +2592,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2647,6 +2677,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2731,6 +2762,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2815,6 +2847,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2899,6 +2932,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2986,6 +3020,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3073,6 +3108,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1, nist-ai-100-1-measure-2-7
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3178,6 +3214,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-manage-3-2
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3292,6 +3329,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-measure-2-7
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8

--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -101,6 +101,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -236,6 +237,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -344,6 +346,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -429,6 +432,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -527,6 +531,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -625,6 +630,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -710,6 +716,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -797,6 +804,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -887,6 +895,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -974,6 +983,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1061,6 +1071,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1142,6 +1153,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1223,6 +1235,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1304,6 +1317,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1383,6 +1397,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1462,6 +1477,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1543,6 +1559,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1622,6 +1639,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1701,6 +1719,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1780,6 +1799,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1859,6 +1879,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -1938,6 +1959,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2025,6 +2047,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2112,6 +2135,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2191,6 +2215,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2277,6 +2302,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2363,6 +2389,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2449,6 +2476,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2535,6 +2563,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2621,6 +2650,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2707,6 +2737,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2793,6 +2824,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2879,6 +2911,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -2965,6 +2998,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3054,6 +3088,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3143,6 +3178,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-govern-6-1, nist-ai-100-1-measure-2-7
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3250,6 +3286,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-manage-3-2
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
@@ -3366,6 +3403,7 @@ queries:
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-19
       compliance/nis-2: nis-2-21-2-e
+      compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-measure-2-7
       compliance/nist-csf-1: nist-csf-1-de-cm-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8


### PR DESCRIPTION
Adds `compliance/nist-ai-100-1` tags to the 38 checks in `content/mondoo-ai-security.mql.yaml`.

## Why

NIST AI 100-1 (AI RMF 1.0) ships in `cnspec-enterprise-policies` but is one of five frameworks that **no check in `content/` tags** (alongside BSI C5, CIS Controls 8, CRA, and IKT-Minimalstandard). Its map is hand-written instead — `frameworks/maps/nist-ai-100-1/cnspec.mql.yaml`, added in mondoohq/cnspec-enterprise-policies#2985 — while the other 13 frameworks generate theirs from these tags.

That is fragile. The hand-written file sits at the exact path and map uid that `utils/cnspec_compliance_mapping.py` emits, so it is one `make generate` away from being silently overwritten. Tagging the checks makes `content/` the single source of truth and lets the map be generated like every other framework.

## The mappings are ported, not re-derived

All 38 checks and 45 check-to-control edges are taken **verbatim** from the existing hand-written map — this PR invents no new compliance claims. Coverage is `govern-1-6` (38), `govern-6-1` (4), `manage-3-2` (1), `measure-2-7` (2).

Six checks satisfy 2-3 controls each and use the comma-separated form, since check tags are `map[string]string` and cannot hold a YAML list:

```yaml
compliance/nist-ai-100-1: nist-ai-100-1-govern-1-6, nist-ai-100-1-measure-2-7
```

## Merge order

Requires mondoohq/cnspec-enterprise-policies#3004, which teaches the generator to split comma-separated control uids. **Land that first** — without it the whole value is read as one control uid and the map gets a dangling reference.

## Verification

- `cnspec policy lint content/mondoo-ai-security.mql.yaml` → valid
- Regenerating the map from these tags reproduces the hand-written map **exactly**: same map uid, same policy dependency, same 4 controls, all 45 edges
- The other 12 framework maps regenerate **byte-identical** — this change touches nothing but NIST AI 100-1
- Diff is purely additive: 38 insertions, 0 deletions

## Not addressed here

The audit that surfaced this also flagged two pre-existing mappings on these same checks as factually wrong — `compliance/hipaa: §164.308(a)(5)(ii)(B)` ("malicious software") and `compliance/nist-sp-800-53-rev5: cm-10` (a copyright/licensing control; CM-7 or CM-11 would be right). Both are out of scope for this PR and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)