### PR TITLE
fix(http-security): skip header checks on hosts that serve no HTTP

### DIFF
--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -30,7 +30,8 @@ policies:
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Headers for HTTP/HTTPS communication
-        filters: asset.platform == 'host'
+        filters: |
+          asset.platform == 'host' && http.get.header != empty
         checks:
           - uid: mondoo-http-security-x-content-type-options-nosniff
           - uid: mondoo-http-security-content-security-policy


### PR DESCRIPTION
## Problem

The "Headers for HTTP/HTTPS communication" group is gated only by `asset.platform == 'host'`. On a host that serves no HTTP — mail servers, DNS servers, infra subdomains commonly surfaced by attack-surface enumeration — every general header check (`content-security-policy`, `referrer-policy`, `x-content-type-options`, `x-frame-options`, `obfuscate-server`, `no-x-powered-by`, `no-public-key-pins`, `no-x-aspnet[mvc]-version`) **errors**, producing a wall of "could not be evaluated" noise per non-web host.

Every other group already gates on resource presence: TLS on `tls.params != empty`, HSTS on `tls.certificates != empty`, email on `dns.mx != empty`. The general HTTP-header group was the exception.

## Fix

Add `http.get.header != empty` to the group filter, so the header checks **skip** on non-HTTP hosts instead of erroring.

## Blocker cleared

This was drafted pending mondoohq/mql#9336 ("http.get.header resolves to null when the target has no HTTP"), because without it the filter would error rather than skip.

That is resolved, and it does not depend on a cnspec release. The fix lives entirely in `providers/network/`, and `network` is not a builtin provider — `providers/builtin.go` compiles in only `core`, `mock`, `sbom`, and `recording`, so the network provider is fetched at runtime and versions independently of cnspec's `go.mod`.

The provider release carrying the fix is already out:

| | date |
|---|---|
| mql#9336 merged | 2026-07-21 21:56 |
| **network-13.2.6 released** | 2026-07-21 22:18 — first release with the fix |
| network-13.2.7 | 2026-07-22 |
| network-13.2.8 (current) | 2026-07-24 |

Confirmed at runtime against network-13.2.8:

```
cnquery run host a.gtld-servers.net -c 'http.get.header'   ->  null
cnquery run host mx.zoho.com        -c 'http.get.header'   ->  null
```

`null`, not an error — which is exactly what `!= empty` needs to skip cleanly.

## Re-validated on current main

Non-HTTP host, scanned with the HTTP and DNS policies together (the realistic case — scanning the HTTP policy alone leaves such a host with no applicable group at all):

| | errored checks |
|---|---|
| `a.gtld-servers.net` before | **9** |
| `a.gtld-servers.net` after | **1** |

The one remaining error is `Ensure at least two NS records exist` from the DNS policy — unrelated to this change.

Real web host, `example.com`, before vs. after: **byte-identical output**, 5 passing / 8 failing / 0 errors both ways. No regression.

One extra benefit worth noting: on main today the non-HTTP host also scores a spurious **pass** on "Remove or obfuscate the Server header", because that check reads `http.get.header.server == empty || ...` and `null == empty` is true. A host serving no HTTP was being credited with having obfuscated its server banner. This change removes that false pass along with the errors.

`cnspec policy lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
