### PR TITLE
✨ tls/dns/http/email: map to OWASP Top 10 2025, ASVS 5, MITRE ATT&CK

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.3.2
+    version: 1.3.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -38,6 +38,7 @@ policies:
           - uid: mondoo-dns-security-no-wildcard
           - uid: mondoo-dns-security-ns-redundancy
           - uid: mondoo-dns-security-reasonable-ttls
+    scoring_system: highest impact
 queries:
   - uid: mondoo-dns-security-no-cname-for-root-domain
     title: Ensure no CNAME is used for root domain
@@ -54,6 +55,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -72,10 +74,55 @@ queries:
         Run the `dig <domain>` command and inspect the answer section for the root domain.
 
         A passing result shows the root domain resolving through A or AAAA records with no CNAME present. A failing result shows a CNAME record returned for the root domain.
-      remediation: |
-        1. Replace the CNAME record at the root domain with an A or ALIAS record, if your DNS provider supports ALIAS records, pointing to the appropriate IP address or hostname.
-        2. Ensure the A or ALIAS record is correctly configured to maintain DNS compatibility and avoid resolution failures.
-        3. Verify the updated DNS configuration with `dig <domain>` to confirm proper resolution and functionality.
+      remediation:
+        - id: console
+          desc: |
+            To replace an apex CNAME using your DNS provider's control panel:
+
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Note the target the apex `CNAME` currently points to, then delete the record.
+            3. Create an `A` record at the apex (`@`) pointing to the service IP address. If the target is a hostname whose address changes, create an `ALIAS`, `ANAME`, or `CNAME flattening` record instead, whichever your provider offers.
+            4. Save the zone and confirm the apex now returns an address record.
+        - id: cli
+          desc: |
+            To confirm the apex resolves through an address record rather than a CNAME:
+
+            1. Inspect the current apex answer:
+
+                ```bash
+                dig +noall +answer example.com CNAME
+                dig +noall +answer example.com A
+                ```
+
+            2. Remove the apex `CNAME` and publish an `A` or `ALIAS` record through your provider's API or CLI.
+            3. Re-run the commands. The `CNAME` query must return no answer and the `A` query must return an address.
+        - id: terraform
+          desc: |
+            To publish an apex address record with Terraform, use the alias-style resource your DNS provider offers rather than a `CNAME`:
+
+            ```hcl
+            # AWS Route 53 - alias record at the apex
+            resource "aws_route53_record" "apex" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "A"
+
+              alias {
+                name                   = aws_lb.web.dns_name
+                zone_id                = aws_lb.web.zone_id
+                evaluate_target_health = true
+              }
+            }
+
+            # Cloudflare - CNAME flattening applies automatically at the apex
+            resource "cloudflare_record" "apex" {
+              zone_id = var.cloudflare_zone_id
+              name    = "@"
+              type    = "CNAME"
+              content = "web.example.net"
+              proxied = true
+            }
+            ```
     refs:
       - url: https://www.cisa.gov/dns-security
         title: CISA DNS Security
@@ -93,6 +140,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -115,18 +163,55 @@ queries:
         Run the `dig NS <domain>` and `dig MX <domain>` commands and inspect the answer sections.
 
         A passing result shows every NS and MX record pointing to a hostname such as `ns1.example.com` or `mail.example.com`. A failing result shows any NS or MX record whose target is a literal IPv4 or IPv6 address.
-      remediation: |
-        For NS records:
-          1. Identify the authoritative DNS servers for your domain.
-          2. Update the NS records in your DNS settings to point to the fully qualified domain names (FQDNs) of these servers (e.g., ns1.example.com).
-          3. Remove any NS records pointing to IP addresses to ensure compliance with DNS standards.
-          4. Verify the configuration using DNS validation tools to confirm proper resolution.
+      remediation:
+        - id: console
+          desc: |
+            To replace literal IP addresses in NS and MX records using your DNS provider's control panel:
 
-        For MX records:
-          1. Identify the correct mail server FQDNs for your email provider (e.g., mail.example.com).
-          2. Update the MX records in your DNS settings to point to these FQDNs, ensuring the correct priority values are set.
-          3. Remove any MX records pointing to IP addresses or outdated servers to avoid misrouting or security risks.
-          4. Test the configuration by sending and receiving emails to confirm proper functionality.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. For each `NS` record whose value is an IP address, create or confirm a hostname for that nameserver (for example `ns1.example.com`), publish an `A`/`AAAA` record for it, then change the `NS` record to reference that hostname.
+            3. For each `MX` record whose value is an IP address, replace it with the fully qualified hostname of the mail server (for example `mail.example.com`) and keep the existing preference value.
+            4. Delete the records that still carry literal addresses, then save the zone.
+        - id: cli
+          desc: |
+            To confirm no NS or MX record resolves to a literal address:
+
+            1. Inspect the current values:
+
+                ```bash
+                dig +noall +answer example.com NS
+                dig +noall +answer example.com MX
+                ```
+
+            2. Publish hostname-based replacements through your provider's API or CLI, adding `A`/`AAAA` records for any nameserver hostname that does not already have one.
+            3. Re-run the commands. Every answer must be a hostname; a passing zone shows values such as `ns1.example.com.` and `10 mail.example.com.`, never a dotted-quad or IPv6 literal.
+        - id: terraform
+          desc: |
+            To publish hostname-based NS and MX records with Terraform:
+
+            ```hcl
+            resource "aws_route53_record" "mx" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "MX"
+              ttl     = 3600
+              records = [
+                "10 mail.example.com",
+                "20 mail2.example.com",
+              ]
+            }
+
+            resource "aws_route53_record" "ns" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "NS"
+              ttl     = 172800
+              records = [
+                "ns1.example.com",
+                "ns2.example.com",
+              ]
+            }
+            ```
     refs:
       - url: https://www.cisa.gov/dns-security
         title: CISA DNS Security
@@ -144,6 +229,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -166,15 +252,41 @@ queries:
         Run the `dig MX <domain>` command and inspect the answer section.
 
         A passing result shows MX records pointing to current Microsoft 365 endpoints under `*.mail.protection.outlook.com`. A failing result shows an MX record pointing to a legacy host such as `mail.outlook.com` or `mail.global.frontbridge.com`.
-      remediation: |
-        Replace all legacy MX records with the current Microsoft 365 MX records shown in the Microsoft 365 admin center.
+      remediation:
+        - id: console
+          desc: |
+            To replace legacy Microsoft 365 MX records using your DNS provider's control panel:
 
