### PR TITLE
✨ validation: add databricks CLI remediation validator

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -115,6 +115,26 @@ jobs:
           sudo mv /tmp/hcloud-extract/hcloud /usr/local/bin/hcloud
           hcloud version
 
+      - name: Install databricks CLI
+        # Pinned release zip from
+        # https://github.com/databricks/cli/releases. Bump DATABRICKS_VERSION
+        # and DATABRICKS_SHA256 in lockstep when Databricks ships new commands
+        # or flags — the SHA-256 is published in the per-release
+        # `databricks_cli_<version>_SHA256SUMS` file. No auth needed for the
+        # `__complete` / `--help` introspection the validator performs.
+        env:
+          DATABRICKS_VERSION: "1.8.0"
+          DATABRICKS_SHA256: "915150a284f24376f44a2f89741319da32e6891eb4a7568199bbe0f6f3dfea02"
+        run: |
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://github.com/databricks/cli/releases/download/v${DATABRICKS_VERSION}/databricks_cli_${DATABRICKS_VERSION}_linux_amd64.zip" \
+            -o /tmp/databricks.zip
+          echo "${DATABRICKS_SHA256}  /tmp/databricks.zip" | sha256sum -c -
+          mkdir -p /tmp/databricks-extract
+          unzip -q /tmp/databricks.zip -d /tmp/databricks-extract
+          sudo mv /tmp/databricks-extract/databricks /usr/local/bin/databricks
+          databricks version
+
       - name: Validate remediation commands
         run: python3 content/validation/validate_remediation_commands.py --github-actions
 

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -263,11 +263,12 @@ python3 content/validation/validate_remediation_commands.py nutanix
 # Validate Vercel (runs BOTH the `vercel` CLI and the REST API checks)
 python3 content/validation/validate_remediation_commands.py vercel
 
-# Validate a Cobra-based CLI (kubectl / gh / glab / hcloud)
+# Validate a Cobra-based CLI (kubectl / gh / glab / hcloud / databricks)
 python3 content/validation/validate_remediation_commands.py kubernetes
 python3 content/validation/validate_remediation_commands.py github
 python3 content/validation/validate_remediation_commands.py gitlab
 python3 content/validation/validate_remediation_commands.py hetzner
+python3 content/validation/validate_remediation_commands.py databricks
 
 # Validate a specific REST API (curl commands against a vendor API)
 python3 content/validation/validate_remediation_commands.py cloudflare
@@ -277,7 +278,7 @@ python3 content/validation/validate_remediation_commands.py atlassian
 python3 content/validation/validate_remediation_commands.py grafana
 ```
 
-The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli`/`vercel`/`kubectl`/`gh`/`glab`/`hcloud` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections. For the REST API and Cobra CLI targets, ```` ```bash ```` blocks in `audit:` sections are validated too (these products' verification paths use the same CLI/API surface, and the new validators have no backlog of unvalidated audit blocks). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli`/`vercel`/`kubectl`/`gh`/`glab`/`hcloud`/`databricks` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections. For the REST API and Cobra CLI targets, ```` ```bash ```` blocks in `audit:` sections are validated too (these products' verification paths use the same CLI/API surface, and the new validators have no backlog of unvalidated audit blocks). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
 
 The `vercel` target is the only one that runs a **CLI validator and a REST API validator together** (both keyed `vercel`): the Vercel policy fixes some settings with the `vercel` CLI (`- id: cli`) and others with `curl` against the Vercel REST API (`- id: api`). Both remediation ids and the `audit:` blocks are validated.
 
@@ -293,7 +294,7 @@ For `aws`, `oci`, `gcp`, and `digitalocean`, the database is built **in-memory**
 - **oci**: walks the Click command tree from the `oci_cli` Python package
 - **gcp**: reads the Google Cloud SDK's static completion tree
 - **digitalocean**: walks the `doctl --help` Cobra tree breadth-first (parallelized; ~1s for the full ~475-command tree)
-- **kubernetes / github / gitlab / hetzner**: walk the CLI's hidden Cobra `__complete` command (`kubectl`/`gh`/`glab`/`hcloud` must be on PATH), which returns machine-readable subcommand and flag candidates regardless of each CLI's custom help layout. Valid flags are the union of flag completions and flag lines parsed from `--help` (hcloud filters its flag completions to required-only). The walk runs with cloud credentials stripped (`KUBECONFIG=/dev/null`, tokens unset) so positional-value completions stay empty, and only tab-described candidates count as subcommands (kubectl's `rollout restart` statically completes resource types as bare names). Each CLI is an entry in the `COBRA_CLIS` registry in `validators/cobra.py`.
+- **kubernetes / github / gitlab / hetzner / databricks**: walk the CLI's hidden Cobra `__complete` command (`kubectl`/`gh`/`glab`/`hcloud`/`databricks` must be on PATH), which returns machine-readable subcommand and flag candidates regardless of each CLI's custom help layout. Valid flags are the union of flag completions and flag lines parsed from `--help` (hcloud filters its flag completions to required-only). The walk runs with cloud credentials stripped (`KUBECONFIG=/dev/null`, tokens unset, `DATABRICKS_CONFIG_FILE=/dev/null` so the databricks CLI loads no profile) so positional-value completions stay empty, and only tab-described candidates count as subcommands (kubectl's `rollout restart` statically completes resource types as bare names). Each CLI is an entry in the `COBRA_CLIS` registry in `validators/cobra.py`.
 
 The REST API targets (**cloudflare**, **tailscale**, **slack**, **atlassian**, **grafana**, **vercel**) need no CLI: each provider is an entry in the `API_PROVIDERS` registry in `validators/openapi.py` that maps an API host to the vendor's OpenAPI (or Swagger 2.0) spec. The validator verifies each curl call's path + HTTP method, plus the `--data` JSON payload against the operation's `requestBody` schema: field names, types, enums, and required properties. Angle-bracket (`<account-name>`) and environment-variable (`$ORG_ID`) placeholders act as wildcards. Known spec-vs-docs divergences are listed per provider under `body_exemptions`; Cloudflare additionally narrows the generic `/zones/{zone_id}/settings/{setting_id}` schema to the per-setting component via its `path_hook`. Two more per-provider options exist for API-first products: `strip_api_version` normalizes a leading `/vN` URL segment on both the curl path and the spec (Vercel versions every path and keeps several versions live, but the spec documents one version per operation), and `path_exemptions` allowlists endpoints the API serves but omits from its published spec.
 

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -2005,7 +2005,7 @@ queries:
             2. Update the setting to disable public access, keeping the existing name, region, and access level:
 
                 ```bash
