### PR TITLE
✨ databricks: add Mondoo Databricks Security policy (25 checks)

### DIFF
--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -1,4 +1,4 @@
-# Copyright Mondoo, Inc. 2026
+# Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 policies:
   - uid: mondoo-databricks-security

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -1,0 +1,2580 @@
+# Copyright Mondoo, Inc. 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-databricks-security
+    name: Mondoo Databricks Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: databricks,saas
+    require:
+      - provider: databricks
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Secure Databricks accounts, workspaces, clusters, and access controls
+    docs:
+      desc: |
+        The Mondoo Databricks Security policy identifies critical misconfigurations in Databricks accounts and workspaces that could expose data, analytics, and AI workloads to attackers. This policy helps organizations detect and remediate weaknesses before they can be exploited, reducing the likelihood of unauthorized data access, credential theft, and abuse of privileged identities across the Databricks lakehouse platform.
+
+        This policy provides security checks across key Databricks areas:
+
+        - Workspace security settings and hardening profiles
+        - Compute cluster isolation, encryption, and governance
+        - Personal access token lifecycle and secret scope access
+        - Network access controls and private connectivity
+        - Customer-managed encryption keys
+        - Delta Sharing recipient controls
+        - Mosaic AI model serving guardrails
+        - Account identity and service principal hygiene
+
+        Learn more about scanning Databricks in the [cnspec documentation](https://mondoo.com/docs/cnspec/saas/databricks).
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Workspace Security Settings
+        checks:
+          - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled
+          - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled
+          - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled
+          - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled
+          - uid: mondoo-databricks-security-workspace-legacy-access-disabled
+          - uid: mondoo-databricks-security-workspace-token-lifetime-capped
+          - uid: mondoo-databricks-security-workspace-admins-restricted
+          - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled
+          - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled
+          - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account
+      - title: Compute Clusters
+        checks:
+          - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled
+          - uid: mondoo-databricks-security-cluster-access-mode-user-isolation
+          - uid: mondoo-databricks-security-cluster-autotermination-configured
+          - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets
+          - uid: mondoo-databricks-security-cluster-governed-by-policy
+      - title: Tokens and Secrets
+        checks:
+          - uid: mondoo-databricks-security-token-no-nonexpiring
+          - uid: mondoo-databricks-security-token-lifetime-under-90-days
+          - uid: mondoo-databricks-security-secret-scope-not-world-readable
+      - title: Network Access Controls
+        checks:
+          - uid: mondoo-databricks-security-workspace-public-access-disabled
+          - uid: mondoo-databricks-security-private-access-restrict-endpoints
+          - uid: mondoo-databricks-security-workspace-customer-managed-keys
+          - uid: mondoo-databricks-security-ip-access-list-no-allow-all
+      - title: Data Sharing and AI
+        checks:
+          - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted
+          - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails
+      - title: Identity and Access Management
+        checks:
+          - uid: mondoo-databricks-security-no-inactive-service-principals
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled
+    title: Ensure enhanced security monitoring is enabled on the workspace
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-16
+      compliance/nis-2: nis-2-21-2-g
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-6
+      compliance/pci-dss-4: pcidss-requirement-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      databricks.workspaceConf.enhancedSecurityMonitoringEnabled == true
+    docs:
+      desc: |
+        This check ensures that Enhanced Security Monitoring is turned on for the workspace so that compute nodes run a hardened operating system image and carry additional antivirus and behavior based monitoring agents. By default the setting is disabled, which leaves cluster hosts running a standard image with no host level threat detection.
+
+        **Why this matters**
+
+        - **Detects host compromise:** Behavior based agents surface malware, unexpected processes, and file integrity changes on the compute nodes that run your jobs.
+        - **Hardens the base image:** The hardened operating system image reduces the attack surface exposed on every cluster node.
+        - **Feeds security telemetry:** Monitoring agents forward findings that let responders investigate suspicious activity on Databricks compute.
+
+        **Risk mitigation**
+
+        - **Enable on every workspace:** Turn on Enhanced Security Monitoring so all clusters inherit the hardened image and monitoring agents automatically.
+        - **Review the findings:** Route the generated security signals to your monitoring pipeline so detections are triaged promptly.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace as an administrator.
+        2. Open **Settings** and select the **Security and compliance** tab.
+        3. Locate **Enhanced security monitoring** and confirm the toggle is enabled.
+
+        A passing result shows the toggle enabled; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Run the settings command with the Databricks CLI configured for the workspace:
+
+        ```bash
+        databricks settings enhanced-security-monitoring get
+        ```
+
+        A passing result returns an `is_enabled` value of `true`; a failing result returns `false` or an unset value.
+      remediation:
+        - id: console
+          desc: |
+            To enable Enhanced Security Monitoring using the Databricks workspace admin console:
+
+            1. Sign in to the workspace as an administrator.
+            2. Open **Settings** and select the **Security and compliance** tab.
+            3. Find **Enhanced security monitoring** and set the toggle to enabled.
+            4. Save the change. Existing clusters pick up the hardened image and agents on their next restart.
+        - id: cli
+          desc: |
+            To enable Enhanced Security Monitoring using the Databricks CLI:
+
+            1. Confirm the current state:
+
+                ```bash
+                databricks settings enhanced-security-monitoring get
+                ```
+
+            2. Enable the setting:
+
+                ```bash
+                databricks settings enhanced-security-monitoring update --json '{"enhanced_security_monitoring": {"enabled": true}}'
+                ```
+        - id: terraform
+          desc: |
+            To enable Enhanced Security Monitoring using Terraform, declare the workspace setting resource with the `databricks/databricks` provider configured at workspace level:
+
+            ```hcl
+            resource "databricks_enhanced_security_monitoring_workspace_setting" "this" {
+              enhanced_security_monitoring_workspace {
+                is_enabled = true
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-monitoring
+        title: Databricks enhanced security monitoring documentation
+  - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled
+    title: Ensure the compliance security profile is enabled on the workspace
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
+    mql: |
+      databricks.workspaceConf.complianceSecurityProfileEnabled == true
+    docs:
+      desc: |
+        This check ensures that the Compliance Security Profile is enabled on the workspace. The profile applies a hardened baseline that adds a hardened operating system image, enforces FIPS validated cryptography, and turns on enhanced monitoring. By default the profile is disabled, so the workspace runs without the hardened controls required by frameworks such as FedRAMP, HIPAA, and PCI DSS.
+
+        **Why this matters**
+
+        - **Establishes a hardened baseline:** The profile enforces a consistent set of hardened configuration settings across the workspace rather than relying on defaults.
+        - **Enforces strong cryptography:** FIPS validated cryptographic modules protect data in transit and at rest on compliant compute.
+        - **Anchors regulated workloads:** The profile is the prerequisite baseline for running FedRAMP, HIPAA, and PCI DSS workloads on Databricks.
+
+        **Risk mitigation**
+
+        - **Enable before onboarding regulated data:** Turn on the profile so the hardened controls are active before sensitive workloads run.
+        - **Select the applicable standards:** Attach the compliance standards that match your obligations so the correct controls are enforced.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace as an administrator.
+        2. Open **Settings** and select the **Security and compliance** tab.
+        3. Locate **Compliance security profile** and confirm the toggle is enabled.
+
+        A passing result shows the toggle enabled; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Run the settings command with the Databricks CLI configured for the workspace:
+
+        ```bash
+        databricks settings compliance-security-profile get
+        ```
+
+        A passing result returns an `is_enabled` value of `true`; a failing result returns `false` or an unset value.
+      remediation:
+        - id: console
+          desc: |
+            To enable the Compliance Security Profile using the Databricks workspace admin console:
+
+            1. Sign in to the workspace as an administrator.
+            2. Open **Settings** and select the **Security and compliance** tab.
+            3. Find **Compliance security profile** and set the toggle to enabled.
+            4. Select the compliance standards that apply to your workloads and save.
+
+            > **Warning:** Enabling the Compliance Security Profile on a workspace is permanent and cannot be reversed, so confirm the workspace is the correct target before you enable it.
+        - id: cli
+          desc: |
+            To enable the Compliance Security Profile using the Databricks CLI:
+
+            1. Confirm the current state:
+
+                ```bash
+                databricks settings compliance-security-profile get
+                ```
+
+            2. Enable the setting. Enabling it is permanent, so verify the target workspace first:
+
+                ```bash
+                databricks settings compliance-security-profile update --json '{"compliance_security_profile": {"enabled": true}}'
+                ```
+        - id: terraform
+          desc: |
+            To enable the Compliance Security Profile using Terraform, declare the workspace setting resource with the `databricks/databricks` provider configured at workspace level and list the standards you must meet:
+
+            ```hcl
+            resource "databricks_compliance_security_profile_workspace_setting" "this" {
+              compliance_security_profile_workspace {
+                is_enabled           = true
+                compliance_standards = ["HIPAA", "PCI_DSS"]
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-compliance
+        title: Databricks enhanced security and compliance settings documentation
+  - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled
+    title: Ensure automatic cluster update is enabled on the workspace
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    mql: |
+      databricks.workspaceConf.automaticClusterUpdateEnabled == true
+    docs:
+      desc: |
+        This check ensures that Automatic Cluster Update is enabled on the workspace so that compute node virtual machine images are updated and patched during scheduled maintenance windows. By default the setting is disabled, which lets clusters keep running outdated images that carry known, unpatched vulnerabilities.
+
+        **Why this matters**
+
+        - **Closes known vulnerabilities:** Scheduled image updates remove flaws in the operating system and runtime before they can be exploited on compute nodes.
+        - **Removes manual toil:** Automated patching during maintenance windows keeps clusters current without operators tracking and applying updates by hand.
+        - **Shrinks the exposure window:** Timely updates reduce the time a cluster runs a vulnerable image.
+
+        **Risk mitigation**
+
+        - **Enable workspace wide:** Turn on Automatic Cluster Update so every cluster is patched on a predictable schedule.
+        - **Set a maintenance window:** Choose a window that limits disruption while keeping the update cadence frequent.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace as an administrator.
+        2. Open **Settings** and select the **Security and compliance** tab.
+        3. Locate **Automatic cluster update** and confirm the toggle is enabled.
+
+        A passing result shows the toggle enabled; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Run the settings command with the Databricks CLI configured for the workspace:
+
+        ```bash
+        databricks settings automatic-cluster-update get
+        ```
+
+        A passing result returns an `enabled` value of `true`; a failing result returns `false` or an unset value.
+      remediation:
+        - id: console
+          desc: |
+            To enable Automatic Cluster Update using the Databricks workspace admin console:
+
+            1. Sign in to the workspace as an administrator.
+            2. Open **Settings** and select the **Security and compliance** tab.
+            3. Find **Automatic cluster update** and set the toggle to enabled.
+            4. Configure the maintenance window and save.
+        - id: cli
+          desc: |
+            To enable Automatic Cluster Update using the Databricks CLI:
+
+            1. Confirm the current state:
+
+                ```bash
+                databricks settings automatic-cluster-update get
+                ```
+
+            2. Enable the setting:
+
+                ```bash
+                databricks settings automatic-cluster-update update --json '{"automatic_cluster_update": {"enabled": true}}'
+                ```
+        - id: terraform
+          desc: |
+            To enable Automatic Cluster Update using Terraform, declare the workspace setting resource with the `databricks/databricks` provider configured at workspace level and define a maintenance window:
+
+            ```hcl
+            resource "databricks_automatic_cluster_update_workspace_setting" "this" {
+              automatic_cluster_update_workspace {
+                enabled = true
+                maintenance_window {
+                  week_day_based_schedule {
+                    day_of_week = "SUNDAY"
+                    frequency   = "EVERY_WEEK"
+                    window_start_time {
+                      hours   = 1
+                      minutes = 0
+                    }
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-compliance
+        title: Databricks enhanced security and compliance settings documentation
+  - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled
+    title: Ensure IP access lists are enabled for the workspace
+    impact: 80
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      databricks.workspaceConf.ipAccessListsEnabled == true
+    docs:
+      desc: |
+        This check ensures that IP access list enforcement is enabled for the workspace so that the web application and REST API only accept connections from approved networks. By default enforcement is off, which leaves the workspace reachable from any address on the internet even when allow lists have been defined.
+
+        **Why this matters**
+
+        - **Closes global exposure:** With enforcement off, the workspace endpoints are reachable from any IP address in the world.
+        - **Contains stolen credentials:** Network gating prevents leaked tokens or passwords from being used outside trusted networks.
+        - **Adds a defense layer:** IP allow and block lists protect the workspace independently of authentication.
+
+        **Risk mitigation**
+
+        - **Enable enforcement:** Turn on IP access lists so the defined allow and block lists are actually applied.
+        - **Scope to trusted ranges:** Populate allow lists with corporate networks and VPN egress ranges, and confirm your own address is covered before enforcing.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace as an administrator.
+        2. Open **Settings** and select the **Security** tab.
+        3. Locate **IP access lists** and confirm enforcement is enabled and at least one allow list is defined.
+
+        A passing result shows enforcement enabled; a failing result shows it disabled.
+
+        ### Audit via CLI
+
+        Check the enforcement flag and the configured lists with the Databricks CLI configured for the workspace:
+
+        ```bash
+        databricks workspace-conf get-status enableIpAccessLists
+        databricks ip-access-lists list
+        ```
+
+        A passing result returns `enableIpAccessLists` as `true`; a failing result returns `false` or an unset value.
+      remediation:
+        - id: console
+          desc: |
+            To enable IP access list enforcement using the Databricks workspace admin console:
+
+            1. Sign in to the workspace as an administrator.
+            2. Open **Settings** and select the **Security** tab.
+            3. Under **IP access lists**, add an allow list with the CIDR ranges for your corporate networks and VPN egress addresses.
+            4. Enable enforcement and save.
+
+            > **Warning:** Enabling enforcement without an allow list that includes your current public address blocks everyone, including you. Confirm your egress range is covered before you enable it.
+        - id: cli
+          desc: |
+            To enable IP access list enforcement using the Databricks CLI:
+
+            1. Create at least one allow list that includes your trusted ranges. Replace the reserved documentation range below with your real egress ranges:
+
+                ```bash
+                databricks ip-access-lists create --json '{"label": "corp-allow", "list_type": "ALLOW", "ip_addresses": ["203.0.113.0/24"]}'
+                ```
+
+            2. Enable enforcement:
+
+                ```bash
+                databricks workspace-conf set-status --json '{"enableIpAccessLists": "true"}'
+                ```
+
+            3. Verify the flag and lists:
+
+                ```bash
+                databricks workspace-conf get-status enableIpAccessLists
+                databricks ip-access-lists list
+                ```
+        - id: terraform
+          desc: |
+            To enable IP access list enforcement using Terraform, set the workspace configuration flag with the `databricks/databricks` provider and define at least one allow list. The `203.0.113.0/24` value is a reserved documentation range you must replace with your real egress ranges:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "enableIpAccessLists" = "true"
+              }
+            }
+
+            resource "databricks_ip_access_list" "allow_in" {
+              label        = "corp-allow"
+              list_type    = "ALLOW"
+              ip_addresses = ["203.0.113.0/24"]
+              depends_on   = [databricks_workspace_conf.this]
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list
+        title: Databricks IP access lists documentation
+  - uid: mondoo-databricks-security-workspace-legacy-access-disabled
+    title: Ensure legacy access protocols are disabled on the workspace
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      databricks.workspaceConf.disableLegacyAccess == true
+    docs:
+      desc: |
+        This check ensures that legacy access paths are disabled on the workspace so that data access is forced through Unity Catalog governance. When legacy access is allowed, the workspace still permits direct legacy Hive metastore access and fallback mode on external locations, both of which bypass Unity Catalog controls. By default legacy access remains available.
+
+        **Why this matters**
+
+        - **Removes ungoverned paths:** Direct Hive metastore access and external location fallback bypass Unity Catalog permissions and lineage.
+        - **Enforces least functionality:** Disabling deprecated data access protocols shrinks the attack surface to the governed path only.
+        - **Retires outdated runtimes:** The setting blocks Databricks Runtime versions that predate the governed access model.
+
+        **Risk mitigation**
+
+        - **Disable legacy access:** Turn on the setting so all data access flows through Unity Catalog.
+        - **Migrate before enforcing:** Move any workloads that still depend on legacy Hive metastore access to Unity Catalog first to avoid breakage.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace as an administrator.
+        2. Open **Settings** and select the **Security** tab.
+        3. Locate the legacy access setting and confirm it is disabled so access is forced through Unity Catalog.
+
+        A passing result shows legacy access disabled; a failing result shows it still permitted.
+
+        ### Audit via CLI
+
+        Run the settings command with the Databricks CLI configured for the workspace:
+
+        ```bash
+        databricks settings disable-legacy-access get
+        ```
+
+        A passing result returns a `disabled` value of `true`; a failing result returns `false` or an unset value.
+      remediation:
+        - id: console
+          desc: |
+            To disable legacy access using the Databricks workspace admin console:
+
+            1. Sign in to the workspace as an administrator.
+            2. Open **Settings** and select the **Security** tab.
+            3. Locate the legacy access setting and set it to disabled so access is forced through Unity Catalog.
+            4. Save the change.
+        - id: cli
+          desc: |
+            To disable legacy access using the Databricks CLI:
+
+            1. Confirm the current state:
+
+                ```bash
+                databricks settings disable-legacy-access get
+                ```
+
+            2. Disable legacy access:
+
+                ```bash
+                databricks settings disable-legacy-access update --json '{"disable_legacy_access": {"disabled": true}}'
+                ```
+        - id: terraform
+          desc: |
+            To disable legacy access using Terraform, declare the workspace setting resource with the `databricks/databricks` provider configured at workspace level:
+
+            ```hcl
+            resource "databricks_disable_legacy_access_setting" "this" {
+              disable_legacy_access {
+                value = true
+              }
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/data-governance/unity-catalog/hive-metastore
+        title: Databricks legacy Hive metastore and Unity Catalog documentation
+  - uid: mondoo-databricks-security-workspace-token-lifetime-capped
+    title: Ensure personal access tokens are disabled or lifetime is capped
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: false
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      databricks.workspaceConf.tokensEnabled == false || databricks.workspaceConf.maxTokenLifetimeDays != empty && databricks.workspaceConf.maxTokenLifetimeDays <= 90
+    docs:
+      desc: |
+        Personal access tokens are long-lived bearer credentials that authenticate to the full Databricks REST API. This check passes when personal access tokens are disabled for the entire workspace, or when a maximum token lifetime of 90 days or fewer is enforced. By default Databricks allows personal access tokens to be created with no maximum lifetime, so a single token can remain valid until it is manually revoked. The evaluation relies on MQL boolean precedence, in which the AND operator binds more tightly than the OR operator, so the disabled test and the lifetime test compose correctly without any grouping punctuation.
+
+        **Why this matters**
+
+        - **Limits the credential exposure window:** A capped lifetime bounds how long a leaked or stolen token remains usable.
+        - **Reduces standing attack surface:** Disabling tokens removes an entire class of static credentials that bypass interactive authentication.
+        - **Forces credential rotation:** Expiring tokens require periodic reissue, which surfaces stale automation and unused integrations.
+
+        **Risk mitigation**
+
+        - **Contains compromised credentials:** An attacker who exfiltrates a token loses access when the token expires.
+        - **Enforces least persistence:** Short-lived credentials align machine access with the duration of the work it performs.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an admin.
+        2. Open Settings, then the Advanced section.
+        3. Review the Personal Access Tokens setting and its configured maximum lifetime.
+
+        A passing result shows personal access tokens disabled, or a maximum lifetime set to 90 days or fewer. A failing result shows tokens enabled with no maximum lifetime or a lifetime greater than 90 days.
+
+        ### Audit via CLI
+
+        1. Query the workspace configuration for the token settings:
+
+        ```bash
+        databricks workspace-conf get-status enableTokens
+        databricks workspace-conf get-status maxTokenLifetimeDays
+        ```
+
+        2. Compare the returned values against the required thresholds.
+
+        A passing result shows `enableTokens` set to `false`, or `maxTokenLifetimeDays` set to `90` or fewer. A failing result shows `enableTokens` set to `true` with `maxTokenLifetimeDays` empty or greater than `90`.
+      remediation:
+        - id: console
+          desc: |
+            To disable personal access tokens or cap their lifetime using the Databricks console:
+
+            1. Sign in to the workspace as an admin.
+            2. Open Settings, then Advanced.
+            3. Turn the Personal Access Tokens setting off to disable tokens, or open the token permission settings and set a maximum lifetime of 90 days or fewer.
+
+            ```text
+            Settings > Advanced > Personal Access Tokens
+            ```
+        - id: cli
+          desc: |
+            To cap the personal access token lifetime using the Databricks CLI:
+
+            1. Set the workspace maximum token lifetime to 90 days or fewer:
+
+            ```bash
+            databricks workspace-conf set-status --json '{"maxTokenLifetimeDays": "90"}'
+            ```
+
+            2. To disable personal access tokens for the whole workspace instead:
+
+            ```bash
+            databricks workspace-conf set-status --json '{"enableTokens": "false"}'
+            ```
+        - id: terraform
+          desc: |
+            To cap the personal access token lifetime using the Databricks Terraform provider, set the workspace configuration keys:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "enableTokens"         = "true"
+                "maxTokenLifetimeDays" = "90"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-workspace-admins-restricted
+    title: Ensure workspace admin privileges are restricted
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      databricks.workspaceConf.restrictWorkspaceAdminsStatus == "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+    docs:
+      desc: |
+        Workspace admins hold broad control over a Databricks workspace. This check passes when the workspace admin restriction status is set to `RESTRICT_TOKENS_AND_JOB_RUN_AS`, which prevents workspace admins from generating personal access tokens on behalf of arbitrary service principals and from changing the run-as identity of jobs. The insecure default is `ALLOW_ALL`, under which a workspace admin can mint tokens for any service principal and execute jobs under any identity.
+
+        **Why this matters**
+
+        - **Blocks privilege escalation:** Restricting run-as identity changes stops an admin from executing workloads under a more privileged service principal.
+        - **Prevents token minting abuse:** Admins can no longer issue long-lived tokens for identities they do not own.
+        - **Narrows the blast radius of a compromised admin:** A stolen admin session cannot pivot into arbitrary service-principal contexts.
+
+        **Risk mitigation**
+
+        - **Enforces identity boundaries:** Jobs and tokens stay bound to their legitimate owners.
+        - **Supports separation of duties:** Administrative control is decoupled from the ability to act as other principals.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an admin.
+        2. Open Settings, then the Security section.
+        3. Review the Restrict workspace admins setting.
+
+        A passing result shows the setting restricting token generation and job run-as changes. A failing result shows the setting allowing all admin actions.
+
+        ### Audit via CLI
+
+        1. Read the current restrict workspace admins setting:
+
+        ```bash
+        databricks settings restrict-workspace-admins get
+        ```
+
+        A passing result shows a `status` of `RESTRICT_TOKENS_AND_JOB_RUN_AS`. A failing result shows a `status` of `ALLOW_ALL`.
+      remediation:
+        - id: console
+          desc: |
+            To restrict workspace admin privileges using the Databricks console:
+
+            1. Sign in to the workspace as an admin.
+            2. Open Settings, then Security.
+            3. Set Restrict workspace admins to the option that limits token generation and job run-as identity changes.
+
+            ```text
+            Settings > Security > Restrict workspace admins
+            ```
+        - id: cli
+          desc: |
+            To restrict workspace admin privileges using the Databricks CLI:
+
+            1. Update the restrict workspace admins setting to the restricted status:
+
+            ```bash
+            databricks settings restrict-workspace-admins update --json '{
+              "allow_missing": true,
+              "setting": {
+                "restrict_workspace_admins": { "status": "RESTRICT_TOKENS_AND_JOB_RUN_AS" },
+                "setting_name": "default"
+              },
+              "field_mask": "restrict_workspace_admins.status"
+            }'
+            ```
+        - id: terraform
+          desc: |
+            To restrict workspace admin privileges using the Databricks Terraform provider, declare the restrict workspace admins setting:
+
+            ```hcl
+            resource "databricks_restrict_workspace_admins_setting" "this" {
+              setting_name = "default"
+
+              restrict_workspace_admins {
+                status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled
+    title: Ensure deprecated global init scripts are disabled
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      databricks.workspaceConf.deprecatedGlobalInitScriptsEnabled == false
+    docs:
+      desc: |
+        Legacy global init scripts run automatically on every cluster in the workspace during startup, executing with root privileges. This check passes when the deprecated global init script mechanism is disabled. On older workspaces this legacy mechanism can remain enabled, where the scripts are unversioned, are not individually access controlled, and leave no per-script audit trail. Databricks replaced it with named global init scripts, which are versioned and auditable.
+
+        **Why this matters**
+
+        - **Removes an unaudited root execution path:** Legacy scripts run as root on every cluster with no per-script logging.
+        - **Eliminates unversioned configuration:** Changes to legacy scripts cannot be tracked or reviewed.
+        - **Shrinks the cluster attack surface:** Disabling the mechanism prevents silent code execution across all compute.
+
+        **Risk mitigation**
+
+        - **Prevents persistent compromise:** An attacker cannot hide root-level code in an unauditable legacy script.
+        - **Enforces supported configuration:** Init logic moves to the named, access-controlled replacement.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an admin.
+        2. Open Settings, then the Compute section.
+        3. Review the Legacy global init scripts setting.
+
+        A passing result shows legacy global init scripts disabled. A failing result shows them enabled.
+
+        ### Audit via CLI
+
+        1. Read the workspace configuration key:
+
+        ```bash
+        databricks workspace-conf get-status enableDeprecatedGlobalInitScripts
+        ```
+
+        A passing result shows `enableDeprecatedGlobalInitScripts` set to `false`. A failing result shows it set to `true`.
+      remediation:
+        - id: console
+          desc: |
+            To disable deprecated global init scripts using the Databricks console:
+
+            1. Sign in to the workspace as an admin.
+            2. Open Settings, then Compute.
+            3. Turn the Legacy global init scripts setting off.
+
+            ```text
+            Settings > Compute > Legacy global init scripts
+            ```
+        - id: cli
+          desc: |
+            To disable deprecated global init scripts using the Databricks CLI:
+
+            1. Set the workspace configuration key to false:
+
+            ```bash
+            databricks workspace-conf set-status --json '{"enableDeprecatedGlobalInitScripts": "false"}'
+            ```
+        - id: terraform
+          desc: |
+            To disable deprecated global init scripts using the Databricks Terraform provider, set the workspace configuration key:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "enableDeprecatedGlobalInitScripts" = "false"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled
+    title: Ensure deprecated cluster-named init scripts are disabled
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      databricks.workspaceConf.deprecatedClusterNamedInitScriptsEnabled == false
+    docs:
+      desc: |
+        Legacy cluster-named init scripts are stored in DBFS and run automatically when a cluster whose name matches the script starts. This check passes when the deprecated cluster-named init script mechanism is disabled. On older workspaces this legacy mechanism can remain enabled, where any workspace user with DBFS write access can create or modify a script that then executes at cluster startup. Databricks replaced it with access-controlled cluster-scoped and named global init scripts.
+
+        **Why this matters**
+
+        - **Closes a shared-write execution path:** DBFS-stored scripts can be modified by any user with DBFS access and then run at startup.
+        - **Removes an integrity gap:** Cluster startup can execute code that the cluster owner never reviewed.
+        - **Shrinks the cluster attack surface:** Disabling the mechanism prevents name-based script injection.
+
+        **Risk mitigation**
+
+        - **Prevents unauthorized code execution:** Cluster startup no longer trusts mutable DBFS paths.
+        - **Enforces supported configuration:** Init logic moves to access-controlled alternatives.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an admin.
+        2. Open Settings, then the Compute section.
+        3. Review the Legacy cluster-named init scripts setting.
+
+        A passing result shows legacy cluster-named init scripts disabled. A failing result shows them enabled.
+
+        ### Audit via CLI
+
+        1. Read the workspace configuration key:
+
+        ```bash
+        databricks workspace-conf get-status enableDeprecatedClusterNamedInitScripts
+        ```
+
+        A passing result shows `enableDeprecatedClusterNamedInitScripts` set to `false`. A failing result shows it set to `true`.
+      remediation:
+        - id: console
+          desc: |
+            To disable deprecated cluster-named init scripts using the Databricks console:
+
+            1. Sign in to the workspace as an admin.
+            2. Open Settings, then Compute.
+            3. Turn the Legacy cluster-named init scripts setting off.
+
+            ```text
+            Settings > Compute > Legacy cluster-named init scripts
+            ```
+        - id: cli
+          desc: |
+            To disable deprecated cluster-named init scripts using the Databricks CLI:
+
+            1. Set the workspace configuration key to false:
+
+            ```bash
+            databricks workspace-conf set-status --json '{"enableDeprecatedClusterNamedInitScripts": "false"}'
+            ```
+        - id: terraform
+          desc: |
+            To disable deprecated cluster-named init scripts using the Databricks Terraform provider, set the workspace configuration key:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "enableDeprecatedClusterNamedInitScripts" = "false"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account
+    title: Ensure interactive notebook results are stored in the customer account
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-19
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-5-3-4
+    mql: |
+      databricks.workspaceConf.storeInteractiveNotebookResultsInCustomerAccount == true
+    docs:
+      desc: |
+        Interactive notebook command results can be stored either in the Databricks-managed control plane or in the customer's own cloud storage account. This check passes when interactive notebook results are stored in the customer account. By default results may be held in the Databricks control plane, which places query output outside the customer's own storage, encryption, and access-control boundary.
+
+        **Why this matters**
+
+        - **Keeps result data in the customer trust boundary:** Output stays under the customer's own storage and key management.
+        - **Applies customer encryption controls:** Results at rest are protected by the customer's storage encryption.
+        - **Reduces third-party data exposure:** Sensitive query output does not persist in the vendor control plane.
+
+        **Risk mitigation**
+
+        - **Limits data residency risk:** Result data remains in the customer's chosen cloud account and region.
+        - **Strengthens confidentiality at rest:** Access to results is governed by the customer's storage permissions.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an admin.
+        2. Open Settings, then the Security section.
+        3. Review the Store interactive notebook results in customer account setting.
+
+        A passing result shows results stored in the customer account. A failing result shows results stored in the Databricks control plane.
+
+        ### Audit via CLI
+
+        1. Read the workspace configuration key:
+
+        ```bash
+        databricks workspace-conf get-status storeInteractiveNotebookResultsInCustomerAccount
+        ```
+
+        A passing result shows `storeInteractiveNotebookResultsInCustomerAccount` set to `true`. A failing result shows it set to `false`.
+      remediation:
+        - id: console
+          desc: |
+            To store interactive notebook results in the customer account using the Databricks console:
+
+            1. Sign in to the workspace as an admin.
+            2. Open Settings, then Security.
+            3. Turn the Store interactive notebook results in customer account setting on.
+
+            ```text
+            Settings > Security > Store interactive notebook results in customer account
+            ```
+        - id: cli
+          desc: |
+            To store interactive notebook results in the customer account using the Databricks CLI:
+
+            1. Set the workspace configuration key to true:
+
+            ```bash
+            databricks workspace-conf set-status --json '{"storeInteractiveNotebookResultsInCustomerAccount": "true"}'
+            ```
+        - id: terraform
+          desc: |
+            To store interactive notebook results in the customer account using the Databricks Terraform provider, set the workspace configuration key:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "storeInteractiveNotebookResultsInCustomerAccount" = "true"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled
+    title: Ensure local disk encryption is enabled on all compute clusters
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a28
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      databricks.clusters.all(localDiskEncryptionEnabled == true)
+    docs:
+      desc: |
+        Every compute cluster should encrypt the locally attached disks that worker nodes use for scratch storage such as shuffle spill and cached data. By default local disk encryption is off, so intermediate data written to worker node storage during query and job execution is left unencrypted at rest.
+
+        **Why this matters**
+
+        - **Sensitive data reaches local disk:** Spark spills shuffle partitions and cached datasets to node-local storage, so records that never leave memory in principle are written in clear text on the worker.
+        - **Node storage outlives the workload:** Cloud instance storage and its snapshots can be recovered by anyone with access to the underlying infrastructure, exposing the spilled data long after a job finishes.
+        - **Encryption at rest is a baseline expectation:** Regulated data sets require that all copies, including transient and temporary ones, remain encrypted wherever they are stored.
+
+        **Risk mitigation**
+
+        - **Turn on local disk encryption for every cluster:** Set the cluster specification so worker node scratch storage is encrypted with an ephemeral key that lives only for the lifetime of the cluster.
+        - **Enforce it through a cluster policy:** Fix the encryption attribute in a cluster policy so no user can launch a cluster that writes unencrypted data to local disk.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Compute** and open each all-purpose or job cluster.
+        3. Open the **JSON** view of the cluster and locate the `enable_local_disk_encryption` field.
+
+        A passing result shows `enable_local_disk_encryption` set to `true` on every cluster; a failing result shows the field absent or set to `false` on at least one cluster.
+
+        ### Audit via CLI
+
+        1. List the clusters in the workspace:
+
+           ```bash
+           databricks clusters list --output JSON
+           ```
+
+        2. Inspect each cluster specification:
+
+           ```bash
+           databricks clusters get <cluster-id> --output JSON
+           ```
+
+        A passing result shows `enable_local_disk_encryption` set to `true` for every cluster; a failing result shows the field missing or `false` for at least one cluster.
+      remediation:
+        - id: console
+          desc: |
+            To enforce local disk encryption on compute clusters using the workspace console:
+
+            1. Sign in to the Databricks workspace as an administrator.
+            2. Go to **Compute** and select the **Policies** tab.
+            3. Create or edit the cluster policy that governs your clusters and set the encryption attribute in the policy definition:
+
+               ```json
+               {
+                 "enable_local_disk_encryption": {
+                   "type": "fixed",
+                   "value": true
+                 }
+               }
+               ```
+
+            4. Recreate any existing clusters under the updated policy so the setting takes effect.
+        - id: cli
+          desc: |
+            To enable local disk encryption on a cluster using the Databricks CLI:
+
+            1. Retrieve the current cluster specification so you can resubmit it with the encryption flag:
+
+               ```bash
+               databricks clusters get <cluster-id> --output JSON
+               ```
+
+            2. Resubmit the full specification with encryption enabled:
+
+               ```bash
+               databricks clusters edit --json '{
+                 "cluster_id": "<cluster-id>",
+                 "num_workers": 2,
+                 "spark_version": "<runtime-version>",
+                 "node_type_id": "<node-type>",
+                 "enable_local_disk_encryption": true
+               }'
+               ```
+        - id: terraform
+          desc: |
+            To enable local disk encryption on a cluster using Terraform, set `enable_local_disk_encryption` on the `databricks_cluster` resource:
+
+            ```hcl
+            resource "databricks_cluster" "this" {
+              cluster_name                 = "secured-cluster"
+              spark_version                = "15.4.x-scala2.12"
+              node_type_id                 = "i3.xlarge"
+              num_workers                  = 2
+              enable_local_disk_encryption = true
+            }
+            ```
+  - uid: mondoo-databricks-security-cluster-access-mode-user-isolation
+    title: Ensure compute clusters enforce an access mode with user isolation
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a15
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      databricks.clusters.all(dataSecurityMode != empty && dataSecurityMode != "NONE")
+    docs:
+      desc: |
+        Every compute cluster should run with a data security mode that enforces user isolation so Unity Catalog governance and table access controls apply. The `NONE` mode disables isolation entirely, runs without Unity Catalog, and ignores table access controls, which lets any code on the cluster read all data the cluster identity can reach. This check fails a cluster whose data security mode is unset or set to `NONE`.
+
+        Isolation enforcing modes include `SINGLE_USER`, `USER_ISOLATION`, and the newer `DATA_SECURITY_MODE_DEDICATED`, `DATA_SECURITY_MODE_STANDARD`, and `DATA_SECURITY_MODE_AUTO` modes. The `LEGACY_*` modes are deprecated but still provide some isolation and therefore pass. Only `NONE` provides no isolation at all.
+
+        **Why this matters**
+
+        - **No governance without isolation:** A cluster in `NONE` mode bypasses Unity Catalog and table access controls, so row and column level permissions and audit lineage do not apply to workloads running on it.
+        - **Shared clusters leak between users:** Without user isolation, arbitrary Python, Scala, or JVM code can read credentials, mounted data, and other users' results present on the same cluster.
+        - **Privilege escalation surface:** Unisolated clusters expose the underlying instance identity and its cloud permissions to any code that runs, widening the blast radius of a single compromised notebook.
+
+        **Risk mitigation**
+
+        - **Select an isolation enforcing access mode:** Configure each cluster for single user or standard shared access rather than no isolation shared, so Unity Catalog and access controls are enforced.
+        - **Constrain the choice with a cluster policy:** Fix the data security mode in a cluster policy so users cannot create clusters that run without isolation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Compute** and open each all-purpose or job cluster.
+        3. Review the **Access mode** shown for the cluster, and confirm it is not **No isolation shared**.
+
+        A passing result shows every cluster set to single user or a standard shared access mode; a failing result shows at least one cluster set to no isolation shared.
+
+        ### Audit via CLI
+
+        1. Inspect each cluster specification:
+
+           ```bash
+           databricks clusters get <cluster-id> --output JSON
+           ```
+
+        A passing result shows `data_security_mode` set to a value other than `NONE` on every cluster; a failing result shows `data_security_mode` unset or set to `NONE` on at least one cluster.
+      remediation:
+        - id: console
+          desc: |
+            To enforce an isolation aware access mode using the workspace console:
+
+            1. Sign in to the Databricks workspace as an administrator.
+            2. Go to **Compute** and open the cluster to change.
+            3. Set **Access mode** to **Single user** or **Shared** so it is no longer **No isolation shared**.
+            4. Save and restart the cluster.
+        - id: cli
+          desc: |
+            To set an isolation aware data security mode on a cluster using the Databricks CLI, resubmit the cluster specification with `data_security_mode`:
+
+            ```bash
+            databricks clusters edit --json '{
+              "cluster_id": "<cluster-id>",
+              "num_workers": 2,
+              "spark_version": "<runtime-version>",
+              "node_type_id": "<node-type>",
+              "data_security_mode": "USER_ISOLATION"
+            }'
+            ```
+        - id: terraform
+          desc: |
+            To set an isolation aware access mode using Terraform, set `data_security_mode` on the `databricks_cluster` resource to `USER_ISOLATION` or `SINGLE_USER`:
+
+            ```hcl
+            resource "databricks_cluster" "this" {
+              cluster_name       = "governed-cluster"
+              spark_version      = "15.4.x-scala2.12"
+              node_type_id       = "i3.xlarge"
+              num_workers        = 2
+              data_security_mode = "USER_ISOLATION"
+            }
+            ```
+  - uid: mondoo-databricks-security-cluster-autotermination-configured
+    title: Ensure compute clusters have auto-termination configured
+    impact: 40
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iii-access-control-automatic-logoff
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-11
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-12
+      compliance/pci-dss-4: pcidss-requirement-8-2-8
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    mql: |
+      databricks.clusters.all(autoterminationMinutes > 0 && autoterminationMinutes <= 120)
+    docs:
+      desc: |
+        Every compute cluster should terminate automatically after a bounded period of inactivity so idle compute does not stay running indefinitely. This check requires an idle timeout of 120 minutes or fewer. A value of `0` means auto-termination is disabled and the cluster runs until stopped by hand.
+
+        **Why this matters**
+
+        - **Idle compute is standing attack surface:** A running cluster keeps an authenticated environment, mounted data, and cloud instance credentials available for an attacker to reach even when no one is using it.
+        - **Forgotten clusters accumulate risk and cost:** Clusters left running without a timeout drift out of monitoring attention and continue to consume resources and hold access to data.
+        - **Bounded lifetime limits exposure:** Terminating idle compute shrinks the window during which a stale, unattended environment can be abused.
+
+        **Risk mitigation**
+
+        - **Set a conservative idle timeout:** Configure each cluster to auto-terminate after an idle period no longer than 120 minutes, and shorter where workloads allow.
+        - **Enforce the timeout with a cluster policy:** Fix a maximum auto-termination value in a cluster policy so users cannot disable it or set an unbounded idle period.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Compute** and open each all-purpose cluster.
+        3. Review the **Terminate after ... minutes of inactivity** setting under the cluster configuration.
+
+        A passing result shows every cluster set to terminate after 120 minutes of inactivity or fewer; a failing result shows a cluster with auto-termination disabled or set above 120 minutes.
+
+        ### Audit via CLI
+
+        1. Inspect each cluster specification:
+
+           ```bash
+           databricks clusters get <cluster-id> --output JSON
+           ```
+
+        A passing result shows `autotermination_minutes` set between `1` and `120` on every cluster; a failing result shows the value set to `0` or above `120` on at least one cluster.
+      remediation:
+        - id: console
+          desc: |
+            To configure auto-termination on a cluster using the workspace console:
+
+            1. Sign in to the Databricks workspace as an administrator.
+            2. Go to **Compute** and open the cluster to change.
+            3. Enable **Terminate after ... minutes of inactivity** and set a value of 120 or fewer.
+            4. Save and restart the cluster.
+        - id: cli
+          desc: |
+            To configure auto-termination on a cluster using the Databricks CLI, resubmit the cluster specification with `autotermination_minutes`:
+
+            ```bash
+            databricks clusters edit --json '{
+              "cluster_id": "<cluster-id>",
+              "num_workers": 2,
+              "spark_version": "<runtime-version>",
+              "node_type_id": "<node-type>",
+              "autotermination_minutes": 60
+            }'
+            ```
+        - id: terraform
+          desc: |
+            To configure auto-termination using Terraform, set `autotermination_minutes` on the `databricks_cluster` resource:
+
+            ```hcl
+            resource "databricks_cluster" "this" {
+              cluster_name            = "job-cluster"
+              spark_version           = "15.4.x-scala2.12"
+              node_type_id            = "i3.xlarge"
+              num_workers             = 2
+              autotermination_minutes = 60
+            }
+            ```
+  - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets
+    title: Ensure no plaintext secrets are set in cluster Spark configuration
+    impact: 80
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-6-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      databricks.clusters.all(sparkConf.where( key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/ ).all( value == /\{\{secrets\// ))
+    docs:
+      desc: |
+        Sensitive values in a cluster Spark configuration should reference the Databricks secrets store rather than embed a credential in clear text. Any Spark configuration key whose name looks like a credential, such as a password, secret, token, API key, access key, or credential, should hold a `{{secrets/scope/key}}` reference. By default a Spark configuration value is stored and displayed verbatim, so a pasted credential is retained as plaintext.
+
+        **Why this matters**
+
+        - **Cluster configuration is widely readable:** Spark configuration is visible to anyone who can view the cluster and is captured in cluster event logs and API responses, so an embedded credential is exposed far beyond its intended use.
+        - **Plaintext credentials get copied and leaked:** A secret pasted into a Spark configuration is easily duplicated into cloned clusters, exported specifications, and version control, multiplying where it can be stolen.
+        - **Secret references keep values out of sight:** The `{{secrets/scope/key}}` syntax resolves the value at runtime and redacts it in logs and the user interface, so the credential is never persisted in the configuration.
+
+        **Risk mitigation**
+
+        - **Move every credential into a secret scope:** Store sensitive values in a Databricks secret scope and replace the plaintext Spark configuration value with a `{{secrets/scope/key}}` reference.
+        - **Restrict access to the secret scope:** Grant read access on the secret scope only to the principals that need it, so referencing a secret does not expose it to everyone on the cluster.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Compute** and open each cluster, then expand **Advanced options** and review the **Spark config** entries.
+        3. Look for keys named like credentials whose values are not `{{secrets/scope/key}}` references.
+
+        A passing result shows every credential named Spark configuration key holding a `{{secrets/...}}` reference; a failing result shows at least one such key holding a plaintext value.
+
+        ### Audit via CLI
+
+        1. Inspect each cluster specification and review the `spark_conf` map:
+
+           ```bash
+           databricks clusters get <cluster-id> --output JSON
+           ```
+
+        A passing result shows every credential named key under `spark_conf` set to a `{{secrets/...}}` reference; a failing result shows at least one such key set to a literal value.
+      remediation:
+        - id: console
+          desc: |
+            To replace a plaintext Spark configuration secret with a secret reference using the workspace console:
+
+            1. Store the value in a secret scope. Secret scopes and secrets are created with the Databricks CLI or API, for example `databricks secrets create-scope` and `databricks secrets put-secret`.
+            2. In the workspace, go to **Compute** and open the cluster to change.
+            3. Expand **Advanced options** and edit the **Spark config** entry so the value reads:
+
+               ```text
+               spark.myservice.password {{secrets/my-scope/my-key}}
+               ```
+
+            4. Save and restart the cluster.
+        - id: cli
+          desc: |
+            To move a plaintext Spark configuration secret into the secrets store using the Databricks CLI:
+
+            1. Create a secret scope and store the value:
+
+               ```bash
+               databricks secrets create-scope my-scope
+               databricks secrets put-secret my-scope my-key
+               ```
+
+            2. Resubmit the cluster specification so the Spark configuration references the secret instead of a literal value:
+
+               ```bash
+               databricks clusters edit --json '{
+                 "cluster_id": "<cluster-id>",
+                 "num_workers": 2,
+                 "spark_version": "<runtime-version>",
+                 "node_type_id": "<node-type>",
+                 "spark_conf": {
+                   "spark.myservice.password": "{{secrets/my-scope/my-key}}"
+                 }
+               }'
+               ```
+        - id: terraform
+          desc: |
+            To store a secret and reference it from a cluster Spark configuration using Terraform, create a `databricks_secret_scope` and `databricks_secret`, then reference them from `spark_conf` on the `databricks_cluster` resource:
+
+            ```hcl
+            resource "databricks_secret_scope" "this" {
+              name = "my-scope"
+            }
+
+            resource "databricks_secret" "svc_password" {
+              scope        = databricks_secret_scope.this.name
+              key          = "my-key"
+              string_value = var.service_password
+            }
+
+            resource "databricks_cluster" "this" {
+              cluster_name  = "app-cluster"
+              spark_version = "15.4.x-scala2.12"
+              node_type_id  = "i3.xlarge"
+              num_workers   = 2
+
+              spark_conf = {
+                "spark.myservice.password" = "{{secrets/my-scope/my-key}}"
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-cluster-governed-by-policy
+    title: Ensure every compute cluster is governed by a cluster policy
+    impact: 40
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: bsi-sys-1-5-a14
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: false
+    mql: |
+      databricks.clusters.all(policy != empty)
+    docs:
+      desc: |
+        Every compute cluster should be bound to a cluster policy so administrators can constrain how clusters are created rather than allowing unconstrained ad-hoc compute. A cluster policy limits instance types, runtime versions, tags, and security settings to an approved baseline. By default clusters can be created without any policy, leaving their configuration entirely up to the person who launches them.
+
+        **Why this matters**
+
+        - **Unconstrained clusters drift from baseline:** Without a policy, users can select any runtime, node type, and security setting, so security controls such as encryption and isolation are applied inconsistently or not at all.
+        - **Policies enforce security settings centrally:** A cluster policy is the mechanism that fixes attributes like local disk encryption, data security mode, and auto-termination across every cluster it governs.
+        - **Governance and cost controls depend on it:** Required tags, instance limits, and approved runtimes can only be enforced when clusters are created through a policy.
+
+        **Risk mitigation**
+
+        - **Bind every cluster to a policy:** Create cluster policies that encode your secure baseline and require users to select one when they create a cluster.
+        - **Restrict unrestricted cluster creation:** Limit the entitlement to create clusters without a policy so ad-hoc compute cannot bypass the baseline.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Compute** and open each all-purpose or job cluster.
+        3. Confirm the cluster shows an assigned **Policy** rather than **Unrestricted**.
+
+        A passing result shows every cluster bound to a cluster policy; a failing result shows at least one cluster created with no policy.
+
+        ### Audit via CLI
+
+        1. Inspect each cluster specification and review the `policy_id` field:
+
+           ```bash
+           databricks clusters get <cluster-id> --output JSON
+           ```
+
+        A passing result shows `policy_id` populated on every cluster; a failing result shows the field absent on at least one cluster.
+      remediation:
+        - id: console
+          desc: |
+            To bind a cluster to a cluster policy using the workspace console:
+
+            1. Sign in to the Databricks workspace as an administrator.
+            2. Go to **Compute**, select the **Policies** tab, and create a policy that encodes your secure baseline if one does not exist.
+            3. Open the cluster to change and select the policy in the **Policy** field.
+            4. Save and restart the cluster.
+        - id: cli
+          desc: |
+            To create a cluster policy and bind a cluster to it using the Databricks CLI:
+
+            1. Create the policy from a policy definition document:
+
+               ```bash
+               databricks cluster-policies create --json '{
+                 "name": "secure-baseline",
+                 "definition": "{\"enable_local_disk_encryption\":{\"type\":\"fixed\",\"value\":true}}"
+               }'
+               ```
+
+            2. Resubmit the cluster specification with the returned `policy_id`:
+
+               ```bash
+               databricks clusters edit --json '{
+                 "cluster_id": "<cluster-id>",
+                 "num_workers": 2,
+                 "spark_version": "<runtime-version>",
+                 "node_type_id": "<node-type>",
+                 "policy_id": "<policy-id>"
+               }'
+               ```
+        - id: terraform
+          desc: |
+            To define a cluster policy and bind a cluster to it using Terraform, create a `databricks_cluster_policy` and set `policy_id` on the `databricks_cluster` resource:
+
+            ```hcl
+            resource "databricks_cluster_policy" "baseline" {
+              name = "secure-baseline"
+              definition = jsonencode({
+                "enable_local_disk_encryption" : {
+                  "type" : "fixed",
+                  "value" : true
+                }
+              })
+            }
+
+            resource "databricks_cluster" "this" {
+              cluster_name  = "governed-cluster"
+              spark_version = "15.4.x-scala2.12"
+              node_type_id  = "i3.xlarge"
+              num_workers   = 2
+              policy_id     = databricks_cluster_policy.baseline.id
+            }
+            ```
+  - uid: mondoo-databricks-security-token-no-nonexpiring
+    title: Ensure no personal access tokens are set to never expire
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      databricks.tokens.all(expiryTime != empty)
+    docs:
+      desc: |
+        Databricks personal access tokens are long-lived bearer credentials that authenticate to the workspace REST API. Every token should have an expiry time set. The insecure default appears when a token is created with no lifetime, because such a token never expires and remains valid until someone manually revokes it.
+
+        **Why this matters**
+
+        - **Never rotates:** A token with no expiry stays valid indefinitely, so a credential that leaks today can still be used months or years later.
+        - **Evades cleanup:** Non-expiring tokens accumulate as employees and pipelines change, leaving forgotten credentials that no one revokes.
+        - **Grants standing access:** Anyone who obtains the token holds continuous API access to the workspace with no automatic cutoff.
+
+        **Risk mitigation**
+
+        - **Always set a lifetime:** Create every token with an expiry so it becomes invalid automatically.
+        - **Enforce a maximum lifetime:** Configure a workspace-wide maximum token lifetime so new tokens cannot be created without an expiry.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Settings** > **Developer** and open **Access tokens** to review your own tokens.
+        3. Confirm the CLI or API is used for a workspace-wide review, because the UI shows only the current user's tokens.
+
+        A passing result shows every token with an expiration date; a failing result shows at least one token that never expires.
+
+        ### Audit via CLI
+
+        1. List all tokens in the workspace:
+
+            ```bash
+            databricks token-management list
+            ```
+
+        2. Inspect the `expiry_time` of each token. A value of `-1` means the token never expires.
+
+        A passing result shows every token with a positive `expiry_time`; a failing result shows at least one token whose `expiry_time` is `-1`.
+      remediation:
+        - id: console
+          desc: |
+            To ensure personal access tokens are created with an expiry using the workspace UI:
+
+            1. Sign in to the Databricks workspace.
+            2. Go to **Settings** > **Developer** and open **Access tokens**.
+            3. When generating a token, enter a value in the **Lifetime (days)** field rather than leaving it blank.
+            4. Revoke any existing token that was created with no lifetime by selecting it and choosing **Revoke**.
+
+            Enforcing this across the whole workspace requires the maximum token lifetime setting shown in the CLI and Terraform steps.
+        - id: cli
+          desc: |
+            To prevent non-expiring tokens and revoke existing ones using the Databricks CLI:
+
+            1. Set a workspace-wide maximum token lifetime so new tokens must carry an expiry:
+
+                ```bash
+                databricks workspace-conf set-status --json '{"maxTokenLifetimeDays": "90"}'
+                ```
+
+            2. Find tokens that never expire, which report an `expiry_time` of `-1`:
+
+                ```bash
+                databricks token-management list
+                ```
+
+            3. Revoke each non-expiring token by its ID:
+
+                ```bash
+                databricks token-management delete <token-id>
+                ```
+        - id: terraform
+          desc: |
+            To enforce token expiry as code using the `databricks/databricks` provider, set a workspace-wide maximum lifetime and always define `lifetime_seconds` on managed tokens. Omitting `lifetime_seconds` creates a token that never expires:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "maxTokenLifetimeDays" = "90"
+              }
+            }
+
+            resource "databricks_token" "pipeline" {
+              comment          = "pipeline token"
+              lifetime_seconds = 7776000
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/admin/access-control/tokens
+        title: Monitor and revoke Databricks personal access tokens
+  - uid: mondoo-databricks-security-token-lifetime-under-90-days
+    title: Ensure personal access token lifetimes do not exceed 90 days
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-6-3
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      databricks.tokens.all(expiryTime - creationTime <= 90 * time.day)
+    docs:
+      desc: |
+        Databricks personal access tokens should have a short lifetime so a leaked credential is valid for only a bounded window. Each token's lifetime from creation to expiry should be at most 90 days. The insecure default appears when a token is created with a longer lifetime, because the workspace maximum is 730 days unless an administrator lowers it, leaving tokens valid for as long as two years.
+
+        **Why this matters**
+
+        - **Extends exposure:** A long-lived token that leaks stays usable for months, giving an attacker a wide window to reach workspace data and APIs.
+        - **Delays natural cleanup:** Short lifetimes retire stale credentials automatically, while long lifetimes let forgotten tokens linger.
+        - **Weakens rotation:** Bounded lifetimes force regular reissue, which limits how long any single compromised credential remains valid.
+
+        **Risk mitigation**
+
+        - **Cap the lifetime:** Configure a workspace-wide maximum token lifetime of 90 days or fewer.
+        - **Reissue short-lived tokens:** Replace long-lived tokens with new tokens that carry a lifetime within the limit.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Settings** > **Developer** and open **Access tokens** to review your own tokens and their expiration dates.
+        3. Confirm the CLI or API is used for a workspace-wide review, because the UI shows only the current user's tokens.
+
+        A passing result shows every token expiring within 90 days of its creation; a failing result shows at least one token with a longer lifetime.
+
+        ### Audit via CLI
+
+        1. List all tokens in the workspace:
+
+            ```bash
+            databricks token-management list
+            ```
+
+        2. For each token, subtract `creation_time` from `expiry_time`, both epoch millisecond values, and confirm the difference is at most 90 days.
+
+        A passing result shows every token within a 90-day lifetime; a failing result shows at least one token whose lifetime exceeds 90 days.
+      remediation:
+        - id: console
+          desc: |
+            To keep token lifetimes within 90 days using the workspace UI:
+
+            1. Sign in to the Databricks workspace.
+            2. Go to **Settings** > **Developer** and open **Access tokens**.
+            3. When generating a token, set the **Lifetime (days)** field to 90 or fewer.
+            4. Revoke any existing token whose lifetime exceeds 90 days by selecting it and choosing **Revoke**, then reissue it with a shorter lifetime.
+
+            Enforcing this across the whole workspace requires the maximum token lifetime setting shown in the CLI and Terraform steps.
+        - id: cli
+          desc: |
+            To cap token lifetimes and reissue long-lived tokens using the Databricks CLI:
+
+            1. Set the workspace-wide maximum token lifetime to 90 days. The default is 730 days:
+
+                ```bash
+                databricks workspace-conf set-status --json '{"maxTokenLifetimeDays": "90"}'
+                ```
+
+            2. Find tokens whose `expiry_time` minus `creation_time` exceeds 90 days:
+
+                ```bash
+                databricks token-management list
+                ```
+
+            3. Revoke each long-lived token by its ID, then reissue it with a shorter lifetime:
+
+                ```bash
+                databricks token-management delete <token-id>
+                ```
+        - id: terraform
+          desc: |
+            To bound token lifetimes as code using the `databricks/databricks` provider, set a workspace-wide maximum lifetime and keep `lifetime_seconds` at or below 90 days, which is 7776000 seconds:
+
+            ```hcl
+            resource "databricks_workspace_conf" "this" {
+              custom_config = {
+                "maxTokenLifetimeDays" = "90"
+              }
+            }
+
+            resource "databricks_token" "pipeline" {
+              comment          = "pipeline token"
+              lifetime_seconds = 7776000
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/admin/access-control/tokens
+        title: Monitor and revoke Databricks personal access tokens
+  - uid: mondoo-databricks-security-secret-scope-not-world-readable
+    title: Ensure secret scopes are not readable by all workspace users
+    impact: 80
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      databricks.secretScopes.all(acls["users"] == empty)
+    docs:
+      desc: |
+        Databricks secret scopes hold sensitive values such as database credentials, cloud storage keys, and API tokens. No secret scope should grant any permission to the built-in `users` group, which contains every workspace user. The insecure default appears whenever an ACL entry assigns MANAGE, READ, or WRITE to `users`, because that single grant makes the scope's secrets available to the entire workspace.
+
+        **Why this matters**
+
+        - **Exposes stored credentials broadly:** A READ grant to `users` lets any workspace member retrieve the secrets in the scope, turning a shared credential store into a workspace-wide leak.
+        - **Enables privilege escalation:** Secrets often unlock downstream systems, so broad read access lets a low-privileged user reach data and services well beyond their assigned role.
+        - **Breaks need-to-know:** Access to secrets should follow job function, and a grant to all users removes any separation between those who need a credential and those who do not.
+
+        **Risk mitigation**
+
+        - **Grant to named principals:** Assign secret scope ACLs only to the specific users, groups, or service principals that require them.
+        - **Remove the `users` grant:** Delete any ACL that assigns a permission to the `users` group and replace it with a narrowly scoped grant.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Confirm the CLI or API is used for ACL review, because the workspace UI does not display secret scope ACLs directly.
+        3. Treat any scope whose ACL list includes the `users` principal as a finding.
+
+        A passing result shows no secret scope granting a permission to `users`; a failing result shows at least one scope with a `users` ACL entry.
+
+        ### Audit via CLI
+
+        1. List the secret scopes:
+
+            ```bash
+            databricks secrets list-scopes
+            ```
+
+        2. For each scope, list its ACLs:
+
+            ```bash
+            databricks secrets list-acls <scope-name>
+            ```
+
+        A passing result shows no ACL whose principal is `users`; a failing result shows a `users` principal with a MANAGE, READ, or WRITE permission.
+      remediation:
+        - id: console
+          desc: |
+            To remove world-readable access from a secret scope using the workspace admin tooling:
+
+            1. Identify the scope with a `users` grant from the CLI or API audit, because secret scope ACLs are not editable in the workspace UI.
+            2. Determine which specific users, groups, or service principals genuinely need the secrets.
+            3. Apply the ACL changes with the CLI or Terraform steps below, granting only those principals and deleting the `users` entry.
+        - id: cli
+          desc: |
+            To revoke the `users` grant and scope access to named principals using the Databricks CLI:
+
+            1. Delete the ACL that grants access to all workspace users:
+
+                ```bash
+                databricks secrets delete-acl <scope-name> users
+                ```
+
+            2. Grant the required permission only to the principals that need it:
+
+                ```bash
+                databricks secrets put-acl <scope-name> data-engineering READ
+                ```
+
+            3. Confirm the `users` principal is gone:
+
+                ```bash
+                databricks secrets list-acls <scope-name>
+                ```
+        - id: terraform
+          desc: |
+            To manage secret scope ACLs as code using the `databricks/databricks` provider, define `databricks_secret_acl` resources only for specific principals and never for the `users` group:
+
+            ```hcl
+            resource "databricks_secret_scope" "app" {
+              name = "app-secrets"
+            }
+
+            resource "databricks_secret_acl" "engineering" {
+              scope     = databricks_secret_scope.app.name
+              principal = "data-engineering"
+              permission = "READ"
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/secrets/acl
+        title: Databricks secret access control lists
+  - uid: mondoo-databricks-security-ip-access-list-no-allow-all
+    title: Ensure IP access lists contain no unrestricted (allow-all) ranges
+    impact: 70
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      databricks.ipAccessLists.where(listType == "ALLOW").all(ipAddresses.none(_ == "0.0.0.0/0" || _ == "::/0"))
+    docs:
+      desc: |
+        Databricks IP access lists restrict which source networks can reach a workspace. No ALLOW-type list should include an open CIDR such as `0.0.0.0/0` for IPv4 or `::/0` for IPv6. The insecure default appears when an ALLOW entry contains one of these wildcards, because that single range admits the entire internet and defeats the purpose of the access list.
+
+        **Why this matters**
+
+        - **Nullifies network restriction:** An ALLOW list containing `0.0.0.0/0` or `::/0` permits connections from any address, so the workspace has no effective network boundary.
+        - **Creates false assurance:** The presence of an access list can make a workspace look protected while the wildcard entry silently gates nothing.
+        - **Widens the attack surface:** Every host on the internet can attempt authentication, exposing the workspace to credential stuffing and token abuse from anywhere.
+
+        **Risk mitigation**
+
+        - **Replace wildcards with real ranges:** Substitute open CIDRs with the specific office, VPN, and egress ranges your organization uses.
+        - **Apply least-privilege CIDRs:** Use the smallest ranges that still cover legitimate access, and review them regularly for over-permissive entries.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks workspace as an administrator.
+        2. Go to **Settings** > **Security** and open the **IP access list** section.
+        3. Review each allow entry for the `0.0.0.0/0` or `::/0` range.
+
+        A passing result shows no allow entry with an open CIDR; a failing result shows at least one allow entry containing `0.0.0.0/0` or `::/0`.
+
+        ### Audit via CLI
+
+        1. List the IP access lists:
+
+            ```bash
+            databricks ip-access-lists list
+            ```
+
+        2. Inspect the `ip_addresses` of every list whose `list_type` is `ALLOW`.
+
+        A passing result shows no ALLOW list containing `0.0.0.0/0` or `::/0`; a failing result shows at least one that does.
+      remediation:
+        - id: console
+          desc: |
+            To remove an unrestricted range from an IP access list using the workspace UI:
+
+            1. Sign in to the Databricks workspace as an administrator.
+            2. Go to **Settings** > **Security** and open the **IP access list** section.
+            3. Edit the allow list that contains `0.0.0.0/0` or `::/0`.
+            4. Replace the open range with the specific CIDR ranges your organization uses, then save.
+
+            Confirm your own current public IP falls within an allowed range before saving, or you will lose access to the workspace.
+        - id: cli
+          desc: |
+            To replace an unrestricted range using the Databricks CLI:
+
+            1. Find the offending list and read its current entries:
+
+                ```bash
+                databricks ip-access-lists list
+                ```
+
+            2. Update the ALLOW list with specific ranges only, omitting any wildcard. The `203.0.113.0/24` and `198.51.100.0/24` values are reserved documentation ranges from RFC 5737, so replace them with your real egress ranges:
+
+                ```bash
+                databricks ip-access-lists update <list-id> --json '{
+                  "label": "corp-allow",
+                  "list_type": "ALLOW",
+                  "enabled": true,
+                  "ip_addresses": ["203.0.113.0/24", "198.51.100.0/24"]
+                }'
+                ```
+
+            3. Verify the wildcard is gone:
+
+                ```bash
+                databricks ip-access-lists get <list-id>
+                ```
+        - id: terraform
+          desc: |
+            To manage IP access lists as code using the `databricks/databricks` provider, set `ip_addresses` on every ALLOW list to specific trusted CIDR ranges and never include `0.0.0.0/0` or `::/0`:
+
+            ```hcl
+            resource "databricks_ip_access_list" "allowed" {
+              label        = "corp-allow"
+              list_type    = "ALLOW"
+              ip_addresses = ["203.0.113.0/24", "198.51.100.0/24"]
+            }
+            ```
+    refs:
+      - url: https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list
+        title: Databricks IP access lists
+  - uid: mondoo-databricks-security-workspace-public-access-disabled
+    title: Ensure public network access is disabled for workspaces
+    impact: 80
+    filters: asset.platform == "databricks-account"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      databricks.privateAccessSettings.all(publicAccessEnabled == false)
+    docs:
+      desc: |
+        This check ensures that every private access setting in the Databricks account keeps public network access disabled, so a workspace is reachable only through its private endpoint. By default a workspace accepts connections from any address on the public internet, which exposes the control plane and data plane to credential-based attacks from untrusted networks.
+
+        **Why this matters**
+
+        - **Removes internet exposure:** Disabling public access forces all traffic through the cloud provider private endpoint and keeps the workspace off the public internet.
+        - **Contains stolen credentials:** Private-only connectivity prevents leaked tokens or passwords from being used outside trusted networks.
+        - **Adds a network control layer:** Endpoint-based access operates independently of authentication, so it holds even when a credential is compromised.
+
+        **Risk mitigation**
+
+        - **Enforce private connectivity:** Route access through AWS PrivateLink, Azure Private Link, or GCP Private Service Connect instead of public endpoints.
+        - **Review settings regularly:** Confirm that no private access setting re-enables public access after infrastructure changes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks account console as an account admin.
+        2. Open **Cloud resources** then **Network**, and review each private access setting, or open a workspace and review its network configuration.
+        3. Confirm that public access is disabled for every private access setting.
+
+        A passing result shows public access disabled on all private access settings. A failing result shows at least one setting with public access enabled.
+
+        ### Audit via CLI
+
+        1. List the private access settings in the account:
+
+            ```bash
+            databricks account private-access list
+            ```
+
+        2. Inspect an individual setting to read its public access flag:
+
+            ```bash
+            databricks account private-access get <private-access-settings-id>
+            ```
+
+        A passing result shows `public_access_enabled` set to `false` on every setting. A failing result shows `true` on any of them.
+      remediation:
+        - id: console
+          desc: |
+            To disable public network access on a private access setting using the account console:
+
+            1. Sign in to the Databricks account console as an account admin.
+            2. Open **Cloud resources** then **Network**, and select the private access setting bound to the workspace.
+            3. Turn off **Public access enabled** and save the setting.
+
+            ```text
+            Public access enabled: Disabled
+            ```
+        - id: cli
+          desc: |
+            To disable public network access on a private access setting using the Databricks CLI:
+
+            1. Find the private access settings ID:
+
+                ```bash
+                databricks account private-access list
+                ```
+
+            2. Update the setting to disable public access, keeping the existing name, region, and access level:
+
+                ```bash
+                databricks account private-access update <private-access-settings-id> --json '{
+                  "private_access_settings_name": "prod-pas",
+                  "region": "us-east-1",
+                  "public_access_enabled": false,
+                  "private_access_level": "ENDPOINT"
+                }'
+                ```
+        - id: terraform
+          desc: |
+            To disable public network access using the `databricks/databricks` Terraform provider, set `public_access_enabled` to `false` on the private access settings and bind them to the workspace:
+
+            ```hcl
+            resource "databricks_mws_private_access_settings" "this" {
+              provider                     = databricks.mws
+              private_access_settings_name = "prod-pas"
+              region                       = var.region
+              public_access_enabled        = false
+              private_access_level         = "ENDPOINT"
+            }
+
+            resource "databricks_mws_workspaces" "this" {
+              # ... other workspace configuration ...
+              private_access_settings_id = databricks_mws_private_access_settings.this.private_access_settings_id
+            }
+            ```
+  - uid: mondoo-databricks-security-private-access-restrict-endpoints
+    title: Ensure private access settings restrict connections to allowed endpoints
+    impact: 70
+    filters: asset.platform == "databricks-account"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      databricks.privateAccessSettings.all(privateAccessLevel == "ENDPOINT" && allowedVpcEndpointIds != empty)
+    docs:
+      desc: |
+        This check ensures that each private access setting uses the most restrictive private access level, `ENDPOINT`, and defines an explicit allow-list of VPC endpoint IDs. The private access level accepts the values `ACCOUNT` and `ENDPOINT`. With `ACCOUNT`, any registered endpoint in the account can reach the workspace, so only named endpoints should be permitted for sensitive workloads.
+
+        **Why this matters**
+
+        - **Limits the reachable surface:** The `ENDPOINT` level allows only the VPC endpoints listed in the allow-list to connect, rather than every endpoint registered in the account.
+        - **Prevents lateral reach:** An endpoint created for one workspace cannot connect to another workspace unless it is explicitly named.
+        - **Makes access intentional:** An explicit allow-list turns connectivity into a reviewed decision instead of a broad default.
+
+        **Risk mitigation**
+
+        - **Name every endpoint:** Populate the allow-list with only the VPC endpoint IDs that must reach the workspace.
+        - **Prune stale entries:** Remove endpoint IDs from the allow-list when the corresponding infrastructure is decommissioned.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks account console as an account admin.
+        2. Open **Cloud resources** then **Network**, and select the private access setting bound to the workspace.
+        3. Confirm the private access level is set to **Endpoint** and that the allowed VPC endpoints list contains the expected endpoints.
+
+        A passing result shows the level set to Endpoint with a non-empty allow-list. A failing result shows the level set to Account, or an empty allow-list.
+
+        ### Audit via CLI
+
+        1. List the private access settings in the account:
+
+            ```bash
+            databricks account private-access list
+            ```
+
+        2. Inspect an individual setting to read its access level and endpoint allow-list:
+
+            ```bash
+            databricks account private-access get <private-access-settings-id>
+            ```
+
+        A passing result shows `private_access_level` set to `ENDPOINT` and a non-empty `allowed_vpc_endpoint_ids` array. A failing result shows `ACCOUNT`, or an empty allow-list.
+      remediation:
+        - id: console
+          desc: |
+            To restrict a private access setting to named endpoints using the account console:
+
+            1. Sign in to the Databricks account console as an account admin.
+            2. Open **Cloud resources** then **Network**, and select the private access setting bound to the workspace.
+            3. Set the private access level to **Endpoint**, add the VPC endpoints that must reach the workspace to the allowed list, and save.
+
+            ```text
+            Private access level: Endpoint
+            Allowed VPC endpoints: vpce-0abc..., vpce-0def...
+            ```
+        - id: cli
+          desc: |
+            To restrict a private access setting to named endpoints using the Databricks CLI:
+
+            1. Find the private access settings ID and the VPC endpoint IDs to allow:
+
+                ```bash
+                databricks account private-access list
+                databricks account vpc-endpoints list
+                ```
+
+            2. Update the setting to the `ENDPOINT` level with an explicit endpoint allow-list:
+
+                ```bash
+                databricks account private-access update <private-access-settings-id> --json '{
+                  "private_access_settings_name": "prod-pas",
+                  "region": "us-east-1",
+                  "public_access_enabled": false,
+                  "private_access_level": "ENDPOINT",
+                  "allowed_vpc_endpoint_ids": ["<vpc-endpoint-id>"]
+                }'
+                ```
+        - id: terraform
+          desc: |
+            To restrict private access to named endpoints using the `databricks/databricks` Terraform provider, register the backend VPC endpoint and reference it from the private access settings allow-list:
+
+            ```hcl
+            resource "databricks_mws_vpc_endpoint" "backend" {
+              provider            = databricks.mws
+              vpc_endpoint_name   = "backend-endpoint"
+              aws_vpc_endpoint_id = aws_vpc_endpoint.backend.id
+              region              = var.region
+            }
+
+            resource "databricks_mws_private_access_settings" "this" {
+              provider                     = databricks.mws
+              private_access_settings_name = "prod-pas"
+              region                       = var.region
+              public_access_enabled        = false
+              private_access_level         = "ENDPOINT"
+              allowed_vpc_endpoint_ids     = [databricks_mws_vpc_endpoint.backend.vpc_endpoint_id]
+            }
+            ```
+  - uid: mondoo-databricks-security-workspace-customer-managed-keys
+    title: Ensure workspaces use customer-managed encryption keys
+    impact: 70
+    filters: asset.platform == "databricks-account"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      databricks.workspaces.all(managedServicesCustomerManagedKey != empty && storageCustomerManagedKey != empty)
+    docs:
+      desc: |
+        This check ensures that every workspace is configured with a customer-managed key for both managed services and workspace storage. Managed services covers notebooks, secrets, and other control-plane data, while workspace storage covers the DBFS root and cluster EBS volumes. By default Databricks encrypts this data with keys it controls, which leaves customers unable to independently rotate or revoke access to the encryption keys.
+
+        **Why this matters**
+
+        - **Keeps key control with the customer:** A customer-managed key lets the organization rotate, disable, or revoke the key, which cuts off access to encrypted data on demand.
+        - **Separates duties:** Splitting the key from the platform means access to stored data requires both platform access and key access.
+        - **Covers both data domains:** Requiring keys for managed services and for storage closes the gap where one domain stays on platform-managed keys.
+
+        **Risk mitigation**
+
+        - **Encrypt with organization keys:** Register keys in the cloud provider key service and assign them to both the managed services and storage use cases.
+        - **Rotate on a schedule:** Rotate the customer-managed keys according to the organization key-management policy.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks account console as an account admin.
+        2. Open **Workspaces** and select a workspace.
+        3. Review the encryption configuration and confirm that a customer-managed key is assigned for both managed services and storage.
+
+        A passing result shows a customer-managed key set for both managed services and storage on every workspace. A failing result shows either key unset.
+
+        ### Audit via CLI
+
+        1. List the customer-managed keys registered in the account:
+
+            ```bash
+            databricks account encryption-keys list
+            ```
+
+        2. Inspect a workspace to read its assigned key IDs:
+
+            ```bash
+            databricks account workspaces get <workspace-id>
+            ```
+
+        A passing result shows non-empty `managed_services_customer_managed_key_id` and `storage_customer_managed_key_id` values. A failing result shows either field empty.
+      remediation:
+        - id: console
+          desc: |
+            To assign customer-managed keys to a workspace using the account console:
+
+            1. Sign in to the Databricks account console as an account admin.
+            2. Register the encryption keys under **Cloud resources** then **Encryption keys**, one for the managed services use case and one for the storage use case.
+            3. Open the workspace, assign both keys under its encryption configuration, and save.
+
+            ```text
+            Managed services key: assigned
+            Storage key: assigned
+            ```
+        - id: cli
+          desc: |
+            To assign customer-managed keys to a workspace using the Databricks CLI:
+
+            1. Register a key for each use case and note the returned key IDs:
+
+                ```bash
+                databricks account encryption-keys create --json '{
+                  "aws_key_info": {"key_arn": "<kms-key-arn>", "key_alias": "<kms-key-alias>"},
+                  "use_cases": ["MANAGED_SERVICES"]
+                }'
+                ```
+
+            2. Assign both keys to the workspace:
+
+                ```bash
+                databricks account workspaces update <workspace-id> --json '{
+                  "managed_services_customer_managed_key_id": "<managed-services-key-id>",
+                  "storage_customer_managed_key_id": "<storage-key-id>"
+                }'
+                ```
+        - id: terraform
+          desc: |
+            To assign customer-managed keys using the `databricks/databricks` Terraform provider, register a key for each use case and reference both from the workspace:
+
+            ```hcl
+            resource "databricks_mws_customer_managed_keys" "managed_services" {
+              provider   = databricks.mws
+              account_id = var.databricks_account_id
+              aws_key_info {
+                key_arn   = aws_kms_key.managed_services.arn
+                key_alias = aws_kms_alias.managed_services.name
+              }
+              use_cases = ["MANAGED_SERVICES"]
+            }
+
+            resource "databricks_mws_customer_managed_keys" "storage" {
+              provider   = databricks.mws
+              account_id = var.databricks_account_id
+              aws_key_info {
+                key_arn   = aws_kms_key.storage.arn
+                key_alias = aws_kms_alias.storage.name
+              }
+              use_cases = ["STORAGE"]
+            }
+
+            resource "databricks_mws_workspaces" "this" {
+              # ... other workspace configuration ...
+              managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.managed_services.customer_managed_key_id
+              storage_customer_managed_key_id          = databricks_mws_customer_managed_keys.storage.customer_managed_key_id
+            }
+            ```
+  - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted
+    title: Ensure token-authenticated Delta Sharing recipients are IP restricted
+    impact: 70
+    filters: asset.platform == "databricks-account"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    mql: |
+      databricks.deltaSharingRecipients.where(authenticationType == "TOKEN").all(ipAccessList != empty)
+    docs:
+      desc: |
+        This check ensures that every open-sharing Delta Sharing recipient that authenticates with a bearer token has an IP access list configured, so shared data can be retrieved only from approved networks. The other authentication types are `DATABRICKS`, `OAUTH_CLIENT_CREDENTIALS`, and `OIDC_FEDERATION`. A token recipient without an IP access list can pull the shared data from any network that holds the token.
+
+        **Why this matters**
+
+        - **Binds sharing to trusted networks:** An IP access list limits data retrieval to the recipient approved address ranges.
+        - **Contains token leakage:** A bearer token that leaks cannot be used from an address outside the allow-list.
+        - **Targets the weakest auth type:** Token authentication carries no network binding on its own, so an explicit list restores that control.
+
+        **Risk mitigation**
+
+        - **Scope every token recipient:** Add the recipient known egress ranges to its IP access list before sharing data.
+        - **Prefer stronger auth:** Where possible, move recipients to an identity-federated authentication type instead of long-lived tokens.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to a workspace with access to the Unity Catalog metastore as a metastore admin.
+        2. Open **Catalog**, then **Delta Sharing**, and review the recipients under **Shared by me**.
+        3. For each recipient whose authentication type is token, confirm that an IP access list is set.
+
+        A passing result shows an IP access list on every token recipient. A failing result shows a token recipient with no IP access list.
+
+        ### Audit via CLI
+
+        1. List the recipients and their authentication types:
+
+            ```bash
+            databricks recipients list
+            ```
+
+        2. Inspect a recipient to read its authentication type and IP access list:
+
+            ```bash
+            databricks recipients get <recipient-name>
+            ```
+
+        A passing result shows a non-empty `ip_access_list.allowed_ip_addresses` array on every recipient whose `authentication_type` is `TOKEN`. A failing result shows a token recipient with no allowed addresses.
+      remediation:
+        - id: console
+          desc: |
+            To restrict a token recipient to approved networks using the console:
+
+            1. Sign in to a workspace with access to the Unity Catalog metastore as a metastore admin.
+            2. Open **Catalog**, then **Delta Sharing**, and select the recipient under **Shared by me**.
+            3. Edit the recipient, add the approved CIDR ranges to its IP access list, and save.
+
+            ```text
+            IP access list: 203.0.113.0/24
+            ```
+        - id: cli
+          desc: |
+            To restrict a token recipient to approved networks using the Databricks CLI:
+
+            1. Confirm the recipient name and current authentication type:
+
+                ```bash
+                databricks recipients get <recipient-name>
+                ```
+
+            2. Update the recipient with the approved CIDR ranges. Replace the RFC 5737 documentation range below with your real egress ranges:
+
+                ```bash
+                databricks recipients update <recipient-name> --json '{
+                  "ip_access_list": {"allowed_ip_addresses": ["203.0.113.0/24"]}
+                }'
+                ```
+        - id: terraform
+          desc: |
+            To restrict a token recipient to approved networks using the `databricks/databricks` Terraform provider, set the `ip_access_list` block on the recipient:
+
+            ```hcl
+            resource "databricks_recipient" "external" {
+              name                = "partner-org"
+              authentication_type = "TOKEN"
+              comment             = "Partner analytics team"
+
+              ip_access_list {
+                allowed_ip_addresses = ["203.0.113.0/24"]
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails
+    title: Ensure AI Gateway guardrails are configured on model serving endpoints
+    impact: 60
+    filters: asset.platform == "databricks-workspace"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-10
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-12
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-3
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-7-1
+      compliance/vda-isa-5: false
+    mql: |
+      databricks.servingEndpoints.all(aiGateway != empty && aiGateway.guardrails != empty)
+    docs:
+      desc: |
+        This check ensures that every Mosaic AI model serving endpoint has an AI Gateway with guardrails configured. Guardrails apply input and output content filtering, PII detection, and topic or keyword blocking to requests and responses. By default a serving endpoint has no guardrails, so prompts and generated output flow through unfiltered.
+
+        **Why this matters**
+
+        - **Blocks data exfiltration:** Output filtering and PII detection stop sensitive data from leaving through model responses.
+        - **Reduces prompt-injection impact:** Input filtering screens malicious or unsafe prompts before the model processes them.
+        - **Controls unsafe content:** Topic and keyword blocking keep the endpoint from returning content outside its intended purpose.
+
+        **Risk mitigation**
+
+        - **Enable guardrails everywhere:** Attach an AI Gateway with input and output guardrails to every serving endpoint that handles untrusted prompts.
+        - **Tune the filters:** Configure PII behavior and safety filters to match the sensitivity of the data the endpoint can reach.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the workspace and open **Serving**.
+        2. Select a model serving endpoint and open its **AI Gateway** configuration.
+        3. Confirm that guardrails are configured for input and output.
+
+        A passing result shows an AI Gateway with guardrails on every endpoint. A failing result shows an endpoint with no AI Gateway or no guardrails.
+
+        ### Audit via CLI
+
+        1. List the serving endpoints in the workspace:
+
+            ```bash
+            databricks serving-endpoints list
+            ```
+
+        2. Inspect an endpoint to read its AI Gateway configuration:
+
+            ```bash
+            databricks serving-endpoints get <endpoint-name>
+            ```
+
+        A passing result shows a populated `ai_gateway.guardrails` block on every endpoint. A failing result shows the `ai_gateway` or `guardrails` block absent.
+      remediation:
+        - id: console
+          desc: |
+            To configure guardrails on a serving endpoint using the console:
+
+            1. Sign in to the workspace and open **Serving**.
+            2. Select the model serving endpoint and edit its **AI Gateway** configuration.
+            3. Enable input and output guardrails, set the PII and safety filters, and save.
+
+            ```text
+            AI Gateway guardrails: enabled (input + output)
+            ```
+        - id: cli
+          desc: |
+            To configure guardrails on a serving endpoint using the Databricks CLI:
+
+            1. Confirm the endpoint name:
+
+                ```bash
+                databricks serving-endpoints list
+                ```
+
+            2. Apply the AI Gateway guardrails to the endpoint:
+
+                ```bash
+                databricks serving-endpoints put-ai-gateway <endpoint-name> --json '{
+                  "guardrails": {
+                    "input": {"safety": true, "pii": {"behavior": "BLOCK"}},
+                    "output": {"safety": true, "pii": {"behavior": "BLOCK"}}
+                  }
+                }'
+                ```
+        - id: terraform
+          desc: |
+            To configure guardrails using the `databricks/databricks` Terraform provider, set the `ai_gateway` block with `guardrails` on the `databricks_model_serving` resource:
+
+            ```hcl
+            resource "databricks_model_serving" "this" {
+              name = "llm-endpoint"
+
+              ai_gateway {
+                guardrails {
+                  input {
+                    safety = true
+                    pii {
+                      behavior = "BLOCK"
+                    }
+                  }
+                  output {
+                    safety = true
+                    pii {
+                      behavior = "BLOCK"
+                    }
+                  }
+                }
+              }
+
+              config {
+                # ... served_entities configuration ...
+              }
+            }
+            ```
+  - uid: mondoo-databricks-security-no-inactive-service-principals
+    title: Ensure there are no inactive account service principals
+    impact: 40
+    filters: asset.platform == "databricks-account"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-ii-c-information-access-management-access-establishment-and-modification
+      compliance/iso-27001-2022: iso-27001-2022-a-5-16
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-6
+      compliance/pci-dss-4: pcidss-requirement-8-2-6
+      compliance/soc2-2017: soc2-control-cc6-2-3
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    mql: |
+      databricks.servicePrincipals.all(active == true)
+    docs:
+      desc: |
+        This check ensures that no account service principal is left in a deactivated or inactive state. A deactivated service principal keeps its identity and its assigned entitlements, so it can be reactivated later and used to access resources. Inactive machine identities should be removed rather than retained as dormant credentials.
+
+        **Why this matters**
+
+        - **Removes dormant access paths:** A deactivated service principal still carries entitlements that return the moment it is reactivated.
+        - **Shrinks the attack surface:** Every identity that no longer serves a purpose is one more credential an attacker could target or revive.
+        - **Keeps the inventory honest:** Removing inactive identities keeps the service principal list aligned with what is actually in use.
+
+        **Risk mitigation**
+
+        - **Delete unused identities:** Remove service principals that are no longer needed instead of leaving them deactivated.
+        - **Review on a schedule:** Audit the account service principals periodically and act on any that are inactive.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the Databricks account console as an account admin.
+        2. Open **User management** and select **Service principals**.
+        3. Review the status column and identify any service principal that is not active.
+
+        A passing result shows every account service principal active. A failing result shows at least one inactive service principal.
+
+        ### Audit via CLI
+
+        1. List the account service principals and their status:
+
+            ```bash
+            databricks account service-principals list
+            ```
+
+        A passing result shows `active` set to `true` on every service principal. A failing result shows `false` on any of them.
+      remediation:
+        - id: console
+          desc: |
+            To remove an inactive service principal using the account console:
+
+            1. Sign in to the Databricks account console as an account admin.
+            2. Open **User management** and select **Service principals**.
+            3. Select the inactive service principal and delete it. Reactivate it instead only if it is still required.
+
+            ```text
+            Service principals: no inactive entries
+            ```
+        - id: cli
+          desc: |
+            To remove an inactive service principal using the Databricks CLI:
+
+            1. Identify the inactive service principal ID:
+
+                ```bash
+                databricks account service-principals list
+                ```
+
+            2. Delete it, or reactivate it if it is still required:
+
+                ```bash
+                databricks account service-principals delete <service-principal-id>
+                ```
+        - id: terraform
+          desc: |
+            To keep managed service principals active using the `databricks/databricks` Terraform provider, set `active` to `true`, and remove the resource entirely for identities that are no longer needed:
+
+            ```hcl
+            resource "databricks_service_principal" "automation" {
+              display_name = "ci-automation"
+              active       = true
+            }
+            ```


### PR DESCRIPTION
## Summary

Adds a new content policy, **Mondoo Databricks Security**, covering Databricks accounts and workspaces via the `databricks` provider (v13.1.0). No Databricks policy existed in `content/` before this.

**25 security checks** across six groups:

| Group | Checks |
|---|---|
| Workspace Security Settings | enhanced security monitoring, compliance security profile, automatic cluster update, IP access lists enabled, legacy access disabled, PAT lifetime capped, workspace admins restricted, legacy global init scripts disabled, legacy cluster-named init scripts disabled, notebook results in customer account |
| Compute Clusters | local disk encryption, user-isolation access mode, auto-termination, no plaintext Spark secrets, governed by cluster policy |
| Tokens and Secrets | no non-expiring PATs, PAT lifetime ≤ 90 days, secret scopes not world-readable |
| Network Access Controls | public access disabled, private access restricted to endpoints, customer-managed keys, no allow-all IP ranges |
| Data Sharing and AI | token-auth Delta Sharing recipients IP-restricted, AI Gateway guardrails |
| Identity and Access Management | no inactive account service principals |

Each check ships full `docs` (`desc`/`audit`/`remediation`) with **console + cli + terraform** remediation, scoped by asset platform (`databricks-account` vs `databricks-workspace`).

## Compliance

Every check carries verified tags across **all 13 frameworks** the sibling `mondoo-snowflake-security` policy uses. Non-`false` control UIDs were confirmed to exist literally in each framework file (`279` valid UIDs), and `false` (unquoted) is used where no control genuinely fits (`46` — e.g. AI Gateway guardrails, auto-termination), per the repo convention that a missing mapping beats a wrong one.

## Grounding / correctness

- All enum comparisons (`dataSecurityMode`, `privateAccessLevel` = ACCOUNT/ENDPOINT, delta-sharing `authenticationType` = TOKEN, `restrictWorkspaceAdminsStatus`) were taken from the `databricks-sdk-go` constants, not guessed.
- Impact bands anchored per the content authoring guide (80 for public exposure / plaintext secrets / world-readable secrets / IP enforcement; 70 for encryption and network hardening; 60 for defense-in-depth toggles; 40 for governance hygiene).
- `cnspec policy lint` passes. The two non-trivial MQL forms were verified to compile: the map `sparkConf.where(key==…).all(value==/\{\{secrets\//)` secret check and `expiryTime - creationTime <= 90 * time.day`.

## Notes for reviewers

- **CLI remediation is not machine-validated.** There is no `databricks` entry in `content/validation/validate_remediation_commands.py`, so the `databricks ...` commands were written against the official CLI reference by hand. Happy to add a `databricks` validator in a follow-up.
- A live scan would further confirm `restrictWorkspaceAdminsStatus`, `dataSecurityMode` on newer runtimes, and the `aiGateway.guardrails` shape. The MQL asserts presence and excludes only the known-insecure value, so it will not false-pass on unresolved data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)