### PR TITLE
🐛 content(gcp): repoint 59 checks off the non-existent bare `gcp` platform

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -163,10 +163,12 @@ Both ride along with every new or modified check — don't ship one without the 
 
 Convert single-platform checks to a `variants:` block with up to four children:
 
-- `<uid>-<cloud>` — runtime check (`asset.platform == 'gcp'`, `'aws'`, …)
+- `<uid>-<cloud>` — runtime check (`asset.platform == 'aws'`, `'azure'`, `'gcp-project'`, `'oci'`, …)
 - `<uid>-terraform-hcl` — `terraform.resources(...)` against HCL source
 - `<uid>-terraform-plan` — `terraform.plan.resourceChanges` against `terraform plan` JSON
 - `<uid>-terraform-state` — `terraform.state.resources` against `terraform.tfstate`
+
+**The runtime platform name must come from the provider's catalog, not from the cloud's short name.** A filter naming a platform the provider never emits compiles, lints, and passes CI — it just never matches an asset, so the check silently never runs. Check the name against `providers/<cloud>/connection/platforms.go` (or `providers/<cloud>/resources/platforms.go`) in the mql repo, or the `Platforms` array in the installed `~/.config/mondoo/providers/<cloud>/<cloud>.json`. AWS, Azure, and OCI do have an account-level platform named for the cloud (`aws`, `azure`, `oci`); **GCP does not** — use `gcp-project`, `gcp-org`, `gcp-folder`, or a per-resource platform such as `gcp-storage-bucket`.
 
 Reference patterns in this repo:
 

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.6.1
+    version: 9.7.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -11538,7 +11538,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-logging-sinks-configured-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-sinks-configured-terraform-hcl
         tags:
@@ -11631,7 +11631,7 @@ queries:
       - url: https://cloud.google.com/logging/docs/export/configure_export_v2
         title: Configure log sinks
   - uid: mondoo-gcp-security-logging-sinks-configured-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.loggingservice.sinks().where(id != "_Required" && id != "_Default").length > 0
   - uid: mondoo-gcp-security-logging-sinks-configured-terraform-hcl
@@ -14326,7 +14326,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-gcp
         tags:
-          mondoo.com/filter-title: GCP Binary Authorization Policy
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-terraform-hcl
         tags:
@@ -14421,7 +14421,7 @@ queries:
       - url: https://cloud.google.com/binary-authorization/docs/configuring-policy-cli
         title: Configuring a Binary Authorization policy
   - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.binaryAuthorizationControl.policy.defaultAdmissionRule.evaluationMode != "ALWAYS_ALLOW"
   - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-terraform-hcl
@@ -14469,7 +14469,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-gcp
         tags:
-          mondoo.com/filter-title: GCP Binary Authorization Policy
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-terraform-hcl
         tags:
@@ -14561,7 +14561,7 @@ queries:
       - url: https://cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
   - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.binaryAuthorizationControl.policy.globalPolicyEvaluationMode == "ENABLE"
   - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-terraform-hcl
@@ -15167,7 +15167,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-terraform-hcl
         tags:
@@ -15253,7 +15253,7 @@ queries:
       - url: https://cloud.google.com/dns/docs/monitoring
         title: Cloud DNS logging and monitoring
   - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.dnsService.policies().length > 0
       gcp.project.dnsService.policies().all(enableLogging == true)
@@ -16951,7 +16951,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-terraform-hcl
         tags:
@@ -17051,7 +17051,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts
         title: Google Cloud - Forwarding rule concepts
   - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.forwardingRules.where(
         loadBalancingScheme == "EXTERNAL" || loadBalancingScheme == "EXTERNAL_MANAGED"
@@ -18237,7 +18237,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud Armor
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-terraform-hcl
         tags:
@@ -18333,7 +18333,7 @@ queries:
       - url: https://cloud.google.com/armor/docs/configure-security-policies
         title: Configure Cloud Armor security policies
   - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.securityPolicies.all(
         rules().none(preview == true)
@@ -18383,7 +18383,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud Armor
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-terraform-hcl
         tags:
@@ -18499,7 +18499,7 @@ queries:
       - url: https://cloud.google.com/armor/docs/configure-security-policies
         title: Configure Cloud Armor security policies
   - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.securityPolicies.all(
         rules().where(priority == 2147483647).all(action != "allow")
@@ -18549,7 +18549,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-gcp
         tags:
-          mondoo.com/filter-title: GCP SSL Policy
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-terraform-hcl
         tags:
@@ -18631,7 +18631,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/use-ssl-policies
         title: Using SSL policies
   - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.sslPolicies.all(
         minTlsVersion == "TLS_1_2"
@@ -18677,7 +18677,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-server-tls-policy-disallow-plaintext-gcp
         tags:
-          mondoo.com/filter-title: GCP Server TLS Policy
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-server-tls-policy-disallow-plaintext-terraform-hcl
         tags:
@@ -18784,7 +18784,7 @@ queries:
       - url: https://cloud.google.com/traffic-director/docs/reference/network-security/rest/v1beta1/projects.locations.serverTlsPolicies
         title: ServerTlsPolicy resource reference
   - uid: mondoo-gcp-security-server-tls-policy-disallow-plaintext-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.networkSecurity.serverTlsPolicies.all(
         allowOpen != true
@@ -18830,7 +18830,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-gcp
         tags:
-          mondoo.com/filter-title: GCP SSL Policy
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-terraform-hcl
         tags:
@@ -18909,7 +18909,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: SSL policies concepts
   - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.sslPolicies.all(
         profile == "MODERN" || profile == "RESTRICTED"
@@ -18959,7 +18959,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-ssl-certificate-not-expired-gcp
         tags:
-          mondoo.com/filter-title: GCP SSL Certificate
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
     docs:
       desc: |
@@ -19060,7 +19060,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/ssl-certificates-concepts
         title: SSL certificates overview
   - uid: mondoo-gcp-security-ssl-certificate-not-expired-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.sslCertificates.where(type == "SELF_MANAGED").all(
         parse.date(expireTime) > time.now + 30 * time.day
@@ -19085,7 +19085,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud NAT
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-terraform-hcl
         tags:
@@ -19183,7 +19183,7 @@ queries:
       - url: https://cloud.google.com/nat/docs/ports-and-addresses
         title: Cloud NAT ports and addresses
   - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.routers.all(
         natServices.all(enableEndpointIndependentMapping == false)
@@ -19344,7 +19344,7 @@ queries:
       - url: https://cloud.google.com/logging/docs/audit/configure-data-access
         title: Configure Data Access audit logs
   - uid: mondoo-gcp-security-audit-logging-enabled-all-services-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.auditConfig.where(service == "allServices").length > 0
       gcp.project.auditConfig.where(service == "allServices").all(
@@ -19503,7 +19503,7 @@ queries:
       - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.orgPolicies.where(constraintName == "constraints/compute.vmExternalIpAccess").length > 0
   - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-terraform-hcl
@@ -19635,7 +19635,7 @@ queries:
       - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.orgPolicies.where(constraintName == "constraints/compute.disableSerialPortAccess").any(enforced)
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-terraform-hcl
@@ -19777,7 +19777,7 @@ queries:
       - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.orgPolicies.where(constraintName == "constraints/storage.uniformBucketLevelAccess").any(enforced)
   - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-terraform-hcl
@@ -20825,7 +20825,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
         tags:
-          mondoo.com/filter-title: GCP VPN Tunnel
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-terraform-hcl
         tags:
@@ -20917,7 +20917,7 @@ queries:
       - url: https://cloud.google.com/network-connectivity/docs/vpn/how-to/creating-vpn-dynamic-routes
         title: Creating VPN tunnels
   - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.vpnTunnels.all(
         ikeVersion == 2
@@ -25360,7 +25360,7 @@ queries:
       - url: https://cloud.google.com/vpc-service-controls/docs/create-access-levels
         title: Create access levels
   - uid: mondoo-gcp-security-vpc-sc-access-policies-defined-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.accessPolicies.length > 0
   # No Terraform variants: org-posture existence check (the organization has at least one
@@ -25481,7 +25481,7 @@ queries:
       - url: https://cloud.google.com/vpc-service-controls/docs/create-service-perimeters
         title: Create a service perimeter
   - uid: mondoo-gcp-security-vpc-sc-service-perimeters-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.accessPolicies.any(servicePerimeters.length > 0)
   - uid: mondoo-gcp-security-vpc-sc-perimeter-enforced
@@ -25602,7 +25602,7 @@ queries:
       - url: https://cloud.google.com/vpc-service-controls/docs/manage-perimeters
         title: Manage service perimeters
   - uid: mondoo-gcp-security-vpc-sc-perimeter-enforced-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.accessPolicies.all(servicePerimeters.all(useExplicitDryRunSpec == false))
   - uid: mondoo-gcp-security-vpc-sc-perimeter-enforced-terraform-hcl
@@ -25735,7 +25735,7 @@ queries:
       - url: https://cloud.google.com/vpc-service-controls/docs/create-access-levels
         title: Create an access level
   - uid: mondoo-gcp-security-vpc-sc-access-levels-defined-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.accessPolicies.any(accessLevels.length > 0)
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled
@@ -26133,7 +26133,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
         tags:
-          mondoo.com/filter-title: GCP VPC Routes
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl
         tags:
@@ -26228,7 +26228,7 @@ queries:
       - url: https://cloud.google.com/vpc/docs/routes
         title: GCP VPC Routes
   - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.routes.where(destRange == "0.0.0.0/0").all(
         nextHopGateway == "" || nextHopGateway == null
@@ -26274,7 +26274,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
         tags:
-          mondoo.com/filter-title: GCP Private Service Connect
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-terraform-hcl
         tags:
@@ -26362,7 +26362,7 @@ queries:
       - url: https://cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect
   - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.serviceAttachments.all(
         connectionPreference == "ACCEPT_MANUAL" ||
@@ -26587,7 +26587,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
         tags:
-          mondoo.com/filter-title: GCP Compute (Target SSL Proxy)
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
         tags:
@@ -26673,7 +26673,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: GCP - SSL policies
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.targetSslProxies.all(sslPolicy != null)
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-terraform-hcl
@@ -26976,7 +26976,7 @@ queries:
   - uid: mondoo-gcp-security-gke-backup-plan-exists
     title: Ensure every GKE cluster is protected by at least one backup plan
     impact: 70
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08
@@ -27102,7 +27102,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-terraform-hcl
         tags:
@@ -27187,7 +27187,7 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/vector-search/setup/setup-index-endpoint
         title: Vertex AI - Setup index endpoint
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.vertexaiService.indexEndpoints.all(
         publicEndpointEnabled == false
@@ -27343,7 +27343,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
         tags:
-          mondoo.com/filter-title: GCP IAP (Tunnel destination groups)
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-terraform-hcl
         tags:
@@ -27430,7 +27430,7 @@ queries:
       - url: https://cloud.google.com/iap/docs/tcp-by-host
         title: IAP - TCP forwarding with destination groups
   - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.iapService.tunnelDestGroups.all(
         cidrs.none(_ == /\/([0-9]|1[0-5])$/)
@@ -27463,7 +27463,7 @@ queries:
   - uid: mondoo-gcp-security-dlp-job-trigger-healthy
     title: Ensure Cloud DLP job triggers are healthy and not stale
     impact: 70
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-17
@@ -27604,7 +27604,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
         tags:
-          mondoo.com/filter-title: GCP DLP (Sensitive Data Protection)
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-terraform-hcl
         tags:
@@ -27719,7 +27719,7 @@ queries:
       - url: https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference
         title: DLP - InfoTypes reference
   - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.dlpService.inspectTemplates.all(
         inspectConfig != null &&
@@ -28903,7 +28903,7 @@ queries:
       - url: https://cloud.google.com/security-command-center/docs/how-to-notifications
         title: Setting up finding notifications
   - uid: mondoo-gcp-security-scc-notification-configs-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.sccNotificationConfigs.length > 0
   # No Terraform variants: org-posture existence check (the organization has at least one SCC
@@ -29012,7 +29012,7 @@ queries:
       - url: https://cloud.google.com/security-command-center/docs/how-to-export-data-bigquery
         title: Exporting findings to BigQuery
   - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-org'
     mql: |
       gcp.organization.sccBigQueryExports.length > 0
   - uid: mondoo-gcp-security-alloydb-audit-logging-flags
@@ -31205,7 +31205,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-terraform-hcl
         tags:
@@ -31295,7 +31295,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/use-cmek
         title: Use CMEK with Datastream
   - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.streams.all(kmsKey != null)
   - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-terraform-hcl
@@ -31342,7 +31342,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-terraform-hcl
         tags:
@@ -31443,7 +31443,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.connectionProfiles.all(connectivityType != "staticServiceIp")
   - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-terraform-hcl
@@ -31489,7 +31489,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-terraform-hcl
         tags:
@@ -31577,7 +31577,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.connectionProfiles.all(connectivityType != "forwardSsh")
   - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-terraform-hcl
@@ -31623,7 +31623,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-terraform-hcl
         tags:
@@ -31733,7 +31733,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/configure-your-source-database
         title: Configure your Datastream source database (Secret Manager)
   - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.connectionProfiles.where(
         profileType == "mysql" || profileType == "postgresql" || profileType == "sqlserver" || profileType == "oracle"
@@ -31845,7 +31845,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl
         tags:
@@ -31935,7 +31935,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/private-connectivity
         title: Datastream private connectivity
   - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.privateConnections.all(
         routes.all(
@@ -31989,7 +31989,7 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.connectionProfiles.where(profileType == "gcs").all(
         bucket.iamConfiguration["uniformBucketLevelAccess"]["enabled"] == true &&
@@ -32095,7 +32095,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-gcp
         tags:
-          mondoo.com/filter-title: GCP Datastream
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-terraform-hcl
         tags:
@@ -32185,7 +32185,7 @@ queries:
       - url: https://cloud.google.com/datastream/docs/private-connectivity
         title: Datastream private connectivity
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.datastream.privateConnections.all(network.name != "default")
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-terraform-hcl
@@ -32606,7 +32606,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-public-principals-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-public-principals-terraform-hcl
         tags:
@@ -32703,7 +32703,7 @@ queries:
       - url: https://cloud.google.com/iam/docs/overview#allusers
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-compute-snapshot-iam-no-public-principals-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.snapshots.all(
         iamPolicy.all(
@@ -32766,7 +32766,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-terraform-hcl
         tags:
@@ -32855,7 +32855,7 @@ queries:
       - url: https://cloud.google.com/iam/docs/understanding-roles#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.snapshots.all(
         iamPolicy.all(
@@ -33688,7 +33688,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud Build Trigger
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions-terraform-hcl
         tags:
@@ -33802,7 +33802,7 @@ queries:
       - url: https://cloud.google.com/build/docs/securing-builds/use-secrets
         title: Cloud Build - Use secrets from Secret Manager
   - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudBuildService.triggers.all(
         substitutions.keys.none(
@@ -33859,7 +33859,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-build-worker-pool-private-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud Build Worker Pool
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-build-worker-pool-private-terraform-hcl
         tags:
@@ -33968,7 +33968,7 @@ queries:
       - url: https://cloud.google.com/build/docs/private-pools/private-pools-overview
         title: Cloud Build - Private pools overview
   - uid: mondoo-gcp-security-cloud-build-worker-pool-private-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudBuildService.workerPools.all(
         networkConfig != null &&
@@ -34031,7 +34031,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud Build Trigger
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-terraform-hcl
         tags:
@@ -34125,7 +34125,7 @@ queries:
       - url: https://cloud.google.com/build/docs/cloud-build-service-account
         title: Cloud Build service account
   - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.cloudBuildService.triggers.all(
         iamServiceAccount != null &&
@@ -34178,7 +34178,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-dataflow-job-no-public-ips-gcp
         tags:
-          mondoo.com/filter-title: GCP Dataflow Job
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataflow-job-no-public-ips-terraform-hcl
         tags:
@@ -34280,7 +34280,7 @@ queries:
       - url: https://cloud.google.com/dataflow/docs/guides/routes-firewall#turn_off_external_ip_address
         title: Dataflow - Turn off external IP addresses
   - uid: mondoo-gcp-security-dataflow-job-no-public-ips-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.dataflowService.jobs.where(
         currentState == "JOB_STATE_RUNNING" || currentState == "JOB_STATE_PENDING" || currentState == "JOB_STATE_QUEUED"
@@ -34343,7 +34343,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-dataflow-job-no-default-service-account-gcp
         tags:
-          mondoo.com/filter-title: GCP Dataflow Job
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataflow-job-no-default-service-account-terraform-hcl
         tags:
@@ -34444,7 +34444,7 @@ queries:
       - url: https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#worker_service_account
         title: Dataflow - Worker service account
   - uid: mondoo-gcp-security-dataflow-job-no-default-service-account-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.dataflowService.jobs.where(
         currentState == "JOB_STATE_RUNNING" || currentState == "JOB_STATE_PENDING" || currentState == "JOB_STATE_QUEUED"
@@ -34518,7 +34518,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-filestore-instance-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Filestore Instance
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-filestore-instance-cmek-encryption-terraform-hcl
         tags:
@@ -34625,7 +34625,7 @@ queries:
       - url: https://cloud.google.com/filestore/docs/cmek
         title: Filestore - Customer-managed encryption keys
   - uid: mondoo-gcp-security-filestore-instance-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.filestoreService.instances.all(
         kmsKey != null
@@ -34770,7 +34770,7 @@ queries:
       - url: https://cloud.google.com/datastore/docs/access/iam
         title: Firestore in Datastore mode - Identity and Access Management
   - uid: mondoo-gcp-security-firestore-project-iam-no-public-datastore-roles-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.iamPolicy.where(
         role == /^roles\/datastore\./
@@ -35016,7 +35016,7 @@ queries:
       - url: https://cloud.google.com/resource-manager/docs/managing-notification-contacts
         title: Manage Essential Contacts
   - uid: mondoo-gcp-security-essential-contacts-security-category-configured-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.essentialContacts.any(
         notificationCategories.any(_ == "SECURITY" || _ == "ALL")
@@ -35062,7 +35062,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-gcp
         tags:
-          mondoo.com/filter-title: GCP App Engine
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-hcl
         tags:
@@ -35172,7 +35172,7 @@ queries:
       - url: https://cloud.google.com/iap/docs/enabling-app-engine
         title: Enabling IAP for App Engine
   - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.appEngine.application.iap['enabled'] == true
   - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-terraform-hcl
@@ -35369,7 +35369,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-gcp
         tags:
-          mondoo.com/filter-title: GCP Cloud CDN
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-terraform-hcl
         tags:
@@ -35479,7 +35479,7 @@ queries:
       - url: https://cloud.google.com/cdn/docs/using-signed-cookies
         title: Using signed cookies with Cloud CDN
   - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.backendServices.where(enableCDN == true).all(
         cdnPolicy.signedUrlCacheMaxAgeSec > 0
@@ -35991,7 +35991,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-composer-environment-private-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-composer-environment-private-terraform-hcl
         tags:
@@ -36093,7 +36093,7 @@ queries:
       - url: https://cloud.google.com/composer/docs/composer-3/configure-network-access-control
         title: Configure web server network access control
   - uid: mondoo-gcp-security-composer-environment-private-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.composer.environments.all(privateEnvironmentEnabled == true)
   - uid: mondoo-gcp-security-composer-environment-private-terraform-hcl
@@ -36157,7 +36157,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Dataflow Job
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-terraform-hcl
         tags:
@@ -36258,7 +36258,7 @@ queries:
       - url: https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys
         title: Use customer-managed encryption keys with Dataflow
   - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.dataflow.jobs.where(currentState == 'JOB_STATE_RUNNING' || currentState == 'JOB_STATE_PENDING' || currentState == 'JOB_STATE_QUEUED').all(
         environment['serviceKmsKeyName'] != null && environment['serviceKmsKeyName'] != ''
@@ -36581,7 +36581,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-logging-log-router-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-logging-log-router-cmek-encryption-terraform-hcl
         tags:
@@ -36684,7 +36684,7 @@ queries:
       - url: https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.locations/getCmekSettings
         title: Logging CMEK settings API
   - uid: mondoo-gcp-security-logging-log-router-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.loggingservice.cmekKmsKeyName != ""
   - uid: mondoo-gcp-security-logging-log-router-cmek-encryption-terraform-hcl
@@ -36961,7 +36961,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-gcp
         tags:
-          mondoo.com/filter-title: GCP Compute (Target HTTPS Proxy)
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-terraform-hcl
         tags:
@@ -37067,7 +37067,7 @@ queries:
       - url: https://cloud.google.com/load-balancing/docs/use-ssl-policies
         title: GCP - Using SSL policies
   - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.targetHttpsProxies.all(
         sslPolicy != null &&
@@ -37476,7 +37476,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-hcl
         tags:
@@ -37568,7 +37568,7 @@ queries:
       - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.computeService.snapshots.all(kmsKey != empty)
   - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-terraform-hcl
@@ -38039,7 +38039,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-terraform-hcl
         tags:
@@ -38129,7 +38129,7 @@ queries:
       - url: https://cloud.google.com/appengine/docs/standard/creating-firewalls
         title: Creating App Engine firewalls
   - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.appEngineService.firewallRules.none(
         action == "ALLOW" && sourceRange == "*"
@@ -38176,7 +38176,7 @@ queries:
     # customer-managed encryption-key argument for the issued-certificate content
     # encryption surfaced by CaPool.EncryptionSpec; the setting is configured through
     # the API and console. Revisit if the provider adds an encryption_spec argument.
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.certificateAuthorityService.caPools.all(kmsKey != null)
     docs:
@@ -38262,7 +38262,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP
+          mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-hcl
         tags:
@@ -38344,7 +38344,7 @@ queries:
       - url: https://cloud.google.com/eventarc/docs/use-cmek
         title: Use customer-managed encryption keys with Eventarc
   - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-gcp
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.eventarcService.channels.all(kmsKey != null)
   - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-terraform-hcl
@@ -38391,7 +38391,7 @@ queries:
     # No Terraform variants: encryption_spec coverage for these Vertex AI resource types is
     # inconsistent across the google Terraform provider; the check evaluates the live
     # encryption key reference on each resource. Revisit per-resource as provider support stabilizes.
-    filters: asset.platform == 'gcp'
+    filters: asset.platform == 'gcp-project'
     mql: |
       gcp.project.vertexaiService.indexes.all(kmsKey != null)
       gcp.project.vertexaiService.indexEndpoints.all(kmsKey != null)


### PR DESCRIPTION
Follow-up to #3127, which fixed the other three dead platform filters in this policy.

## The bug

The GCP provider has **no platform named `gcp`**. Its catalog (`providers/gcp/connection/platforms.go`, 42 entries) is `gcp-org` / `gcp-project` / `gcp-folder` plus per-resource object platforms. `PlatformInfo()` even treats a `gcp` platform override as *no* override (`platform.go:53`) before falling through to one of the three roots, and every literal in `discovery.go` is a catalog name.

59 checks filtered on `asset.platform == 'gcp'`. They compile, they lint, they pass CI — they just never match an asset, so they have never run.

GCP is the odd one out here: AWS, Azure and OCI all *do* have an account-level platform named for the cloud (`aws`, `azure`, `oci`), which is exactly why the mistake looks correct.

## The fix

Each check is repointed at the root platform its MQL actually needs. Classification is mechanical — the MQL root determines it, with no ambiguous cases:

| Target | Checks | Rule |
|---|---:|---|
| `gcp-project` | 53 | queries `gcp.project.*`, or an alias of it (`gcp.compute.*`, `gcp.datastream.*`, …) |
| `gcp-org` | 6 | queries `gcp.organization.*` — 4 VPC Service Controls, 2 Security Command Center |

**No MQL changed.** The diff is 59 filter lines and 42 filter-title lines, nothing else. The policy has no group-level filters, so applicability is entirely per-check and `gcp-org` assets pick up the six org checks correctly.

## Filter titles

The 42 retitled variants had labels naming the *service* (`GCP Cloud Armor`, `GCP Datastream`, `GCP Binary Authorization Policy`, plain `GCP`). `mondoo.com/filter-title` labels the **asset platform** the variant targets, so these become `GCP Project` / `GCP Organization`.

This trades some descriptive detail in the UI grouping for accuracy. Worth a second opinion if you'd rather keep the service names — but as written they claimed a platform grouping that does not exist, and the 12 variants that already said `GCP Project` / `GCP Organization` were the ones doing it right.

## Root cause

`content/CLAUDE.md` documented `asset.platform == 'gcp'` as *the* GCP runtime-variant pattern. That is why this reproduced 59 times rather than once. The line is corrected, plus a note on sourcing platform names from the provider catalog and why this class of bug is invisible to CI.

## Expected scoring impact

59 checks go from never running to running. On any GCP project scan this is a real change in results — mostly new findings, since none of these controls have ever been evaluated. The 6 org-scoped checks only apply when scanning at organization scope.

## Verification

- `cnspec policy lint content/mondoo-gcp-security.mql.yaml` → `valid policy bundle(s)`.
- Re-scan of the policy against the provider catalog: **zero** remaining filters naming a platform the GCP provider cannot emit (was 62 across this PR and #3127).
- Filter-title audit: 156 → 212 correct, 112 → 55 mismatched.
- Diff is exactly 59 + 42 = 101 changed lines in the policy, confirming no incidental edits.
- Policy version bumped `9.6.1` → `9.7.0`.

## Not in scope

The remaining 55 filter-title mismatches are pre-existing near-miss wording on *live* platforms (`GCP Cloud Storage Bucket` vs `GCP Storage Bucket`, `GCP AlloyDB` vs `GCP AlloyDB Cluster`, 13 Vertex AI checks on `gcp-project`). Separately, ~20 checks now on `gcp-project` iterate collections that have their own per-resource platform (Model Armor templates, Vertex AI endpoints / pipeline jobs / notebook runtime templates, Datastream connection profiles) and could be scoped per-resource so each resource scores individually. Both are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)