### PR TITLE
✨ aws/azure/gcp: add 16 AI-service security checks

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.6.1
+    version: 9.7.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -391,11 +391,15 @@ policies:
           - uid: mondoo-azure-security-cognitive-services-network-acl-default-deny
           - uid: mondoo-azure-security-cognitive-services-managed-identity
           - uid: mondoo-azure-security-cognitive-services-cmk-encryption
+          - uid: mondoo-azure-security-cognitive-services-defender-for-ai-enabled
+          - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network
       - title: Azure Machine Learning
         checks:
           - uid: mondoo-azure-security-ml-workspace-public-network-access-disabled
           - uid: mondoo-azure-security-ml-compute-no-public-ip
           - uid: mondoo-azure-security-ml-online-endpoint-key-auth-disabled
+          - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled
+          - uid: mondoo-azure-security-ml-workspace-cmk-encryption
       - title: Azure Event Grid
         checks:
           - uid: mondoo-azure-security-eventgrid-local-auth-disabled
@@ -48973,4 +48977,520 @@ queries:
     mql: |
       bicep.resources.where(type == "Microsoft.Cache/redis/firewallRules").none(
         properties["startIP"] == "0.0.0.0" && properties["endIP"] == "255.255.255.255"
+      )
+  # No Terraform variants: Defender for AI is a Microsoft Defender for Cloud plan whose enablement is subscription-level runtime posture, not a per-resource argument on the Cognitive Services account.
+  - uid: mondoo-azure-security-cognitive-services-defender-for-ai-enabled
+    title: Ensure Defender for AI is enabled on Azure AI Services accounts
+    impact: 75
+    filters: asset.platform == "azure"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-308-a-1-ii-d-security-management-process-information-system-activity-review
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/pci-dss-4: pcidss-requirement-11-5-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+      compliance/nist-ai-100-1: nist-ai-100-1-measure-2-4, nist-ai-100-1-measure-2-7, nist-ai-100-1-manage-4-1
+    mql: |
+      azure.subscription.cognitiveServicesService.accounts.all(
+        defenderForAIEnabled == true
+      )
+    docs:
+      desc: |
+        This check ensures that Microsoft Defender for AI is enabled on Azure AI Services (Cognitive Services and Azure OpenAI) accounts. Defender for AI provides runtime threat protection for generative-AI workloads: it inspects model prompts and responses to detect prompt-injection and jailbreak attempts, sensitive-data leakage, wallet-abuse, and credential-theft, and surfaces alerts in Microsoft Defender for Cloud. Without it, attacks that manipulate or abuse the deployed model go undetected.
+
+        **Why this matters**
+
+        - **Prompt-injection detection:** Defender for AI identifies attempts to override system instructions or exfiltrate data through crafted prompts, a primary attack class against LLM applications.
+        - **Runtime visibility:** Threats against a model are only observable at inference time; without runtime monitoring there is no signal that an application is being abused.
+        - **Centralized alerting:** Detections flow into Defender for Cloud alongside other cloud security alerts, so AI threats are triaged in the same incident-response workflow as the rest of the environment.
+
+        **Risk mitigation**
+
+        - **Enable the Defender for AI plan:** Turn on the AI workload protection plan in Microsoft Defender for Cloud so all AI Services accounts in the subscription are monitored.
+        - **Route alerts to incident response:** Connect Defender for Cloud alerts to the security operations workflow so AI threat detections are acted on.
+      audit: |
+        ### Audit via Portal
+
+        1. In the Azure Portal, open **Microsoft Defender for Cloud** > **Environment settings**.
+        2. Select the subscription and review the **Defender plans**.
+        3. Confirm that the **AI** (AI workload protection) plan is set to **On**.
+
+        A passing subscription has the AI plan enabled, and its AI Services accounts report Defender for AI as active. A failing subscription has the AI plan off.
+
+        ### Audit via CLI
+
+        1. Check the Defender for Cloud pricing tier for the AI plan:
+
+        ```bash
+        az security pricing show --name AI --query "pricingTier"
+        ```
+
+        A passing subscription returns `"Standard"`. A failing subscription returns `"Free"`.
+      remediation:
+        - id: portal
+          desc: |
+            To enable Defender for AI using the Azure Portal:
+
+            1. Open **Microsoft Defender for Cloud** > **Environment settings** and select the subscription.
+            2. In **Defender plans**, set the **AI** plan to **On**.
+            3. Select **Save**.
+        - id: cli
+          desc: |
+            To enable Defender for AI using the Azure CLI:
+
+            ```bash
+            az security pricing create --name AI --tier Standard
+            ```
+        - id: terraform
+          desc: |
+            To enable Defender for AI in Terraform, set the `AI` plan tier on the subscription with `azurerm_security_center_subscription_pricing`:
+
+            ```hcl
+            resource "azurerm_security_center_subscription_pricing" "ai" {
+              tier          = "Standard"
+              resource_type = "AI"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable Defender for AI in Bicep, set the `AI` pricing plan on the subscription:
+
+            ```bicep
+            targetScope = 'subscription'
+
+            resource aiPlan 'Microsoft.Security/pricings@2024-01-01' = {
+              name: 'AI'
+              properties: {
+                pricingTier: 'Standard'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/ai-threat-protection
+        title: AI threat protection in Microsoft Defender for Cloud
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network
+    title: Ensure Azure AI Services accounts restrict outbound network access
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-3-2
+    variants:
+      - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-azure
+        tags:
+          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure AI Services (Cognitive Services and Azure OpenAI) accounts restrict outbound network access to an approved list of destinations. When outbound access is unrestricted, features that let the service reach external endpoints, such as retrieval and connection settings, can be pointed at arbitrary hosts, creating a path for data exfiltration from the AI service. Restricting outbound access confines the service to an allowed set of fully qualified domain names.
+
+        **Why this matters**
+
+        - **Exfiltration path:** An AI account that can call arbitrary external endpoints can be used to move prompt content, grounding data, or responses out of the environment.
+        - **Defense in depth:** Restricting egress complements inbound controls such as disabled public network access, closing the reverse direction that inbound rules do not cover.
+        - **Explicit allow-listing:** With outbound access restricted, only the destinations the workload genuinely needs are permitted, and everything else is denied by default.
+
+        **Risk mitigation**
+
+        - **Restrict outbound access:** Set the account to restrict outbound network access and define the allowed FQDNs the workload requires.
+        - **Review allowed destinations:** Periodically review the allowed-FQDN list so it stays limited to what the workload needs.
+      audit: |
+        ### Audit via Portal
+
+        1. In the Azure Portal, open the **Azure AI Services** (or **Azure OpenAI**) account.
+        2. Under **Networking**, review the **Outbound access** configuration.
+        3. Confirm that outbound network access is restricted rather than unrestricted.
+
+        A passing account shows outbound network access restricted. A failing account allows unrestricted outbound access.
+
+        ### Audit via CLI
+
+        1. Inspect the account's outbound restriction setting:
+
+        ```bash
+        az cognitiveservices account show --name <account-name> --resource-group <resource-group> --query "properties.restrictOutboundNetworkAccess"
+        ```
+
+        A passing account returns `true`. A failing account returns `false` or `null`.
+      remediation:
+        - id: portal
+          desc: |
+            To restrict outbound network access using the Azure Portal:
+
+            1. Open the **Azure AI Services** account and select **Networking**.
+            2. Enable the outbound access restriction and add the fully qualified domain names the workload requires.
+            3. Select **Save**.
+        - id: cli
+          desc: |
+            To restrict outbound network access using the Azure CLI, set the property on the account resource:
+
+            ```bash
+            az resource update --resource-type Microsoft.CognitiveServices/accounts --resource-group <resource-group> --name <account-name> --set properties.restrictOutboundNetworkAccess=true
+            ```
+        - id: terraform
+          desc: |
+            To restrict outbound network access in Terraform, set `outbound_network_access_restricted` to `true` on the `azurerm_cognitive_account` resource:
+
+            ```hcl
+            resource "azurerm_cognitive_account" "example" {
+              name                                = "example-openai"
+              location                            = azurerm_resource_group.example.location
+              resource_group_name                 = azurerm_resource_group.example.name
+              kind                                = "OpenAI"
+              sku_name                            = "S0"
+              outbound_network_access_restricted  = true
+              fqdns                               = ["contoso.blob.core.windows.net"]
+            }
+            ```
+        - id: bicep
+          desc: |
+            To restrict outbound network access in Bicep, set `restrictOutboundNetworkAccess` to `true` on the account:
+
+            ```bicep
+            resource account 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+              name: 'example-openai'
+              location: resourceGroup().location
+              kind: 'OpenAI'
+              sku: {
+                name: 'S0'
+              }
+              properties: {
+                restrictOutboundNetworkAccess: true
+                allowedFqdnList: [
+                  'contoso.blob.core.windows.net'
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-virtual-networks
+        title: Configure Azure AI services virtual networks
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-azure
+    filters: asset.platform == "azure"
+    mql: |
+      azure.subscription.cognitiveServicesService.accounts.all(
+        restrictOutboundNetworkAccess == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
+    mql: |
+      terraform.resources("azurerm_cognitive_account").all(
+        arguments['outbound_network_access_restricted'] == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_cognitive_account").all(
+        change.after.outbound_network_access_restricted == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_cognitive_account")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_cognitive_account").all(
+        values.outbound_network_access_restricted == true
+      )
+  - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.CognitiveServices/accounts")
+    mql: |
+      bicep.resources.where(type == "Microsoft.CognitiveServices/accounts").all(
+        properties["restrictOutboundNetworkAccess"] == true
+      )
+  - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled
+    title: Ensure Machine Learning serverless endpoints disable key authentication
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Machine Learning serverless (pay-as-you-go) inference endpoints do not use static key authentication, requiring Microsoft Entra ID or Azure Machine Learning token authentication instead. Key authentication issues long-lived keys that grant full access to invoke the endpoint with no user context or expiry.
+
+        **Why this matters**
+
+        - **Model abuse:** A serverless endpoint serves a deployed model for inference; a leaked static key lets anyone invoke the model, run up cost, and probe its behavior with no attribution.
+        - **Token-based access:** Microsoft Entra ID and Azure Machine Learning tokens are short-lived and tied to an identity, which makes access revocable and auditable.
+        - **No rotation gap:** Removing key authentication eliminates the risk of a compromised key remaining valid until someone remembers to rotate it.
+
+        **Risk mitigation**
+
+        - **Use token authentication:** Configure serverless endpoints with token-based authentication rather than key-based authentication.
+        - **Least privilege:** Grant least-privilege roles to the identities that invoke the endpoint.
+      audit: |
+        ### Audit via Portal
+
+        1. In the Azure Portal, open **Azure Machine Learning** and select the workspace.
+        2. Open **Endpoints** and select each serverless endpoint.
+        3. Review the authentication setting and confirm it is token-based rather than key-based.
+
+        A passing serverless endpoint uses token authentication. A failing endpoint uses key authentication.
+
+        ### Audit via CLI
+
+        1. Inspect each serverless endpoint's auth mode:
+
+        ```bash
+        az ml serverless-endpoint show --name <EndpointName> --resource-group <ResourceGroupName> --workspace-name <WorkspaceName> --query "auth_mode"
+        ```
+
+        A passing serverless endpoint returns a token-based auth mode. A failing endpoint returns `Key`.
+      remediation:
+        - id: portal
+          desc: |
+            To require token authentication on a Machine Learning serverless endpoint using the Azure Portal:
+
+            1. Open **Azure Machine Learning** and select the workspace, then **Endpoints**.
+            2. Create the serverless endpoint with a token-based authentication mode. The authentication mode is fixed at creation, so an existing key-based endpoint must be recreated.
+        - id: cli
+          desc: |
+            To require token authentication on a Machine Learning serverless endpoint using the Azure CLI, create the endpoint from a YAML spec whose `auth_mode` is token-based (for example `aad_token`). The auth mode is fixed at creation, so an existing key-based endpoint must be recreated:
+
+            ```bash
+            az ml serverless-endpoint create --resource-group-name <ResourceGroupName> --workspace-name <WorkspaceName> --file serverless-endpoint.yml
+            ```
+        # No Terraform remediation: the azurerm provider exposes no Machine Learning serverless endpoint resource, so there is no Terraform argument to set.
+        - id: bicep
+          desc: |
+            To require token authentication on a Machine Learning serverless endpoint in Bicep:
+
+            ```bicep
+            resource serverlessEndpoint 'Microsoft.MachineLearningServices/workspaces/serverlessEndpoints@2024-04-01' = {
+              parent: mlWorkspace
+              name: 'example-serverless'
+              location: resourceGroup().location
+              properties: {
+                authMode: 'AADToken'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-authenticate-online-endpoint
+        title: Authenticate clients for online endpoints
+  - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-azure
+    filters: asset.platform == "azure"
+    mql: |
+      azure.subscription.machineLearningService.workspaces.all(
+        serverlessEndpoints.all(authMode != "Key")
+      )
+  - uid: mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.MachineLearningServices/workspaces/serverlessEndpoints")
+    mql: |
+      bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces/serverlessEndpoints").all(
+        properties["authMode"] != "Key"
+      )
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption
+    title: Ensure Machine Learning workspaces use customer-managed key encryption
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-ml-workspace-cmk-encryption-azure
+        tags:
+          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-ml-workspace-cmk-encryption-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Azure Machine Learning workspaces are encrypted with a customer-managed key (CMK) rather than the default Microsoft-managed key. A workspace stores experiment metadata, model artifacts, and references to training data, and by default Azure encrypts this with a platform key the customer cannot rotate, audit, or revoke independently.
+
+        **Why this matters**
+
+        - **Key control:** A CMK gives the organization direct authority over the key protecting workspace data, enabling custom rotation and access policies beyond what the Microsoft-managed key allows.
+        - **Revocability:** Disabling or deleting the Key Vault key immediately blocks access to encrypted workspace data, a containment mechanism unavailable with the platform key.
+        - **Decryption audit trail:** Key Vault logs every key use, providing an auditable record of access to the encryption key.
+
+        **Risk mitigation**
+
+        - **Incident containment:** If workspace data is found to be exposed, revoking the CMK prevents further access while remediation proceeds.
+        - **Regulatory alignment:** CMK encryption satisfies bring-your-own-key requirements for AI and ML workloads handling regulated data.
+      audit: |
+        ### Audit via Portal
+
+        1. In the Azure Portal, open **Azure Machine Learning** and select the workspace.
+        2. Under **Settings** > **Encryption**, review the encryption configuration.
+        3. Confirm that the workspace uses a customer-managed key stored in Azure Key Vault.
+
+        A passing workspace shows customer-managed key encryption. A failing workspace shows Microsoft-managed key encryption.
+
+        ### Audit via CLI
+
+        1. Inspect the workspace encryption status:
+
+        ```bash
+        az ml workspace show --name <WorkspaceName> --resource-group <ResourceGroupName> --query "encryption.status"
+        ```
+
+        A passing workspace returns `"Enabled"`. A failing workspace returns `"Disabled"`.
+      remediation:
+        - id: portal
+          desc: |
+            Workspace encryption type is set at creation. To use a customer-managed key with the Azure Portal:
+
+            1. In the Azure Portal, create a new **Azure Machine Learning** workspace.
+            2. On the **Encryption** tab, select **Customer-managed keys** and choose a Key Vault key.
+            3. Migrate assets to the new workspace and decommission the old one.
+        - id: cli
+          desc: |
+            To create a Machine Learning workspace encrypted with a customer-managed key using the Azure CLI, provide a YAML spec whose `customer_managed_key` references the Key Vault key:
+
+            ```bash
+            az ml workspace create --name <WorkspaceName> --resource-group-name <ResourceGroupName> --file workspace-cmk.yml
+            ```
+        - id: terraform
+          desc: |
+            To encrypt a Machine Learning workspace with a customer-managed key in Terraform, add an `encryption` block to the `azurerm_machine_learning_workspace` resource:
+
+            ```hcl
+            resource "azurerm_machine_learning_workspace" "example" {
+              name                    = "example-workspace"
+              location                = azurerm_resource_group.example.location
+              resource_group_name     = azurerm_resource_group.example.name
+              application_insights_id = azurerm_application_insights.example.id
+              key_vault_id            = azurerm_key_vault.example.id
+              storage_account_id      = azurerm_storage_account.example.id
+
+              identity {
+                type = "SystemAssigned"
+              }
+
+              encryption {
+                key_vault_id = azurerm_key_vault.example.id
+                key_id       = azurerm_key_vault_key.example.id
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To encrypt a Machine Learning workspace with a customer-managed key in Bicep, set the `encryption` property to `Enabled` with a Key Vault key:
+
+            ```bicep
+            resource workspace 'Microsoft.MachineLearningServices/workspaces@2024-04-01' = {
+              name: 'example-workspace'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                encryption: {
+                  status: 'Enabled'
+                  keyVaultProperties: {
+                    keyVaultArmId: keyVault.id
+                    keyIdentifier: keyUri
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/machine-learning/concept-customer-managed-keys
+        title: Customer-managed keys for Azure Machine Learning
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption-azure
+    filters: asset.platform == "azure"
+    mql: |
+      azure.subscription.machineLearningService.workspaces.all(
+        encryptionStatus == "Enabled"
+      )
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.resources("azurerm_machine_learning_workspace").all(
+        blocks.where(type == "encryption") != empty
+      )
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_machine_learning_workspace").all(
+        change.after['encryption'] != null && change.after['encryption'] != []
+      )
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_machine_learning_workspace")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_machine_learning_workspace").all(
+        values['encryption'] != null && values['encryption'] != []
+      )
+  - uid: mondoo-azure-security-ml-workspace-cmk-encryption-bicep
+    filters: asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.MachineLearningServices/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces").all(
+        properties["encryption"]["status"] == "Enabled"
       )

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.5.1
+    version: 9.6.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -432,6 +432,12 @@ policies:
           - uid: mondoo-gcp-security-vertexai-custom-job-private-network
           - uid: mondoo-gcp-security-vertexai-custom-job-web-access-disabled
           - uid: mondoo-gcp-security-vertexai-additional-resources-cmek-encryption
+          - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption
+          - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm
+          - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network
+          - uid: mondoo-gcp-security-workbench-instance-no-default-service-account
+          - uid: mondoo-gcp-security-vertexai-rag-corpus-cmek-encryption
+          - uid: mondoo-gcp-security-vertexai-job-cmek-encryption
       - title: Cloud Workstations
         checks:
           - uid: mondoo-gcp-security-workstations-cluster-private-cluster
@@ -42491,3 +42497,705 @@ queries:
     refs:
       - url: https://cloud.google.com/domains/docs/dnssec-advanced
         title: DNSSEC configuration in Cloud Domains
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption
+    title: Ensure Vertex AI notebook runtime templates are encrypted with CMEK
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI notebook runtime templates are encrypted with a customer-managed encryption key (CMEK) rather than a Google-managed key. A runtime template defines the machine, disk, and software configuration that Colab Enterprise notebooks run on, and the disks provisioned from it hold notebook code, cached data, and credentials. By default Google encrypts them with a key the customer cannot rotate, audit, or revoke independently.
+
+        **Why this matters**
+
+        - **Key control:** CMEK gives the organization direct authority over the key protecting notebook runtime disks, enabling custom rotation and access policies.
+        - **Revocability:** Disabling or destroying the Cloud KMS key immediately blocks access to disks provisioned from the template, a containment mechanism unavailable with Google-managed keys.
+        - **Audit visibility:** Key usage appears in Cloud KMS audit logs, providing a verifiable record of access to the encryption key.
+
+        **Risk mitigation**
+
+        - **Incident containment:** If a notebook runtime is found to hold sensitive data, revoking the CMEK key prevents further access while remediation proceeds.
+        - **Separation of duties:** Storing the key in a separate KMS project enforces a boundary between notebook operators and key custodians.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+        2. Select each runtime template and open its details.
+        3. Under **Encryption**, confirm that a Cloud KMS key is configured.
+
+        A passing runtime template shows a customer-managed Cloud KMS key. A failing template shows Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. List runtime templates and their encryption specification:
+
+        ```bash
+        gcloud colab runtime-templates list \
+          --region=REGION \
+          --format="table(name,displayName,encryptionSpec.kmsKeyName)"
+        ```
+
+        A passing template returns a KMS key name. A failing template returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            The encryption key is set at creation. To use a CMEK key with the Google Cloud Console:
+
+            1. Go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+            2. Create a new runtime template, and under **Encryption**, select **Customer-managed key** and choose your Cloud KMS key.
+            3. Replace references to the old template and delete it.
+        - id: cli
+          desc: |
+            To create a Vertex AI notebook runtime template encrypted with a CMEK key using the Google Cloud CLI:
+
+            ```bash
+            gcloud colab runtime-templates create \
+              --display-name=NAME \
+              --machine-type=e2-standard-4 \
+              --region=REGION \
+              --kms-key=KEY \
+              --kms-keyring=KEYRING \
+              --kms-location=LOCATION \
+              --kms-project=PROJECT
+            ```
+        - id: terraform
+          desc: |
+            To encrypt a Vertex AI notebook runtime template with a CMEK key in Terraform, set `kms_key_name` in the `encryption_spec` block of the `google_colab_runtime_template` resource:
+
+            ```hcl
+            resource "google_colab_runtime_template" "example" {
+              name         = "example-template"
+              display_name = "example-template"
+              location     = "us-central1"
+              machine_spec {
+                machine_type = "e2-standard-4"
+              }
+
+              encryption_spec {
+                kms_key_name = google_kms_crypto_key.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+        title: Customer-managed encryption keys (CMEK) for Vertex AI
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-gcp
+    filters: asset.platform == 'gcp-project'
+    mql: |
+      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
+        kmsKey != null
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
+    mql: |
+      terraform.resources('google_colab_runtime_template').all(
+        blocks.where(type == 'encryption_spec') != empty &&
+        blocks.where(type == 'encryption_spec').all(arguments['kms_key_name'] != null && arguments['kms_key_name'] != "")
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_colab_runtime_template').all(
+        change.after['encryption_spec'] != empty &&
+        change.after['encryption_spec'].all(_['kms_key_name'] != null && _['kms_key_name'] != "")
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.state.resources.where(type == 'google_colab_runtime_template').all(
+        values['encryption_spec'] != empty &&
+        values['encryption_spec'].all(_['kms_key_name'] != null && _['kms_key_name'] != "")
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm
+    title: Ensure Vertex AI notebook runtime templates enable Shielded VM
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-c-1-integrity
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ds-6
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-8-2
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    variants:
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI notebook runtime templates enable Shielded VM secure boot. Shielded VM protects the runtime against boot- and kernel-level malware by verifying, through secure boot, that only signed and trusted boot components load. Without secure boot, a rootkit or bootkit that compromises a notebook runtime can persist undetected across restarts.
+
+        **Why this matters**
+
+        - **Boot integrity:** Secure boot ensures the runtime loads only signed firmware and kernel components, blocking persistence techniques that tamper with the boot chain.
+        - **Tamper evidence:** Shielded VM integrity monitoring surfaces changes to the boot baseline, giving early warning of a compromised runtime.
+        - **Defense in depth:** Notebook runtimes hold code and credentials, so boot-level assurance complements network and encryption controls.
+
+        **Risk mitigation**
+
+        - **Enable secure boot at creation:** Configure the runtime template with Shielded VM secure boot so every runtime provisioned from it is protected.
+        - **Monitor integrity:** Review Shielded VM integrity monitoring signals to detect boot-level tampering.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+        2. Select each runtime template and open its details.
+        3. Confirm that **Secure boot** is enabled under the Shielded VM configuration.
+
+        A passing runtime template has secure boot enabled. A failing template has it disabled.
+
+        ### Audit via CLI
+
+        1. List runtime templates and their Shielded VM configuration:
+
+        ```bash
+        gcloud colab runtime-templates list \
+          --region=REGION \
+          --format="table(name,displayName,shieldedVmConfig.enableSecureBoot)"
+        ```
+
+        A passing template returns `True` for secure boot. A failing template returns `False` or an empty value.
+      remediation:
+        - id: console
+          desc: |
+            Shielded VM configuration is set at creation. To enable secure boot with the Google Cloud Console:
+
+            1. Go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+            2. Create a new runtime template and enable **Secure boot** under the Shielded VM options.
+            3. Replace references to the old template and delete it.
+        - id: cli
+          desc: |
+            To create a Vertex AI notebook runtime template with Shielded VM secure boot using the Google Cloud CLI:
+
+            ```bash
+            gcloud colab runtime-templates create \
+              --display-name=NAME \
+              --machine-type=e2-standard-4 \
+              --region=REGION \
+              --enable-secure-boot
+            ```
+        - id: terraform
+          desc: |
+            To enable Shielded VM secure boot on a Vertex AI notebook runtime template in Terraform, set `enable_secure_boot` in the `shielded_vm_config` block of the `google_colab_runtime_template` resource:
+
+            ```hcl
+            resource "google_colab_runtime_template" "example" {
+              name         = "example-template"
+              display_name = "example-template"
+              location     = "us-central1"
+              machine_spec {
+                machine_type = "e2-standard-4"
+              }
+
+              shielded_vm_config {
+                enable_secure_boot = true
+              }
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/security/shielded-cloud/shielded-vm
+        title: Shielded VM
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
+    filters: asset.platform == 'gcp-project'
+    mql: |
+      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
+        shieldedVmConfig != empty && shieldedVmConfig['enableSecureBoot'] == true
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
+    mql: |
+      terraform.resources('google_colab_runtime_template').all(
+        blocks.where(type == 'shielded_vm_config') != empty &&
+        blocks.where(type == 'shielded_vm_config').all(arguments['enable_secure_boot'] == true)
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_colab_runtime_template').all(
+        change.after['shielded_vm_config'] != empty &&
+        change.after['shielded_vm_config'].all(_['enable_secure_boot'] == true)
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.state.resources.where(type == 'google_colab_runtime_template').all(
+        values['shielded_vm_config'] != empty &&
+        values['shielded_vm_config'].all(_['enable_secure_boot'] == true)
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network
+    title: Ensure Vertex AI notebook runtime templates use a private VPC network
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI notebook runtime templates are bound to a specific VPC network rather than defaulting to a Google-managed network with direct internet access. Binding the runtime to a customer VPC forces its traffic through the organization's own subnets, routes, firewall rules, and private service endpoints, so egress can be governed centrally rather than leaving the runtime with an uncontrolled path to the internet.
+
+        **Why this matters**
+
+        - **Controlled egress:** A runtime on a customer VPC reaches Google services through Private Google Access or private endpoints, and internet-bound traffic is subject to the organization's firewall and NAT policy.
+        - **Exfiltration resistance:** A runtime with an unbound, internet-attached default network can move notebook data or credentials to arbitrary destinations without passing any customer control.
+        - **Consistent segmentation:** Binding runtimes to designated subnets keeps them within the network segmentation model applied to the rest of the environment.
+
+        **Risk mitigation**
+
+        - **Bind runtimes to a VPC:** Configure the runtime template with an explicit VPC network and subnetwork that enforce the required egress policy.
+        - **Disable direct internet access:** Combine the private network binding with disabled internet access so the runtime relies on private paths and controlled egress.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+        2. Select each runtime template and open its details.
+        3. Under **Networking**, confirm that a VPC network and subnetwork are configured.
+
+        A passing runtime template shows an explicit VPC network. A failing template shows no network binding or a default network with internet access.
+
+        ### Audit via CLI
+
+        1. List runtime templates and their network configuration:
+
+        ```bash
+        gcloud colab runtime-templates list \
+          --region=REGION \
+          --format="table(name,displayName,networkSpec.network)"
+        ```
+
+        A passing template returns a VPC network name. A failing template returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            The network configuration is set at creation. To bind the runtime to a VPC using the Google Cloud Console:
+
+            1. Go to **Vertex AI** > **Colab Enterprise** > **Runtime templates**.
+            2. Create a new runtime template, and under **Networking**, select your VPC network and subnetwork and disable external internet access.
+            3. Replace references to the old template and delete it.
+        - id: cli
+          desc: |
+            To create a Vertex AI notebook runtime template bound to a VPC network using the Google Cloud CLI:
+
+            ```bash
+            gcloud colab runtime-templates create \
+              --display-name=NAME \
+              --machine-type=e2-standard-4 \
+              --region=REGION \
+              --network=projects/PROJECT/global/networks/NETWORK \
+              --subnetwork=projects/PROJECT/regions/REGION/subnetworks/SUBNET \
+              --no-enable-internet-access
+            ```
+        - id: terraform
+          desc: |
+            To bind a Vertex AI notebook runtime template to a VPC network in Terraform, set `network` in the `network_spec` block of the `google_colab_runtime_template` resource:
+
+            ```hcl
+            resource "google_colab_runtime_template" "example" {
+              name         = "example-template"
+              display_name = "example-template"
+              location     = "us-central1"
+              machine_spec {
+                machine_type = "e2-standard-4"
+              }
+
+              network_spec {
+                enable_internet_access = false
+                network                = google_compute_network.example.id
+                subnetwork             = google_compute_subnetwork.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/colab/docs/runtimes
+        title: Colab Enterprise runtimes
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-gcp
+    filters: asset.platform == 'gcp-project'
+    mql: |
+      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
+        networkSpec != empty && networkSpec['network'] != null && networkSpec['network'] != ""
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
+    mql: |
+      terraform.resources('google_colab_runtime_template').all(
+        blocks.where(type == 'network_spec') != empty &&
+        blocks.where(type == 'network_spec').all(arguments['network'] != null && arguments['network'] != "")
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_colab_runtime_template').all(
+        change.after['network_spec'] != empty &&
+        change.after['network_spec'].all(_['network'] != null && _['network'] != "")
+      )
+  - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_colab_runtime_template')
+    mql: |
+      terraform.state.resources.where(type == 'google_colab_runtime_template').all(
+        values['network_spec'] != empty &&
+        values['network_spec'].all(_['network'] != null && _['network'] != "")
+      )
+  # No Terraform variants for the runtime resource: google_workbench_instance gen-2 stores its service account in a nested gce_setup.service_accounts block; the Terraform coverage below targets the legacy google_notebooks_instance whose flat service_account argument matches the runtime notebooksService.instances resource this check evaluates.
+  - uid: mondoo-gcp-security-workbench-instance-no-default-service-account
+    title: Ensure Vertex AI Workbench instances use a non-default service account
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-gcp
+        tags:
+          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-icon: gcp
+      - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check ensures that Vertex AI Workbench and Notebooks instances do not run as the default Compute Engine service account. The default Compute Engine service account is granted the broad Editor role on the project, so an instance that runs as it can act across nearly every project resource. Because a Workbench instance runs user-supplied notebook code, a compromise of that code inherits the instance's identity, making a default, over-privileged service account a direct path to project-wide access.
+
+        **Why this matters**
+
+        - **Least privilege:** A dedicated service account can be scoped to only the APIs and resources the notebook workflow needs, rather than the project-wide Editor role the default account holds.
+        - **Blast-radius containment:** If notebook code is compromised, a narrowly scoped service account limits what the attacker can reach.
+        - **Attribution:** A per-workload service account makes it clear in audit logs which workflow performed an action.
+
+        **Risk mitigation**
+
+        - **Assign a dedicated service account:** Create the instance with a purpose-built service account granted only the roles the workflow requires.
+        - **Avoid the default Compute Engine account:** Do not leave the service account unset, which causes the instance to fall back to the default Compute Engine account.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** > **Workbench**.
+        2. Select each instance and open its details.
+        3. Under **Permission** or **System information**, review the service account.
+
+        A passing instance uses a dedicated service account. A failing instance uses the default Compute Engine service account (an address ending in `-compute@developer.gserviceaccount.com`).
+
+        ### Audit via CLI
+
+        1. List Workbench instances and their service account:
+
+        ```bash
+        gcloud workbench instances list \
+          --location=LOCATION \
+          --format="table(name,gceSetup.serviceAccounts[0].email)"
+        ```
+
+        A passing instance returns a dedicated service account email. A failing instance returns an address ending in `-compute@developer.gserviceaccount.com`.
+      remediation:
+        - id: console
+          desc: |
+            The service account is set at instance creation. To use a dedicated service account with the Google Cloud Console:
+
+            1. Go to **Vertex AI** > **Workbench** and create a new instance.
+            2. Under **Permission**, select **Service account** and choose a dedicated, least-privilege service account.
+            3. Migrate work to the new instance and delete the old one.
+        - id: cli
+          desc: |
+            To create a Vertex AI Workbench instance with a dedicated service account using the Google Cloud CLI:
+
+            ```bash
+            gcloud workbench instances create INSTANCE_NAME \
+              --location=LOCATION \
+              --service-account-email=dedicated-sa@PROJECT.iam.gserviceaccount.com
+            ```
+        - id: terraform
+          desc: |
+            To assign a dedicated service account to a legacy Notebooks instance in Terraform, set `service_account` on the `google_notebooks_instance` resource:
+
+            ```hcl
+            resource "google_notebooks_instance" "example" {
+              name         = "example-instance"
+              location     = "us-central1-a"
+              machine_type = "e2-medium"
+
+              service_account = google_service_account.notebook.email
+            }
+            ```
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-identity
+        title: Manage identity and access for Vertex AI Workbench instances
+  - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-gcp
+    filters: asset.platform == 'gcp-project'
+    mql: |
+      gcp.project.notebooksService.instances.all(
+        serviceAccount != empty && serviceAccount.contains("-compute@developer.gserviceaccount.com") == false
+      )
+  - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl
+    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_notebooks_instance')
+    mql: |
+      terraform.resources('google_notebooks_instance').all(
+        arguments['service_account'] != null && arguments['service_account'] != "" &&
+        arguments['service_account'].contains("-compute@developer.gserviceaccount.com") == false
+      )
+  - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-plan
+    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_notebooks_instance')
+    mql: |
+      terraform.plan.resourceChanges.where(type == 'google_notebooks_instance').all(
+        change.after['service_account'] != null && change.after['service_account'] != "" &&
+        change.after['service_account'].contains("-compute@developer.gserviceaccount.com") == false
+      )
+  - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-state
+    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_notebooks_instance')
+    mql: |
+      terraform.state.resources.where(type == 'google_notebooks_instance').all(
+        values['service_account'] != null && values['service_account'] != "" &&
+        values['service_account'].contains("-compute@developer.gserviceaccount.com") == false
+      )
+  # No Terraform variants: RAG corpora are created imperatively through the Vertex AI RAG Engine API and have no dedicated Terraform resource that expresses the encryption key.
+  - uid: mondoo-gcp-security-vertexai-rag-corpus-cmek-encryption
+    title: Ensure Vertex AI RAG corpora are encrypted with CMEK
+    impact: 70
+    filters: asset.platform == 'gcp-project'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      gcp.project.vertexaiService.ragCorpora.all(
+        kmsKey != null
+      )
+    docs:
+      desc: |
+        This check ensures that Vertex AI RAG (retrieval-augmented generation) corpora are encrypted with a customer-managed encryption key (CMEK) rather than a Google-managed key. A RAG corpus stores the ingested documents and their vector embeddings that ground model responses, so it holds the source content the organization has chosen to expose to its models. By default Google encrypts it with a key the customer cannot rotate, audit, or revoke independently.
+
+        **Why this matters**
+
+        - **Grounding-data sensitivity:** A RAG corpus often contains internal knowledge-base content, contracts, or support data that is exactly the material that should be encrypted under customer-controlled keys.
+        - **Revocability:** Disabling or destroying the Cloud KMS key immediately blocks access to the corpus and its embeddings, a containment mechanism unavailable with Google-managed keys.
+        - **Audit visibility:** Key usage appears in Cloud KMS audit logs, providing a verifiable record of access to the encryption key.
+
+        **Risk mitigation**
+
+        - **Incident containment:** If corpus content is found to be exposed, revoking the CMEK key prevents further access while remediation proceeds.
+        - **Separation of duties:** Storing the key in a separate KMS project enforces a boundary between corpus operators and key custodians.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** > **RAG Engine**.
+        2. Select each corpus and open its details.
+        3. Confirm that a Cloud KMS key is configured for encryption.
+
+        A passing corpus shows a customer-managed Cloud KMS key. A failing corpus shows Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. List RAG corpora and inspect the encryption specification through the Vertex AI API:
+
+        ```bash
+        curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+          "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT/locations/REGION/ragCorpora"
+        ```
+
+        A passing corpus returns an `encryptionSpec.kmsKeyName` value. A failing corpus returns no encryption key.
+      remediation:
+        - id: console
+          desc: |
+            The encryption key is set when the corpus is created. To use a CMEK key with the Google Cloud Console:
+
+            1. Go to **Vertex AI** > **RAG Engine** and create a new corpus.
+            2. Under the encryption settings, select a Cloud KMS customer-managed key.
+            3. Re-ingest content into the new corpus and delete the old one.
+        - id: cli
+          desc: |
+            RAG corpus encryption is set at creation through the Vertex AI RAG Engine API. To create a corpus with a CMEK key, include an `encryptionSpec` in the request body:
+
+            ```bash
+            curl -s -X POST \
+              -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              -H "Content-Type: application/json" \
+              "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT/locations/REGION/ragCorpora" \
+              -d '{"displayName":"example-corpus","encryptionSpec":{"kmsKeyName":"projects/PROJECT/locations/REGION/keyRings/KEYRING/cryptoKeys/KEY"}}'
+            ```
+        # No Terraform remediation: RAG corpora are created through the Vertex AI RAG Engine API and have no dedicated Terraform resource that expresses the encryption key.
+    refs:
+      - url: https://cloud.google.com/vertex-ai/generative-ai/docs/rag-engine/rag-overview
+        title: Vertex AI RAG Engine overview
+  - uid: mondoo-gcp-security-vertexai-job-cmek-encryption
+    title: Ensure Vertex AI batch prediction and tuning jobs use CMEK
+    impact: 70
+    filters: asset.platform == 'gcp-project'
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      gcp.project.vertexaiService.batchPredictionJobs.all(
+        kmsKey != null
+      )
+      gcp.project.vertexaiService.tuningJobs.all(
+        kmsKey != null
+      )
+    docs:
+      desc: |
+        This check ensures that Vertex AI batch prediction jobs and tuning jobs are encrypted with a customer-managed encryption key (CMEK) rather than a Google-managed key. A batch prediction job reads an input dataset and writes prediction output, and a tuning job reads training data and produces a tuned model, so both process and persist data derived from potentially sensitive inputs. By default Google encrypts the job's resources with a key the customer cannot rotate, audit, or revoke independently.
+
+        **Why this matters**
+
+        - **Derived-data sensitivity:** Prediction outputs and tuned models encode patterns from the input and training data, which may be regulated or proprietary.
+        - **Revocability:** Disabling or destroying the Cloud KMS key immediately blocks access to the job's encrypted resources, a containment mechanism unavailable with Google-managed keys.
+        - **Audit visibility:** Key usage appears in Cloud KMS audit logs, providing a verifiable record of access to the encryption key.
+
+        **Risk mitigation**
+
+        - **Set CMEK at job submission:** Provide an `encryptionSpec` with a Cloud KMS key when creating batch prediction and tuning jobs.
+        - **Separation of duties:** Storing the key in a separate KMS project enforces a boundary between job operators and key custodians.
+      audit: |
+        ### Audit via Console
+
+        1. In the Google Cloud Console, go to **Vertex AI** and open **Batch predictions** and **Tuning**.
+        2. Select each job and open its details.
+        3. Confirm that a Cloud KMS key is shown under encryption.
+
+        A passing job shows a customer-managed Cloud KMS key. A failing job shows Google-managed encryption.
+
+        ### Audit via CLI
+
+        1. List batch prediction jobs and their encryption specification:
+
+        ```bash
+        gcloud ai batch-prediction-jobs list \
+          --region=REGION \
+          --format="table(name,displayName,encryptionSpec.kmsKeyName)"
+        ```
+
+        A passing job returns a KMS key name. A failing job returns an empty value.
+      remediation:
+        - id: console
+          desc: |
+            A job's encryption key is fixed at submission. To use a CMEK key with the Google Cloud Console:
+
+            1. Go to **Vertex AI** and start a new **Batch prediction** or **Tuning** job.
+            2. Under the encryption settings, select a Cloud KMS customer-managed key.
+            3. Submit the job. Existing jobs cannot be re-encrypted; resubmit them with a CMEK key.
+        - id: cli
+          desc: |
+            Job encryption is set at submission through the Vertex AI API. To create a batch prediction job with a CMEK key, include an `encryptionSpec` in the request body:
+
+            ```bash
+            curl -s -X POST \
+              -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              -H "Content-Type: application/json" \
+              "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT/locations/REGION/batchPredictionJobs" \
+              -d '{"displayName":"example-job","model":"MODEL","encryptionSpec":{"kmsKeyName":"projects/PROJECT/locations/REGION/keyRings/KEYRING/cryptoKeys/KEY"}}'
+            ```
+        # No Terraform remediation: Vertex AI batch prediction and tuning jobs are imperative API calls with no dedicated Terraform resource that expresses the encryption key.
+    refs:
+      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+        title: Customer-managed encryption keys (CMEK) for Vertex AI


### PR DESCRIPTION
## Summary

Adds 16 new security checks across the AI/ML services of AWS, Azure, and GCP, targeting the largely-untapped surface of **AI safety configuration** and **AI-service hardening**. The clouds' AI resources are richly modeled by the providers but thinly checked today (Bedrock had only 3 checks; Azure Cognitive/ML had 8; Vertex AI notebook runtimes had none).

### AWS (`mondoo-aws-security` → 12.7.0) — 6
- `bedrock-guardrails-configured` — at least one guardrail in `READY` state *(AI-safety)*
- `bedrock-guardrail-cmk-encryption`, `bedrock-agent-cmk-encryption`, `bedrock-flow-cmk-encryption`
- `sagemaker-endpoint-data-capture-cmk-encryption` — encrypt captured inference payloads
- `sagemaker-domain-vpc-only` — VpcOnly app network access

### Azure (`mondoo-azure-security` → 9.7.0) — 4
- `cognitive-services-defender-for-ai-enabled` — runtime AI threat detection *(AI-safety)*
- `cognitive-services-restrict-outbound-network` — egress/exfiltration control
- `ml-serverless-endpoint-key-auth-disabled` — token auth over static keys
- `ml-workspace-cmk-encryption`

### GCP (`mondoo-gcp-security` → 9.6.0) — 6
- `vertexai-notebook-runtime-template-cmek-encryption` / `-shielded-vm` / `-private-network`
- `workbench-instance-no-default-service-account`
- `vertexai-rag-corpus-cmek-encryption`
- `vertexai-job-cmek-encryption` (batch prediction + tuning)

## Compliance & NIST AI 100-1

Every check carries verified tags across the 13 baseline frameworks (control text read, not copied from neighbors). **NIST AI 100-1 is mapped only to the two checks that evidence genuine AI risk management** — consistent with the line drawn in #3074 that generic CMK/network/IAM hygiene on AI-named resources is not AI RMF coverage:

- **Bedrock guardrails** → `measure-2-6, measure-2-7, measure-2-10` (safe outputs / prompt-attack / PII)
- **Defender for AI** → `measure-2-4, measure-2-7, manage-4-1` (production monitoring / adversarial detection / incident response)

## Notes
- Terraform/CloudFormation/Bicep variants included where a real IaC resource exists; runtime-only checks carry a `# No Terraform variants:` comment explaining why (account-level posture, imperative job/RAG APIs, Defender plan state).
- Impact bands anchored to sibling checks (CMK 70–80, network/auth/host 70).
- Dropped a proposed Workbench no-public-IP check — already covered by the existing `vertex-ai-workbench-no-public-ip`; scoped the ML key-auth check to *serverless* endpoints since the *online*-endpoint version already exists.

## Verification

| Gate | AWS | Azure | GCP |
|---|---|---|---|
| `cnspec policy lint` | ✅ valid | ✅ valid | ✅ valid |
| `validate_remediation_commands.py` | 986 / 0 | 388 / 0 | 397 / 0 |
| `typos` | clean | clean | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)