### PR TITLE
fix(http-security): null-guard hsts-max-age so it fails instead of erroring

### DIFF
--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -1135,7 +1135,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
-    mql: http.get.header.sts.maxAge >= 365 * time.day
+    mql: http.get.header.sts != null && http.get.header.sts.maxAge >= 365 * time.day
     docs:
       desc: |
         This check ensures that the Strict-Transport-Security (HSTS) header specifies a max-age of at least 365 days (31536000 seconds). A short max-age reduces the effectiveness of HSTS, as browsers will stop enforcing HTTPS-only connections sooner.


### PR DESCRIPTION
## Problem

`mondoo-http-security-hsts-max-age` errors (instead of failing) on any host that serves HTTP(S) but sends **no** `Strict-Transport-Security` header.

The check is:
```mql
http.get.header.sts.maxAge >= 365 * time.day
```
When no HSTS header is present, `http.get.header.sts` is null, and a **relational** comparison (`>=`) on a null field **errors** rather than evaluating to false. Its two sibling checks use equality:
```mql
http.get.header.sts.includeSubDomains == true   # -> false on null -> fail (graceful)
http.get.header.sts.preload == true             # -> false on null -> fail (graceful)
```
so `max-age` was the odd one out — it surfaced as an undetermined/errored result, which downstream (e.g. EASM/attack-surface reporting) shows as a noisy "could not be evaluated" finding instead of a clean fail.

## Fix

Guard the nested access so the check fails like its siblings when HSTS is absent:
```mql
http.get.header.sts != null && http.get.header.sts.maxAge >= 365 * time.day
```

## Validation

`cnspec policy lint ./content/mondoo-http-security.mql.yaml` → valid.

Ran the policy against **example.com** (HTTPS 200, no HSTS header) with `cnspec scan host … --incognito`:

| | `hsts-max-age` |
|---|---|
| before | **error** |
| after | **fail** |

Post-fix, all three HSTS checks report `fail` consistently and the scan has **zero** errored checks (9 fail / 5 pass). No behavior change on hosts that *do* send HSTS (the guard is true, so the `>=` comparison runs exactly as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
