### PR TITLE
🐛 policy: keep implicit props on shared queries

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -1372,6 +1372,13 @@ func (c *bundleCache) compileQueries(queries []*Mquery, policy *Policy) error {
 				queries[i].Checksum = query.Checksum
 				queries[i].CodeId = query.CodeId
 				queries[i].Type = query.Type
+				// Compilation turns implicit properties (eg: a query that uses
+				// props.name, where name is only defined on the policy) into
+				// explicit properties on the query. Shared queries are compiled
+				// on a merged copy, so those new properties would be lost here.
+				// Without them the resolver has nothing to compile the query
+				// against and fails with "cannot find property".
+				addMissingProps(queries[i], query.Props)
 			}
 		}
 	}
@@ -1380,6 +1387,27 @@ func (c *bundleCache) compileQueries(queries []*Mquery, policy *Policy) error {
 	// Since shared queries may be used in other places, any errors here will prevent
 	// us from compiling further.
 	return c.error()
+}
+
+// addMissingProps adds all properties to the query that it doesn't carry yet.
+// Properties are identified by their MRN, existing ones are left untouched.
+func addMissingProps(query *Mquery, props []*Property) {
+	if len(props) == 0 {
+		return
+	}
+
+	existing := make(map[string]struct{}, len(query.Props))
+	for _, prop := range query.Props {
+		existing[prop.Mrn] = struct{}{}
+	}
+
+	for _, prop := range props {
+		if _, ok := existing[prop.Mrn]; ok {
+			continue
+		}
+		existing[prop.Mrn] = struct{}{}
+		query.Props = append(query.Props, prop)
+	}
 }
 
 // precompileQuery indexes the query, turns UIDs into MRNs, compiles properties

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/cnspec/v13/internal/datalakes/inmemory"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/providers"
+	llxtypes "go.mondoo.com/mql/v13/types"
 )
 
 type s3Fake struct {
@@ -828,4 +829,50 @@ queries:
 	require.Equal(t, b.Queries[1].Props[0].Mrn, b.Policies[0].Props[0].For[0].Mrn)
 	require.Equal(t, b.Queries[2].Props[0].Mrn, b.Policies[0].Props[0].For[1].Mrn)
 	require.Equal(t, b.Queries[3].Props[0].Mrn, b.Policies[0].Props[0].For[2].Mrn)
+}
+
+func TestProps_ImplicitPropsOnSharedQueries(t *testing.T) {
+	// Checks that live in the shared `queries` section and are only referenced
+	// by uid from a group are compiled on a merged copy of the query. The
+	// implicit property that the compiler creates for `props.crontabDir` has to
+	// end up on the shared query itself, otherwise the resolver has no property
+	// to compile the check against.
+	bundleYaml := `
+policies:
+  - uid: example1
+    name: Example policy 1
+    version: "1.0.0"
+    groups:
+      - title: group1
+        filters: return true
+        checks:
+          - uid: check-1
+          - uid: check-2
+    props:
+      - uid: crontabDir
+        mql: return "/etc/cron.d"
+
+queries:
+  - uid: check-1
+    mql: props.crontabDir != ""
+  - uid: check-2
+    mql: props.crontabDir == "/etc/cron.d"`
+
+	b, err := policy.BundleFromYAML([]byte(bundleYaml))
+	require.NoError(t, err)
+	_, err = b.CompileExt(context.Background(), policy.BundleCompileConf{
+		CompilerConfig: conf,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, b.Policies[0].Props, 1)
+	policyProp := b.Policies[0].Props[0]
+	require.Len(t, policyProp.For, 2)
+
+	require.Len(t, b.Queries, 2)
+	for i, query := range b.Queries {
+		require.Len(t, query.Props, 1, "query %s has no property", query.Mrn)
+		require.Equal(t, policyProp.For[i].Mrn, query.Props[0].Mrn)
+		require.Equal(t, string(llxtypes.String), query.Props[0].Type)
+	}
 }

--- a/policy/resolver_v2_test.go
+++ b/policy/resolver_v2_test.go
@@ -2389,6 +2389,52 @@ policies:
 	})
 }
 
