### PR TITLE
🐛 tls/dns/email: fix three checks that could not report correctly

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.3.3
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -491,7 +491,15 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: dns.records.none(name == /\*/)
+    # Detection has to probe a name that should not exist. A wildcard RR has the
+    # owner name `*.example.com`, and the provider only ever queries the exact
+    # FQDN, so the wildcard is never present in an answer for `example.com` —
+    # matching on `name == /\*/` could not fail. The authoritative server
+    # expands the wildcard, so an improbable label resolving is the signal.
+    # Uses dns.fqdn rather than domainName.fqdn: domainName errors with
+    # "cannot derive eTLD+1" on a name that is itself a public suffix.
+    mql: |
+      dns(fqdn: "mondoo-wildcard-probe-x7f3q9." + dns.fqdn).records.where(type == "A") == empty
     docs:
       desc: |
         This check verifies that a domain has no wildcard DNS records, such as a record whose name begins with `*`. A wildcard makes every undefined subdomain resolve to a single target, including names the operator never intended to publish.
@@ -503,9 +511,25 @@ queries:
         - **Resolution control:** Defining each subdomain explicitly keeps traffic routed only to names the operator deliberately published.
         - **Standards compliance:** Security best practices discourage wildcard DNS records on production domains.
       audit: |
-        Run the `dig '*.<domain>'` command and inspect the answer section.
+        A wildcard is detected by asking for a name that should not exist. If the zone answers for an arbitrary label, a wildcard is expanding it.
 
-        A passing result shows no answer for the wildcard query, indicating no wildcard record is configured. A failing result shows the wildcard query resolving to an IP address or hostname.
+        1. Query an improbable subdomain:
+
+            ```bash
+            dig +noall +answer wildcard-probe-x7f3q9.example.com A
+            ```
+
+            A passing domain returns nothing, because the name genuinely does not exist. A failing domain returns an address, meaning a wildcard answered for a name nobody published.
+
+        2. Confirm by querying the wildcard record directly. A wildcard is a real resource record whose owner name is `*`, so it can be looked up:
+
+            ```bash
+            dig +noall +answer '*.example.com' A
+            ```
+
+            An answer here names the wildcard target explicitly.
+
+        Note that step 1 is the reliable test. Querying the zone apex or any specific hostname will never reveal a wildcard, because the authoritative server expands the wildcard and answers with the name that was asked for.
       remediation:
         - id: console
           desc: |

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.2.3
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -355,7 +355,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      dns.spf.length == 1
+      dns.spf.length >= 1
     docs:
       desc: |
         Ensures Sender Policy Framework (SPF) records correctly specify authorized mail servers, preventing email spoofing.

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security
-    version: 1.7.4
+    version: 1.8.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -3311,8 +3311,11 @@ queries:
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc8446
         title: TLS 1.3 RFC 8446
+  # The uid still says "ocsp" for continuity: renaming a shipped uid would break
+  # existing exceptions and the framework maps that reference it. The assertion is
+  # revocation availability by either mechanism, as the title and docs describe.
   - uid: mondoo-tls-security-cert-ocsp-configured
-    title: Ensure OCSP responder is configured for the certificate
+    title: Ensure the certificate publishes OCSP or CRL revocation information
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -3331,48 +3334,70 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      tls.certificates.first.ocspServer.length > 0
+      tls.certificates.first.ocspServer != empty || tls.certificates.first.crlDistributionPoints != empty
     docs:
       desc: |
-        This check ensures that the server's leaf certificate is issued with at least one OCSP responder URL in its Authority Information Access extension. An OCSP responder lets clients confirm the real-time revocation status of the certificate.
+        This check ensures that the server's leaf certificate tells clients how to determine whether it has been revoked, by publishing an OCSP responder URL in its Authority Information Access extension, a CRL distribution point, or both. Either mechanism satisfies the requirement.
 
         **Why this matters**
 
