### PR TITLE
🧹 Improve SynchronizeAssets failure-stability & reduce memory pressure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260722123108-9429573bd8ad
-	go.mondoo.com/mql/v13 v13.30.1
+	go.mondoo.com/mql/v13 v13.30.2-0.20260723101245-b3f795688d5e
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1084,6 +1084,8 @@ go.mondoo.com/mondoo-go v0.0.0-20260722123108-9429573bd8ad h1:lK/kn5e/4SIQpE2DYZ
 go.mondoo.com/mondoo-go v0.0.0-20260722123108-9429573bd8ad/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.30.1 h1:npjGfQPlYOgNRfGapY4aWXtBPj1uwC1ALAnXDQLoih4=
 go.mondoo.com/mql/v13 v13.30.1/go.mod h1:pahZP9hhR17f0iIRI3K7tecoMpkqNQ2pp9e2hz5Wdoo=
+go.mondoo.com/mql/v13 v13.30.2-0.20260723101245-b3f795688d5e h1:suv+76XKSjbskT2abmQVg5IcnJIeBiem811dRiV3y3I=
+go.mondoo.com/mql/v13 v13.30.2-0.20260723101245-b3f795688d5e/go.mod h1:pahZP9hhR17f0iIRI3K7tecoMpkqNQ2pp9e2hz5Wdoo=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -738,17 +738,38 @@ func syncBatchWithUpstream(
 	rec llx.Recording,
 ) error {
 	if services != nil {
-		log.Info().Msg("synchronize assets")
+		log.Info().Int("batch-size", len(batch)).Msg("synchronizing assets with upstream")
 		assetsToSync := make([]*inventory.Asset, 0, len(batch))
 		for _, tracked := range batch {
 			assetsToSync = append(assetsToSync, tracked.Asset)
 		}
-		log.Debug().Int("assets", len(assetsToSync)).Msg("synchronizing assets upstream")
-		resp, err := services.SynchronizeAssets(ctx, &policy.SynchronizeAssetsReq{
-			SpaceMrn: spaceMrn,
-			List:     assetsToSync,
-		})
+
+		const maxSyncRetries = 3
+		var resp *policy.SynchronizeAssetsResp
+		var err error
+		for attempt := 1; attempt <= maxSyncRetries; attempt++ {
+			resp, err = services.SynchronizeAssets(ctx, &policy.SynchronizeAssetsReq{
+				SpaceMrn: spaceMrn,
+				List:     assetsToSync,
+			})
+			if err == nil {
+				break
+			}
+			if attempt < maxSyncRetries {
+				backoff := time.Duration(attempt) * 2 * time.Second
+				log.Warn().Err(err).Int("attempt", attempt).Dur("backoff", backoff).
+					Msg("SynchronizeAssets failed, retrying")
+				t := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					t.Stop()
+					return ctx.Err()
+				case <-t.C:
+				}
+			}
+		}
 		if err != nil {
+			log.Error().Err(err).Int("attempts", maxSyncRetries).Msg("SynchronizeAssets failed after all retries")
 			return err
 		}
 		log.Debug().Int("assets", len(resp.Details)).Msg("got assets details")

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -567,9 +567,14 @@ type scanContext struct {
 
 func (sc *scanContext) skipAsset(asset *discovery.TrackedAsset) {
 	sc.multiprogress.Filtered(1)
-	if err := sc.explorer.CloseAsset(asset); err != nil {
-		log.Error().Err(err).Str("asset", asset.Asset.Name).Msg("failed to close asset")
+	assetName := ""
+	if asset.Asset != nil {
+		assetName = asset.Asset.Name
 	}
+	if err := sc.explorer.CloseAsset(asset); err != nil {
+		log.Error().Err(err).Str("asset", assetName).Msg("failed to close asset")
+	}
+	asset.Asset = nil
 	<-sc.connSem
 }
 
@@ -701,13 +706,24 @@ func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedA
 		}
 	} else {
 		sc.multiprogress.Filtered(1)
-		if err := sc.explorer.CloseAsset(node); err != nil {
-			log.Error().Err(err).Str("asset", node.Asset.Name).Msg("failed to close asset")
+		nodeName := ""
+		if node.Asset != nil {
+			nodeName = node.Asset.Name
 		}
+		if err := sc.explorer.CloseAsset(node); err != nil {
+			log.Error().Err(err).Str("asset", nodeName).Msg("failed to close asset")
+		}
+		node.Asset = nil
 	}
 
 	// Wait for all scans (children + node) to complete before returning.
 	sc.dispatcher.Wait()
+
+	// Release the subtree's children references. All children have been
+	// scanned and closed, so these pointers only prevent GC. Clearing
+	// them before processing the next subtree (namespace) keeps peak
+	// memory proportional to one subtree, not the entire tree.
+	node.Children = nil
 
 	return nil
 }

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -105,9 +105,14 @@ func (sb *syncBatcher) Flush(ctx context.Context) error {
 	if len(readyToSync) > 0 {
 		if err := syncBatchWithUpstream(ctx, readyToSync, sb.services, sb.spaceMrn, sb.recording); err != nil {
 			for _, tracked := range batch {
-				if closeErr := sb.dispatcher.explorer.CloseAsset(tracked); closeErr != nil {
-					log.Error().Err(closeErr).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+				assetName := ""
+				if tracked.Asset != nil {
+					assetName = tracked.Asset.Name
 				}
+				if closeErr := sb.dispatcher.explorer.CloseAsset(tracked); closeErr != nil {
+					log.Error().Err(closeErr).Str("asset", assetName).Msg("failed to close asset")
+				}
+				tracked.Asset = nil
 				<-sb.dispatcher.connSem
 			}
 			return err
@@ -191,15 +196,20 @@ func (d *scanDispatcher) Submit(ctx context.Context, tracked *discovery.TrackedA
 		case d.scanSem <- struct{}{}:
 			defer func() { <-d.scanSem }()
 		case <-ctx.Done():
-			if err := d.explorer.CloseAsset(tracked); err != nil {
-				log.Error().Err(err).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+			assetName := ""
+			if tracked.Asset != nil {
+				assetName = tracked.Asset.Name
 			}
+			if err := d.explorer.CloseAsset(tracked); err != nil {
+				log.Error().Err(err).Str("asset", assetName).Msg("failed to close asset")
+			}
+			tracked.Asset = nil
 			return
 		}
 
 		// Mark asset as in-progress as soon as we pick it up, not when
 		// the first query result comes back.
-		if len(tracked.Asset.PlatformIds) > 0 {
+		if tracked.Asset != nil && len(tracked.Asset.PlatformIds) > 0 {
 			d.multiprogress.OnProgress(tracked.Asset.PlatformIds[0], 0)
 		}
 
@@ -230,8 +240,9 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 		if err != nil {
 			d.reporter.AddScanError(asset, err)
 			if err := d.explorer.CloseAsset(tracked); err != nil {
-				log.Error().Err(err).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+				log.Error().Err(err).Str("asset", asset.Name).Msg("failed to close asset")
 			}
+			tracked.Asset = nil
 			return
 		}
 		asset = updatedAsset
@@ -246,8 +257,9 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 				d.multiprogress.Errored(asset.PlatformIds[0])
 			}
 			if err := d.explorer.CloseAsset(tracked); err != nil {
-				log.Error().Err(err).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+				log.Error().Err(err).Str("asset", asset.Name).Msg("failed to close asset")
 			}
+			tracked.Asset = nil
 			return
 		}
 	}
@@ -255,8 +267,9 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 	if len(asset.PlatformIds) == 0 {
 		log.Warn().Str("name", asset.Name).Msg("asset has no platform IDs after discovery, skipping")
 		if err := d.explorer.CloseAsset(tracked); err != nil {
-			log.Error().Err(err).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+			log.Error().Err(err).Str("asset", asset.Name).Msg("failed to close asset")
 		}
+		tracked.Asset = nil
 		return
 	}
 
@@ -291,8 +304,15 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 
 	// Close asset after scanning to free the gRPC connection.
 	if err := d.explorer.CloseAsset(tracked); err != nil {
-		log.Error().Err(err).Str("asset", tracked.Asset.Name).Msg("failed to close asset")
+		log.Error().Err(err).Str("asset", asset.Name).Msg("failed to close asset")
 	}
+
+	// Break the allAssets → Asset reference so the proto data (connections,
+	// platform, labels, etc.) becomes GC-eligible immediately. The local
+	// `asset` variable still holds a reference for logMemoryStats below;
+	// reporters that need the data (AggregateReporter) already captured
+	// their own reference via AddReport.
+	tracked.Asset = nil
 
 	debug.FreeOSMemory()
 
@@ -354,7 +374,7 @@ func (d *scanDispatcher) reportPanic(tracked *discovery.TrackedAsset) {
 		tags := map[string]string{
 			"spaceMrn": d.spaceMrn,
 		}
-		if tracked != nil {
+		if tracked != nil && tracked.Asset != nil {
 			tags["assetMrn"] = tracked.Asset.Mrn
 			tags["assetName"] = tracked.Asset.Name
 			tags["platformIDs"] = strings.Join(tracked.Asset.PlatformIds, ",")


### PR DESCRIPTION
## Summary

Harden the scan pipeline against SynchronizeAssets failures and reduce memory pressure during large K8s scans (~4000+ assets), addressing OOM kills, transient EOF errors, and scan timeouts.

- **Nil-safe asset access and eager GC after close**: Every `CloseAsset` call site now sets `tracked.Asset = nil` so proto data (connections, platform, labels) becomes GC-eligible immediately instead of staying reachable through `allAssets` for the entire scan. Asset names are captured before close to keep error logs informative. Nil guards added to `reportPanic` and `OnProgress`. `scanSubtree` releases `node.Children` after `dispatcher.Wait()` so the previous namespace's subtree is freed before scanning the next.
- **SynchronizeAssets retry with exponential backoff**: Transient EOF errors from upstream (load balancer resets, connection pool churn) now retry up to 3 times with 2s/4s backoff. The loop respects context cancellation. Log message improved from bare "synchronize assets" to "synchronizing assets with upstream" with `batch-size` field for easier correlation in logs without requiring debug level.

## Context

Companion mql changes handle the asset explorer side (break reference chains on close/eviction, O(1) platform ID dedup).

Depends on https://github.com/mondoohq/mql/pull/9390

## Test plan

- [x] Local reproduction with ~4200 discoverable K8s objects in Docker Desktop cluster, memory-limited container (256MB-1GB)
- [x] Upstream binary and patched binary both complete scan without OOM at 256MB
- [x] Zero SynchronizeAssets errors in both runs
- [x] `go vet ./policy/scan/` passes (pre-existing warning in disk_queue.go only)
