### PR TITLE
✨ aws/oci: map 5 cloud AI checks to NIST AI 100-1

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -11738,6 +11738,7 @@ queries:
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-26
       compliance/nis-2: false
+      compliance/nist-ai-100-1: nist-ai-100-1-measure-2-7
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-10
@@ -11813,6 +11814,7 @@ queries:
       compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-12
       compliance/nis-2: false
+      compliance/nist-ai-100-1: nist-ai-100-1-measure-2-10
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
@@ -11888,6 +11890,7 @@ queries:
       compliance/hipaa: false
       compliance/iso-27001-2022: false
       compliance/nis-2: false
+      compliance/nist-ai-100-1: nist-ai-100-1-measure-2-6
       compliance/nist-csf-1: false
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false


### PR DESCRIPTION
Maps 5 of the 58 cloud AI-service checks to NIST AI 100-1 (AI RMF 1.0). **The headline is what is *not* mapped.**

## The surface

The cloud policies carry 58 base AI/ML-service checks (excluding Terraform/CloudFormation/Bicep variants), none of which map to AI RMF — the framework written for exactly this surface:

| Policy | Checks | Families |
|---|---|---|
| `mondoo-aws-security` | 29 | SageMaker (26), Bedrock (3) |
| `mondoo-gcp-security` | 17 | Vertex AI |
| `mondoo-azure-security` | 7 | Cognitive Services (5), Databricks (2) |
| `mondoo-oci-security` | 5 | GenAI (4), Data Science (1) |

## Why only 5

53 of the 58 are the same encryption-at-rest, VPC/private-endpoint, IAM least-privilege and secrets-hygiene controls these policies apply to **every** cloud resource, with an AI service name attached. They are already carried by ISO 27001 A.8.24, NIST 800-53 SC-7/SC-28/AC-6 and the other 11 frameworks. Tagging them AI RMF would inflate AI-RMF coverage without evidencing AI risk management — the same failure mode as the 4 Arista doc-hygiene checks that claim 12 of 13 frameworks for assertions with no security property.

Rejected in bulk: 14 CMK/CMEK encryption-at-rest · 20 network isolation/private endpoint/no-public-IP · 10 IAM and authentication · 4 secrets management · 2 in-transit encryption · 3 host hardening.

## The 5, with control text

| Check | Control(s) | Basis |
|---|---|---|
| `oci…genai-endpoint-prompt-injection-detection` | `measure-2-7` | *"AI system security and resilience … are evaluated and documented"* — prompt injection has no non-AI analogue |
| `oci…genai-endpoint-pii-detection` | `measure-2-10` | *"Privacy risk of the AI system … is examined and documented"* — inspects prompts/responses, not storage |
| `oci…genai-endpoint-content-moderation` | `measure-2-6` | *"demonstrated to be safe … and it can fail safely"* |
| `aws…sagemaker-hub-public-content-documented` | `map-4-1` | *"mapping AI technology and legal risks of its components — including the use of third-party data or software — are … documented"* |
| `aws…sagemaker-model-package-approval-validated` | `manage-1-1`, `measure-2-5` | *"demonstrated to be valid and reliable"* / recorded determination whether deployment *"should proceed"* |

The two SageMaker checks are the only ones in the entire corpus that assert a documented human review of a pre-trained model — the closest thing to what AI RMF actually asks for.

## Method

Two independent reviewers (a strict compliance auditor and an AI-security SME) judged all 58 against the verbatim control text, instructed to default to NO. They converged on these 5. **This PR takes the intersection of their control sets, not the union** — so `measure-2-4` (proposed by one reviewer on the three OCI guardrails) and `manage-3-1`/`manage-3-2` (proposed by the other on hub-content) are deliberately omitted.

## Open question for review

`gcp…vertexai-index-endpoint-not-public` is the one genuine disagreement — one reviewer proposed `measure-2-7` (vector index endpoints enable embedding-inversion and membership-inference), the other rejected it as SC-7 perimeter hygiene. **Excluded here.** The deciding argument: the same reviewer rejected `vertexai-endpoint-private-service-connect`, yet a model-serving endpoint is a model-extraction surface just as much as an index endpoint is an inversion surface. That line is arbitrary, and arbitrary lines are how over-mapping starts. Happy to add it if you read it the other way.

## Honest caveat

AI RMF MEASURE/MANAGE controls are phrased as *"evaluated and documented"* **processes**. These checks evidence that a technical control is in place, not that an evaluation was performed — partial evidence toward a control, never full satisfaction. The two documentation checks assert non-empty free text, which a user can satisfy by typing "x".

## Depends on

- mondoohq/cnspec-enterprise-policies#3004 — comma-separated control uids, needed for the two-control value on `model-package-approval-validated`
- Independent of mondoohq/cnspec#3071 (endpoint AI tags); either can land first

## Verification

- `cnspec policy lint` → valid on both files
- All 6 control uids resolve against `nist-ai-100-1.mql.yaml` — no dangling refs
- Diff purely additive: 5 insertions, 0 deletions
- Generated map: 6 controls / 6 edges; the other 12 framework maps regenerate byte-identical
- Combined with #3071: 9 controls, 51 edges, 3 policy dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)