### PR TITLE
✨ content(azure): add 30 checks across 12 under-covered platforms

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 9.7.1
+    version: 9.8.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -131,6 +131,8 @@ policies:
           - uid: mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled
           - uid: mondoo-azure-security-sql-managed-instance-min-tls-1-2
           - uid: mondoo-azure-security-sql-managed-instance-tde-cmk-encryption
+          - uid: mondoo-azure-security-mysql-server-backup-retention
+          - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule
       - title: Azure Key Vault
         checks:
           - uid: mondoo-azure-security-ensure-the-expiration-date-is-set-for-all-keys-and-secrets-in-kv
@@ -144,6 +146,10 @@ policies:
           - uid: mondoo-azure-security-managed-hsm-purge-protection
           - uid: mondoo-azure-security-managed-hsm-public-access-disabled
           - uid: mondoo-azure-security-managed-hsm-private-endpoints
+          - uid: mondoo-azure-security-managed-hsm-key-expiration
+          - uid: mondoo-azure-security-managed-hsm-key-auto-rotation
+          - uid: mondoo-azure-security-managed-hsm-network-acls-deny
+          - uid: mondoo-azure-security-managed-hsm-soft-delete-retention
       - title: Azure Compute
         checks:
           - uid: mondoo-azure-security-ensure-os-disk-are-encrypted
@@ -160,6 +166,8 @@ policies:
           - uid: mondoo-azure-security-vm-vtpm-enabled
           - uid: mondoo-azure-security-compute-snapshot-public-access-disabled
           - uid: mondoo-azure-security-compute-snapshot-cmk-encryption
+          - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled
+          - uid: mondoo-azure-security-compute-vm-defender-endpoint-installed
       - title: Azure Network
         checks:
           - uid: mondoo-azure-security-ssh-access-restricted-from-internet
@@ -179,6 +187,7 @@ policies:
           - uid: mondoo-azure-security-nsg-sensitive-ports-restricted
           - uid: mondoo-azure-security-network-manager-security-admin-deny-rule
           - uid: mondoo-azure-security-network-security-perimeter-enforced
+          - uid: mondoo-azure-security-network-peering-encryption-enabled
       - title: Azure Subscription
         checks:
           - uid: mondoo-azure-security-diagnostic-settings-essential-categories
@@ -255,6 +264,7 @@ policies:
           - uid: mondoo-azure-security-app-service-scm-min-tls
           - uid: mondoo-azure-security-app-service-vnet-route-all
           - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny
+          - uid: mondoo-azure-security-app-service-auth-no-anonymous
       - title: Azure Cache for Redis
         checks:
           - uid: mondoo-azure-security-redis-ssl-only
@@ -286,6 +296,9 @@ policies:
           - uid: mondoo-azure-security-firewall-premium-sku
           - uid: mondoo-azure-security-firewall-policy-configured
           - uid: mondoo-azure-security-firewall-idps-enabled
+          - uid: mondoo-azure-security-firewall-no-idps-bypass-rules
+          - uid: mondoo-azure-security-firewall-no-any-any-allow-rule
+          - uid: mondoo-azure-security-firewall-no-dnat-management-ports
       - title: Azure Batch
         checks:
           - uid: mondoo-azure-security-batch-public-access-disabled
@@ -301,6 +314,11 @@ policies:
           - uid: mondoo-azure-security-appgw-no-weak-ciphers
           - uid: mondoo-azure-security-application-gateway-no-public-frontend
           - uid: mondoo-azure-security-appgw-waf-prevention-mode
+          - uid: mondoo-azure-security-appgw-listeners-https-only
+          - uid: mondoo-azure-security-appgw-backend-https
+          - uid: mondoo-azure-security-appgw-backend-cert-validation
+          - uid: mondoo-azure-security-appgw-waf-policy-enabled
+          - uid: mondoo-azure-security-appgw-waf-request-body-check
       - title: VPN Gateway
         checks:
           - uid: mondoo-azure-security-vpn-gateway-ikev2
@@ -320,6 +338,9 @@ policies:
           - uid: mondoo-azure-security-synapse-managed-vnet
           - uid: mondoo-azure-security-synapse-aad-only-auth
           - uid: mondoo-azure-security-synapse-cmk-encryption
+          - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled
+          - uid: mondoo-azure-security-synapse-managed-identity
+          - uid: mondoo-azure-security-synapse-default-storage-secure-transfer
       - title: Azure Container Registry
         checks:
           - uid: mondoo-azure-security-acr-admin-user-disabled
@@ -370,6 +391,10 @@ policies:
           - uid: mondoo-azure-security-function-app-public-network-access-disabled
           - uid: mondoo-azure-security-function-app-cmk-encryption
           - uid: mondoo-azure-security-function-app-min-tls-1-2
+          - uid: mondoo-azure-security-function-app-ftps-required
+          - uid: mondoo-azure-security-function-app-remote-debugging-disabled
+          - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny
+          - uid: mondoo-azure-security-function-app-secrets-in-key-vault
       - title: Azure AI Search
         checks:
           - uid: mondoo-azure-security-search-service-public-network-access-disabled
@@ -440,11 +465,16 @@ policies:
           - uid: mondoo-azure-security-iot-hub-public-network-access-disabled
           - uid: mondoo-azure-security-iot-hub-min-tls-1-2
           - uid: mondoo-azure-security-iot-hub-diagnostic-settings-enabled
+          - uid: mondoo-azure-security-iot-hub-network-rule-set-deny
       - title: Azure Container Apps
         checks:
           - uid: mondoo-azure-security-container-app-https-ingress
           - uid: mondoo-azure-security-container-app-managed-identity-registries
           - uid: mondoo-azure-security-container-app-image-digest-pinned
+          - uid: mondoo-azure-security-container-app-ingress-ip-restrictions
+          - uid: mondoo-azure-security-container-app-cors-no-wildcard
+          - uid: mondoo-azure-security-container-app-auth-no-anonymous
+          - uid: mondoo-azure-security-container-app-managed-identity
       - title: Azure Container Instances
         checks:
           - uid: mondoo-azure-security-container-instance-private-registry
@@ -9039,13 +9069,13 @@ queries:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
       compliance/iso-27001-2022: iso-27001-2022-a-8-5
       compliance/nis-2: nis-2-21-2-g
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -9205,7 +9235,7 @@ queries:
       compliance/nist-csf-1: nist-csf-1-pr-ac-1
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
-      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -11516,7 +11546,7 @@ queries:
       compliance/nis-2: nis-2-21-2-e
       compliance/nist-csf-1: nist-csf-1-pr-pt-3
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-4
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-1-6
@@ -25497,18 +25527,18 @@ queries:
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
       compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
-      compliance/iso-27001-2022: iso-27001-2022-a-8-20
-      compliance/nis-2: nis-2-21-2-e
-      compliance/nist-csf-1: nist-csf-1-pr-ac-5
-      compliance/nist-csf-2: nist-csf-2-pr-ir-01
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-18
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
-      compliance/pci-dss-4: pcidss-requirement-1-3-1
-      compliance/soc2-2017: soc2-control-cc6-6-1
-      compliance/vda-isa-5: vda-isa-5-5-2-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
       - uid: mondoo-azure-security-app-service-ssh-disabled-azure
         tags:
@@ -42195,6 +42225,10 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     variants:
+      - uid: mondoo-azure-security-function-app-min-tls-1-2-azure
+        tags:
+          mondoo.com/filter-title: Azure Function App
+          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-function-app-min-tls-1-2-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -42296,6 +42330,11 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
         title: Configure TLS/SSL settings for Azure App Service and Functions
+  - uid: mondoo-azure-security-function-app-min-tls-1-2-azure
+    filters: |
+      asset.platform == "azure-function-app"
+    mql: |
+      azure.subscription.functionsService.functionApp.configuration.minTlsVersion.in(["1.2", "1.3"])
   - uid: mondoo-azure-security-function-app-min-tls-1-2-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
     mql: |
