### PR TITLE
🐛 kubernetes-security: fix compliance tag rows deferred from #3073

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -358,7 +358,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       kubelet.configuration['makeIPTablesUtilChains'] == true
     docs:
@@ -442,7 +442,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       kubelet.configuration['readOnlyPort'] == 0 || kubelet.configuration['readOnlyPort'] == null
     docs:
@@ -472,7 +472,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -671,7 +671,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -771,7 +771,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -871,7 +871,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -969,7 +969,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1066,7 +1066,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1164,7 +1164,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1262,7 +1262,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1360,7 +1360,7 @@ queries:
     impact: 65
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1547,7 +1547,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1616,7 +1616,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1685,7 +1685,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1751,7 +1751,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1817,7 +1817,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1883,7 +1883,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -1949,7 +1949,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2015,7 +2015,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2081,7 +2081,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2147,7 +2147,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2213,7 +2213,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2279,7 +2279,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2345,7 +2345,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2411,7 +2411,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2477,7 +2477,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2543,7 +2543,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2609,7 +2609,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2675,7 +2675,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2741,7 +2741,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2807,7 +2807,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2873,7 +2873,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-3
@@ -2939,7 +2939,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3004,7 +3004,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3077,7 +3077,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3146,7 +3146,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3215,7 +3215,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3284,7 +3284,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3353,7 +3353,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3420,7 +3420,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3497,7 +3497,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3586,7 +3586,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3669,7 +3669,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3752,7 +3752,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3835,7 +3835,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -3918,7 +3918,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4498,7 +4498,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4594,7 +4594,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4706,7 +4706,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4809,7 +4809,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -4912,7 +4912,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5016,7 +5016,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5119,7 +5119,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -5233,7 +5233,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.pod.hostNetwork != true
     docs:
       desc: |
@@ -5298,7 +5298,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.cronjob.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5371,7 +5371,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.statefulset.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5440,7 +5440,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5509,7 +5509,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.job.podSpec['hostNetwork'] != true
     docs:
       desc: |
@@ -5578,7 +5578,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.replicaset.podSpec['hostNetwork'] != true
     docs:
@@ -5648,7 +5648,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostNetwork'] != true
     docs:
@@ -5718,7 +5718,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.pod.hostPID != true
     docs:
       desc: |
@@ -5781,7 +5781,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.cronjob.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5852,7 +5852,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.statefulset.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5919,7 +5919,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -5986,7 +5986,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.job.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -6053,7 +6053,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.replicaset.podSpec['hostPID'] != true
     docs:
       desc: |
@@ -6120,7 +6120,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostPID'] != true
     docs:
@@ -6188,7 +6188,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.pod.hostIPC != true
     docs:
@@ -6252,7 +6252,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.cronjob.podSpec['hostIPC'] != true
     docs:
@@ -6324,7 +6324,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.statefulset.podSpec['hostIPC'] != true
     docs:
@@ -6392,7 +6392,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: k8s.deployment.podSpec['hostIPC'] != true
     docs:
       desc: |
@@ -6448,7 +6448,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.job.podSpec['hostIPC'] != true
     docs:
@@ -6505,7 +6505,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.replicaset.podSpec['hostIPC'] != true
     docs:
@@ -6562,7 +6562,7 @@ queries:
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
-      compliance/vda-isa-5: vda-isa-5-5-2-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       k8s.daemonset.podSpec['hostIPC'] != true
     docs:
@@ -6608,7 +6608,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6698,7 +6698,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6804,7 +6804,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -6902,7 +6902,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7000,7 +7000,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7098,7 +7098,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7196,7 +7196,7 @@ queries:
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -7834,16 +7834,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -7900,16 +7900,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -7974,16 +7974,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8044,16 +8044,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8114,16 +8114,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8184,16 +8184,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8254,16 +8254,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8324,16 +8324,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8392,16 +8392,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8457,16 +8457,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8529,16 +8529,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8601,16 +8601,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8673,16 +8673,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8745,16 +8745,16 @@ queries:
     impact: 20
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-02
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/hipaa: false
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
       compliance/nis-2: nis-2-21-2-c
       compliance/nist-csf-1: nist-csf-1-pr-ds-4
       compliance/nist-csf-2: nist-csf-2-pr-ir-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-6
       compliance/nist-sp-800-171: false
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
     mql: |
@@ -8817,7 +8817,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -8901,7 +8901,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -8985,7 +8985,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9069,7 +9069,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9153,7 +9153,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9237,7 +9237,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9321,7 +9321,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9409,7 +9409,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9470,7 +9470,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9531,7 +9531,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9582,7 +9582,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9643,7 +9643,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9703,7 +9703,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -9764,7 +9764,7 @@ queries:
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11578,7 +11578,7 @@ queries:
     impact: 100
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11678,7 +11678,7 @@ queries:
     impact: 90
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2
@@ -11774,7 +11774,7 @@ queries:
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-6
@@ -12316,7 +12316,7 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
       compliance/iso-27001-2022: iso-27001-2022-a-8-2

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -1642,7 +1642,7 @@ queries:
     filters: asset.platform == 'tailscale'
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-lo-04
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-04
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-15


### PR DESCRIPTION
> **Stacked on #3073.** Base is `fix/compliance-tag-mapping-corrections`, not `main` — these changes touch adjacent lines in the same tag blocks. Merge #3073 first; this will retarget to `main` automatically.

