### PR TITLE
✨ cnspec upload: SBOM formats (CycloneDX/SPDX) via platform scan

### DIFF
--- a/apps/cnspec/cmd/upload.go
+++ b/apps/cnspec/cmd/upload.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -110,10 +109,26 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	space, _ := cmd.Flags().GetString("space")
 	opts := upload.Opts{ConfigPath: configPath, ScopeMrn: space}
 
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
 	var docs []*fex.FindingDocument
 	if sbomFormats[format] {
-		// SBOM path: decode → scan on Mondoo Platform (returns VEX) → documents.
-		docs, err = scanSBOMFile(cmd.Context(), opts, data)
+		// SBOM path: decode locally, then scan on Mondoo Platform (remote) for VEX.
+		bom, perr := sbom.DefaultMultiDecoder().Parse(bytes.NewReader(data))
+		if perr != nil {
+			return fmt.Errorf("parse SBOM (expected CycloneDX, SPDX, or Mondoo JSON): %w", perr)
+		}
+		// --dry-run must not touch the network: stop after the local decode.
+		if dryRun {
+			fmt.Printf("Parsed SBOM from %s (dry run — not scanned or uploaded)\n", args[0])
+			return nil
+		}
+		vex, serr := upload.ScanSBOM(cmd.Context(), opts, bom)
+		if serr != nil {
+			err = serr
+		} else {
+			docs = fex.VexToDocuments(vex)
+		}
 	} else {
 		docs, err = conv(data)
 	}
@@ -133,7 +148,8 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+	// Converter (local) dry-run: findings were produced without any network call.
+	if dryRun {
 		fmt.Printf("Converted %d finding(s) from %s (dry run — not uploaded)\n", len(docs), args[0])
 		return nil
 	}
@@ -153,18 +169,4 @@ func runUpload(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Uploaded %d finding(s) from %s\n", len(docs), args[0])
 	return nil
-}
-
-// scanSBOMFile decodes SBOM bytes (CycloneDX/SPDX/Mondoo JSON, auto-detected),
-// scans them on Mondoo Platform, and wraps the resulting VEX as documents.
-func scanSBOMFile(ctx context.Context, opts upload.Opts, data []byte) ([]*fex.FindingDocument, error) {
-	bom, err := sbom.DefaultMultiDecoder().Parse(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("parse SBOM (expected CycloneDX, SPDX, or Mondoo JSON): %w", err)
-	}
-	vex, err := upload.ScanSBOM(ctx, opts, bom)
-	if err != nil {
-		return nil, err
-	}
-	return fex.VexToDocuments(vex), nil
 }

--- a/apps/cnspec/cmd/upload.go
+++ b/apps/cnspec/cmd/upload.go
@@ -4,19 +4,43 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"go.mondoo.com/cnspec/v13/upload"
 	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/all"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"go.mondoo.com/mql/v13/sbom"
 )
 
 // maxReportSize caps the report file read into memory (512 MiB).
 const maxReportSize = 512 << 20
