### PR TITLE
👷 ci: bump remediation validator tool versions to latest

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -57,8 +57,8 @@ jobs:
         # `doctl-<version>-checksums.sha256` file. No auth needed for
         # `doctl --help` introspection.
         env:
-          DOCTL_VERSION: "1.161.0"
-          DOCTL_SHA256: "955771393b8b40b6e53a5babae5c56d8bf3bd775e15fcc3db649a1f61536e541"
+          DOCTL_VERSION: "1.163.0"
+          DOCTL_SHA256: "04413587db80236f80b02b586db094ffa94096891b14c2b4883b623ff3d59b48"
         run: |
           # --fail makes curl exit non-zero on HTTP 4xx/5xx (default -sSL silently
           # writes the error body to disk and trips the sha256 check below).
@@ -85,8 +85,8 @@ jobs:
         # registry. Bump GLAB_VERSION and GLAB_SHA256 in lockstep when
         # GitLab ships new commands or flags.
         env:
-          GLAB_VERSION: "1.102.0"
-          GLAB_SHA256: "2e06f278bb1762126e9b695f67baf5e3210df431b2039c76c1991252bf9c0868"
+          GLAB_VERSION: "1.109.0"
+          GLAB_SHA256: "67b4a8557727a058f44e0839babdcf214ea6f6f829062cf0bae02f7b25814e5d"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/${GLAB_VERSION}/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
@@ -103,8 +103,8 @@ jobs:
         # and HCLOUD_SHA256 in lockstep when Hetzner ships new commands or
         # flags — the SHA-256 is published in the per-release checksums.txt.
         env:
-          HCLOUD_VERSION: "1.65.0"
-          HCLOUD_SHA256: "f78d2db65b7ab58603d343739cb4397e13acef23182e41692a06e147a8d4c011"
+          HCLOUD_VERSION: "1.66.0"
+          HCLOUD_SHA256: "8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz" \
@@ -123,8 +123,8 @@ jobs:
         # `databricks_cli_<version>_SHA256SUMS` file. No auth needed for the
         # `__complete` / `--help` introspection the validator performs.
         env:
-          DATABRICKS_VERSION: "1.8.0"
-          DATABRICKS_SHA256: "915150a284f24376f44a2f89741319da32e6891eb4a7568199bbe0f6f3dfea02"
+          DATABRICKS_VERSION: "1.9.0"
+          DATABRICKS_SHA256: "10938da31db7f89e6e90f6be41d340e3387231e5da5125cfc97ecb8cb66f6394"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/databricks/cli/releases/download/v${DATABRICKS_VERSION}/databricks_cli_${DATABRICKS_VERSION}_linux_amd64.zip" \
@@ -157,7 +157,7 @@ jobs:
           # Keep at the latest release. Note that the `signature` attribute the
           # validator sets on ruleset plugins needs >= 0.62; v0.61.0 and earlier
           # silently ignore it.
-          tflint_version: v0.63.1
+          tflint_version: v0.64.0
 
       - name: Validate terraform remediation blocks
         env:
@@ -183,7 +183,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install ansible-lint
-        run: pipx install ansible-lint==26.3.0
+        run: pipx install ansible-lint==26.6.0
 
       - name: Validate ansible remediation blocks
         run: python3 content/validation/validate_ansible_remediation.py --github-actions


### PR DESCRIPTION
## Summary

Bumps the pinned CLI tool versions (and their SHA256 checksums) used by the remediation validation workflow so each validator introspects the current command tree / flags.

| Tool | Old | New |
|------|-----|-----|
| doctl | 1.161.0 | 1.163.0 |
| glab | 1.102.0 | 1.109.0 |
| hcloud | 1.65.0 | 1.66.0 |
| databricks | 1.8.0 | 1.9.0 |
| tflint | v0.63.1 | v0.64.0 |
| ansible-lint | 26.3.0 | 26.6.0 |

Each SHA256 was taken from the vendor's published checksum file (doctl, hcloud, databricks) or computed from the exact release artifact URL CI fetches (glab, which publishes no checksums file). GitHub Actions (`checkout`, `setup-python`, `setup-tflint`) and `oci-cli` were already at latest.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [ ] CI validation jobs pass with the bumped tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)