### PR TITLE
✨ Add `cnspec upload` for third-party scan reports (hidden/experimental)

### DIFF
--- a/apps/cnspec/cmd/upload.go
+++ b/apps/cnspec/cmd/upload.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd

--- a/apps/cnspec/cmd/upload.go
+++ b/apps/cnspec/cmd/upload.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/v13/upload"
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/all"
+)
+
+func init() {
+	rootCmd.AddCommand(uploadCmd)
+	uploadCmd.Flags().String("format", "", "Source report format (use --format list to see all)")
+	uploadCmd.Flags().String("source", "", "Producing-tool name recorded on findings (default: the --format value)")
+	uploadCmd.Flags().String("space", "", "Target space MRN (default: from the Mondoo config)")
+	uploadCmd.Flags().String("config", "", "Path to the Mondoo config / service account")
+	uploadCmd.Flags().Bool("dry-run", false, "Convert and summarize, but do not upload")
+}
+
+var uploadCmd = &cobra.Command{
+	Use: "upload --format <format> [flags] <file>",
+	// Hidden until validated in production; the command works but is not yet
+	// advertised in `cnspec --help`.
+	Hidden: true,
+	Short:  "Experimental: Upload a third-party scan report to Mondoo Platform as findings",
+	Long: `Convert a third-party scanner's report file into Mondoo findings (FEX/VEX)
+and upload them to Mondoo Platform.
+
+Use --format list to see the supported formats. Standard open formats
+(e.g. SARIF) are converted locally by cnspec; other formats are converted by the
+Mondoo Platform after upload.
+
+Example:
+  cnspec upload --format sarif results.sarif
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runUpload,
+}
+
+func runUpload(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+
+	if format == "list" {
+		fmt.Println("Supported formats:")
+		for _, f := range rc.Formats() {
+			fmt.Println("  " + f)
+		}
+		return nil
+	}
+	if format == "" {
+		return fmt.Errorf("--format is required (use --format list to see supported formats)")
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("exactly one report file is required")
+	}
+
+	conv, ok := rc.Get(format)
+	if !ok {
+		return fmt.Errorf("unknown format %q; use --format list to see supported formats", format)
+	}
+
+	data, err := os.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("read %s: %w", args[0], err)
+	}
+	docs, err := conv(data)
+	if err != nil {
+		return fmt.Errorf("convert %s: %w", args[0], err)
+	}
+	if len(docs) == 0 {
+		fmt.Printf("No findings in %s\n", args[0])
+		return nil
+	}
+	for i, d := range docs {
+		if verr := rc.Validate(d); verr != nil {
+			log.Warn().Msgf("finding %d is not clean and may be rejected: %v", i, verr)
+		}
+	}
+
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		fmt.Printf("Converted %d finding(s) from %s (dry run — not uploaded)\n", len(docs), args[0])
+		return nil
+	}
+
+	source, _ := cmd.Flags().GetString("source")
+	if source == "" {
+		source = format
+	}
+	configPath, _ := cmd.Flags().GetString("config")
+	space, _ := cmd.Flags().GetString("space")
+
+	err = upload.UploadFindings(context.Background(), upload.Opts{ConfigPath: configPath, ScopeMrn: space}, docs, source)
+	if err != nil {
+		if upload.IsNoCredentials(err) {
+			return fmt.Errorf("no Mondoo credentials found; run `cnspec login` or pass --config <path>")
+		}
+		return fmt.Errorf("upload findings: %w", err)
+	}
+
+	fmt.Printf("Uploaded %d finding(s) from %s\n", len(docs), args[0])
+	return nil
+}

--- a/apps/cnspec/cmd/upload.go
+++ b/apps/cnspec/cmd/upload.go
@@ -15,6 +15,9 @@ import (
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/all"
 )
 
+// maxReportSize caps the report file read into memory (512 MiB).
+const maxReportSize = 512 << 20
+
 func init() {
 	rootCmd.AddCommand(uploadCmd)
 	uploadCmd.Flags().String("format", "", "Source report format (use --format list to see all)")
@@ -64,6 +67,14 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	conv, ok := rc.Get(format)
 	if !ok {
 		return fmt.Errorf("unknown format %q; use --format list to see supported formats", format)
+	}
+
+	// Guard against reading an accidentally huge file into memory (arbitrary
+	// user-supplied path).
+	if info, err := os.Stat(args[0]); err != nil {
+		return fmt.Errorf("stat %s: %w", args[0], err)
+	} else if info.Size() > maxReportSize {
+		return fmt.Errorf("report %s is %d bytes, which exceeds the %d byte limit", args[0], info.Size(), int64(maxReportSize))
 	}
 
 	data, err := os.ReadFile(args[0])

--- a/upload/report_conversion/all/all.go
+++ b/upload/report_conversion/all/all.go
@@ -1,0 +1,11 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package all blank-imports every cnspec-resident converter so their init()
+// registrations run. Import it (with _) from the CLI and any server entry point
+// that needs the full set of standard-format converters.
+package all
+
+import (
+	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/sarif"
+)

--- a/upload/report_conversion/all/all.go
+++ b/upload/report_conversion/all/all.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 // Package all blank-imports every cnspec-resident converter so their init()

--- a/upload/report_conversion/assert.go
+++ b/upload/report_conversion/assert.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package report_conversion

--- a/upload/report_conversion/assert.go
+++ b/upload/report_conversion/assert.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package report_conversion
+
+import (
+	"os"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+// AssertClean is the standard converter test: it runs conv on the report file at
+// path and asserts it produces at least one document and that every document
+// passes Validate. A converter is "done" when a real sample report converts clean
+// — there are no golden files to maintain.
+func AssertClean(t *testing.T, conv Converter, path string) []*fex.FindingDocument {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	docs, err := conv(data)
+	if err != nil {
+		t.Fatalf("convert %s: %v", path, err)
+	}
+	if len(docs) == 0 {
+		t.Fatalf("convert %s: produced no documents", path)
+	}
+	for i, d := range docs {
+		if err := Validate(d); err != nil {
+			t.Errorf("document %d not clean: %v", i, err)
+		}
+	}
+	return docs
+}

--- a/upload/report_conversion/registry.go
+++ b/upload/report_conversion/registry.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 // Package report_conversion turns third-party scanner report files into Mondoo

--- a/upload/report_conversion/registry.go
+++ b/upload/report_conversion/registry.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package report_conversion turns third-party scanner report files into Mondoo
+// FEX/VEX findings (FindingDocument). Each supported format registers a Converter
+// under a format name; the `cnspec upload` command and the server console-upload
+// path look converters up by name.
+//
+// This package holds the public, open-standard converters (SARIF, CycloneDX,
+// SPDX, JUnit). Vendor/proprietary formats are converted server-side; see
+// ADR-062 (docs/adr/062-third-party-data-management.md) for the placement split.
+package report_conversion
+
+import (
+	"sort"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+// Converter parses one tool's native report bytes into FEX/VEX documents. It is
+// pure: no network, no disk access beyond the input arg.
+type Converter func(data []byte) ([]*fex.FindingDocument, error)
+
+var registry = map[string]Converter{}
+
+// Register wires a format name (the value passed to `--format`) to its converter.
+// It is meant to be called from a converter subpackage's init(); registering the
+// same format twice panics, which surfaces duplicate wiring at startup.
+func Register(format string, c Converter) {
+	if _, exists := registry[format]; exists {
+		panic("report_conversion: duplicate converter registered for format " + format)
+	}
+	registry[format] = c
+}
+
+// Get returns the converter for a format, or (nil, false) if none is registered.
+func Get(format string) (Converter, bool) {
+	c, ok := registry[format]
+	return c, ok
+}
+
+// Formats returns the registered format names, sorted.
+func Formats() []string {
+	out := make([]string, 0, len(registry))
+	for k := range registry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/upload/report_conversion/registry.go
+++ b/upload/report_conversion/registry.go
@@ -13,6 +13,7 @@ package report_conversion
 
 import (
 	"sort"
+	"sync"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
 )
@@ -21,12 +22,19 @@ import (
 // pure: no network, no disk access beyond the input arg.
 type Converter func(data []byte) ([]*fex.FindingDocument, error)
 
-var registry = map[string]Converter{}
+// mu guards registry. Registration happens at init() today, but the lock keeps
+// the map safe if a converter is ever registered at runtime.
+var (
+	mu       sync.RWMutex
+	registry = map[string]Converter{}
+)
 
 // Register wires a format name (the value passed to `--format`) to its converter.
 // It is meant to be called from a converter subpackage's init(); registering the
 // same format twice panics, which surfaces duplicate wiring at startup.
 func Register(format string, c Converter) {
+	mu.Lock()
+	defer mu.Unlock()
 	if _, exists := registry[format]; exists {
 		panic("report_conversion: duplicate converter registered for format " + format)
 	}
@@ -35,12 +43,16 @@ func Register(format string, c Converter) {
 
 // Get returns the converter for a format, or (nil, false) if none is registered.
 func Get(format string) (Converter, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
 	c, ok := registry[format]
 	return c, ok
 }
 
 // Formats returns the registered format names, sorted.
 func Formats() []string {
+	mu.RLock()
+	defer mu.RUnlock()
 	out := make([]string, 0, len(registry))
 	for k := range registry {
 		out = append(out, k)

--- a/upload/report_conversion/sarif/sarif.go
+++ b/upload/report_conversion/sarif/sarif.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package sarif converts SARIF (Static Analysis Results Interchange Format)
+// reports into Mondoo FEX findings. SARIF is an open standard emitted by many
+// SAST/IaC tools, so this one converter reaches a broad set of scanners.
+package sarif
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	gosarif "github.com/owenrumney/go-sarif/v2/sarif"
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func init() { rc.Register("sarif", Convert) }
+
+// Convert parses a SARIF report (JSON) and returns one FEX document per result.
+func Convert(data []byte) ([]*fex.FindingDocument, error) {
+	report, err := gosarif.FromBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse sarif report: %w", err)
+	}
+
+	var docs []*fex.FindingDocument
+	for _, run := range report.Runs {
+		source := &fex.Source{Name: run.Tool.Driver.Name}
+		for _, result := range run.Results {
+			docs = append(docs, fex.FexToDocument(convertResult(result, source)))
+		}
+	}
+	return docs, nil
+}
+
+func convertResult(result *gosarif.Result, source *fex.Source) *fex.FindingExchange {
+	ruleID := deref(result.RuleID)
+	message := ""
+	if result.Message.Text != nil {
+		message = *result.Message.Text
+	}
+
+	// Id must be stable and non-empty; prefer the rule id, fall back to a hash of
+	// the message so a result without a ruleId still validates.
+	id := ruleID
+	if id == "" {
+		id = shortHash(message)
+	}
+	// Summary must be non-empty; prefer the message, fall back to the rule id.
+	summary := message
+	if summary == "" {
+		summary = ruleID
+	}
+
+	f := &fex.FindingExchange{
+		Id:          id,
+		Ref:         ruleID,
+		Summary:     summary,
+		Source:      source,
+		Status:      fex.Status_STATUS_AFFECTED,
+		FirstSeenAt: timestamppb.Now(),
+		Details: &fex.FindingDetail{
+			Category:    fex.FindingDetail_CATEGORY_SECURITY,
+			Description: message,
+			Severity:    convertSeverity(result.Level),
+			Properties:  stringProps(result.Properties),
+		},
+	}
+	f.Affects = convertAffects(result)
+	f.Remediations = convertRemediations(result)
+	return f
+}
+
+func convertSeverity(level *string) *fex.Severity {
+	if level == nil {
+		return nil
+	}
+	var rating fex.SeverityRating
+	switch strings.ToLower(*level) {
+	case "error":
+		rating = fex.SeverityRating_SEVERITY_RATING_HIGH
+	case "warning":
+		rating = fex.SeverityRating_SEVERITY_RATING_MEDIUM
+	case "note":
+		rating = fex.SeverityRating_SEVERITY_RATING_LOW
+	default:
+		return nil
+	}
+	return &fex.Severity{Rating: rating}
+}
+
+func convertAffects(result *gosarif.Result) []*fex.Affects {
+	var out []*fex.Affects
+	seen := map[string]bool{}
+	for _, loc := range result.Locations {
+		if loc.PhysicalLocation == nil || loc.PhysicalLocation.ArtifactLocation == nil {
+			continue
+		}
+		uri := loc.PhysicalLocation.ArtifactLocation.URI
+		if uri == nil || seen[*uri] {
+			continue
+		}
+		seen[*uri] = true
+		out = append(out, &fex.Affects{Component: &fex.Component{
+			Id:      shortHash(*uri),
+			Details: &fex.Component_File{File: &fex.FileComponent{Path: *uri}},
+		}})
+	}
+	return out
+}
+
+func convertRemediations(result *gosarif.Result) []*fex.Remediation {
+	if len(result.Fixes) == 0 {
+		return nil
+	}
+	var out []*fex.Remediation
+	for _, fix := range result.Fixes {
+		var b strings.Builder
+		b.WriteString("### Automated fix\n\n")
+		for _, change := range fix.ArtifactChanges {
+			if change.ArtifactLocation.URI != nil {
+				fmt.Fprintf(&b, "File: %s\n\n", *change.ArtifactLocation.URI)
+			}
+			for _, r := range change.Replacements {
+				b.WriteString("```diff\n")
+				if r.DeletedRegion.Snippet != nil && r.DeletedRegion.Snippet.Text != nil {
+					fmt.Fprintf(&b, "- %s\n", *r.DeletedRegion.Snippet.Text)
+				}
+				if r.InsertedContent != nil && r.InsertedContent.Text != nil {
+					fmt.Fprintf(&b, "+ %s\n", *r.InsertedContent.Text)
+				}
+				b.WriteString("```\n\n")
+			}
+		}
+		out = append(out, &fex.Remediation{
+			Category: fex.Remediation_Fix,
+			Summary:  "Automated fix",
+			FixType:  "markdown",
+			Details:  b.String(),
+		})
+	}
+	return out
+}
+
+func stringProps(p gosarif.Properties) map[string]string {
+	if len(p) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for k, v := range p {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h)[:16]
+}

