### PR TITLE
📄 dedup Generated-code section and add null && null MQL gotcha to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ This section is for any automated reviewer (mondoo-code-review, Claude, etc.) co
 - **`!= ""` is not null-safe.** `"" == empty` is true, but `null != ""` is also true — use `!= empty` for null-safe non-empty assertions.
 - **`filters:` is asset selection, not logic.** `filters:` only selects which assets a check applies to (`asset.platform == "..."`). Predicate logic (`field != empty`, `flag == true`, …) belongs in `mql:`. Don't flag a query for "duplicating" a condition that legitimately lives in `mql:` rather than `filters:`, and don't suggest lifting predicates into `filters:` — that silently drops assets from scoring. Multi-line `filters:` join with explicit `&&`; multi-line `mql:` uses newline-as-AND.
 - **Newline-as-AND in `mql:`.** Multiple lines in an `mql:` block are implicitly AND-ed. A query that "looks like it ignores" an earlier line is usually relying on this — verify before flagging.
+- **`null && null` is `true`.** MQL boolean logic is three-valued — two null operands `&&`-ed yield `true`, not null or false. A check like `field_a == "x" && field_b == "y"` silently *passes* when both fields are absent (each comparison is null, and `null && null` is true), scoring the asset compliant on data that never resolved. Assert presence first (`field_a != empty`) before comparing, or the check reports a false pass.
 
 ### Policy/content specifics
 

--- a/policy/CLAUDE.md
+++ b/policy/CLAUDE.md
@@ -135,11 +135,4 @@ Protobuf is central to cnspec's architecture.
 
 ## Generated code
 
-Never edit these files manually:
-
-- `*.pb.go` — Generated from proto files.
-- `*.ranger.go` — Generated ranger-rpc code.
-- `*.vtproto.pb.go` — Optimized vtproto marshaling.
-- `*_gen.go` — Generated via `go generate`.
-
-Regenerate with `make cnspec/generate` after source changes. When proto files reference mql types, ensure the mql repo is present via `make prep/repos`.
+Same as the root `CLAUDE.md` — never hand-edit generated files (`*.pb.go`, `*.ranger.go`, `*.vtproto.pb.go`, `*_gen.go`); regenerate with `make cnspec/generate`.


### PR DESCRIPTION
## What

Two small `CLAUDE.md` improvements from an audit of the repo's context files.

## Changes

- **`policy/CLAUDE.md` — dedup the "Generated code" section.** It duplicated the root `CLAUDE.md` block verbatim (`*.pb.go` / `*.ranger.go` / `*.vtproto.pb.go` / `*_gen.go`), and the root is always loaded alongside `policy/`. Collapsed to a one-line pointer.
- **`CLAUDE.md` — add the `null && null` gotcha** to the "MQL gotchas that cause false positives" list. A check like `field_a == "x" && field_b == "y"` silently *passes* when both fields are absent: each comparison is `null`, and MQL's three-valued boolean logic makes `null && null` evaluate to `true`, so the asset scores compliant on data that never resolved. The fix is to assert presence (`!= empty`) before comparing. This sits next to the existing null-safety entries (`.all()`-on-null, `!= ""` not null-safe).

Docs-only; no code or behavior change.