-        - **Undetected revocation:** Without an OCSP responder, clients cannot determine that a certificate has been revoked and may continue to trust it.
-        - **Costly CRL fallback:** Relying solely on certificate revocation lists forces clients to download large files, degrading connection performance.
-        - **Stapling prerequisite:** OCSP stapling, which improves both privacy and performance, requires an OCSP responder URL in the certificate.
-        - **Inconsistent client behavior:** When revocation checking is unavailable, some clients fail open and accept the certificate anyway, creating a security gap.
-        - **Compliance expectations:** Many security frameworks expect a functional revocation checking mechanism to be in place.
+        - **Undetected revocation:** A certificate carrying neither an OCSP responder nor a CRL distribution point gives clients no way to learn it was revoked, so a compromised key stays trusted until the certificate expires on its own.
+        - **Key compromise response:** Revocation is the only tool for withdrawing trust in a certificate before its natural expiry. Without a published mechanism, the response to a stolen private key is to wait.
+        - **Inconsistent client behavior:** When revocation information is unavailable, some clients fail open and accept the certificate anyway, creating a silent security gap.
+        - **Compliance expectations:** Security frameworks expect a functional revocation mechanism, without mandating which one.
+
+        **Why both mechanisms count**
+
+        The industry has moved revocation checking from OCSP toward CRLs. Let's Encrypt, the largest certificate authority by volume, stopped including OCSP URLs in its certificates in May 2025 and shut down its OCSP responders that August, citing the privacy cost of OCSP: a responder learns which site each visitor is browsing. Its certificates publish a CRL distribution point instead. Requiring OCSP specifically would therefore fail a large share of correctly configured, modern certificates, so this check accepts either mechanism.
 
         **Risk mitigation**
 
-        - **Use a CA that publishes OCSP:** Obtain certificates from a Certificate Authority that includes OCSP responder URLs, and confirm OCSP support with the CA first, since some CAs, including Let's Encrypt, no longer publish OCSP responders.
-        - **Enable OCSP stapling:** Have the server staple a fresh OCSP response so clients receive revocation status without contacting the responder directly.
+        - **Confirm your CA publishes revocation data:** Any publicly trusted CA does, though which mechanism varies. A certificate with neither is the case to investigate.
+        - **Enable OCSP stapling where OCSP exists:** If your CA still publishes an OCSP responder, stapling lets the server deliver a fresh signed status so clients never contact the responder themselves, removing the privacy and latency cost.
       audit: |
         ### Audit via openssl
 
-        Inspect the certificate's Authority Information Access extension for an OCSP responder URL:
+        Check both revocation mechanisms. The certificate needs at least one of them.
 
-        ```bash
-        openssl s_client -connect example.com:443 -servername example.com 2>/dev/null | openssl x509 -noout -ocsp_uri
-        ```
+        1. Look for an OCSP responder URL:
 
-        The check passes when the command prints at least one OCSP responder URL, and fails when it prints nothing, which means the certificate was issued without an OCSP responder.
+            ```bash
+            openssl s_client -connect example.com:443 -servername example.com </dev/null 2>/dev/null \
+              | openssl x509 -noout -ocsp_uri
+            ```
+
+        2. Look for a CRL distribution point:
+
+            ```bash
+            openssl s_client -connect example.com:443 -servername example.com </dev/null 2>/dev/null \
+              | openssl x509 -noout -text \
+              | grep -A4 "CRL Distribution Points"
+            ```
+
+        The check passes when either command returns a URL. It fails only when both return nothing, meaning the certificate publishes no way to check its revocation status at all.
+
+        An empty result from step 1 alone is expected for certificates from a CA that has retired OCSP, such as Let's Encrypt, and is not a finding on its own.
       remediation:
         - id: apache
           desc: |
             **Using Apache**
 
-            1. Confirm the cert advertises an OCSP responder:
+            This check fails only when the certificate publishes neither an OCSP responder nor a CRL distribution point, which is rare for a publicly trusted certificate. Confirm which mechanism is present before changing anything:
+
+            1. Check for both mechanisms:
 
                 ```bash
                 openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
                   | openssl x509 -noout -ocsp_uri
+
+                openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
+                  | openssl x509 -noout -text \
+                  | grep -A4 "CRL Distribution Points"
                 ```
 
-                If the command returns nothing, the certificate was issued without an OCSP responder URL. Let's Encrypt stopped including OCSP URLs in May 2025 and shut down its responders in August 2025, so Let's Encrypt certificates cannot satisfy this requirement. To keep OCSP, obtain the certificate from a CA that still publishes OCSP responders, such as DigiCert, Sectigo, or GlobalSign, and confirm OCSP support with the CA first because the industry is shifting revocation checking to CRLs.
+            2. If both are empty, the certificate itself is the problem and no server setting will fix it. Reissue from a publicly trusted CA. A self-signed or internally issued certificate is the usual cause. Note that an empty OCSP result with a populated CRL is fine and satisfies this check.
 
