### PR TITLE
🐛 onboarding(ms365): grant missing Microsoft Graph permissions

### DIFF
--- a/internal/onboarding/ms365.go
+++ b/internal/onboarding/ms365.go
@@ -61,6 +61,62 @@ var Ms365AppPermissions = Permissions{
 				ID:   "OrgSettings-AppsAndServices.Read.All",
 				Type: "Role",
 			},
+			{
+				// PIM role definitions, assignments, role management policies, and eligibility schedules.
+				// Required by the cis-microsoft-365 5.3.x checks and the PIM privileged-roles check.
+				ID:   "RoleManagement.Read.All",
+				Type: "Role",
+			},
+			{
+				// Required by the cis-microsoft-365 5.3.2/5.3.3 access-review checks.
+				ID:   "AccessReview.Read.All",
+				Type: "Role",
+			},
+			{
+				ID:   "UserAuthenticationMethod.Read.All",
+				Type: "Role",
+			},
+			{
+				// Sign-in activity, sign-in logs, and authentication method registration details.
+				ID:   "AuditLog.Read.All",
+				Type: "Role",
+			},
+			{
+				ID:   "IdentityRiskEvent.Read.All",
+				Type: "Role",
+			},
+			{
+				ID:   "IdentityRiskyUser.Read.All",
+				Type: "Role",
+			},
+			{
+				// Intune managed apps, app configurations, and app protection policies.
+				ID:   "DeviceManagementApps.Read.All",
+				Type: "Role",
+			},
+			{
+				// Intune role-based access control (RBAC) settings.
+				ID:   "DeviceManagementRBAC.Read.All",
+				Type: "Role",
+			},
+			{
+				// Microsoft Graph security alerts_v2 (not covered by SecurityEvents.Read.All).
+				ID:   "SecurityAlert.Read.All",
+				Type: "Role",
+			},
+			{
+				ID:   "SecurityIncident.Read.All",
+				Type: "Role",
+			},
+			{
+				ID:   "InformationProtectionPolicy.Read.All",
+				Type: "Role",
+			},
+			{
+				// Directory reads such as OAuth2 permission grants, service principals, and group settings.
+				ID:   "Directory.Read.All",
+				Type: "Role",
+			},
 		},
 	},
 	{

--- a/internal/onboarding/ms365_test.go
+++ b/internal/onboarding/ms365_test.go
@@ -102,6 +102,54 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["RoleManagement.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["AccessReview.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["UserAuthenticationMethod.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["AuditLog.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskEvent.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskyUser.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementApps.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementRBAC.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityAlert.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityIncident.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["InformationProtectionPolicy.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Directory.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -198,6 +246,78 @@ resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" 
 
 resource "azuread_app_role_assignment" "OrgSettings-AppsAndServices_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "RoleManagement_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["RoleManagement.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "AccessReview_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["AccessReview.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "UserAuthenticationMethod_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["UserAuthenticationMethod.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "AuditLog_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["AuditLog.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "IdentityRiskEvent_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskEvent.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "IdentityRiskyUser_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskyUser.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementApps_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementApps.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementRBAC_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementRBAC.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityAlert_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityAlert.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityIncident_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityIncident.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "InformationProtectionPolicy_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["InformationProtectionPolicy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "Directory_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Directory.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }
@@ -318,6 +438,54 @@ resource "azuread_application" "mondoo" {
       id   = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
       type = "Role"
     }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["RoleManagement.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["AccessReview.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["UserAuthenticationMethod.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["AuditLog.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskEvent.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskyUser.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementApps.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementRBAC.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityAlert.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityIncident.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["InformationProtectionPolicy.Read.All"]
+      type = "Role"
+    }
+    resource_access {
+      id   = azuread_service_principal.MicrosoftGraph.app_role_ids["Directory.Read.All"]
+      type = "Role"
+    }
   }
 
   required_resource_access {
@@ -414,6 +582,78 @@ resource "azuread_app_role_assignment" "DeviceManagementServiceConfig_Read_All" 
 
 resource "azuread_app_role_assignment" "OrgSettings-AppsAndServices_Read_All" {
   app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["OrgSettings-AppsAndServices.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "RoleManagement_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["RoleManagement.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "AccessReview_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["AccessReview.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "UserAuthenticationMethod_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["UserAuthenticationMethod.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "AuditLog_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["AuditLog.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "IdentityRiskEvent_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskEvent.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "IdentityRiskyUser_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["IdentityRiskyUser.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementApps_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementApps.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "DeviceManagementRBAC_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["DeviceManagementRBAC.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityAlert_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityAlert.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "SecurityIncident_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["SecurityIncident.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "InformationProtectionPolicy_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["InformationProtectionPolicy.Read.All"]
+  principal_object_id = azuread_service_principal.mondoo.object_id
+  resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
+}
+
+resource "azuread_app_role_assignment" "Directory_Read_All" {
+  app_role_id         = azuread_service_principal.MicrosoftGraph.app_role_ids["Directory.Read.All"]
   principal_object_id = azuread_service_principal.mondoo.object_id
   resource_object_id  = azuread_service_principal.MicrosoftGraph.object_id
 }


### PR DESCRIPTION
## Summary

The M365 integration onboarding (`internal/onboarding/ms365.go`) provisions an app registration and the scan authenticates **app-only** (client credentials) using the `https://graph.microsoft.com/.default` scope. With `.default`, the service principal's token carries **exactly** the Graph application permissions consented on the app registration — nothing more. Any provider call to an endpoint whose permission was never granted fails with `PermissionScopeNotGranted` / *"Attempted to perform an unauthorized operation."*

`Ms365AppPermissions` was missing several permissions the ms365 provider actually requires. In the field this surfaced as failed checks (internal ref: customer-issues #257 — `cis-microsoft-365` 5.3.2/5.3.3/5.3.4/5.3.5 and the PIM privileged-roles check).

This PR adds the missing Microsoft Graph application permissions (all `Type: "Role"`) to the onboarding automation.

## Permissions added & why

### Confirmed by the failing checks' error messages
| Permission | Fixes |
|---|---|
| `RoleManagement.Read.All` | `cis-microsoft-365--5.3.4`, `5.3.5`, `mondoo-m365-security-require-pim-for-privileged-roles` (role definitions/assignments, PIM role management policies, `roleEligibilityScheduleInstances`) |
| `AccessReview.Read.All` | `cis-microsoft-365--5.3.2`, `5.3.3` (identity governance access reviews) |

The scan errors named these scopes directly, e.g. `missing permission scope RoleManagement...Read.All` and the unauthorized access-review calls.

### Declared as required in the provider source
| Permission | Resource / evidence |
|---|---|
| `UserAuthenticationMethod.Read.All` | `microsoft.user.authMethods` — `users.go` raises *"UserAuthenticationMethod.Read.All permission is required"* |
| `IdentityRiskEvent.Read.All` | `microsoft.security.riskDetections` — comment in `security_riskdetections.go` |
| `IdentityRiskyUser.Read.All` | `microsoft.security.riskyUsers` — comment in `security_riskyusers.go` |
| `Directory.Read.All` | `oauth2_permission_grants.go` ("Requires the Directory.Read.All application permission"); also service-principal grants, group lifecycle policies, group settings |

### Required by endpoints the provider reads
| Permission | Resource |
|---|---|
| `AuditLog.Read.All` | user `signInActivity`, sign-in logs, MFA/auth-method registration details |
| `DeviceManagementApps.Read.All` | Intune managed apps, app configs, app-protection policies (`deviceAppManagement/*`, not covered by the existing `DeviceManagement*` scopes) |
| `DeviceManagementRBAC.Read.All` | Intune role definitions/assignments/scope tags |
| `SecurityAlert.Read.All` | Graph security `alerts_v2` (not covered by `SecurityEvents.Read.All`, which covers legacy alerts + secure scores) |
| `SecurityIncident.Read.All` | Graph security incidents |
| `InformationProtectionPolicy.Read.All` | sensitivity labels (beta) |

## Audit scope / what was intentionally left out

A full sweep of all 54 ms365 provider resource files was done to map each Graph endpoint to its least-privilege permission and diff against what onboarding grants.

- **Plain directory-object reads** (`Users()`, `Groups()`, `Applications()`, `ServicePrincipals()`, `Devices()`, `Domains()`, `Organization()`, Teams inventory) were **not** added. Onboarding also assigns the service principal the **Global Reader** and **Exchange Administrator** Entra directory roles, and app-only Graph honors Entra-role RBAC for these directory reads — so adding explicit app permissions would over-privilege for no gain. (If we later decide not to rely on role RBAC, a single `Directory.Read.All` — already added here — covers most of them.)
- **Non-Graph APIs** are out of scope: `powerbi.go` uses the Power BI/Fabric REST admin API (needs a Power BI `Tenant.Read.All` + a tenant setting, already degrades gracefully); Exchange/SharePoint config use the already-granted `Exchange.ManageAsApp` / `Sites.FullControl.All`.

## Notes for reviewers / follow-up

- The `SecurityAlert.Read.All` / `SecurityIncident.Read.All` / `InformationProtectionPolicy.Read.All` mappings are based on the Graph docs for the `alerts_v2` / `incidents` / sensitivity-label endpoints; worth a sanity check against a live tenant, but they can only help (read-only, admin-consented).
- **Existing integrations are not auto-updated** — the app registration only gets these once the onboarding Terraform is re-applied, or the permissions are added + admin-consented manually. `cis-microsoft-365--7.2.8` reported in the same ticket is a **separate** SharePoint/`Get-PnPTenant` issue, not a Graph-permission gap, and is not addressed here.

## Test

`internal/onboarding/ms365_test.go` golden HCL updated (both `TestGenerateMs365HCL_Basic` and `_Minimal`); `go test ./internal/onboarding/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)