-                databricks account private-access update <private-access-settings-id> --json '{
+                databricks account private-access replace <private-access-settings-id> --json '{
                   "private_access_settings_name": "prod-pas",
                   "region": "us-east-1",
                   "public_access_enabled": false,
@@ -2115,7 +2115,7 @@ queries:
             2. Update the setting to the `ENDPOINT` level with an explicit endpoint allow-list:
 
                 ```bash
-                databricks account private-access update <private-access-settings-id> --json '{
+                databricks account private-access replace <private-access-settings-id> --json '{
                   "private_access_settings_name": "prod-pas",
                   "region": "us-east-1",
                   "public_access_enabled": false,

--- a/content/validation/validators/cobra.py
+++ b/content/validation/validators/cobra.py
@@ -98,6 +98,15 @@ COBRA_CLIS = {
             "  Linux:            https://github.com/hetznercloud/cli/releases"
         ),
     },
+    "databricks": {
+        "cli": "databricks",
+        "policies": ["mondoo-databricks-security.mql.yaml"],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew tap databricks/tap && brew install databricks\n"
+            "  All platforms:    https://docs.databricks.com/dev-tools/cli/install.html"
+        ),
+    },
 }
 
 
@@ -107,10 +116,16 @@ def _walk_env() -> dict:
     completions (pod names, server names) come back empty."""
     env = dict(os.environ)
     env["KUBECONFIG"] = "/dev/null"
+    # Keep the databricks CLI from loading a ~/.databrickscfg profile and
+    # reaching a live workspace/account during completion.
+    env["DATABRICKS_CONFIG_FILE"] = "/dev/null"
     for var in (
         "GH_TOKEN", "GITHUB_TOKEN",
         "GITLAB_TOKEN", "GLAB_TOKEN",
         "HCLOUD_TOKEN",
+        "DATABRICKS_HOST", "DATABRICKS_TOKEN",
+        "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_ACCOUNT_ID",
     ):
         env.pop(var, None)
     return env


### PR DESCRIPTION
## Summary

Adds the **Databricks CLI** to the Cobra-based remediation-command validator, so the `databricks ...` commands in `mondoo-databricks-security` (merged in #3108) are checked against the CLI's real command tree in CI, the same machinery used for `kubectl` / `gh` / `glab` / `hcloud`.

## Changes

- **`validators/cobra.py`** — new `databricks` entry in `COBRA_CLIS`. The validator walks the CLI's hidden Cobra `__complete` tree to verify subcommands and flags, covering both `id: cli` remediation and `audit:` bash blocks.
- **`validators/cobra.py` (`_walk_env`)** — strips `DATABRICKS_HOST`/`DATABRICKS_TOKEN`/`DATABRICKS_CLIENT_ID`/`DATABRICKS_CLIENT_SECRET`/`DATABRICKS_ACCOUNT_ID` and pins `DATABRICKS_CONFIG_FILE=/dev/null`, so completion loads no `~/.databrickscfg` profile and can't reach a live workspace/account. Keeps the walk deterministic, matching the credential-stripping the other Cobra CLIs already do.
- **`mondoo-databricks-security.mql.yaml`** — fixes the two commands the new validator caught: `databricks account private-access update` is not a real subcommand. The account API uses **`replace`** (a full PUT); the JSON payloads already contain the complete object, so the remediation semantics are unchanged.
- **`content/CLAUDE.md`** — documents the `databricks` target.

## Verification

```
$ python3 content/validation/validate_remediation_commands.py databricks
86 passed, 0 failed
```

`cnspec policy lint content/mondoo-databricks-security.mql.yaml` → valid policy bundle.

The `databricks` CLI is Cobra-based and distributed via `brew tap databricks/tap && brew install databricks` (or the official installer). As with the other Cobra validators, CI must have the binary on PATH for this target to run; when it's missing the validator prints an install hint and exits non-zero rather than silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)