-        Steps to remediate:
-          1. Sign in to your DNS hosting provider's control panel.
-          2. Locate the DNS settings for your domain.
-          3. Add or update the MX records to match the Microsoft 365 configuration, setting the correct priorities.
-          4. Remove any legacy or non-Microsoft MX records to avoid misrouting or security vulnerabilities.
-          5. Save the changes and verify the configuration with `dig MX <domain>`.
+            1. Sign in to the Microsoft 365 admin center, open **Settings > Domains**, select the domain, and copy the MX value Microsoft currently publishes for it. It has the form `<domain-key>.mail.protection.outlook.com`.
+            2. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            3. Add an `MX` record at the apex with that value and preference `0`.
+            4. Delete the legacy records — `mail.outlook.com`, `mail.messaging.microsoft.com`, `mail.global.frontbridge.com`, and `mail.global.bigfish.com` are all retired endpoints.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the domain uses the current Microsoft 365 mail endpoint:
+
+            1. Inspect the published MX records:
+
+                ```bash
+                dig +noall +answer example.com MX
+                ```
+
+            2. Replace any retired endpoint with the `*.mail.protection.outlook.com` host shown for the domain in the Microsoft 365 admin center, using your DNS provider's API or CLI.
+            3. Re-run the command. A passing zone returns a single `0 <domain-key>.mail.protection.outlook.com.` answer and none of the retired hostnames.
+        - id: terraform
+          desc: |
+            To publish the current Microsoft 365 MX record with Terraform:
+
+            ```hcl
+            resource "aws_route53_record" "m365_mx" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "MX"
+              ttl     = 3600
+              records = ["0 example-com.mail.protection.outlook.com"]
+            }
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide
         title: Add DNS records to connect your domain
@@ -192,6 +304,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -213,21 +326,55 @@ queries:
         Run the `dig MX <domain>` command and inspect the answer section.
 
         A passing result shows MX records pointing only to `aspmx.l.google.com` and its `alt1` through `alt4` variants. A failing result shows a record under `l.google.com` that points to any other host.
-      remediation: |
-        To ensure proper email routing and security, configure the domain's MX records to point to Google's designated email servers:
+      remediation:
+        - id: console
+          desc: |
+            To publish the Google Workspace MX records using your DNS provider's control panel:
 
-          - ASPMX.L.GOOGLE.COM (Priority: 1)
-          - ALT1.ASPMX.L.GOOGLE.COM (Priority: 5)
-          - ALT2.ASPMX.L.GOOGLE.COM (Priority: 5)
-          - ALT3.ASPMX.L.GOOGLE.COM (Priority: 10)
-          - ALT4.ASPMX.L.GOOGLE.COM (Priority: 10)
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Add `MX` records at the apex for the five Google endpoints, with these preference values:
 
-        Steps to remediate:
-          1. Log in to your DNS hosting provider's control panel.
-          2. Locate the DNS settings for your domain.
-          3. Add or update the MX records to match the above configuration, ensuring the correct priorities are set.
-          4. Remove any legacy or non-Google MX records to avoid misrouting or security vulnerabilities.
-          5. Save the changes and verify the configuration with `dig MX <domain>`.
+                | Preference | Mail server |
+                |---|---|
+                | 1 | `ASPMX.L.GOOGLE.COM` |
+                | 5 | `ALT1.ASPMX.L.GOOGLE.COM` |
+                | 5 | `ALT2.ASPMX.L.GOOGLE.COM` |
+                | 10 | `ALT3.ASPMX.L.GOOGLE.COM` |
+                | 10 | `ALT4.ASPMX.L.GOOGLE.COM` |
+
+            3. Delete any remaining MX records that point at a previous mail provider, so mail cannot be routed to a system nobody monitors.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the domain routes mail to the Google Workspace endpoints:
+
+            1. Inspect the published MX records:
+
+                ```bash
+                dig +noall +answer example.com MX
+                ```
+
+            2. Publish the five `ASPMX`/`ALT*.ASPMX` records with the preferences above through your provider's API or CLI, and remove any others.
+            3. Re-run the command. A passing zone returns exactly the five Google endpoints and no third-party mail hosts.
+        - id: terraform
+          desc: |
+            To publish the Google Workspace MX records with Terraform:
+
+            ```hcl
+            resource "aws_route53_record" "google_mx" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "MX"
+              ttl     = 3600
+              records = [
+                "1 ASPMX.L.GOOGLE.COM",
+                "5 ALT1.ASPMX.L.GOOGLE.COM",
+                "5 ALT2.ASPMX.L.GOOGLE.COM",
+                "10 ALT3.ASPMX.L.GOOGLE.COM",
+                "10 ALT4.ASPMX.L.GOOGLE.COM",
+              ]
+            }
+            ```
     refs:
       - url: https://support.google.com/a/answer/140034?hl=en
         title: Set up MX records for Google Workspace email
@@ -240,11 +387,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -263,13 +412,63 @@ queries:
         Run the `dig DNSKEY <domain>` command and inspect the answer section.
 
         A passing result shows one or more DNSKEY records published for the domain. A failing result shows an empty answer section, indicating DNSSEC is not enabled.
-      remediation: |
-        * Enable DNSSEC for your domain through your DNS hosting provider or domain registrar's control panel, following their instructions for signing the zone.
-        * Publish the DS (Delegation Signer) record at your domain registrar so it appears in the parent zone. Signing the zone at the DNS host only generates the keys. Until the matching DS record exists in the parent zone, resolvers have no trust anchor and DNSSEC validation never activates. This missing DS-record step is the most common reason DNSSEC appears configured but provides no protection. If your DNS host and registrar are different providers, copy the DS record (or the DNSKEY values used to build it) from the host into the registrar's DNSSEC settings.
-        * Verify the DS record is live in the parent zone with `dig DS <domain>`. An empty answer section means the registrar has not published it yet and the chain of trust is broken.
-        * Monitor DNSSEC signatures so they remain valid and do not expire. Set up alerts or reminders for signature expiration dates.
-        * Verify proper configuration with `dig DNSKEY <domain>` and `dig +dnssec <domain>`, and address any validation warnings promptly.
-        * Establish a process for periodic DNSSEC reviews to ensure ongoing compliance and security.
+      remediation:
+        - id: console
+          desc: |
+            To enable DNSSEC, sign the zone at the DNS host **and** publish the DS record at the registrar. Doing only the first step is the most common reason DNSSEC appears configured but provides no protection:
+
+            1. Sign in to the control panel for the provider that hosts the zone, open the DNS settings for the domain, and enable DNSSEC. The provider generates the signing keys and serves `DNSKEY` and `RRSIG` records.
+            2. Copy the DS record the host displays, or the DNSKEY values needed to build it.
+            3. Sign in to the domain registrar, open the DNSSEC settings for the domain, and publish that DS record. Until the DS exists in the parent zone, resolvers have no trust anchor and never validate.
+            4. If the host and the registrar are the same provider, confirm it published the DS on your behalf rather than assuming it did.
+            5. Set a reminder to review signature expiry and any planned key rollover.
+        - id: cli
+          desc: |
+            To confirm the full chain of trust is live, check both the zone signature and the parent-zone delegation:
+
+            1. Confirm the zone is signed:
+
+                ```bash
+                dig +noall +answer example.com DNSKEY
+                ```
+
+            2. Confirm the registrar published the DS record in the parent zone:
+
+                ```bash
+                dig +noall +answer example.com DS
+                ```
+
+            3. Confirm a validating resolver accepts the answer:
+
+                ```bash
+                dig +dnssec example.com A
+                ```
+
+            A passing domain returns DNSKEY records, at least one DS record, and an answer carrying the `ad` (authenticated data) flag. An empty `DS` answer means the zone is signed but the chain of trust is broken at the registrar.
+        - id: terraform
+          desc: |
+            To enable DNSSEC with Terraform, sign the zone and publish the delegation:
+
+            ```hcl
+            # Cloudflare - enabling DNSSEC returns the DS values to hand to the registrar
+            resource "cloudflare_zone_dnssec" "example" {
+              zone_id = var.cloudflare_zone_id
+            }
+
+            # AWS Route 53 - sign the zone, then publish the DS at the registrar
+            resource "aws_route53_key_signing_key" "example" {
+              hosted_zone_id             = aws_route53_zone.primary.id
+              key_management_service_arn = aws_kms_key.dnssec.arn
+              name                       = "example-ksk"
+            }
+
+            resource "aws_route53_hosted_zone_dnssec" "example" {
+              depends_on     = [aws_route53_key_signing_key.example]
+              hosted_zone_id = aws_route53_key_signing_key.example.hosted_zone_id
+            }
+            ```
+
+            Terraform can sign the zone, but publishing the DS record at the registrar is a registrar operation. Where the registrar is not the DNS host, complete that step in the registrar's control panel or API.
     refs:
       - url: https://www.icann.org/resources/pages/dnssec-what-is-it-why-is-it-important-2019-03-05-en
         title: ICANN DNSSEC Overview
@@ -282,11 +481,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1584-002
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -305,10 +506,51 @@ queries:
         Run the `dig '*.<domain>'` command and inspect the answer section.
 
         A passing result shows no answer for the wildcard query, indicating no wildcard record is configured. A failing result shows the wildcard query resolving to an IP address or hostname.
-      remediation: |
-        * Avoid wildcard DNS records, such as `*.example.com`, unless a specific and well-documented use case requires one.
-        * Replace wildcard records with explicit DNS records for each required subdomain to maintain precise control over DNS resolution.
-        * If a wildcard record is genuinely required, monitor and secure it to prevent misuse or exploitation.
+      remediation:
+        - id: console
+          desc: |
+            To remove a wildcard record using your DNS provider's control panel:
+
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Find records whose name begins with `*`, such as `*.example.com`, and list the subdomains that legitimately rely on them.
+            3. Create an explicit record for each of those subdomains.
+            4. Delete the wildcard record once the explicit records resolve correctly.
+            5. If a wildcard is genuinely required — a multi-tenant product that provisions customer subdomains on demand, for example — document the reason and monitor which names get requested, since a wildcard answers for every name an attacker invents.
+        - id: cli
+          desc: |
+            To confirm the zone publishes no wildcard record:
+
+            1. Query a name that should not exist:
+
+                ```bash
+                dig +noall +answer this-name-should-not-exist.example.com A
+                ```
+
+            2. Replace any wildcard with explicit records for the subdomains that need them, using your provider's API or CLI.
+            3. Re-run the command. A passing zone returns no answer; a zone with a wildcard still in place returns an address for the invented name.
+        - id: terraform
+          desc: |
+            To replace a wildcard with explicit records in Terraform, declare each subdomain you actually serve:
+
+            ```hcl
+            resource "aws_route53_record" "www" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "www.example.com"
+              type    = "A"
+              ttl     = 300
+              records = ["203.0.113.10"]
+            }
+
+            resource "aws_route53_record" "api" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "api.example.com"
+              type    = "A"
+              ttl     = 300
+              records = ["203.0.113.11"]
+            }
+            ```
+
+            Remove any `name = "*.example.com"` resource once the explicit records are in place.
     refs:
       - url: https://www.cisa.gov/dns-security
         title: CISA DNS Security
@@ -326,6 +568,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-11
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc9-1-1
       compliance/vda-isa-5: vda-isa-5-3-1-2
@@ -346,14 +589,54 @@ queries:
         Run the `dig NS <domain>` command and inspect the answer section.
 
         A passing result shows two or more NS records returned for the domain. A failing result shows a single NS record or none, indicating no nameserver redundancy.
-      remediation: |
-        Configure at least two authoritative nameservers for your domain, ideally hosted on separate networks or with different DNS providers for maximum resilience.
+      remediation:
+        - id: console
+          desc: |
+            To add nameserver redundancy using your DNS provider's control panel:
 
-        Steps to remediate:
-          1. Identify your current nameservers using `dig NS <domain>` and inspecting the answer section.
-          2. If only one nameserver is listed, add a secondary nameserver through your DNS provider or a third-party DNS service.
-          3. Ensure the additional nameserver is on a different network or subnet to avoid correlated failures.
-          4. Verify the configuration using DNS validation tools to confirm all nameservers respond correctly.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Review the `NS` records at the apex. If only one is present, add at least one more.
+            3. Prefer nameservers on separate networks, ideally at a second DNS provider, so a single provider outage cannot take the domain offline. Most managed DNS providers assign four nameservers across distinct networks by default.
+            4. Update the nameserver delegation at the domain registrar so the parent zone lists the same set.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the domain has redundant authoritative nameservers:
+
+            1. Inspect the delegation:
+
+                ```bash
+                dig +noall +answer example.com NS
+                ```
+
+            2. Confirm each one answers authoritatively for the zone:
+
+                ```bash
+                dig @ns1.example.com example.com SOA
+                dig @ns2.example.com example.com SOA
+                ```
+
+            3. A passing domain lists two or more `NS` records and every one returns the SOA. A single `NS` record, or one that fails to answer, is a single point of failure.
+        - id: terraform
+          desc: |
+            To declare redundant nameservers with Terraform:
+
+            ```hcl
+            resource "aws_route53_record" "ns" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "example.com"
+              type    = "NS"
+              ttl     = 172800
+              records = [
+                "ns1.example.com",
+                "ns2.example.com",
+                "ns3.example.net",
+                "ns4.example.net",
+              ]
+            }
+            ```
+
+            Publishing the NS set in the zone is only half of it — the registrar's delegation must list the same nameservers. Where the registrar has a Terraform provider, manage the delegation there too; otherwise update it in the registrar's control panel.
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc1034#section-4.1
         title: 'RFC 1034: Domain Names - Concepts and Facilities'
@@ -366,11 +649,13 @@ queries:
       compliance/dora: dora-art-10
       compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/mitre-attack: mitre-attack-t1568-001
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-de-cm-1
       compliance/nist-csf-2: nist-csf-2-de-cm-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: false
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -389,14 +674,48 @@ queries:
         Run the `dig <domain>` command and inspect the TTL column of the A and AAAA records in the answer section.
 
         A passing result shows every A and AAAA record with a TTL of 60 seconds or greater. A failing result shows an A or AAAA record with a TTL below 60 seconds.
-      remediation: |
-        Review and increase TTL values for A and AAAA records that have been set below 60 seconds.
+      remediation:
+        - id: console
+          desc: |
+            To raise suspiciously low TTLs using your DNS provider's control panel:
 
-        Steps to remediate:
-          1. Identify records with low TTLs using `dig <domain>` and checking the TTL column.
-          2. For production records that are not undergoing migration, set TTLs to at least 300 seconds (5 minutes). Common production values range from 300 to 3600 seconds.
-          3. If low TTLs were set temporarily for a migration or troubleshooting, restore them to normal production values once the change is complete.
-          4. Verify the updated TTL values are in effect by querying the domain and confirming the new TTL is returned.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Review the TTL column for every `A` and `AAAA` record and note any below 60 seconds.
+            3. Set production records to at least 300 seconds. Values between 300 and 3600 are typical.
+            4. If a low TTL was set deliberately to shorten a cutover window, restore the normal value once the migration is finished rather than leaving it in place.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm no address record carries an unusually low TTL:
+
+            1. Inspect the TTL column, which is the second field of each answer:
+
+                ```bash
+                dig +noall +answer example.com A
+                dig +noall +answer example.com AAAA
+                ```
+
+            2. Raise any value below 60 through your provider's API or CLI.
+            3. Re-run the commands against an authoritative nameserver so a cached answer does not show a decremented TTL:
+
+                ```bash
+                dig @ns1.example.com +noall +answer example.com A
+                ```
+        - id: terraform
+          desc: |
+            To set explicit production TTLs with Terraform:
+
+            ```hcl
+            resource "aws_route53_record" "www" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "www.example.com"
+              type    = "A"
+              ttl     = 300
+              records = ["203.0.113.10"]
+            }
+            ```
+
+            Where a short TTL is needed for a planned cutover, change `ttl` in a dedicated commit and revert it once the migration completes, so the low value does not silently become permanent.
     refs:
       - url: https://www.cisa.gov/dns-security
         title: CISA DNS Security

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -64,6 +64,7 @@ policies:
           - uid: mondoo-email-security-dmarc-policy
           - uid: mondoo-email-security-dmarc-rua
           - uid: mondoo-email-security-dmarc-ruf
+    scoring_system: highest impact
 queries:
   - uid: mondoo-email-security-reverse-ip-ptr-record-set
     title: Ensure Reverse IP Lookup PTR record is set (DNS Forward confirmed)
@@ -79,6 +80,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
@@ -109,28 +111,66 @@ queries:
         ```text
         123.123.123.123.in-addr.arpa  name = mail.example.com.
         ```
-      remediation: |
-        Set up valid reverse DNS records for the IP addresses of your outbound mail servers. Reverse DNS ensures that when a receiving mail server performs a lookup on the sending IP, it resolves to a fully qualified domain name associated with your organization's domain. This helps validate the authenticity of your emails and reduces the likelihood of your messages being marked as spam.
+      remediation:
+        - id: console
+          desc: |
+            A PTR record lives in the reverse zone for the IP address, which is controlled by whoever owns the IP range, not by your domain registrar. To publish one:
 
-        For example, if mail.lunalectric.com sends email from the IP address 123.123.123.123, the reverse DNS for that IP should resolve to a name within your domain, such as mail.lunalectric.com.
+            1. Identify the public IP addresses your outbound mail servers send from.
+            2. Sign in to the control panel of the hosting or cloud provider that owns those addresses and open its reverse DNS or PTR settings. On most clouds this is a property of the instance or the allocated public IP, not of your DNS zone.
+            3. Set the PTR for each address to a fully qualified hostname in your own domain, such as `mail.lunalectric.com`.
+            4. In your own DNS zone, publish a matching forward `A` record so `mail.lunalectric.com` resolves back to the same address. Without both halves the lookup is not forward-confirmed.
+            5. Where the provider does not expose PTR settings, open a support request naming the address and the desired hostname.
+        - id: cli
+          desc: |
+            To confirm the round trip resolves in both directions:
 
-        Steps to configure reverse DNS:
-          1.  Identify the public IP addresses of your mail servers.
-          2.  Contact your hosting provider or whoever controls the IP range to request that a PTR record be set for each IP.
-          3.  Ensure each PTR record resolves to a valid fully qualified domain name like mail.lunalectric.com.
-          4.  Confirm that the forward DNS for mail.lunalectric.com also resolves back to 123.123.123.123 to establish a valid forward-confirmed reverse DNS match.
+            1. Look up the PTR for the sending address:
 
-        You can verify the reverse DNS setup with `dig -x`, which queries the PTR record directly:
+                ```bash
+                dig -x 203.0.113.10 +short
+                ```
 
-        ```bash
-        dig -x 123.123.123.123 +short
-        ```
+                A configured address returns a hostname such as `mail.lunalectric.com.`
 
-        A properly configured setup will show:
+            2. Look up the forward record for that hostname:
 
-        ```text
-        123.123.123.123.in-addr.arpa  name = mail.lunalectric.com.
-        ```
+                ```bash
+                dig +short A mail.lunalectric.com
+                ```
+
+            3. The check passes only when step 2 returns the address used in step 1. A PTR that points at a hostname which resolves elsewhere, or not at all, is not forward-confirmed and receiving mail servers treat it as unverified.
+        - id: terraform
+          desc: |
+            To publish the forward record and, where the provider supports it, the PTR:
+
+            ```hcl
+            # Forward record in your own zone
+            resource "aws_route53_record" "mail" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "mail.lunalectric.com"
+              type    = "A"
+              ttl     = 3600
+              records = ["203.0.113.10"]
+            }
+
+            # Reverse record, set on the IP allocation rather than the domain zone
+            resource "google_compute_instance" "mail" {
+              name         = "mail"
+              machine_type = "e2-medium"
+              zone         = "us-central1-a"
+
+              network_interface {
+                network = "default"
+                access_config {
+                  nat_ip                 = google_compute_address.mail.address
+                  public_ptr_domain_name = "mail.lunalectric.com."
+                }
+              }
+            }
+            ```
+
+            AWS does not expose EC2 reverse DNS through Terraform; request the PTR for an Elastic IP through AWS Support and manage only the forward record here.
     refs:
       - url: https://en.wikipedia.org/wiki/Reverse_DNS_lookup
         title: Reverse DNS Lookup
@@ -152,6 +192,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/owasp-top-10-2025: false
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
@@ -182,28 +223,43 @@ queries:
         ```
 
         If one or more TXT records are returned, the check passes. If the output is empty, the check fails.
