### PR TITLE
🐛 SARIF: keep NONE severity + document error→HIGH mapping

### DIFF
--- a/upload/report_conversion/sarif/sarif.go
+++ b/upload/report_conversion/sarif/sarif.go
@@ -266,11 +266,16 @@ func convertSeverity(level *string) *fex.Severity {
 	var rating fex.SeverityRating
 	switch strings.ToLower(*level) {
 	case "error":
+		// SARIF "error" is the tool's highest level, but a SAST/lint error is not
+		// the same as a CVSS-critical vulnerability, so map it to HIGH rather than
+		// CRITICAL (reserve CRITICAL for scanners that carry a real CVSS score).
 		rating = fex.SeverityRating_SEVERITY_RATING_HIGH
 	case "warning":
 		rating = fex.SeverityRating_SEVERITY_RATING_MEDIUM
 	case "note":
 		rating = fex.SeverityRating_SEVERITY_RATING_LOW
+	case "none":
+		rating = fex.SeverityRating_SEVERITY_RATING_NONE
 	default:
 		return nil
 	}

--- a/upload/report_conversion/sarif/sarif_test.go
+++ b/upload/report_conversion/sarif/sarif_test.go
@@ -157,3 +157,27 @@ func TestConvertRuleEnrichmentAndSuppression(t *testing.T) {
 		t.Errorf("suppressed status = %v, want NOT_AFFECTED", got)
 	}
 }
+
+func TestConvertNoneLevelKeepsSeverity(t *testing.T) {
+	report := []byte(`{
+	  "version": "2.1.0",
+	  "runs": [{
+	    "tool": {"driver": {"name": "toolx"}},
+	    "results": [
+	      {"ruleId": "r1", "level": "none", "message": {"text": "informational"},
+	       "locations": [{"physicalLocation": {"artifactLocation": {"uri": "a.go"}}}]}
+	    ]
+	  }]
+	}`)
+	docs, err := sarif.Convert(report)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("want 1 document, got %d", len(docs))
+	}
+	sev := docs[0].GetFex().GetDetails().GetSeverity()
+	if sev == nil || sev.GetRating() != fex.SeverityRating_SEVERITY_RATING_NONE {
+		t.Errorf("level none → %v, want SEVERITY_RATING_NONE (not dropped)", sev.GetRating())
+	}
+}


### PR DESCRIPTION
Small follow-up to #3099 review feedback (the fix landed after #3099 was already merged).

- **`level: "none"` silently dropped severity** — it fell through the `convertSeverity` default branch and returned `nil`, so findings from tools that emit `none` lost their severity. Map it explicitly to `SEVERITY_RATING_NONE`.
- **Document the `error → HIGH` rationale** — a SARIF/SAST "error" is the tool's highest level but is not the same as a CVSS-critical vulnerability; the comment prevents it being "fixed" back to `CRITICAL`.

Regression test added (`TestConvertNoneLevelKeepsSeverity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)