### PR TITLE
🐛 content(azure): fix dead app-service filters, scope checks to per-resource platforms

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -5791,7 +5791,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-storage-container-no-anonymous-access-azure
         tags:
-          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-title: Azure Storage Account Container
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-hcl
         tags:
@@ -5884,11 +5884,10 @@ queries:
         title: Configure anonymous read access for containers and blobs
   - uid: mondoo-azure-security-storage-container-no-anonymous-access-azure
     filters: |
-      asset.platform == "azure-storage-account"
+      asset.platform == "azure-storage-container"
     mql: |
-      azure.subscription.storage.account.containers.all(
-        publicAccess != "Blob" && publicAccess != "Container"
-      )
+      azure.subscription.storage.account.container.publicAccess != "Blob"
+      azure.subscription.storage.account.container.publicAccess != "Container"
   - uid: mondoo-azure-security-storage-container-no-anonymous-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container")
     mql: |
@@ -5937,7 +5936,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-storage-container-immutability-policy-locked-azure
         tags:
-          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-title: Azure Storage Account Container
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-hcl
         tags:
@@ -6015,11 +6014,10 @@ queries:
         title: Time-based retention policies for immutable blob data
   - uid: mondoo-azure-security-storage-container-immutability-policy-locked-azure
     filters: |
-      asset.platform == "azure-storage-account"
+      asset.platform == "azure-storage-container"
     mql: |
-      azure.subscription.storage.account.containers.where(immutabilityPolicyState != "").all(
-        immutabilityPolicyState == "Locked"
-      )
+      azure.subscription.storage.account.container.immutabilityPolicyState == "" ||
+      azure.subscription.storage.account.container.immutabilityPolicyState == "Locked"
   - uid: mondoo-azure-security-storage-container-immutability-policy-locked-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container_immutability_policy")
     mql: |
@@ -6058,7 +6056,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-azure
         tags:
-          mondoo.com/filter-title: Azure Storage Account
+          mondoo.com/filter-title: Azure Storage Account Container
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-hcl
         tags:
@@ -6153,11 +6151,10 @@ queries:
         title: Encryption scopes for Blob storage
   - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-azure
     filters: |
-      asset.platform == "azure-storage-account"
+      asset.platform == "azure-storage-container"
     mql: |
-      azure.subscription.storage.account.containers.where(defaultEncryptionScope != "").all(
-        denyEncryptionScopeOverride == true
-      )
+      azure.subscription.storage.account.container.defaultEncryptionScope == "" ||
+      azure.subscription.storage.account.container.denyEncryptionScopeOverride == true
   - uid: mondoo-azure-security-storage-container-encryption-scope-override-denied-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_storage_container")
     mql: |
@@ -25589,7 +25586,7 @@ queries:
         title: Configure SSH for Azure App Service
   - uid: mondoo-azure-security-app-service-ssh-disabled-azure
     filters: |
-      asset.platform == "azure-appsite"
+      asset.platform == "azure-app-service-webapp"
     mql: |
       azure.subscription.webService.appsite.sshEnabled == false
   - uid: mondoo-azure-security-app-service-public-network-access-disabled
@@ -25715,7 +25712,7 @@ queries:
         title: Azure App Service Private Endpoints
   - uid: mondoo-azure-security-app-service-public-network-access-disabled-azure
     filters: |
-      asset.platform == "azure-appsite"
+      asset.platform == "azure-app-service-webapp"
     mql: |
       azure.subscription.webService.appsite.publicNetworkAccess == "Disabled"
   - uid: mondoo-azure-security-app-service-public-network-access-disabled-terraform-hcl
@@ -25867,7 +25864,7 @@ queries:
         title: Configure TLS/SSL settings for Azure App Service
   - uid: mondoo-azure-security-app-service-scm-min-tls-azure
     filters: |
-      asset.platform == "azure-appsite"
+      asset.platform == "azure-app-service-webapp"
     mql: |
       azure.subscription.webService.appsite.configuration.scmMinTlsVersion == "1.2"
   - uid: mondoo-azure-security-app-service-scm-min-tls-terraform-hcl
@@ -26023,7 +26020,7 @@ queries:
         title: Azure App Service VNet Integration
   - uid: mondoo-azure-security-app-service-vnet-route-all-azure
     filters: |
-      asset.platform == "azure-appsite"
+      asset.platform == "azure-app-service-webapp"
     mql: |
       azure.subscription.webService.appsite.outboundVnetRouting.allTrafficEnabled == true
   - uid: mondoo-azure-security-app-service-vnet-route-all-terraform-hcl
@@ -26231,7 +26228,7 @@ queries:
       )
   - uid: mondoo-azure-security-app-service-ip-restrictions-default-deny-azure
     filters: |
-      asset.platform == "azure-appsite"
+      asset.platform == "azure-app-service-webapp"
     mql: |
       azure.subscription.webService.appsite.configuration.ipSecurityRestrictionsDefaultAction == "Deny"
   - uid: mondoo-azure-security-storage-cmk-encryption
@@ -48222,7 +48219,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-cognitive-services-cmk-encryption-azure
         tags:
-          mondoo.com/filter-title: Azure Cognitive Services
+          mondoo.com/filter-title: Azure AI Services Account
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl
         tags:
@@ -48327,11 +48324,9 @@ queries:
         title: Customer-managed keys for Azure AI services
   - uid: mondoo-azure-security-cognitive-services-cmk-encryption-azure
     filters: |
-      asset.platform == "azure"
+      asset.platform == "azure-cognitiveservices-account"
     mql: |
-      azure.subscription.cognitiveServices.accounts.all(
-        cmkKeySource == "Microsoft.KeyVault"
-      )
+      azure.subscription.cognitiveServices.account.cmkKeySource == "Microsoft.KeyVault"
   - uid: mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
     mql: |
