### PR TITLE
🐛 mongodbatlas: trim policy summary under 130-char limit

### DIFF
--- a/content/mondoo-mongodbatlas-security.mql.yaml
+++ b/content/mondoo-mongodbatlas-security.mql.yaml
@@ -13,7 +13,7 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Secure MongoDB Atlas organizations and projects by enforcing access control, network exposure, encryption, backup, and audit-logging controls
+    summary: Secure MongoDB Atlas access control, network exposure, encryption, backup, and audit logging across organizations and projects
     docs:
       desc: |
         The Mondoo MongoDB Atlas Security policy identifies misconfigurations in MongoDB Atlas organizations and projects that could expose databases to the public internet, weaken authentication, leave data unencrypted with customer-managed keys, or leave activity unaudited. This policy helps organizations detect and remediate weaknesses before they can be exploited, reducing the likelihood of unauthorized data access, credential misuse, and undetected changes.


### PR DESCRIPTION
## What

Audited every policy in `content/` to confirm each has a `summary:` field. All 67 policies (and all querypacks) already had one — the only defect was that the `mondoo-mongodbatlas-security` summary was **141 characters**, over the repo's required **130-character** cap.

This restructures the sentence to fit while preserving the original scope wording (access control, network exposure, encryption, backup, audit logging).

```diff
- summary: Secure MongoDB Atlas organizations and projects by enforcing access control, network exposure, encryption, backup, and audit-logging controls   (141)
+ summary: Secure MongoDB Atlas access control, network exposure, encryption, backup, and audit logging across organizations and projects                  (126)
```

## Verification

- `cnspec policy lint content/mondoo-mongodbatlas-security.mql.yaml` → `valid policy bundle(s)`
- Confirmed no other policy summary exceeds 130 chars or uses em/en/double-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)