@@ -49484,4 +49523,4881 @@ queries:
     mql: |
       bicep.resources.where(type == "Microsoft.MachineLearningServices/workspaces").all(
         properties["encryption"]["status"] == "Enabled"
+      )
+  - uid: mondoo-azure-security-appgw-listeners-https-only
+    title: Ensure Application Gateway HTTP listeners use HTTPS
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-appgw-listeners-https-only-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-listeners-https-only-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every HTTP listener on an Application Gateway terminates TLS by using the `Https` protocol. A listener configured with the `Http` protocol accepts requests on an unencrypted channel, so credentials, session cookies, and application data traverse the network in cleartext before the gateway ever applies its TLS policy.
+
+        **Why this matters**
+
+        - **TLS policy is not enforced on plaintext listeners:** Minimum protocol version and cipher suite settings apply only to listeners that negotiate TLS, so a single `Http` listener bypasses every TLS hardening control configured on the gateway.
+        - **Credential and session exposure:** Requests arriving on an unencrypted listener expose authentication headers and session cookies to anyone able to observe traffic between the client and the gateway.
+        - **Request tampering:** Without TLS there is no integrity protection, so an on-path attacker can modify request bodies, headers, or responses without detection by either endpoint.
+
+        **Risk mitigation**
+
+        - **End-to-end confidentiality at the edge:** Requiring HTTPS on every listener guarantees that all traffic entering the gateway is encrypted and authenticated against the presented server certificate.
+        - **Consistent policy application:** When all listeners use TLS, the gateway's configured minimum protocol version and cipher suite restrictions govern every inbound connection.
+
+        Where an `Http` listener exists solely to redirect clients to HTTPS, treat it as an accepted exception and record the redirect configuration that proves no application traffic is served over the plaintext listener.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Application gateways** in the Azure Portal.
+        2. Select the gateway and open **Listeners**.
+        3. Review the **Protocol** column for each listener.
+        4. A passing gateway lists `HTTPS` for every listener. A listener showing `HTTP` fails this check.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network application-gateway http-listener list --gateway-name <GatewayName> --resource-group <ResourceGroupName> --query "[].{Name:name, Protocol:protocol}" -o table
+        ```
+
+        A passing gateway returns `Https` for every listener.
+      remediation:
+        - id: portal
+          desc: |
+            To require HTTPS on Application Gateway listeners using the Azure Portal:
+
+            1. Navigate to **Application gateways** in the Azure Portal.
+            2. Select the gateway and open **Listeners**.
+            3. Select the listener that uses the HTTP protocol.
+            4. Set **Protocol** to **HTTPS**.
+            5. Select a **Certificate** to present to clients, or upload one.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To require HTTPS on Application Gateway listeners using the Azure CLI:
+
+            ```bash
+            az network application-gateway http-listener update --gateway-name <GatewayName> --resource-group <ResourceGroupName> --name <ListenerName> --frontend-port <HttpsPortName> --ssl-cert <CertificateName>
+            ```
+        - id: terraform
+          desc: |
+            To require HTTPS on Application Gateway listeners in Terraform:
+
+            ```hcl
+            resource "azurerm_application_gateway" "example" {
+              name                = "example-appgateway"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              http_listener {
+                name                           = "https-listener"
+                frontend_ip_configuration_name = "frontend-ip"
+                frontend_port_name             = "https-port"
+                protocol                       = "Https"
+                ssl_certificate_name           = "example-cert"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To require HTTPS on Application Gateway listeners in Bicep:
+
+            ```bicep
+            resource applicationGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+              name: 'example-appgateway'
+              location: resourceGroup().location
+              properties: {
+                httpListeners: [
+                  {
+                    name: 'https-listener'
+                    properties: {
+                      protocol: 'Https'
+                      sslCertificate: {
+                        id: resourceId('Microsoft.Network/applicationGateways/sslCertificates', 'example-appgateway', 'example-cert')
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/application-gateway/configuration-listeners
+        title: Application Gateway listener configuration
+  - uid: mondoo-azure-security-appgw-listeners-https-only-azure
+    filters: |
+      asset.platform == "azure-application-gateway"
+    mql: |
+      azure.subscription.networkService.applicationGateway.listeners.all(protocol == "Https")
+  - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
+    mql: |
+      terraform.resources("azurerm_application_gateway").all(
+        blocks.where(type == "http_listener").all(arguments['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_application_gateway").all(
+        change.after['http_listener'] == null ||
+        change.after['http_listener'] == empty ||
+        change.after['http_listener'].all(_['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-listeners-https-only-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_application_gateway").all(
+        values['http_listener'] == null ||
+        values['http_listener'] == empty ||
+        values['http_listener'].all(_['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-listeners-https-only-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["httpListeners"] == empty ||
+        properties["httpListeners"].all(_["properties"]["protocol"] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-backend-https
+    title: Ensure Application Gateway backend settings use HTTPS
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-appgw-backend-https-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-backend-https-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-https-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-https-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-https-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the backend HTTP settings on an Application Gateway connect to backend pool members over HTTPS. Terminating TLS at the gateway and then forwarding requests to the backend over plain HTTP leaves the second hop unencrypted, even though clients see a valid HTTPS connection.
+
+        **Why this matters**
+
+        - **Unprotected internal hop:** Traffic between the gateway and the backend pool crosses virtual network infrastructure where other workloads, network appliances, and compromised hosts may be able to observe it.
+        - **False sense of protection:** Clients see a padlock and a valid certificate while the request travels in cleartext for the remainder of its path, which hides the exposure from users and from external TLS scanners.
+        - **Regulated data in transit:** Cardholder data, health records, and authentication material remain subject to encryption-in-transit requirements on internal network segments, not only on the public segment.
+
+        **Risk mitigation**
+
+        - **End-to-end TLS:** Configuring backend settings for HTTPS extends encryption across both hops so no segment of the request path carries plaintext application data.
+        - **Backend authentication:** An HTTPS backend connection lets the gateway validate the backend server certificate, which prevents a rogue host in the backend pool from silently receiving traffic.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Application gateways** in the Azure Portal.
+        2. Select the gateway and open **Backend settings**.
+        3. Review the **Protocol** value for each backend setting.
+        4. A passing gateway shows `HTTPS` for every backend setting.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network application-gateway http-settings list --gateway-name <GatewayName> --resource-group <ResourceGroupName> --query "[].{Name:name, Protocol:protocol}" -o table
+        ```
+
+        A passing gateway returns `Https` for every backend HTTP setting.
+      remediation:
+        - id: portal
+          desc: |
+            To require HTTPS to the backend using the Azure Portal:
+
+            1. Navigate to **Application gateways** in the Azure Portal.
+            2. Select the gateway and open **Backend settings**.
+            3. Select the backend setting that uses the HTTP protocol.
+            4. Set **Backend protocol** to **HTTPS** and set **Backend port** to the port serving TLS on the backend.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To require HTTPS to the backend using the Azure CLI:
+
+            ```bash
+            az network application-gateway http-settings update --gateway-name <GatewayName> --resource-group <ResourceGroupName> --name <SettingsName> --protocol Https --port 443
+            ```
+        - id: terraform
+          desc: |
+            To require HTTPS to the backend in Terraform:
+
+            ```hcl
+            resource "azurerm_application_gateway" "example" {
+              name                = "example-appgateway"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              backend_http_settings {
+                name                  = "https-settings"
+                cookie_based_affinity = "Disabled"
+                port                  = 443
+                protocol              = "Https"
+                request_timeout       = 60
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To require HTTPS to the backend in Bicep:
+
+            ```bicep
+            resource applicationGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+              name: 'example-appgateway'
+              location: resourceGroup().location
+              properties: {
+                backendHttpSettingsCollection: [
+                  {
+                    name: 'https-settings'
+                    properties: {
+                      port: 443
+                      protocol: 'Https'
+                      cookieBasedAffinity: 'Disabled'
+                    }
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/application-gateway/ssl-overview
+        title: Application Gateway TLS termination and end to end TLS
+  - uid: mondoo-azure-security-appgw-backend-https-azure
+    filters: |
+      asset.platform == "azure-application-gateway"
+    mql: |
+      azure.subscription.networkService.applicationGateway.properties["backendHttpSettingsCollection"] == empty ||
+      azure.subscription.networkService.applicationGateway.properties["backendHttpSettingsCollection"].all(
+        _["properties"]["protocol"] == "Https"
+      )
+  - uid: mondoo-azure-security-appgw-backend-https-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
+    mql: |
+      terraform.resources("azurerm_application_gateway").all(
+        blocks.where(type == "backend_http_settings").all(arguments['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-backend-https-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_application_gateway").all(
+        change.after['backend_http_settings'] == null ||
+        change.after['backend_http_settings'] == empty ||
+        change.after['backend_http_settings'].all(_['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-backend-https-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_application_gateway").all(
+        values['backend_http_settings'] == null ||
+        values['backend_http_settings'] == empty ||
+        values['backend_http_settings'].all(_['protocol'] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-backend-https-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["backendHttpSettingsCollection"] == empty ||
+        properties["backendHttpSettingsCollection"].all(_["properties"]["protocol"] == "Https")
+      )
+  - uid: mondoo-azure-security-appgw-backend-cert-validation
+    title: Ensure Application Gateway validates backend certificates
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-appgw-backend-cert-validation-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-backend-cert-validation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Application Gateway backend HTTP settings validate the certificate chain and expiry presented by backend pool members. When validation is turned off, the gateway establishes a TLS session with any backend that answers, including one presenting an expired, self-signed, or attacker-supplied certificate.
+
+        **Why this matters**
+
+        - **Unauthenticated backend connections:** Without chain validation, TLS provides encryption but no assurance about which server is on the other end, so the gateway cannot distinguish the intended backend from an impostor.
+        - **On-path interception:** An attacker who can influence DNS resolution or routing inside the virtual network can terminate the gateway's backend connection and relay traffic, reading and modifying every request and response.
+        - **Expired certificate blind spot:** Disabling expiry validation removes the signal that a backend certificate has lapsed, which hides both an operational failure and the possibility that a revoked or superseded certificate is still in use.
+
+        **Risk mitigation**
+
+        - **Backend identity assurance:** Chain validation ties the backend TLS session to a certificate issued by a trusted authority, so traffic only flows to hosts that can prove their identity.
+        - **Fail-closed on certificate problems:** With validation enabled, an expired or untrusted backend certificate marks the pool member unhealthy instead of silently accepting the connection.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Application gateways** in the Azure Portal.
+        2. Select the gateway and open **Backend settings**.
+        3. Select each backend setting that uses HTTPS and review the certificate validation options.
+        4. A passing gateway leaves certificate chain and expiry validation enabled on every backend setting.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network application-gateway http-settings list --gateway-name <GatewayName> --resource-group <ResourceGroupName> --query "[].{Name:name, Protocol:protocol, TrustedRootCerts:trustedRootCertificates}" -o table
+        ```
+
+        A passing gateway does not disable certificate chain and expiry validation on any backend setting.
+      remediation:
+        - id: portal
+          desc: |
+            To validate backend certificates using the Azure Portal:
+
+            1. Navigate to **Application gateways** in the Azure Portal.
+            2. Select the gateway and open **Backend settings**.
+            3. Select the backend setting that uses HTTPS.
+            4. Leave certificate chain and expiry validation enabled, and upload the issuing certificate under **Trusted root certificate** when the backend uses a private authority.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To validate backend certificates using the Azure CLI:
+
+            ```bash
+            az network application-gateway root-cert create --gateway-name <GatewayName> --resource-group <ResourceGroupName> --name <RootCertName> --cert-file <PathToRootCert>
+            ```
+        - id: terraform
+          desc: |
+            To validate backend certificates in Terraform:
+
+            ```hcl
+            resource "azurerm_application_gateway" "example" {
+              name                = "example-appgateway"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              backend_http_settings {
+                name                                = "https-settings"
+                cookie_based_affinity               = "Disabled"
+                port                                = 443
+                protocol                            = "Https"
+                request_timeout                     = 60
+                certificate_chain_validation_enabled = true
+                trusted_root_certificate_names      = ["example-root-cert"]
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To validate backend certificates in Bicep:
+
+            ```bicep
+            resource applicationGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+              name: 'example-appgateway'
+              location: resourceGroup().location
+              properties: {
+                backendHttpSettingsCollection: [
+                  {
+                    name: 'https-settings'
+                    properties: {
+                      port: 443
+                      protocol: 'Https'
+                      cookieBasedAffinity: 'Disabled'
+                      trustedRootCertificates: [
+                        {
+                          id: resourceId('Microsoft.Network/applicationGateways/trustedRootCertificates', 'example-appgateway', 'example-root-cert')
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/application-gateway/ssl-overview
+        title: Application Gateway end to end TLS and certificate validation
+  - uid: mondoo-azure-security-appgw-backend-cert-validation-azure
+    filters: |
+      asset.platform == "azure-application-gateway"
+    mql: |
+      azure.subscription.networkService.applicationGateway.properties["backendHttpSettingsCollection"] == empty ||
+      azure.subscription.networkService.applicationGateway.properties["backendHttpSettingsCollection"].where(
+        _["properties"]["protocol"] == "Https"
+      ).all(
+        _["properties"]["validateCertChainAndExpiry"] != false
+      )
+  - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_application_gateway")
+    mql: |
+      terraform.resources("azurerm_application_gateway").all(
+        blocks.where(type == "backend_http_settings").all(
+          arguments['certificate_chain_validation_enabled'] != false
+        )
+      )
+  - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_application_gateway").all(
+        change.after['backend_http_settings'] == null ||
+        change.after['backend_http_settings'] == empty ||
+        change.after['backend_http_settings'].all(_['certificate_chain_validation_enabled'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-backend-cert-validation-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_application_gateway")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_application_gateway").all(
+        values['backend_http_settings'] == null ||
+        values['backend_http_settings'] == empty ||
+        values['backend_http_settings'].all(_['certificate_chain_validation_enabled'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-backend-cert-validation-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/applicationGateways")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/applicationGateways").all(
+        properties["backendHttpSettingsCollection"] == empty ||
+        properties["backendHttpSettingsCollection"].where(_["properties"]["protocol"] == "Https").all(
+          _["properties"]["validateCertChainAndExpiry"] != false
+        )
+      )
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled
+    title: Ensure Application Gateway WAF policy is in the enabled state
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-6-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-3-2
+    variants:
+      - uid: mondoo-azure-security-appgw-waf-policy-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-policy-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the web application firewall policy attached to an Application Gateway is in the enabled state. A policy carries two independent switches: the enabled state, which determines whether the firewall evaluates traffic at all, and the mode, which determines whether matches are logged or blocked. A policy set to `Prevention` mode still inspects nothing while its enabled state is `Disabled`.
+
+        **Why this matters**
+
+        - **Silent bypass of a configured firewall:** The gateway reports an attached policy and the policy reports prevention mode, so dashboards and configuration reviews suggest the application is protected while every request passes uninspected.
+        - **Change-window drift:** Operators frequently disable a policy to unblock an incident and do not re-enable it, leaving the application exposed with no configuration difference that stands out during review.
+        - **Managed rules do not apply:** Managed rule sets covering injection, cross-site scripting, and known CVE exploitation are only evaluated while the policy is enabled.
+
+        **Risk mitigation**
+
+        - **Inspection is actually performed:** Asserting the enabled state confirms the firewall evaluates inbound requests rather than only holding a configuration.
+        - **Complete coverage of the prevention control:** Combining the enabled state with prevention mode closes the gap where a policy appears hardened but is inert.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Web Application Firewall policies (WAF)** in the Azure Portal.
+        2. Select the policy associated with the Application Gateway.
+        3. Open **Policy settings** and review the state.
+        4. A passing policy shows the state as **Enabled**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network application-gateway waf-policy show --name <PolicyName> --resource-group <ResourceGroupName> --query "policySettings.{State:state, Mode:mode}"
+        ```
+
+        A passing policy returns a state of `Enabled`.
+      remediation:
+        - id: portal
+          desc: |
+            To enable the web application firewall policy using the Azure Portal:
+
+            1. Navigate to **Web Application Firewall policies (WAF)** in the Azure Portal.
+            2. Select the policy associated with the Application Gateway.
+            3. Open **Policy settings**.
+            4. Set the state to **Enabled** and confirm the mode is **Prevention**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To enable the web application firewall policy using the Azure CLI:
+
+            ```bash
+            az network application-gateway waf-policy policy-setting update --policy-name <PolicyName> --resource-group <ResourceGroupName> --state Enabled --mode Prevention
+            ```
+        - id: terraform
+          desc: |
+            To enable the web application firewall policy in Terraform:
+
+            ```hcl
+            resource "azurerm_web_application_firewall_policy" "example" {
+              name                = "example-wafpolicy"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              policy_settings {
+                enabled = true
+                mode    = "Prevention"
+              }
+
+              managed_rules {
+                managed_rule_set {
+                  type    = "OWASP"
+                  version = "3.2"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable the web application firewall policy in Bicep:
+
+            ```bicep
+            resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-11-01' = {
+              name: 'example-wafpolicy'
+              location: resourceGroup().location
+              properties: {
+                policySettings: {
+                  state: 'Enabled'
+                  mode: 'Prevention'
+                }
+                managedRules: {
+                  managedRuleSets: [
+                    {
+                      ruleSetType: 'OWASP'
+                      ruleSetVersion: '3.2'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/policy-overview
+        title: Azure Web Application Firewall policy for Application Gateway
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled-azure
+    filters: |
+      asset.platform == "azure-application-gateway"
+    mql: |
+      azure.subscription.networkService.applicationGateway.policy != empty
+      azure.subscription.networkService.applicationGateway.policy.enabled == true
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.resources("azurerm_web_application_firewall_policy").all(
+        blocks.where(type == "policy_settings") != empty &&
+        blocks.where(type == "policy_settings").all(arguments['enabled'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_web_application_firewall_policy").all(
+        change.after['policy_settings'] != empty &&
+        change.after['policy_settings'].all(_['enabled'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_web_application_firewall_policy").all(
+        values['policy_settings'] != empty &&
+        values['policy_settings'].all(_['enabled'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-policy-enabled-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies").all(
+        properties["policySettings"]["state"] == "Enabled"
+      )
+  - uid: mondoo-azure-security-appgw-waf-request-body-check
+    title: Ensure Application Gateway WAF inspects request bodies
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-6-4-2
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-3-2
+    variants:
+      - uid: mondoo-azure-security-appgw-waf-request-body-check-azure
+        tags:
+          mondoo.com/filter-title: Azure Application Gateway
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-appgw-waf-request-body-check-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that request body inspection is enabled on the web application firewall policy attached to an Application Gateway. With body inspection turned off, the firewall evaluates only the request line, headers, and query string, so any payload delivered in the body reaches the application unexamined.
+
+        **Why this matters**
+
+        - **Most injection payloads travel in the body:** SQL injection, command injection, and deserialization attacks against modern APIs are typically delivered in POST or PUT bodies as form data or JSON, which is exactly the content skipped when body inspection is disabled.
+        - **Managed rules become partially ineffective:** OWASP and Microsoft managed rule sets contain rules that match on request body content, and those rules never fire while inspection is off.
+        - **Detection gap is invisible in logs:** Requests carrying malicious bodies are logged as clean because the firewall never evaluated the portion of the request that carried the attack.
+
+        **Risk mitigation**
+
+        - **Full request coverage:** Enabling body inspection lets managed and custom rules evaluate the complete request, closing the gap between what the firewall reports and what it actually examined.
+        - **API protection:** JSON and form payloads used by modern application front ends are inspected before reaching application code.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Web Application Firewall policies (WAF)** in the Azure Portal.
+        2. Select the policy associated with the Application Gateway.
+        3. Open **Policy settings**.
+        4. A passing policy shows **Inspect request body** as enabled.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network application-gateway waf-policy show --name <PolicyName> --resource-group <ResourceGroupName> --query "policySettings.requestBodyCheck"
+        ```
+
+        A passing policy returns `true`.
+      remediation:
+        - id: portal
+          desc: |
+            To enable request body inspection using the Azure Portal:
+
+            1. Navigate to **Web Application Firewall policies (WAF)** in the Azure Portal.
+            2. Select the policy associated with the Application Gateway.
+            3. Open **Policy settings**.
+            4. Enable **Inspect request body** and set a maximum request body size that fits the application.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To enable request body inspection using the Azure CLI:
+
+            ```bash
+            az network application-gateway waf-policy policy-setting update --policy-name <PolicyName> --resource-group <ResourceGroupName> --request-body-check true --max-request-body-size-in-kb 128
+            ```
+        - id: terraform
+          desc: |
+            To enable request body inspection in Terraform:
+
+            ```hcl
+            resource "azurerm_web_application_firewall_policy" "example" {
+              name                = "example-wafpolicy"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              policy_settings {
+                enabled                     = true
+                mode                        = "Prevention"
+                request_body_check          = true
+                max_request_body_size_in_kb = 128
+              }
+
+              managed_rules {
+                managed_rule_set {
+                  type    = "OWASP"
+                  version = "3.2"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To enable request body inspection in Bicep:
+
+            ```bicep
+            resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-11-01' = {
+              name: 'example-wafpolicy'
+              location: resourceGroup().location
+              properties: {
+                policySettings: {
+                  state: 'Enabled'
+                  mode: 'Prevention'
+                  requestBodyCheck: true
+                  maxRequestBodySizeInKb: 128
+                }
+                managedRules: {
+                  managedRuleSets: [
+                    {
+                      ruleSetType: 'OWASP'
+                      ruleSetVersion: '3.2'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/application-gateway-waf-request-size-limits
+        title: Web Application Firewall request size limits and exclusion lists
+  - uid: mondoo-azure-security-appgw-waf-request-body-check-azure
+    filters: |
+      asset.platform == "azure-application-gateway"
+    mql: |
+      azure.subscription.networkService.applicationGateway.policy != empty
+      azure.subscription.networkService.applicationGateway.policy.requestBodyCheck == true
+  - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.resources("azurerm_web_application_firewall_policy").all(
+        blocks.where(type == "policy_settings").all(arguments['request_body_check'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_web_application_firewall_policy").all(
+        change.after['policy_settings'] == null ||
+        change.after['policy_settings'] == empty ||
+        change.after['policy_settings'].all(_['request_body_check'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-request-body-check-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_web_application_firewall_policy")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_web_application_firewall_policy").all(
+        values['policy_settings'] == null ||
+        values['policy_settings'] == empty ||
+        values['policy_settings'].all(_['request_body_check'] != false)
+      )
+  - uid: mondoo-azure-security-appgw-waf-request-body-check-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies").all(
+        properties["policySettings"]["requestBodyCheck"] != false
+      )
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules
+    title: Ensure Azure Firewall Policy has no IDPS bypass rules
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-azure
+        tags:
+          mondoo.com/filter-title: Azure Firewall
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that no intrusion detection and prevention bypass rules are configured on an Azure Firewall Policy. A bypass rule exempts matching traffic from IDPS inspection entirely, so signatures never evaluate the flows it covers even when the policy is otherwise set to deny.
+
+        **Why this matters**
+
+        - **Inspection is silently skipped:** Traffic matched by a bypass rule is forwarded without signature evaluation, so the firewall reports IDPS as active while a defined slice of traffic is never examined.
+        - **Bypass rules are broad by nature:** Rules added to resolve a false positive commonly match on whole source or destination address ranges rather than a single flow, which exempts far more traffic than the original issue required.
+        - **Temporary exemptions become permanent:** Bypass entries created during incident response or a migration rarely carry an expiry, so the exemption outlives the reason it was added.
+        - **Attractive to an attacker with policy access:** An adversary who can modify firewall policy can add a narrow-looking bypass rule to create a covert channel that leaves IDPS alerting untouched.
+
+        **Risk mitigation**
+
+        - **Uniform inspection:** Removing bypass rules ensures every flow permitted by the firewall is subject to the same signature evaluation.
+        - **Exceptions become visible:** Handling false positives through signature overrides rather than traffic bypass keeps the exemption scoped to a specific signature and recorded where it can be reviewed.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Firewall Policies** in the Azure Portal.
+        2. Select the policy and open **IDPS**.
+        3. Select the **Bypass list** tab.
+        4. A passing policy has an empty bypass list.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network firewall policy show --name <PolicyName> --resource-group <ResourceGroupName> --query "intrusionDetection.configuration.bypassTrafficSettings"
+        ```
+
+        A passing policy returns an empty list or null.
+      remediation:
+        - id: portal
+          desc: |
+            To remove IDPS bypass rules using the Azure Portal:
+
+            1. Navigate to **Firewall Policies** in the Azure Portal.
+            2. Select the policy and open **IDPS**.
+            3. Select the **Bypass list** tab.
+            4. Select each bypass rule and delete it.
+            5. Where a rule was added to suppress a false positive, add a targeted signature override on the **Signature rules** tab instead.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To remove IDPS bypass rules using the Azure CLI:
+
+            ```bash
+            az network firewall policy intrusion-detection remove --policy-name <PolicyName> --resource-group <ResourceGroupName> --rule-name <BypassRuleName>
+            ```
+        - id: terraform
+          desc: |
+            To remove IDPS bypass rules in Terraform, delete every `traffic_bypass` block from the `intrusion_detection` block:
+
+            ```hcl
+            resource "azurerm_firewall_policy" "example" {
+              name                = "example-fwpolicy"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              sku                 = "Premium"
+
+              intrusion_detection {
+                mode = "Deny"
+
+                signature_overrides {
+                  id    = "2024897"
+                  state = "Off"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To remove IDPS bypass rules in Bicep, leave `bypassTrafficSettings` empty:
+
+            ```bicep
+            resource firewallPolicy 'Microsoft.Network/firewallPolicies@2023-11-01' = {
+              name: 'example-fwpolicy'
+              location: resourceGroup().location
+              properties: {
+                sku: {
+                  tier: 'Premium'
+                }
+                intrusionDetection: {
+                  mode: 'Deny'
+                  configuration: {
+                    bypassTrafficSettings: []
+                    signatureOverrides: [
+                      {
+                        id: '2024897'
+                        mode: 'Off'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/firewall/premium-features
+        title: Azure Firewall Premium IDPS features
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-azure
+    filters: |
+      asset.platform == "azure-firewall"
+    mql: |
+      azure.subscription.networkService.firewall.policy.intrusionDetectionBypassRules.length == 0
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall_policy")
+    mql: |
+      terraform.resources("azurerm_firewall_policy").all(
+        blocks.where(type == "intrusion_detection").all(
+          blocks.where(type == "traffic_bypass") == empty
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_firewall_policy")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_firewall_policy").all(
+        change.after['intrusion_detection'] == null ||
+        change.after['intrusion_detection'] == empty ||
+        change.after['intrusion_detection'].all(
+          _['traffic_bypass'] == null || _['traffic_bypass'] == empty
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_firewall_policy")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_firewall_policy").all(
+        values['intrusion_detection'] == null ||
+        values['intrusion_detection'] == empty ||
+        values['intrusion_detection'].all(
+          _['traffic_bypass'] == null || _['traffic_bypass'] == empty
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-idps-bypass-rules-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/firewallPolicies")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/firewallPolicies").all(
+        properties["intrusionDetection"]["configuration"] == empty ||
+        properties["intrusionDetection"]["configuration"]["bypassTrafficSettings"] == empty
+      )
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule
+    title: Ensure Azure Firewall network rules do not allow any to any
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-azure
+        tags:
+          mondoo.com/filter-title: Azure Firewall
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that no allow network rule on an Azure Firewall matches every source address and every destination address at once. A rule with `*` in both positions permits unrestricted traffic through the firewall for the protocols and ports it covers, which defeats the segmentation the firewall exists to enforce.
+
+        **Why this matters**
+
+        - **Segmentation collapses:** An any-to-any allow rule lets any workload behind the firewall reach any destination it routes to, removing the boundary between environments, tiers, and trust zones.
+        - **Lateral movement path:** Once an attacker gains a foothold on any host in scope, an unrestricted allow rule provides a ready route to every other reachable system without needing to defeat further controls.
+        - **Data exfiltration channel:** Wildcard destination matching permits outbound connections to arbitrary internet endpoints, giving an attacker a straightforward path for staging and removing data.
+        - **Rule ordering hides the problem:** A broad allow rule at a low priority silently overrides carefully scoped deny rules placed above it, so the effective policy differs from what the rule list suggests on inspection.
+
+        **Risk mitigation**
+
+        - **Explicit permit-by-exception:** Constraining source and destination to the address ranges a flow actually needs keeps the firewall's default deny posture meaningful.
+        - **Contained blast radius:** Scoped rules ensure a compromised workload can only reach the destinations its function requires rather than the entire routed network.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Firewall Policies** in the Azure Portal.
+        2. Select the policy and open **Network rules**.
+        3. Review each rule collection whose action is **Allow**.
+        4. A passing policy has no rule where both **Source** and **Destination** are `*`.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network firewall policy rule-collection-group collection list --policy-name <PolicyName> --resource-group <ResourceGroupName> --rule-collection-group-name <GroupName>
+        ```
+
+        A passing policy returns no network rule where `sourceAddresses` and `destinationAddresses` both contain `*`.
+      remediation:
+        - id: portal
+          desc: |
+            To scope overly broad network rules using the Azure Portal:
+
+            1. Navigate to **Firewall Policies** in the Azure Portal.
+            2. Select the policy and open **Network rules**.
+            3. Select the rule collection whose action is **Allow** and edit the rule that uses `*` for both source and destination.
+            4. Replace **Source** with the specific address ranges or IP groups that originate the traffic.
+            5. Replace **Destination** with the specific address ranges, IP groups, or service tags the traffic must reach.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To scope overly broad network rules using the Azure CLI:
+
+            ```bash
+            az network firewall policy rule-collection-group collection rule update --policy-name <PolicyName> --resource-group <ResourceGroupName> --rule-collection-group-name <GroupName> --collection-name <CollectionName> --name <RuleName> --source-addresses 10.0.1.0/24 --destination-addresses 10.0.2.0/24 --destination-ports 443
+            ```
+        - id: terraform
+          desc: |
+            To scope overly broad network rules in Terraform:
+
+            ```hcl
+            resource "azurerm_firewall_policy_rule_collection_group" "example" {
+              name               = "example-fwpolicy-rcg"
+              firewall_policy_id = azurerm_firewall_policy.example.id
+              priority           = 500
+
+              network_rule_collection {
+                name     = "app-to-db"
+                priority = 400
+                action   = "Allow"
+
+                rule {
+                  name                  = "app-tier-to-db-tier"
+                  protocols             = ["TCP"]
+                  source_addresses      = ["10.0.1.0/24"]
+                  destination_addresses = ["10.0.2.0/24"]
+                  destination_ports     = ["1433"]
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To scope overly broad network rules in Bicep:
+
+            ```bicep
+            resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-11-01' = {
+              name: 'example-fwpolicy/example-rcg'
+              properties: {
+                priority: 500
+                ruleCollections: [
+                  {
+                    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+                    name: 'app-to-db'
+                    priority: 400
+                    action: {
+                      type: 'Allow'
+                    }
+                    rules: [
+                      {
+                        ruleType: 'NetworkRule'
+                        name: 'app-tier-to-db-tier'
+                        ipProtocols: [ 'TCP' ]
+                        sourceAddresses: [ '10.0.1.0/24' ]
+                        destinationAddresses: [ '10.0.2.0/24' ]
+                        destinationPorts: [ '1433' ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/firewall/rule-processing
+        title: Azure Firewall rule processing logic
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-azure
+    filters: |
+      asset.platform == "azure-firewall"
+    mql: |
+      azure.subscription.networkService.firewall.networkRules.where(action == "Allow").all(
+        rules.none(
+          _['sourceAddresses'] != empty && _['sourceAddresses'].contains("*") &&
+          _['destinationAddresses'] != empty && _['destinationAddresses'].contains("*")
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.resources("azurerm_firewall_policy_rule_collection_group").all(
+        blocks.where(type == "network_rule_collection").where(arguments['action'] == "Allow").all(
+          blocks.where(type == "rule").all(
+            arguments['source_addresses'] == empty ||
+            arguments['source_addresses'].none(_ == "*") ||
+            arguments['destination_addresses'] == empty ||
+            arguments['destination_addresses'].none(_ == "*")
+          )
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_firewall_policy_rule_collection_group").all(
+        change.after['network_rule_collection'] == null ||
+        change.after['network_rule_collection'] == empty ||
+        change.after['network_rule_collection'].where(_['action'] == "Allow").all(
+          _['rule'] == null ||
+          _['rule'] == empty ||
+          _['rule'].none(
+            _['source_addresses'] != empty && _['source_addresses'].contains("*") &&
+            _['destination_addresses'] != empty && _['destination_addresses'].contains("*")
+          )
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_firewall_policy_rule_collection_group").all(
+        values['network_rule_collection'] == null ||
+        values['network_rule_collection'] == empty ||
+        values['network_rule_collection'].where(_['action'] == "Allow").all(
+          _['rule'] == null ||
+          _['rule'] == empty ||
+          _['rule'].none(
+            _['source_addresses'] != empty && _['source_addresses'].contains("*") &&
+            _['destination_addresses'] != empty && _['destination_addresses'].contains("*")
+          )
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-any-any-allow-rule-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/firewallPolicies/ruleCollectionGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/firewallPolicies/ruleCollectionGroups").all(
+        properties["ruleCollections"] == empty ||
+        properties["ruleCollections"].where(_["action"]["type"] == "Allow").all(
+          _["rules"] == empty ||
+          _["rules"].none(
+            _["sourceAddresses"] != empty && _["sourceAddresses"].contains("*") &&
+            _["destinationAddresses"] != empty && _["destinationAddresses"].contains("*")
+          )
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports
+    title: Ensure Azure Firewall DNAT rules do not expose SSH or RDP
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-firewall-no-dnat-management-ports-azure
+        tags:
+          mondoo.com/filter-title: Azure Firewall
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-firewall-no-dnat-management-ports-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that no destination network address translation rule on an Azure Firewall forwards inbound traffic to SSH on port 22 or RDP on port 3389. A DNAT rule publishes an internal service on the firewall's public address, so a rule translating to a management port places an interactive administrative service directly on the internet.
+
+        **Why this matters**
+
+        - **Continuous credential attack:** Management ports reachable from the internet are found by mass scanning within minutes and subjected to sustained brute force and credential stuffing against every account the service accepts.
+        - **Single credential from full compromise:** SSH and RDP grant interactive operating system access, so one working credential or one unpatched service vulnerability yields host control rather than access to a single application.
+        - **Bypasses the intended access path:** Publishing management ports through DNAT circumvents Azure Bastion, just-in-time VM access, and VPN or ExpressRoute paths that provide brokered access with logging and multifactor authentication.
+        - **Obscured by port shifting:** Translating an arbitrary public port to 3389 internally hides the exposure from reviews that only read the public-side port number.
+
+        **Risk mitigation**
+
+        - **Brokered administrative access:** Removing management-port DNAT rules forces administrative sessions through Azure Bastion or a VPN, where identity, multifactor authentication, and session logging are enforced.
+        - **Reduced internet-facing attack surface:** Only the application protocols a service is meant to publish remain reachable from outside the network boundary.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Firewall Policies** in the Azure Portal.
+        2. Select the policy and open **DNAT rules**.
+        3. Review the **Translated port** for every rule.
+        4. A passing policy has no DNAT rule whose translated port is `22` or `3389`.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network firewall policy rule-collection-group collection list --policy-name <PolicyName> --resource-group <ResourceGroupName> --rule-collection-group-name <GroupName>
+        ```
+
+        A passing policy returns no NAT rule whose `translatedPort` is `22` or `3389`.
+      remediation:
+        - id: portal
+          desc: |
+            To remove management-port DNAT rules using the Azure Portal:
+
+            1. Navigate to **Firewall Policies** in the Azure Portal.
+            2. Select the policy and open **DNAT rules**.
+            3. Select the rule whose translated port is `22` or `3389` and delete it.
+            4. Deploy **Azure Bastion** in the virtual network, or enable just-in-time VM access in Microsoft Defender for Cloud, to provide administrative access without publishing the port.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To remove management-port DNAT rules using the Azure CLI:
+
+            ```bash
+            az network firewall policy rule-collection-group collection rule remove --policy-name <PolicyName> --resource-group <ResourceGroupName> --rule-collection-group-name <GroupName> --collection-name <CollectionName> --name <RuleName>
+            ```
+        - id: terraform
+          desc: |
+            To remove management-port DNAT rules in Terraform, delete the `nat_rule_collection` rule that translates to port 22 or 3389 and publish only application ports:
+
+            ```hcl
+            resource "azurerm_firewall_policy_rule_collection_group" "example" {
+              name               = "example-fwpolicy-rcg"
+              firewall_policy_id = azurerm_firewall_policy.example.id
+              priority           = 500
+
+              nat_rule_collection {
+                name     = "published-web"
+                priority = 300
+                action   = "Dnat"
+
+                rule {
+                  name                = "https-to-web-tier"
+                  protocols           = ["TCP"]
+                  source_addresses    = ["203.0.113.0/24"]
+                  destination_address = "20.0.0.1"
+                  destination_ports   = ["443"]
+                  translated_address  = "10.0.1.10"
+                  translated_port     = "443"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To remove management-port DNAT rules in Bicep, publish only application ports:
+
+            ```bicep
+            resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-11-01' = {
+              name: 'example-fwpolicy/example-rcg'
+              properties: {
+                priority: 500
+                ruleCollections: [
+                  {
+                    ruleCollectionType: 'FirewallPolicyNatRuleCollection'
+                    name: 'published-web'
+                    priority: 300
+                    action: {
+                      type: 'Dnat'
+                    }
+                    rules: [
+                      {
+                        ruleType: 'NatRule'
+                        name: 'https-to-web-tier'
+                        ipProtocols: [ 'TCP' ]
+                        sourceAddresses: [ '203.0.113.0/24' ]
+                        destinationAddresses: [ '20.0.0.1' ]
+                        destinationPorts: [ '443' ]
+                        translatedAddress: '10.0.1.10'
+                        translatedPort: '443'
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/firewall/tutorial-firewall-dnat
+        title: Filter inbound internet traffic with Azure Firewall DNAT
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports-azure
+    filters: |
+      asset.platform == "azure-firewall"
+    mql: |
+      azure.subscription.networkService.firewall.natRules.all(
+        rules.none(_['translatedPort'] == "22" || _['translatedPort'] == "3389")
+      )
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.resources("azurerm_firewall_policy_rule_collection_group").all(
+        blocks.where(type == "nat_rule_collection").all(
+          blocks.where(type == "rule").all(
+            arguments['translated_port'] != "22" && arguments['translated_port'] != "3389"
+          )
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_firewall_policy_rule_collection_group").all(
+        change.after['nat_rule_collection'] == null ||
+        change.after['nat_rule_collection'] == empty ||
+        change.after['nat_rule_collection'].all(
+          _['rule'] == null ||
+          _['rule'] == empty ||
+          _['rule'].none(_['translated_port'] == "22" || _['translated_port'] == "3389")
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_firewall_policy_rule_collection_group")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_firewall_policy_rule_collection_group").all(
+        values['nat_rule_collection'] == null ||
+        values['nat_rule_collection'] == empty ||
+        values['nat_rule_collection'].all(
+          _['rule'] == null ||
+          _['rule'] == empty ||
+          _['rule'].none(_['translated_port'] == "22" || _['translated_port'] == "3389")
+        )
+      )
+  - uid: mondoo-azure-security-firewall-no-dnat-management-ports-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/firewallPolicies/ruleCollectionGroups")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/firewallPolicies/ruleCollectionGroups").all(
+        properties["ruleCollections"] == empty ||
+        properties["ruleCollections"].where(_["ruleCollectionType"] == "FirewallPolicyNatRuleCollection").all(
+          _["rules"] == empty ||
+          _["rules"].none(_["translatedPort"] == "22" || _["translatedPort"] == "3389")
+        )
+      )
+  - uid: mondoo-azure-security-function-app-ftps-required
+    title: Ensure Function Apps disable plaintext FTP deployment
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-function-app-ftps-required-azure
+        tags:
+          mondoo.com/filter-title: Azure Function App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-function-app-ftps-required-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ftps-required-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ftps-required-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ftps-required-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the deployment endpoint on a Function App refuses plaintext FTP by requiring FTPS or disabling the FTP endpoint entirely. App Service accepts both FTP and FTPS on the deployment endpoint by default, so publishing credentials and application code cross the network unencrypted unless the plaintext protocol is turned off.
+
+        **Why this matters**
+
+        - **Publishing credentials in cleartext:** FTP transmits the deployment username and password without encryption, so anyone observing the connection recovers credentials that grant write access to the application.
+        - **Code injection through the deployment channel:** Write access to the deployment endpoint lets an attacker replace function code, which executes with the application's managed identity and its access to storage, databases, and key vaults.
+        - **Unencrypted source disclosure:** Application code, configuration files, and any secrets embedded in them are readable in transit during every plaintext deployment.
+
+        **Risk mitigation**
+
+        - **Encrypted deployment channel:** Requiring FTPS protects publishing credentials and code in transit against observation and modification.
+        - **Reduced deployment surface:** Disabling FTP entirely removes the endpoint as an attack target where deployments run through source control or a pipeline instead.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Function App** in the Azure Portal.
+        2. Select the function app and open **Settings**, then **Configuration**.
+        3. Select the **General settings** tab and review **FTP state**.
+        4. A passing function app shows **FTPS only** or **Disabled**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az functionapp config show --name <FunctionAppName> --resource-group <ResourceGroupName> --query "ftpsState"
+        ```
+
+        A passing function app returns `FtpsOnly` or `Disabled`.
+      remediation:
+        - id: portal
+          desc: |
+            To disable plaintext FTP deployment using the Azure Portal:
+
+            1. Navigate to **Function App** in the Azure Portal.
+            2. Select the function app and open **Settings**, then **Configuration**.
+            3. Select the **General settings** tab.
+            4. Set **FTP state** to **Disabled**, or to **FTPS only** where FTP deployment is still required.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable plaintext FTP deployment using the Azure CLI:
+
+            ```bash
+            az functionapp config set --name <FunctionAppName> --resource-group <ResourceGroupName> --ftps-state Disabled
+            ```
+        - id: terraform
+          desc: |
+            To disable plaintext FTP deployment in Terraform:
+
+            ```hcl
+            resource "azurerm_linux_function_app" "example" {
+              name                = "example-function-app"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              service_plan_id     = azurerm_service_plan.example.id
+              storage_account_name = azurerm_storage_account.example.name
+
+              site_config {
+                ftps_state = "Disabled"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable plaintext FTP deployment in Bicep:
+
+            ```bicep
+            resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+              name: 'example-function-app'
+              location: resourceGroup().location
+              kind: 'functionapp'
+              properties: {
+                serverFarmId: appServicePlan.id
+                siteConfig: {
+                  ftpsState: 'Disabled'
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/deploy-ftp
+        title: Deploy content to App Service using FTP or FTPS
+  - uid: mondoo-azure-security-function-app-ftps-required-azure
+    filters: |
+      asset.platform == "azure-function-app"
+    mql: |
+      azure.subscription.functionsService.functionApp.configuration.ftpsState.in(["Disabled", "FtpsOnly"])
+  - uid: mondoo-azure-security-function-app-ftps-required-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.resources(/azurerm_(linux|windows)_function_app/).all(
+        blocks.where(type == "site_config") != empty &&
+        blocks.where(type == "site_config").all(
+          arguments['ftps_state'] == "Disabled" || arguments['ftps_state'] == "FtpsOnly"
+        )
+      )
+  - uid: mondoo-azure-security-function-app-ftps-required-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.plan.resourceChanges.where(type == /azurerm_(linux|windows)_function_app/).all(
+        change.after['site_config'] != empty &&
+        change.after['site_config'].all(
+          _['ftps_state'] == "Disabled" || _['ftps_state'] == "FtpsOnly"
+        )
+      )
+  - uid: mondoo-azure-security-function-app-ftps-required-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
+        values['site_config'] != empty &&
+        values['site_config'].all(
+          _['ftps_state'] == "Disabled" || _['ftps_state'] == "FtpsOnly"
+        )
+      )
+  - uid: mondoo-azure-security-function-app-ftps-required-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["ftpsState"] == "Disabled" ||
+        properties["siteConfig"]["ftpsState"] == "FtpsOnly"
+      )
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled
+    title: Ensure remote debugging is disabled for Function Apps
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-7
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-6
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-function-app-remote-debugging-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Function App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-remote-debugging-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that remote debugging is disabled on a Function App. Remote debugging opens a debugger port on the running application and attaches a development tool to production code, which grants the ability to read memory, inspect variables, and alter execution flow.
+
+        **Why this matters**
+
+        - **Full access to in-memory data:** An attached debugger can read decrypted secrets, access tokens, and customer data held in application memory, none of which is protected by encryption at rest or in transit.
+        - **Execution control:** A debugger can change variable values and redirect control flow, which allows authorization checks to be bypassed without modifying any stored code.
+        - **Automatic expiry is not a control:** Azure disables remote debugging automatically after 48 hours, which is ample time for an attacker to use an endpoint that was enabled and forgotten.
+        - **Nonessential in production:** Remote debugging serves development workflows and has no operational purpose on a production workload, so leaving it enabled adds attack surface with no benefit.
+
+        **Risk mitigation**
+
+        - **Reduced attack surface:** Disabling remote debugging removes a high-value interactive entry point into running application processes.
+        - **Least functionality:** Production workloads expose only the capabilities required to serve their function.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Function App** in the Azure Portal.
+        2. Select the function app and open **Settings**, then **Configuration**.
+        3. Select the **General settings** tab and review **Remote debugging**.
+        4. A passing function app shows remote debugging as **Off**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az functionapp config show --name <FunctionAppName> --resource-group <ResourceGroupName> --query "remoteDebuggingEnabled"
+        ```
+
+        A passing function app returns `false`.
+      remediation:
+        - id: portal
+          desc: |
+            To disable remote debugging using the Azure Portal:
+
+            1. Navigate to **Function App** in the Azure Portal.
+            2. Select the function app and open **Settings**, then **Configuration**.
+            3. Select the **General settings** tab.
+            4. Set **Remote debugging** to **Off**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable remote debugging using the Azure CLI:
+
+            ```bash
+            az functionapp config set --name <FunctionAppName> --resource-group <ResourceGroupName> --remote-debugging-enabled false
+            ```
+        - id: terraform
+          desc: |
+            To disable remote debugging in Terraform:
+
+            ```hcl
+            resource "azurerm_linux_function_app" "example" {
+              name                 = "example-function-app"
+              resource_group_name  = azurerm_resource_group.example.name
+              location             = azurerm_resource_group.example.location
+              service_plan_id      = azurerm_service_plan.example.id
+              storage_account_name = azurerm_storage_account.example.name
+
+              site_config {
+                remote_debugging_enabled = false
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To disable remote debugging in Bicep:
+
+            ```bicep
+            resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+              name: 'example-function-app'
+              location: resourceGroup().location
+              kind: 'functionapp'
+              properties: {
+                serverFarmId: appServicePlan.id
+                siteConfig: {
+                  remoteDebuggingEnabled: false
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/configure-common
+        title: Configure an App Service app
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled-azure
+    filters: |
+      asset.platform == "azure-function-app"
+    mql: |
+      azure.subscription.functionsService.functionApp.configuration.remoteDebuggingEnabled == false
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.resources(/azurerm_(linux|windows)_function_app/).all(
+        blocks.where(type == "site_config").all(
+          arguments['remote_debugging_enabled'] != true
+        )
+      )
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.plan.resourceChanges.where(type == /azurerm_(linux|windows)_function_app/).all(
+        change.after['site_config'] == null ||
+        change.after['site_config'] == empty ||
+        change.after['site_config'].all(_['remote_debugging_enabled'] != true)
+      )
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
+        values['site_config'] == null ||
+        values['site_config'] == empty ||
+        values['site_config'].all(_['remote_debugging_enabled'] != true)
+      )
+  - uid: mondoo-azure-security-function-app-remote-debugging-disabled-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["remoteDebuggingEnabled"] != true
+      )
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny
+    title: Ensure Function App IP restrictions default to deny
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-azure
+        tags:
+          mondoo.com/filter-title: Azure Function App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the unmatched-rule action for Function App access restrictions is set to `Deny`. Access restriction rules are evaluated in priority order, and the default action decides what happens to a request that matches none of them. When that default is `Allow`, the rule list behaves as a block list rather than an allow list, so every address not explicitly denied reaches the application.
+
+        **Why this matters**
+
+        - **Allow rules provide no protection on their own:** Adding rules that permit an office range or a partner network restricts nothing while unmatched traffic is still allowed, so the restrictions appear configured but enforce nothing.
+        - **Silent exposure of new endpoints:** With an allow default, any function added later is reachable from the internet without a configuration change, so exposure grows without review.
+        - **Enumeration of internal functions:** Endpoints intended for internal callers remain reachable and can be discovered and probed by anyone who learns the hostname.
+
+        **Risk mitigation**
+
+        - **Deny-by-default posture:** Setting the unmatched action to `Deny` turns the rule list into an allow list, so only sources explicitly permitted can reach the application.
+        - **Explicit, reviewable access:** Every permitted network becomes a deliberate rule that appears in configuration review rather than an implicit consequence of the default.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Function App** in the Azure Portal.
+        2. Select the function app and open **Settings**, then **Networking**.
+        3. Select **Public network access**, then **Access restriction**.
+        4. A passing function app shows **Unmatched rule action** as **Deny**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az functionapp config access-restriction show --name <FunctionAppName> --resource-group <ResourceGroupName> --query "ipSecurityRestrictionsDefaultAction"
+        ```
+
+        A passing function app returns `Deny`.
+      remediation:
+        - id: portal
+          desc: |
+            To set the unmatched rule action to deny using the Azure Portal:
+
+            1. Navigate to **Function App** in the Azure Portal.
+            2. Select the function app and open **Settings**, then **Networking**.
+            3. Select **Public network access**, then **Access restriction**.
+            4. Add rules that permit the source ranges the application must serve.
+            5. Set **Unmatched rule action** to **Deny**.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To set the unmatched rule action to deny using the Azure CLI:
+
+            ```bash
+            az functionapp config access-restriction set --name <FunctionAppName> --resource-group-name <ResourceGroupName> --default-action Deny
+            ```
+        - id: terraform
+          desc: |
+            To set the unmatched rule action to deny in Terraform:
+
+            ```hcl
+            resource "azurerm_linux_function_app" "example" {
+              name                 = "example-function-app"
+              resource_group_name  = azurerm_resource_group.example.name
+              location             = azurerm_resource_group.example.location
+              service_plan_id      = azurerm_service_plan.example.id
+              storage_account_name = azurerm_storage_account.example.name
+
+              site_config {
+                ip_restriction_default_action = "Deny"
+
+                ip_restriction {
+                  name       = "allow-corporate-range"
+                  action     = "Allow"
+                  priority   = 100
+                  ip_address = "203.0.113.0/24"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set the unmatched rule action to deny in Bicep:
+
+            ```bicep
+            resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+              name: 'example-function-app'
+              location: resourceGroup().location
+              kind: 'functionapp'
+              properties: {
+                serverFarmId: appServicePlan.id
+                siteConfig: {
+                  ipSecurityRestrictionsDefaultAction: 'Deny'
+                  ipSecurityRestrictions: [
+                    {
+                      name: 'allow-corporate-range'
+                      action: 'Allow'
+                      priority: 100
+                      ipAddress: '203.0.113.0/24'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions
+        title: Set up Azure App Service access restrictions
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-azure
+    filters: |
+      asset.platform == "azure-function-app"
+    mql: |
+      azure.subscription.functionsService.functionApp.configuration.ipSecurityRestrictionsDefaultAction == "Deny"
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.resources(/azurerm_(linux|windows)_function_app/).all(
+        blocks.where(type == "site_config") != empty &&
+        blocks.where(type == "site_config").all(
+          arguments['ip_restriction_default_action'] == "Deny"
+        )
+      )
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.plan.resourceChanges.where(type == /azurerm_(linux|windows)_function_app/).all(
+        change.after['site_config'] != empty &&
+        change.after['site_config'].all(_['ip_restriction_default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
+        values['site_config'] != empty &&
+        values['site_config'].all(_['ip_restriction_default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["ipSecurityRestrictionsDefaultAction"] == "Deny"
+      )
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault
+    title: Ensure Function App secret settings use Key Vault references
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-6-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    variants:
+      - uid: mondoo-azure-security-function-app-secrets-in-key-vault-azure
+        tags:
+          mondoo.com/filter-title: Azure Function App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-function-app-secrets-in-key-vault-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that Function App application settings whose names indicate they hold a credential resolve through a Key Vault reference rather than storing the value inline. App Service stores application settings as part of the site configuration, so an inline value is a plaintext credential living in the resource definition.
+
+        **Why this matters**
+
+        - **Broad read access to the value:** Any principal with Reader-level access to the function app can list application settings and read inline secrets, a far wider audience than the data plane the credential protects.
+        - **Propagation into unexpected places:** Application settings appear in ARM exports, deployment templates, activity log entries, support bundles, and infrastructure-as-code state files, so an inline secret is copied into systems with weaker access controls.
+        - **No rotation path:** An inline value has no lifecycle, so rotating the underlying credential requires finding and editing every application that embedded it, which in practice means credentials are rarely rotated.
+        - **No access audit:** Retrieval of an inline setting is not recorded against the secret, so there is no trail showing who read the credential or when.
+
+        **Risk mitigation**
+
+        - **Centralized secret custody:** A Key Vault reference keeps the value in a vault with its own access policies, logging, and rotation, while the application setting holds only a pointer.
+        - **Rotation without redeployment:** Updating the secret in Key Vault takes effect without editing the function app, which makes routine rotation practical.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Function App** in the Azure Portal.
+        2. Select the function app and open **Settings**, then **Environment variables**.
+        3. Review each setting whose name indicates a credential, such as one containing `PASSWORD`, `SECRET`, `KEY`, or `CONNECTIONSTRING`.
+        4. A passing setting shows a **Key vault reference** source rather than a literal value.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az functionapp config appsettings list --name <FunctionAppName> --resource-group <ResourceGroupName> --query "[].{Name:name, Value:value}" -o table
+        ```
+
+        A passing function app returns values beginning with `@Microsoft.KeyVault(` for every credential-bearing setting.
+      remediation:
+        - id: portal
+          desc: |
+            To move secret settings into Key Vault using the Azure Portal:
+
+            1. Store the credential as a secret in **Key Vault**.
+            2. Navigate to **Function App** in the Azure Portal, select the function app, and open **Identity**. Turn on the **System assigned** identity.
+            3. In the key vault, grant that identity the **Key Vault Secrets User** role.
+            4. Return to the function app and open **Settings**, then **Environment variables**.
+            5. Replace the inline value with a reference in the form `@Microsoft.KeyVault(SecretUri=https://<VaultName>.vault.azure.net/secrets/<SecretName>/)`.
+            6. Select **Apply**.
+        - id: cli
+          desc: |
+            To move secret settings into Key Vault using the Azure CLI:
+
+            ```bash
+            az functionapp identity assign --name <FunctionAppName> --resource-group <ResourceGroupName>
+            az functionapp config appsettings set --name <FunctionAppName> --resource-group-name <ResourceGroupName> --settings "MyConnectionString=@Microsoft.KeyVault(SecretUri=https://<VaultName>.vault.azure.net/secrets/<SecretName>/)"
+            ```
+        - id: terraform
+          desc: |
+            To move secret settings into Key Vault in Terraform:
+
+            ```hcl
+            resource "azurerm_linux_function_app" "example" {
+              name                 = "example-function-app"
+              resource_group_name  = azurerm_resource_group.example.name
+              location             = azurerm_resource_group.example.location
+              service_plan_id      = azurerm_service_plan.example.id
+              storage_account_name = azurerm_storage_account.example.name
+
+              identity {
+                type = "SystemAssigned"
+              }
+
+              app_settings = {
+                "MyConnectionString" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.example.versionless_id})"
+              }
+
+              site_config {}
+            }
+            ```
+        - id: bicep
+          desc: |
+            To move secret settings into Key Vault in Bicep:
+
+            ```bicep
+            resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+              name: 'example-function-app'
+              location: resourceGroup().location
+              kind: 'functionapp'
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                serverFarmId: appServicePlan.id
+                siteConfig: {
+                  appSettings: [
+                    {
+                      name: 'MyConnectionString'
+                      value: '@Microsoft.KeyVault(SecretUri=https://examplevault.vault.azure.net/secrets/my-connection-string/)'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+        title: Use Key Vault references as app settings
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault-azure
+    filters: |
+      asset.platform == "azure-function-app"
+    mql: |
+      azure.subscription.functionsService.functionApp.appSettings.where(
+        isLikelySecret == true && hasValue == true
+      ).all(hasKeyVaultReference == true)
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.resources(/azurerm_(linux|windows)_function_app/).all(
+        arguments['app_settings'] == empty ||
+        arguments['app_settings'].where(
+          key == /(?i)(password|passwd|pwd|secret|token|connectionstring|apikey|accountkey|clientsecret)/
+        ).values.all(_ == /^@Microsoft\.KeyVault\(/)
+      )
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.plan.resourceChanges.where(type == /azurerm_(linux|windows)_function_app/).all(
+        change.after['app_settings'] == null ||
+        change.after['app_settings'] == empty ||
+        change.after['app_settings'].where(
+          key == /(?i)(password|passwd|pwd|secret|token|connectionstring|apikey|accountkey|clientsecret)/
+        ).values.all(_ == /^@Microsoft\.KeyVault\(/)
+      )
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_function_app/)
+    mql: |
+      terraform.state.resources.where(type == /azurerm_(linux|windows)_function_app/).all(
+        values['app_settings'] == null ||
+        values['app_settings'] == empty ||
+        values['app_settings'].where(
+          key == /(?i)(password|passwd|pwd|secret|token|connectionstring|apikey|accountkey|clientsecret)/
+        ).values.all(_ == /^@Microsoft\.KeyVault\(/)
+      )
+  - uid: mondoo-azure-security-function-app-secrets-in-key-vault-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites").all(
+        properties["siteConfig"]["appSettings"] == empty ||
+        properties["siteConfig"]["appSettings"].where(
+          _["name"] == /(?i)(password|passwd|pwd|secret|token|connectionstring|apikey|accountkey|clientsecret)/
+        ).all(_["value"] == /^@Microsoft\.KeyVault\(/)
+      )
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous
+    title: Ensure App Service authentication denies anonymous requests
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-azure-security-app-service-auth-no-anonymous-azure
+        tags:
+          mondoo.com/filter-title: Azure App Service App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-app-service-auth-no-anonymous-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the built-in authentication feature on an App Service app rejects unauthenticated requests rather than passing them through to application code. Turning the feature on is only half the configuration: the action taken for unauthenticated clients decides whether the platform actually enforces sign-in. When that action is `AllowAnonymous`, the platform validates tokens that are present but forwards requests without one, leaving enforcement entirely to the application.
+
+        **Why this matters**
+
+        - **Enabled authentication that enforces nothing:** Configuration reviews and dashboards report authentication as on, while anonymous requests continue reaching application code exactly as they did before.
+        - **Enforcement gaps in application code:** Every route must independently verify identity, and a single handler that omits the check becomes an unauthenticated entry point.
+        - **Newly added routes default to open:** A route added later inherits anonymous access unless its author remembers to add an authorization check, so exposure grows quietly over time.
+
+        **Risk mitigation**
+
+        - **Platform-level enforcement:** Rejecting or redirecting unauthenticated clients at the platform means requests reach application code only after identity is established.
+        - **Consistent coverage:** A single platform setting protects every route uniformly, including endpoints the application team has not individually reviewed.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **App Services** in the Azure Portal.
+        2. Select the app and open **Settings**, then **Authentication**.
+        3. Review **Restrict access** under the authentication settings.
+        4. A passing app shows **Require authentication** rather than **Allow unauthenticated access**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az webapp auth show --name <AppName> --resource-group <ResourceGroupName> --query "{Enabled:enabled, UnauthenticatedAction:unauthenticatedClientAction}"
+        ```
+
+        A passing app returns an enabled state of `true` and an unauthenticated action other than `AllowAnonymous`.
+      remediation:
+        - id: portal
+          desc: |
+            To require authentication using the Azure Portal:
+
+            1. Navigate to **App Services** in the Azure Portal.
+            2. Select the app and open **Settings**, then **Authentication**.
+            3. Select **Edit** next to the authentication settings.
+            4. Set **Restrict access** to **Require authentication**.
+            5. Choose the redirect behavior for unauthenticated requests, such as **HTTP 401 Unauthorized** for APIs or the identity provider sign-in page for browser applications.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To require authentication using the Azure CLI:
+
+            ```bash
+            az webapp auth update --name <AppName> --resource-group <ResourceGroupName> --enabled true --action LoginWithAzureActiveDirectory
+            ```
+        - id: terraform
+          desc: |
+            To require authentication in Terraform:
+
+            ```hcl
+            resource "azurerm_linux_web_app" "example" {
+              name                = "example-web-app"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_service_plan.example.location
+              service_plan_id     = azurerm_service_plan.example.id
+
+              auth_settings_v2 {
+                auth_enabled           = true
+                require_authentication = true
+                unauthenticated_action = "RedirectToLoginPage"
+                default_provider       = "azureactivedirectory"
+
+                active_directory_v2 {
+                  client_id                  = var.client_id
+                  tenant_auth_endpoint       = "https://login.microsoftonline.com/${var.tenant_id}/v2.0"
+                  allowed_audiences          = [var.client_id]
+                  client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+                }
+
+                login {}
+              }
+
+              site_config {}
+            }
+            ```
+        - id: bicep
+          desc: |
+            To require authentication in Bicep:
+
+            ```bicep
+            resource authSettings 'Microsoft.Web/sites/config@2023-01-01' = {
+              name: 'authsettingsV2'
+              parent: webApp
+              properties: {
+                globalValidation: {
+                  requireAuthentication: true
+                  unauthenticatedClientAction: 'RedirectToLoginPage'
+                  redirectToProvider: 'azureactivedirectory'
+                }
+                platform: {
+                  enabled: true
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+        title: Authentication and authorization in Azure App Service
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous-azure
+    filters: |
+      asset.platform == "azure-app-service-webapp"
+    mql: |
+      azure.subscription.webService.appsite.authenticationSettings.enabled == true
+      azure.subscription.webService.appsite.authenticationSettings.unauthenticatedClientAction != "AllowAnonymous"
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /azurerm_(linux|windows)_web_app/)
+    mql: |
+      terraform.resources(/azurerm_(linux|windows)_web_app/).all(
+        blocks.where(type == "auth_settings_v2") != empty &&
+        blocks.where(type == "auth_settings_v2").all(
+          arguments['require_authentication'] == true &&
+          arguments['unauthenticated_action'] != "AllowAnonymous"
+        )
+      )
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /azurerm_(linux|windows)_web_app/)
+    mql: |
+      terraform.plan.resourceChanges.where(type == /azurerm_(linux|windows)_web_app/).all(
+        change.after['auth_settings_v2'] != empty &&
+        change.after['auth_settings_v2'].all(
+          _['require_authentication'] == true &&
+          _['unauthenticated_action'] != "AllowAnonymous"
+        )
+      )
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == /azurerm_(linux|windows)_web_app/)
+    mql: |
+      terraform.state.resources.where(type == /azurerm_(linux|windows)_web_app/).all(
+        values['auth_settings_v2'] != empty &&
+        values['auth_settings_v2'].all(
+          _['require_authentication'] == true &&
+          _['unauthenticated_action'] != "AllowAnonymous"
+        )
+      )
+  - uid: mondoo-azure-security-app-service-auth-no-anonymous-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Web/sites/config" && name == "authsettingsV2")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Web/sites/config" && name == "authsettingsV2").all(
+        properties["globalValidation"]["requireAuthentication"] == true &&
+        properties["globalValidation"]["unauthenticatedClientAction"] != "AllowAnonymous"
+      )
+  # No Terraform variants: the azurerm provider exposes no proxy agent or Metadata
+  # Security Protocol attribute on any virtual machine resource, so the setting cannot be
+  # expressed in HCL, plan, or state. Revisit when azurerm adds securityProfile.proxyAgentSettings.
+  - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled
+    title: Ensure virtual machines enforce Metadata Security Protocol
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Compute VM
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a virtual machine runs the Azure Metadata Security Protocol proxy agent in enforcement mode. The Instance Metadata Service answers on a link-local address that every process on the machine can reach, and it issues managed identity access tokens to any caller that asks. The proxy agent places an authenticating broker in front of that endpoint so only approved processes obtain tokens.
+
+        **Why this matters**
+
+        - **Server-side request forgery yields cloud credentials:** An application flaw that lets an attacker control an outbound URL can be pointed at the metadata endpoint to retrieve a managed identity token, converting a web vulnerability into cloud resource access.
+        - **Any local process can impersonate the machine:** Without the proxy agent, a low-privileged local account, a compromised dependency, or a sidecar process can request tokens with the machine's full identity, because the metadata service performs no caller authentication.
+        - **Stolen tokens leave the machine:** Tokens obtained this way are bearer credentials that work from anywhere until expiry, so the compromise outlives the process and the host.
+        - **Identity permissions become the blast radius:** The token carries every role assigned to the machine identity, so the reachable damage is the union of that identity's permissions across the subscription.
+
+        **Risk mitigation**
+
+        - **Authenticated metadata access:** The proxy agent validates the requesting process before issuing a token, so an untrusted process cannot obtain machine credentials.
+        - **Enforcement over observation:** Running in enforce mode blocks unauthorized requests rather than only recording them, which stops the credential theft rather than documenting it.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Virtual machines** in the Azure Portal.
+        2. Select the virtual machine and open **Settings**, then **Configuration**.
+        3. Review the **Metadata Security Protocol** section.
+        4. A passing machine shows the proxy agent enabled with mode **Enforce**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az vm show --name <VMName> --resource-group <ResourceGroupName> --query "securityProfile.proxyAgentSettings"
+        ```
+
+        A passing machine returns an enabled value of `true` and a mode of `Enforce`.
+      remediation:
+        - id: portal
+          desc: |
+            To enforce Metadata Security Protocol using the Azure Portal:
+
+            1. Navigate to **Virtual machines** in the Azure Portal.
+            2. Select the virtual machine and open **Settings**, then **Configuration**.
+            3. In the **Metadata Security Protocol** section, enable the proxy agent.
+            4. Set the mode to **Enforce**. Run in **Audit** first if you need to confirm which processes request tokens.
+            5. Select **Save** and restart the machine so the setting takes effect.
+        - id: cli
+          desc: |
+            To enforce Metadata Security Protocol using the Azure CLI:
+
+            ```bash
+            az vm update --name <VMName> --resource-group <ResourceGroupName> --set securityProfile.proxyAgentSettings.enabled=true securityProfile.proxyAgentSettings.mode=Enforce
+            ```
+        - id: bicep
+          desc: |
+            To enforce Metadata Security Protocol in Bicep:
+
+            ```bicep
+            resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-07-01' = {
+              name: 'example-vm'
+              location: resourceGroup().location
+              properties: {
+                securityProfile: {
+                  proxyAgentSettings: {
+                    enabled: true
+                    mode: 'Enforce'
+                  }
+                }
+              }
+            }
+            ```
+        # No Terraform remediation: the azurerm provider has no proxy agent attribute on any virtual machine resource, and shelling out through a null_resource would not produce a managed setting.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/metadata-security-protocol
+        title: Azure Metadata Security Protocol
+  - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-azure
+    filters: |
+      asset.platform == "azure-compute-vm-api"
+    mql: |
+      azure.subscription.compute.vm.proxyAgentEnabled == true
+      azure.subscription.compute.vm.proxyAgentMode == "Enforce"
+  - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Compute/virtualMachines")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Compute/virtualMachines").all(
+        properties["securityProfile"]["proxyAgentSettings"]["enabled"] == true &&
+        properties["securityProfile"]["proxyAgentSettings"]["mode"] == "Enforce"
+      )
+  # No Terraform or Bicep variants: the agent is deployed as a separate virtual machine
+  # extension resource, and neither HCL, plan, state, nor Bicep expresses which machines an
+  # extension is attached to in a form that proves every machine is covered. The runtime
+  # check reads the installed extension list on each machine, which IaC cannot reproduce.
+  - uid: mondoo-azure-security-compute-vm-defender-endpoint-installed
+    title: Ensure Microsoft Defender for Endpoint is installed on VMs
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-09
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-09
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/pci-dss-4: pcidss-requirement-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    variants:
+      - uid: mondoo-azure-security-compute-vm-defender-endpoint-installed-azure
+        tags:
+          mondoo.com/filter-title: Azure Compute VM
+          mondoo.com/filter-icon: azure
+    docs:
+      desc: |
+        This check ensures that the Microsoft Defender for Endpoint extension is installed on a virtual machine. Enabling the Defender for Servers plan on a subscription licenses the capability, but a machine is only protected once the endpoint agent is actually deployed and reporting.
+
+        **Why this matters**
+
+        - **Licensing is not coverage:** A subscription can show Defender for Servers as enabled while individual machines carry no agent, so plan-level checks report protection that does not exist on the host.
+        - **No detection of on-host activity:** Without the agent there is no behavioral monitoring, no malware detection, and no visibility into process execution, credential theft, or lateral movement originating on the machine.
+        - **Machines miss automatic onboarding:** Virtual machines built from custom images, restored from backup, or created while auto-provisioning was disabled commonly end up without the extension, and nothing surfaces the gap.
+        - **Incident response has no telemetry:** After a compromise, an unmonitored machine provides no timeline of attacker actions, which prevents scoping the incident.
+
+        **Risk mitigation**
+
+        - **Behavioral detection on the host:** The agent detects malicious activity that network controls cannot observe, including in-memory execution and credential dumping.
+        - **Verified per-machine coverage:** Asserting the extension per machine closes the gap between a licensed subscription and an actually protected fleet.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Virtual machines** in the Azure Portal.
+        2. Select the virtual machine and open **Settings**, then **Extensions + applications**.
+        3. Look for the **MDE.Linux** or **MDE.Windows** extension.
+        4. A passing machine lists the extension with a provisioning state of **Succeeded**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az vm extension list --vm-name <VMName> --resource-group <ResourceGroupName> --query "[].{Name:name, Publisher:publisher, State:provisioningState}" -o table
+        ```
+
+        A passing machine returns an `MDE.Linux` or `MDE.Windows` extension in a succeeded state.
+      remediation:
+        - id: portal
+          desc: |
+            To install Microsoft Defender for Endpoint using the Azure Portal:
+
+            1. Navigate to **Microsoft Defender for Cloud** in the Azure Portal.
+            2. Open **Environment settings** and select the subscription.
+            3. Confirm the **Defender for Servers** plan is on.
+            4. Open **Settings and monitoring** and enable **Endpoint protection** so the extension is provisioned automatically on every machine.
+            5. For a machine that remains uncovered, open the machine, select **Extensions + applications**, then **Add**, and install the Microsoft Defender for Endpoint extension.
+        - id: cli
+          desc: |
+            To install Microsoft Defender for Endpoint using the Azure CLI:
+
+            ```bash
+            az vm extension set --vm-name <VMName> --resource-group-name <ResourceGroupName> --vm-extension-name MDE.Linux --publisher Microsoft.Azure.AzureDefenderForServers --enable-auto-upgrade true
+            ```
+        - id: terraform
+          desc: |
+            To install Microsoft Defender for Endpoint in Terraform:
+
+            ```hcl
+            resource "azurerm_virtual_machine_extension" "mde" {
+              name                       = "MDE.Linux"
+              virtual_machine_id         = azurerm_linux_virtual_machine.example.id
+              publisher                  = "Microsoft.Azure.AzureDefenderForServers"
+              type                       = "MDE.Linux"
+              type_handler_version       = "1.0"
+              auto_upgrade_minor_version = true
+              automatic_upgrade_enabled  = true
+            }
+            ```
+        - id: bicep
+          desc: |
+            To install Microsoft Defender for Endpoint in Bicep:
+
+            ```bicep
+            resource mdeExtension 'Microsoft.Compute/virtualMachines/extensions@2024-07-01' = {
+              name: 'MDE.Linux'
+              parent: virtualMachine
+              location: resourceGroup().location
+              properties: {
+                publisher: 'Microsoft.Azure.AzureDefenderForServers'
+                type: 'MDE.Linux'
+                typeHandlerVersion: '1.0'
+                autoUpgradeMinorVersion: true
+                enableAutomaticUpgrade: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/integration-defender-for-endpoint
+        title: Microsoft Defender for Endpoint integration with Defender for Cloud
+  - uid: mondoo-azure-security-compute-vm-defender-endpoint-installed-azure
+    filters: |
+      asset.platform == "azure-compute-vm-api"
+    mql: |
+      azure.subscription.compute.vm.mdeInstalled == true
+  - uid: mondoo-azure-security-mysql-server-backup-retention
+    title: Ensure MySQL servers retain backups for at least seven days
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-171: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cp-9
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    variants:
+      - uid: mondoo-azure-security-mysql-server-backup-retention-azure
+        tags:
+          mondoo.com/filter-title: Azure MySQL Server
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-backup-retention-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that an Azure Database for MySQL server retains automated backups for at least seven days. The retention window sets the outer bound of the point-in-time restore range, so it decides how far back a database can be recovered after data is destroyed or corrupted.
+
+        **Why this matters**
+
+        - **Detection is slower than the minimum window:** Ransomware, malicious deletion by an insider, and silent application corruption are frequently discovered days after they begin, and a retention window shorter than the detection interval leaves no clean restore point.
+        - **Restore range cannot be extended retroactively:** Increasing retention applies only to future backups, so the shortfall is discovered at the moment of the incident when nothing can be done about it.
+        - **Attackers target recoverability first:** An adversary with management-plane access commonly reduces retention before destroying data, which shrinks the recovery window ahead of the damage.
+
+        **Risk mitigation**
+
+        - **Usable recovery window:** Seven days of retention gives operators room to detect a problem and select a restore point from before the damage occurred.
+        - **Point-in-time granularity:** A longer retention window preserves the ability to restore to a moment just before a corrupting change rather than to the last full backup.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Azure Database for MySQL servers** in the Azure Portal.
+        2. Select the server and open **Settings**, then **Compute + storage**.
+        3. Review **Backup retention period**.
+        4. A passing server shows a retention period of seven days or more.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az mysql server show --name <ServerName> --resource-group <ResourceGroupName> --query "storageProfile.backupRetentionDays"
+        ```
+
+        A passing server returns a value of `7` or greater.
+      remediation:
+        - id: portal
+          desc: |
+            To extend the backup retention period using the Azure Portal:
+
+            1. Navigate to **Azure Database for MySQL servers** in the Azure Portal.
+            2. Select the server and open **Settings**, then **Compute + storage**.
+            3. Set **Backup retention period** to seven days or more.
+            4. Select **OK**, then **Save**.
+        - id: cli
+          desc: |
+            To extend the backup retention period using the Azure CLI:
+
+            ```bash
+            az mysql server update --server-name <ServerName> --resource-group-name <ResourceGroupName> --backup-retention 7
+            ```
+        - id: terraform
+          desc: |
+            To extend the backup retention period in Terraform:
+
+            ```hcl
+            resource "azurerm_mysql_server" "example" {
+              name                = "example-mysql-server"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              sku_name              = "GP_Gen5_2"
+              storage_mb            = 5120
+              version               = "8.0"
+              backup_retention_days = 7
+
+              administrator_login          = var.admin_login
+              administrator_login_password = var.admin_password
+              ssl_enforcement_enabled      = true
+            }
+            ```
+        - id: bicep
+          desc: |
+            To extend the backup retention period in Bicep:
+
+            ```bicep
+            resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
+              name: 'example-mysql-server'
+              location: resourceGroup().location
+              properties: {
+                storageProfile: {
+                  backupRetentionDays: 7
+                }
+                sslEnforcement: 'Enabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-backup
+        title: Backup and restore in Azure Database for MySQL
+  - uid: mondoo-azure-security-mysql-server-backup-retention-azure
+    filters: |
+      asset.platform == "azure-mysql-server"
+    mql: |
+      azure.subscription.mySql.server.backupRetentionDays >= 7
+  - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mysql_server")
+    mql: |
+      terraform.resources("azurerm_mysql_server").all(
+        arguments['backup_retention_days'] >= 7
+      )
+  - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_mysql_server")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_mysql_server").all(
+        change.after.backup_retention_days >= 7
+      )
+  - uid: mondoo-azure-security-mysql-server-backup-retention-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_mysql_server")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_mysql_server").all(
+        values.backup_retention_days >= 7
+      )
+  - uid: mondoo-azure-security-mysql-server-backup-retention-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers").all(
+        properties["storageProfile"]["backupRetentionDays"] >= 7
+      )
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule
+    title: Ensure MySQL servers do not allow access from all Azure services
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-azure
+        tags:
+          mondoo.com/filter-title: Azure MySQL Server
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that an Azure Database for MySQL server has no firewall rule spanning `0.0.0.0` to `0.0.0.0`. Azure treats that specific range as the "Allow public access from any Azure service" setting rather than as a literal address, and it permits connections from every resource in every Azure subscription, not only from the account that owns the server.
+
+        **Why this matters**
+
+        - **The rule is tenant-wide, not tenancy-scoped:** Any virtual machine, function, or container in any Azure customer's subscription can open a network connection to the server, so the network control provides no meaningful boundary and only the database credentials stand between an attacker and the data.
+        - **The range is misleading:** The rule reads as a single address rather than a wildcard, so it survives firewall reviews that would immediately reject an obvious `0.0.0.0` to `255.255.255.255` entry.
+        - **Enabled by convenience defaults:** The setting is commonly turned on to unblock an App Service or Function App that could instead reach the server through virtual network integration or a private endpoint.
+        - **Credential attacks become reachable:** With the network path open tenant-wide, brute force and credential stuffing against the administrator login can be run from inside Azure at no cost to the attacker.
+
+        **Risk mitigation**
+
+        - **Restricted network reachability:** Removing the rule limits connections to the address ranges and virtual networks explicitly permitted for the workload.
+        - **Defense in depth for credentials:** A network boundary in front of the database means a leaked or guessed credential is not immediately usable from arbitrary Azure infrastructure.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Azure Database for MySQL servers** in the Azure Portal.
+        2. Select the server and open **Settings**, then **Connection security**.
+        3. Review **Allow access to Azure services** and the firewall rule list.
+        4. A passing server shows the setting as **No** and no rule spanning `0.0.0.0` to `0.0.0.0`.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az mysql server firewall-rule list --server-name <ServerName> --resource-group <ResourceGroupName> --query "[].{Name:name, Start:startIpAddress, End:endIpAddress}" -o table
+        ```
+
+        A passing server returns no rule where the start and end addresses are both `0.0.0.0`.
+      remediation:
+        - id: portal
+          desc: |
+            To remove access from all Azure services using the Azure Portal:
+
+            1. Navigate to **Azure Database for MySQL servers** in the Azure Portal.
+            2. Select the server and open **Settings**, then **Connection security**.
+            3. Set **Allow access to Azure services** to **No**.
+            4. Add explicit firewall rules for the address ranges that must reach the server, or configure a virtual network rule or private endpoint for Azure-hosted callers.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To remove access from all Azure services using the Azure CLI:
+
+            ```bash
+            az mysql server firewall-rule delete --server-name <ServerName> --resource-group <ResourceGroupName> --name AllowAllWindowsAzureIps
+            ```
+        - id: terraform
+          desc: |
+            To remove access from all Azure services in Terraform, delete any firewall rule spanning `0.0.0.0` to `0.0.0.0` and scope rules to real ranges:
+
+            ```hcl
+            resource "azurerm_mysql_firewall_rule" "corporate_range" {
+              name                = "corporate-range"
+              resource_group_name = azurerm_resource_group.example.name
+              server_name         = azurerm_mysql_server.example.name
+              start_ip_address    = "203.0.113.10"
+              end_ip_address      = "203.0.113.20"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To remove access from all Azure services in Bicep, scope firewall rules to real ranges:
+
+            ```bicep
+            resource firewallRule 'Microsoft.DBforMySQL/servers/firewallRules@2017-12-01' = {
+              name: 'corporate-range'
+              parent: mysqlServer
+              properties: {
+                startIpAddress: '203.0.113.10'
+                endIpAddress: '203.0.113.20'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-firewall-rules
+        title: Azure Database for MySQL firewall rules
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-azure
+    filters: |
+      asset.platform == "azure-mysql-server"
+    mql: |
+      azure.subscription.mySql.server.firewallRules.none(
+        startIpAddress == "0.0.0.0" && endIpAddress == "0.0.0.0"
+      )
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_mysql_firewall_rule")
+    mql: |
+      terraform.resources("azurerm_mysql_firewall_rule").all(
+        arguments['start_ip_address'] != "0.0.0.0" || arguments['end_ip_address'] != "0.0.0.0"
+      )
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_mysql_firewall_rule")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_mysql_firewall_rule").all(
+        change.after.start_ip_address != "0.0.0.0" || change.after.end_ip_address != "0.0.0.0"
+      )
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_mysql_firewall_rule")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_mysql_firewall_rule").all(
+        values.start_ip_address != "0.0.0.0" || values.end_ip_address != "0.0.0.0"
+      )
+  - uid: mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.DBforMySQL/servers/firewallRules")
+    mql: |
+      bicep.resources.where(type == "Microsoft.DBforMySQL/servers/firewallRules").all(
+        properties["startIpAddress"] != "0.0.0.0" || properties["endIpAddress"] != "0.0.0.0"
+      )
+  - uid: mondoo-azure-security-managed-hsm-key-expiration
+    title: Ensure expiration dates are set for all Managed HSM keys
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-17
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-managed-hsm-key-expiration-azure
+        tags:
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-key-expiration-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every enabled key in a Managed HSM pool carries an expiration date. A key created without one remains valid indefinitely, so nothing in the platform ever forces it out of service.
+
+        **Why this matters**
+
+        - **Unbounded exposure window:** The longer a key stays in use, the more ciphertext it protects and the more systems and people have touched it, so the consequences of an eventual compromise grow without limit.
+        - **Cryptoperiod cannot be enforced:** Standards expect a defined operational lifetime for key material, and without an expiry the platform has no mechanism to enforce one.
+        - **Departed access is never invalidated:** Keys accessible to former employees or decommissioned services remain valid, because no automatic event retires them.
+        - **Rotation is never triggered:** Without an expiry there is no forcing function for replacement, so keys silently outlive the algorithm choices and threat assumptions they were created under.
+
+        **Risk mitigation**
+
+        - **Enforced cryptoperiod:** An expiration date bounds how long any single key protects data, which limits the value of compromising it.
+        - **Operational forcing function:** A dated key produces a scheduled replacement event rather than relying on someone remembering to rotate it.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Managed HSMs** in the Azure Portal.
+        2. Select the pool and open **Keys**.
+        3. Select each enabled key and review its **Expiration date**.
+        4. A passing pool shows an expiration date set on every enabled key.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az keyvault key list --hsm-name <HsmName> --query "[].{Name:name, Enabled:attributes.enabled, Expires:attributes.expires}" -o table
+        ```
+
+        A passing pool returns a non-empty expiry for every enabled key.
+      remediation:
+        - id: portal
+          desc: |
+            To set expiration dates on Managed HSM keys using the Azure Portal:
+
+            1. Navigate to **Managed HSMs** in the Azure Portal.
+            2. Select the pool and open **Keys**.
+            3. Select the key, then select its current version.
+            4. Set **Expiration date** to the end of the intended cryptoperiod.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To set expiration dates on Managed HSM keys using the Azure CLI:
+
+            ```bash
+            az keyvault key set-attributes --hsm-name <HsmName> --name <KeyName> --expires 2027-01-01T00:00:00Z
+            ```
+        - id: terraform
+          desc: |
+            To set expiration dates on Managed HSM keys in Terraform:
+
+            ```hcl
+            resource "azurerm_key_vault_managed_hardware_security_module_key" "example" {
+              name           = "example-key"
+              managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.example.id
+              key_type       = "RSA-HSM"
+              key_size       = 2048
+              key_opts        = ["decrypt", "encrypt", "sign", "verify"]
+              expiration_date = "2027-01-01T00:00:00Z"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set expiration dates on Managed HSM keys in Bicep:
+
+            ```bicep
+            resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+              name: 'example-key'
+              parent: managedHsm
+              properties: {
+                kty: 'RSA-HSM'
+                keySize: 2048
+                attributes: {
+                  enabled: true
+                  exp: 1798761600
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/overview
+        title: Azure Key Vault Managed HSM overview
+  - uid: mondoo-azure-security-managed-hsm-key-expiration-azure
+    filters: |
+      asset.platform == "azure-keyvault-managedhsm"
+    mql: |
+      azure.subscription.keyVaultService.managedHsm.keys.where(enabled == true).all(expires != empty)
+  - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module_key")
+    mql: |
+      terraform.resources("azurerm_key_vault_managed_hardware_security_module_key").all(
+        arguments['expiration_date'] != empty
+      )
+  - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_key_vault_managed_hardware_security_module_key")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_key_vault_managed_hardware_security_module_key").all(
+        change.after.expiration_date != empty
+      )
+  - uid: mondoo-azure-security-managed-hsm-key-expiration-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_key_vault_managed_hardware_security_module_key")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module_key").all(
+        values.expiration_date != empty
+      )
+  - uid: mondoo-azure-security-managed-hsm-key-expiration-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs/keys")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs/keys").all(
+        properties["attributes"]["exp"] != empty
+      )
+  # No Terraform variants: azurerm_key_vault_managed_hardware_security_module_key exposes no
+  # rotation policy attribute, unlike azurerm_key_vault_key which has a rotation_policy block.
+  # Revisit when the azurerm provider adds rotation policy support for Managed HSM keys.
+  - uid: mondoo-azure-security-managed-hsm-key-auto-rotation
+    title: Ensure Managed HSM keys have automatic rotation enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-12
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    variants:
+      - uid: mondoo-azure-security-managed-hsm-key-auto-rotation-azure
+        tags:
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-managed-hsm-key-auto-rotation-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that every enabled key in a Managed HSM pool has an automatic rotation policy. Rotation replaces key material on a schedule without operator involvement, so the cryptoperiod is enforced by the platform rather than by a calendar reminder.
+
+        **Why this matters**
+
+        - **Manual rotation does not happen:** Rotation that depends on a person remembering competes with operational work and is deferred indefinitely, so keys stay in service far beyond their intended lifetime.
+        - **Rotation is feared as an outage risk:** Teams avoid manual rotation because a mistake breaks decryption for everything the key protects, and that fear grows the longer a key has been in place.
+        - **Compromise stays useful:** Key material exfiltrated from a backup, a memory dump, or a misconfigured application remains valid for as long as the key is active, so rotation is what bounds the damage.
+        - **Volume protected by one key keeps growing:** Every day without rotation adds ciphertext protected by the same key, increasing what a single compromise exposes.
+
+        **Risk mitigation**
+
+        - **Bounded key lifetime without operator action:** An automatic policy retires and replaces key material on schedule, so the cryptoperiod holds without depending on anyone.
+        - **Rotation is routinely exercised:** Regular automated rotation keeps the path working, rather than leaving it untested until an emergency.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Managed HSMs** in the Azure Portal.
+        2. Select the pool and open **Keys**.
+        3. Select each enabled key and open **Rotation policy**.
+        4. A passing pool shows an enabled rotation policy on every key.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az keyvault key rotation-policy show --hsm-name <HsmName> --name <KeyName>
+        ```
+
+        A passing key returns a policy containing a `lifetimeActions` entry with a `rotate` action.
+      remediation:
+        - id: portal
+          desc: |
+            To enable automatic rotation on Managed HSM keys using the Azure Portal:
+
+            1. Navigate to **Managed HSMs** in the Azure Portal.
+            2. Select the pool and open **Keys**.
+            3. Select the key, then select **Rotation policy**.
+            4. Set **Enable auto rotation** to **Enabled** and choose a rotation interval that matches the intended cryptoperiod.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To enable automatic rotation on Managed HSM keys using the Azure CLI:
+
+            ```bash
+            az keyvault key rotation-policy update --hsm-name <HsmName> --name <KeyName> --value <PathToPolicyJson>
+            ```
+        - id: bicep
+          desc: |
+            To enable automatic rotation on Managed HSM keys in Bicep:
+
+            ```bicep
+            resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+              name: 'example-key'
+              parent: managedHsm
+              properties: {
+                kty: 'RSA-HSM'
+                keySize: 2048
+                rotationPolicy: {
+                  lifetimeActions: [
+                    {
+                      action: {
+                        type: 'Rotate'
+                      }
+                      trigger: {
+                        timeAfterCreate: 'P350D'
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+        # No Terraform remediation: the azurerm Managed HSM key resource has no rotation policy attribute, so the policy must be applied through the portal, the CLI, or an ARM or Bicep deployment.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/key-vault/keys/how-to-configure-key-rotation
+        title: Configure cryptographic key auto-rotation in Azure Key Vault
+  - uid: mondoo-azure-security-managed-hsm-key-auto-rotation-azure
+    filters: |
+      asset.platform == "azure-keyvault-managedhsm"
+    mql: |
+      azure.subscription.keyVaultService.managedHsm.keys.where(enabled == true).all(rotationPolicy.enabled == true)
+  - uid: mondoo-azure-security-managed-hsm-key-auto-rotation-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs/keys")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs/keys").all(
+        properties["rotationPolicy"]["lifetimeActions"] != empty
+      )
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny
+    title: Ensure Managed HSM network ACLs default to deny
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-managed-hsm-network-acls-deny-azure
+        tags:
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-network-acls-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the default action on a Managed HSM network rule set is `Deny`. The rule set lists the addresses and virtual networks permitted to reach the pool, and the default action decides what happens to everything else. With a default of `Allow`, the listed rules restrict nothing and the pool accepts connections from any network.
+
+        **Why this matters**
+
+        - **Rules become decorative:** Adding permitted ranges implies a restriction that is not enforced while unmatched traffic is allowed, so the pool looks network-restricted in review but is not.
+        - **A Managed HSM is the highest-value target in the subscription:** It holds the root of trust for encryption across storage, databases, and disks, so network reachability materially widens the attack surface for the keys everything else depends on.
+        - **Credential attacks reach the control plane:** With the network open, stolen or phished credentials for a principal with HSM data-plane roles are usable from anywhere.
+
+        **Risk mitigation**
+
+        - **Deny-by-default network posture:** Setting the default action to `Deny` turns the rule set into an allow list so only named networks reach the pool.
+        - **Layered with identity controls:** A network boundary in front of the HSM means role assignments are not the only barrier protecting key material.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Managed HSMs** in the Azure Portal.
+        2. Select the pool and open **Settings**, then **Networking**.
+        3. Review the firewall and virtual network settings.
+        4. A passing pool denies access from networks that are not explicitly listed.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az keyvault show --hsm-name <HsmName> --query "properties.networkAcls.defaultAction"
+        ```
+
+        A passing pool returns `Deny`.
+      remediation:
+        - id: portal
+          desc: |
+            To set the Managed HSM network default action to deny using the Azure Portal:
+
+            1. Navigate to **Managed HSMs** in the Azure Portal.
+            2. Select the pool and open **Settings**, then **Networking**.
+            3. Select **Selected networks** rather than **All networks**.
+            4. Add the virtual networks and address ranges that must reach the pool.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To set the Managed HSM network default action to deny using the Azure CLI:
+
+            ```bash
+            az keyvault update-hsm --hsm-name <HsmName> --resource-group <ResourceGroupName> --default-action Deny
+            ```
+        - id: terraform
+          desc: |
+            To set the Managed HSM network default action to deny in Terraform:
+
+            ```hcl
+            resource "azurerm_key_vault_managed_hardware_security_module" "example" {
+              name                       = "example-hsm"
+              resource_group_name        = azurerm_resource_group.example.name
+              location                   = azurerm_resource_group.example.location
+              sku_name                   = "Standard_B1"
+              tenant_id                  = data.azurerm_client_config.current.tenant_id
+              admin_object_ids           = [data.azurerm_client_config.current.object_id]
+              purge_protection_enabled   = true
+              soft_delete_retention_days = 90
+
+              network_acls {
+                bypass         = "AzureServices"
+                default_action = "Deny"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set the Managed HSM network default action to deny in Bicep:
+
+            ```bicep
+            resource managedHsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+              name: 'example-hsm'
+              location: resourceGroup().location
+              sku: {
+                family: 'B'
+                name: 'Standard_B1'
+              }
+              properties: {
+                tenantId: subscription().tenantId
+                networkAcls: {
+                  bypass: 'AzureServices'
+                  defaultAction: 'Deny'
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/network-security
+        title: Configure Azure Key Vault Managed HSM network security
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny-azure
+    filters: |
+      asset.platform == "azure-keyvault-managedhsm"
+    mql: |
+      azure.subscription.keyVaultService.managedHsm.networkAcls != empty
+      azure.subscription.keyVaultService.managedHsm.networkAcls["defaultAction"] == "Deny"
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.resources("azurerm_key_vault_managed_hardware_security_module").all(
+        blocks.where(type == "network_acls") != empty &&
+        blocks.where(type == "network_acls").all(arguments['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
+        change.after['network_acls'] != empty &&
+        change.after['network_acls'].all(_['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
+        values['network_acls'] != empty &&
+        values['network_acls'].all(_['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-managed-hsm-network-acls-deny-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs").all(
+        properties["networkAcls"]["defaultAction"] == "Deny"
+      )
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention
+    title: Ensure Managed HSM soft delete retention is at least 90 days
+    impact: 65
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
+      compliance/dora: dora-art-12
+      compliance/hipaa: hipaa-security-ss164-308-a-7-ii-a-contingency-plan-data-backup-plan
+      compliance/iso-27001-2022: iso-27001-2022-a-8-13
+      compliance/nis-2: nis-2-21-2-c
+      compliance/nist-csf-1: nist-csf-1-pr-ip-4
+      compliance/nist-csf-2: nist-csf-2-pr-ds-11
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: soc2-control-cc9-1-1
+      compliance/vda-isa-5: vda-isa-5-3-1-2
+    variants:
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-azure
+        tags:
+          mondoo.com/filter-title: Azure Key Vault Managed HSM
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a Managed HSM pool retains soft-deleted objects for at least 90 days. Soft delete moves a deleted pool or key into a recoverable state instead of destroying it, and the retention period sets how long recovery remains possible before the deletion becomes permanent.
+
+        **Why this matters**
+
+        - **Deleting keys destroys the data they protect:** Encryption keys held in a Managed HSM secure storage accounts, managed disks, and databases, so losing key material renders that data permanently unreadable even though the data itself is intact.
+        - **Accidental deletion is discovered late:** A key removed during a cleanup or a mistaken automation run is often noticed only when a dependent workload fails to decrypt, which can be weeks later.
+        - **Short windows suit an attacker:** An adversary who deletes keys to cause destruction benefits from a short retention period, because it converts a recoverable incident into permanent data loss faster.
+        - **Recovery needs time for approvals:** Restoring a deleted HSM object frequently requires incident escalation and privileged access that takes days to arrange.
+
+        **Risk mitigation**
+
+        - **Adequate recovery window:** Ninety days gives operators time to detect the deletion, escalate, and recover before the object is purged.
+        - **Protection against destructive actions:** A long retention period limits how quickly either an error or a deliberate attack can become irreversible.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Managed HSMs** in the Azure Portal.
+        2. Select the pool and open **Overview**, then review the properties.
+        3. Check the **Soft delete retention period**.
+        4. A passing pool shows 90 days or more.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az keyvault show --hsm-name <HsmName> --query "properties.softDeleteRetentionInDays"
+        ```
+
+        A passing pool returns a value of `90` or greater.
+      remediation:
+        - id: portal
+          desc: |
+            To set the Managed HSM soft delete retention period using the Azure Portal:
+
+            1. The retention period is fixed when the pool is created and cannot be changed afterwards, so plan the value before deployment.
+            2. Navigate to **Managed HSMs** in the Azure Portal and select **Create**.
+            3. On the **Basics** tab, set **Days to retain deleted vaults** to 90.
+            4. Enable **Purge protection** so a deleted pool cannot be removed before the retention period elapses.
+            5. Complete the wizard and select **Create**.
+        - id: cli
+          desc: |
+            To create a Managed HSM with a 90-day soft delete retention period using the Azure CLI:
+
+            ```bash
+            az keyvault create --hsm-name <HsmName> --resource-group <ResourceGroupName> --location <Location> --administrators <ObjectId> --retention-days 90 --enable-purge-protection true
+            ```
+        - id: terraform
+          desc: |
+            To set the Managed HSM soft delete retention period in Terraform:
+
+            ```hcl
+            resource "azurerm_key_vault_managed_hardware_security_module" "example" {
+              name                       = "example-hsm"
+              resource_group_name        = azurerm_resource_group.example.name
+              location                   = azurerm_resource_group.example.location
+              sku_name                   = "Standard_B1"
+              tenant_id                  = data.azurerm_client_config.current.tenant_id
+              admin_object_ids           = [data.azurerm_client_config.current.object_id]
+              soft_delete_retention_days = 90
+              purge_protection_enabled   = true
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set the Managed HSM soft delete retention period in Bicep:
+
+            ```bicep
+            resource managedHsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+              name: 'example-hsm'
+              location: resourceGroup().location
+              sku: {
+                family: 'B'
+                name: 'Standard_B1'
+              }
+              properties: {
+                tenantId: subscription().tenantId
+                enableSoftDelete: true
+                softDeleteRetentionInDays: 90
+                enablePurgeProtection: true
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/soft-delete-overview
+        title: Managed HSM soft delete overview
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-azure
+    filters: |
+      asset.platform == "azure-keyvault-managedhsm"
+    mql: |
+      azure.subscription.keyVaultService.managedHsm.softDeleteRetentionInDays >= 90
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.resources("azurerm_key_vault_managed_hardware_security_module").all(
+        arguments['soft_delete_retention_days'] >= 90
+      )
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
+        change.after.soft_delete_retention_days >= 90
+      )
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_key_vault_managed_hardware_security_module")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_key_vault_managed_hardware_security_module").all(
+        values.soft_delete_retention_days >= 90
+      )
+  - uid: mondoo-azure-security-managed-hsm-soft-delete-retention-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.KeyVault/managedHSMs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.KeyVault/managedHSMs").all(
+        properties["softDeleteRetentionInDays"] >= 90
+      )
+  # No Terraform variants: azurerm_synapse_workspace exposes no trusted service bypass
+  # attribute, so the setting cannot be expressed in HCL, plan, or state. Revisit when the
+  # azurerm provider surfaces trustedServiceBypassEnabled.
+  - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled
+    title: Ensure Synapse workspaces disable trusted service bypass
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Synapse Analytics Workspace
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that trusted service bypass is disabled on a Synapse Analytics workspace. The bypass allows Azure first-party services to reach the workspace without matching its firewall or private endpoint rules, which opens a path around the network controls configured on the workspace.
+
+        **Why this matters**
+
+        - **It overrides the public access setting:** A workspace configured to deny public network access still accepts connections through the bypass, so the network restriction does not hold in the way its configuration suggests.
+        - **Trust extends to a broad service category, not to specific resources:** The bypass admits a class of Azure services rather than named resources belonging to the account, so the trust boundary is far wider than most operators expect.
+        - **Provides a route to analytics data:** A Synapse workspace fronts data lake storage and dedicated SQL pools, so a path around its network controls reaches consolidated organizational data.
+
+        **Risk mitigation**
+
+        - **Network controls are authoritative:** Disabling the bypass means the firewall rules, private endpoints, and public access setting fully determine who can reach the workspace.
+        - **Explicit connectivity for Azure callers:** First-party services that genuinely need access connect through managed private endpoints, which are named, reviewable, and scoped to specific resources.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Azure Synapse Analytics** in the Azure Portal.
+        2. Select the workspace and open **Security**, then **Networking**.
+        3. Review the option allowing Azure services and resources to access the workspace.
+        4. A passing workspace has the trusted service bypass turned off.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az synapse workspace show --name <WorkspaceName> --resource-group <ResourceGroupName> --query "trustedServiceBypassEnabled"
+        ```
+
+        A passing workspace returns `false`.
+      remediation:
+        - id: portal
+          desc: |
+            To disable trusted service bypass using the Azure Portal:
+
+            1. Navigate to **Azure Synapse Analytics** in the Azure Portal.
+            2. Select the workspace and open **Security**, then **Networking**.
+            3. Clear the option allowing Azure services and resources to access the workspace.
+            4. Create managed private endpoints for any first-party service that still requires connectivity.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To disable trusted service bypass using the Azure CLI:
+
+            ```bash
+            az rest --method patch --uri "https://management.azure.com/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroupName>/providers/Microsoft.Synapse/workspaces/<WorkspaceName>?api-version=2021-06-01" --body '{"properties":{"trustedServiceBypassEnabled":false}}'
+            ```
+        - id: bicep
+          desc: |
+            To disable trusted service bypass in Bicep:
+
+            ```bicep
+            resource synapseWorkspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
+              name: 'example-synapse-workspace'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+                trustedServiceBypassEnabled: false
+              }
+            }
+            ```
+        # No Terraform remediation: azurerm_synapse_workspace has no trusted service bypass attribute, so the setting must be applied through the portal, the CLI, or an ARM or Bicep deployment.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/synapse-analytics/security/connectivity-settings
+        title: Azure Synapse Analytics connectivity settings
+  - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled-azure
+    filters: |
+      asset.platform == "azure-synapse-workspace"
+    mql: |
+      azure.subscription.synapse.workspace.trustedServiceBypassEnabled == false
+  - uid: mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        properties["trustedServiceBypassEnabled"] != true
+      )
+  - uid: mondoo-azure-security-synapse-managed-identity
+    title: Ensure Synapse workspaces use a managed identity
+    impact: 65
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    variants:
+      - uid: mondoo-azure-security-synapse-managed-identity-azure
+        tags:
+          mondoo.com/filter-title: Azure Synapse Analytics Workspace
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-synapse-managed-identity-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-managed-identity-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-managed-identity-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-synapse-managed-identity-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a Synapse Analytics workspace has a managed identity assigned. A workspace without one authenticates to storage accounts, key vaults, and databases using credentials embedded in linked service definitions, which means long-lived secrets stored in the workspace configuration.
+
+        **Why this matters**
+
+        - **Embedded credentials replace short-lived tokens:** Without a managed identity, linked services hold account keys, connection strings, or service principal secrets that remain valid until someone manually rotates them.
+        - **Credentials spread through pipeline definitions:** Linked service configuration is exported, copied between environments, and committed to source control, carrying the embedded secret with it.
+        - **Attribution is lost:** Shared credentials produce data-plane audit entries that identify the credential rather than the workspace, so access cannot be traced to a specific resource during an investigation.
+        - **Rotation breaks pipelines:** Because rotating an embedded key breaks every pipeline using it, rotation is deferred and credentials stay valid for years.
+
+        **Risk mitigation**
+
+        - **No stored credentials:** A managed identity obtains short-lived tokens from the platform, so there is no secret in the workspace configuration to leak or rotate.
+        - **Traceable, revocable access:** Data-plane access is attributed to the workspace identity and can be revoked centrally by removing its role assignments.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Azure Synapse Analytics** in the Azure Portal.
+        2. Select the workspace and open **Settings**, then **Managed identities**.
+        3. Review the system-assigned and user-assigned identity status.
+        4. A passing workspace has at least one managed identity assigned.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az synapse workspace show --name <WorkspaceName> --resource-group <ResourceGroupName> --query "identity"
+        ```
+
+        A passing workspace returns an identity with a type other than `None`.
+      remediation:
+        - id: portal
+          desc: |
+            To assign a managed identity using the Azure Portal:
+
+            1. Navigate to **Azure Synapse Analytics** in the Azure Portal.
+            2. Select the workspace and open **Settings**, then **Managed identities**.
+            3. Turn on the **System assigned** identity and select **Save**.
+            4. Grant the identity the roles it needs on the target storage accounts and key vaults.
+            5. Update each linked service to authenticate with the managed identity rather than an account key.
+        - id: cli
+          desc: |
+            To grant a Synapse managed identity access to a storage account using the Azure CLI:
+
+            ```bash
+            az role assignment create --assignee <WorkspacePrincipalId> --role "Storage Blob Data Contributor" --scope <StorageAccountResourceId>
+            ```
+        - id: terraform
+          desc: |
+            To assign a managed identity in Terraform:
+
+            ```hcl
+            resource "azurerm_synapse_workspace" "example" {
+              name                                 = "example-synapse-workspace"
+              resource_group_name                  = azurerm_resource_group.example.name
+              location                             = azurerm_resource_group.example.location
+              storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
+              sql_administrator_login              = var.sql_admin_login
+              sql_administrator_login_password     = var.sql_admin_password
+
+              identity {
+                type = "SystemAssigned"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To assign a managed identity in Bicep:
+
+            ```bicep
+            resource synapseWorkspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
+              name: 'example-synapse-workspace'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                publicNetworkAccess: 'Disabled'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/synapse-analytics/security/synapse-workspace-managed-identity
+        title: Azure Synapse workspace managed identity
+  - uid: mondoo-azure-security-synapse-managed-identity-azure
+    filters: |
+      asset.platform == "azure-synapse-workspace"
+    mql: |
+      azure.subscription.synapse.workspace.identity != empty
+  - uid: mondoo-azure-security-synapse-managed-identity-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_synapse_workspace")
+    mql: |
+      terraform.resources("azurerm_synapse_workspace").all(
+        blocks.where(type == "identity") != empty
+      )
+  - uid: mondoo-azure-security-synapse-managed-identity-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_synapse_workspace")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_synapse_workspace").all(
+        change.after['identity'] != null &&
+        change.after['identity'] != empty
+      )
+  - uid: mondoo-azure-security-synapse-managed-identity-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_synapse_workspace")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_synapse_workspace").all(
+        values['identity'] != null &&
+        values['identity'] != empty
+      )
+  - uid: mondoo-azure-security-synapse-managed-identity-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Synapse/workspaces")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Synapse/workspaces").all(
+        body["identity"]["type"] != empty && body["identity"]["type"] != "None"
+      )
+  # No Terraform or Bicep variants: the assertion spans two resources, resolving the workspace's
+  # default Data Lake Storage account and reading its secure transfer setting. IaC expresses the
+  # link as a resource reference that neither the terraform nor the bicep provider dereferences,
+  # so a variant could only assert the setting on unrelated storage accounts.
+  - uid: mondoo-azure-security-synapse-default-storage-secure-transfer
+    title: Ensure Synapse default storage requires secure transfer
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-synapse-default-storage-secure-transfer-azure
+        tags:
+          mondoo.com/filter-title: Azure Synapse Analytics Workspace
+          mondoo.com/filter-icon: azure
+    docs:
+      desc: |
+        This check ensures that the Data Lake Storage account backing a Synapse Analytics workspace requires secure transfer. Every Spark job, pipeline run, and serverless SQL query in the workspace reads and writes through this account, so its transport setting governs the confidentiality of the workspace's entire data path.
+
+        **Why this matters**
+
+        - **The primary data path is at stake:** Unlike an incidental storage account, the default account carries the workspace's analytical datasets, so allowing plaintext exposes the data the workspace exists to process.
+        - **A workspace setting cannot compensate:** Hardening the workspace network does not change how clients connect to the storage account, because the transport requirement lives on the storage account itself.
+        - **Shared account keys travel with the request:** Requests authorized with an account key send that key on every call, so a plaintext connection exposes a credential granting full access to the account.
+        - **The gap is easy to miss:** Storage accounts created automatically alongside a workspace are frequently excluded from the review that covers deliberately provisioned accounts.
+
+        **Risk mitigation**
+
+        - **Encrypted analytics data path:** Requiring secure transfer forces HTTPS for every read and write against the workspace's primary storage.
+        - **Rejected plaintext clients:** Older tools and SDK versions that would silently connect over HTTP fail closed rather than transmitting data unencrypted.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Azure Synapse Analytics** in the Azure Portal.
+        2. Select the workspace and open **Overview** to identify the primary Data Lake Storage account.
+        3. Navigate to **Storage accounts**, select that account, and open **Settings**, then **Configuration**.
+        4. A passing account shows **Secure transfer required** as **Enabled**.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az storage account show --name <DefaultStorageAccountName> --resource-group <ResourceGroupName> --query "enableHttpsTrafficOnly"
+        ```
+
+        A passing account returns `true`.
+      remediation:
+        - id: portal
+          desc: |
+            To require secure transfer on the default storage account using the Azure Portal:
+
+            1. Navigate to **Azure Synapse Analytics** in the Azure Portal and open the workspace **Overview** to identify the primary Data Lake Storage account.
+            2. Navigate to **Storage accounts** and select that account.
+            3. Open **Settings**, then **Configuration**.
+            4. Set **Secure transfer required** to **Enabled**.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To require secure transfer on the default storage account using the Azure CLI:
+
+            ```bash
+            az storage account update --name <DefaultStorageAccountName> --resource-group <ResourceGroupName> --https-only true
+            ```
+        - id: terraform
+          desc: |
+            To require secure transfer on the storage account backing a Synapse workspace in Terraform:
+
+            ```hcl
+            resource "azurerm_storage_account" "synapse" {
+              name                     = "examplesynapsestorage"
+              resource_group_name      = azurerm_resource_group.example.name
+              location                 = azurerm_resource_group.example.location
+              account_tier             = "Standard"
+              account_replication_type = "LRS"
+              account_kind             = "StorageV2"
+              is_hns_enabled           = true
+
+              https_traffic_only_enabled = true
+              min_tls_version            = "TLS1_2"
+            }
+            ```
+        - id: bicep
+          desc: |
+            To require secure transfer on the storage account backing a Synapse workspace in Bicep:
+
+            ```bicep
+            resource synapseStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'examplesynapsestorage'
+              location: resourceGroup().location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+              properties: {
+                isHnsEnabled: true
+                supportsHttpsTrafficOnly: true
+                minimumTlsVersion: 'TLS1_2'
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/storage/common/storage-require-secure-transfer
+        title: Require secure transfer to ensure secure connections
+  - uid: mondoo-azure-security-synapse-default-storage-secure-transfer-azure
+    filters: |
+      asset.platform == "azure-synapse-workspace"
+    mql: |
+      azure.subscription.synapse.workspace.defaultStorage == empty ||
+      azure.subscription.synapse.workspace.defaultStorage.enableHttpsTrafficOnly == true
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny
+    title: Ensure Azure IoT Hub network rule sets default to deny
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-azure
+        tags:
+          mondoo.com/filter-title: Azure IoT Hub
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the default action on an IoT Hub network rule set is `Deny`. The rule set names the IP ranges allowed to reach the hub, and the default action governs everything that matches no rule. When that default is `Allow`, the listed ranges restrict nothing and the hub accepts connections from any address.
+
+        **Why this matters**
+
+        - **Allow rules imply protection that is absent:** Adding the ranges used by a device fleet or a partner network suggests the hub is restricted, while unmatched traffic continues to be accepted from anywhere.
+        - **Device credentials are widely distributed:** Device keys and certificates live on hardware in the field that is physically accessible and frequently extractable, so a stolen credential should not be usable from an arbitrary internet host.
+        - **A hub is a pivot into the estate:** Device-to-cloud messages flow onward into storage, Event Hubs, and stream processing, so unrestricted hub access reaches downstream systems.
+        - **Both endpoints are covered:** The rule set governs the built-in Event Hub-compatible endpoint as well as the device endpoint, so an open default exposes the telemetry read path too.
+
+        **Risk mitigation**
+
+        - **Deny-by-default posture:** Setting the default action to `Deny` makes the rule list an allow list, so only named ranges reach the hub.
+        - **Stolen credentials are geographically bounded:** A device key lifted from field hardware only works from a permitted network range rather than from anywhere on the internet.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **IoT Hub** in the Azure Portal.
+        2. Select the hub and open **Security settings**, then **Networking**.
+        3. Select the **Public access** tab and review the IP filter rules.
+        4. A passing hub rejects traffic that matches no rule.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az iot hub show --name <IoTHubName> --query "properties.networkRuleSets.defaultAction"
+        ```
+
+        A passing hub returns `Deny`.
+      remediation:
+        - id: portal
+          desc: |
+            To set the IoT Hub network rule default action to deny using the Azure Portal:
+
+            1. Navigate to **IoT Hub** in the Azure Portal.
+            2. Select the hub and open **Security settings**, then **Networking**.
+            3. Select the **Public access** tab.
+            4. Add IP filter rules for the ranges your devices and services connect from.
+            5. Set the default action so unmatched traffic is denied.
+            6. Select **Save**.
+        - id: cli
+          desc: |
+            To set the IoT Hub network rule default action to deny using the Azure CLI:
+
+            ```bash
+            az iot hub update --name <IoTHubName> --resource-group <ResourceGroupName> --set properties.networkRuleSets.defaultAction=Deny
+            ```
+        - id: terraform
+          desc: |
+            To set the IoT Hub network rule default action to deny in Terraform:
+
+            ```hcl
+            resource "azurerm_iothub" "example" {
+              name                = "example-iothub"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+
+              sku {
+                name     = "S1"
+                capacity = 1
+              }
+
+              network_rule_set {
+                default_action                     = "Deny"
+                apply_to_builtin_eventhub_endpoint = true
+
+                ip_rule {
+                  name    = "allow-device-network"
+                  ip_mask = "203.0.113.0/24"
+                  action  = "Allow"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To set the IoT Hub network rule default action to deny in Bicep:
+
+            ```bicep
+            resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+              name: 'example-iothub'
+              location: resourceGroup().location
+              sku: {
+                name: 'S1'
+                capacity: 1
+              }
+              properties: {
+                networkRuleSets: {
+                  defaultAction: 'Deny'
+                  applyToBuiltInEventHubEndpoint: true
+                  ipRules: [
+                    {
+                      filterName: 'allow-device-network'
+                      action: 'Allow'
+                      ipMask: '203.0.113.0/24'
+                    }
+                  ]
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ip-filtering
+        title: Use IP filters to restrict connectivity to IoT Hub
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-azure
+    filters: |
+      asset.platform == "azure-iot-iothub"
+    mql: |
+      azure.subscription.iotService.iotHub.networkRuleSet != empty
+      azure.subscription.iotService.iotHub.networkRuleSet["defaultAction"] == "Deny"
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_iothub")
+    mql: |
+      terraform.resources("azurerm_iothub").all(
+        blocks.where(type == "network_rule_set") != empty &&
+        blocks.where(type == "network_rule_set").all(arguments['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_iothub").all(
+        change.after['network_rule_set'] != empty &&
+        change.after['network_rule_set'].all(_['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_iothub")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_iothub").all(
+        values['network_rule_set'] != empty &&
+        values['network_rule_set'].all(_['default_action'] == "Deny")
+      )
+  - uid: mondoo-azure-security-iot-hub-network-rule-set-deny-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Devices/IotHubs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Devices/IotHubs").all(
+        properties["networkRuleSets"]["defaultAction"] == "Deny"
+      )
+  - uid: mondoo-azure-security-network-peering-encryption-enabled
+    title: Ensure virtual network peerings encrypt traffic in transit
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-azure-security-network-peering-encryption-enabled-azure
+        tags:
+          mondoo.com/filter-title: Azure Virtual Network
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-network-peering-encryption-enabled-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that traffic crossing a virtual network peering is encrypted. Virtual network encryption applies AES to packets moving between peered networks on the Azure backbone. Because encryption must be enabled on both sides of a peering, a peer that has not enabled it leaves the link carrying plaintext regardless of the local configuration.
+
+        **Why this matters**
+
+        - **Peered traffic is not encrypted by default:** Azure isolates virtual networks logically but does not encrypt traffic between them, so packets cross physical infrastructure in whatever form the application produced.
+        - **Peering carries the most sensitive internal flows:** Database replication, internal service calls, and management traffic move across peerings, and these are often the flows least likely to carry their own TLS.
+        - **Application-layer encryption is inconsistent:** Legacy protocols, internal APIs built without TLS, and database wire protocols configured without encryption all rely on the network being trusted.
+        - **The peer controls half the outcome:** A network owned by another team or subscription that has not enabled encryption silently downgrades the link, so the local setting alone does not establish the guarantee.
+
+        **Risk mitigation**
+
+        - **Encryption on the backbone:** Enabling virtual network encryption protects inter-network traffic without changing any application.
+        - **Verified on both ends:** Checking the peering rather than only the local network confirms the remote side also enforces encryption, which is what determines whether the link is actually protected.
+
+        Encryption requires supported virtual machine sizes on both sides, and setting the enforcement mode to drop unencrypted traffic makes the protection fail closed rather than falling back to plaintext.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Virtual networks** in the Azure Portal.
+        2. Select the network and open **Settings**, then **Peerings**.
+        3. Select each peering and review the encryption status.
+        4. A passing peering shows encryption as enabled on both the local and remote networks.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az network vnet peering list --vnet-name <VNetName> --resource-group <ResourceGroupName> --query "[].{Name:name, Encryption:remoteVirtualNetworkEncryption}" -o table
+        ```
+
+        A passing network reports encryption as enabled for every peering.
+      remediation:
+        - id: portal
+          desc: |
+            To encrypt virtual network peering traffic using the Azure Portal:
+
+            1. Navigate to **Virtual networks** in the Azure Portal.
+            2. Select the network and open **Settings**, then **Encryption**.
+            3. Enable **Virtual network encryption** and set the enforcement to drop unencrypted traffic.
+            4. Repeat these steps on the peered network, since encryption only applies when both sides enable it.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To encrypt virtual network peering traffic using the Azure CLI:
+
+            ```bash
+            az network vnet update --name <VNetName> --resource-group <ResourceGroupName> --enable-encryption true --encryption-enforcement-policy dropUnencrypted
+            ```
+        - id: terraform
+          desc: |
+            To encrypt virtual network peering traffic in Terraform, enable encryption on both peered networks:
+
+            ```hcl
+            resource "azurerm_virtual_network" "example" {
+              name                = "example-network"
+              resource_group_name = azurerm_resource_group.example.name
+              location            = azurerm_resource_group.example.location
+              address_space       = ["10.0.0.0/16"]
+
+              encryption {
+                enforcement = "DropUnencrypted"
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To encrypt virtual network peering traffic in Bicep, enable encryption on both peered networks:
+
+            ```bicep
+            resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+              name: 'example-network'
+              location: resourceGroup().location
+              properties: {
+                addressSpace: {
+                  addressPrefixes: [ '10.0.0.0/16' ]
+                }
+                encryption: {
+                  enabled: true
+                  enforcement: 'DropUnencrypted'
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-encryption-overview
+        title: Azure Virtual Network encryption overview
+  - uid: mondoo-azure-security-network-peering-encryption-enabled-azure
+    filters: |
+      asset.platform == "azure-virtual-network"
+    mql: |
+      azure.subscription.network.virtualNetwork.peerings.all(remoteVirtualNetworkEncryptionEnabled == true)
+  - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_virtual_network")
+    mql: |
+      terraform.resources("azurerm_virtual_network").all(
+        blocks.where(type == "encryption") != empty &&
+        blocks.where(type == "encryption").all(arguments['enforcement'] == "DropUnencrypted")
+      )
+  - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_virtual_network")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_virtual_network").all(
+        change.after['encryption'] != empty &&
+        change.after['encryption'].all(_['enforcement'] == "DropUnencrypted")
+      )
+  - uid: mondoo-azure-security-network-peering-encryption-enabled-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_virtual_network")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_virtual_network").all(
+        values['encryption'] != empty &&
+        values['encryption'].all(_['enforcement'] == "DropUnencrypted")
+      )
+  - uid: mondoo-azure-security-network-peering-encryption-enabled-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.Network/virtualNetworks")
+    mql: |
+      bicep.resources.where(type == "Microsoft.Network/virtualNetworks").all(
+        properties["encryption"]["enabled"] == true &&
+        properties["encryption"]["enforcement"] == "DropUnencrypted"
+      )
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions
+    title: Ensure Container Apps with external ingress restrict source IPs
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
+    variants:
+      - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-azure
+        tags:
+          mondoo.com/filter-title: Azure Container App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a Container App accepting external ingress also defines IP security restrictions. External ingress publishes the app on a public fully qualified domain name reachable from the internet, and without source restrictions every address on the internet can reach the application.
+
+        **Why this matters**
+
+        - **Public exposure is the default for external ingress:** Enabling external ingress to make an app reachable from a corporate network or a partner also makes it reachable from everywhere, because the two are not distinguished without restrictions.
+        - **Application code becomes the only control:** With no network filter, every request reaches the application, so authentication flaws, unpatched dependencies, and debug endpoints are directly exploitable from the internet.
+        - **Internal APIs are published unintentionally:** Container Apps used as backend services frequently enable external ingress for convenience during development and retain it in production.
+        - **Discovery is trivial:** Container App hostnames follow a predictable pattern and appear in certificate transparency logs, so an unrestricted app is found without targeting.
+
+        **Risk mitigation**
+
+        - **Reduced reachable surface:** Source restrictions confine access to known networks, so internet-wide scanning and exploitation never reach the application.
+        - **Defense in depth:** A network filter in front of the app limits exposure from an authentication flaw or a vulnerable dependency until it can be fixed.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Container Apps** in the Azure Portal.
+        2. Select the app and open **Settings**, then **Ingress**.
+        3. Check whether ingress traffic is accepted from anywhere, and review the **IP Security Restrictions** list.
+        4. A passing app either limits ingress to the Container Apps environment or defines source IP restrictions.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az containerapp ingress show --name <ContainerAppName> --resource-group <ResourceGroupName> --query "{External:external, IpRestrictions:ipSecurityRestrictions}"
+        ```
+
+        A passing app returns `false` for external ingress, or a non-empty IP restriction list.
+      remediation:
+        - id: portal
+          desc: |
+            To restrict source addresses on external ingress using the Azure Portal:
+
+            1. Navigate to **Container Apps** in the Azure Portal.
+            2. Select the app and open **Settings**, then **Ingress**.
+            3. Set **Ingress traffic** to **Limited to Container Apps Environment** where the app serves only internal callers.
+            4. Where public ingress is required, add entries under **IP Security Restrictions** for the ranges permitted to reach the app, and set the restriction behavior to allow only those ranges.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To restrict source addresses on external ingress using the Azure CLI:
+
+            ```bash
+            az containerapp ingress access-restriction set --name <ContainerAppName> --resource-group-name <ResourceGroupName> --rule-name allow-corporate-range --ip-address 203.0.113.0/24 --action Allow
+            ```
+        - id: terraform
+          desc: |
+            To restrict source addresses on external ingress in Terraform:
+
+            ```hcl
+            resource "azurerm_container_app" "example" {
+              name                         = "example-container-app"
+              resource_group_name          = azurerm_resource_group.example.name
+              container_app_environment_id = azurerm_container_app_environment.example.id
+              revision_mode                = "Single"
+
+              ingress {
+                external_enabled = true
+                target_port      = 8080
+
+                ip_security_restriction {
+                  name             = "allow-corporate-range"
+                  action           = "Allow"
+                  ip_address_range = "203.0.113.0/24"
+                }
+
+                traffic_weight {
+                  latest_revision = true
+                  percentage      = 100
+                }
+              }
+
+              template {
+                container {
+                  name   = "example"
+                  image  = "mcr.microsoft.com/k8se/quickstart:latest"
+                  cpu    = 0.25
+                  memory = "0.5Gi"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To restrict source addresses on external ingress in Bicep:
+
+            ```bicep
+            resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+              name: 'example-container-app'
+              location: resourceGroup().location
+              properties: {
+                managedEnvironmentId: containerAppEnvironment.id
+                configuration: {
+                  ingress: {
+                    external: true
+                    targetPort: 8080
+                    ipSecurityRestrictions: [
+                      {
+                        name: 'allow-corporate-range'
+                        action: 'Allow'
+                        ipAddressRange: '203.0.113.0/24'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/container-apps/ip-restrictions
+        title: Configure IP ingress restrictions in Azure Container Apps
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-azure
+    filters: |
+      asset.platform == "azure-container-app"
+    mql: |
+      azure.subscription.containerAppService.containerApp.ingressExternal != true ||
+      azure.subscription.containerAppService.containerApp.ipSecurityRestrictions != empty
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
+    mql: |
+      terraform.resources("azurerm_container_app").all(
+        blocks.where(type == "ingress").all(
+          arguments['external_enabled'] != true ||
+          blocks.where(type == "ip_security_restriction") != empty
+        )
+      )
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_container_app").all(
+        change.after['ingress'] == null ||
+        change.after['ingress'] == empty ||
+        change.after['ingress'].all(
+          _['external_enabled'] != true ||
+          _['ip_security_restriction'] != empty
+        )
+      )
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_container_app").all(
+        values['ingress'] == null ||
+        values['ingress'] == empty ||
+        values['ingress'].all(
+          _['external_enabled'] != true ||
+          _['ip_security_restriction'] != empty
+        )
+      )
+  - uid: mondoo-azure-security-container-app-ingress-ip-restrictions-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        properties["configuration"]["ingress"]["external"] != true ||
+        properties["configuration"]["ingress"]["ipSecurityRestrictions"] != empty
+      )
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard
+    title: Ensure Container Apps do not allow wildcard CORS origins
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-4
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-azure-security-container-app-cors-no-wildcard-azure
+        tags:
+          mondoo.com/filter-title: Azure Container App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-cors-no-wildcard-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that the cross-origin resource sharing policy on a Container App does not list `*` as an allowed origin. A wildcard instructs browsers to permit scripts from any website to issue requests to the application and read the responses.
+
+        **Why this matters**
+
+        - **Any website can call the API through a visitor's browser:** A wildcard origin lets a malicious or compromised page issue requests to the application from a user's browser and read what comes back.
+        - **Session cookies and tokens ride along:** Where the browser attaches credentials, the attacking page acts with the victim's identity, so the response contains that user's data.
+        - **The application cannot tell the difference:** Requests originating from an attacker's page look identical to requests from the legitimate front end, so server-side logic offers no protection.
+        - **Added during development and left in place:** Wildcards are commonly set to unblock local development and then ship to production, where the permissive policy is invisible to users.
+
+        **Risk mitigation**
+
+        - **Explicit origin allow list:** Naming the front-end origins that may call the application means no other site can read responses through a visitor's browser.
+        - **Browser-enforced boundary:** A correct policy makes the browser reject cross-origin reads before the response is exposed to attacker-controlled script.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Container Apps** in the Azure Portal.
+        2. Select the app and open **Settings**, then **CORS**.
+        3. Review the **Allowed Origins** list.
+        4. A passing app lists specific origins and does not include `*`.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az containerapp ingress cors show --name <ContainerAppName> --resource-group <ResourceGroupName> --query "allowedOrigins"
+        ```
+
+        A passing app returns an origin list that does not contain `*`.
+      remediation:
+        - id: portal
+          desc: |
+            To remove wildcard CORS origins using the Azure Portal:
+
+            1. Navigate to **Container Apps** in the Azure Portal.
+            2. Select the app and open **Settings**, then **CORS**.
+            3. Remove the `*` entry from **Allowed Origins**.
+            4. Add the specific origins that must call the application, such as `https://app.example.com`.
+            5. Select **Save**.
+        - id: cli
+          desc: |
+            To remove wildcard CORS origins using the Azure CLI:
+
+            ```bash
+            az containerapp ingress cors update --name <ContainerAppName> --resource-group-name <ResourceGroupName> --allowed-origins https://app.example.com
+            ```
+        - id: terraform
+          desc: |
+            To remove wildcard CORS origins in Terraform:
+
+            ```hcl
+            resource "azurerm_container_app" "example" {
+              name                         = "example-container-app"
+              resource_group_name          = azurerm_resource_group.example.name
+              container_app_environment_id = azurerm_container_app_environment.example.id
+              revision_mode                = "Single"
+
+              ingress {
+                external_enabled = true
+                target_port      = 8080
+
+                cors {
+                  allowed_origins = ["https://app.example.com"]
+                  allowed_methods = ["GET", "POST"]
+                }
+
+                traffic_weight {
+                  latest_revision = true
+                  percentage      = 100
+                }
+              }
+
+              template {
+                container {
+                  name   = "example"
+                  image  = "mcr.microsoft.com/k8se/quickstart:latest"
+                  cpu    = 0.25
+                  memory = "0.5Gi"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To remove wildcard CORS origins in Bicep:
+
+            ```bicep
+            resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+              name: 'example-container-app'
+              location: resourceGroup().location
+              properties: {
+                managedEnvironmentId: containerAppEnvironment.id
+                configuration: {
+                  ingress: {
+                    external: true
+                    targetPort: 8080
+                    corsPolicy: {
+                      allowedOrigins: [ 'https://app.example.com' ]
+                      allowedMethods: [ 'GET', 'POST' ]
+                    }
+                  }
+                }
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/container-apps/cors
+        title: Configure CORS in Azure Container Apps
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard-azure
+    filters: |
+      asset.platform == "azure-container-app"
+    mql: |
+      azure.subscription.containerAppService.containerApp.corsAllowedOrigins.none(_ == "*")
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
+    mql: |
+      terraform.resources("azurerm_container_app").all(
+        blocks.where(type == "ingress").all(
+          blocks.where(type == "cors").all(
+            arguments['allowed_origins'] == empty ||
+            arguments['allowed_origins'].none(_ == "*")
+          )
+        )
+      )
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_container_app").all(
+        change.after['ingress'] == null ||
+        change.after['ingress'] == empty ||
+        change.after['ingress'].all(
+          _['cors'] == null ||
+          _['cors'] == empty ||
+          _['cors'].none(_['allowed_origins'] != empty && _['allowed_origins'].contains("*"))
+        )
+      )
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_container_app").all(
+        values['ingress'] == null ||
+        values['ingress'] == empty ||
+        values['ingress'].all(
+          _['cors'] == null ||
+          _['cors'] == empty ||
+          _['cors'].none(_['allowed_origins'] != empty && _['allowed_origins'].contains("*"))
+        )
+      )
+  - uid: mondoo-azure-security-container-app-cors-no-wildcard-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        properties["configuration"]["ingress"]["corsPolicy"]["allowedOrigins"] == empty ||
+        properties["configuration"]["ingress"]["corsPolicy"]["allowedOrigins"].none(_ == "*")
+      )
+  # No Terraform variants: the azurerm provider has no resource for Container Apps auth
+  # configuration. azurerm_container_app exposes dapr, identity, ingress, registry, secret,
+  # and template blocks only, and no separate authConfig resource exists. Revisit if azurerm
+  # adds an azurerm_container_app_auth_config resource.
+  - uid: mondoo-azure-security-container-app-auth-no-anonymous
+    title: Ensure Container App authentication denies anonymous requests
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-2
+    variants:
+      - uid: mondoo-azure-security-container-app-auth-no-anonymous-azure
+        tags:
+          mondoo.com/filter-title: Azure Container App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-container-app-auth-no-anonymous-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a Container App has an authentication configuration that rejects unauthenticated requests. The built-in authentication feature validates tokens before requests reach the container, but only when the action for unauthenticated clients is set to reject or redirect. Where the action is `AllowAnonymous`, the platform validates tokens that are present and forwards everything else untouched.
+
+        **Why this matters**
+
+        - **Configured authentication that enforces nothing:** The app reports an authentication configuration while anonymous requests continue reaching container code exactly as before.
+        - **Enforcement falls to every container:** Each container image must implement its own identity checks, and a service added to the app without them becomes an unauthenticated entry point.
+        - **Containers are frequently built without auth:** Images assembled from internal services or third-party components often assume a trusted network and implement no authentication at all.
+
+        **Risk mitigation**
+
+        - **Platform-level rejection:** Unauthenticated requests are refused before reaching container code, so identity is established regardless of what the image implements.
+        - **Uniform coverage across revisions:** The configuration applies to every revision and every container, including ones not individually reviewed.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Container Apps** in the Azure Portal.
+        2. Select the app and open **Settings**, then **Authentication**.
+        3. Review the behavior configured for unauthenticated requests.
+        4. A passing app requires authentication rather than allowing anonymous access.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az containerapp auth show --name <ContainerAppName> --resource-group <ResourceGroupName> --query "globalValidation"
+        ```
+
+        A passing app returns an unauthenticated client action other than `AllowAnonymous`.
+      remediation:
+        - id: portal
+          desc: |
+            To require authentication using the Azure Portal:
+
+            1. Navigate to **Container Apps** in the Azure Portal.
+            2. Select the app and open **Settings**, then **Authentication**.
+            3. Select **Add identity provider** and choose **Microsoft** to use Microsoft Entra ID.
+            4. Set the restriction for unauthenticated requests to **Return HTTP 401 Unauthorized** for APIs, or to redirect to the sign-in page for browser applications.
+            5. Select **Add**.
+        - id: cli
+          desc: |
+            To require authentication using the Azure CLI:
+
+            ```bash
+            az containerapp auth update --name <ContainerAppName> --resource-group-name <ResourceGroupName> --unauthenticated-client-action Return401
+            ```
+        - id: bicep
+          desc: |
+            To require authentication in Bicep:
+
+            ```bicep
+            resource authConfig 'Microsoft.App/containerApps/authConfigs@2024-03-01' = {
+              name: 'current'
+              parent: containerApp
+              properties: {
+                platform: {
+                  enabled: true
+                }
+                globalValidation: {
+                  unauthenticatedClientAction: 'Return401'
+                }
+                identityProviders: {
+                  azureActiveDirectory: {
+                    enabled: true
+                    registration: {
+                      openIdIssuer: 'https://login.microsoftonline.com/${subscription().tenantId}/v2.0'
+                      clientId: clientId
+                    }
+                  }
+                }
+              }
+            }
+            ```
+        # No Terraform remediation: the azurerm provider has no Container Apps auth configuration resource, so authentication must be configured through the portal, the CLI, or an ARM or Bicep deployment.
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/container-apps/authentication
+        title: Authentication and authorization in Azure Container Apps
+  - uid: mondoo-azure-security-container-app-auth-no-anonymous-azure
+    filters: |
+      asset.platform == "azure-container-app"
+    mql: |
+      azure.subscription.containerAppService.containerApp.authConfigs.length > 0
+      azure.subscription.containerAppService.containerApp.authConfigs.all(
+        enabled == true && unauthenticatedClientAction != "AllowAnonymous"
+      )
+  - uid: mondoo-azure-security-container-app-auth-no-anonymous-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps/authConfigs")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps/authConfigs").all(
+        properties["platform"]["enabled"] == true &&
+        properties["globalValidation"]["unauthenticatedClientAction"] != "AllowAnonymous"
+      )
+  - uid: mondoo-azure-security-container-app-managed-identity
+    title: Ensure Container Apps use a managed identity
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-9
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-8
+      compliance/vda-isa-5: vda-isa-5-4-1-3
+    variants:
+      - uid: mondoo-azure-security-container-app-managed-identity-azure
+        tags:
+          mondoo.com/filter-title: Azure Container App
+          mondoo.com/filter-icon: azure
+      - uid: mondoo-azure-security-container-app-managed-identity-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-managed-identity-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-managed-identity-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-azure-security-container-app-managed-identity-bicep
+        tags:
+          mondoo.com/filter-title: Bicep
+          mondoo.com/filter-icon: bicep
+    docs:
+      desc: |
+        This check ensures that a Container App has a managed identity assigned. Without one, the app authenticates to storage accounts, databases, key vaults, and service buses using credentials supplied as secrets or environment variables, which means long-lived static credentials distributed into the container runtime.
+
+        **Why this matters**
+
+        - **Secrets reach the container environment:** Credentials passed as environment variables are visible to every process in the container, appear in crash dumps and diagnostic output, and are readable by anyone who can exec into a replica.
+        - **Static credentials outlive their purpose:** A connection string or account key configured once remains valid indefinitely, so a value leaked through a log or an image layer stays usable long after the incident.
+        - **Credentials are baked into images and manifests:** Secrets supplied at build time persist in image layers and deployment manifests, spreading into registries and source control.
+        - **Access cannot be attributed:** Shared credentials produce audit entries naming the credential rather than the workload, so access cannot be traced to a specific app during an investigation.
+
+        **Risk mitigation**
+
+        - **Short-lived platform tokens:** A managed identity obtains tokens from the platform on demand, so no durable credential exists in the container or its configuration.
+        - **Centralized revocation and attribution:** Access is granted through role assignments on the identity, so it can be audited per app and revoked centrally without redeploying.
+      audit: |
+        ### Audit via Azure Portal
+
+        1. Navigate to **Container Apps** in the Azure Portal.
+        2. Select the app and open **Settings**, then **Identity**.
+        3. Review the **System assigned** and **User assigned** tabs.
+        4. A passing app has at least one managed identity assigned.
+
+        ### Audit via Azure CLI
+
+        ```bash
+        az containerapp identity show --name <ContainerAppName> --resource-group <ResourceGroupName>
+        ```
+
+        A passing app returns an identity with a type other than `None`.
+      remediation:
+        - id: portal
+          desc: |
+            To assign a managed identity using the Azure Portal:
+
+            1. Navigate to **Container Apps** in the Azure Portal.
+            2. Select the app and open **Settings**, then **Identity**.
+            3. On the **System assigned** tab, set **Status** to **On** and select **Save**.
+            4. Grant the identity the roles it needs on the target resources.
+            5. Update the application to acquire tokens through the identity and remove the credential secrets it previously used.
+        - id: cli
+          desc: |
+            To assign a managed identity using the Azure CLI:
+
+            ```bash
+            az containerapp identity assign --name <ContainerAppName> --resource-group <ResourceGroupName> --system-assigned
+            ```
+        - id: terraform
+          desc: |
+            To assign a managed identity in Terraform:
+
+            ```hcl
+            resource "azurerm_container_app" "example" {
+              name                         = "example-container-app"
+              resource_group_name          = azurerm_resource_group.example.name
+              container_app_environment_id = azurerm_container_app_environment.example.id
+              revision_mode                = "Single"
+
+              identity {
+                type = "SystemAssigned"
+              }
+
+              template {
+                container {
+                  name   = "example"
+                  image  = "mcr.microsoft.com/k8se/quickstart:latest"
+                  cpu    = 0.25
+                  memory = "0.5Gi"
+                }
+              }
+            }
+            ```
+        - id: bicep
+          desc: |
+            To assign a managed identity in Bicep:
+
+            ```bicep
+            resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+              name: 'example-container-app'
+              location: resourceGroup().location
+              identity: {
+                type: 'SystemAssigned'
+              }
+              properties: {
+                managedEnvironmentId: containerAppEnvironment.id
+              }
+            }
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/azure/container-apps/managed-identity
+        title: Managed identities in Azure Container Apps
+  - uid: mondoo-azure-security-container-app-managed-identity-azure
+    filters: |
+      asset.platform == "azure-container-app"
+    mql: |
+      azure.subscription.containerAppService.containerApp.systemAssignedIdentity != empty ||
+      azure.subscription.containerAppService.containerApp.userAssignedIdentities != empty
+  - uid: mondoo-azure-security-container-app-managed-identity-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_container_app")
+    mql: |
+      terraform.resources("azurerm_container_app").all(
+        blocks.where(type == "identity") != empty
+      )
+  - uid: mondoo-azure-security-container-app-managed-identity-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "azurerm_container_app").all(
+        change.after['identity'] != null &&
+        change.after['identity'] != empty
+      )
+  - uid: mondoo-azure-security-container-app-managed-identity-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_container_app")
+    mql: |
+      terraform.state.resources.where(type == "azurerm_container_app").all(
+        values['identity'] != null &&
+        values['identity'] != empty
+      )
+  - uid: mondoo-azure-security-container-app-managed-identity-bicep
+    filters: |
+      asset.platform == "bicep" && bicep.resources.any(type == "Microsoft.App/containerApps")
+    mql: |
+      bicep.resources.where(type == "Microsoft.App/containerApps").all(
+        body["identity"]["type"] != empty && body["identity"]["type"] != "None"
       )


### PR DESCRIPTION
Adds security checks for the twelve Azure platforms with the thinnest coverage in `mondoo-azure-security`, selected from a gap analysis of what each platform already asserts versus what the provider exposes.

## New checks

| Platform | Checks added |
|---|---|
| Application Gateway | HTTPS listeners, HTTPS backend, backend cert validation, WAF policy enabled state, WAF request body inspection |
| Azure Firewall | no IDPS bypass rules, no any-to-any allow rule, no DNAT to SSH/RDP |
| Azure Functions | FTPS required, remote debugging disabled, IP restrictions default deny, secrets via Key Vault references |
| App Service | authentication denies anonymous |
| Azure Compute | Metadata Security Protocol enforced, Defender for Endpoint installed |
| MySQL single server | backup retention ≥ 7 days, no "allow all Azure services" firewall rule |
| Key Vault Managed HSM | key expiration, key auto-rotation, network ACLs deny, soft-delete retention ≥ 90 days |
| Synapse Analytics | trusted service bypass disabled, managed identity, default storage secure transfer |
| IoT Hub | network rule set defaults to deny |
| Virtual Network | peering traffic encrypted |
| Container Apps | ingress IP restrictions, no wildcard CORS, auth denies anonymous, managed identity |

Every check carries a parent with `desc`/`audit`/`remediation` (portal, cli, terraform, bicep) plus runtime and IaC variants, and compliance tags across all 13 frameworks the policy already maps. Policy version bumped to 9.8.0; the policy now has 336 checks.

Also adds the missing runtime variant to `function-app-min-tls-1-2`, which shipped Terraform and Bicep variants but never scored against a live subscription.

## Compliance map corrections

Four existing checks carried tags that don't match their control objective:

- **`app-service-remote-debugging-disabled`** — `800-53 si-4` (System Monitoring) → **`cm-7`** (Least Functionality). Every other framework in its row (`pr-pt-3`, `3-4-7`, `ccc-04`) points at least-functionality, and `aks-run-command-disabled` uses `cm-7` for the same objective.
- **`app-service-ftp-disabled`** — `800-171 3-4-7` → **`3-5-2`**, HIPAA `312(e)(1)` transmission → **`312(d)`** authentication. The check disables basic-auth publishing credentials, so its row belongs with `storage-shared-key-access-disabled`.
- **`app-service-scm-disabled`** — `800-171 3-4-7` → **`3-5-2`**, same objective, same outlier.
- **`app-service-ssh-disabled`** — realigned from the network-boundary family to least functionality. `sshEnabled == false` toggles off a platform feature and restricts no network path. ISO `a-8-18` "Use of privileged utility programs" fits an SSH console far better than `a-8-20` "Networks security".

Also investigated and confirmed **not** a defect: `compliance/csa-cloud-controls-matrix-4` matches no framework `uid` (the CSA framework declares `cloud-controls-matrix-4`), which looks like the dangling-`framework_owner` failure `content/CLAUDE.md` warns about. It's intentional — `cnspec-enterprise-policies/utils/cnspec_compliance_mapping.py` carries a `FRAMEWORK_OWNER_OVERRIDES` alias table with that entry. A validator run resolving keys through that table finds **0 dangling control references across all 32,116 compliance values in `content/`**.

## Coverage limits

Recorded as YAML comments on the affected checks rather than left for a future pass:

- `compute-vm-proxy-agent-enabled`, `synapse-trusted-service-bypass-disabled`, `managed-hsm-key-auto-rotation` are **Bicep-only** — azurerm exposes no proxy agent, trusted-service-bypass, or Managed HSM key rotation attribute.
- `compute-vm-defender-endpoint-installed` and `synapse-default-storage-secure-transfer` are **runtime-only** — both need cross-resource correlation that no IaC form expresses.
- `container-app-auth-no-anonymous` is **Bicep-only** — azurerm has no Container Apps auth configuration resource.

## Two provider issues worth a follow-up

1. **`applicationGateway.backendHttpSettings` is unreachable from MQL.** The field name is identical to its sub-resource's full path, so the compiler resolves the identifier to the type and rejects `.all()` with *"is not a list type"* — the same collision class as `dns.dnssec`. Worked around by reading `properties["backendHttpSettingsCollection"]`, which has precedent in `appgw-ssl-policy-tls12`.
2. **The typed `validateCertChainAndExpiry` would have produced false positives.** The provider initialises it to `false` and only overwrites when ARM returns the property, but ARM omits it when validation is on (Terraform's own default is `true`). Asserting `== true` would fail every gateway where the property is absent; the dict form asserts `!= false`.

## Verification

- `cnspec policy lint ./content` — valid; the two deprecation warnings are pre-existing in the Snowflake and Hetzner policies.
- `validate_remediation_commands.py azure` — **408 commands pass, 0 fail.** Eleven of my commands were corrected against the checked-in grammar, including `az iot hub network-rule-set update` (does not exist; replaced with `az iot hub update --set`) and `az synapse workspace update --allow-all-connections` (no such flag and no generic `--set`; replaced with `az rest`).
- `typos` — clean.
- The five riskiest HCL assertions (firewall any-to-any, firewall DNAT, container app IP restrictions, container app CORS, Function App secret settings) were round-trip tested with `cnquery run terraform` against purpose-built fixtures, confirming each fails on an unsafe config and passes on a safe one.
- Terraform attribute names verified against a locally generated `terraform providers schema -json` dump of azurerm 4.81.0 rather than from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)