-            2. Enable OCSP stapling. Add the following to your global SSL config, for example `/etc/apache2/mods-enabled/ssl.conf`. `SSLUseStapling` and `SSLStaplingCache` must live in the global scope, not per-vhost:
+            3. If an OCSP responder *is* present, enabling stapling is worthwhile hardening: the server delivers a fresh signed status so clients never contact the responder, removing the latency and the privacy leak. `SSLUseStapling` and `SSLStaplingCache` must live in the global scope, not per-vhost:
 
                 ```apache
                 SSLUseStapling          on
@@ -3381,36 +3406,38 @@ queries:
                 SSLStaplingReturnResponderErrors off
                 ```
 
-            3. Reload Apache:
+            4. Reload and verify:
 
                 ```bash
                 apachectl configtest
                 systemctl reload apache2   # Debian/Ubuntu
                 systemctl reload httpd     # RHEL/CentOS
-                ```
 
-            4. Verify the response is being stapled:
-
-                ```bash
                 openssl s_client -connect yourdomain.com:443 -status </dev/null 2>&1 \
                   | grep -A5 "OCSP Response"
                 ```
 
-                A `Cert Status: good` line confirms stapling is working.
+                A `Cert Status: good` line confirms stapling is working. Nothing to verify here if the CA publishes no OCSP responder.
         - id: nginx
           desc: |
             **Using Nginx**
 
-            1. Confirm the cert advertises an OCSP responder:
+            This check fails only when the certificate publishes neither an OCSP responder nor a CRL distribution point, which is rare for a publicly trusted certificate. Confirm which mechanism is present before changing anything:
+
+            1. Check for both mechanisms:
 
                 ```bash
                 openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
                   | openssl x509 -noout -ocsp_uri
+
+                openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
+                  | openssl x509 -noout -text \
+                  | grep -A4 "CRL Distribution Points"
                 ```
 
-                If the command returns nothing, the certificate was issued without an OCSP responder URL. Let's Encrypt stopped including OCSP URLs in May 2025 and shut down its responders in August 2025, so Let's Encrypt certificates cannot satisfy this requirement. To keep OCSP, obtain the certificate from a CA that still publishes OCSP responders, such as DigiCert, Sectigo, or GlobalSign, and confirm OCSP support with the CA first because the industry is shifting revocation checking to CRLs.
+            2. If both are empty, reissue the certificate from a publicly trusted CA. No Nginx directive can add revocation information the CA did not put in the certificate. An empty OCSP result with a populated CRL is fine and satisfies this check.
 
-            2. Enable OCSP stapling in the `server` block or globally in `http`. `ssl_trusted_certificate` must point at a file containing the issuing CA so Nginx can validate the OCSP response:
+            3. If an OCSP responder *is* present, enable stapling. `ssl_trusted_certificate` must point at a file containing the issuing CA so Nginx can validate the response:
 
                 ```nginx
                 ssl_stapling          on;
@@ -3420,72 +3447,57 @@ queries:
                 resolver_timeout      5s;
                 ```
 
-            3. Reload Nginx:
+            4. Reload and verify:
 
                 ```bash
                 nginx -t && systemctl reload nginx
-                ```
 