-      remediation: |
-        Add at least one TXT record to your DNS zone file. TXT records hold domain ownership verification tokens and email authentication policies. If your domain has no TXT records yet, publishing your SPF policy is the most useful first record:
+      remediation:
+        - id: console
+          desc: |
+            To publish a TXT record at the domain apex using your DNS provider's control panel:
 
-        ```dns
-        lunalectric.com. IN TXT "v=spf1 include:_spf.google.com ~all"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Add a `TXT` record with the name left blank or set to `@`, which both mean the apex.
+            3. If the domain has no TXT records at all, the SPF policy is the most useful first one to publish: `v=spf1 include:_spf.google.com ~all`, adjusted to the mail services the domain actually uses.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the apex publishes at least one TXT record:
 
-        Replace the include mechanism with the mail services your domain actually uses.
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        You can verify that the TXT record was added correctly using the following command:
+            A configured domain returns one or more quoted strings, for example:
 
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
+            ```text
+            "v=spf1 include:_spf.google.com ~all"
+            ```
 
-        Example output:
+            No output means the apex has no TXT record.
+        - id: terraform
+          desc: |
+            To publish an apex TXT record with Terraform:
 
-        ```text
-        "v=spf1 include:_spf.google.com ~all"
-        ```
-
-        If the command returns no output, no TXT record is set.
+            ```hcl
+            resource "aws_route53_record" "apex_txt" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://en.wikipedia.org/wiki/TXT_record
         title: TXT Record
