### PR TITLE
🐛 Fix compliance tag mappings for nis-2, vda-isa-5 and bsi-sys-1-5

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -107,7 +107,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     props:
       - uid: mondooAiSecurityApprovedProcesses
         title: Regex matching approved AI process names
@@ -240,7 +240,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     props:
       - uid: mondooAiSecurityApprovedPackages
         title: Regex matching approved AI package names
@@ -346,7 +346,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     props:
       - uid: mondooAiSecurityApprovedHomebrewPackages
         title: Regex matching approved Homebrew AI package names
@@ -429,7 +429,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       cursor.skills.none()
       cursor.mcpServers.none()
@@ -525,7 +525,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       windsurf.skills.none()
       windsurf.mcpServers.none()
@@ -621,7 +621,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       goose.skills.none()
       goose.extensions.none()
@@ -704,7 +704,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       zed.extensions.none()
     docs:
@@ -789,7 +789,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       cline.skills.none()
     docs:
@@ -877,7 +877,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       roo.skills.none()
     docs:
@@ -962,7 +962,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       continuedev.skills.none()
     docs:
@@ -1047,7 +1047,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       trae.skills.none()
     docs:
@@ -1126,7 +1126,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       opencode.skills.none()
     docs:
@@ -1205,7 +1205,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       kiro.skills.none()
     docs:
@@ -1284,7 +1284,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       pi.skills.none()
     docs:
@@ -1361,7 +1361,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       mistral.vibe.skills.none()
     docs:
@@ -1438,7 +1438,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       antigravity.skills.none()
     docs:
@@ -1517,7 +1517,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       ibm.bob.skills.none()
     docs:
@@ -1594,7 +1594,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       openclaw.skills.none()
     docs:
@@ -1671,7 +1671,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       snowflake.cortex.skills.none()
     docs:
@@ -1748,7 +1748,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       junie.skills.none()
     docs:
@@ -1825,7 +1825,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       augment.skills.none()
     docs:
@@ -1902,7 +1902,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       warp.skills.none()
     docs:
@@ -1987,7 +1987,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       kilocode.skills.none()
     docs:
@@ -2072,7 +2072,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       openhands.skills.none()
     docs:
@@ -2149,7 +2149,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       qwen.code.skills.none()
     docs:
@@ -2233,7 +2233,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)codeium\./
@@ -2317,7 +2317,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)tabnine\./
@@ -2401,7 +2401,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)supermaven\./
@@ -2485,7 +2485,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)continue\.continue/
@@ -2569,7 +2569,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)saoudrizwan\.claude-dev|cline\./
@@ -2653,7 +2653,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)sourcegraph\.cody/
@@ -2737,7 +2737,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)openai\./
@@ -2821,7 +2821,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)anthropic\.claude/
@@ -2905,7 +2905,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)(cursor|anysphere)\./
@@ -2992,7 +2992,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       vscode.extensions.where(
         identifier == /(?i)rooveterinaryinc\.roo-cline|roocode\./
@@ -3079,7 +3079,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     props:
       - uid: mondooAiSecurityApprovedMcpServers
         title: Regex matching approved MCP server names (applies to all agents)
@@ -3184,7 +3184,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       processes.where(
         executable == /(?i)\b(ollama|llama|lmstudio|lm-studio|localai|gpt4all)\b/
@@ -3298,7 +3298,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-1-3-3
     mql: |
       ports.listening.where(address.notIn(["127.0.0.1", "::1", "[::1]"])).none(
         port == 11434 || port == 1234 || port == 1337

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -470,7 +470,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       arista.eos.runningConfig.content.lines.one(_ == "aaa authorization console")
     docs:
@@ -533,7 +533,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       arista.eos.users.one(
         name == "admin" &&
@@ -1386,7 +1386,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       arista.eos.users.where(name != "admin").all(
         privilege.downcase != "15" || role != ""

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -15008,7 +15008,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-16
-      compliance/nis-2: nis-2-21-2-b
+      compliance/nis-2: nis-2-21-2-f
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
@@ -43540,7 +43540,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
@@ -44163,7 +44163,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -44537,7 +44537,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -2667,7 +2667,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-11
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-ensure-the-kv-is-recoverable-azure
         tags:
@@ -5471,7 +5471,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-storage-blob-soft-delete-enabled-azure
         tags:
@@ -5627,7 +5627,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-storage-container-soft-delete-enabled-azure
         tags:
@@ -15801,7 +15801,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-azure
         tags:
@@ -16857,7 +16857,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-cosmosdb-continuous-backup-azure
         tags:
@@ -17008,7 +17008,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-cosmosdb-multi-region-write-azure
         tags:
@@ -26907,7 +26907,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-postgresql-flexible-geo-backup-azure
         tags:
@@ -34498,7 +34498,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-managed-hsm-soft-delete-azure
         tags:
@@ -34647,7 +34647,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-11
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-managed-hsm-purge-protection-azure
         tags:
@@ -35917,7 +35917,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-recovery-vault-soft-delete-azure
         tags:
@@ -36068,7 +36068,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-recovery-vault-immutability-azure
         tags:
@@ -36223,7 +36223,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-recovery-vault-enhanced-security-azure
         tags:
@@ -36970,7 +36970,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-azure-security-recovery-vault-backup-policies-azure
         tags:

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -820,7 +820,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       bigip.snmp.allowedAddresses.none(_.in(["0.0.0.0/0", "0.0.0.0", "::/0", "ALL"]))
     docs:

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -68,7 +68,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/chef").exists) {
         file("/etc/chef") {
@@ -154,7 +154,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/var/chef").exists) {
         file("/var/chef") {
@@ -240,7 +240,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/var/log/chef").exists) {
         file("/var/log/chef") {
@@ -326,7 +326,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/chef/client.rb").exists) {
         file("/etc/chef/client.rb") {
@@ -413,7 +413,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/chef/client.pem").exists) {
         file("/etc/chef/client.pem") {
@@ -573,7 +573,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       command("chef-client -v") {
         stdout == /^(Chef Infra|Cinc) Client: (18|19|20|21|22).*/m

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -73,7 +73,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/opscode") {
         user.name == 'root'
@@ -157,7 +157,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/opscode/pivotal.pem") {
         user.name == 'opscode'
@@ -242,7 +242,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/opscode/private-chef-secrets.json") {
         user.name == 'root'
@@ -327,7 +327,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/opscode/webui_priv.pem").exists) {
         file("/etc/opscode/webui_priv.pem") {
@@ -414,7 +414,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/opscode/chef-server.rb") {
         user.name == 'root'
@@ -498,7 +498,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       file("/opt/opscode/version-manifest.txt").content == /^chef-server (14|15|16|17)/
     docs:
@@ -574,7 +574,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       package("opscode-reporting").installed == false
     docs:
@@ -669,7 +669,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       package("opscode-push-jobs-server").installed == false
     docs:
@@ -764,7 +764,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       package("opscode-analytics").installed == false
     docs:
@@ -859,7 +859,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       package("chef-ha").installed == false
     docs:
@@ -1300,7 +1300,7 @@ queries:
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       file("/var/opt/opscode/local-mode-cache/backup") {
         user.name == 'root'

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -1517,7 +1517,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (cisco.iosxe.snmp.enabled == true && cisco.iosxe.snmp.communities.length > 0) {
         cisco.iosxe.snmp.communities.all(aclId != "")
@@ -1718,7 +1718,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       cisco.iosxe.vtyLines.all(
         accessClassIn != ""

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -418,7 +418,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       cisco.iosxr.aaaAuthorization.length > 0
     docs:
@@ -1191,7 +1191,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (cisco.iosxr.runSnmpCommunities.length > 0) {
         cisco.iosxr.runSnmpCommunities.all(
@@ -1629,7 +1629,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       cisco.iosxr.vtyLines.all(
         cisco.iosxr.runLineAcl(lineTemplate: templateName).acl.length > 0

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -1266,7 +1266,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (cisco.nxos.snmp.communities.length > 0) {
         cisco.nxos.snmp.communities.all(
@@ -1595,7 +1595,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       cisco.nxos.lineConfigs.where(type == "vty").all(
         accessClassInName != ""

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3454,7 +3454,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-digitalocean-security-spaces-bucket-versioning-enabled-digitalocean
         tags:
@@ -3762,7 +3762,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       digitalocean.spacesBucket.mfaDeleteEnabled == true
     docs:

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -328,7 +328,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       dns.records.where(type == "NS") != empty
       dns.records.where(type == "NS").first.rdata.length >= 2

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -324,7 +324,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       docker.file.stages.all(run.all(commands.none(binary == "sudo")))
     docs:
@@ -452,7 +452,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       docker.file.finalStage.runsAsRoot == false
     docs:
@@ -782,7 +782,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       docker.file.stages.all(volumes.none(path == /^\/(etc|proc|sys|dev|boot|root)(\/|$)/ || path == "/"))
     docs:
@@ -1238,7 +1238,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       docker.file.stages.all(run.all(mounts.where(from == empty).where(type == "bind" || type == empty).none(source == /^\/(etc|proc|sys|dev|boot|root|home|tmp|var|run)?(\/|$)/)))
     docs:

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -1665,7 +1665,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
@@ -1748,7 +1748,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
@@ -1916,7 +1916,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -2006,7 +2006,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -2085,7 +2085,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -109,7 +109,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: fortios.system.firmware.current.releaseType == "GA"
     docs:
       desc: |
@@ -201,7 +201,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: fortios.system.firmware.current.maturity == "M"
     docs:
       desc: |
@@ -292,7 +292,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-2
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     # Review annually — update when older major versions reach EOL
     mql: fortios.system.firmware.current.major >= 7
     docs:
@@ -681,7 +681,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: fortios.system.ha.mode != "standalone"
     docs:
       desc: |
@@ -761,7 +761,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: fortios.system.ha.mode == "standalone" || fortios.system.ha.sessionPickup == "enable"
     docs:
       desc: |
@@ -2346,7 +2346,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-6-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: fortios.router.bgp.neighbors.length == 0 || fortios.router.bgp.gracefulRestart == "enable"
     docs:
       desc: |

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -1961,7 +1961,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/ssh/sshd_config") {
         user.name == 'root'
@@ -2047,7 +2047,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.find(from: "/etc/ssh", type: "file").where(path == /ssh_host_.*key$/).list {
         path
@@ -2142,7 +2142,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.find(from: "/etc/ssh", type: "file").where(path == /ssh_host_.*key\.pub$/).list {
         path
@@ -3665,7 +3665,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/passwd") {
         user.name == 'root'
@@ -3750,7 +3750,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/group") {
         user.name == 'root'
@@ -3835,7 +3835,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/master.passwd") {
         user.name == 'root'
@@ -3922,7 +3922,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/shells") {
         user.name == 'root'
@@ -4006,7 +4006,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/boot/loader.conf") {
         user.name == 'root'
@@ -4839,7 +4839,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       package("sudo").installed
     docs:
@@ -4920,7 +4920,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: |
       package("sudo").installed
     mql: |
@@ -5019,7 +5019,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: |
       package("sudo").installed
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -1659,7 +1659,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-7
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-gcp
         tags:
@@ -15606,7 +15606,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-memorystore-redis
         tags:
@@ -15866,7 +15866,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-memorystore-rediscluster
         tags:
@@ -25884,7 +25884,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-8-9
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: gcp.storage.bucket.objectRetentionMode == "Enabled"
     docs:
       desc: |

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -302,7 +302,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-github-organization-security-default-permission-level-github
         tags:
@@ -554,7 +554,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       github.repository.branches
         .where( isDefault == true )
@@ -685,7 +685,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     props:
       - uid: mondooGithubReleaseBranches
         title: Pattern for release branch
@@ -811,7 +811,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-prevent-force-pushes-default-branch-github
         tags:
@@ -964,7 +964,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     props:
       - uid: mondooGithubReleaseBranches
         title: Pattern for release branch
@@ -1084,7 +1084,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-require-conversation-resolution-github
         tags:
@@ -1230,7 +1230,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-require-status-checks-before-merging-github
         tags:
@@ -1382,7 +1382,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-required-signed-commits-github
         tags:
@@ -1522,7 +1522,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-enforce-branch-protection-github
         tags:
@@ -1969,7 +1969,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-github-organization-security-fork-private-repos-github
         tags:
@@ -2586,7 +2586,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: github.organization.membersCanChangeRepoVisibility == false
     docs:
       desc: |
@@ -2660,7 +2660,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: github.organization.membersCanDeleteRepositories == false
     docs:
       desc: |
@@ -2963,7 +2963,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-actions-require-sha-pinning-github
         tags:
@@ -3293,7 +3293,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-require-pull-request-reviews-github
         tags:
@@ -3442,7 +3442,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-block-creations-default-branch-github
         tags:
@@ -3598,7 +3598,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-github-repository-security-environment-prevent-self-review-github
         tags:

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -91,7 +91,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-private-group-gitlab
         tags:
@@ -342,7 +342,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-private-projects-gitlab
         tags:
@@ -498,7 +498,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-private-project-gitlab
         tags:
@@ -629,7 +629,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     filters: gitlab.namespace.plan != "free"
     mql: |
       gitlab.project.approvalSettings.approvalsBeforeMerge >= 1
@@ -731,7 +731,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-no-author-approval-gitlab
         tags:
@@ -861,7 +861,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-reset-approvals-on-push-gitlab
         tags:
@@ -991,7 +991,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-no-committer-approval-gitlab
         tags:
@@ -1120,7 +1120,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-no-force-push-default-branch-gitlab
         tags:
@@ -1383,7 +1383,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-group-prevent-forking-outside-gitlab
         tags:
@@ -1767,7 +1767,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-deploy-keys-no-push-access-gitlab
         tags:
@@ -1991,7 +1991,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-8-6-2
       compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-push-rule-prevent-secrets-gitlab
         tags:
@@ -2120,7 +2120,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-push-rule-reject-unsigned-commits-gitlab
         tags:
@@ -2249,7 +2249,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-push-rule-committer-check-gitlab
         tags:
@@ -2376,7 +2376,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-push-rule-member-check-gitlab
         tags:
@@ -2508,7 +2508,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-8-6-2
       compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     filters: asset.platform == "gitlab-project" && gitlab.namespace.plan == "ultimate"
     mql: |
       gitlab.project.preReceiveSecretDetectionEnabled == true
@@ -2606,7 +2606,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-8-6-2
       compliance/soc2-2017: false
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     variants:
       - uid: mondoo-gitlab-security-ci-variables-masked-gitlab
         tags:
@@ -2735,7 +2735,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-ci-variables-protected-gitlab
         tags:
@@ -2864,7 +2864,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-job-token-scope-enabled-gitlab
         tags:
@@ -2988,7 +2988,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-7-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
       - uid: mondoo-gitlab-security-webhook-ssl-verification-gitlab
         tags:
@@ -3111,7 +3111,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-no-merge-on-skipped-pipeline-gitlab
         tags:
@@ -3239,7 +3239,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-8-2
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     variants:
       - uid: mondoo-gitlab-security-discussions-resolved-gitlab
         tags:
@@ -3362,7 +3362,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-gitlab-security-no-public-jobs-gitlab
         tags:

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -107,7 +107,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
@@ -403,7 +403,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -470,7 +470,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-10
@@ -531,7 +531,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-10
@@ -595,7 +595,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -680,7 +680,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
@@ -982,7 +982,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1046,7 +1046,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-4
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
@@ -1113,7 +1113,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-3
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
@@ -1459,7 +1459,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1913,7 +1913,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-22
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-id-am-2
       compliance/nist-csf-2: nist-csf-2-id-am-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-8

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -114,7 +114,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.sshConfig.rootLogin == "deny" || junos.sshConfig.rootLogin == "deny-password"
     docs:
@@ -477,7 +477,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.sshConfig.connectionLimit > 0
     docs:
@@ -538,7 +538,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-10
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.sshConfig.rateLimit > 0
     docs:
@@ -687,7 +687,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.users.where(class == "super-user").length <= 3
     docs:
@@ -1053,7 +1053,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.snmpCommunities.all(authorization == "read-only")
     docs:
@@ -1120,7 +1120,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       junos.snmpCommunities.all(clients.length > 0)
     docs:

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -483,7 +483,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       kubelet.configuration['authorization']['mode'] != "AlwaysAllow"
     docs:
@@ -682,7 +682,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (kubelet.configFile != empty) {
         if (kubelet.configFile.exists) {
@@ -782,7 +782,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       kubelet.configuration['authentication']['x509']['clientCAFile'] != empty
       if (kubelet.configuration['authentication']['x509']['clientCAFile'] != empty) {
@@ -882,7 +882,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/kubernetes/manifests/kube-apiserver.yaml").exists) {
         file("/etc/kubernetes/manifests/kube-apiserver.yaml") {
@@ -980,7 +980,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/var/lib/etcd").exists) {
         file("/var/lib/etcd") {
@@ -1077,7 +1077,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/kubernetes/admin.conf").exists) {
         file("/etc/kubernetes/admin.conf") {
@@ -1175,7 +1175,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/kubernetes/scheduler.conf").exists) {
         file("/etc/kubernetes/scheduler.conf") {
@@ -1273,7 +1273,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/kubernetes/controller-manager.conf").exists) {
         file("/etc/kubernetes/controller-manager.conf") {
@@ -1371,7 +1371,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (processes.where(executable == /kube-apiserver/).list[0].flags["etcd-certfile"] != empty) {
         clientCAFile = processes.where(executable == /kube-apiserver/).list[0].flags["etcd-certfile"]
@@ -1558,7 +1558,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod {
         podSpec['volumes'] == null || podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
@@ -1627,7 +1627,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob {
         podSpec['volumes'] == null || podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
@@ -1696,7 +1696,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
@@ -1762,7 +1762,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
@@ -1828,7 +1828,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
@@ -1894,7 +1894,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
@@ -1960,7 +1960,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
@@ -2026,7 +2026,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2092,7 +2092,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2158,7 +2158,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2224,7 +2224,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2290,7 +2290,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2356,7 +2356,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2422,7 +2422,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
@@ -2488,7 +2488,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2554,7 +2554,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2620,7 +2620,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2686,7 +2686,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2752,7 +2752,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2818,7 +2818,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2884,7 +2884,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
@@ -2950,7 +2950,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod.allowsPrivilegeEscalation == false
     docs:
@@ -3015,7 +3015,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob.allowsPrivilegeEscalation == false
     docs:
@@ -3088,7 +3088,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.allowsPrivilegeEscalation == false
     docs:
@@ -3157,7 +3157,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.deployment.allowsPrivilegeEscalation == false
     docs:
@@ -3226,7 +3226,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.job.allowsPrivilegeEscalation == false
     docs:
@@ -3295,7 +3295,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.allowsPrivilegeEscalation == false
     docs:
@@ -3364,7 +3364,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.allowsPrivilegeEscalation == false
     docs:
@@ -3431,7 +3431,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod.runsPrivileged == false
     docs:
@@ -3508,7 +3508,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob.runsPrivileged == false
     docs:
@@ -3597,7 +3597,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.runsPrivileged == false
     docs:
@@ -3680,7 +3680,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.deployment.runsPrivileged == false
     docs:
@@ -3763,7 +3763,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.job.runsPrivileged == false
     docs:
@@ -3846,7 +3846,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.runsPrivileged == false
     docs:
@@ -3929,7 +3929,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.runsPrivileged == false
     docs:
@@ -4509,7 +4509,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: k8s.pod.annotations['policies.k8s.mondoo.com/mondoo-kubernetes-security-pod-runasnonroot'] != 'ignore'
     mql: |
       k8s.pod.runsAsRoot == false
@@ -4605,7 +4605,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: k8s.cronjob.annotations['policies.k8s.mondoo.com/mondoo-kubernetes-security-cronjob-runasnonroot'] != 'ignore'
     mql: |
       k8s.cronjob.runsAsRoot == false
@@ -4717,7 +4717,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.runsAsRoot == false
     docs:
@@ -4820,7 +4820,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.deployment.runsAsRoot == false
     docs:
@@ -4923,7 +4923,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: k8s.job.annotations['policies.k8s.mondoo.com/mondoo-kubernetes-security-job-runasnonroot'] != 'ignore'
     mql: |
       k8s.job.runsAsRoot == false
@@ -5027,7 +5027,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.runsAsRoot == false
     docs:
@@ -5130,7 +5130,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.runsAsRoot == false
     docs:
@@ -6619,7 +6619,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod.podSpec['serviceAccount'] == null || k8s.pod.podSpec['serviceAccount'] == k8s.pod.serviceAccountName
       k8s.pod.serviceAccountName != '' || k8s.pod.automountServiceAccountToken == false
@@ -6709,7 +6709,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob.podSpec['serviceAccount'] == null || k8s.cronjob.podSpec['serviceAccount'] == k8s.cronjob.podSpec['serviceAccountName']
       k8s.cronjob.podSpec['serviceAccountName'] != '' || k8s.cronjob.podSpec['automountServiceAccountToken'] == false
@@ -6815,7 +6815,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.podSpec['serviceAccount'] == null || k8s.statefulset.podSpec['serviceAccount'] == k8s.statefulset.podSpec['serviceAccountName']
       k8s.statefulset.podSpec['serviceAccountName'] != '' || k8s.statefulset.podSpec['automountServiceAccountToken'] == false
@@ -6913,7 +6913,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.deployment.podSpec['serviceAccount'] == null || k8s.deployment.podSpec['serviceAccount'] == k8s.deployment.podSpec['serviceAccountName']
       k8s.deployment.podSpec['serviceAccountName'] != '' || k8s.deployment.podSpec['automountServiceAccountToken'] == false
@@ -7011,7 +7011,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.job.podSpec['serviceAccount'] == null || k8s.job.podSpec['serviceAccount'] == k8s.job.podSpec['serviceAccountName']
       k8s.job.podSpec['serviceAccountName'] != '' || k8s.job.podSpec['automountServiceAccountToken'] == false
@@ -7109,7 +7109,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.podSpec['serviceAccount'] == null || k8s.replicaset.podSpec['serviceAccount'] == k8s.replicaset.podSpec['serviceAccountName']
       k8s.replicaset.podSpec['serviceAccountName'] != '' || k8s.replicaset.podSpec['automountServiceAccountToken'] == false
@@ -7207,7 +7207,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.podSpec['serviceAccount'] == null || k8s.daemonset.podSpec['serviceAccount'] == k8s.daemonset.podSpec['serviceAccountName']
       k8s.daemonset.podSpec['serviceAccountName'] != '' || k8s.daemonset.podSpec['automountServiceAccountToken'] == false
@@ -7845,7 +7845,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.pod.hasCpuLimit == true
     docs:
@@ -7911,7 +7911,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.cronjob.hasCpuLimit == true
     docs:
@@ -7985,7 +7985,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.statefulset.hasCpuLimit == true
     docs:
@@ -8055,7 +8055,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.deployment.hasCpuLimit == true
     docs:
@@ -8125,7 +8125,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.job.hasCpuLimit == true
     docs:
@@ -8195,7 +8195,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.replicaset.hasCpuLimit == true
     docs:
@@ -8265,7 +8265,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.daemonset.hasCpuLimit == true
     docs:
@@ -8335,7 +8335,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.pod.hasMemoryLimit == true
     docs:
@@ -8403,7 +8403,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.cronjob.hasMemoryLimit == true
     docs:
@@ -8468,7 +8468,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.statefulset.hasMemoryLimit == true
     docs:
@@ -8540,7 +8540,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.deployment.hasMemoryLimit == true
     docs:
@@ -8612,7 +8612,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.job.hasMemoryLimit == true
     docs:
@@ -8684,7 +8684,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.replicaset.hasMemoryLimit == true
     docs:
@@ -8756,7 +8756,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       k8s.daemonset.hasMemoryLimit == true
     docs:
@@ -8828,7 +8828,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod.ephemeralContainers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.pod.ephemeralContainers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -8912,7 +8912,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.daemonset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -8996,7 +8996,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.replicaset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -9080,7 +9080,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.job.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.job.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -9164,7 +9164,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.deployment.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -9248,7 +9248,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.statefulset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -9332,7 +9332,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob.containers.all( addedCapabilities.none( _.upcase == /^NET_RAW$|^ALL$/ ) )
       k8s.cronjob.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
@@ -9420,7 +9420,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.pod.initContainers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
       k8s.pod.ephemeralContainers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
@@ -9481,7 +9481,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.daemonset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
@@ -9542,7 +9542,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.replicaset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
@@ -9593,7 +9593,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.job.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
@@ -9654,7 +9654,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
@@ -9714,7 +9714,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.statefulset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
@@ -9775,7 +9775,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       k8s.cronjob.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
@@ -11589,7 +11589,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       processes.where(executable == /kube-apiserver/).list {
         flags["authorization-mode"] != null
@@ -11689,7 +11689,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       processes.where(executable == /kube-apiserver/).list {
         flags["enable-admission-plugins"] != null
@@ -11785,7 +11785,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: false
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       processes.where(executable == /kube-apiserver/).list {
         flags["enable-admission-plugins"] != null
@@ -12327,7 +12327,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-4
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       processes.where(executable == /kube-apiserver/).list {
         flags["service-account-lookup"] == null || flags["service-account-lookup"] == "true"

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -358,7 +358,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       kubelet.configuration['makeIPTablesUtilChains'] == true
     docs:
@@ -442,7 +442,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       kubelet.configuration['readOnlyPort'] == 0 || kubelet.configuration['readOnlyPort'] == null
     docs:
@@ -472,7 +472,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -671,7 +671,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -771,7 +771,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -871,7 +871,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -969,7 +969,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1066,7 +1066,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1164,7 +1164,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1262,7 +1262,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1360,7 +1360,7 @@ queries:
     impact: 65
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1547,7 +1547,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1616,7 +1616,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1685,7 +1685,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1751,7 +1751,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1817,7 +1817,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1883,7 +1883,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1949,7 +1949,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2015,7 +2015,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2081,7 +2081,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2147,7 +2147,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2213,7 +2213,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2279,7 +2279,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2345,7 +2345,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2411,7 +2411,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2477,7 +2477,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2543,7 +2543,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2609,7 +2609,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2675,7 +2675,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2741,7 +2741,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2807,7 +2807,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2873,7 +2873,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2939,7 +2939,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3004,7 +3004,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3077,7 +3077,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3146,7 +3146,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3215,7 +3215,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3284,7 +3284,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3353,7 +3353,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3420,7 +3420,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3497,7 +3497,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3586,7 +3586,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3669,7 +3669,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3752,7 +3752,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3835,7 +3835,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3918,7 +3918,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4498,7 +4498,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4594,7 +4594,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4706,7 +4706,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4809,7 +4809,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4912,7 +4912,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5016,7 +5016,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5119,7 +5119,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5233,7 +5233,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.pod.hostNetwork != true
     docs:
       desc: |
@@ -5298,7 +5298,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.cronjob.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5371,7 +5371,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.statefulset.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5440,7 +5440,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5509,7 +5509,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.job.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5578,7 +5578,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.replicaset.podSpec['hostNetwork'] != true
     docs:
@@ -5648,7 +5648,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostNetwork'] != true
     docs:
@@ -5718,7 +5718,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.pod.hostPID != true
     docs:
       desc: |
@@ -5781,7 +5781,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.cronjob.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5852,7 +5852,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.statefulset.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5919,7 +5919,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5986,7 +5986,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.job.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -6053,7 +6053,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.replicaset.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -6120,7 +6120,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostPID'] != true
     docs:
@@ -6188,7 +6188,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.pod.hostIPC != true
     docs:
@@ -6252,7 +6252,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.cronjob.podSpec['hostIPC'] != true
     docs:
@@ -6324,7 +6324,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.statefulset.podSpec['hostIPC'] != true
     docs:
@@ -6392,7 +6392,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostIPC'] != true
     docs:
       desc: |
@@ -6448,7 +6448,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.job.podSpec['hostIPC'] != true
     docs:
@@ -6505,7 +6505,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.replicaset.podSpec['hostIPC'] != true
     docs:
@@ -6562,7 +6562,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostIPC'] != true
     docs:
@@ -6608,7 +6608,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6698,7 +6698,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6804,7 +6804,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6902,7 +6902,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7000,7 +7000,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7098,7 +7098,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7196,7 +7196,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7834,16 +7834,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -7900,16 +7900,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -7974,16 +7974,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8044,16 +8044,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8114,16 +8114,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8184,16 +8184,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8254,16 +8254,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8324,16 +8324,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8392,16 +8392,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8457,16 +8457,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8529,16 +8529,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8601,16 +8601,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8673,16 +8673,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8745,16 +8745,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8817,7 +8817,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -8901,7 +8901,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -8985,7 +8985,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9069,7 +9069,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9153,7 +9153,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9237,7 +9237,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9321,7 +9321,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9409,7 +9409,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9470,7 +9470,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9531,7 +9531,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9582,7 +9582,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9643,7 +9643,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9703,7 +9703,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9764,7 +9764,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11578,7 +11578,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11678,7 +11678,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11774,7 +11774,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
@@ -12316,7 +12316,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -9344,7 +9344,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       sudoers.defaults.where(parameter == "logfile").any(value == "/var/log/sudo.log")
     docs:
@@ -9473,7 +9473,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/ssh/sshd_config") {
         user.name == "root"
@@ -10363,7 +10363,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
@@ -10482,7 +10482,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
@@ -12982,7 +12982,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/passwd") {
         permissions.user_executable == false
@@ -13084,7 +13084,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/shadow").exists) {
         file("/etc/shadow") {
@@ -13208,7 +13208,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       file("/etc/group") {
         permissions.user_executable == false
@@ -13303,7 +13303,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/gshadow").exists) {
         file("/etc/gshadow") {
@@ -13418,7 +13418,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/passwd-").exists) {
         file("/etc/passwd-") {
@@ -13528,7 +13528,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/shadow-").exists) {
         file("/etc/shadow-") {
@@ -13661,7 +13661,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/group-").exists) {
         file("/etc/group-") {
@@ -13778,7 +13778,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/etc/gshadow-").exists) {
         file("/etc/gshadow-") {
@@ -13894,7 +13894,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       users.list.duplicates(uid).none()
     docs:
@@ -13953,7 +13953,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       users.list.duplicates(name).none()
     docs:
@@ -14012,7 +14012,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       groups.list.duplicates(gid).none()
     docs:
@@ -14071,7 +14071,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       groups.list.duplicates(name).none()
     docs:
@@ -14785,7 +14785,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     filters: |
       asset.kind != "container-image"
       pam.conf.exists
@@ -14921,7 +14921,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       selinux.mode == "enforcing"
     docs:
@@ -15007,7 +15007,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       selinux.configMode == "enforcing"
     docs:

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -15303,7 +15303,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -72,7 +72,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       if (file("/boot/grub/grub.cfg").exists) {
         file("/boot/grub/grub.cfg") {

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -2076,7 +2076,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -2177,7 +2177,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -2274,7 +2274,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -2915,7 +2915,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       sudoers.defaults.where(parameter == "timestamp_timeout") != empty
       sudoers.defaults.where(parameter == "timestamp_timeout").all(value == "0")

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -642,7 +642,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45

--- a/content/mondoo-nextdns-security.mql.yaml
+++ b/content/mondoo-nextdns-security.mql.yaml
@@ -61,7 +61,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -131,7 +131,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-21
@@ -201,7 +201,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -271,7 +271,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -341,7 +341,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -411,7 +411,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -481,7 +481,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-23
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: false
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -551,7 +551,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
@@ -691,7 +691,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
       compliance/iso-27001-2022: iso-27001-2022-a-8-7
-      compliance/nis-2: nis-2-21-1
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-4
       compliance/nist-csf-2: nist-csf-2-de-cm-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -575,7 +575,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-b
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
@@ -918,7 +918,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-2

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -165,7 +165,7 @@ queries:
     title: Ensure encryption-in-transit is enabled on clusters
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a11
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
@@ -233,7 +233,7 @@ queries:
     title: Ensure clusters use an external key management server
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-08
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -9644,7 +9644,7 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-23
-      compliance/nis-2: nis-2-21-2-f
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
@@ -9732,7 +9732,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-32
-      compliance/nis-2: nis-2-21-2-f
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-3

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -798,7 +798,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-oci-security-object-storage-buckets-versioning-enabled-oci
         tags:
@@ -1877,7 +1877,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-oci-security-object-storage-buckets-replication-enabled-oci
         tags:
@@ -2026,7 +2026,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-oci-security-object-storage-archive-buckets-versioning-oci
         tags:

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -1473,7 +1473,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1582,7 +1582,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
@@ -1689,7 +1689,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1796,7 +1796,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1903,7 +1903,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2010,7 +2010,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2118,7 +2118,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2226,7 +2226,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2334,7 +2334,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2442,7 +2442,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2550,7 +2550,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2658,7 +2658,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2766,7 +2766,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -2874,7 +2874,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
@@ -2982,7 +2982,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-7
@@ -3090,7 +3090,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -3198,7 +3198,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -3307,7 +3307,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: nis-2-21-2-g
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -220,7 +220,7 @@ queries:
     title: Ensure Keystone users have multi-factor authentication enabled
     impact: 85
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -709,7 +709,7 @@ queries:
     title: Ensure compute servers have at least one security group attached
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1916,7 +1916,7 @@ queries:
     title: Ensure Neutron ports have port security enabled
     impact: 85
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2036,7 +2036,7 @@ queries:
     title: Ensure Cinder block-storage volumes are encrypted at rest
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -3848,7 +3848,7 @@ queries:
     impact: 80
     filters: asset.platform == "openstack-project"
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a11
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
@@ -3913,7 +3913,7 @@ queries:
     title: Ensure application credentials do not grant the admin role
     impact: 85
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a12
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4254,7 +4254,7 @@ queries:
     title: Ensure ports have no allowed address pair open to all addresses
     impact: 75
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -943,7 +943,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -1030,7 +1030,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-5
@@ -1194,7 +1194,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
@@ -1297,7 +1297,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
@@ -1645,7 +1645,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
@@ -1814,7 +1814,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-3
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1907,7 +1907,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
@@ -1990,7 +1990,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-22
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
@@ -2749,7 +2749,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-d
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ip-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -682,7 +682,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: false
       compliance/iso-27001-2022: false
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-j
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: false
@@ -779,7 +779,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -894,7 +894,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
@@ -1107,7 +1107,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-5-17
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-i
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
@@ -1174,7 +1174,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-16
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-3
@@ -1270,7 +1270,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-5-16
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-7
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-3
@@ -1370,7 +1370,7 @@ queries:
       compliance/dora: false
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-18
-      compliance/nis-2: false
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -573,7 +573,7 @@ queries:
     title: Ensure regular users cannot browse volume contents
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a12
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -170,7 +170,7 @@ queries:
     title: Ensure two-factor authentication is configured
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -308,7 +308,7 @@ queries:
     title: Ensure the Administrator role is assigned sparingly
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a12
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -547,7 +547,7 @@ queries:
     title: Ensure SSH root login is key-only (Proxmox-adapted)
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -660,7 +660,7 @@ queries:
     title: Ensure SSH password authentication is disabled
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
@@ -998,7 +998,7 @@ queries:
     title: Ensure cluster firewall is enabled
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1154,7 +1154,7 @@ queries:
     title: Ensure firewall default input policy is DROP
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1308,7 +1308,7 @@ queries:
     title: Ensure host firewall is enabled on each node
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1408,7 +1408,7 @@ queries:
     title: Ensure at least one firewall rule is configured
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1548,7 +1548,7 @@ queries:
     title: Ensure PVE uses a trusted TLS certificate (not cluster-internal CA)
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a26
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1679,7 +1679,7 @@ queries:
     title: Ensure TLS certificate does not expire within 30 days
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a26
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-12
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -1821,7 +1821,7 @@ queries:
     title: Ensure all LXC containers are unprivileged
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1953,7 +1953,7 @@ queries:
     title: Ensure container nesting is disabled
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2100,7 +2100,7 @@ queries:
     title: Ensure containers do not disable AppArmor
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2211,7 +2211,7 @@ queries:
     title: Ensure container network interfaces have firewall enabled
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -2341,7 +2341,7 @@ queries:
     title: Ensure containers do not allow mknod
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2485,7 +2485,7 @@ queries:
     title: Ensure containers do not allow FUSE mounts
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2756,7 +2756,7 @@ queries:
     title: Ensure VMs have Spectre/Meltdown CPU mitigations
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -2915,7 +2915,7 @@ queries:
     title: Ensure VM network interfaces have firewall enabled
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3043,7 +3043,7 @@ queries:
     title: Ensure VMs do not use raw QEMU arguments
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -3167,7 +3167,7 @@ queries:
     title: Ensure Corosync cluster communication is encrypted
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a11
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3374,7 +3374,7 @@ queries:
     title: Ensure live migration traffic is encrypted
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a11
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3475,7 +3475,7 @@ queries:
     title: Ensure VLAN segmentation is used
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a4
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
@@ -3623,7 +3623,7 @@ queries:
     title: Ensure PBS backups are encrypted
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -3748,7 +3748,7 @@ queries:
     title: Ensure PBS master key is configured
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-20
       compliance/dora: dora-art-12
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
@@ -3890,7 +3890,7 @@ queries:
     title: Ensure Kernel Samepage Merging (KSM) is disabled
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -4014,7 +4014,7 @@ queries:
     title: Ensure PCI ACS override is not enabled
     impact: 90
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -4146,7 +4146,7 @@ queries:
     title: Ensure IOMMU is enabled for PCI passthrough isolation
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -1373,7 +1373,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     variants:
       - uid: mondoo-snowflake-security-databases-retention-configured-snowflake
         tags:

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -1642,7 +1642,7 @@ queries:
     filters: asset.platform == 'tailscale'
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-lo-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15

--- a/content/mondoo-unifi-security.mql.yaml
+++ b/content/mondoo-unifi-security.mql.yaml
@@ -1820,7 +1820,7 @@ queries:
       compliance/nist-sp-800-171: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
-      compliance/vda-isa-5: false
+      compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
       unifi.controller.autobackupEnabled == true
     docs:
@@ -1871,7 +1871,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     variants:
       - uid: mondoo-unifi-security-auto-upgrade-enabled-unifi
         tags:
@@ -2627,7 +2627,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-1
-      compliance/vda-isa-5: vda-isa-5-5-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       unifi.devices.all(upgradable == false && semver(version) >= semver(requiredVersion))
     docs:

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -75,7 +75,7 @@ queries:
     title: Ensure account lockout is set to 15 minutes
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
@@ -486,7 +486,7 @@ queries:
     title: Ensure idle ESXi shell and SSH sessions time out after 300 seconds or less
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
@@ -1296,7 +1296,7 @@ queries:
     title: Ensure the DCUI timeout is set to 600 seconds or less
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a25
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
@@ -1366,7 +1366,7 @@ queries:
     title: Ensure the default value of individual salt per vm is configured
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a22
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: false
@@ -1512,7 +1512,7 @@ queries:
     title: Ensure the ESXi host SSL certificate is not expired or expiring soon
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a26
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
@@ -1727,7 +1727,7 @@ queries:
     title: Ensure the maximum failed login attempts is set to 5
     impact: 80
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-308-a-5-ii-c-security-awareness-training-and-tools-log-in-monitoring
@@ -1801,7 +1801,7 @@ queries:
     title: Ensure the shell services timeout is set to 1 hour or less
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a5
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -95,7 +95,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
@@ -187,7 +187,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -291,7 +291,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -392,7 +392,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -497,7 +497,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -602,7 +602,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -707,7 +707,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -812,7 +812,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -917,7 +917,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1022,7 +1022,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1126,7 +1126,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1231,7 +1231,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1335,7 +1335,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1439,7 +1439,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-5
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1546,7 +1546,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1621,7 +1621,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-10
@@ -1724,7 +1724,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -1803,7 +1803,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -1908,7 +1908,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2013,7 +2013,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4
@@ -2116,7 +2116,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2221,7 +2221,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
@@ -2315,7 +2315,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -2407,7 +2407,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -2499,7 +2499,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2604,7 +2604,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2709,7 +2709,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2814,7 +2814,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -2919,7 +2919,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -3024,7 +3024,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -3131,7 +3131,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -3201,7 +3201,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -3271,7 +3271,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -3353,7 +3353,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -3435,7 +3435,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-2
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-41
@@ -3503,7 +3503,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -3608,7 +3608,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -3781,7 +3781,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-6
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
@@ -3875,7 +3875,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -3976,7 +3976,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -4077,7 +4077,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -4178,7 +4178,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
@@ -4279,7 +4279,7 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15
-      compliance/nis-2: nis-2-21-2-a
+      compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-1
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-4

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -1616,7 +1616,7 @@ queries:
     title: Ensure only one remote console connection is permitted to a VM at any time
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a25
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -1719,7 +1719,7 @@ queries:
     title: Ensure PCI and PCIe device pass-through is disabled
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2310,7 +2310,7 @@ queries:
     title: Ensure unauthorized connection of devices is disabled
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -2402,7 +2402,7 @@ queries:
     title: Ensure unauthorized modification and disconnection of devices is disabled
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3126,7 +3126,7 @@ queries:
     title: Ensure unnecessary CD/DVD devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3196,7 +3196,7 @@ queries:
     title: Ensure unnecessary floppy devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3266,7 +3266,7 @@ queries:
     title: Ensure unnecessary parallel ports are disconnected
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3348,7 +3348,7 @@ queries:
     title: Ensure unnecessary serial ports are disconnected
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -3430,7 +3430,7 @@ queries:
     title: Ensure unnecessary USB devices are disconnected
     impact: 60
     tags:
-      compliance/bsi-sys-1-5: bsi-sys-1-5-a23
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a3
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
@@ -5365,7 +5365,7 @@ queries:
     title: Ensure vSAN data-in-transit encryption is enabled
     impact: 70
     tags:
-      compliance/bsi-sys-1-5: false
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -152,7 +152,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       secpol.privilegerights['SeDebugPrivilege'] == empty
     docs:
@@ -737,7 +737,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System', name: 'LocalAccountTokenFilterPolicy' ).data == 0
     docs:
@@ -5093,7 +5093,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       secpol.systemaccess['LSAAnonymousNameLookup'] == 0
     docs:
@@ -5190,7 +5190,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RestrictAnonymousSAM' ).data == 1
     docs:
@@ -5287,7 +5287,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'RestrictAnonymous' ).data == 1
     docs:
@@ -5481,7 +5481,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa', name: 'EveryoneIncludesAnonymous' ).data == 0
     docs:
@@ -5575,7 +5575,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none-dc
         tags:
@@ -5709,7 +5709,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'RestrictNullSessAccess' ).data == 1
     docs:
@@ -5822,7 +5822,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa', name: 'restrictremotesam' ).data == 'O:BAG:BAD:(A;;RC;;;BA)'
     docs:
@@ -5930,7 +5930,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-1-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionShares' ).data == empty
     docs:


### PR DESCRIPTION
Corrects `compliance/*` tags on security checks for three European frameworks, following an audit of all 2604 tagged checks. **Tags only** — 473 insertions, 473 deletions, all one-for-one swaps on `compliance/` lines. No check text, query, or docs modified.

`content/*.mql.yaml` is the source of truth here: the enterprise repo generates `frameworks/maps/*/cnspec.mql.yaml` from these tags via `utils/cnspec_compliance_mapping.py`, so that map should be regenerated after this merges.

## How each change was justified

Every change cites either the control's own text or the repo's **curated control-to-control maps**, which both `nis-2` and `vda-isa-5` already activate via `dependencies: iso-27001-2022` but which the per-check tags had drifted away from:

- `frameworks/maps/nis-2/iso-27001-2022.mql.yaml`
- `frameworks/maps/vda-isa-5/iso-27001-2022.mql.yaml`

Where the direct tag and the curated ISO path disagreed, the curated path wins. No tag was changed by copying a neighbouring check.

## Review commit-by-commit

Each commit is one framework and carries its full rationale.

| commit | framework | changes |
|---|---|---|
| `ded1f08` | bsi-sys-1-5 | 54 |
| `edaa5f2` | nis-2 | 124 |
| `aafc2a0` | vda-isa-5 | 295 |

### bsi-sys-1-5 (BSI IT-Grundschutz SYS.1.5 Virtualisierung)
The ~2500 `false` tags are **correct** and stay — it is a narrow virtualization module and most of the corpus is genuinely out of scope. Two real problems fixed:
- **proxmox-security 0/46 and openstack-security 0/35 were entirely unmapped.** Proxmox VE is a KVM/LXC virtualization server. A22 names Mandatory Access Controls explicitly while "Ensure containers do not disable AppArmor" was `false`.
- **The one sentence in A23 that names a mechanism had no check on it.** A23: *"Virtuelle IT-Systeme SOLLTEN NICHT die sogenannten Pages des Arbeitsspeichers teilen."* The ESXi page-sharing salt sat on A22; the Proxmox KSM check was `false`. Both now on A23.
- A23 (erhöhter Schutzbedarf) had absorbed device-passthrough checks that **A3 covers as a Basis MUSS**. Tier placement drives what is required at normal protection level.
- **A25 was unused** while its evidence sat on A23 and `false`.

### nis-2
- **21.2(a)** inherits A.5.1/A.5.2/A.5.7/A.5.12/A.5.37 (policies, roles, threat intel, classification, procedures) but held 44 vSphere VM-hardening checks. Now correctly empty.
- **21.2(d)** supply chain inherits A.5.19-A.5.23 but held firewall rulebases. Genuine supply-chain checks (approved registries, image signing, digest pinning, M365 app consent) stay.
- **21.1** is the Article chapeau — an obligation on Member States, not a measure holding evidence.
- **21.2(f)** held 2 preventive guardrails while the posture-assessment family it describes was split across (b) and (e).
- 19 `false` tags that were omissions: mapped in up to 11 other frameworks, several to ISO controls NIS2 already inherits.

### vda-isa-5
- **4.1.1** ("use of identification means" — keys, badges, cryptographic tokens; ISO map A.5.18 alone) had become the framework's largest access-control bucket at 186 checks, including 90 Kubernetes privilege checks and `/etc/passwd` permissions. Drained to 4.2.1; only genuine token/certificate/device-key lifecycle checks remain.
- **`false` was decided by cloud provider, not control text.** "Ensure RDS DB instances have backup retention enabled" was `false` while its GCP twin was on 3.1.2. 24 branch-protection checks were `false` while 5.2.1 Should-Have is literally *"A formal approval procedure is established"*.
- The 38-check ai-security shadow-IT family was `false` while 1.3.3, the approved-external-IT-services control, held 5 checks.

## Deliberately not changed

- **nis-2 21.3 stays unmapped.** Its text is an obligation to take *suppliers'* secure development procedures into account, not to run your own SDLC — so own-repo branch protection does not belong there, despite the ISO map routing it to A.8.25-A.8.27.
- **vda-isa-5 5.2.6** still holds ~150 network/host hardening checks that are not audit-programme evidence (ISO map: A.5.36). The OCI and Kubernetes subsets need per-check review rather than a blanket move.
- **Proxmox host-OS Linux hardening** (sysctl, cron permissions, password aging) stays `false` on SYS.1.5 — that is SYS.1.1/SYS.1.3 territory.
- The Kubernetes CPU/memory-limit rows also carry CSA IAM-04, HIPAA access-control and PCI 7.2.1 tags that look like the same copied row. Out of scope here; those frameworks were not audited.

## Known architectural issues this does NOT fix

These need a design decision, not a tag edit:

1. **NIS2 is too coarse to be a per-check tag target.** Article 21.2 has ten outcome categories; 21.2(e) now holds 942 checks. This PR makes the tags internally consistent, but the honest fix is to retire `compliance/nis-2` as a per-check tag and let NIS2 inherit through the curated ISO map that already exists. Two independent control-to-evidence paths currently coexist and can drift apart again.
2. **bsi-sys-1-5 is one Grundschutz building block shipped alongside 12 full frameworks.** Forcing a 28-control module through a per-check boolean generates ~2500 permanent "not applicable" rows, and `false` means something different here (out of scope) than it does for a full framework (no matching control). A platform-scoped filter would fit better. Note `maps/bsi-grundschutz-sys15/` already maps it onto CIS ESXi policies — the right shape for a module.
3. **vda-isa-5 chapter 9** (`vda-isa-5-9-1` .. `-9-4`, Data Protection) is declared as groups with titles but no controls — dead scaffolding that will render as four empty sections.

## Verification

- `go test ./content/...` passes
- `cnspec policy lint` clean on all touched bundles
- All 473 tag values verified to reference controls that exist in the framework definitions (0 phantom references)
- Diff contains zero non-`compliance/` line changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)