+
+// sbomFormats are handled by the SBOM path: the file is decoded into an SBOM and
+// scanned by Mondoo Platform (ExtendedVulnMgmt.ScanUploadedSbom), which returns
+// VEX. The mql multi-decoder auto-detects the concrete encoding, so these names
+// are for discoverability; all route through the same path.
+var sbomFormats = map[string]bool{
+	"sbom":      true,
+	"cyclonedx": true,
+	"spdx":      true,
+}
+
+// allFormats lists every accepted --format value (pure converters + SBOM).
+func allFormats() []string {
+	out := rc.Formats()
+	for f := range sbomFormats {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
+}
 
 func init() {
 	rootCmd.AddCommand(uploadCmd)
@@ -52,7 +76,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 
 	if format == "list" {
 		fmt.Println("Supported formats:")
-		for _, f := range rc.Formats() {
+		for _, f := range allFormats() {
 			fmt.Println("  " + f)
 		}
 		return nil
@@ -64,8 +88,8 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("exactly one report file is required")
 	}
 
-	conv, ok := rc.Get(format)
-	if !ok {
+	conv, isConverter := rc.Get(format)
+	if !isConverter && !sbomFormats[format] {
 		return fmt.Errorf("unknown format %q; use --format list to see supported formats", format)
 	}
 
@@ -81,9 +105,23 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", args[0], err)
 	}
-	docs, err := conv(data)
+
+	configPath, _ := cmd.Flags().GetString("config")
+	space, _ := cmd.Flags().GetString("space")
+	opts := upload.Opts{ConfigPath: configPath, ScopeMrn: space}
+
+	var docs []*fex.FindingDocument
+	if sbomFormats[format] {
+		// SBOM path: decode → scan on Mondoo Platform (returns VEX) → documents.
+		docs, err = scanSBOMFile(cmd.Context(), opts, data)
+	} else {
+		docs, err = conv(data)
+	}
 	if err != nil {
-		return fmt.Errorf("convert %s: %w", args[0], err)
+		if upload.IsNoCredentials(err) {
+			return fmt.Errorf("no Mondoo credentials found; run `cnspec login` or pass --config <path>")
+		}
+		return fmt.Errorf("process %s: %w", args[0], err)
 	}
 	if len(docs) == 0 {
 		fmt.Printf("No findings in %s\n", args[0])
@@ -104,10 +142,8 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	if source == "" {
 		source = format
 	}
-	configPath, _ := cmd.Flags().GetString("config")
-	space, _ := cmd.Flags().GetString("space")
 
-	err = upload.UploadFindings(context.Background(), upload.Opts{ConfigPath: configPath, ScopeMrn: space}, docs, source)
+	err = upload.UploadFindings(cmd.Context(), opts, docs, source)
 	if err != nil {
 		if upload.IsNoCredentials(err) {
 			return fmt.Errorf("no Mondoo credentials found; run `cnspec login` or pass --config <path>")
@@ -117,4 +153,18 @@ func runUpload(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Uploaded %d finding(s) from %s\n", len(docs), args[0])
 	return nil
+}
+
+// scanSBOMFile decodes SBOM bytes (CycloneDX/SPDX/Mondoo JSON, auto-detected),
+// scans them on Mondoo Platform, and wraps the resulting VEX as documents.
+func scanSBOMFile(ctx context.Context, opts upload.Opts, data []byte) ([]*fex.FindingDocument, error) {
+	bom, err := sbom.DefaultMultiDecoder().Parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("parse SBOM (expected CycloneDX, SPDX, or Mondoo JSON): %w", err)
+	}
+	vex, err := upload.ScanSBOM(ctx, opts, bom)
+	if err != nil {
+		return nil, err
+	}
+	return fex.VexToDocuments(vex), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260711002324-faeac77769dd
-	go.mondoo.com/mql/v13 v13.29.2
+	go.mondoo.com/mql/v13 v13.29.3-0.20260719101831-263900a23443
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1078,6 +1078,8 @@ go.mondoo.com/mondoo-go v0.0.0-20260711002324-faeac77769dd h1:j2rWkLU4+b9a+Wp7iP
 go.mondoo.com/mondoo-go v0.0.0-20260711002324-faeac77769dd/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.29.2 h1:yhkK3ulAl7gFlY9cETUHa26nwvUAHNfq1ytThzCSjX4=
 go.mondoo.com/mql/v13 v13.29.2/go.mod h1:/3qVUYSMyBN+vkYf9jBAiFf1upT/vtkx4po3ipGQa3s=
+go.mondoo.com/mql/v13 v13.29.3-0.20260719101831-263900a23443 h1:+jmSfhpTGbnFNaysnO5aP+LenAD7ZE7apHQVn9SZx9Y=
+go.mondoo.com/mql/v13 v13.29.3-0.20260719101831-263900a23443/go.mod h1:/3qVUYSMyBN+vkYf9jBAiFf1upT/vtkx4po3ipGQa3s=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/upload/sbomscan.go
+++ b/upload/sbomscan.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"fmt"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/sbomscan"
+	"go.mondoo.com/mql/v13/sbom"
+	ranger "go.mondoo.com/ranger-rpc"
+)
+
+// sbomScanner is the slice of the ExtendedVulnMgmt client that ScanSBOM needs; a
+// fake can stand in for tests.
+type sbomScanner interface {
+	ScanUploadedSbom(ctx context.Context, in *sbomscan.ScanUploadedSbomRequest) (*sbomscan.ScanUploadedSbomResponse, error)
+}
+
+// ScanSBOM sends an SBOM to Mondoo Platform's ExtendedVulnMgmt.ScanUploadedSbom
+// and returns the resulting VEX. The scan is ephemeral — the platform stores
+// nothing; the caller uploads the returned VEX itself (e.g. via UploadFindings).
+// This is the same flow xgrep uses for dependency vulnerability scanning.
+func ScanSBOM(ctx context.Context, opts Opts, bom *sbom.Sbom) ([]*fex.VulnerabilityExchange, error) {
+	creds, spaceMrn, err := LoadCredentials(opts)
+	if err != nil {
+		return nil, err
+	}
+	plugin, err := upstream.NewServiceAccountRangerPlugin(creds)
+	if err != nil {
+		return nil, fmt.Errorf("create auth plugin: %w", err)
+	}
+	scanner, err := sbomscan.NewExtendedVulnMgmtClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	if err != nil {
+		return nil, fmt.Errorf("create vuln scan client: %w", err)
+	}
+	return scanSBOM(ctx, scanner, spaceMrn, bom)
+}
+
+// scanSBOM is the testable core: it issues the scan against an injected scanner.
+func scanSBOM(ctx context.Context, scanner sbomScanner, spaceMrn string, bom *sbom.Sbom) ([]*fex.VulnerabilityExchange, error) {
+	resp, err := scanner.ScanUploadedSbom(ctx, &sbomscan.ScanUploadedSbomRequest{
+		// The field keeps the server's historical name asset_mrn; we pass the
+		// space scope, which the server resolves.
+		AssetMrn: spaceMrn,
+		Sbom:     bom,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan sbom: %w", err)
+	}
+	return resp.GetVex(), nil
+}

--- a/upload/sbomscan_test.go
+++ b/upload/sbomscan_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/sbomscan"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+type fakeScanner struct {
+	gotMrn  string
+	gotSbom *sbom.Sbom
+	resp    *sbomscan.ScanUploadedSbomResponse
+	err     error
+}
+
+func (f *fakeScanner) ScanUploadedSbom(_ context.Context, in *sbomscan.ScanUploadedSbomRequest) (*sbomscan.ScanUploadedSbomResponse, error) {
+	f.gotMrn = in.GetAssetMrn()
+	f.gotSbom = in.GetSbom()
+	return f.resp, f.err
+}
+
+func TestScanSBOM(t *testing.T) {
+	bom := &sbom.Sbom{Packages: []*sbom.Package{{Name: "openssl", Version: "1.1.1"}}}
+	fs := &fakeScanner{resp: &sbomscan.ScanUploadedSbomResponse{
+		Vex: []*fex.VulnerabilityExchange{{Id: "CVE-2024-0001"}},
+	}}
+
+	vex, err := scanSBOM(context.Background(), fs, "//captain.api.mondoo.app/spaces/s1", bom)
+	if err != nil {
+		t.Fatalf("scanSBOM: %v", err)
+	}
+	if fs.gotMrn != "//captain.api.mondoo.app/spaces/s1" {
+		t.Errorf("scoped mrn = %q", fs.gotMrn)
+	}
+	if len(fs.gotSbom.Packages) != 1 {
+		t.Errorf("sbom not forwarded: %+v", fs.gotSbom)
+	}
+	if len(vex) != 1 || vex[0].GetId() != "CVE-2024-0001" {
+		t.Errorf("vex = %+v", vex)
+	}
+}
+
+func TestScanSBOMError(t *testing.T) {
+	fs := &fakeScanner{err: errors.New("boom")}
+	if _, err := scanSBOM(context.Background(), fs, "s1", &sbom.Sbom{}); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## What

Extends `cnspec upload` (from #3081) with the **SBOM ingest path**. For `--format cyclonedx`, `spdx`, or `sbom`, the file is decoded and scanned by Mondoo Platform, and the resulting vulnerabilities are uploaded as VEX.

```
cnspec upload --format cyclonedx sbom.cdx.json
cnspec upload --format spdx sbom.spdx.json
cnspec upload --format sbom any-sbom.json     # auto-detects encoding
```

## How

- **`upload.ScanSBOM`** — sends an SBOM to `ExtendedVulnMgmt.ScanUploadedSbom` (the shared client promoted to mql in #9150) and returns VEX. Same ephemeral-scan flow xgrep uses for dependency scanning; the platform's MVD does the matching, so results are **Mondoo-native and consistent with cnspec's own scans** rather than a third-party tool's verdicts (ADR-062 §4.1). Testable core (`scanSBOM` + injected scanner) with unit tests.
- **`cnspec upload` command** — routes SBOM formats through decode (mql multi-decoder, auto-detects CycloneDX/SPDX/Mondoo JSON) → `ScanSBOM` → `VexToDocuments` → `UploadFindings`. Pure converters (SARIF) are unchanged; `--format list` shows both kinds.
- Bumps `go.mondoo.com/mql/v13` to the version that includes `providers-sdk/v1/upstream/sbomscan`.

## Why SBOM ≠ a pure converter

A SARIF/JUnit converter is a pure `func([]byte) → docs`. An SBOM needs a **network scan** to produce VEX, so it's a distinct path — not a registry `Converter` — exactly as the ADR's three-ingest-path model prescribes.

## Verification

- `go build`, `go test ./upload/` (incl. new `scanSBOM` tests)
- `--format list` → `cyclonedx, sarif, sbom, spdx`
- a real CycloneDX fixture decodes and reaches the scan step; bad input → clear decode error; no-creds → friendly login message
- gofmt / golangci-lint clean; go.mod diff is version bumps only

Command remains `Hidden` (experimental) until validated in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)