@@ -221,6 +277,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-1
+      compliance/owasp-top-10-2025: false
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
@@ -244,20 +301,37 @@ queries:
         Run the `dig +short A <domain>` command and verify that an A record is returned.
 
         If the command returns one or more IPv4 addresses, the check passes. If the output is empty or returns `NXDOMAIN`, the check fails.
-      remediation: |
-        Add an A record for the domain apex to your DNS zone file. If you're not hosting a dedicated service on the root domain, consider pointing the A record to a web server that redirects visitors to your main corporate website.
+      remediation:
+        - id: console
+          desc: |
+            To publish an address record at the domain apex using your DNS provider's control panel:
 
-        ```dns
-        lunalectric.com. IN A 203.0.113.10
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Add an `A` record with the name left blank or set to `@`, pointing to the server that serves the root domain.
+            3. If nothing is hosted on the root domain, point it at a web server that redirects to your main site rather than leaving the apex unresolvable.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the apex resolves to an address:
 
-        To verify that an A record exists for your domain, run the following command:
+            ```bash
+            dig +short A lunalectric.com
+            ```
 
-        ```bash
-        dig +short A lunalectric.com
-        ```
+            A configured domain returns the address of the server hosting the root domain. No output means the apex has no `A` record.
+        - id: terraform
+          desc: |
+            To publish an apex address record with Terraform:
 
-        The output should show the IP address of the server that hosts your website. If the command returns no output, the A record is not set up.
+            ```hcl
+            resource "aws_route53_record" "apex_a" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "A"
+              ttl     = 300
+              records = ["203.0.113.10"]
+            }
+            ```
     refs:
       - url: https://www.easyredir.com/blog/what-is-an-apex-domain/
         title: A Record
@@ -270,11 +344,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -299,22 +375,38 @@ queries:
         Run the `dig +short TXT <domain>` command and look for a record beginning with `v=spf1`.
 
         If exactly one TXT record starting with `v=spf1` is returned, the check passes. If no such record is returned, the check fails.
-      remediation: |
-        Add a single TXT record to your DNS zone file listing every server allowed to send mail for the domain, ending with an `all` mechanism that tells receivers how to treat everyone else:
+      remediation:
+        - id: console
+          desc: |
+            To publish an SPF policy using your DNS provider's control panel:
 
-        ```dns
-        lunalectric.com. IN TXT "v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Add a single `TXT` record at the apex (name blank or `@`) listing every server allowed to send mail for the domain, for example `v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all`.
+            3. Use only the `include`, `ip4`, `ip6`, `a`, and `mx` mechanisms for senders you actually use. Authorizing a provider you do not use weakens the policy; omitting one you do use makes legitimate mail fail.
+            4. Choose the trailing qualifier deliberately. `~all` (soft fail) marks unlisted senders suspicious and is the safe starting point; `-all` (hard fail) tells receivers to reject them and is the recommended end state.
+            5. Save the zone, confirm from DMARC aggregate reports that every legitimate sender passes, then tighten `~all` to `-all`.
+        - id: cli
+          desc: |
+            To confirm the domain publishes exactly one SPF policy:
 
-        Replace the mechanisms with the `include`, `ip4`, `ip6`, `a`, or `mx` mechanisms for your own senders. Only list mechanisms for senders you actually use. Authorizing providers you don't use weakens the policy, and omitting providers you do use causes legitimate mail to fail SPF checks. The trailing qualifier decides the outcome for unlisted servers: `-all` (hard fail) tells receivers to reject them and is the recommended end state, while `~all` (soft fail) only marks them suspicious. Roll out with `~all` first, confirm from your DMARC aggregate reports that all legitimate senders pass, then tighten to `-all`.
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        You can verify that the SPF record was added correctly using the following command:
+            The output must include one record starting with `v=spf1`. No such record means SPF is not configured.
+        - id: terraform
+          desc: |
+            To publish the SPF record with Terraform:
 
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        The output should include the SPF record you added. If no record starting with `v=spf1` is returned, the SPF record is not set up.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://en.wikipedia.org/wiki/Sender_Policy_Framework
         title: SPF Record