-            4. Verify the response is being stapled:
-
-                ```bash
-                openssl s_client -connect yourdomain.com:443 -status </dev/null 2>&1 \
-                  | grep -A5 "OCSP Response"
-                ```
-
-                A `Cert Status: good` line confirms stapling is working. Nginx caches the response for about an hour, so the first request after a reload may not include one.
-        - id: haproxy
-          desc: |
-            **Using HAProxy**
-
-            1. Confirm the cert advertises an OCSP responder:
-
-                ```bash
-                openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
-                  | openssl x509 -noout -ocsp_uri
-                ```
-
-                If the command returns nothing, the certificate was issued without an OCSP responder URL. Let's Encrypt stopped including OCSP URLs in May 2025 and shut down its responders in August 2025, so Let's Encrypt certificates cannot satisfy this requirement. To keep OCSP, obtain the certificate from a CA that still publishes OCSP responders, such as DigiCert, Sectigo, or GlobalSign, and confirm OCSP support with the CA first because the industry is shifting revocation checking to CRLs.
-
-            2. On HAProxy 2.8 and newer, let HAProxy fetch and refresh the stapled response automatically with a crt-list:
-
-                ```haproxy
-                # /etc/haproxy/crt-list.txt
-                /etc/haproxy/certs/yourdomain.com.pem [ocsp-update on]
-                ```
-
-                ```haproxy
-                frontend https-in
-                    bind *:443 ssl crt-list /etc/haproxy/crt-list.txt
-                ```
-
-            3. On older HAProxy releases, generate the sibling `.ocsp` file yourself with a script such as `/usr/local/sbin/refresh-ocsp.sh`, mode 0755:
-
-                ```bash
-                #!/bin/bash
-                set -euo pipefail
-                cert=/etc/haproxy/certs/yourdomain.com.pem
-                issuer=/etc/haproxy/certs/yourdomain.com.issuer.pem
-                url=$(openssl x509 -in "$cert" -noout -ocsp_uri)
-                openssl ocsp -no_nonce -issuer "$issuer" -cert "$cert" \
-                  -url "$url" -respout "$cert.ocsp"
-                systemctl reload haproxy
-                ```
-
-                Run it daily from cron, since OCSP responses typically have a 7-day lifetime:
-
-                ```cron
-                15 3 * * * /usr/local/sbin/refresh-ocsp.sh
-                ```
-
-            4. Verify the response is being stapled:
-
-                ```bash
                 openssl s_client -connect yourdomain.com:443 -status </dev/null 2>&1 \
                   | grep -A5 "OCSP Response"
                 ```
 
                 A `Cert Status: good` line confirms stapling is working.
+        - id: haproxy
+          desc: |
+            **Using HAProxy**
+
+            This check fails only when the certificate publishes neither an OCSP responder nor a CRL distribution point, which is rare for a publicly trusted certificate.
+
+            1. Check for both mechanisms:
+
+                ```bash
+                openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
+                  | openssl x509 -noout -ocsp_uri
+
+                openssl s_client -connect yourdomain.com:443 </dev/null 2>/dev/null \
+                  | openssl x509 -noout -text \
+                  | grep -A4 "CRL Distribution Points"
+                ```
+
+            2. If both are empty, reissue the certificate from a publicly trusted CA. An empty OCSP result with a populated CRL is fine and satisfies this check.
+
+            3. If an OCSP responder *is* present, HAProxy serves a stapled response from a `.ocsp` file placed alongside the certificate rather than fetching it itself. Fetch and refresh it on a schedule:
+
+                ```bash
+                openssl ocsp \
+                  -issuer /etc/haproxy/certs/issuer.pem \
+                  -cert /etc/haproxy/certs/yourdomain.com.pem \
+                  -url "$(openssl x509 -in /etc/haproxy/certs/yourdomain.com.pem -noout -ocsp_uri)" \
+                  -respout /etc/haproxy/certs/yourdomain.com.pem.ocsp \
+                  -no_nonce
+                ```
+
+            4. Reload HAProxy and verify:
+
+                ```bash
+                haproxy -c -f /etc/haproxy/haproxy.cfg
+                systemctl reload haproxy
+
+                openssl s_client -connect yourdomain.com:443 -status </dev/null 2>&1 \
+                  | grep -A5 "OCSP Response"
+                ```
+
+                Because the response expires, refresh the `.ocsp` file from cron or a timer; a stale file causes clients to see an expired status.
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc6960
         title: OCSP RFC 6960


### PR DESCRIPTION
Three independent check-logic defects in the network-surface policies. **No filter or group changes** — those are a separate concern and follow separately.

Two of these were found by sweeping all 60 checks for assertions that structurally cannot fail, prompted by the review discussion on #3109.

## 1. `mondoo-dns-security-no-wildcard` was vacuous (impact 85)

It asserted `dns.records.none(name == /\*/)`. A wildcard resource record's owner name is `*.example.com`, and `dnsshake.Query()` only ever queries the **exact** FQDN — so the wildcard never appears in an answer for `example.com`. The assertion could not fail.

Proven against two domains that demonstrably have wildcards:

