### PR TITLE
🐛 content(gcp): fix three dead platform filters in the GCP policy

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.6.0
+    version: 9.6.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -16812,7 +16812,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-hcl
         tags:
@@ -16902,9 +16902,9 @@ queries:
       - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
-    filters: asset.platform == 'gcp-compute-disk'
+    filters: asset.platform == 'gcp-project'
     mql: |
-      gcp.compute.disk.kmsKey != empty
+      gcp.project.computeService.disks.all(kmsKey != empty)
   - uid: mondoo-gcp-security-compute-disk-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_disk')
@@ -23876,7 +23876,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud SQL Instance
+          mondoo.com/filter-title: GCP Cloud SQL
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-terraform-hcl
         tags:
@@ -23969,7 +23969,7 @@ queries:
       - url: https://cloud.google.com/sql/docs/mysql/backup-recovery/backing-up
         title: Google Cloud Documentation - Backing up and restoring Cloud SQL
   - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
-    filters: asset.platform == "gcp-sql"
+    filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
     mql: |
       gcp.sql.instance.settings.backupConfiguration.enabled == true
   - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-terraform-hcl
@@ -24820,7 +24820,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Compute Disk
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-disk-csek-encryption-terraform-hcl
         tags:
@@ -24909,10 +24909,12 @@ queries:
       - url: https://cloud.google.com/compute/docs/disks/customer-supplied-encryption
         title: Google Cloud Documentation - Customer-supplied encryption keys
   - uid: mondoo-gcp-security-compute-disk-csek-encryption-gcp
-    filters: asset.platform == "gcp-compute-disk"
+    filters: asset.platform == 'gcp-project'
     mql: |
-      gcp.compute.disk.diskEncryptionKey != empty
-      gcp.compute.disk.diskEncryptionKey['sha256'] != empty
+      gcp.project.computeService.disks.all(
+        diskEncryptionKey != empty &&
+        diskEncryptionKey['sha256'] != empty
+      )
   - uid: mondoo-gcp-security-compute-disk-csek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_disk')


### PR DESCRIPTION
Three checks in `mondoo-gcp-security` filtered on platform names the GCP provider never emits, so they never matched an asset and never ran. The provider's catalog (`providers/gcp/connection/platforms.go`, 42 entries) contains no `gcp-sql` and no `gcp-compute-disk`.

## Cloud SQL automated backups

Filter-only fix. `mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp` already used the singular `gcp.sql.instance.settings.backupConfiguration.enabled` binding, identical to the 29 working engine-scoped Cloud SQL checks — only the platform name was wrong.

```yaml
filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
```

The filter and the `GCP Cloud SQL` filter-title are both taken from `mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp`, which already solves the "applies to all three engines" case in this file.

## Compute Engine disk CMEK / CSEK

These needed the MQL rewritten, not just the filter swapped. There is no disk platform anywhere in the catalog, so `gcp.compute.disk` could never bind to an asset. Both checks now iterate at project scope — the same shape `mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp` already uses, for the same reason (snapshots have no per-resource platform either).

```yaml
gcp.project.computeService.disks.all(kmsKey != empty)
```

```yaml
gcp.project.computeService.disks.all(
  diskEncryptionKey != empty &&
  diskEncryptionKey['sha256'] != empty
)
```

The CSEK check collapses its two newline-AND statements into a single `.all()` predicate. Two separate `.all()` calls would preserve the two-datapoint output, but the second would index `diskEncryptionKey['sha256']` on disks where the key is null; the single-predicate form scores those a clean fail instead.

Filter titles now name the platforms the checks actually target (`GCP Project` for both disk checks, replacing `GCP` and `GCP Compute Disk`).

## Expected scoring impact

These checks go from *never running* to *running at project granularity*. Because every boot disk defaults to Google-managed keys, the CMEK check will start failing broadly on first scan, and the CSEK check (`impact: 30`) will fail near-universally. That is the check working as written rather than a regression, but it will look like one to anyone who did not know it was dead. Per-disk scoring would require adding a `gcp-compute-disk` platform in mql first.

## Verification

- `cnspec policy lint content/mondoo-gcp-security.mql.yaml` → `valid policy bundle(s)`, which also confirms all three queries compile against the installed provider schema.
- Re-scan of the policy: zero remaining `gcp-sql` / `gcp-compute-disk` references.
- Policy version bumped `9.6.0` → `9.6.1`.

## Not in scope

An audit of the same policy found 59 further checks filtering on a bare `asset.platform == 'gcp'`, which is also not a platform the provider emits — the root cause is `content/CLAUDE.md:166`, which documents that filter as the GCP runtime-variant pattern. That is a much larger change and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)