Closes the two Kubernetes items deferred from #3073, after deep-dive validating each tag against the actual framework definitions rather than against my earlier assertion. **Tags only** — 142 insertions, 142 deletions, all one-for-one. No check text, query, or docs modified.

## The deep dive corrected my own audit

#3073's notes claimed the CPU/memory limit rows were broadly wrong and that *"only its ISO tag (A.8.6 capacity management) is right."* **That was an overstatement.** Reading the actual control text:

| tag | control text | verdict |
|---|---|---|
| `nist-sp-800-53-rev5-sc-6` | "Resource Availability — Protect the availability of resources by allocating [resources] by [priority; **quota**]" | ✅ correct, left alone |
| `nist-csf-1-pr-ds-4` | "Adequate capacity to ensure availability is maintained" | ✅ correct, left alone |
| `nist-csf-2-pr-ir-04` | "Adequate resource capacity to ensure availability is maintained" | ✅ correct, left alone |
| `iso-27001-2022-a-8-6` | "Capacity management" | ✅ correct, left alone |
| `csa ... iam-04` | "Separation of Duties" | ❌ → `ivs-02` |
| `hipaa ... 164-312-a-1` | "Access Control" | ❌ → `false` |
| `pcidss-requirement-7-2-1` | "An access control model is defined" | ❌ → `false` |

4 of the 7 substantive tags were already right. Only 3 needed fixing. Good reminder that "this row looks copied" is a hypothesis, not a finding.

## What changed

The k8s tag rows turned out to be **internally coherent**, not randomly copied — which makes each defect precise: on each row, exactly one framework disagrees with all the others.

**1. CSA `iam-04` → `iam-05` (76 checks).** `iam-04` is *"Separation of Duties: Employ the separation of duties principle when implementing information system access."* None of these checks test duty segregation — they're privileged containers, `runAsNonRoot`, `allowPrivilegeEscalation`, NET_RAW/SYS_ADMIN capabilities, runtime socket mounts, control-plane file permissions, default service accounts. **Every other framework on the same rows already says least privilege**: ISO A.8.2, AC-6 ("Least Privilege"), 800-171 3.1.5, PR.AC-4. `iam-05` is *"Least Privilege"* verbatim. CSA was the lone dissenter.

**2. Capacity family (14 checks × 3 tags).** `iam-04`→`ivs-02` *"Capacity and Resource Planning"* (exact match, and agrees with the row's already-correct SC-6/A.8.6/PR.DS-4/PR.IR-04). HIPAA and PCI → `false`: I verified **HIPAA has no capacity/availability standard and PCI DSS 4.0 has zero controls matching capacity/resource-availability/DoS**, so there is nothing to map to. SOC2 has only the Common Criteria here (no A1 availability series), so `cc9-1-1` stays as the closest fit.

**3. VDA `5.2.6` → `5.2.7` (23 checks).** All 23 already carry ISO A.8.20 or A.8.22, and `maps/vda-isa-5/iso-27001-2022.mql.yaml` routes **5.2.7 → A.8.20 + A.8.22** exactly. Closes the Kubernetes half of the 5.2.6 item deferred in #3073.

**4. Phantom control reference (separate commit).** `cloud-controls-matrix-4-lo-04` doesn't exist — the CSA domain prefix is `log-`. Pre-existing on `main`; the generated map has been emitting an entry pointing at a nonexistent control. Fixed to `log-04` "Audit Logs Access and Accountability", preserving intent (the rest of that row is unambiguously logging: ISO A.8.15, AU-6, PCI 10.2.1, HIPAA audit controls).

## ⚠️ Follow-up needed: `iam-04` is left in a split state

The identical `iam-04` defect exists in **88 checks across 18 other policies** — same copied access-control row, same wrong control:

```
15 linux-security     11 freebsd-security   10 windows-security    8 gitlab-security
 6 aws-security        6 junos-security      5 chef-infra-client   5 chef-infra-server
 4 dockerfile-security 3 arista-eos-security 3 cisco-iosxr-security 3 github-security
 2 azure-security      2 cisco-iosxe-security 2 cisco-nxos-security 1 bigip-security
 1 linux-workstation-security                1 macos-security
```

I scoped this PR to `kubernetes-security` as asked, but that leaves `iam-04` and `iam-05` both holding least-privilege checks — arguably worse than uniform wrongness. **Recommend a follow-up applying the same `iam-04`→`iam-05` rule to those 88**, which is a one-line predicate change. Worth checking in that pass whether *any* check legitimately belongs on `iam-04`: candidates are aws "IAM users receive permissions only through groups" and azure "custom roles do not allow role creation". If none do, `iam-04` should end up empty.

Also spotted, not fixed here (belongs with the deferred 5.3.1 review): tailscale "exports the configuration audit log" carries `vda-isa-5-5-3-1` ("new or further developed IT systems"), but its ISO A.8.15 tag points at 5.2.4 ("event logs recorded and analyzed").

## Verification

- `go test ./content/...` passes
- `cnspec policy lint` clean
- **All 30,025 control references across all 13 frameworks resolve — 0 phantom refs** (was 1 before this PR)
- Diff contains zero non-`compliance/` line changes
- Change count reconciles exactly: 76 + 14 + 14 + 14 + 23 = 141, plus 1 typo = 142

🤖 Generated with [Claude Code](https://claude.com/claude-code)