### PR TITLE
✨ stackit: add compliance tags to 33 security checks

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -111,6 +111,20 @@ queries:
     title: Ensure STACKIT servers are attached to a security group
     impact: 60
     filters: asset.platform == "stackit-server"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.server.securityGroups.length > 0
     docs:
@@ -161,6 +175,20 @@ queries:
     title: Ensure STACKIT block storage volumes are encrypted
     impact: 80
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       stackit.volumes.all(encrypted == true)
     docs:
@@ -201,6 +229,20 @@ queries:
     title: Ensure no security group exposes SSH (port 22) to the internet
     impact: 90
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin <= 22 && portRangeMax >= 22).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
     docs:
@@ -242,6 +284,20 @@ queries:
     title: Ensure no security group exposes RDP (port 3389) to the internet
     impact: 90
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.securityGroups.all(rules.where(direction == "ingress" && portRangeMin <= 3389 && portRangeMax >= 3389).none(ipRange == "0.0.0.0/0" || ipRange == "::/0"))
     docs:
@@ -283,6 +339,20 @@ queries:
     title: Ensure no security group exposes all ports to the internet
     impact: 85
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.securityGroups.all(rules.where(direction == "ingress").where(ipRange == "0.0.0.0/0" || ipRange == "::/0").where(portRangeMin == null || portRangeMin <= 1).none(portRangeMax == null || portRangeMax >= 65535))
     docs:
@@ -324,6 +394,20 @@ queries:
     title: Ensure STACKIT application load balancers assign target security groups
     impact: 60
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-4-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.albLoadBalancers.all(disableTargetSecurityGroupAssignment == false)
     docs:
@@ -362,6 +446,20 @@ queries:
     title: Ensure STACKIT Object Storage buckets have Object Lock enabled
     impact: 70
     filters: asset.platform == "stackit-object-storage-bucket"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-16
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
+      compliance/iso-27001-2022: iso-27001-2022-a-5-33
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       stackit.objectStorage.bucket.objectLockEnabled == true
     docs:
@@ -396,6 +494,20 @@ queries:
     title: Ensure Object-Locked buckets define a default retention period
     impact: 60
     filters: asset.platform == "stackit-object-storage-bucket"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-16
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
+      compliance/iso-27001-2022: iso-27001-2022-a-5-33
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-12
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       stackit.objectStorage.bucket.objectLockEnabled == false || stackit.objectStorage.bucket.defaultRetentionDays > 0
     docs:
@@ -419,6 +531,20 @@ queries:
     title: Ensure STACKIT SFS resource pools restrict their mount IP allow-list
     impact: 85
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.sfs.resourcePools.all(ipAcl.none(_ == "0.0.0.0/0" || _ == "::/0"))
     docs:
@@ -457,6 +583,20 @@ queries:
     title: Ensure STACKIT SFS export policies do not allow world-open NFS access
     impact: 85
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.sfs.exportPolicies.all(rules.all(ipAcl.none(_ == "0.0.0.0/0" || _ == "::/0")))
     docs:
@@ -494,6 +634,20 @@ queries:
     title: Ensure STACKIT SFS resource pools have a snapshot policy attached
     impact: 50
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.sfs.resourcePools.all(snapshotPolicyId != "")
     docs:
@@ -533,6 +687,20 @@ queries:
     title: Ensure PostgreSQL Flex instances do not allow access from the internet
     impact: 90
     filters: asset.platform == "stackit-postgres-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-4
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.postgresFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
@@ -574,6 +742,20 @@ queries:
     title: Ensure PostgreSQL Flex instances have a backup schedule configured
     impact: 60
     filters: asset.platform == "stackit-postgres-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.postgresFlex.instance.backupSchedule != ""
     docs:
@@ -616,6 +798,20 @@ queries:
     title: Ensure MongoDB Flex instances do not allow access from the internet
     impact: 90
     filters: asset.platform == "stackit-mongodb-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-4
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.mongoDbFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
@@ -657,6 +853,20 @@ queries:
     title: Ensure MongoDB Flex instances have a backup schedule configured
     impact: 60
     filters: asset.platform == "stackit-mongodb-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.mongoDbFlex.instance.backupSchedule != ""
     docs:
@@ -699,6 +909,20 @@ queries:
     title: Ensure SQLServer Flex instances do not allow access from the internet
     impact: 90
     filters: asset.platform == "stackit-sqlserver-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-4
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.sqlServerFlex.instance.acl.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
@@ -740,6 +964,20 @@ queries:
     title: Ensure SQLServer Flex instances have a backup schedule configured
     impact: 60
     filters: asset.platform == "stackit-sqlserver-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.sqlServerFlex.instance.backupSchedule != ""
     docs:
@@ -782,6 +1020,20 @@ queries:
     title: Ensure PostgreSQL Flex instances run with multiple replicas
     impact: 40
     filters: asset.platform == "stackit-postgres-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-11
+      compliance/dora: dora-art-12
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-36
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.postgresFlex.instance.replicas >= 2
     docs:
@@ -827,6 +1079,20 @@ queries:
     title: Ensure MongoDB Flex instances run with multiple replicas
     impact: 40
     filters: asset.platform == "stackit-mongodb-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-11
+      compliance/dora: dora-art-12
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-36
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.mongoDbFlex.instance.replicas >= 2
     docs:
@@ -875,6 +1141,20 @@ queries:
     title: Ensure SQLServer Flex instances run with multiple replicas
     impact: 40
     filters: asset.platform == "stackit-sqlserver-flex-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-11
+      compliance/dora: dora-art-12
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-14
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-pt-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-36
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       stackit.sqlServerFlex.instance.replicas >= 2
     docs:
@@ -900,6 +1180,20 @@ queries:
     title: Ensure Secrets Manager instances do not allow access from the internet
     impact: 85
     filters: asset.platform == "stackit-secrets-manager-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.secretsManager.instance.acls.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
@@ -933,6 +1227,20 @@ queries:
     title: Ensure active service account keys have a bounded validity
     impact: 70
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.serviceAccounts.all(keys.where(_['active'] == true).all(_['validUntil'] != null))
     docs:
@@ -965,6 +1273,20 @@ queries:
     title: Ensure active service account access tokens have a bounded validity
     impact: 70
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.serviceAccounts.all(accessTokens.where(_['active'] == true).all(_['validUntil'] != null))
     docs:
@@ -988,6 +1310,20 @@ queries:
     title: Ensure STACKIT KMS keys are not scheduled for deletion
     impact: 60
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       stackit.kms.keys.all(deletionDate == null)
     docs:
@@ -1010,6 +1346,20 @@ queries:
     title: Ensure STACKIT KMS keys are in a healthy state
     impact: 50
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       stackit.kms.keys.none(state == "errors_exist" || state == "not_available")
     docs:
@@ -1033,6 +1383,20 @@ queries:
     title: Ensure STACKIT SKE clusters are not in an unhealthy state
     impact: 40
     filters: asset.platform == "stackit-ske-cluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       stackit.ske.cluster.status != "STATE_UNHEALTHY"
     docs:
@@ -1055,6 +1419,20 @@ queries:
     title: Ensure STACKIT SKE clusters enable Kubernetes version auto-update
     impact: 50
     filters: asset.platform == "stackit-ske-cluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-4-8
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       stackit.ske.cluster.maintenance['autoUpdate']['kubernetesVersion'] == true
     docs:
@@ -1092,6 +1470,20 @@ queries:
     title: Ensure STACKIT SKE clusters restrict Kubernetes API server access
     impact: 80
     filters: asset.platform == "stackit-ske-cluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.ske.cluster.apiServerAclEnabled == true
     docs:
@@ -1132,6 +1524,20 @@ queries:
     title: Ensure STACKIT SKE API server ACL is not open to the internet
     impact: 85
     filters: asset.platform == "stackit-ske-cluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       stackit.ske.cluster.apiServerAclAllowedCidrs.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
@@ -1173,6 +1579,20 @@ queries:
     title: Ensure STACKIT telemetry router access tokens have an expiry
     impact: 50
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.telemetry.routers.all(accessTokens.all(expiresAt != null))
     docs:
@@ -1207,6 +1627,20 @@ queries:
     title: Ensure STACKIT telemetry router access tokens are not expired
     impact: 60
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.telemetry.routers.all(accessTokens.all(expiresAt == null || expiresAt > time.now))
     docs:
@@ -1230,6 +1664,20 @@ queries:
     title: Ensure STACKIT Model Serving tokens have a bounded validity
     impact: 50
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.modelServing.tokens.all(validUntil != null)
     docs:
@@ -1262,6 +1710,20 @@ queries:
     title: Ensure STACKIT Model Serving tokens are not expired
     impact: 60
     filters: asset.platform == "stackit-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: false
     mql: |
       stackit.modelServing.tokens.all(validUntil == null || validUntil > time.now)
     docs:


### PR DESCRIPTION
## Why

