### PR TITLE
✨ alicloud: target per-resource platforms in the Alibaba policy

### DIFF
--- a/content/mondoo-alibaba-security.mql.yaml
+++ b/content/mondoo-alibaba-security.mql.yaml
@@ -176,7 +176,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-ram-user-mfa-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.users.where(loginProfile != empty).all(mfaDevice != empty)
 
@@ -268,7 +268,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-oss-bucket-encryption-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(sseAlgorithm != empty)
   - uid: mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl
@@ -372,7 +372,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-ram-access-key-rotation-90-days-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.users.all(accessKeys.where(status == "Active").all(createDate > time.now - 90 * time.day))
 
@@ -456,7 +456,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-ram-password-policy-min-length-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.passwordPolicy.minimumPasswordLength >= 14
   - uid: mondoo-alibaba-security-ram-password-policy-min-length-terraform-hcl
@@ -568,7 +568,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-ram-password-policy-complexity-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.passwordPolicy.requireUppercaseCharacters == true
       alicloud.ram.passwordPolicy.requireLowercaseCharacters == true
@@ -685,7 +685,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ram-password-policy-max-login-attempts-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.passwordPolicy.maxLoginAttempts > 0
       alicloud.ram.passwordPolicy.maxLoginAttempts <= 5
@@ -790,7 +790,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ram-policy-no-full-admin-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.policies.where(policyType == "Custom").all(
         policyDocument == empty ||
@@ -872,7 +872,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-ram-user-inactive-credentials-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ram.users.where(loginProfile != empty).all(lastLoginDate != empty && lastLoginDate > time.now - 90 * time.day)
 
@@ -964,7 +964,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-7
       compliance/vda-isa-5: vda-isa-5-4-1-2
   - uid: mondoo-alibaba-security-oss-bucket-no-public-acl-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(acl != "public-read" && acl != "public-read-write")
   - uid: mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl
@@ -1054,7 +1054,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-7
       compliance/vda-isa-5: vda-isa-5-4-1-2
   - uid: mondoo-alibaba-security-oss-bucket-block-public-access-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(blockPublicAccess == true)
   - uid: mondoo-alibaba-security-oss-bucket-block-public-access-terraform-hcl
@@ -1149,7 +1149,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-7
       compliance/vda-isa-5: vda-isa-5-4-1-2
   - uid: mondoo-alibaba-security-oss-bucket-policy-no-anonymous-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(
         policy == empty ||
@@ -1243,7 +1243,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-oss-bucket-kms-encryption-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(sseAlgorithm == "KMS" && kmsKey != empty)
   - uid: mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl
@@ -1356,7 +1356,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-oss-bucket-logging-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(logging != empty)
   - uid: mondoo-alibaba-security-oss-bucket-logging-enabled-terraform-hcl
@@ -1465,7 +1465,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-oss-bucket-versioning-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.oss.buckets.all(versioning == "Enabled")
   - uid: mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl
@@ -1584,7 +1584,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-ssh-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.securityGroups.all(permissions.where(direction.downcase == "ingress").where(policy.downcase == "accept").where(sourceCidrIp == "0.0.0.0/0").none(ipProtocol.downcase == "all" || ipProtocol.downcase == "tcp" && portRange == "22/22" || ipProtocol.downcase == "tcp" && portRange == "-1/-1" || ipProtocol.downcase == "tcp" && portRange == "1/65535"))
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl
@@ -1688,7 +1688,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-rdp-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.securityGroups.all(permissions.where(direction.downcase == "ingress").where(policy.downcase == "accept").where(sourceCidrIp == "0.0.0.0/0").none(ipProtocol.downcase == "all" || ipProtocol.downcase == "tcp" && portRange == "3389/3389" || ipProtocol.downcase == "tcp" && portRange == "-1/-1" || ipProtocol.downcase == "tcp" && portRange == "1/65535"))
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-rdp-terraform-hcl
@@ -1792,7 +1792,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-all-ports-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.securityGroups.all(permissions.where(direction.downcase == "ingress").where(policy.downcase == "accept").where(sourceCidrIp == "0.0.0.0/0").none(ipProtocol.downcase == "all" || portRange == "-1/-1" || portRange == "1/65535"))
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-all-ports-terraform-hcl
@@ -1896,7 +1896,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.securityGroups.all(permissions.where(direction.downcase == "ingress").where(policy.downcase == "accept").where(ipv6SourceCidrIp == "::/0").none(ipProtocol.downcase == "all" || ipProtocol.downcase == "tcp" && portRange == "22/22" || ipProtocol.downcase == "tcp" && portRange == "3389/3389" || ipProtocol.downcase == "tcp" && portRange == "-1/-1" || ipProtocol.downcase == "tcp" && portRange == "1/65535"))
   - uid: mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-terraform-hcl
@@ -1988,7 +1988,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-ecs-instance-no-public-ip-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.instances.all(internetExposed == false)
 
@@ -2077,7 +2077,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-ecs-disk-encryption-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.disks.all(encrypted == true)
   - uid: mondoo-alibaba-security-ecs-disk-encryption-enabled-terraform-hcl
@@ -2179,7 +2179,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-ecs-disk-kms-encryption-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.disks.where(encrypted == true).all(kmsKey != empty)
   - uid: mondoo-alibaba-security-ecs-disk-kms-encryption-terraform-hcl
@@ -2275,7 +2275,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-rds-instance-no-public-network-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.rds.instances.all(dbInstanceNetType != empty && dbInstanceNetType != "Internet")
 
@@ -2353,7 +2353,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-rds-instance-ssl-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.rds.instances.all(sslEnabled == true)
 
@@ -2444,7 +2444,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-rds-instance-tde-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.rds.instances.all(tdeEnabled == true)
   - uid: mondoo-alibaba-security-rds-instance-tde-enabled-terraform-hcl
@@ -2554,7 +2554,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-rds-instance-restrict-security-ip-list-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.rds.instances.all(
         securityIPList == empty || securityIPList.none(_.contains("/0"))
@@ -2669,7 +2669,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-rds-instance-deletion-protection-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.rds.instances.all(deletionProtection == true)
   - uid: mondoo-alibaba-security-rds-instance-deletion-protection-terraform-hcl
@@ -2783,7 +2783,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-polardb-cluster-tde-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.polardb.clusters.all(tdeEnabled == true)
   - uid: mondoo-alibaba-security-polardb-cluster-tde-enabled-terraform-hcl
@@ -2899,7 +2899,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-polardb-cluster-restrict-access-whitelist-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.polardb.clusters.all(
         accessWhitelist == empty || accessWhitelist.none(_.contains("/0"))
@@ -3022,7 +3022,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-3
   - uid: mondoo-alibaba-security-redis-instance-auth-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.redis.instances.all(authEnabled == true)
   - uid: mondoo-alibaba-security-redis-instance-auth-enabled-terraform-hcl
@@ -3137,7 +3137,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-redis-instance-ssl-and-private-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.redis.instances.all(sslEnabled == true)
       alicloud.redis.instances.all(networkType == "VPC")
@@ -3246,7 +3246,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-redis-instance-tde-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.redis.instances.all(tdeEnabled == true)
   - uid: mondoo-alibaba-security-redis-instance-tde-enabled-terraform-hcl
@@ -3357,7 +3357,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-mongodb-instance-tde-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.mongodb.instances.all(tdeEnabled == true)
   - uid: mondoo-alibaba-security-mongodb-instance-tde-enabled-terraform-hcl
@@ -3475,7 +3475,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-mongodb-instance-ssl-and-audit-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.mongodb.instances.all(sslEnabled == true)
       alicloud.mongodb.instances.all(auditPolicyEnabled == true)
@@ -3585,7 +3585,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-mongodb-instance-restrict-security-ip-list-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.mongodb.instances.all(
         securityIPList == empty || securityIPList.none(_ == "0.0.0.0/0")
@@ -3695,7 +3695,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-kms-key-rotation-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.kms.keys.where(keyState.downcase == "enabled").where(origin == "Aliyun_KMS").where(keyUsage.downcase == "encrypt/decrypt").all(automaticRotation == "Enabled")
   - uid: mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl
@@ -3794,7 +3794,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-kms-key-rotation-interval-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.kms.keys.where(automaticRotation == "Enabled").all(nextRotationDate != empty && nextRotationDate <= time.now + 365 * time.day)
 
@@ -3888,7 +3888,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
   - uid: mondoo-alibaba-security-actiontrail-trail-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.actiontrail.trails.any(status == "Enable" && isLogging == true)
   - uid: mondoo-alibaba-security-actiontrail-trail-enabled-terraform-hcl
@@ -4003,9 +4003,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
   - uid: mondoo-alibaba-security-vpc-flow-logs-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-vpc"
     mql: |
-      alicloud.vpc.flowLogs.any(status == "Active")
+      alicloud.vpc.network.flowLogs.any(status == "Active")
   - uid: mondoo-alibaba-security-vpc-flow-logs-enabled-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "alicloud_vpc_flow_log")
@@ -4110,9 +4110,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-cs-cluster-no-public-apiserver-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-ack-cluster"
     mql: |
-      alicloud.cs.clusters.all(apiServerInternetExposed == false)
+      alicloud.cs.cluster.apiServerInternetExposed == false
   - uid: mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "alicloud_cs_managed_kubernetes" || nameLabel == "alicloud_cs_kubernetes")
@@ -4206,9 +4206,9 @@ queries:
       compliance/soc2-2017: soc2-group-cc7-2
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-cs-cluster-audit-log-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-ack-cluster"
     mql: |
-      alicloud.cs.clusters.all(auditLogEnabled == true)
+      alicloud.cs.cluster.auditLogEnabled == true
 
   - uid: mondoo-alibaba-security-cs-cluster-rrsa-enabled
     title: Ensure ACK clusters enable RRSA (RAM Roles for Service Accounts)
@@ -4291,9 +4291,9 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-cs-cluster-rrsa-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-ack-cluster"
     mql: |
-      alicloud.cs.clusters.all(rrsaEnabled == true)
+      alicloud.cs.cluster.rrsaEnabled == true
   - uid: mondoo-alibaba-security-cs-cluster-rrsa-enabled-terraform-hcl
     filters: |
       asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "alicloud_cs_managed_kubernetes")
@@ -4405,7 +4405,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-3-2
   - uid: mondoo-alibaba-security-nas-access-rule-restrict-source-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.nas.accessGroups.all(
         accessRules.where(rwAccess == "RDWR").all(sourceCidrIp != "0.0.0.0/0" && ipv6SourceCidrIp != "::/0")
@@ -4504,7 +4504,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-3-2
   - uid: mondoo-alibaba-security-cloudfirewall-enabled-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-cloud-firewall"
     mql: |
       alicloud.cloudFirewall.enabled == true
 
@@ -4581,7 +4581,7 @@ queries:
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
   - uid: mondoo-alibaba-security-antiddos-instance-protection-active-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.antiddos.instances.all(enabled == true)
 
@@ -4661,7 +4661,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-slb-listener-not-plaintext-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.slb.loadBalancers.where(internetFacing == true).all(
         listeners.where(protocol == "http") == empty
@@ -4724,8 +4724,6 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-1
   - uid: mondoo-alibaba-security-waf-domain-tls-hardened-alicloud
-    filters: asset.platform == "alicloud"
+    filters: asset.platform == "alicloud-waf-instance"
     mql: |
-      alicloud.waf.instances.all(
-        domains.where(httpsEnabled == true).all(tlsVersion != "tlsv1" && tlsVersion != "tlsv1.1")
-      )
+      alicloud.waf.instance.domains.where(httpsEnabled == true).all(tlsVersion != "tlsv1" && tlsVersion != "tlsv1.1")


### PR DESCRIPTION
## Summary

The alicloud provider retired the bare `alicloud` platform (mondoohq/mql#9343): the account is now `alicloud-account`, and fine-grained discovery emits a per-object platform for ACK clusters, ALBs, NLBs, VPCs, WAF instances, and Cloud Firewall. Every runtime check in this policy filtered on `asset.platform == "alicloud"` — which **no longer matches any asset** — so this repoints each check at the platform that actually carries its resource.

## What changed

- **40 account-level checks** (RAM, OSS, ECS, RDS, PolarDB, Redis, MongoDB, KMS, ActionTrail, NAS, Anti-DDoS, classic SLB) → `alicloud-account`.
- **6 service-specific checks** move to their object platform and query the singular resource that now binds bare on that asset:

| Check family | Platform | Query |
|---|---|---|
| ACK cluster (×3) | `alicloud-ack-cluster` | `alicloud.cs.cluster.<field>` |
| VPC flow logs | `alicloud-vpc` | `alicloud.vpc.network.flowLogs.any(...)` |
| WAF domain TLS | `alicloud-waf-instance` | `alicloud.waf.instance.domains.where(...)` |
| Cloud Firewall | `alicloud-cloud-firewall` | `alicloud.cloudFirewall.enabled` |

No SLB/ALB/NLB-platform checks: the only load-balancer check targets classic SLB (`alicloud.slb`), which has no discovery platform, so it stays on `alicloud-account`.

Only `filters:` lines and the six MQL bodies change — no docs, tags, or Terraform variants are touched (the variant children carry no `mondoo.com/filter-title` tags).

## Dependency

The singular-resource forms (`alicloud.cs.cluster`, `alicloud.vpc.network.flowLogs`, …) require the scope binding added in **mondoohq/mql#9344**. Merge that first; this PR lints clean against a provider built from that branch.

## Testing

`cnspec policy lint content/mondoo-alibaba-security.mql.yaml` → valid, against the locally built alicloud `13.2.1` provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)