### PR TITLE
✨ cnspec vuln: --upload discovered vulnerabilities as VEX (hidden/experimental)

### DIFF
--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -155,8 +155,9 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		log.Fatal().Err(err).Msg("failed to print")
 	}
 
-	if upload, _ := cmd.Flags().GetBool("upload"); upload {
-		uploadVulnFindings(ctx, cnspecReport.ToCnqueryReport())
+	if doUpload, _ := cmd.Flags().GetBool("upload"); doUpload {
+		// Target the same space the scan resolved, honoring the user's config.
+		uploadVulnFindings(ctx, cnspecReport.ToCnqueryReport(), upstreamConf.SpaceMrn)
 	}
 }
 
@@ -164,14 +165,15 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 // as VEX findings. It builds an SBOM from the scan report, scans it on the
 // platform (ExtendedVulnMgmt.ScanUploadedSbom returns VEX), and uploads the VEX —
 // the same SBOM-scan flow the `cnspec upload --format sbom` path and xgrep use.
-func uploadVulnFindings(ctx context.Context, cnqueryReport *cr.Report) {
+// spaceMrn targets the same space the scan used (empty falls back to the config).
+func uploadVulnFindings(ctx context.Context, cnqueryReport *cr.Report, spaceMrn string) {
 	boms := mqlsbomgen.GenerateBom(cnqueryReport)
 	if len(boms) != 1 {
 		log.Error().Msg("skipping upload: expected exactly one asset SBOM")
 		return
 	}
 
-	opts := upload.Opts{}
+	opts := upload.Opts{ScopeMrn: spaceMrn}
 	vex, err := upload.ScanSBOM(ctx, opts, boms[0])
 	if err != nil {
 		if upload.IsNoCredentials(err) {

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -13,10 +13,18 @@ import (
 	"go.mondoo.com/cnspec/v13/internal/sbom/generator"
 	"go.mondoo.com/cnspec/v13/internal/sbom/pack"
 	"go.mondoo.com/cnspec/v13/internal/scandump"
+	"go.mondoo.com/cnspec/v13/upload"
+	cr "go.mondoo.com/mql/v13/cli/reporter"
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/mvd"
+	mqlsbomgen "go.mondoo.com/mql/v13/sbom/generator"
 )
+
+// vulnUploadSource identifies cnspec-produced vulnerability findings uploaded to
+// Mondoo Platform.
+const vulnUploadSource = "cnspec"
 
 func init() {
 	rootCmd.AddCommand(vulnCmd)
@@ -30,6 +38,10 @@ func init() {
 	vulnCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
 	vulnCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible")
 	vulnCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list")
+
+	// Experimental: upload discovered vulnerabilities to Mondoo Platform as VEX.
+	vulnCmd.Flags().Bool("upload", false, "Experimental: upload discovered vulnerabilities to Mondoo Platform as findings")
+	_ = vulnCmd.Flags().MarkHidden("upload")
 }
 
 var vulnCmd = &cobra.Command{
@@ -142,4 +154,42 @@ var vulnCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	if err := r.PrintVulns(vulnReport, bom.Asset.Name); err != nil {
 		log.Fatal().Err(err).Msg("failed to print")
 	}
+
+	if upload, _ := cmd.Flags().GetBool("upload"); upload {
+		uploadVulnFindings(ctx, cnspecReport.ToCnqueryReport())
+	}
+}
+
+// uploadVulnFindings emits the scanned asset's vulnerabilities to Mondoo Platform
+// as VEX findings. It builds an SBOM from the scan report, scans it on the
+// platform (ExtendedVulnMgmt.ScanUploadedSbom returns VEX), and uploads the VEX —
+// the same SBOM-scan flow the `cnspec upload --format sbom` path and xgrep use.
+func uploadVulnFindings(ctx context.Context, cnqueryReport *cr.Report) {
+	boms := mqlsbomgen.GenerateBom(cnqueryReport)
+	if len(boms) != 1 {
+		log.Error().Msg("skipping upload: expected exactly one asset SBOM")
+		return
+	}
+
+	opts := upload.Opts{}
+	vex, err := upload.ScanSBOM(ctx, opts, boms[0])
+	if err != nil {
+		if upload.IsNoCredentials(err) {
+			log.Error().Msg("skipping upload: run `cnspec login` to authenticate with Mondoo Platform")
+			return
+		}
+		log.Error().Err(err).Msg("failed to scan SBOM for upload")
+		return
+	}
+
+	docs := fex.VexToDocuments(vex)
+	if len(docs) == 0 {
+		log.Info().Msg("no vulnerabilities to upload")
+		return
+	}
+	if err := upload.UploadFindings(ctx, opts, docs, vulnUploadSource); err != nil {
+		log.Error().Err(err).Msg("failed to upload vulnerability findings")
+		return
+	}
+	log.Info().Msgf("uploaded %d vulnerability finding(s) to Mondoo Platform", len(docs))
 }


### PR DESCRIPTION
## What

Phase 2 of native self-emit (ADR-062 WP-SE1): let `cnspec vuln` upload the vulnerabilities it discovers to Mondoo Platform as VEX findings.

```
cnspec vuln --upload <target>
```

`--upload` is **Hidden/experimental** until validated in production.

## How

Reuses the SBOM-scan capability (from xgrep, promoted to mql as `sbomscan` in #9150; wrapped as `upload.ScanSBOM` for the file path in #3088):

1. `cnspec vuln` already runs the SBOM query pack and builds a scan report.
2. With `--upload`, cnspec generates an **mql SBOM** from that same report and sends it to Mondoo Platform (`ExtendedVulnMgmt.ScanUploadedSbom`).
3. The **platform** computes the VEX and returns it; cnspec uploads it via the existing `UploadFindings`.

cnspec does no local vulnerability matching — the platform calculates everything. The existing display path (`AnalyseAsset` → printed report) is unchanged.

## Relationship to Phase 1

This is a **separate phase** from #3088 (the file-based `cnspec upload --format sbom` path). Phase 1 = upload an SBOM *file*; Phase 2 = a live `cnspec vuln` scan emits its own findings. Both reuse `upload.ScanSBOM`.

## Verification

- `go build ./apps/cnspec/...`; gofmt / golangci-lint clean
- `--upload` is hidden from `cnspec vuln --help` but parses and is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)