@@ -327,11 +419,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -355,31 +449,38 @@ queries:
         Run the `dig +short TXT <domain>` command and count the records beginning with `v=spf1`.
 
         If zero or one record starting with `v=spf1` is returned, the check passes. If two or more such records are returned, the check fails.
-      remediation: |
-        Merge all SPF records into a single TXT record, then delete the others. Receivers treat multiple records starting with `v=spf1` as a permanent error, but the mechanisms from every record must be combined into one before any record is removed.
+      remediation:
+        - id: console
+          desc: |
+            Receivers treat two records starting with `v=spf1` as a permanent error, so the policy fails open. Merge them rather than deleting one:
 
-        For example, replace these two records:
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. List every apex `TXT` record starting with `v=spf1` and collect the mechanisms from all of them.
+            3. Create one combined record carrying every mechanism, for example merging `v=spf1 include:_spf.google.com ~all` and `v=spf1 ip4:203.0.113.10 ~all` into `v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all`.
+            4. Delete the remaining SPF records only after the merged record is in place. Removing one without carrying its mechanisms across silently stops authorizing those senders.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm only one SPF policy is published:
 
-        ```text
-        "v=spf1 include:_spf.google.com ~all"
-        "v=spf1 ip4:203.0.113.10 ~all"
-        ```
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        with this single record:
+            Exactly one returned string may start with `v=spf1`. Two or more is a permanent error and SPF stops protecting the domain entirely.
+        - id: terraform
+          desc: |
+            To keep a single merged SPF record under Terraform, declare one resource carrying every mechanism:
 
-        ```dns
-        lunalectric.com. IN TXT "v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all"
-        ```
-
-        Do not simply delete the extra records. Removing a record without merging its mechanisms causes mail from those senders to fail SPF checks.
-
-        You can verify the result using the following command:
-
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        The output should show exactly one record starting with `v=spf1`.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 ip4:203.0.113.10 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://en.wikipedia.org/wiki/Sender_Policy_Framework
         title: SPF Record
@@ -397,6 +498,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -420,16 +522,38 @@ queries:
         Run the `dig +short TXT <domain>` command and measure the length of the record beginning with `v=spf1`.
 
         If the SPF record is 255 characters or fewer, the check passes. If it exceeds 255 characters, the check fails.
-      remediation: |
-        SPF records have two limits to respect: the 255-character limit on a single DNS string this check measures, and a separate hard limit of 10 DNS lookups (each `include`, `a`, `mx`, `ptr`, and `exists` mechanism counts) that breaks SPF evaluation when exceeded. Don't just delete entries, since that silently stops authorizing legitimate senders. Instead, consolidate: remove `include:` mechanisms for services you no longer use, merge providers where possible, and "flatten" includes by replacing an `include:` with the `ip4:` and `ip6:` addresses it resolves to, which cuts both the length and the lookup count.
+      remediation:
+        - id: console
+          desc: |
+            SPF has two separate limits: the 255-character cap on a single DNS string that this check measures, and a hard cap of 10 DNS lookups (each `include`, `a`, `mx`, `ptr`, and `exists` counts) that breaks evaluation when exceeded. Shorten the record by consolidating, not by deleting senders:
 
-        You can verify the SPF record using the following command:
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Remove `include:` mechanisms for services the domain no longer sends through.
+            3. Merge providers where one `include` already covers another.
+            4. Flatten an `include:` by replacing it with the `ip4:` and `ip6:` addresses it resolves to. This cuts both the character count and the lookup count, at the cost of having to track the provider's address changes yourself.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To measure the published record:
 
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
+            ```bash
+            dig +short TXT lunalectric.com | grep 'v=spf1' | wc -c
+            ```
 
-        The record starting with `v=spf1` should be 255 characters or fewer.
+            The record starting with `v=spf1` must be 255 characters or fewer.
+        - id: terraform
+          desc: |
+            To keep the record short under Terraform, prefer explicit addresses over deep include chains:
+
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 ip4:203.0.113.10 ip4:203.0.113.11 -all"]
+            }
+            ```
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc7208#section-3.3
         title: Sender Policy Framework (SPF) for Authorizing Use of Domains in Email, Version 1
@@ -447,6 +571,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -470,26 +595,37 @@ queries:
         Run the `dig +short TXT <domain>` command and inspect the record beginning with `v=spf1` for runs of consecutive spaces.
 
         If the SPF record contains no excess whitespace, the check passes. If it contains two or more consecutive spaces, the check fails.
-      remediation: |
-        Edit your SPF record so its mechanisms are separated by single spaces, with no leading or trailing whitespace. For example, replace:
+      remediation:
+        - id: console
+          desc: |
+            To normalize whitespace in the SPF record using your DNS provider's control panel:
 
-        ```text
-        "v=spf1  include:_spf.google.com   ~all"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the apex `TXT` record starting with `v=spf1` so mechanisms are separated by exactly one space, with no leading or trailing whitespace.
+            3. For example, replace `v=spf1  include:_spf.google.com   ~all` with `v=spf1 include:_spf.google.com ~all`.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To inspect the published record for doubled spaces:
 
-        with:
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        ```text
-        "v=spf1 include:_spf.google.com ~all"
-        ```
+            The record starting with `v=spf1` must contain no consecutive spaces.
+        - id: terraform
+          desc: |
+            To publish a normalized record with Terraform:
 
-        You can verify the SPF record using the following command:
-
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        The record starting with `v=spf1` should contain no consecutive spaces.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://en.wikipedia.org/wiki/Sender_Policy_Framework
         title: SPF Record
@@ -502,11 +638,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -528,25 +666,38 @@ queries:
         Run the `dig +short TXT <domain>` command and inspect the end of the record beginning with `v=spf1`.
 
         If the SPF record ends with `-all` (hard fail) or `~all` (soft fail), the check passes. If it ends with any other mechanism or omits an `all` mechanism, the check fails.
-      remediation: |
-        End your SPF record with `-all` or `~all` so receivers know how to treat mail from servers you have not authorized. A bare `all` or `+all` permits every sender and must not be used.
+      remediation:
+        - id: console
+          desc: |
+            The trailing `all` mechanism decides what receivers do with mail from servers you have not authorized. A bare `all` or `+all` permits everyone and must not be used:
 
-        - `~all` marks mail from unauthorized servers as a soft fail. Receivers typically accept the message but treat it with suspicion. This is the safer choice while you confirm that every legitimate sender is listed in the record.
-        - `-all` tells receivers to reject mail from unauthorized servers. Move to this once your DMARC reports show that all legitimate mail passes SPF.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the apex `TXT` record starting with `v=spf1` so it ends with `~all` or `-all`.
+            3. `~all` is a soft fail: receivers usually accept the message but treat it as suspicious. Use it while confirming every legitimate sender is listed.
+            4. `-all` is a hard fail: receivers reject the mail. Move to it once DMARC reports show all legitimate mail passes SPF.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the record ends with a failing qualifier:
 
-        Example:
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        ```dns
-        lunalectric.com. IN TXT "v=spf1 include:_spf.google.com ~all"
-        ```
+            The record starting with `v=spf1` must end with `-all` or `~all`.
+        - id: terraform
+          desc: |
+            To publish a record with a failing qualifier under Terraform:
 
-        You can verify the SPF record using the following command:
-
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        The record starting with `v=spf1` should end with `-all` or `~all`.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -559,11 +710,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -601,27 +754,37 @@ queries:
         ```text
         "v=spf1 include:_spf.google.com -all"
         ```
-      remediation: |
-        Replace `+all` in your SPF record with `~all` or `-all`.
+      remediation:
+        - id: console
+          desc: |
+            `+all` authorizes every server on the internet to send as your domain, which is worse than publishing no SPF at all. Replace it, but list your real senders first:
 
