### PR TITLE
✨ cnspec upload: JUnit XML converter

### DIFF
--- a/upload/report_conversion/all/all.go
+++ b/upload/report_conversion/all/all.go
@@ -8,5 +8,6 @@ package all
 
 import (
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/defectdojo"
+	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/junit"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/sarif"
 )

--- a/upload/report_conversion/junit/junit.go
+++ b/upload/report_conversion/junit/junit.go
@@ -1,0 +1,158 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package junit converts a JUnit XML report into Mondoo FEX findings. Each test
+// case with a <failure> or <error> becomes one finding; passing and skipped
+// cases are ignored. JUnit is a widely-emitted open format, so security test
+// suites and CI gates that report JUnit can be imported without a tool-specific
+// converter.
+package junit
+
+import (
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func init() { rc.Register("junit", Convert) }
+
+// testsuites is the root; some tools omit it and emit a bare <testsuite>, so both
+// are handled (see Convert).
+type testsuites struct {
+	XMLName xml.Name    `xml:"testsuites"`
+	Suites  []testsuite `xml:"testsuite"`
+}
+
+type testsuite struct {
+	XMLName   xml.Name   `xml:"testsuite"`
+	Name      string     `xml:"name,attr"`
+	Testcases []testcase `xml:"testcase"`
+}
+
+type testcase struct {
+	Name      string  `xml:"name,attr"`
+	Classname string  `xml:"classname,attr"`
+	Failure   *result `xml:"failure"`
+	Error     *result `xml:"error"`
+}
+
+type result struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+// Convert parses a JUnit XML report and returns one FEX document per failed or
+// errored test case.
+func Convert(data []byte) ([]*fex.FindingDocument, error) {
+	suites, err := parse(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []*fex.FindingDocument
+	for _, ts := range suites {
+		source := &fex.Source{Name: sourceName(ts.Name)}
+		for _, tc := range ts.Testcases {
+			res, rating := failureOf(tc)
+			if res == nil {
+				continue // passing or skipped case — not a finding
+			}
+			docs = append(docs, fex.FexToDocument(toFex(tc, res, rating, source)))
+		}
+	}
+	return docs, nil
+}
+
+// parse accepts either a <testsuites> root or a bare <testsuite>.
+func parse(data []byte) ([]testsuite, error) {
+	var root testsuites
+	if err := xml.Unmarshal(data, &root); err == nil && len(root.Suites) > 0 {
+		return root.Suites, nil
+	}
+	var single testsuite
+	if err := xml.Unmarshal(data, &single); err != nil {
+		return nil, fmt.Errorf("parse JUnit XML: %w", err)
+	}
+	if single.XMLName.Local != "testsuite" {
+		return nil, fmt.Errorf("parse JUnit XML: no testsuite element found")
+	}
+	return []testsuite{single}, nil
+}
+
+// failureOf returns the failure/error result of a test case and its severity, or
+// nil if the case passed or was skipped. An <error> is rated higher than a plain
+// <failure>.
+func failureOf(tc testcase) (*result, fex.SeverityRating) {
+	if tc.Error != nil {
+		return tc.Error, fex.SeverityRating_SEVERITY_RATING_HIGH
+	}
+	if tc.Failure != nil {
+		return tc.Failure, fex.SeverityRating_SEVERITY_RATING_MEDIUM
+	}
+	return nil, fex.SeverityRating_SEVERITY_RATING_UNSPECIFIED
+}
+
+func toFex(tc testcase, res *result, rating fex.SeverityRating, source *fex.Source) *fex.FindingExchange {
+	name := caseName(tc)
+	summary := name
+	if res.Message != "" {
+		summary = res.Message
+	}
+	if summary == "" {
+		summary = "Test failure"
+	}
+	if name == "" {
+		name = summary
+	}
+	return &fex.FindingExchange{
+		Id:      shortHash(source.Name + "\x00" + name),
+		Ref:     name,
+		Summary: summary,
+		Source:  source,
+		Status:  fex.Status_STATUS_AFFECTED,
+		Details: &fex.FindingDetail{
+			Category:    fex.FindingDetail_CATEGORY_SECURITY,
+			Description: description(res),
+			Severity:    &fex.Severity{Rating: rating},
+		},
+	}
+}
+
+func description(res *result) string {
+	parts := make([]string, 0, 2)
+	if res.Message != "" {
+		parts = append(parts, res.Message)
+	}
+	if c := strings.TrimSpace(res.Contents); c != "" {
+		parts = append(parts, c)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func caseName(tc testcase) string {
+	switch {
+	case tc.Classname != "" && tc.Name != "":
+		return tc.Classname + "." + tc.Name
+	case tc.Name != "":
+		return tc.Name
+	default:
+		return tc.Classname
+	}
+}
+
+func sourceName(name string) string {
+	if name == "" {
+		return "junit"
+	}
+	return name
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h)[:16]
+}

--- a/upload/report_conversion/junit/junit.go
+++ b/upload/report_conversion/junit/junit.go
@@ -11,6 +11,7 @@ package junit
 import (
 	"crypto/sha256"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -84,8 +85,15 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 // parse accepts either a <testsuites> root or a bare <testsuite>.
 func parse(data []byte) ([]testsuite, error) {
 	var root testsuites
-	if err := xml.Unmarshal(data, &root); err == nil && len(root.Suites) > 0 {
+	err := xml.Unmarshal(data, &root)
+	if err == nil && len(root.Suites) > 0 {
 		return root.Suites, nil
+	}
+	// A genuine syntax error won't be fixed by trying a different root element —
+	// surface it instead of falling through to a misleading structural message.
+	var syntaxErr *xml.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return nil, fmt.Errorf("parse JUnit XML: %w", err)
 	}
 	var single testsuite
 	if err := xml.Unmarshal(data, &single); err != nil {

--- a/upload/report_conversion/junit/junit.go
+++ b/upload/report_conversion/junit/junit.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
+	"strconv"
 	"strings"
 
 	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
@@ -54,6 +55,11 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 		return nil, err
 	}
 
+	// seen disambiguates test cases that share the same suite + name (e.g.
+	// parameterized tests or merged reports), which would otherwise produce
+	// identical ids and collapse into one finding downstream.
+	seen := map[string]int{}
+
 	var docs []*fex.FindingDocument
 	for _, ts := range suites {
 		source := &fex.Source{Name: sourceName(ts.Name)}
@@ -62,7 +68,14 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 			if res == nil {
 				continue // passing or skipped case — not a finding
 			}
-			docs = append(docs, fex.FexToDocument(toFex(tc, res, rating, source)))
+			f := toFex(tc, res, rating, source)
+			key := source.Name + "\x00" + f.Ref
+			if n := seen[key]; n > 0 {
+				// Keep the first occurrence's id stable; suffix the rest.
+				f.Id = shortHash(key + "#" + strconv.Itoa(n))
+			}
+			seen[key]++
+			docs = append(docs, fex.FexToDocument(f))
 		}
 	}
 	return docs, nil

--- a/upload/report_conversion/junit/junit_test.go
+++ b/upload/report_conversion/junit/junit_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package junit_test
+
+import (
+	"testing"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/cnspec/v13/upload/report_conversion/junit"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func TestConvert(t *testing.T) {
+	// 3 test cases: one failure, one error, one pass → 2 findings.
+	docs := rc.AssertClean(t, junit.Convert, "testdata/basic.xml")
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents (failure + error, pass ignored), got %d", len(docs))
+	}
+
+	f := docs[0].GetFex()
+	if f == nil {
+		t.Fatal("expected FEX")
+	}
+	if f.GetSource().GetName() != "security-checks" {
+		t.Errorf("source = %q", f.GetSource().GetName())
+	}
+	if f.GetDetails().GetSeverity().GetRating() != fex.SeverityRating_SEVERITY_RATING_MEDIUM {
+		t.Errorf("failure severity = %v, want MEDIUM", f.GetDetails().GetSeverity().GetRating())
+	}
+	// The error case is rated higher than a plain failure.
+	if got := docs[1].GetFex().GetDetails().GetSeverity().GetRating(); got != fex.SeverityRating_SEVERITY_RATING_HIGH {
+		t.Errorf("error severity = %v, want HIGH", got)
+	}
+}
+
+func TestConvertBareTestsuite(t *testing.T) {
+	xml := []byte(`<testsuite name="s"><testcase name="t"><failure message="boom"/></testcase></testsuite>`)
+	docs, err := junit.Convert(xml)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("want 1 document, got %d", len(docs))
+	}
+}

--- a/upload/report_conversion/junit/junit_test.go
+++ b/upload/report_conversion/junit/junit_test.go
@@ -4,6 +4,7 @@
 package junit_test
 
 import (
+	"strings"
 	"testing"
 
 	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
@@ -50,6 +51,18 @@ func TestConvertDuplicateCasesGetDistinctIDs(t *testing.T) {
 	}
 	if docs[0].GetFex().GetId() == docs[1].GetFex().GetId() {
 		t.Errorf("duplicate cases collapsed to the same id %q", docs[0].GetFex().GetId())
+	}
+}
+
+func TestConvertMalformedXML(t *testing.T) {
+	// A genuine syntax error should surface as a parse error, not a misleading
+	// "no testsuite element found".
+	_, err := junit.Convert([]byte(`<testsuite name="s"><testcase`))
+	if err == nil {
+		t.Fatal("expected a parse error for malformed XML")
+	}
+	if strings.Contains(err.Error(), "no testsuite element found") {
+		t.Errorf("got misleading structural error instead of the syntax error: %v", err)
 	}
 }
 

--- a/upload/report_conversion/junit/junit_test.go
+++ b/upload/report_conversion/junit/junit_test.go
@@ -34,6 +34,25 @@ func TestConvert(t *testing.T) {
 	}
 }
 
+func TestConvertDuplicateCasesGetDistinctIDs(t *testing.T) {
+	// Two failing cases with the same suite + classname + name (e.g. a merged
+	// report) must not collapse into one id.
+	xml := []byte(`<testsuite name="s">
+	  <testcase classname="c" name="t"><failure message="a"/></testcase>
+	  <testcase classname="c" name="t"><failure message="b"/></testcase>
+	</testsuite>`)
+	docs, err := junit.Convert(xml)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+	if docs[0].GetFex().GetId() == docs[1].GetFex().GetId() {
+		t.Errorf("duplicate cases collapsed to the same id %q", docs[0].GetFex().GetId())
+	}
+}
+
 func TestConvertBareTestsuite(t *testing.T) {
 	xml := []byte(`<testsuite name="s"><testcase name="t"><failure message="boom"/></testcase></testsuite>`)
 	docs, err := junit.Convert(xml)

--- a/upload/report_conversion/junit/testdata/basic.xml
+++ b/upload/report_conversion/junit/testdata/basic.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="security-checks" tests="3" failures="1" errors="1">
+    <testcase classname="tls" name="enforces_tls_1_2">
+      <failure message="TLS 1.0 is still enabled">server accepted a TLS 1.0 handshake</failure>
+    </testcase>
+    <testcase classname="auth" name="mfa_required">
+      <error message="check crashed">panic: nil pointer in mfa probe</error>
+    </testcase>
+    <testcase classname="headers" name="csp_present"></testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## What

Adds a `junit` converter to `cnspec upload`. Each JUnit test case with a `<failure>` or `<error>` becomes a FEX finding.

```
cnspec upload --format junit results.xml
```

## Why

JUnit is a widely-emitted open format — security test suites and CI gates often report results as JUnit XML. Supporting it lets those failures land as findings without a tool-specific converter. It's also the **last of the standard open formats** the ADR-062 plan designated for cnspec (SARIF, CycloneDX, SPDX are already supported).

## How

A pure `report_conversion` converter (same pattern as SARIF):

- Parses a `<testsuites>` root **or** a bare `<testsuite>`.
- A test case with `<error>` → **HIGH**; `<failure>` → **MEDIUM**; passing/skipped cases are ignored (not findings).
- Produces **FEX** (`CATEGORY_SECURITY`) with a stable content-hash id, the testsuite name as source, and the failure message/output as description.

Registered in `report_conversion/all`.

## Verification

- build; `go test ./upload/report_conversion/junit/...` — failure+error+pass fixture (2 findings, pass ignored, error rated higher) and a bare-`<testsuite>` case
- `--format list` shows `junit`; `--dry-run` converts
- gofmt / golangci-lint clean

Part of the third-party data-management plan (ADR-062). `cnspec upload` remains Hidden/experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)