### PR TITLE
🐛 Null-safe HSTS max-age check to avoid null comparison error

### DIFF
--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -1135,7 +1135,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: http.get.header.sts.maxAge >= 365 * time.day
+    mql: http.get.header.sts != empty && http.get.header.sts.maxAge >= 365 * time.day
     docs:
       desc: |
         This check ensures that the Strict-Transport-Security (HSTS) header specifies a max-age of at least 365 days (31536000 seconds). A short max-age reduces the effectiveness of HSTS, as browsers will stop enforcing HTTPS-only connections sooner.

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.4
+    version: 1.2.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security


### PR DESCRIPTION
## Problem

`mondoo-http-security-hsts-max-age` was logging:

```
cannot find function '>=    ' for type 'null'
```

The check queried:

```
http.get.header.sts.maxAge >= 365 * time.day
```

`http.get.header.sts` is populated only when a `Strict-Transport-Security` response header is present. When the header is absent, `sts` is `null`, `sts.maxAge` null-propagates to `null`, and the query becomes `null >= <duration>`. MQL null-propagates on field access but has no `>=` overload for `null`, so the operator throws instead of returning a result.

The sibling checks (`hsts-include-subdomains`, `hsts-preload`) use `== true`, and `null == true` is a defined comparison that returns `false` — so only the ordered `>=` comparison errored.

## Fix

```
http.get.header.sts != empty && http.get.header.sts.maxAge >= 365 * time.day
```

`!= empty` is the null-safe presence guard (`empty` matches `null`). When the header is absent the left operand is a concrete `false`, `&&` short-circuits, and `>=` is never evaluated — so a missing header **fails the check cleanly** instead of erroring. This matches the audit doc: "A failing result returns no header, or a `max-age` below `31536000`."

No provider change is needed — `sts` is correctly `null` when the header doesn't exist; null-safety belongs at the query layer.

## Verification

Reproduced the original error, then confirmed the fix with `cnquery run host`:

| Target | Old query | New query |
|--------|-----------|-----------|
| No HSTS (`example.com`, `neverssl.com`) | error | `false` (fails cleanly) |
| HSTS ≥ 1yr over HTTPS (`github.com`) | — | `true` (passes) |

`cnspec policy lint ./content/mondoo-http-security.mql.yaml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)