### PR TITLE
🚧 Comment out multi-control NIST AI 100-1 compliance tags

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -48997,7 +48997,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-11-5-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
-      compliance/nist-ai-100-1: nist-ai-100-1-measure-2-4, nist-ai-100-1-measure-2-7, nist-ai-100-1-manage-4-1
+      # compliance/nist-ai-100-1: nist-ai-100-1-measure-2-4, nist-ai-100-1-measure-2-7, nist-ai-100-1-manage-4-1
     mql: |
       azure.subscription.cognitiveServicesService.accounts.all(
         defenderForAIEnabled == true


### PR DESCRIPTION
## What

The recently added `compliance/nist-ai-100-1` tags in two policies pack **more than one control mapping** into a single value using commas:

- `content/mondoo-azure-security.mql.yaml` — `defenderForAIEnabled` check: `measure-2-4, measure-2-7, manage-4-1`
- `content/mondoo-aws-security.mql.yaml` — Bedrock guardrails check: `measure-2-6, measure-2-7, measure-2-10`

Since compliance tags are a `map[string]string`, this comma-list is a workaround for one-to-many control mappings that we're **not ready to ship yet**. This PR comments out those two lines until the multi-mapping format is finalized.

Single-mapping `nist-ai-100-1` tags (AWS map-4-1 / measure-2-5, OCI measure-2-6/2-7/2-10) are left untouched.

## Verification

- `cnspec policy lint` passes on both edited policies.
- No active (uncommented) comma-bearing `nist-ai` tags remain in `content/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)