@@ -48982,7 +48977,7 @@ queries:
   - uid: mondoo-azure-security-cognitive-services-defender-for-ai-enabled
     title: Ensure Defender for AI is enabled on Azure AI Services accounts
     impact: 75
-    filters: asset.platform == "azure"
+    filters: asset.platform == "azure-cognitiveservices-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-03
@@ -48999,9 +48994,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-4
       # compliance/nist-ai-100-1: nist-ai-100-1-measure-2-4, nist-ai-100-1-measure-2-7, nist-ai-100-1-manage-4-1
     mql: |
-      azure.subscription.cognitiveServicesService.accounts.all(
-        defenderForAIEnabled == true
-      )
+      azure.subscription.cognitiveServicesService.account.defenderForAIEnabled == true
     docs:
       desc: |
         This check ensures that Microsoft Defender for AI is enabled on Azure AI Services (Cognitive Services and Azure OpenAI) accounts. Defender for AI provides runtime threat protection for generative-AI workloads: it inspects model prompts and responses to detect prompt-injection and jailbreak attempts, sensitive-data leakage, wallet-abuse, and credential-theft, and surfaces alerts in Microsoft Defender for Cloud. Without it, attacks that manipulate or abuse the deployed model go undetected.
@@ -49096,7 +49089,7 @@ queries:
     variants:
       - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-azure
         tags:
-          mondoo.com/filter-title: Azure Subscription
+          mondoo.com/filter-title: Azure AI Services Account
           mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl
         tags:
@@ -49200,11 +49193,9 @@ queries:
       - url: https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-virtual-networks
         title: Configure Azure AI services virtual networks
   - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-azure
-    filters: asset.platform == "azure"
+    filters: asset.platform == "azure-cognitiveservices-account"
     mql: |
-      azure.subscription.cognitiveServicesService.accounts.all(
-        restrictOutboundNetworkAccess == true
-      )
+      azure.subscription.cognitiveServicesService.account.restrictOutboundNetworkAccess == true
   - uid: mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cognitive_account")
     mql: |


### PR DESCRIPTION
## Dead filters: five App Service checks never ran

These five checks filtered on `asset.platform == "azure-appsite"`:

- `mondoo-azure-security-app-service-ssh-disabled-azure`
- `mondoo-azure-security-app-service-public-network-access-disabled-azure`
- `mondoo-azure-security-app-service-scm-min-tls-azure`
- `mondoo-azure-security-app-service-vnet-route-all-azure`
- `mondoo-azure-security-app-service-ip-restrictions-default-deny-azure`

`azure-appsite` is not a platform the Azure provider emits — it appears nowhere in the provider's platform catalog (`providers/azure/resources/platforms.go`) or in the installed `azure.json`. The filter simply evaluated to false on every asset, so the checks never matched and never scored. Nothing surfaced this, because a filter naming an unknown platform is valid MQL that just returns false.

They now filter on `azure-app-service-webapp`, the platform their 12 sibling App Service checks already use. Their MQL bodies were already in the correct singular `azure.subscription.webService.appsite.*` form and are unchanged.

## Per-resource scoping for six more checks

Six checks iterated a collection with `.all()` under a broad filter, even though a per-resource asset platform already exists for that resource. That scores one pass/fail for the whole subscription (or storage account), letting a single bad resource hide inside the aggregate. Each now targets its own platform and queries the singular resource, so results are per-resource:

| Check | From | To |
|---|---|---|
| `cognitive-services-cmk-encryption-azure` | `azure` | `azure-cognitiveservices-account` |
| `cognitive-services-defender-for-ai-enabled` | `azure` | `azure-cognitiveservices-account` |
| `cognitive-services-restrict-outbound-network-azure` | `azure` | `azure-cognitiveservices-account` |
| `storage-container-no-anonymous-access-azure` | `azure-storage-account` | `azure-storage-container` |
| `storage-container-immutability-policy-locked-azure` | `azure-storage-account` | `azure-storage-container` |
| `storage-container-encryption-scope-override-denied-azure` | `azure-storage-account` | `azure-storage-container` |

`azure-storage-container` had no checks pointing at it before this change.

The two container checks that used `.where(P).all(Q)` become `!P || Q` guards rather than dropping the predicate, which would have silently widened their scope:

```yaml
# before
azure.subscription.storage.account.containers.where(immutabilityPolicyState != "").all(
  immutabilityPolicyState == "Locked"
)
# after
azure.subscription.storage.account.container.immutabilityPolicyState == "" ||
azure.subscription.storage.account.container.immutabilityPolicyState == "Locked"
```

Containers with a null immutability state behave identically under both forms.

`mondoo.com/filter-title` tags updated to the provider platform titles: **Azure AI Services Account** and **Azure Storage Account Container**.

## Scope notes

- The remaining 70 checks on `asset.platform == "azure"` stay there — Defender/Security Center settings, activity logs, IAM roles, and collections with no discoverable asset platform (disks, snapshots, Service Bus and Event Hub namespaces, API Management, Databricks, Kusto, ML and Log Analytics workspaces, SQL managed instances, Front Door, network watchers and gateways, private DNS zones, container groups).
- The two Trusted Launch VM checks (`vm-secure-boot-enabled-azure`, `vm-vtpm-enabled-azure`) are deliberately left on `azure`.
- Pre-existing inconsistency left alone: the `azure-app-service-webapp` checks use filter-title "Azure App Service" while the provider platform title is "Azure App Service App". The five fixed here match their siblings; realigning all 17 is a separate change.

## Testing

`cnspec policy lint ./content` passes with no new warnings. Each rewritten query was compiled against the installed Azure provider schema in a scratch bundle before being applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)