### PR TITLE
🐛 converters: fix status mapping, HTTP evidence, and id collisions

### DIFF
--- a/upload/report_conversion/burp/burp.go
+++ b/upload/report_conversion/burp/burp.go
@@ -28,19 +28,20 @@ type burpReport struct {
 }
 
 type burpIssue struct {
-	SerialNumber     string                `xml:"serialNumber"`
-	Type             string                `xml:"type"`
-	Name             string                `xml:"name"`
-	Host             burpHost              `xml:"host"`
-	Path             string                `xml:"path"`
-	Location         string                `xml:"location"`
-	Severity         string                `xml:"severity"`
-	Confidence       string                `xml:"confidence"`
-	Background       string                `xml:"issueBackground"`
-	Detail           string                `xml:"issueDetail"`
-	Remediation      string                `xml:"remediationBackground"`
-	Classification   string                `xml:"vulnerabilityClassifications"`
-	RequestResponses []burpRequestResponse `xml:"requestresponse"`
+	SerialNumber      string                `xml:"serialNumber"`
+	Type              string                `xml:"type"`
+	Name              string                `xml:"name"`
+	Host              burpHost              `xml:"host"`
+	Path              string                `xml:"path"`
+	Location          string                `xml:"location"`
+	Severity          string                `xml:"severity"`
+	Confidence        string                `xml:"confidence"`
+	Background        string                `xml:"issueBackground"`
+	Detail            string                `xml:"issueDetail"`
+	Remediation       string                `xml:"remediationBackground"`
+	RemediationDetail string                `xml:"remediationDetail"`
+	Classification    string                `xml:"vulnerabilityClassifications"`
+	RequestResponses  []burpRequestResponse `xml:"requestresponse"`
 }
 
 type burpHost struct {
@@ -191,12 +192,18 @@ func references(iss burpIssue) []*fex.Reference {
 	return out
 }
 
+// remediations carries Burp's general remediation guidance (remediationBackground)
+// and, when present, the instance-specific remediation (remediationDetail) as a
+// separate entry.
 func remediations(iss burpIssue) []*fex.Remediation {
-	rem := clean(iss.Remediation)
-	if rem == "" {
-		return nil
+	var out []*fex.Remediation
+	if rem := clean(iss.Remediation); rem != "" {
+		out = append(out, &fex.Remediation{Summary: "Remediation", Details: rem})
 	}
-	return []*fex.Remediation{{Summary: "Remediation", Details: rem}}
+	if detail := clean(iss.RemediationDetail); detail != "" {
+		out = append(out, &fex.Remediation{Summary: "Remediation detail", Details: detail})
+	}
+	return out
 }
 
 func description(iss burpIssue) string {

--- a/upload/report_conversion/burp/burp.go
+++ b/upload/report_conversion/burp/burp.go
@@ -9,6 +9,7 @@ package burp
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"html"
@@ -27,23 +28,47 @@ type burpReport struct {
 }
 
 type burpIssue struct {
-	SerialNumber   string   `xml:"serialNumber"`
-	Type           string   `xml:"type"`
-	Name           string   `xml:"name"`
-	Host           burpHost `xml:"host"`
-	Path           string   `xml:"path"`
-	Location       string   `xml:"location"`
-	Severity       string   `xml:"severity"`
-	Confidence     string   `xml:"confidence"`
-	Background     string   `xml:"issueBackground"`
-	Detail         string   `xml:"issueDetail"`
-	Remediation    string   `xml:"remediationBackground"`
-	Classification string   `xml:"vulnerabilityClassifications"`
+	SerialNumber     string                `xml:"serialNumber"`
+	Type             string                `xml:"type"`
+	Name             string                `xml:"name"`
+	Host             burpHost              `xml:"host"`
+	Path             string                `xml:"path"`
+	Location         string                `xml:"location"`
+	Severity         string                `xml:"severity"`
+	Confidence       string                `xml:"confidence"`
+	Background       string                `xml:"issueBackground"`
+	Detail           string                `xml:"issueDetail"`
+	Remediation      string                `xml:"remediationBackground"`
+	Classification   string                `xml:"vulnerabilityClassifications"`
+	RequestResponses []burpRequestResponse `xml:"requestresponse"`
 }
 
 type burpHost struct {
 	IP    string `xml:"ip,attr"`
 	Value string `xml:",chardata"`
+}
+
+type burpRequestResponse struct {
+	Request  burpData `xml:"request"`
+	Response burpData `xml:"response"`
+}
+
+// burpData is a request or response payload. Burp base64-encodes these when
+// base64="true" (the common case); otherwise the raw bytes are inline.
+type burpData struct {
+	Base64 bool   `xml:"base64,attr"`
+	Value  string `xml:",chardata"`
+}
+
+// decode returns the payload, base64-decoding it when Burp marked it encoded.
+// If decoding fails, the raw value is returned unchanged.
+func (d burpData) decode() string {
+	if d.Base64 {
+		if decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(d.Value)); err == nil {
+			return string(decoded)
+		}
+	}
+	return d.Value
 }
 
 var (
@@ -71,10 +96,15 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 }
 
 func toFex(iss burpIssue, source *fex.Source) *fex.FindingExchange {
-	id := iss.SerialNumber
-	if id == "" {
-		id = firstNonEmpty(iss.Type, shortHash(iss.Name))
-	}
+	// Burp regenerates serialNumber on every scan, so it is not stable across
+	// re-uploads. Derive a deterministic id from the issue's identity (type +
+	// host + path + location) so the same finding keeps the same id.
+	id := shortHash(strings.Join([]string{
+		iss.Type,
+		clean(iss.Host.Value),
+		clean(iss.Path),
+		clean(iss.Location),
+	}, "\x00"))
 	summary := clean(iss.Name)
 	if summary == "" {
 		summary = "Burp issue"
@@ -104,22 +134,43 @@ func affects(iss burpIssue) []*fex.Affects {
 	if host == "" && path == "" {
 		return nil
 	}
-	return []*fex.Affects{{Component: &fex.Component{Id: host + path}}}
+	comp := &fex.Component{Id: host + path}
+	if ip := strings.TrimSpace(iss.Host.IP); ip != "" {
+		comp.Identifiers = map[string]string{"ip": ip}
+	}
+	return []*fex.Affects{{Component: comp}}
 }
 
-// httpEvidence carries the affected URL and the tested parameter (from Burp's
-// location, e.g. "/x [q parameter]") as first-class HttpRequest evidence.
+// httpEvidence carries the captured HTTP request/response pairs (Burp's headline
+// evidence) plus the affected URL and tested parameter (from Burp's location,
+// e.g. "/x [q parameter]") as first-class HttpRequest evidence. An issue may
+// carry multiple requestresponse elements; each becomes one evidence entry.
 func httpEvidence(iss burpIssue) []*fex.Evidence {
 	host := clean(iss.Host.Value)
 	path := clean(iss.Path)
-	if host == "" && path == "" {
-		return nil
-	}
-	hr := &fex.HttpRequest{Url: host + path}
+	url := host + path
+	var param string
 	if m := locParam.FindStringSubmatch(clean(iss.Location)); len(m) == 2 {
-		hr.Param = strings.TrimSpace(m[1])
+		param = strings.TrimSpace(m[1])
 	}
-	return []*fex.Evidence{{Details: &fex.Evidence_HttpRequest{HttpRequest: hr}}}
+
+	var out []*fex.Evidence
+	for _, rr := range iss.RequestResponses {
+		out = append(out, &fex.Evidence{Details: &fex.Evidence_HttpRequest{HttpRequest: &fex.HttpRequest{
+			Url:      url,
+			Param:    param,
+			Request:  rr.Request.decode(),
+			Response: rr.Response.decode(),
+		}}})
+	}
+	// No captured request/response: still surface the URL context if we have one.
+	if len(out) == 0 && url != "" {
+		out = append(out, &fex.Evidence{Details: &fex.Evidence_HttpRequest{HttpRequest: &fex.HttpRequest{
+			Url:   url,
+			Param: param,
+		}}})
+	}
+	return out
 }
 
 func references(iss burpIssue) []*fex.Reference {
@@ -131,7 +182,11 @@ func references(iss burpIssue) []*fex.Reference {
 			continue
 		}
 		seen[name] = true
-		out = append(out, &fex.Reference{Type: "CWE", Name: name})
+		out = append(out, &fex.Reference{
+			Type: "CWE",
+			Name: name,
+			Url:  "https://cwe.mitre.org/data/definitions/" + m[1] + ".html",
+		})
 	}
 	return out
 }
@@ -191,15 +246,6 @@ func confidence(c string) fex.Confidence {
 func clean(s string) string {
 	s = tagRe.ReplaceAllString(s, "")
 	return strings.TrimSpace(html.UnescapeString(s))
-}
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func shortHash(s string) string {

--- a/upload/report_conversion/burp/burp_test.go
+++ b/upload/report_conversion/burp/burp_test.go
@@ -22,8 +22,14 @@ func TestConvert(t *testing.T) {
 	if xss == nil {
 		t.Fatal("expected FEX")
 	}
-	if xss.GetId() != "123456789" {
-		t.Errorf("id = %q, want serialNumber 123456789", xss.GetId())
+	// id is a deterministic hash of the issue identity, NOT Burp's volatile
+	// serialNumber (which is regenerated each scan and would cause duplicates).
+	if xss.GetId() == "" || xss.GetId() == "123456789" {
+		t.Errorf("id = %q, want a deterministic hash, not the serialNumber", xss.GetId())
+	}
+	// Ref keeps the Burp type/plugin id.
+	if xss.GetRef() != "2097936" {
+		t.Errorf("ref = %q, want burp type 2097936", xss.GetRef())
 	}
 	if xss.GetSource().GetName() != "burp" {
 		t.Errorf("source = %q", xss.GetSource().GetName())
@@ -41,8 +47,13 @@ func TestConvert(t *testing.T) {
 	if len(xss.GetAffects()) != 1 {
 		t.Fatalf("want 1 affected URL, got %d", len(xss.GetAffects()))
 	}
-	if got := xss.GetAffects()[0].GetComponent().GetId(); got != "https://example.com/search" {
+	comp := xss.GetAffects()[0].GetComponent()
+	if got := comp.GetId(); got != "https://example.com/search" {
 		t.Errorf("affected url = %q", got)
+	}
+	// Host IP is carried as a component identifier.
+	if got := comp.GetIdentifiers()["ip"]; got != "93.184.216.34" {
+		t.Errorf("component ip identifier = %q, want 93.184.216.34", got)
 	}
 	// Request context is first-class HttpRequest evidence.
 	if len(xss.GetEvidences()) != 1 {
@@ -55,9 +66,19 @@ func TestConvert(t *testing.T) {
 	if hr.GetParam() != "q parameter" {
 		t.Errorf("http evidence param = %q, want 'q parameter'", hr.GetParam())
 	}
-	// CWE reference + remediation.
+	// The captured request/response are base64-decoded from Burp's XML.
+	if got := hr.GetRequest(); got != "GET /search?q=test" {
+		t.Errorf("http evidence request = %q, want decoded 'GET /search?q=test'", got)
+	}
+	if got := hr.GetResponse(); got != "HTTP/1.1 200 OK" {
+		t.Errorf("http evidence response = %q, want decoded 'HTTP/1.1 200 OK'", got)
+	}
+	// CWE reference (with mitre URL) + remediation.
 	if len(xss.GetDetails().GetReferences()) != 1 || xss.GetDetails().GetReferences()[0].GetName() != "CWE-79" {
 		t.Errorf("expected CWE-79 reference, got %+v", xss.GetDetails().GetReferences())
+	}
+	if got := xss.GetDetails().GetReferences()[0].GetUrl(); got != "https://cwe.mitre.org/data/definitions/79.html" {
+		t.Errorf("CWE reference url = %q", got)
 	}
 	if len(xss.GetRemediations()) != 1 {
 		t.Errorf("expected a remediation, got %d", len(xss.GetRemediations()))
@@ -70,6 +91,25 @@ func TestConvert(t *testing.T) {
 	}
 	if hsts.GetDetails().GetConfidence() != fex.Confidence_CONFIDENCE_MEDIUM {
 		t.Errorf("confidence Firm → %v, want MEDIUM", hsts.GetDetails().GetConfidence())
+	}
+}
+
+func TestConvertDeterministicID(t *testing.T) {
+	// The same Burp export converted twice must produce the same finding ids,
+	// even though Burp regenerates serialNumbers per scan.
+	first := rc.AssertClean(t, burp.Convert, "testdata/basic.xml")
+	second := rc.AssertClean(t, burp.Convert, "testdata/basic.xml")
+	if len(first) != len(second) {
+		t.Fatalf("doc count differs: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		a, b := first[i].GetFex().GetId(), second[i].GetFex().GetId()
+		if a == "" {
+			t.Fatalf("doc %d has empty id", i)
+		}
+		if a != b {
+			t.Errorf("doc %d id not deterministic: %q vs %q", i, a, b)
+		}
 	}
 }
 

--- a/upload/report_conversion/burp/burp_test.go
+++ b/upload/report_conversion/burp/burp_test.go
@@ -80,8 +80,17 @@ func TestConvert(t *testing.T) {
 	if got := xss.GetDetails().GetReferences()[0].GetUrl(); got != "https://cwe.mitre.org/data/definitions/79.html" {
 		t.Errorf("CWE reference url = %q", got)
 	}
-	if len(xss.GetRemediations()) != 1 {
-		t.Errorf("expected a remediation, got %d", len(xss.GetRemediations()))
+	// Both the general remediation (remediationBackground) and the
+	// instance-specific one (remediationDetail) are surfaced.
+	rems := xss.GetRemediations()
+	if len(rems) != 2 {
+		t.Fatalf("expected 2 remediations (background + detail), got %d", len(rems))
+	}
+	if got := rems[0].GetDetails(); got != "Encode output." {
+		t.Errorf("remediation[0] = %q, want the background", got)
+	}
+	if got := rems[1].GetDetails(); got != "HTML-encode the q parameter before echoing it." {
+		t.Errorf("remediation[1] = %q, want the instance-specific detail", got)
 	}
 
 	// Second issue: Low + Firm.

--- a/upload/report_conversion/burp/testdata/basic.xml
+++ b/upload/report_conversion/burp/testdata/basic.xml
@@ -12,6 +12,7 @@
     <issueBackground>&lt;p&gt;Reflected XSS arises when input is echoed unsafely.&lt;/p&gt;</issueBackground>
     <issueDetail>&lt;p&gt;The value of the q parameter is reflected.&lt;/p&gt;</issueDetail>
     <remediationBackground>&lt;p&gt;Encode output.&lt;/p&gt;</remediationBackground>
+    <remediationDetail>&lt;p&gt;HTML-encode the q parameter before echoing it.&lt;/p&gt;</remediationDetail>
     <vulnerabilityClassifications>&lt;li&gt;CWE-79: Improper Neutralization&lt;/li&gt;</vulnerabilityClassifications>
     <requestresponse>
       <request base64="true">R0VUIC9zZWFyY2g/cT10ZXN0</request>

--- a/upload/report_conversion/defectdojo/defectdojo.go
+++ b/upload/report_conversion/defectdojo/defectdojo.go
@@ -35,20 +35,33 @@ type report struct {
 }
 
 type finding struct {
-	Title            string `json:"title"`
-	Severity         string `json:"severity"`
-	Description      string `json:"description"`
-	Mitigation       string `json:"mitigation"`
-	Impact           string `json:"impact"`
-	CVE              string `json:"cve"`
-	CWE              int    `json:"cwe"`
-	FilePath         string `json:"file_path"`
-	Line             int    `json:"line"`
-	ComponentName    string `json:"component_name"`
-	ComponentVersion string `json:"component_version"`
-	UniqueIDFromTool string `json:"unique_id_from_tool"`
-	References       string `json:"references"`
-	Date             string `json:"date"` // RFC3339 or YYYY-MM-DD
+	Title            string  `json:"title"`
+	Severity         string  `json:"severity"`
+	Description      string  `json:"description"`
+	Mitigation       string  `json:"mitigation"`
+	Impact           string  `json:"impact"`
+	CVE              string  `json:"cve"`
+	CWE              int     `json:"cwe"`
+	CVSSv3           string  `json:"cvssv3"`       // CVSSv3 vector string
+	CVSSv3Score      float64 `json:"cvssv3_score"` // CVSSv3 base score
+	FilePath         string  `json:"file_path"`
+	Line             int     `json:"line"`
+	ComponentName    string  `json:"component_name"`
+	ComponentVersion string  `json:"component_version"`
+	UniqueIDFromTool string  `json:"unique_id_from_tool"`
+	References       string  `json:"references"`
+	Date             string  `json:"date"` // RFC3339 or YYYY-MM-DD
+
+	// Status flags. DefectDojo emits these as booleans; they are pointers so we
+	// can tell "absent" from an explicit false (Active defaults to true in
+	// DefectDojo). See status() for the mapping to fex.Status.
+	Active       *bool `json:"active"`
+	Verified     *bool `json:"verified"`
+	FalseP       *bool `json:"false_p"`
+	OutOfScope   *bool `json:"out_of_scope"`
+	RiskAccepted *bool `json:"risk_accepted"`
+	Duplicate    *bool `json:"duplicate"`
+	IsMitigated  *bool `json:"is_mitigated"`
 }
 
 // Convert parses an OWASP DefectDojo Generic Findings Import report (JSON or CSV,
@@ -139,11 +152,24 @@ func parseCSV(data []byte) ([]finding, error) {
 			Mitigation:  get(row, "Mitigation"),
 			Impact:      get(row, "Impact"),
 			CVE:         get(row, "CVE"),
+			CVSSv3:      firstNonEmpty(get(row, "CVSSV3"), get(row, "CvssV3")),
 			References:  firstNonEmpty(get(row, "References"), get(row, "Url")),
 			Date:        get(row, "Date"),
+			// Status columns (TitleCase in the DefectDojo CSV export). Header
+			// names vary slightly between exports, so accept a couple variants.
+			Active:       parseCSVBool(firstNonEmpty(get(row, "Active"))),
+			Verified:     parseCSVBool(firstNonEmpty(get(row, "Verified"))),
+			FalseP:       parseCSVBool(firstNonEmpty(get(row, "FalsePositive"), get(row, "False Positive"))),
+			OutOfScope:   parseCSVBool(firstNonEmpty(get(row, "OutOfScope"), get(row, "Out Of Scope"))),
+			RiskAccepted: parseCSVBool(firstNonEmpty(get(row, "RiskAccepted"), get(row, "Risk Accepted"))),
+			Duplicate:    parseCSVBool(firstNonEmpty(get(row, "Duplicate"))),
+			IsMitigated:  parseCSVBool(firstNonEmpty(get(row, "IsMitigated"), get(row, "Is Mitigated"))),
 		}
 		if cwe := get(row, "CweId"); cwe != "" {
 			f.CWE, _ = strconv.Atoi(cwe)
+		}
+		if s := firstNonEmpty(get(row, "CVSSV3 Score"), get(row, "CvssV3Score")); s != "" {
+			f.CVSSv3Score, _ = strconv.ParseFloat(s, 64)
 		}
 		findings = append(findings, f)
 	}
@@ -153,15 +179,20 @@ func parseCSV(data []byte) ([]finding, error) {
 func toFex(f finding, source *fex.Source) *fex.FindingExchange {
 	id := f.UniqueIDFromTool
 	if id == "" {
-		// Content-based id so it's stable across reorderings of the input.
-		id = shortHash(f.Title + "\x00" + f.Description)
+		// Content-based id so it's stable across reorderings of the input. Include
+		// the file/line/component so otherwise-identical findings at different
+		// locations do not collapse onto the same id.
+		id = shortHash(strings.Join([]string{
+			f.Title, f.Description, f.FilePath, strconv.Itoa(f.Line),
+			f.ComponentName, f.ComponentVersion,
+		}, "\x00"))
 	}
 	fx := &fex.FindingExchange{
 		Id:      id,
 		Ref:     f.UniqueIDFromTool,
 		Summary: f.Title,
 		Source:  source,
-		Status:  fex.Status_STATUS_AFFECTED,
+		Status:  status(f),
 		Details: &fex.FindingDetail{
 			Category:    fex.FindingDetail_CATEGORY_SECURITY,
 			Description: joinDetail(f),
@@ -185,12 +216,14 @@ func toVex(f finding, source *fex.Source) *fex.VulnerabilityExchange {
 		Ref:     f.UniqueIDFromTool,
 		Summary: f.Title,
 		Source:  source,
-		Status:  fex.Status_STATUS_AFFECTED,
+		Status:  status(f),
 		Details: &fex.VulnerabilityDetails{
 			Details:        joinDetail(f),
 			Recommendation: f.Mitigation,
 		},
-		Affects: affects(f),
+		Affects:    affects(f),
+		Ratings:    ratings(f),
+		References: references(f),
 	}
 	if ts := parseTime(f.Date); ts != nil {
 		vx.FirstSeen = ts
@@ -198,18 +231,97 @@ func toVex(f finding, source *fex.Source) *fex.VulnerabilityExchange {
 	return vx
 }
 
+// status maps the DefectDojo status booleans onto fex.Status. Checked in order
+// of precedence; the same mapping is used for both FEX and VEX documents.
+func status(f finding) fex.Status {
+	switch {
+	case boolVal(f.FalseP):
+		return fex.Status_STATUS_FALSE_POSITIVE
+	case boolVal(f.RiskAccepted):
+		return fex.Status_STATUS_WONT_FIX // accepted risk
+	case boolVal(f.IsMitigated):
+		return fex.Status_STATUS_FIXED
+	case f.Active != nil && !*f.Active:
+		// Explicitly inactive: DefectDojo marks a finding inactive once it is no
+		// longer present. Active defaults to true, so an absent flag stays affected.
+		return fex.Status_STATUS_FIXED
+	case boolVal(f.OutOfScope):
+		return fex.Status_STATUS_NOT_AFFECTED
+	default:
+		return fex.Status_STATUS_AFFECTED
+	}
+}
+
+// ratings builds a CVSSv3 rating from the severity mapping and any CVSS score or
+// vector present in the finding. Returns nil when there is nothing to report.
+func ratings(f finding) []*fex.Rating {
+	r := &fex.Rating{}
+	has := false
+	if severity(f.Severity) != nil {
+		r.Severity = strings.ToLower(strings.TrimSpace(f.Severity))
+		has = true
+	}
+	if f.CVSSv3Score > 0 {
+		r.Score = float32(f.CVSSv3Score)
+		r.Method = fex.ScoringMethod_SCOREMETHOD_CVSSv3
+		has = true
+	}
+	if v := strings.TrimSpace(f.CVSSv3); v != "" {
+		r.Vector = v
+		r.Method = fex.ScoringMethod_SCOREMETHOD_CVSSv3
+		has = true
+	}
+	if !has {
+		return nil
+	}
+	return []*fex.Rating{r}
+}
+
+func boolVal(b *bool) bool {
+	return b != nil && *b
+}
+
+// parseCSVBool parses a CSV cell into an optional bool. Empty cells stay nil so
+// an absent column does not read as false.
+func parseCSVBool(s string) *bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	b, err := strconv.ParseBool(strings.ToLower(s))
+	if err != nil {
+		return nil
+	}
+	return &b
+}
+
 func affects(f finding) []*fex.Affects {
+	// Build the file location (path + optional 1-based start line) up front so it
+	// can be attached whether or not a component name is also present.
+	var file *fex.FileComponent
+	if f.FilePath != "" {
+		file = &fex.FileComponent{Path: f.FilePath}
+		if f.Line > 0 {
+			file.StartLine = int32(f.Line)
+		}
+	}
+
 	switch {
 	case f.ComponentName != "":
 		ids := map[string]string{}
 		if f.ComponentVersion != "" {
 			ids["version"] = f.ComponentVersion
 		}
-		return []*fex.Affects{{Component: &fex.Component{Id: f.ComponentName, Identifiers: ids}}}
-	case f.FilePath != "":
+		comp := &fex.Component{Id: f.ComponentName, Identifiers: ids}
+		// Represent both the component and the file location when we have both.
+		if file != nil {
+			comp.Details = &fex.Component_File{File: file}
+		}
+		return []*fex.Affects{{Component: comp}}
+	case file != nil:
 		return []*fex.Affects{{Component: &fex.Component{
 			Id:      f.FilePath,
-			Details: &fex.Component_File{File: &fex.FileComponent{Path: f.FilePath}},
+			Details: &fex.Component_File{File: file},
 		}}}
 	default:
 		return nil

--- a/upload/report_conversion/defectdojo/defectdojo.go
+++ b/upload/report_conversion/defectdojo/defectdojo.go
@@ -54,7 +54,9 @@ type finding struct {
 
 	// Status flags. DefectDojo emits these as booleans; they are pointers so we
 	// can tell "absent" from an explicit false (Active defaults to true in
-	// DefectDojo). See status() for the mapping to fex.Status.
+	// DefectDojo). Active/FalseP/OutOfScope/RiskAccepted/IsMitigated feed
+	// status(); Verified feeds confidence(); Duplicate causes the finding to be
+	// skipped in Convert.
 	Active       *bool `json:"active"`
 	Verified     *bool `json:"verified"`
 	FalseP       *bool `json:"false_p"`
@@ -82,6 +84,12 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 		}
 		if f.Title == "" || f.Severity == "" || f.Description == "" {
 			return nil, fmt.Errorf("finding %d: title, severity, and description are required", i)
+		}
+		// Skip findings DefectDojo already marked as duplicates of another finding
+		// — fex has no duplicate status, and importing them would just create
+		// redundant findings.
+		if boolVal(f.Duplicate) {
+			continue
 		}
 		if f.CVE != "" {
 			docs = append(docs, fex.VexToDocument(toVex(f, source)))
@@ -157,12 +165,12 @@ func parseCSV(data []byte) ([]finding, error) {
 			Date:        get(row, "Date"),
 			// Status columns (TitleCase in the DefectDojo CSV export). Header
 			// names vary slightly between exports, so accept a couple variants.
-			Active:       parseCSVBool(firstNonEmpty(get(row, "Active"))),
-			Verified:     parseCSVBool(firstNonEmpty(get(row, "Verified"))),
+			Active:       parseCSVBool(get(row, "Active")),
+			Verified:     parseCSVBool(get(row, "Verified")),
 			FalseP:       parseCSVBool(firstNonEmpty(get(row, "FalsePositive"), get(row, "False Positive"))),
 			OutOfScope:   parseCSVBool(firstNonEmpty(get(row, "OutOfScope"), get(row, "Out Of Scope"))),
 			RiskAccepted: parseCSVBool(firstNonEmpty(get(row, "RiskAccepted"), get(row, "Risk Accepted"))),
-			Duplicate:    parseCSVBool(firstNonEmpty(get(row, "Duplicate"))),
+			Duplicate:    parseCSVBool(get(row, "Duplicate")),
 			IsMitigated:  parseCSVBool(firstNonEmpty(get(row, "IsMitigated"), get(row, "Is Mitigated"))),
 		}
 		if cwe := get(row, "CweId"); cwe != "" {
@@ -197,6 +205,7 @@ func toFex(f finding, source *fex.Source) *fex.FindingExchange {
 			Category:    fex.FindingDetail_CATEGORY_SECURITY,
 			Description: joinDetail(f),
 			Severity:    severity(f.Severity),
+			Confidence:  confidence(f.Verified),
 			References:  references(f),
 		},
 		Affects: affects(f),
@@ -249,6 +258,20 @@ func status(f finding) fex.Status {
 		return fex.Status_STATUS_NOT_AFFECTED
 	default:
 		return fex.Status_STATUS_AFFECTED
+	}
+}
+
+// confidence maps DefectDojo's "verified" flag (a human confirmed the finding)
+// onto fex confidence: verified → HIGH, explicitly unverified → LOW, absent →
+// unspecified.
+func confidence(verified *bool) fex.Confidence {
+	switch {
+	case verified == nil:
+		return fex.Confidence_CONFIDENCE_UNSPECIFIED
+	case *verified:
+		return fex.Confidence_CONFIDENCE_HIGH
+	default:
+		return fex.Confidence_CONFIDENCE_LOW
 	}
 }
 

--- a/upload/report_conversion/defectdojo/defectdojo_test.go
+++ b/upload/report_conversion/defectdojo/defectdojo_test.go
@@ -65,8 +65,9 @@ func TestConvertMissingRequired(t *testing.T) {
 
 func TestConvertStatusAndMappings(t *testing.T) {
 	docs := rc.AssertClean(t, defectdojo.Convert, "testdata/extended.json")
+	// 6 findings in the fixture, but the DefectDojo-flagged duplicate is skipped.
 	if len(docs) != 5 {
-		t.Fatalf("want 5 documents, got %d", len(docs))
+		t.Fatalf("want 5 documents (duplicate skipped), got %d", len(docs))
 	}
 
 	// A false_p finding maps to STATUS_FALSE_POSITIVE (not AFFECTED).
@@ -123,6 +124,17 @@ func TestConvertStatusAndMappings(t *testing.T) {
 	}
 	if file.GetStartLine() != 12 {
 		t.Errorf("file start line = %d, want 12", file.GetStartLine())
+	}
+	// verified:true maps to HIGH confidence.
+	if fc.GetDetails().GetConfidence() != fex.Confidence_CONFIDENCE_HIGH {
+		t.Errorf("verified finding confidence = %v, want HIGH", fc.GetDetails().GetConfidence())
+	}
+
+	// The DefectDojo-flagged duplicate must not appear in the output.
+	for _, d := range docs {
+		if d.GetFex().GetSummary() == "Duplicate of the hardcoded secret finding" {
+			t.Error("duplicate finding should have been skipped")
+		}
 	}
 
 	// Two findings with the same title/description but different files get

--- a/upload/report_conversion/defectdojo/defectdojo_test.go
+++ b/upload/report_conversion/defectdojo/defectdojo_test.go
@@ -62,3 +62,76 @@ func TestConvertMissingRequired(t *testing.T) {
 		t.Fatal("expected error for missing severity/description")
 	}
 }
+
+func TestConvertStatusAndMappings(t *testing.T) {
+	docs := rc.AssertClean(t, defectdojo.Convert, "testdata/extended.json")
+	if len(docs) != 5 {
+		t.Fatalf("want 5 documents, got %d", len(docs))
+	}
+
+	// A false_p finding maps to STATUS_FALSE_POSITIVE (not AFFECTED).
+	fp := docs[0].GetFex()
+	if fp == nil {
+		t.Fatal("finding 0: expected FEX")
+	}
+	if fp.GetStatus() != fex.Status_STATUS_FALSE_POSITIVE {
+		t.Errorf("false_p status = %v, want STATUS_FALSE_POSITIVE", fp.GetStatus())
+	}
+
+	// A CVE finding becomes VEX with Ratings (severity + CVSSv3) and References.
+	v := docs[1].GetVex()
+	if v == nil {
+		t.Fatal("finding 1: expected VEX")
+	}
+	if v.GetStatus() != fex.Status_STATUS_AFFECTED {
+		t.Errorf("vex status = %v, want STATUS_AFFECTED", v.GetStatus())
+	}
+	if len(v.GetRatings()) == 0 {
+		t.Fatal("vex: expected Ratings to be set")
+	}
+	rating := v.GetRatings()[0]
+	if rating.GetSeverity() != "high" {
+		t.Errorf("vex rating severity = %q, want high", rating.GetSeverity())
+	}
+	if rating.GetScore() != 7.5 {
+		t.Errorf("vex rating score = %v, want 7.5", rating.GetScore())
+	}
+	if rating.GetMethod() != fex.ScoringMethod_SCOREMETHOD_CVSSv3 {
+		t.Errorf("vex rating method = %v, want CVSSv3", rating.GetMethod())
+	}
+	if rating.GetVector() == "" {
+		t.Error("vex rating vector should be set")
+	}
+	if len(v.GetReferences()) == 0 {
+		t.Error("vex: expected References to be set")
+	}
+
+	// file_path + line populate FileComponent.StartLine.
+	fc := docs[2].GetFex()
+	if fc == nil {
+		t.Fatal("finding 2: expected FEX")
+	}
+	if len(fc.GetAffects()) == 0 {
+		t.Fatal("finding 2: expected an affected component")
+	}
+	file := fc.GetAffects()[0].GetComponent().GetFile()
+	if file == nil {
+		t.Fatal("finding 2: expected a FileComponent")
+	}
+	if file.GetPath() != "config/app.yaml" {
+		t.Errorf("file path = %q", file.GetPath())
+	}
+	if file.GetStartLine() != 12 {
+		t.Errorf("file start line = %d, want 12", file.GetStartLine())
+	}
+
+	// Two findings with the same title/description but different files get
+	// distinct ids (the fallback hash includes the file path).
+	a, b := docs[3].GetFex(), docs[4].GetFex()
+	if a == nil || b == nil {
+		t.Fatal("findings 3/4: expected FEX")
+	}
+	if a.GetId() == "" || a.GetId() == b.GetId() {
+		t.Errorf("expected distinct ids, got %q and %q", a.GetId(), b.GetId())
+	}
+}

--- a/upload/report_conversion/defectdojo/testdata/extended.json
+++ b/upload/report_conversion/defectdojo/testdata/extended.json
@@ -1,0 +1,42 @@
+{
+  "name": "manual-pentest",
+  "findings": [
+    {
+      "title": "Deprecated TLS cipher offered",
+      "severity": "Medium",
+      "description": "Server negotiates a deprecated cipher suite.",
+      "false_p": true
+    },
+    {
+      "title": "Vulnerable libxml2 with XXE",
+      "severity": "High",
+      "description": "libxml2 2.9.10 is affected by CVE-2025-9999.",
+      "cve": "CVE-2025-9999",
+      "cwe": 611,
+      "cvssv3_score": 7.5,
+      "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "references": "https://nvd.nist.gov/vuln/detail/CVE-2025-9999",
+      "component_name": "libxml2",
+      "component_version": "2.9.10"
+    },
+    {
+      "title": "Hardcoded secret in config",
+      "severity": "High",
+      "description": "An API token is committed in the config file.",
+      "file_path": "config/app.yaml",
+      "line": 12
+    },
+    {
+      "title": "Missing input validation",
+      "severity": "Low",
+      "description": "The handler does not validate its input.",
+      "file_path": "handlers/a.go"
+    },
+    {
+      "title": "Missing input validation",
+      "severity": "Low",
+      "description": "The handler does not validate its input.",
+      "file_path": "handlers/b.go"
+    }
+  ]
+}

--- a/upload/report_conversion/defectdojo/testdata/extended.json
+++ b/upload/report_conversion/defectdojo/testdata/extended.json
@@ -24,7 +24,8 @@
       "severity": "High",
       "description": "An API token is committed in the config file.",
       "file_path": "config/app.yaml",
-      "line": 12
+      "line": 12,
+      "verified": true
     },
     {
       "title": "Missing input validation",
@@ -37,6 +38,12 @@
       "severity": "Low",
       "description": "The handler does not validate its input.",
       "file_path": "handlers/b.go"
+    },
+    {
+      "title": "Duplicate of the hardcoded secret finding",
+      "severity": "High",
+      "description": "DefectDojo flagged this as a duplicate.",
+      "duplicate": true
     }
   ]
 }

--- a/upload/report_conversion/junit/junit.go
+++ b/upload/report_conversion/junit/junit.go
@@ -33,13 +33,20 @@ type testsuite struct {
 	XMLName   xml.Name   `xml:"testsuite"`
 	Name      string     `xml:"name,attr"`
 	Testcases []testcase `xml:"testcase"`
+	// Aggregated reports (pytest, Maven Surefire, Jest) nest <testsuite> inside
+	// <testsuite>; without this the nested cases (and their failures) are dropped.
+	Suites []testsuite `xml:"testsuite"`
 }
 
 type testcase struct {
 	Name      string  `xml:"name,attr"`
 	Classname string  `xml:"classname,attr"`
+	File      string  `xml:"file,attr"`
+	Line      string  `xml:"line,attr"`
 	Failure   *result `xml:"failure"`
 	Error     *result `xml:"error"`
+	SystemOut string  `xml:"system-out"`
+	SystemErr string  `xml:"system-err"`
 }
 
 type result struct {
@@ -63,13 +70,13 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 
 	var docs []*fex.FindingDocument
 	for _, ts := range suites {
-		source := &fex.Source{Name: sourceName(ts.Name)}
-		for _, tc := range ts.Testcases {
-			res, rating := failureOf(tc)
+		for _, c := range flatten(ts, "") {
+			res, rating := failureOf(c.tc)
 			if res == nil {
 				continue // passing or skipped case — not a finding
 			}
-			f := toFex(tc, res, rating, source)
+			source := &fex.Source{Name: sourceName(c.suiteName)}
+			f := toFex(c.tc, res, rating, source)
 			key := source.Name + "\x00" + f.Ref
 			if n := seen[key]; n > 0 {
 				// Keep the first occurrence's id stable; suffix the rest.
@@ -80,6 +87,30 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 		}
 	}
 	return docs, nil
+}
+
+// caseInSuite pairs a test case with the name of the suite that contains it.
+type caseInSuite struct {
+	tc        testcase
+	suiteName string
+}
+
+// flatten walks the suite tree (aggregated reports nest <testsuite> inside
+// <testsuite>) and returns every test case with its effective suite name. A
+// nested suite without a name inherits its parent's name.
+func flatten(ts testsuite, parentName string) []caseInSuite {
+	name := ts.Name
+	if name == "" {
+		name = parentName
+	}
+	out := make([]caseInSuite, 0, len(ts.Testcases))
+	for _, tc := range ts.Testcases {
+		out = append(out, caseInSuite{tc: tc, suiteName: name})
+	}
+	for _, child := range ts.Suites {
+		out = append(out, flatten(child, name)...)
+	}
+	return out
 }
 
 // parse accepts either a <testsuites> root or a bare <testsuite>.
@@ -138,19 +169,44 @@ func toFex(tc testcase, res *result, rating fex.SeverityRating, source *fex.Sour
 		Status:  fex.Status_STATUS_AFFECTED,
 		Details: &fex.FindingDetail{
 			Category:    fex.FindingDetail_CATEGORY_SECURITY,
-			Description: description(res),
+			Description: description(tc, res),
 			Severity:    &fex.Severity{Rating: rating},
 		},
+		Affects: affects(tc),
 	}
 }
 
-func description(res *result) string {
-	parts := make([]string, 0, 2)
+// affects maps the testcase's file/line attributes (emitted by many JUnit
+// producers) to a FileComponent so the finding points at the source location.
+func affects(tc testcase) []*fex.Affects {
+	file := strings.TrimSpace(tc.File)
+	if file == "" {
+		return nil
+	}
+	fc := &fex.FileComponent{Path: file}
+	if n, err := strconv.Atoi(strings.TrimSpace(tc.Line)); err == nil && n > 0 {
+		fc.StartLine = int32(n)
+	}
+	return []*fex.Affects{{Component: &fex.Component{
+		Id:      file,
+		Details: &fex.Component_File{File: fc},
+	}}}
+}
+
+func description(tc testcase, res *result) string {
+	parts := make([]string, 0, 4)
 	if res.Message != "" {
 		parts = append(parts, res.Message)
 	}
 	if c := strings.TrimSpace(res.Contents); c != "" {
 		parts = append(parts, c)
+	}
+	// system-out/system-err carry extra failure context (captured stdout/stderr).
+	if o := strings.TrimSpace(tc.SystemOut); o != "" {
+		parts = append(parts, "system-out:\n"+o)
+	}
+	if e := strings.TrimSpace(tc.SystemErr); e != "" {
+		parts = append(parts, "system-err:\n"+e)
 	}
 	return strings.Join(parts, "\n\n")
 }

--- a/upload/report_conversion/junit/junit_test.go
+++ b/upload/report_conversion/junit/junit_test.go
@@ -66,6 +66,55 @@ func TestConvertMalformedXML(t *testing.T) {
 	}
 }
 
+func TestConvertNestedSuites(t *testing.T) {
+	// Aggregated reports nest <testsuite> inside <testsuite>; the nested failing
+	// case must surface, its file/line must map to a FileComponent, and
+	// system-out/system-err must be folded into the description.
+	docs := rc.AssertClean(t, junit.Convert, "testdata/nested.xml")
+	if len(docs) != 1 {
+		t.Fatalf("want 1 document (the nested failure; both passing/outer cases ignored), got %d", len(docs))
+	}
+
+	f := docs[0].GetFex()
+	if f == nil {
+		t.Fatal("expected FEX")
+	}
+	if f.GetRef() != "tests.test_login.test_admin_login" {
+		t.Errorf("ref = %q, want the nested case name", f.GetRef())
+	}
+	// The nested suite name is used as the source.
+	if got := f.GetSource().GetName(); got != "nested-module" {
+		t.Errorf("source = %q, want nested-module", got)
+	}
+
+	// testcase file/line → FileComponent{Path,StartLine}.
+	if len(f.GetAffects()) != 1 {
+		t.Fatalf("want 1 affects (file location), got %d", len(f.GetAffects()))
+	}
+	file := f.GetAffects()[0].GetComponent().GetFile()
+	if file == nil {
+		t.Fatal("expected a FileComponent for the testcase file/line")
+	}
+	if file.GetPath() != "tests/test_login.py" {
+		t.Errorf("file path = %q", file.GetPath())
+	}
+	if file.GetStartLine() != 42 {
+		t.Errorf("file start line = %d, want 42", file.GetStartLine())
+	}
+
+	// system-out is folded into the description alongside the failure message.
+	desc := f.GetDetails().GetDescription()
+	if !strings.Contains(desc, "sending POST /login") {
+		t.Errorf("description missing system-out: %q", desc)
+	}
+	if !strings.Contains(desc, "retrying request") {
+		t.Errorf("description missing system-err: %q", desc)
+	}
+	if !strings.Contains(desc, "admin login rejected") {
+		t.Errorf("description missing failure contents: %q", desc)
+	}
+}
+
 func TestConvertBareTestsuite(t *testing.T) {
 	xml := []byte(`<testsuite name="s"><testcase name="t"><failure message="boom"/></testcase></testsuite>`)
 	docs, err := junit.Convert(xml)

--- a/upload/report_conversion/junit/testdata/nested.xml
+++ b/upload/report_conversion/junit/testdata/nested.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="2" failures="1">
+    <testcase classname="outer" name="outer_ok"></testcase>
+    <testsuite name="nested-module" tests="1" failures="1">
+      <testcase classname="tests.test_login" name="test_admin_login" file="tests/test_login.py" line="42">
+        <failure message="assert 401 == 200">AssertionError: admin login rejected</failure>
+        <system-out>DEBUG: sending POST /login</system-out>
+        <system-err>WARNING: retrying request</system-err>
+      </testcase>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/upload/report_conversion/sarif/sarif.go
+++ b/upload/report_conversion/sarif/sarif.go
@@ -32,19 +32,50 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 	for _, run := range report.Runs {
 		source := &fex.Source{Name: run.Tool.Driver.Name}
 		runTime := runStartTime(run)
+		rules := ruleIndex(run)
 		for _, result := range run.Results {
-			docs = append(docs, fex.FexToDocument(convertResult(result, source, runTime, index)))
+			docs = append(docs, fex.FexToDocument(convertResult(result, source, runTime, rules, index)))
 			index++
 		}
 	}
 	return docs, nil
 }
 
-func convertResult(result *gosarif.Result, source *fex.Source, runTime *time.Time, index int) *fex.FindingExchange {
+// ruleIndex maps a run's rule definitions by id so results can be enriched with
+// the rule's description, help URI, taxa (CWE) and default severity.
+func ruleIndex(run *gosarif.Run) map[string]*gosarif.ReportingDescriptor {
+	out := map[string]*gosarif.ReportingDescriptor{}
+	if run.Tool.Driver != nil {
+		for _, r := range run.Tool.Driver.Rules {
+			if r != nil {
+				out[r.ID] = r
+			}
+		}
+	}
+	for _, ext := range run.Tool.Extensions {
+		for _, r := range ext.Rules {
+			if r != nil {
+				out[r.ID] = r
+			}
+		}
+	}
+	return out
+}
+
+func convertResult(result *gosarif.Result, source *fex.Source, runTime *time.Time, rules map[string]*gosarif.ReportingDescriptor, index int) *fex.FindingExchange {
 	ruleID := deref(result.RuleID)
+	rule := rules[ruleID]
 	message := ""
 	if result.Message.Text != nil {
 		message = *result.Message.Text
+	}
+	// Fall back to the rule's own description when the result carries no message.
+	if message == "" && rule != nil {
+		if d := mfmsText(rule.ShortDescription); d != "" {
+			message = d
+		} else if d := mfmsText(rule.FullDescription); d != "" {
+			message = d
+		}
 	}
 
 	// Id must be stable and non-empty. Prefer the rule id; else a hash of the
@@ -68,16 +99,24 @@ func convertResult(result *gosarif.Result, source *fex.Source, runTime *time.Tim
 		summary = "Finding from " + source.Name
 	}
 
+	// Severity: prefer the result level, fall back to the rule's default level.
+	severity := convertSeverity(result.Level)
+	if severity == nil && rule != nil && rule.DefaultConfiguration != nil {
+		severity = convertSeverity(&rule.DefaultConfiguration.Level)
+	}
+
 	f := &fex.FindingExchange{
 		Id:      id,
 		Ref:     ruleID,
 		Summary: summary,
 		Source:  source,
-		Status:  fex.Status_STATUS_AFFECTED,
+		Status:  resultStatus(result),
 		Details: &fex.FindingDetail{
 			Category:    fex.FindingDetail_CATEGORY_SECURITY,
 			Description: message,
-			Severity:    convertSeverity(result.Level),
+			Severity:    severity,
+			Confidence:  resultConfidence(result, rule),
+			References:  ruleReferences(rule),
 			Properties:  stringProps(result.Properties),
 		},
 	}
@@ -90,6 +129,111 @@ func convertResult(result *gosarif.Result, source *fex.Source, runTime *time.Tim
 	f.Affects = convertAffects(result)
 	f.Remediations = convertRemediations(result)
 	return f
+}
+
+// resultStatus maps SARIF suppressions onto the finding status. A result with any
+// suppression is treated as not affected (the scanner/user has suppressed it).
+func resultStatus(result *gosarif.Result) fex.Status {
+	for _, s := range result.Suppressions {
+		if s == nil {
+			continue
+		}
+		// A suppression with an explicit "rejected" status is not actually
+		// suppressed; anything else (accepted / under review / unset) is.
+		if s.Status != nil && strings.EqualFold(*s.Status, "rejected") {
+			continue
+		}
+		return fex.Status_STATUS_NOT_AFFECTED
+	}
+	return fex.Status_STATUS_AFFECTED
+}
+
+// resultConfidence maps a SARIF "precision" property (on the result, then the
+// rule) onto fex confidence.
+func resultConfidence(result *gosarif.Result, rule *gosarif.ReportingDescriptor) fex.Confidence {
+	precision := propString(result.Properties, "precision")
+	if precision == "" && rule != nil {
+		precision = propString(rule.Properties, "precision")
+	}
+	switch strings.ToLower(precision) {
+	case "very-high", "high":
+		return fex.Confidence_CONFIDENCE_HIGH
+	case "medium":
+		return fex.Confidence_CONFIDENCE_MEDIUM
+	case "low":
+		return fex.Confidence_CONFIDENCE_LOW
+	default:
+		return fex.Confidence_CONFIDENCE_UNSPECIFIED
+	}
+}
+
+// ruleReferences builds structured references from a rule's help URI and any CWE
+// taxa carried in its tags (the "external/cwe/cwe-NNN" convention used by CodeQL,
+// Semgrep, and others).
+func ruleReferences(rule *gosarif.ReportingDescriptor) []*fex.Reference {
+	if rule == nil {
+		return nil
+	}
+	var refs []*fex.Reference
+	if rule.HelpURI != nil && *rule.HelpURI != "" {
+		name := "Help"
+		if rule.Name != nil && *rule.Name != "" {
+			name = *rule.Name
+		}
+		refs = append(refs, &fex.Reference{Name: name, Url: *rule.HelpURI})
+	}
+	for _, tag := range ruleTags(rule) {
+		lower := strings.ToLower(tag)
+		idx := strings.Index(lower, "cwe-")
+		if idx < 0 {
+			continue
+		}
+		num := strings.TrimSpace(tag[idx+len("cwe-"):])
+		if num == "" {
+			continue
+		}
+		refs = append(refs, &fex.Reference{
+			Name: "CWE-" + num,
+			Type: "CWE",
+			Url:  "https://cwe.mitre.org/data/definitions/" + num + ".html",
+		})
+	}
+	return refs
+}
+
+func ruleTags(rule *gosarif.ReportingDescriptor) []string {
+	raw, ok := rule.Properties["tags"]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	var tags []string
+	for _, v := range list {
+		if s, ok := v.(string); ok {
+			tags = append(tags, s)
+		}
+	}
+	return tags
+}
+
+func mfmsText(m *gosarif.MultiformatMessageString) string {
+	if m == nil || m.Text == nil {
+		return ""
+	}
+	return *m.Text
+}
+
+func propString(p gosarif.Properties, key string) string {
+	if p == nil {
+		return ""
+	}
+	if s, ok := p[key].(string); ok {
+		return s
+	}
+	return ""
 }
 
 // runStartTime returns the earliest invocation start time of a run, or nil.

--- a/upload/report_conversion/sarif/sarif_test.go
+++ b/upload/report_conversion/sarif/sarif_test.go
@@ -94,3 +94,66 @@ func TestConvertSameFileDifferentLines(t *testing.T) {
 		t.Errorf("want lines 42 and 100 preserved, got %v", lines)
 	}
 }
+
+func TestConvertRuleEnrichmentAndSuppression(t *testing.T) {
+	report := []byte(`{
+	  "version": "2.1.0",
+	  "runs": [{
+	    "tool": {"driver": {
+	      "name": "codeql",
+	      "rules": [{
+	        "id": "rule1",
+	        "name": "SQL Injection",
+	        "shortDescription": {"text": "SQL injection vulnerability."},
+	        "helpUri": "https://example.com/rules/rule1",
+	        "defaultConfiguration": {"level": "error"},
+	        "properties": {"precision": "high", "tags": ["security", "external/cwe/cwe-89"]}
+	      }]
+	    }},
+	    "results": [
+	      {"ruleId": "rule1", "locations": [{"physicalLocation": {"artifactLocation": {"uri": "a.go"}, "region": {"startLine": 5}}}]},
+	      {"ruleId": "rule1", "message": {"text": "suppressed"}, "suppressions": [{"kind": "inSource"}], "locations": [{"physicalLocation": {"artifactLocation": {"uri": "b.go"}, "region": {"startLine": 9}}}]}
+	    ]
+	  }]
+	}`)
+	docs, err := sarif.Convert(report)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+
+	// First result has no message/level: description, severity, confidence and
+	// references are all enriched from the rule definition.
+	f := docs[0].GetFex()
+	if got := f.GetDetails().GetDescription(); got != "SQL injection vulnerability." {
+		t.Errorf("description = %q, want rule short description", got)
+	}
+	if got := f.GetDetails().GetSeverity().GetRating(); got != fex.SeverityRating_SEVERITY_RATING_HIGH {
+		t.Errorf("severity = %v, want HIGH (from rule default level error)", got)
+	}
+	if got := f.GetDetails().GetConfidence(); got != fex.Confidence_CONFIDENCE_HIGH {
+		t.Errorf("confidence = %v, want HIGH (from precision)", got)
+	}
+	var haveHelp, haveCWE bool
+	for _, r := range f.GetDetails().GetReferences() {
+		if r.GetUrl() == "https://example.com/rules/rule1" {
+			haveHelp = true
+		}
+		if r.GetType() == "CWE" && r.GetName() == "CWE-89" {
+			haveCWE = true
+		}
+	}
+	if !haveHelp || !haveCWE {
+		t.Errorf("expected helpUri + CWE-89 references, got %+v", f.GetDetails().GetReferences())
+	}
+	if f.GetStatus() != fex.Status_STATUS_AFFECTED {
+		t.Errorf("status = %v, want AFFECTED", f.GetStatus())
+	}
+
+	// Second result is suppressed → NOT_AFFECTED.
+	if got := docs[1].GetFex().GetStatus(); got != fex.Status_STATUS_NOT_AFFECTED {
+		t.Errorf("suppressed status = %v, want NOT_AFFECTED", got)
+	}
+}

--- a/upload/report_conversion/zap/testdata/basic.xml
+++ b/upload/report_conversion/zap/testdata/basic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="2.14.0">
+<OWASPZAPReport version="2.14.0" generated="Wed, 1 Jan 2025 12:00:00">
   <site name="https://example.com" host="example.com" port="443" ssl="true">
     <alerts>
       <alertitem>

--- a/upload/report_conversion/zap/zap.go
+++ b/upload/report_conversion/zap/zap.go
@@ -15,16 +15,20 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	rc "go.mondoo.com/cnspec/v13/upload/report_conversion"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/fex"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func init() { rc.Register("zap", Convert) }
 
 type zapReport struct {
-	XMLName xml.Name  `xml:"OWASPZAPReport"`
-	Sites   []zapSite `xml:"site"`
+	XMLName xml.Name `xml:"OWASPZAPReport"`
+	// Report-level generation time, e.g. "Wed, 1 Jan 2025 12:00:00".
+	Generated string    `xml:"generated,attr"`
+	Sites     []zapSite `xml:"site"`
 }
 
 type zapSite struct {
@@ -63,14 +67,47 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 		return nil, fmt.Errorf("parse ZAP XML: not an OWASPZAPReport document")
 	}
 
+	// The report carries a single generation time; use it as the first-seen time
+	// for every finding so re-uploading an old report doesn't reset first-seen to
+	// upload time. Left unset when it can't be parsed (never falls back to now).
+	generated := parseGenerated(report.Generated)
+
 	var docs []*fex.FindingDocument
 	for _, site := range report.Sites {
 		source := &fex.Source{Name: sourceName(site.Name)}
 		for _, a := range site.Alerts {
-			docs = append(docs, fex.FexToDocument(toFex(a, site.Name, source)))
+			f := toFex(a, site.Name, source)
+			if generated != nil {
+				f.FirstSeenAt = timestamppb.New(*generated)
+			}
+			docs = append(docs, fex.FexToDocument(f))
 		}
 	}
 	return docs, nil
+}
+
+// zapDateLayouts covers ZAP's "generated" attribute, which is emitted with
+// Java's "EEE, d MMM yyyy HH:mm:ss" and may or may not carry a timezone.
+var zapDateLayouts = []string{
+	"Mon, 2 Jan 2006 15:04:05",
+	"Mon, 2 Jan 2006 15:04:05 MST",
+	"Mon, 2 Jan 2006 15:04:05 -0700",
+	"Mon, 2 Jan 2006 15:04:05 MST-07:00",
+}
+
+// parseGenerated parses ZAP's report-level date, returning nil when it is empty
+// or in an unrecognized format (callers then leave FirstSeenAt unset).
+func parseGenerated(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, layout := range zapDateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return &t
+		}
+	}
+	return nil
 }
 
 func toFex(a zapAlert, siteName string, source *fex.Source) *fex.FindingExchange {

--- a/upload/report_conversion/zap/zap.go
+++ b/upload/report_conversion/zap/zap.go
@@ -67,17 +67,21 @@ func Convert(data []byte) ([]*fex.FindingDocument, error) {
 	for _, site := range report.Sites {
 		source := &fex.Source{Name: sourceName(site.Name)}
 		for _, a := range site.Alerts {
-			docs = append(docs, fex.FexToDocument(toFex(a, source)))
+			docs = append(docs, fex.FexToDocument(toFex(a, site.Name, source)))
 		}
 	}
 	return docs, nil
 }
 
-func toFex(a zapAlert, source *fex.Source) *fex.FindingExchange {
-	id := a.PluginID
-	if id == "" {
-		id = shortHash(a.Name)
+func toFex(a zapAlert, siteName string, source *fex.Source) *fex.FindingExchange {
+	// Fold the site into the id: the same plugin can fire on multiple sites in
+	// one report, and a bare plugin id would collide across them (only the
+	// source name would differ). Ref keeps the raw plugin id.
+	seed := a.PluginID
+	if seed == "" {
+		seed = a.Name
 	}
+	id := shortHash(siteName + "\x00" + seed)
 	summary := clean(a.Name)
 	if summary == "" {
 		summary = "ZAP alert"

--- a/upload/report_conversion/zap/zap_test.go
+++ b/upload/report_conversion/zap/zap_test.go
@@ -94,3 +94,33 @@ func TestConvertNotZAP(t *testing.T) {
 		t.Fatal("expected error for non-ZAP XML")
 	}
 }
+
+func TestConvertMultiSiteDistinctIDs(t *testing.T) {
+	// The same plugin fires on two sites; the findings must get distinct ids
+	// (previously the bare plugin id collided across sites).
+	xml := []byte(`<OWASPZAPReport>
+	  <site name="https://a.example.com"><alerts><alertitem>
+	    <pluginid>40012</pluginid><name>XSS</name><riskcode>3</riskcode><desc>d</desc>
+	    <instances><instance><uri>https://a.example.com/x</uri><method>GET</method></instance></instances>
+	  </alertitem></alerts></site>
+	  <site name="https://b.example.com"><alerts><alertitem>
+	    <pluginid>40012</pluginid><name>XSS</name><riskcode>3</riskcode><desc>d</desc>
+	    <instances><instance><uri>https://b.example.com/x</uri><method>GET</method></instance></instances>
+	  </alertitem></alerts></site>
+	</OWASPZAPReport>`)
+	docs, err := zap.Convert(xml)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("want 2 findings, got %d", len(docs))
+	}
+	id0, id1 := docs[0].GetFex().GetId(), docs[1].GetFex().GetId()
+	if id0 == id1 {
+		t.Errorf("ids collided across sites: %q", id0)
+	}
+	// Ref still carries the raw plugin id.
+	if docs[0].GetFex().GetRef() != "40012" {
+		t.Errorf("Ref = %q, want 40012", docs[0].GetFex().GetRef())
+	}
+}

--- a/upload/report_conversion/zap/zap_test.go
+++ b/upload/report_conversion/zap/zap_test.go
@@ -64,6 +64,33 @@ func TestConvert(t *testing.T) {
 	if got := docs[1].GetFex().GetDetails().GetSeverity().GetRating(); got != fex.SeverityRating_SEVERITY_RATING_LOW {
 		t.Errorf("riskcode 1 → %v, want LOW", got)
 	}
+
+	// The report-level generated date is used as first-seen for every finding.
+	ts := xss.GetFirstSeenAt()
+	if ts == nil {
+		t.Fatal("expected FirstSeenAt from the report generated date")
+	}
+	if got := ts.AsTime().UTC().Format("2006-01-02 15:04:05"); got != "2025-01-01 12:00:00" {
+		t.Errorf("first-seen = %q, want 2025-01-01 12:00:00", got)
+	}
+	if docs[1].GetFex().GetFirstSeenAt() == nil {
+		t.Error("expected FirstSeenAt on the second finding too")
+	}
+}
+
+func TestConvertUnparsableGeneratedLeavesFirstSeenUnset(t *testing.T) {
+	// An unrecognized generated date must not fall back to time.Now(); leave unset.
+	xml := []byte(`<OWASPZAPReport generated="not a date"><site name="s"><alerts><alertitem>
+	  <pluginid>1</pluginid><name>x</name><riskcode>2</riskcode><desc>d</desc>
+	  <instances><instance><uri>https://a/x</uri><method>GET</method></instance></instances>
+	</alertitem></alerts></site></OWASPZAPReport>`)
+	docs, err := zap.Convert(xml)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if docs[0].GetFex().GetFirstSeenAt() != nil {
+		t.Errorf("expected FirstSeenAt unset for an unparsable date, got %v", docs[0].GetFex().GetFirstSeenAt())
+	}
 }
 
 func TestConvertPreservesDistinctInstances(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3095 — a converter mapping-quality audit (measuring every file converter against the Nessus/`tenablecommon` bar) surfaced several correctness gaps in the DAST/DefectDojo converters. This fixes the 🔴 critical ones.

## DefectDojo
- **Status was hardcoded to `AFFECTED`** — `false_p`, `active`, `risk_accepted`, `out_of_scope`, `is_mitigated` are now parsed from both JSON and CSV and mapped, so **false positives are no longer imported as affected**.
- VEX path now populates `Ratings` (severity + CVSS when present) and `References` — both were dropped for CVE findings.
- `file_path`+`line` now map into `FileComponent`; the fallback finding id includes file/line/component so distinct locations don't collapse.

## Burp
- **`<requestresponse>` was dropped entirely** — now parsed and emitted as base64-decoded first-class `HttpRequest` evidence (request + response).
- Host IP mapped into the component; **deterministic id** (was the per-scan `serialNumber`, which duplicated findings on re-upload); CWE reference URLs added.

## ZAP
- The finding id folded the **site name** in, so the same plugin firing on multiple sites in one report no longer collides (`Ref` keeps the raw plugin id).

Each fix has regression tests. `go build ./upload/...` + converter package tests + golangci-lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)