### PR TITLE
🐛 ci: unblock tflint plugin install after GitHub attestation API change

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -134,7 +134,10 @@ jobs:
       - name: Set up tflint
         uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6.3.0
         with:
-          tflint_version: v0.61.0
+          # Keep at the latest release. Note that the `signature` attribute the
+          # validator sets on ruleset plugins needs >= 0.62; v0.61.0 and earlier
+          # silently ignore it.
+          tflint_version: v0.63.1
 
       - name: Validate terraform remediation blocks
         env:

--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -223,6 +223,17 @@ def write_tflint_config(tmp_dir: Path, providers: set[str]) -> None:
             lines.append(f'  enabled = true\n')
             lines.append(f'  version = "{version}"\n')
             lines.append(f'  source  = "{source}"\n')
+            # TEMPORARY (2026-07-17): pinned to PGP because the default "auto"
+            # verification crashes. GitHub removed the `bundle` field from
+            # attestation API responses, so `tflint --init` nil-derefs in
+            # sigstore-go while verifying the ruleset and never reaches the
+            # lint stage. Upstream fix: terraform-linters/tflint#2593
+            # (unreleased). "pgp" still verifies the plugin cryptographically
+            # via the legacy signing key -- it is NOT "none", which would skip
+            # verification entirely. Requires tflint >= 0.62; 0.61 and earlier
+            # silently ignore this attribute. REVERT (delete this line) once
+            # #2593 ships -- attestations verify provenance, PGP only signing.
+            lines.append('  signature = "pgp"\n')
             lines.append('}\n')
 
     (tmp_dir / ".tflint.hcl").write_text("".join(lines))


### PR DESCRIPTION
## Problem

Every PR touching `content/` is currently blocked — the `validate-terraform` job fails before it lints a single line of HCL. Example: [run on #3074](https://github.com/mondoohq/cnspec/actions/runs/29578064903/job/87876995050).

**The cause is outside this repo.** GitHub removed the `bundle` property from attestation list responses, and the removal reached the `2022-11-28` API version that tflint pins ([documented breaking change](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes)). The endpoint now returns `"bundle": null` alongside a new `bundle_url`. Go's `json.Unmarshal` puts the `null` into a `*bundle.Bundle` as a nil pointer without erroring, and `VerifyAttestations` hands that nil straight to the verifier:

```
sigstore-go/pkg/bundle.(*Bundle).TlogEntries   <- nil deref
tflint/plugin.(*SignatureChecker).VerifyAttestations
tflint/plugin.(*InstallConfig).Install
```

The crash happens while *downloading the ruleset plugin*, so no policy content is at fault. tflint's own CI is broken by this too. Upstream issue: [terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591); fix in [#2593](https://github.com/terraform-linters/tflint/pull/2593), unreleased.

The CI log said `tflint plugin init failed for required providers`, which is our validator's own message — `init_tflint()` only checks the exit code and discards stderr, so the actual panic never surfaced. The stale `GITHUB_TOKEN` rate-limit comment in the workflow points the same wrong direction.

## Fix

Set `signature = "pgp"` on each ruleset plugin block. This **still verifies the plugin cryptographically** via the legacy signing key — it is deliberately **not** `signature = "none"`, which would skip verification entirely.

The attribute needs tflint >= 0.62, so the pin moves `v0.61.0` → `v0.63.1`. Worth being explicit about the two halves:

- **`signature = "pgp"` is temporary** and carries a dated comment pointing at #2593. Revert it once the upstream fix ships — attestations verify provenance, PGP only verifies signing.
- **The v0.63.1 bump is not temporary.** It's a normal upgrade to latest that we want regardless; it just also happens to be a prerequisite here.

## Verification

Ran the full validator locally against tflint v0.63.1 from a cold plugin cache:

- **1172/1172** terraform remediation blocks pass across every target, **exit 0** — matches the pre-break baseline.
- The bundled terraform ruleset moving `0.14.1` → `0.15.0` surfaced no new findings.
- All three pinned rulesets (aws 0.38.0, azurerm 0.28.0, google 0.32.0) install cleanly.

This PR touches `content/`, so `validate-terraform` runs against itself here — a green check is the real proof.

### Alternatives ruled out

- **Bumping tflint alone** — 0.63.1 panics identically on default verification. Confirmed locally.
- **Dropping `GITHUB_TOKEN`** — still panics; the issue's "works without a token" claim did not reproduce.
- **`signature = "pgp"` on v0.61.0** — silently ignored. v0.61.0 doesn't error on a bogus `signature` value either, which is how I confirmed the attribute doesn't exist there.

### Follow-up

Installing plugins directly from pinned release URLs with checksum verification would make this immune to the attestation API entirely (and to API rate limits), but it trades provenance verification for integrity-only. Not worth it as an emergency fix while #2593 is in flight; happy to open it separately if we keep getting burned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)