`mondoo-stackit-security` was the **only** policy in `content/` with zero `compliance/*` tags — every other policy carries all 13 frameworks on every check (2,604 checks × 13). That made all 33 STACKIT checks invisible to every framework map generated into `cnspec-enterprise-policies/frameworks/maps/`.

This adds all 13 framework tags to all 33 checks. Tags only — no version bump, matching the tag-only precedent in d0c41445 (`ai-security: add NIST AI 100-1 compliance tags`).

## How these were mapped

Each check theme was mapped by reading the **control text in the framework definition**, not by copying from neighbouring checks. Every non-false UID was mechanically verified to exist in its framework YAML (a UID typo like the known `cloud-controls-matrix-4-lo-04` dangler cannot get through). `cnspec policy lint` passes.

Per repo convention, **`false` is used wherever no control fits strictly** rather than a weak keyword match — these tags compile into customer-facing compliance reports, so a wrong tag is a false audit claim.

## Scoping decisions worth reviewing

- **`bsi-sys-1-5` is `false` on all 33.** SYS.1.5 is the Grundschutz *Virtualisierung* module — its controls (A22 Härtung des Virtualisierungsservers, A24 Deaktivierung von Snapshots, A28 Verschlüsselung) address whoever operates the hypervisor estate. A STACKIT tenant consumes a cloud API and doesn't. Consistent with SYS.1.5 landing only on vSphere/ESXi/Nutanix/Portainer elsewhere in the corpus. Note A24 is a keyword trap for the SFS snapshot check and means the *opposite*.
- **`soc2-2017` is `false` for backup / HA / snapshot checks.** That definition contains only the CC series; A1.2, the real home for backup and availability, isn't in the file. Declined `cc9-1-1` as a catch-all.
- **`ske-cluster-healthy` and `kms-key-healthy-state` are `false` across all 13.** Both read an operational status. No control is *violated* by the state they detect, and neither was stretched onto the patch-management or key-management controls its sibling check uses.
- **`hipaa` is `false` for network/ACL checks.** §164.312(a)(1) is identity-centric ("persons or software programs that have been granted access rights"); §164.312(e)(1) governs ePHI in transit, not endpoint reachability. The Security Rule has no network-boundary technical safeguard.
- **`pci-dss-4` is `false` for volume encryption.** Req 3.5.1.2 accepts disk-level encryption only on *removable* media and explicitly says it "is not appropriate to protect stored PAN on ... servers, storage arrays, or any other system that provides transparent decryption."

## Calls I'd like a second opinion on

- **SOC 2 `cc7-4-8` for `ske-cluster-auto-update`.** Nine existing checks in the corpus tag auto-upgrade to CC7.1 — but CC7.1's criterion is "uses **detection and monitoring** procedures to identify ... vulnerabilities", which enabling auto-update is not. CC7.4.8's text ("Identified vulnerabilities are remediated through ... remediation activities") does describe it. Caveat: CC7.4 is scoped to incident response, and auto-update isn't incident-driven. SOC 2 2017 has no patch-management criterion, so it's this or `false`.
- **DORA `art-12` for the HA checks.** The YAML transcribes only paragraph 1 of each article (backup), which reads as backup-only — but DORA controls are modelled at *article* level, and the real Art 12(3) mandates entities "maintain redundant ICT capacities". Unlike 800-53, where CP-9 (Backup) is a genuinely distinct control from redundancy and would be wrong here.
- **CSA `cek-14` set to `false` for `kms-key-not-pending-deletion`.** cek-14 (Key Destruction) *requires* destroying keys when no longer needed, so a key correctly being retired satisfies the control but fails this check — inverted. SOC 2 `cc6-1-11` is retained because "protects cryptographic keys during ... destruction" is about *controlled* destruction and isn't inverted.
- **`nis-2-21-2-i` for network checks.** NIS2's 21.2 buckets are coarse and have no network-security measure; (i) is "human resources security, access control policies and asset management", read here as covering network-layer access control. The broadest call in the set.
- **PCI `8.6.3` for the credential-expiry checks.** Its text says "passwords/passphrases" literally; read here as covering service-account keys and bearer tokens, given its stated objective that system-account credentials "cannot be used indefinitely".

## Consistency fixes applied across themes

The same property was mapped independently per theme, then reconciled: the SFS IP-ACL checks were harmonized onto `nist-sp-800-171--3-13-6` ("deny all, permit by exception" — an allowlist containing `0.0.0.0/0` is its literal inverse) and `hipaa: false`, matching the structurally identical DB/secrets/SKE ACL checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)