| Domain | `dig '*.<d>'` | record names returned | old check |
|---|---|---|---|
| `herokuapp.com` | `ie01.ingress.herokuapp.com.` | `["herokuapp.com."]` | `[ok] true` |
| `netlify.app` | `63.176.8.218` | `["netlify.app."]` | `[ok] true` |

This mattered more than a noisy check would. It failed **silently**, at the highest impact in the policy, while carrying `compliance/mitre-attack: mitre-attack-t1584-002` — domain shadowing, defined as *"silently creating subdomains pointing to malicious servers"*. It claimed coverage of exactly the behaviour it could not detect. A check that cannot fail is worse than no check: it manufactures assurance.

Detection has to probe a name that shouldn't exist, because the authoritative server expands the wildcard and answers with whatever was asked for:

```coffee
dns(fqdn: "mondoo-wildcard-probe-x7f3q9." + dns.fqdn).records.where(type == "A") == empty
```

Note `dns.fqdn`, not `domainName.fqdn` — `domainName` raises `publicsuffix: cannot derive eTLD+1` on a name that is itself a public suffix, which `herokuapp.com` is. I hit that while testing.

The `audit:` section is rewritten too. It previously said to run `dig '*.<domain>'`, which only finds a wildcard if you already know it's there.

**Verified:** `herokuapp.com` now fails at HIGH (85); `mondoo.com` passes.

## 2. `mondoo-tls-security-cert-ocsp-configured` false-positived at internet scale

It required `ocspServer.length > 0`. Let's Encrypt [stopped including OCSP URLs on 2025-05-07 and shut its responders down on 2025-08-06](https://letsencrypt.org/2025/08/06/ocsp-service-has-reached-end-of-life), moving revocation to CRLs [for privacy reasons](https://letsencrypt.org/2024/12/05/ending-ocsp) — an OCSP responder learns which site each visitor is browsing. As the largest CA by volume, that made this check fail on a large share of the public web **for doing the modern, recommended thing**.

Two of three hosts I sampled while testing are in exactly that state:

```
mondoo.com   issuer: Let's Encrypt   ocspServer: []   crl: http://yr2.c.lencr.org/9.crl
badssl.com   issuer: Let's Encrypt   ocspServer: []   crl: http://r13.c.lencr.org/52.crl
example.com  issuer: SSL Corporation ocspServer: [o.cf-i.ssl.com]  crl: [...]
```

Now accepts either mechanism, which is what the control objective actually requires:

```coffee
ocspServer != empty || crlDistributionPoints != empty
```

Title, `desc`, `audit`, and all three remediation entries are rewritten — they told the reader to obtain a certificate from a CA that publishes OCSP, which is now wrong advice. The remediation reframes stapling as hardening that applies *only where OCSP exists*, and names the real failure case: a certificate with neither mechanism, which no server directive can fix.

**The uid keeps `ocsp` deliberately.** Renaming a shipped uid would break existing exceptions and the framework maps referencing it; a comment in the file records why. The ASVS mapping (`12.1.4`, *"proper certification revocation ... enabled and configured"*) still fits and is unchanged.

**Verified:** `mondoo.com` TLS goes from 21 passing / 1 failing to 22 / 0.

## 3. `-spf` and `-single-spf` were redundant

`-spf` asserted `dns.spf.length == 1` under the title "Ensure SPF record is set", conflating presence with uniqueness — which made `-single-spf` (`length <= 1`) fully implied, unable to fail on its own. A domain publishing two SPF records failed both, including one claiming the record wasn't set.

`-spf` now asserts `length >= 1`, so each check owns one failure mode and each title matches its query:

| SPF records | `-spf` (`>=1`) | `-single-spf` (`<=1`) |
|---|---|---|
| 0 | fail | pass |
| 1 | pass | pass |
| 2 | pass | **fail** |

Both shipped uids preserved, so no migration cost. Pass/fail totals don't move for a domain with exactly one record — the change corrects *attribution*, so a 2-record domain no longer gets a misleading "record is not set" finding.

## Verification

- `cnspec policy lint ./content` clean (the two warnings are pre-existing, in unrelated files).
- Scans re-run against `herokuapp.com`, `netlify.app`, `mondoo.com`, `example.com`.
- Every changed check exercised against a target where it must fail *and* one where it must pass.

Version bumps: tls 1.8.0, dns 1.4.0, email 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