--- a/upload/report_conversion/sarif/sarif.go
+++ b/upload/report_conversion/sarif/sarif.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 // Package sarif converts SARIF (Static Analysis Results Interchange Format)

--- a/upload/report_conversion/sarif/sarif.go
+++ b/upload/report_conversion/sarif/sarif.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+	"time"
 
 	gosarif "github.com/owenrumney/go-sarif/v2/sarif"
 	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
@@ -27,41 +28,52 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 	}
 
 	var docs []*fex.FindingDocument
+	index := 0
 	for _, run := range report.Runs {
 		source := &fex.Source{Name: run.Tool.Driver.Name}
+		runTime := runStartTime(run)
 		for _, result := range run.Results {
-			docs = append(docs, fex.FexToDocument(convertResult(result, source)))
+			docs = append(docs, fex.FexToDocument(convertResult(result, source, runTime, index)))
+			index++
 		}
 	}
 	return docs, nil
 }
 
-func convertResult(result *gosarif.Result, source *fex.Source) *fex.FindingExchange {
+func convertResult(result *gosarif.Result, source *fex.Source, runTime *time.Time, index int) *fex.FindingExchange {
 	ruleID := deref(result.RuleID)
 	message := ""
 	if result.Message.Text != nil {
 		message = *result.Message.Text
 	}
 
-	// Id must be stable and non-empty; prefer the rule id, fall back to a hash of
-	// the message so a result without a ruleId still validates.
+	// Id must be stable and non-empty. Prefer the rule id; else a hash of the
+	// message; else fall back to the result index so empty-rule/empty-message
+	// results don't collapse into one finding.
 	id := ruleID
 	if id == "" {
-		id = shortHash(message)
+		if message != "" {
+			id = shortHash(message)
+		} else {
+			id = fmt.Sprintf("finding-%d", index)
+		}
 	}
-	// Summary must be non-empty; prefer the message, fall back to the rule id.
+	// Summary must be non-empty; prefer the message, then the rule id, then a
+	// generic label so Validate never rejects it.
 	summary := message
 	if summary == "" {
 		summary = ruleID
 	}
+	if summary == "" {
+		summary = "Finding from " + source.Name
+	}
 
 	f := &fex.FindingExchange{
-		Id:          id,
-		Ref:         ruleID,
-		Summary:     summary,
-		Source:      source,
-		Status:      fex.Status_STATUS_AFFECTED,
-		FirstSeenAt: timestamppb.Now(),
+		Id:      id,
+		Ref:     ruleID,
+		Summary: summary,
+		Source:  source,
+		Status:  fex.Status_STATUS_AFFECTED,
 		Details: &fex.FindingDetail{
 			Category:    fex.FindingDetail_CATEGORY_SECURITY,
 			Description: message,
@@ -69,9 +81,38 @@ func convertResult(result *gosarif.Result, source *fex.Source) *fex.FindingExcha
 			Properties:  stringProps(result.Properties),
 		},
 	}
+	// Prefer the scanner's own first-detection time so re-uploading an old report
+	// doesn't reset first-seen to upload time; leave unset when unknown so the
+	// platform can assign/preserve it.
+	if ts := firstSeen(result, runTime); ts != nil {
+		f.FirstSeenAt = timestamppb.New(*ts)
+	}
 	f.Affects = convertAffects(result)
 	f.Remediations = convertRemediations(result)
 	return f
+}
+
+// runStartTime returns the earliest invocation start time of a run, or nil.
+func runStartTime(run *gosarif.Run) *time.Time {
+	var earliest *time.Time
+	for _, inv := range run.Invocations {
+		if inv.StartTimeUTC == nil {
+			continue
+		}
+		if earliest == nil || inv.StartTimeUTC.Before(*earliest) {
+			earliest = inv.StartTimeUTC
+		}
+	}
+	return earliest
+}
+
+// firstSeen prefers a result's provenance first-detection time, falling back to
+// the run's start time. Returns nil when neither is present.
+func firstSeen(result *gosarif.Result, runTime *time.Time) *time.Time {
+	if result.Provenance != nil && result.Provenance.FirstDetectionTimeUTC != nil {
+		return result.Provenance.FirstDetectionTimeUTC
+	}
+	return runTime
 }
 
 func convertSeverity(level *string) *fex.Severity {

--- a/upload/report_conversion/sarif/sarif_test.go
+++ b/upload/report_conversion/sarif/sarif_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sarif_test

--- a/upload/report_conversion/sarif/sarif_test.go
+++ b/upload/report_conversion/sarif/sarif_test.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sarif_test
+
+import (
+	"testing"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/cnspec/v13/upload/report_conversion/sarif"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func TestConvert(t *testing.T) {
+	docs := rc.AssertClean(t, sarif.Convert, "testdata/basic.sarif")
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+
+	f := docs[0].GetFex()
+	if f == nil {
+		t.Fatal("expected a FEX finding")
+	}
+	if f.GetSource().GetName() != "semgrep" {
+		t.Errorf("source = %q, want semgrep", f.GetSource().GetName())
+	}
+	if f.GetDetails().GetCategory() != fex.FindingDetail_CATEGORY_SECURITY {
+		t.Errorf("category = %v, want SECURITY", f.GetDetails().GetCategory())
+	}
+	if got := f.GetDetails().GetSeverity().GetRating(); got != fex.SeverityRating_SEVERITY_RATING_HIGH {
+		t.Errorf("severity = %v, want HIGH (from sarif level=error)", got)
+	}
+	if len(f.GetAffects()) != 1 {
+		t.Errorf("want 1 affected component, got %d", len(f.GetAffects()))
+	}
+}

--- a/upload/report_conversion/sarif/sarif_test.go
+++ b/upload/report_conversion/sarif/sarif_test.go
@@ -34,3 +34,37 @@ func TestConvert(t *testing.T) {
 		t.Errorf("want 1 affected component, got %d", len(f.GetAffects()))
 	}
 }
+
+// TestConvertEmptyFields checks that results with neither a ruleId nor a message
+// still produce clean, distinctly-identified findings (no collapse, no empty
+// summary).
+func TestConvertEmptyFields(t *testing.T) {
+	report := []byte(`{
+	  "version": "2.1.0",
+	  "runs": [{
+	    "tool": {"driver": {"name": "toolx"}},
+	    "results": [
+	      {"locations": [{"physicalLocation": {"artifactLocation": {"uri": "a.go"}}}]},
+	      {"locations": [{"physicalLocation": {"artifactLocation": {"uri": "b.go"}}}]}
+	    ]
+	  }]
+	}`)
+	docs, err := sarif.Convert(report)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+	ids := map[string]bool{}
+	for i, d := range docs {
+		if err := rc.Validate(d); err != nil {
+			t.Errorf("document %d not clean: %v", i, err)
+		}
+		id := d.GetFex().GetId()
+		if ids[id] {
+			t.Errorf("duplicate id %q — empty-field results collapsed", id)
+		}
+		ids[id] = true
+	}
+}

--- a/upload/report_conversion/sarif/testdata/basic.sarif
+++ b/upload/report_conversion/sarif/testdata/basic.sarif
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "semgrep", "version": "1.0.0" } },
+      "results": [
+        {
+          "ruleId": "go.lang.security.audit.database.string-formatted-query",
+          "level": "error",
+          "message": { "text": "Possible SQL injection via string-formatted query" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "internal/db/query.go" },
+                "region": { "startLine": 42 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "go.lang.correctness.useless-eqeq.useless-eqeq",
+          "level": "warning",
+          "message": { "text": "Useless equality comparison" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "cmd/main.go" }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/upload/report_conversion/validate.go
+++ b/upload/report_conversion/validate.go
@@ -1,0 +1,71 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package report_conversion
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+// Validate reports whether a FindingDocument is "clean": well-formed with the
+// fields the platform needs to ingest it. It is the reusable invariant behind the
+// converter test harness (AssertClean) and can also gate uploads before they are
+// sent. It intentionally checks only the core required fields — richer,
+// converter-specific expectations (severity present, evidence attached) belong in
+// each converter's own tests.
+func Validate(doc *fex.FindingDocument) error {
+	if doc == nil {
+		return fmt.Errorf("finding document is nil")
+	}
+	vex, fexDoc := doc.GetVex(), doc.GetFex()
+	switch {
+	case vex != nil && fexDoc != nil:
+		return fmt.Errorf("finding document has both vex and fex set")
+	case vex != nil:
+		return validateVex(vex)
+	case fexDoc != nil:
+		return validateFex(fexDoc)
+	default:
+		return fmt.Errorf("finding document has neither vex nor fex set")
+	}
+}
+
+func validateVex(v *fex.VulnerabilityExchange) error {
+	if v.GetId() == "" {
+		return fmt.Errorf("vex: id (CVE/advisory) is required")
+	}
+	if v.GetSummary() == "" {
+		return fmt.Errorf("vex %q: summary is required", v.GetId())
+	}
+	if v.GetSource().GetName() == "" {
+		return fmt.Errorf("vex %q: source name is required", v.GetId())
+	}
+	if v.GetStatus() == fex.Status_STATUS_UNSPECIFIED {
+		return fmt.Errorf("vex %q: status is required", v.GetId())
+	}
+	return nil
+}
+
+func validateFex(f *fex.FindingExchange) error {
+	if f.GetId() == "" {
+		return fmt.Errorf("fex: id is required")
+	}
+	if f.GetSummary() == "" {
+		return fmt.Errorf("fex %q: summary is required", f.GetId())
+	}
+	if f.GetSource().GetName() == "" {
+		return fmt.Errorf("fex %q: source name is required", f.GetId())
+	}
+	if f.GetStatus() == fex.Status_STATUS_UNSPECIFIED {
+		return fmt.Errorf("fex %q: status is required", f.GetId())
+	}
+	if f.GetDetails() == nil {
+		return fmt.Errorf("fex %q: details are required", f.GetId())
+	}
+	if f.GetDetails().GetCategory() == fex.FindingDetail_CATEGORY_UNSPECIFIED {
+		return fmt.Errorf("fex %q: details.category is required", f.GetId())
+	}
+	return nil
+}

--- a/upload/report_conversion/validate.go
+++ b/upload/report_conversion/validate.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package report_conversion


### PR DESCRIPTION
## What

Adds a `cnspec upload` command and a file-conversion layer that turns third-party scanner reports into Mondoo findings (FEX/VEX) and uploads them to Mondoo Platform.

```
cnspec upload --format <format> [--source --space --config --dry-run] <file>
cnspec upload --format list      # enumerate supported formats
```

**The command is `Hidden` for now** — it works, but is not advertised in `--help` until we've validated it in production.

## Contents

- **`upload/report_conversion/`** — the converter framework:
  - `registry.go` — a `Converter` (`func([]byte) ([]*fex.FindingDocument, error)`) registry (`Register`/`Get`/`Formats`).
  - `validate.go` — `Validate`, the "clean" `FindingDocument` invariant (required fields set); reusable pre-upload and as a test check.
  - `assert.go` — `AssertClean` test helper (no golden files — assert every produced doc validates).
- **`upload/report_conversion/sarif/`** — the SARIF converter (open standard emitted by many SAST/IaC tools), ported to the mql `fex` types, self-registering, with a test.
- **`apps/cnspec/cmd/upload.go`** — the CLI: read → convert → validate → upload via the existing `upload.UploadFindings`.

## No server change required

The command PUTs pre-converted `FindingDocument`s through the existing signed-URL third-party-findings path (`PolicyResolver.GetUploadURL` → `BulkUploadFex`), so it works against today's platform with no server-side change.

Standard open formats (SARIF here; CycloneDX/SPDX/JUnit next) convert in cnspec; vendor/long-tail formats will convert server-side. Background: ADR-062 (third-party security data management).

## Verification

- `go build` of the package and the full `cnspec` cmd
- SARIF converter test passes
- `cnspec upload --format list` → `sarif`; `--format sarif --dry-run <sample>` → "Converted 2 finding(s) … (dry run)"
- command absent from `cnspec --help` (Hidden), still runnable
- gofmt clean, golangci-lint 0 issues on the new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)