### PR TITLE
✨ cnspec upload: Burp Suite XML converter (DAST)

### DIFF
--- a/upload/report_conversion/all/all.go
+++ b/upload/report_conversion/all/all.go
@@ -7,6 +7,7 @@
 package all
 
 import (
+	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/burp"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/defectdojo"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/junit"
 	_ "go.mondoo.com/cnspec/v13/upload/report_conversion/sarif"

--- a/upload/report_conversion/burp/burp.go
+++ b/upload/report_conversion/burp/burp.go
@@ -1,0 +1,197 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package burp converts a Burp Suite XML report (the <issues> export) into
+// Mondoo FEX findings. Each Burp issue becomes one FEX finding (category
+// SECURITY), with the affected URL from the issue's host+path. Burp Suite is a
+// widely-used web-application (DAST) scanner.
+package burp
+
+import (
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"html"
+	"regexp"
+	"strings"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func init() { rc.Register("burp", Convert) }
+
+type burpReport struct {
+	XMLName xml.Name    `xml:"issues"`
+	Issues  []burpIssue `xml:"issue"`
+}
+
+type burpIssue struct {
+	SerialNumber   string   `xml:"serialNumber"`
+	Type           string   `xml:"type"`
+	Name           string   `xml:"name"`
+	Host           burpHost `xml:"host"`
+	Path           string   `xml:"path"`
+	Location       string   `xml:"location"`
+	Severity       string   `xml:"severity"`
+	Confidence     string   `xml:"confidence"`
+	Background     string   `xml:"issueBackground"`
+	Detail         string   `xml:"issueDetail"`
+	Remediation    string   `xml:"remediationBackground"`
+	Classification string   `xml:"vulnerabilityClassifications"`
+}
+
+type burpHost struct {
+	IP    string `xml:"ip,attr"`
+	Value string `xml:",chardata"`
+}
+
+var (
+	tagRe    = regexp.MustCompile(`<[^>]*>`)
+	cweRe    = regexp.MustCompile(`CWE-(\d+)`)
+	locParam = regexp.MustCompile(`\[(.*)\]`)
+)
+
+// Convert parses a Burp Suite XML report and returns one FEX document per issue.
+func Convert(data []byte) ([]*fex.FindingDocument, error) {
+	var report burpReport
+	if err := xml.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse Burp XML: %w", err)
+	}
+	if report.XMLName.Local != "issues" {
+		return nil, fmt.Errorf("parse Burp XML: not a Burp <issues> document")
+	}
+
+	source := &fex.Source{Name: "burp"}
+	docs := make([]*fex.FindingDocument, 0, len(report.Issues))
+	for _, iss := range report.Issues {
+		docs = append(docs, fex.FexToDocument(toFex(iss, source)))
+	}
+	return docs, nil
+}
+
+func toFex(iss burpIssue, source *fex.Source) *fex.FindingExchange {
+	id := iss.SerialNumber
+	if id == "" {
+		id = firstNonEmpty(iss.Type, shortHash(iss.Name))
+	}
+	summary := clean(iss.Name)
+	if summary == "" {
+		summary = "Burp issue"
+	}
+	return &fex.FindingExchange{
+		Id:      id,
+		Ref:     iss.Type,
+		Summary: summary,
+		Source:  source,
+		Status:  fex.Status_STATUS_AFFECTED,
+		Details: &fex.FindingDetail{
+			Category:    fex.FindingDetail_CATEGORY_SECURITY,
+			Description: description(iss),
+			Severity:    severity(iss.Severity),
+			Confidence:  confidence(iss.Confidence),
+			References:  references(iss),
+		},
+		Affects:      affects(iss),
+		Remediations: remediations(iss),
+	}
+}
+
+func affects(iss burpIssue) []*fex.Affects {
+	host := clean(iss.Host.Value)
+	path := clean(iss.Path)
+	if host == "" && path == "" {
+		return nil
+	}
+	props := map[string]string{}
+	// Burp encodes the affected parameter in location, e.g. "/x [q parameter]".
+	if m := locParam.FindStringSubmatch(clean(iss.Location)); len(m) == 2 {
+		props["location"] = strings.TrimSpace(m[1])
+	}
+	return []*fex.Affects{{Component: &fex.Component{Id: host + path, Properties: props}}}
+}
+
+func references(iss burpIssue) []*fex.Reference {
+	var out []*fex.Reference
+	seen := map[string]bool{}
+	for _, m := range cweRe.FindAllStringSubmatch(iss.Classification, -1) {
+		name := "CWE-" + m[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, &fex.Reference{Type: "CWE", Name: name})
+	}
+	return out
+}
+
+func remediations(iss burpIssue) []*fex.Remediation {
+	rem := clean(iss.Remediation)
+	if rem == "" {
+		return nil
+	}
+	return []*fex.Remediation{{Summary: "Remediation", Details: rem}}
+}
+
+func description(iss burpIssue) string {
+	parts := make([]string, 0, 2)
+	if d := clean(iss.Detail); d != "" {
+		parts = append(parts, d)
+	}
+	if b := clean(iss.Background); b != "" {
+		parts = append(parts, b)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// severity maps Burp's severity strings to a severity rating.
+func severity(s string) *fex.Severity {
+	var rating fex.SeverityRating
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "high":
+		rating = fex.SeverityRating_SEVERITY_RATING_HIGH
+	case "medium":
+		rating = fex.SeverityRating_SEVERITY_RATING_MEDIUM
+	case "low":
+		rating = fex.SeverityRating_SEVERITY_RATING_LOW
+	case "information", "info", "informational":
+		rating = fex.SeverityRating_SEVERITY_RATING_NONE
+	default:
+		return nil
+	}
+	return &fex.Severity{Rating: rating}
+}
+
+// confidence maps Burp's Certain/Firm/Tentative to the FEX confidence enum.
+func confidence(c string) fex.Confidence {
+	switch strings.ToLower(strings.TrimSpace(c)) {
+	case "certain":
+		return fex.Confidence_CONFIDENCE_HIGH
+	case "firm":
+		return fex.Confidence_CONFIDENCE_MEDIUM
+	case "tentative":
+		return fex.Confidence_CONFIDENCE_LOW
+	default:
+		return fex.Confidence_CONFIDENCE_UNSPECIFIED
+	}
+}
+
+// clean strips the HTML Burp wraps text fields in and unescapes entities.
+func clean(s string) string {
+	s = tagRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(html.UnescapeString(s))
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h)[:16]
+}

--- a/upload/report_conversion/burp/burp_test.go
+++ b/upload/report_conversion/burp/burp_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package burp_test
+
+import (
+	"strings"
+	"testing"
+
+	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
+	"go.mondoo.com/cnspec/v13/upload/report_conversion/burp"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+)
+
+func TestConvert(t *testing.T) {
+	docs := rc.AssertClean(t, burp.Convert, "testdata/basic.xml")
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+
+	xss := docs[0].GetFex()
+	if xss == nil {
+		t.Fatal("expected FEX")
+	}
+	if xss.GetId() != "123456789" {
+		t.Errorf("id = %q, want serialNumber 123456789", xss.GetId())
+	}
+	if xss.GetSource().GetName() != "burp" {
+		t.Errorf("source = %q", xss.GetSource().GetName())
+	}
+	if xss.GetDetails().GetSeverity().GetRating() != fex.SeverityRating_SEVERITY_RATING_HIGH {
+		t.Errorf("severity High → %v, want HIGH", xss.GetDetails().GetSeverity().GetRating())
+	}
+	if xss.GetDetails().GetConfidence() != fex.Confidence_CONFIDENCE_HIGH {
+		t.Errorf("confidence Certain → %v, want HIGH", xss.GetDetails().GetConfidence())
+	}
+	if got := xss.GetDetails().GetDescription(); got == "" || containsHTMLTag(got) {
+		t.Errorf("description not cleaned: %q", got)
+	}
+	// Affected URL = host+path, with the location parameter captured.
+	if len(xss.GetAffects()) != 1 {
+		t.Fatalf("want 1 affected URL, got %d", len(xss.GetAffects()))
+	}
+	comp := xss.GetAffects()[0].GetComponent()
+	if comp.GetId() != "https://example.com/search" {
+		t.Errorf("affected url = %q", comp.GetId())
+	}
+	if comp.GetProperties()["location"] != "q parameter" {
+		t.Errorf("location property = %q, want 'q parameter'", comp.GetProperties()["location"])
+	}
+	// CWE reference + remediation.
+	if len(xss.GetDetails().GetReferences()) != 1 || xss.GetDetails().GetReferences()[0].GetName() != "CWE-79" {
+		t.Errorf("expected CWE-79 reference, got %+v", xss.GetDetails().GetReferences())
+	}
+	if len(xss.GetRemediations()) != 1 {
+		t.Errorf("expected a remediation, got %d", len(xss.GetRemediations()))
+	}
+
+	// Second issue: Low + Firm.
+	hsts := docs[1].GetFex()
+	if hsts.GetDetails().GetSeverity().GetRating() != fex.SeverityRating_SEVERITY_RATING_LOW {
+		t.Errorf("severity Low → %v, want LOW", hsts.GetDetails().GetSeverity().GetRating())
+	}
+	if hsts.GetDetails().GetConfidence() != fex.Confidence_CONFIDENCE_MEDIUM {
+		t.Errorf("confidence Firm → %v, want MEDIUM", hsts.GetDetails().GetConfidence())
+	}
+}
+
+func TestConvertNotBurp(t *testing.T) {
+	_, err := burp.Convert([]byte(`<OWASPZAPReport/>`))
+	if err == nil {
+		t.Fatal("expected error for non-Burp XML")
+	}
+}
+
+func containsHTMLTag(s string) bool {
+	return strings.Contains(s, "<") && strings.Contains(s, ">")
+}

--- a/upload/report_conversion/burp/testdata/basic.xml
+++ b/upload/report_conversion/burp/testdata/basic.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<issues burpVersion="2023.10">
+  <issue>
+    <serialNumber>123456789</serialNumber>
+    <type>2097936</type>
+    <name>Cross-site scripting (reflected)</name>
+    <host ip="93.184.216.34">https://example.com</host>
+    <path>/search</path>
+    <location>/search [q parameter]</location>
+    <severity>High</severity>
+    <confidence>Certain</confidence>
+    <issueBackground>&lt;p&gt;Reflected XSS arises when input is echoed unsafely.&lt;/p&gt;</issueBackground>
+    <issueDetail>&lt;p&gt;The value of the q parameter is reflected.&lt;/p&gt;</issueDetail>
+    <remediationBackground>&lt;p&gt;Encode output.&lt;/p&gt;</remediationBackground>
+    <vulnerabilityClassifications>&lt;li&gt;CWE-79: Improper Neutralization&lt;/li&gt;</vulnerabilityClassifications>
+    <requestresponse>
+      <request base64="true">R0VUIC9zZWFyY2g/cT10ZXN0</request>
+      <response base64="true">SFRUUC8xLjEgMjAwIE9L</response>
+    </requestresponse>
+  </issue>
+  <issue>
+    <serialNumber>987654321</serialNumber>
+    <type>5244160</type>
+    <name>Strict transport security not enforced</name>
+    <host ip="93.184.216.34">https://example.com</host>
+    <path>/</path>
+    <location>/</location>
+    <severity>Low</severity>
+    <confidence>Firm</confidence>
+    <issueDetail>&lt;p&gt;HSTS header missing.&lt;/p&gt;</issueDetail>
+    <remediationBackground>&lt;p&gt;Add a Strict-Transport-Security header.&lt;/p&gt;</remediationBackground>
+  </issue>
+</issues>


### PR DESCRIPTION
## What

Adds a `burp` converter to `cnspec upload` for **Burp Suite** XML reports (the `<issues>` export), complementing the ZAP converter for web-DAST coverage.

```
cnspec upload --format burp burp-issues.xml
```

## How

A pure `report_conversion` converter (same pattern as ZAP). Parses `<issues> → <issue>`; each issue → one FEX finding (`CATEGORY_SECURITY`):

- **severity** High/Medium/Low/Information → HIGH/MEDIUM/LOW/NONE
- **confidence** Certain/Firm/Tentative → FEX `Confidence`
- **CWE** extracted from `vulnerabilityClassifications`; **remediationBackground** → `Remediation`
- affected URL from `host`+`path`, with the parameter from `location` captured as a component property
- strips the HTML Burp wraps fields in

### Note on request/response evidence

Burp's base64 request/response pairs are not yet imported — the proper home is a first-class **HTTP-request evidence type** (ADR-062 field-fidelity backlog), which ZAP and Burp will both adopt once it lands. For now the affected URL + parameter are captured.

## Format reference

Grounded on the Burp XML schema (DefectDojo's `burp` parser and `henesy/burpxml`); structs are hand-rolled to avoid a new dependency, consistent with the other converters.

## Verification

- build; `go test ./upload/report_conversion/burp/...` — severity/confidence mapping, HTML cleaning, affected URL + location parameter, CWE reference, remediation, and a non-Burp error case
- `--format list` shows `burp`; `--dry-run` converts
- gofmt / golangci-lint clean

Part of the third-party data-management plan (ADR-062). `cnspec upload` remains Hidden/experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)