-        - `~all`: Instructs receivers to flag email from unauthorized servers as suspicious but still deliver it.
-        - `-all`: Instructs receivers to reject email from unauthorized servers.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Before tightening the qualifier, add the `include`, `ip4`, `ip6`, `a`, and `mx` mechanisms for every service that legitimately sends mail for the domain. A record such as `v=spf1 +all` authorizes everything, so it has never been tested against your real senders.
+            3. Replace `+all` with `~all` and save the zone.
+            4. Review DMARC aggregate reports for legitimate senders failing SPF, fix them, then tighten to `-all`.
+        - id: cli
+          desc: |
+            To confirm the permissive qualifier is gone:
 
-        Before publishing the change, make sure the record lists every service that legitimately sends email for your domain. A record such as `v=spf1 +all` authorizes everything, so tightening it without listing your real senders causes legitimate mail to fail SPF checks. Start with `~all`, monitor your DMARC aggregate reports for legitimate senders failing SPF, then move to `-all`.
+            ```bash
+            dig +short TXT lunalectric.com
+            ```
 
-        Example:
+            The record starting with `v=spf1` must end with `-all` or `~all`, never `+all` or a bare `all`.
+        - id: terraform
+          desc: |
+            To publish a restrictive qualifier with Terraform:
 
-        ```dns
-        lunalectric.com. IN TXT "v=spf1 include:_spf.google.com -all"
-        ```
-
-        You can verify the change using the following command:
-
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        Ensure the output shows `-all` or `~all` at the end of the SPF record.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 include:_spf.google.com -all"]
+            }
+            ```
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc7208#section-5.1
         title: 'RFC 7208: Sender Policy Framework - "all" Mechanism'
@@ -641,6 +804,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -664,25 +828,38 @@ queries:
         Run the `dig +short SPF <domain>` command to query for the deprecated `SPF` DNS record type.
 
         If the command returns no records, the check passes. If any `SPF`-type record is returned, the check fails.
-      remediation: |
-        Publish your SPF policy as a TXT record, then delete any records of the deprecated SPF record type from your DNS zone. RFC 7208 obsoleted the dedicated SPF record type, and receivers only evaluate the TXT version.
+      remediation:
+        - id: console
+          desc: |
+            RFC 7208 obsoleted the dedicated SPF record type; receivers only evaluate the TXT version. Remove the deprecated record, but confirm the TXT record carries the policy first:
 
-        1. Confirm a TXT record starting with `v=spf1` exists at the domain apex. If your SPF policy only exists in the SPF-type record, copy its content into a TXT record first. If both record types exist, compare them before deleting anything — the deprecated SPF-type record may have drifted from the TXT version, and the TXT record must carry the policy you intend to keep.
-        2. Remove the SPF-type record from your DNS zone.
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Confirm an apex `TXT` record starting with `v=spf1` exists. If the policy lives only in the SPF-type record, copy it into a TXT record first.
+            3. If both exist, compare them before deleting anything. The deprecated record may have drifted, and the TXT record must end up carrying the policy you intend to keep.
+            4. Delete the record of type `SPF` and save the zone.
+        - id: cli
+          desc: |
+            To confirm no deprecated SPF-type record remains while the TXT policy is intact:
 
-        You can verify that no SPF-type record remains using the following command:
+            ```bash
+            dig +short SPF lunalectric.com
+            dig +short TXT lunalectric.com
+            ```
 
-        ```bash
-        dig +short SPF lunalectric.com
-        ```
+            The first command must return no output. The second must still include the record starting with `v=spf1`.
+        - id: terraform
+          desc: |
+            To publish the policy as TXT under Terraform, declare only a `TXT` resource and remove any resource declaring the deprecated SPF record type:
 
-        The command should return no output. Then confirm the TXT version is still in place:
-
-        ```bash
-        dig +short TXT lunalectric.com
-        ```
-
-        The output should include your record starting with `v=spf1`.
+            ```hcl
+            resource "aws_route53_record" "spf" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=spf1 include:_spf.google.com ~all"]
+            }
+            ```
     refs:
       - url: https://en.wikipedia.org/wiki/Sender_Policy_Framework#DNS_SPF_Records
         title: DNS SPF Records
@@ -695,11 +872,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -727,24 +906,40 @@ queries:
         ```text
         _dmarc.lunalectric.com.  300 IN TXT "v=DMARC1; p=reject; pct=100; rua=mailto:dmarc-aggregate@lunalectric.com; ruf=mailto:dmarc-forensic@lunalectric.com; fo=1;"
         ```
-      remediation: |
-        Add a TXT record for the `_dmarc` subdomain to your DNS zone file. Start with a monitoring policy and a reporting address you control:
+      remediation:
+        - id: console
+          desc: |
+            DMARC is published as a TXT record on the `_dmarc` subdomain. Start in monitoring mode so you can see who sends as your domain before enforcing anything:
 
-        ```dns
-        _dmarc.lunalectric.com. IN TXT "v=DMARC1; p=none; rua=mailto:dmarc-aggregate@lunalectric.com;"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Add a `TXT` record named `_dmarc` with the value `v=DMARC1; p=none; rua=mailto:dmarc-aggregate@lunalectric.com;`.
+            3. The `rua` tag must point to a mailbox, not a bare domain.
+            4. Review the aggregate reports that arrive, fix any legitimate sender failing SPF or DKIM, then raise the policy to `p=quarantine` and finally `p=reject`. Going straight to `p=reject` rejects legitimate mail that has not yet been fixed.
+            5. Save the zone.
 
-        The `rua` tag must point to a mailbox, not a bare domain. Review the aggregate reports it receives, fix any legitimate senders that fail authentication, then raise the policy to `p=quarantine` and finally `p=reject`. Moving straight to `p=reject` before all legitimate mail passes SPF or DKIM causes that mail to be rejected.
+            The separate DMARC policy check fails while `p=none` is in place. That is expected during monitoring and resolves when you raise the policy.
+        - id: cli
+          desc: |
+            To confirm the DMARC record is published:
 
-        Note that the separate DMARC policy enforcement check in this policy fails while `p=none` is in place; that is expected during the monitoring phase and resolves when you raise the policy to `p=quarantine` or `p=reject`.
+            ```bash
+            dig +short TXT _dmarc.lunalectric.com
+            ```
 
-        You can verify that the DMARC record was added correctly using the following command:
+            A configured domain returns a record starting with `v=DMARC1`. No output means DMARC is not set up. Note the record lives at `_dmarc.<domain>`, not at the apex.
+        - id: terraform
+          desc: |
+            To publish the DMARC record with Terraform:
 
-        ```bash
-        dig +short TXT _dmarc.lunalectric.com
-        ```
-
-        The output should show the DMARC record you added. If the command returns no output, the DMARC record is not set up.
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "_dmarc.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=none; rua=mailto:dmarc-aggregate@lunalectric.com;"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -759,11 +954,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -790,20 +987,37 @@ queries:
         ```text
         _dmarc.lunalectric.com.  300 IN TXT "v=DMARC1; p=reject; pct=100; rua=mailto:dmarc-aggregate@lunalectric.com; ruf=mailto:dmarc-forensic@lunalectric.com; fo=1;"
         ```
-      remediation: |
-        Publish your DMARC record as a TXT record on the `_dmarc` subdomain and make sure it begins with the `v=DMARC1` version tag. The version tag must be the first tag in the record or receivers ignore the policy entirely. The example uses `p=quarantine` because this check assumes an established DMARC record; if you are setting up DMARC for the first time, start with `p=none` as described in the DMARC record check:
+      remediation:
+        - id: console
+          desc: |
+            The version tag must be the first tag in the record or receivers ignore the policy entirely:
 
