### PR TITLE
🐛 test/providers: fail cleanly instead of panicking on an empty query result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /mql/
-./cnspec
+# "./cnspec" never matched anything: gitignore rejects a "./" prefix, so the
+# built binary was only ever untracked by luck. test/providers/setup_test.go
+# builds another copy next to the tests it runs.
+/cnspec
+/test/providers/cnspec
 data/
 .DS_Store
 gha-creds-*.json

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -42,6 +42,35 @@ type mqlTest struct {
 	expected func(*testing.T, test.Runner)
 }
 
+// decodeJSON unmarshals the runner's stdout into dst.
+//
+// It fails the subtest immediately rather than merely recording an assertion,
+// because every caller goes on to index into the decoded result. Continuing
+// past a decode error would reach that index on an empty slice and panic,
+// which takes down the whole test binary instead of this one subtest. The
+// captured output is included so a CI failure says why the payload was
+// unusable, not just that it was.
+func decodeJSON(t *testing.T, r test.Runner, dst any) {
+	t.Helper()
+	if err := r.Json(dst); err != nil {
+		t.Fatalf("could not decode JSON output: %v\n--- stdout ---\n%s\n--- stderr ---\n%s",
+			err, r.Stdout(), r.Stderr())
+	}
+}
+
+// requireResults fails the subtest when a query returned no rows.
+//
+// A well-formed but empty JSON array decodes without error, so the length has
+// to be checked separately before indexing. This is the case a flaky container
+// pull or an unreachable target produces.
+func requireResults(t *testing.T, r test.Runner, n int) {
+	t.Helper()
+	if n == 0 {
+		t.Fatalf("query returned no results\n--- stdout ---\n%s\n--- stderr ---\n%s",
+			r.Stdout(), r.Stderr())
+	}
+}
+
 func TestOsProviderSharedTests(t *testing.T) {
 	once.Do(setup)
 
@@ -55,8 +84,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPackagesQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPackages
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.NotNil(t, x.Packages)
@@ -67,8 +96,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPlatformQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPlatform
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.True(t, len(x.Platform) > 0)
@@ -85,8 +114,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPackagesQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPackages
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.NotNil(t, x.Packages)
@@ -97,8 +126,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPlatformQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPlatform
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.Equal(t, "debian", x.Platform)
@@ -115,8 +144,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPackagesQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPackages
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.NotNil(t, x.Packages)
@@ -127,8 +156,8 @@ func TestOsProviderSharedTests(t *testing.T) {
 					mqlPlatformQuery,
 					func(t *testing.T, r test.Runner) {
 						var c mqlPlatform
-						err := r.Json(&c)
-						assert.NoError(t, err)
+						decodeJSON(t, r, &c)
+						requireResults(t, r, len(c))
 
 						x := c[0]
 						assert.Equal(t, "alpine", x.Platform)


### PR DESCRIPTION
Fixes the CI panic in `TestOsProviderSharedTests`:

```
=== FAIL: test/providers TestOsProviderSharedTests/docker/packages (30.12s)
=== FAIL: test/providers TestOsProviderSharedTests (44.80s)
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
    .../test/providers/os_test.go:121
```

The trigger looks like a flaky container pull, but the reason it took down the whole suite is a code defect worth fixing regardless. **A panic in a test goroutine aborts the entire test binary**, so one bad subtest killed `TestOsProviderSharedTests` as a whole — and the output said nothing about *why* the payload was empty.

## The defect

All six assertion closures shared this shape:

```go
err := r.Json(&c)
assert.NoError(t, err)   // records a failure but does NOT stop
x := c[0]                // panics when c is empty
```

Two separate problems, and the second is the one that actually bites:

1. `assert.NoError` doesn't halt the subtest, so a decode error fell straight through to the index.
2. **There was no length check at all.** `test.Runner.Json` is a bare `json.Unmarshal` over stdout, and an empty result decodes three different ways — only one of which is even an error:

   | stdout | decode error | len |
   |---|---|---|
   | `""` | `unexpected end of JSON input` | 0 |
   | `[]` | *nil* | 0 |
   | `null` | *nil* | 0 |

   For `[]` and `null` the assertion **passed** and the panic arrived with no diagnostic context at all. Upgrading `assert` → `require` would not have caught those. The length guard is the part that matters.

## The fix

Two small helpers that fail via `t.Fatalf` and include the captured stdout/stderr, so the next occurrence reports why the query returned nothing rather than just that it did:

```go
var c mqlPackages
decodeJSON(t, r, &c)
requireResults(t, r, len(c))

x := c[0]
```

This does **not** stop the docker pull from flaking. It contains the blast radius to the affected subtest and makes the failure self-diagnosing — which is what was missing from the CI output above.

`TestProvidersEnvVarsLoading` already guarded its index with `if assert.NotEmpty(t, c)`, so the safe pattern was already in this file; the shared tests just weren't using it.

## Drive-by: a `.gitignore` entry that never worked

`.gitignore` line 2 was `./cnspec`. Gitignore rejects a `./` prefix, so that pattern has **never matched anything** — confirmed with `git check-ignore`. The built binary was only untracked by luck.

Replaced with `/cnspec`, and added `/test/providers/cnspec` — the 111 MB binary `setup_test.go` builds next to the tests, which shows up as untracked for anyone who runs them locally and is an easy accidental commit.

## Verification

- `TestOsProviderSharedTests` — `local`, `fs`, and `docker` subtests all pass locally (docker included, i.e. the one that flaked).
- `go vet ./test/providers/` and `gofmt -l` clean.
- `git check-ignore` confirms both binaries are now ignored and the artifact no longer appears in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
