### PR TITLE
✨ cnspec upload: OWASP ZAP XML converter (DAST)

### DIFF
--- a/upload/report_conversion/all/all.go
+++ b/upload/report_conversion/all/all.go
@@ -10,4 +10,5 @@ import (
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/defectdojo"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/junit"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/sarif"
+	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/zap"
 )

--- a/upload/report_conversion/zap/testdata/basic.xml
+++ b/upload/report_conversion/zap/testdata/basic.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<OWASPZAPReport version="2.14.0">
+  <site name="https://example.com" host="example.com" port="443" ssl="true">
+    <alerts>
+      <alertitem>
+        <pluginid>40012</pluginid>
+        <name>Cross Site Scripting (Reflected)</name>
+        <riskcode>3</riskcode>
+        <confidence>2</confidence>
+        <desc>&lt;p&gt;Reflected XSS in the q parameter.&lt;/p&gt;</desc>
+        <solution>&lt;p&gt;Encode user output.&lt;/p&gt;</solution>
+        <reference>https://owasp.org/xss</reference>
+        <cweid>79</cweid>
+        <instances>
+          <instance>
+            <uri>https://example.com/search?q=test</uri>
+            <method>GET</method>
+            <param>q</param>
+            <attack>&lt;script&gt;alert(1)&lt;/script&gt;</attack>
+            <evidence>&lt;script&gt;alert(1)&lt;/script&gt;</evidence>
+          </instance>
+        </instances>
+      </alertitem>
+      <alertitem>
+        <pluginid>10038</pluginid>
+        <name>Content Security Policy (CSP) Header Not Set</name>
+        <riskcode>1</riskcode>
+        <confidence>3</confidence>
+        <desc>&lt;p&gt;No CSP header.&lt;/p&gt;</desc>
+        <solution>&lt;p&gt;Set a CSP header.&lt;/p&gt;</solution>
+        <cweid>693</cweid>
+        <instances>
+          <instance><uri>https://example.com/</uri><method>GET</method></instance>
+        </instances>
+      </alertitem>
+    </alerts>
+  </site>
+</OWASPZAPReport>