-        ```dns
-        _dmarc.lunalectric.com. IN TXT "v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the `TXT` record named `_dmarc` so it begins with `v=DMARC1`, before any other tag.
+            3. A complete record looks like `v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;`. If you are setting DMARC up for the first time, start with `p=none` instead and raise it once reports are clean.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the version tag leads the record:
 
-        You can verify that the DMARC record was added correctly using the following command:
+            ```bash
+            dig +short TXT _dmarc.lunalectric.com
+            ```
 
-        ```bash
-        dig +short TXT _dmarc.lunalectric.com
-        ```
+            The returned record must start with `v=DMARC1`.
+        - id: terraform
+          desc: |
+            To publish a correctly versioned record with Terraform:
 
-        The output should start with `v=DMARC1`. If the command returns no output, the DMARC record is not set up.
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "_dmarc.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -818,11 +1032,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ac-5
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -847,27 +1063,38 @@ queries:
         Run the `dig +short TXT _dmarc.<domain>` command and inspect the `p=` tag in the DMARC record.
 
         If the policy is set to `p=quarantine` or `p=reject`, the check passes. If the policy is `p=none` or absent, the check fails.
-      remediation: |
-        Set the `p=` policy tag to `quarantine` or `reject` in your `_dmarc` TXT record. The policy tells receivers what to do with mail that fails authentication: `quarantine` sends it to spam, `reject` blocks it outright.
+      remediation:
+        - id: console
+          desc: |
+            The `p=` tag tells receivers what to do with mail that fails authentication. `p=none` only monitors, so it stops nobody from spoofing the domain:
 
-        ```dns
-        _dmarc.lunalectric.com. IN TXT "v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the `TXT` record named `_dmarc` and set `p=quarantine` (failing mail goes to spam) or `p=reject` (failing mail is blocked outright).
+            3. Roll it out in stages to avoid losing legitimate mail: start at `p=none` with a `rua` address, review the aggregate reports, fix any legitimate sender failing SPF or DKIM alignment, move to `p=quarantine`, then to `p=reject`.
+            4. The optional `pct=` tag applies the policy to a fraction of mail during the transition.
+            5. Save the zone.
+        - id: cli
+          desc: |
+            To confirm the policy is enforcing:
 
-        Roll the policy out in stages to avoid losing legitimate mail:
+            ```bash
+            dig +short TXT _dmarc.lunalectric.com
+            ```
 
-        1. Start with `p=none` and a `rua` reporting address, then review the aggregate reports.
-        2. Fix any legitimate senders that fail SPF or DKIM alignment.
-        3. Move to `p=quarantine`, optionally using the `pct` tag to apply it to a fraction of mail at first.
-        4. Move to `p=reject` once reports show all legitimate mail passes.
+            The returned record must contain `p=quarantine` or `p=reject`. `p=none` is monitoring only and does not satisfy this check.
+        - id: terraform
+          desc: |
+            To publish an enforcing policy with Terraform:
 
-        You can verify the record using the following command:
-
-        ```bash
-        dig +short TXT _dmarc.lunalectric.com
-        ```
-
-        The output should show `p=quarantine` or `p=reject`.
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "_dmarc.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -887,6 +1114,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -910,22 +1138,37 @@ queries:
         Run the `dig +short TXT _dmarc.<domain>` command and inspect the DMARC record for a `rua=mailto:` tag.
 
         If the record includes a `rua=mailto:` tag pointing to an aggregate report mailbox, the check passes. If the tag is absent, the check fails.
-      remediation: |
-        Add a `rua` tag to the DMARC record on the `_dmarc` subdomain. The tag takes a `mailto:` URI pointing to the mailbox that should receive aggregate reports:
+      remediation:
+        - id: console
+          desc: |
+            Aggregate reports are how you find out who is sending as your domain. Without a `rua` address, DMARC runs blind:
 