+// A check that is defined in the bundle's shared `queries` section and only
+// referenced by uid from a group is compiled on a merged copy of the query.
+// Implicit properties resolved during that compilation have to make it back
+// into the shared query, otherwise resolving fails with "cannot find property".
+func TestResolveV2_ImplicitProps_SharedQuery(t *testing.T) {
+	ctx := context.Background()
+	b := parseBundle(t, `
+owner_mrn: //test.sth
+policies:
+- uid: policy1
+  props:
+  - uid: name
+    mql: return "definitely not the asset name"
+  groups:
+  - type: chapter
+    filters: "true"
+    checks:
+    - uid: check1
+queries:
+- uid: check1
+  mql: asset.name == props.name
+`)
+
+	srv := initResolver(t, []*testAsset{
+		{asset: "asset1", policies: []string{policyMrn("policy1")}},
+	}, []*policy.Bundle{b})
+
+	t.Run("resolve with correct filters", func(t *testing.T) {
+		rp, err := srv.Resolve(ctx, &policy.ResolveReq{
+			PolicyMrn:    policyMrn("policy1"),
+			AssetFilters: []*policy.Mquery{{Mql: "true"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rp)
+
+		rpTester := newResolvedPolicyTester(b, srv.NewCompilerConfig())
+		rpTester.
+			ExecutesQuery(queryMrn("check1")).
+			WithProps(map[string]string{"name": `return "definitely not the asset name"`})
+		rpTester.CodeIdReportingJobForMrn(queryMrn("check1")).Notifies(queryMrn("check1"))
+		rpTester.ReportingJobByMrn(queryMrn("check1")).Notifies("root")
+
+		rpTester.doTest(t, rp)
+	})
+}
+
 func TestResolveV2_ValidUntil(t *testing.T) {
 	ctx := context.Background()
 	bYaml := `


### PR DESCRIPTION
## Problem

A policy property that a check picks up implicitly is dropped when the check lives in the bundle's shared `queries` section and the group only references it by uid:

```yaml
policies:
  - uid: example
    version: "1.0.0"
    groups:
      - filters: return true
        checks:
          - uid: check-1
    props:
      - uid: crontabDir
        mql: return "/etc/cron.d"

queries:
  - uid: check-1
    mql: file(props.crontabDir).exists
```

`cnspec policy lint` reports this bundle as valid, but scanning with it fails:

```
x error building node error="failed to compile: cannot find property 'crontabDir', please define it first"
error: failed to compile: cannot find property 'crontabDir', please define it first
```

Moving the same check inline into the group, or declaring the property on the check itself, works — so the bug only shows up for shared queries, and only after lint has already passed.

## Cause

`prepareMRNs` merges a group's stub with the shared query via `query.Merge(existing)`, which returns a clone. Only the clone is stored in `cache.lookupQuery`; neither `bundle.Queries[i]` nor the group stub is repointed at it.

Compilation then runs against that clone. `QueryPropsResolver.Get` converts the implicit property into an explicit one and appends it to `query.Props` — landing on the throwaway copy. The `for` back-reference is set on the shared policy object and does survive, so the bundle looks consistent to lint, while the query that gets persisted carries no properties.

At resolve time `compileProps` iterates `query.Props`, finds it empty, and passes no property types to the compiler, which produces the error above.

## Fix

The post-compile loop in `compileQueries` already carries `Checksum`, `CodeId` and `Type` from the merged copy back to the source query. It now carries properties back as well, deduplicated by MRN so properties the query already declares are left untouched.

## Tests

- `TestProps_ImplicitPropsOnSharedQueries` — compile level: asserts both shared queries end up with the implicit property, matching the policy property's `for` entries.
- `TestResolveV2_ImplicitProps_SharedQuery` — resolver level: resolving a policy whose check comes from the shared `queries` section succeeds and the check executes with the policy property's value.

Both fail on `main` and pass with this change. `go test ./policy/...` is green. Verified end to end with a local scan: the bundle above goes from `ERROR … cannot find property` to executing and scoring normally, and a variation where two policies share one check with different property values is fixed by the same change.

## Note

Properties declared at the bundle root (top-level `props:`, outside any policy) still do not resolve, with or without an explicit `for:` — `buildParents` has no notion of the bundle as a parent. That case fails at lint rather than silently, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8jNbDEqQnXqdkmsfquLWv