--- a/upload/report_conversion/zap/zap.go
+++ b/upload/report_conversion/zap/zap.go
@@ -1,0 +1,221 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package zap converts an OWASP ZAP XML report into Mondoo FEX findings. Each
+// ZAP alert becomes one FEX finding (category SECURITY); the affected URLs and
+// their request context come from the alert's instances. ZAP is a widely-used
+// open-source DAST scanner.
+package zap
+
+import (
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"html"
+	"regexp"
+	"strconv"
+	"strings"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func init() { rc.Register("zap", Convert) }
+
+type zapReport struct {
+	XMLName xml.Name  `xml:"OWASPZAPReport"`
+	Sites   []zapSite `xml:"site"`
+}
+
+type zapSite struct {
+	Name   string     `xml:"name,attr"`
+	Alerts []zapAlert `xml:"alerts>alertitem"`
+}
+
+type zapAlert struct {
+	PluginID   string        `xml:"pluginid"`
+	Name       string        `xml:"name"`
+	RiskCode   string        `xml:"riskcode"`
+	Confidence string        `xml:"confidence"`
+	Desc       string        `xml:"desc"`
+	Solution   string        `xml:"solution"`
+	Reference  string        `xml:"reference"`
+	CWEID      string        `xml:"cweid"`
+	OtherInfo  string        `xml:"otherinfo"`
+	Instances  []zapInstance `xml:"instances>instance"`
+}
+
+type zapInstance struct {
+	URI      string `xml:"uri"`
+	Method   string `xml:"method"`
+	Param    string `xml:"param"`
+	Attack   string `xml:"attack"`
+	Evidence string `xml:"evidence"`
+}
+
+// Convert parses an OWASP ZAP XML report and returns one FEX document per alert.
+func Convert(data []byte) ([]*fex.FindingDocument, error) {
+	var report zapReport
+	if err := xml.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse ZAP XML: %w", err)
+	}
+	if report.XMLName.Local != "OWASPZAPReport" {
+		return nil, fmt.Errorf("parse ZAP XML: not an OWASPZAPReport document")
+	}
+
+	var docs []*fex.FindingDocument
+	for _, site := range report.Sites {
+		source := &fex.Source{Name: sourceName(site.Name)}
+		for _, a := range site.Alerts {
+			docs = append(docs, fex.FexToDocument(toFex(a, source)))
+		}
+	}
+	return docs, nil
+}
+
+func toFex(a zapAlert, source *fex.Source) *fex.FindingExchange {
+	id := a.PluginID
+	if id == "" {
+		id = shortHash(a.Name)
+	}
+	summary := clean(a.Name)
+	if summary == "" {
+		summary = "ZAP alert"
+	}
+	return &fex.FindingExchange{
+		Id:      id,
+		Ref:     a.PluginID,
+		Summary: summary,
+		Source:  source,
+		Status:  fex.Status_STATUS_AFFECTED,
+		Details: &fex.FindingDetail{
+			Category:    fex.FindingDetail_CATEGORY_SECURITY,
+			Description: description(a),
+			Severity:    severity(a.RiskCode),
+			Confidence:  confidence(a.Confidence),
+			References:  references(a),
+		},
+		Affects:      affects(a),
+		Remediations: remediations(a),
+	}
+}
+
+// affects lists the vulnerable URLs. The DAST request context (method, param,
+// attack, evidence) is attached as component properties for now; a first-class
+// HTTP-request evidence type is a planned FEX proto extension (ADR-062).
+func affects(a zapAlert) []*fex.Affects {
+	var out []*fex.Affects
+	seen := map[string]bool{}
+	for _, in := range a.Instances {
+		uri := clean(in.URI)
+		if uri == "" || seen[uri] {
+			continue
+		}
+		seen[uri] = true
+		props := map[string]string{}
+		putIf(props, "method", clean(in.Method))
+		putIf(props, "param", clean(in.Param))
+		putIf(props, "attack", clean(in.Attack))
+		putIf(props, "evidence", clean(in.Evidence))
+		out = append(out, &fex.Affects{Component: &fex.Component{Id: uri, Properties: props}})
+	}
+	return out
+}
+
+func references(a zapAlert) []*fex.Reference {
+	var out []*fex.Reference
+	if n, err := strconv.Atoi(strings.TrimSpace(a.CWEID)); err == nil && n > 0 {
+		out = append(out, &fex.Reference{Type: "CWE", Name: fmt.Sprintf("CWE-%d", n)})
+	}
+	for _, url := range splitLines(clean(a.Reference)) {
+		out = append(out, &fex.Reference{Name: "reference", Url: url})
+	}
+	return out
+}
+
+func remediations(a zapAlert) []*fex.Remediation {
+	sol := clean(a.Solution)
+	if sol == "" {
+		return nil
+	}
+	return []*fex.Remediation{{Summary: "Solution", Details: sol}}
+}
+
+func description(a zapAlert) string {
+	parts := make([]string, 0, 2)
+	if d := clean(a.Desc); d != "" {
+		parts = append(parts, d)
+	}
+	if o := clean(a.OtherInfo); o != "" {
+		parts = append(parts, o)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// severity maps ZAP riskcode (0..3) to a severity rating.
+func severity(riskcode string) *fex.Severity {
+	var rating fex.SeverityRating
+	switch strings.TrimSpace(riskcode) {
+	case "3":
+		rating = fex.SeverityRating_SEVERITY_RATING_HIGH
+	case "2":
+		rating = fex.SeverityRating_SEVERITY_RATING_MEDIUM
+	case "1":
+		rating = fex.SeverityRating_SEVERITY_RATING_LOW
+	case "0":
+		rating = fex.SeverityRating_SEVERITY_RATING_NONE
+	default:
+		return nil
+	}
+	return &fex.Severity{Rating: rating}
+}
+
+// confidence maps ZAP confidence (0..4) to the FEX confidence enum.
+func confidence(c string) fex.Confidence {
+	switch strings.TrimSpace(c) {
+	case "3", "4":
+		return fex.Confidence_CONFIDENCE_HIGH
+	case "2":
+		return fex.Confidence_CONFIDENCE_MEDIUM
+	case "1":
+		return fex.Confidence_CONFIDENCE_LOW
+	default:
+		return fex.Confidence_CONFIDENCE_UNSPECIFIED
+	}
+}
+
+var tagRe = regexp.MustCompile(`<[^>]*>`)
+
+// clean strips the simple HTML ZAP wraps some fields in and unescapes entities.
+func clean(s string) string {
+	s = tagRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(html.UnescapeString(s))
+}
+
+func splitLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if l := strings.TrimSpace(line); l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func putIf(m map[string]string, k, v string) {
+	if v != "" {
+		m[k] = v
+	}
+}
+
+func sourceName(name string) string {
+	if name == "" {
+		return "zap"
+	}
+	return name
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h)[:16]
+}

--- a/upload/report_conversion/zap/zap.go
+++ b/upload/report_conversion/zap/zap.go
@@ -108,13 +108,21 @@ func affects(a zapAlert) []*fex.Affects {
 	seen := map[string]bool{}
 	for _, in := range a.Instances {
 		uri := clean(in.URI)
-		if uri == "" || seen[uri] {
+		if uri == "" {
 			continue
 		}
-		seen[uri] = true
+		method, param := clean(in.Method), clean(in.Param)
+		// Key on uri+method+param so distinct request contexts against the same
+		// URL (e.g. a GET and a POST, or two different parameters) are preserved
+		// rather than collapsed to the first instance.
+		key := uri + "\x00" + method + "\x00" + param
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		props := map[string]string{}
-		putIf(props, "method", clean(in.Method))
-		putIf(props, "param", clean(in.Param))
+		putIf(props, "method", method)
+		putIf(props, "param", param)
 		putIf(props, "attack", clean(in.Attack))
 		putIf(props, "evidence", clean(in.Evidence))
 		out = append(out, &fex.Affects{Component: &fex.Component{Id: uri, Properties: props}})
@@ -215,6 +223,9 @@ func sourceName(name string) string {
 	return name
 }
 
+// shortHash returns a 16-hex-char (64-bit) SHA-256 prefix. It is only used as a
+// fallback finding id for alerts without a pluginid; a collision would merge two
+// such findings, which is acceptable given how rare nameless/idless alerts are.
 func shortHash(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return fmt.Sprintf("%x", h)[:16]

--- a/upload/report_conversion/zap/zap_test.go
+++ b/upload/report_conversion/zap/zap_test.go
@@ -59,6 +59,28 @@ func TestConvert(t *testing.T) {
 	}
 }
 
+func TestConvertPreservesDistinctInstances(t *testing.T) {
+	// Same URL, different method/param → distinct Affects (not collapsed);
+	// a truly identical instance is deduped.
+	xml := []byte(`<OWASPZAPReport><site name="s"><alerts><alertitem>
+	  <pluginid>1</pluginid><name>x</name><riskcode>2</riskcode>
+	  <desc>d</desc>
+	  <instances>
+	    <instance><uri>https://a/x</uri><method>GET</method><param>q</param></instance>
+	    <instance><uri>https://a/x</uri><method>POST</method><param>q</param></instance>
+	    <instance><uri>https://a/x</uri><method>GET</method><param>q</param></instance>
+	  </instances>
+	</alertitem></alerts></site></OWASPZAPReport>`)
+	docs, err := zap.Convert(xml)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	affects := docs[0].GetFex().GetAffects()
+	if len(affects) != 2 {
+		t.Fatalf("want 2 distinct instances (GET+POST; duplicate GET deduped), got %d", len(affects))
+	}
+}
+
 func TestConvertNotZAP(t *testing.T) {
 	_, err := zap.Convert([]byte(`<something/>`))
 	if err == nil {

--- a/upload/report_conversion/zap/zap_test.go
+++ b/upload/report_conversion/zap/zap_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package zap_test
+
+import (
+	"testing"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/cnspec/v13/upload/report_conversion/zap"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func TestConvert(t *testing.T) {
+	docs := rc.AssertClean(t, zap.Convert, "testdata/basic.xml")
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+
+	xss := docs[0].GetFex()
+	if xss == nil {
+		t.Fatal("expected FEX")
+	}
+	if xss.GetSource().GetName() != "https://example.com" {
+		t.Errorf("source = %q", xss.GetSource().GetName())
+	}
+	if xss.GetDetails().GetSeverity().GetRating() != fex.SeverityRating_SEVERITY_RATING_HIGH {
+		t.Errorf("riskcode 3 → %v, want HIGH", xss.GetDetails().GetSeverity().GetRating())
+	}
+	if xss.GetDetails().GetConfidence() != fex.Confidence_CONFIDENCE_MEDIUM {
+		t.Errorf("confidence 2 → %v, want MEDIUM", xss.GetDetails().GetConfidence())
+	}
+	// HTML in desc is stripped.
+	if got := xss.GetDetails().GetDescription(); got != "Reflected XSS in the q parameter." {
+		t.Errorf("description = %q (HTML not cleaned?)", got)
+	}
+	// Affected URL + request context.
+	if len(xss.GetAffects()) != 1 {
+		t.Fatalf("want 1 affected URL, got %d", len(xss.GetAffects()))
+	}
+	comp := xss.GetAffects()[0].GetComponent()
+	if comp.GetId() != "https://example.com/search?q=test" {
+		t.Errorf("affected uri = %q", comp.GetId())
+	}
+	if comp.GetProperties()["param"] != "q" {
+		t.Errorf("param property = %q, want q", comp.GetProperties()["param"])
+	}
+	// CWE reference + remediation.
+	if len(xss.GetDetails().GetReferences()) == 0 || xss.GetDetails().GetReferences()[0].GetName() != "CWE-79" {
+		t.Errorf("expected CWE-79 reference, got %+v", xss.GetDetails().GetReferences())
+	}
+	if len(xss.GetRemediations()) != 1 {
+		t.Errorf("expected a remediation, got %d", len(xss.GetRemediations()))
+	}
+
+	// Second alert: riskcode 1 → LOW.
+	if got := docs[1].GetFex().GetDetails().GetSeverity().GetRating(); got != fex.SeverityRating_SEVERITY_RATING_LOW {
+		t.Errorf("riskcode 1 → %v, want LOW", got)
+	}
+}
+
+func TestConvertNotZAP(t *testing.T) {
+	_, err := zap.Convert([]byte(`<something/>`))
+	if err == nil {
+		t.Fatal("expected error for non-ZAP XML")
+	}
+}


### PR DESCRIPTION
## What

Adds a `zap` converter to `cnspec upload` for **OWASP ZAP** XML reports — Mondoo's first web-DAST import.

```
cnspec upload --format zap zap-report.xml
```

## How

A pure `report_conversion` converter (same pattern as SARIF/JUnit). Parses `OWASPZAPReport → site → alertitem`; each alert → one FEX finding (`CATEGORY_SECURITY`):

- **riskcode** 0/1/2/3 → NONE/LOW/MEDIUM/HIGH; **confidence** → FEX `Confidence`
- **cweid** → `Reference`; **solution** → `Remediation`; **reference** URLs → references
- **instances** → affected URLs (`Affects`), with request context (method/param/attack/evidence) attached as component **properties**
- strips the HTML ZAP wraps some fields in

### Note on DAST request evidence

ZAP's per-instance request context (method/param/attack/evidence) is currently attached as component `properties`. A **first-class HTTP-request evidence type** is a planned FEX proto extension (ADR-062 field-fidelity backlog); this converter will move to it once available. For now nothing is dropped.

## Verification

- build; `go test ./upload/report_conversion/zap/...` — severity/confidence mapping, HTML cleaning, affected URL + request properties, CWE reference, remediation, and a non-ZAP error case
- `--format list` shows `zap`; `--dry-run` converts
- gofmt / golangci-lint clean

Part of the third-party data-management plan (ADR-062). `cnspec upload` remains Hidden/experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)