-        ```dns
-        _dmarc.lunalectric.com. IN TXT "v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the `TXT` record named `_dmarc` and add a `rua=` tag holding a `mailto:` URI, for example `rua=mailto:dmarc-aggregate@lunalectric.com`.
+            3. If the reporting mailbox is on a different domain from the one publishing the record, that domain must publish an external reporting authorization record before providers will send reports to it.
+            4. Save the zone.
+        - id: cli
+          desc: |
+            To confirm an aggregate reporting address is published:
 
-        If the reporting mailbox is on a different domain than the one publishing the record, the receiving domain must publish a DMARC external reporting authorization record before mail providers will send your reports to it.
+            ```bash
+            dig +short TXT _dmarc.lunalectric.com
+            ```
 
-        You can verify the record using the following command:
+            The returned record must include a `rua=mailto:` tag pointing at your reporting mailbox.
+        - id: terraform
+          desc: |
+            To publish a reporting address with Terraform:
 
-        ```bash
-        dig +short TXT _dmarc.lunalectric.com
-        ```
-
-        The output should include a `rua=mailto:` tag pointing to your reporting mailbox.
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "_dmarc.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com;"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -945,6 +1188,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -968,22 +1212,37 @@ queries:
         Run the `dig +short TXT _dmarc.<domain>` command and inspect the DMARC record for a `ruf=mailto:` tag.
 
         If the record includes a `ruf=mailto:` tag pointing to a failure report mailbox, the check passes. If the tag is absent, the check fails.
-      remediation: |
-        Add a `ruf` tag to the DMARC record on the `_dmarc` subdomain. The tag takes a `mailto:` URI pointing to the mailbox that should receive failure reports:
+      remediation:
+        - id: console
+          desc: |
+            Failure reports carry per-message detail about mail that failed authentication:
 
-        ```dns
-        _dmarc.lunalectric.com. IN TXT "v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com; ruf=mailto:dmarc-forensic@lunalectric.com; fo=1;"
-        ```
+            1. Sign in to the control panel for the provider that hosts the zone and open the DNS records for the domain.
+            2. Edit the `TXT` record named `_dmarc` and add a `ruf=` tag holding a `mailto:` URI, optionally with `fo=1` to request reports whenever any mechanism fails.
+            3. Failure reports can include full message content, so route them to a restricted security mailbox and confirm this fits your privacy and compliance obligations.
+            4. Save the zone. Many large providers no longer send failure reports, so receiving few or none is normal.
+        - id: cli
+          desc: |
+            To confirm a failure reporting address is published:
 
-        Failure reports can include full message content, so route them to a restricted security mailbox and confirm this fits your privacy and compliance requirements. Many large mail providers no longer send failure reports, so receiving few or none is normal.
+            ```bash
+            dig +short TXT _dmarc.lunalectric.com
+            ```
 
-        You can verify the record using the following command:
+            The returned record must include a `ruf=mailto:` tag pointing at your reporting mailbox.
+        - id: terraform
+          desc: |
+            To publish a failure reporting address with Terraform:
 
-        ```bash
-        dig +short TXT _dmarc.lunalectric.com
-        ```
-
-        The output should include a `ruf=mailto:` tag pointing to your reporting mailbox.
+            ```hcl
+            resource "aws_route53_record" "dmarc" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "_dmarc.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DMARC1; p=quarantine; rua=mailto:dmarc-aggregate@lunalectric.com; ruf=mailto:dmarc-forensic@lunalectric.com; fo=1;"]
+            }
+            ```
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
@@ -996,11 +1255,13 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1566
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1040,24 +1301,40 @@ queries:
         Run the `dig +short TXT <selector>._domainkey.<domain>` command for each DKIM selector your mail provider uses.
 
         If the record returns a DKIM key containing `p=` (the public key) and `k=rsa`, the check passes. If no record is returned or the key material is missing, the check fails.
-      remediation: |
-        DKIM keys are generated by your mail provider, such as Google Workspace, Microsoft 365, or Mailjet, not hand-authored. Enable DKIM in the provider's admin console and it gives you the exact TXT record to publish. The record names a key type in the `k=rsa` tag and the base64-encoded public key in the `p=` tag. The matching private key stays with the provider and signs your outgoing mail.
+      remediation:
+        - id: console
+          desc: |
+            DKIM keys are generated by your mail provider, not hand-authored. Enable DKIM in the provider's admin console and it gives you the exact record to publish:
 
-        Publish the TXT record the provider gives you in your DNS zone file. The `p=` value is a long base64 string, truncated here:
+            1. Sign in to your mail provider's admin console (Google Workspace, Microsoft 365, Mailjet, and so on) and generate a DKIM key. Use RSA 2048-bit or stronger.
+            2. Copy the `TXT` record the provider displays. It is published at `<selector>._domainkey.<domain>` and carries `v=DKIM1`, a `k=` key type, and the base64 public key in `p=`. The private key stays with the provider and signs outgoing mail.
+            3. Sign in to the control panel for the provider that hosts the zone and publish that record.
+            4. Return to the mail provider's console and turn on DKIM signing. Publishing the record alone does not sign anything.
+            5. If your provider uses a selector other than the common defaults (`google`, `selector1`, `selector2`, `k1`, `dkim`, `mx`, `mailjet`), add it to the `mondooEmailSecurityDkimSelectors` property so this check queries the right name.
+        - id: cli
+          desc: |
+            To confirm the DKIM public key is published for a selector:
 
-        ```dns
-        google._domainkey.lunalectric.com. IN TXT "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA..."
-        ```
+            ```bash
+            dig +short TXT google._domainkey.lunalectric.com
+            ```
 
-        Use an RSA key of at least 2048 bits. After publishing the record, enable DKIM signing in your mail provider's admin console so outgoing mail is actually signed. If your provider uses a selector other than the common defaults such as `google`, `selector1`, or `k1`, add it to the `mondooEmailSecurityDkimSelectors` property so the right selector is queried.
+            The returned record must contain `k=rsa` and a `p=` tag holding the public key. No output means either the record is missing or the selector differs from the one queried.
+        - id: terraform
+          desc: |
+            To publish the DKIM public key with Terraform:
 
-        You can verify that the DKIM record was added correctly using the following command:
+            ```hcl
+            resource "aws_route53_record" "dkim" {
+              zone_id = aws_route53_zone.primary.zone_id
+              name    = "google._domainkey.lunalectric.com"
+              type    = "TXT"
+              ttl     = 3600
+              records = ["v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA..."]
+            }
+            ```
 
-        ```bash
-        dig +short TXT google._domainkey.lunalectric.com
-        ```
-
-        The output should show a record containing `k=rsa` and a `p=` tag holding the public key. If the command returns no output, the DKIM record is not set up.
+            The `p=` value comes from the mail provider and is a long base64 string, truncated here. Terraform publishes the public half only; enabling signing remains a console or API action against the mail provider.
     refs:
       - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.5
+    version: 1.2.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -66,6 +66,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-4
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -161,6 +163,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-3
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -285,11 +289,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -382,11 +389,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/mitre-attack: mitre-attack-t1592-002
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-asvs-5: owasp-asvs-5-13-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -531,11 +541,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/mitre-attack: mitre-attack-t1592-002
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-asvs-5: owasp-asvs-5-13-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -626,11 +639,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/mitre-attack: mitre-attack-t1592-002
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-asvs-5: owasp-asvs-5-13-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -726,11 +742,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/mitre-attack: mitre-attack-t1592-002
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-ds-1
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-asvs-5: owasp-asvs-5-13-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -832,6 +851,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-asvs-5: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -927,6 +948,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -1038,6 +1061,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
@@ -1127,11 +1152,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1216,11 +1244,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-3-4-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1306,11 +1337,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-3-7-4
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security
-    version: 1.7.3
+    version: 1.7.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -70,11 +70,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -231,6 +234,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -393,6 +398,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -548,6 +555,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -686,11 +695,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -863,11 +875,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-4
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1080,6 +1095,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-11-4-3
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -1250,11 +1267,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1444,11 +1464,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -1566,11 +1589,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1691,11 +1717,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -1813,11 +1842,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -1935,11 +1967,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2071,11 +2106,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2215,11 +2253,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2356,6 +2397,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2508,6 +2551,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-13
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2643,11 +2688,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1040
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -2785,11 +2833,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -2943,11 +2994,14 @@ queries:
       compliance/dora: dora-art-9
       compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
       compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/mitre-attack: mitre-attack-t1557
       compliance/nis-2: nis-2-21-2-h
       compliance/nist-csf-1: nist-csf-1-pr-ds-2
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-2-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -3135,6 +3189,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -3269,6 +3325,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: owasp-asvs-5-12-1-4
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -3445,6 +3503,8 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-15
+      compliance/owasp-asvs-5: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2


### PR DESCRIPTION
This PR adds OWASP and MITRE ATT&CK compliance mappings to the TLS / DNS / HTTP / email policies and normalizes some metadata. **It deliberately changes no check logic.**

## What changed

Three new tag keys across the four network-surface policies:

| Key | Scope |
|---|---|
| `compliance/owasp-top-10-2025` | all four policies |
| `compliance/owasp-asvs-5` | TLS + HTTP only |
| `compliance/mitre-attack` | all four policies |

ASVS is scoped to TLS and HTTP on purpose. ASVS 5.0 has no requirements covering DNSSEC, SPF, DKIM, or DMARC, so adding the key to DNS and email would mean a column that only ever says "no".

Plus two metadata changes:

- `scoring_system: highest impact` on the DNS and email policies, which TLS and HTTP — and 39 of 50 policies repo-wide — already set. **This changes reported scores**, though not which checks pass.
- DNS and email `remediation:` converted from a single plain string to the structured `- id: console|cli|terraform` blocks TLS and HTTP already use, across all 24 checks.

## How the mappings were derived

Every mapping came from reading the check's `mql:`, not its title. Every ATT&CK technique ID was verified against attack.mitre.org rather than recalled — several turned out to anchor unusually well:

- **T1566 Phishing** lists SPF, DKIM, and DMARC in its own mitigation text, which anchors the email anti-spoofing checks.
- **T1557 Adversary-in-the-Middle** explicitly names DNS manipulation and protocol downgrade — anchoring DNSSEC, the HSTS family, weak TLS versions, anonymous suites, and certificate trust.
- **T1592.002** names "server banners" verbatim, anchoring the `Server` / `X-Powered-By` / `X-AspNet-Version` checks.
- **T1040 Network Sniffing** mitigates to "web traffic ... protected by SSL/TLS", anchoring the broken-cipher checks.
- **T1568.001 Fast Flux DNS** is defined by short TTLs, anchoring the TTL check.

The DMARC reporting checks map to **A09 Security Logging and Alerting Failures** rather than A02, since `rua`/`ruf` are the alerting channel rather than a hardening setting.

## Two deliberate departures worth reviewing

**1. The ATT&CK key is omitted where nothing fits, rather than set to `false`.**

The 13 pre-existing framework keys are maintained as a uniform block using the `false` sentinel, and this PR leaves those exactly as they are. The new ATT&CK key does not follow that pattern: 27 of 60 checks have no honest technique, so a `false` column would be 45% noise. ATT&CK models adversary behaviour, not configuration controls — record-hygiene checks like "SPF record contains no excess whitespace" have no technique that genuinely applies. 33 checks carry a real technique ID; the rest carry no key.

**2. `cnspec policy fmt` must not be run on these files.**

It rewrites every unquoted `false` into `"false"`, contradicting the convention documented in `content/CLAUDE.md` (~150+ tags repo-wide), and it reorders policy-level keys. These files were hand-edited and validated with `cnspec policy lint` instead. Worth knowing before anyone reformats them.

## Note for the control-reference validation

The three new keys will **not** resolve against the compliance frameworks we ship, because no OWASP or ATT&CK framework is being authored here — this is a tags-only change by design. That matches `compliance/nist-ai-100-1`, which already ships on four policies with no framework definition. Flagging it so the next validation run treats these as intentional rather than as typos.

## Verification

- `cnspec policy lint ./content` — clean (the two warnings are pre-existing, in unrelated files).
- **No logic touched**, checked mechanically rather than by eye: every check's parsed `mql`, and every group's `filters` and check membership, compared against `main`. Zero differences across all four policies.
- Scans against `mondoo.com` return the same pass/fail sets as before the change.

One caveat on that last point: `mondoo-dns-security-reasonable-ttls` flaps between runs. It reads the *remaining* TTL from a caching resolver, which counts down toward zero, so it false-positives for the last 60 of every 300 seconds on a correctly-configured domain (`mondoo.com`'s authoritative TTL is 300; a cached answer returns 208, then 144, ...). Pre-existing and unrelated to this PR — the diff provably changes no MQL — and worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

