### PR TITLE
🐛 dns/email/http: fix asset gating so checks reach the assets that need them

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.4.0
+    version: 1.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -27,8 +27,17 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # `dns.fqdn != empty` keeps these checks off assets that have no domain
+      # name. Scanning by IP leaves the fqdn empty, and the dns resource answers
+      # an empty fqdn with the DNS ROOT ZONE — so `cnspec scan host 1.1.1.1`
+      # previously reported DNSSEC as enabled, NS redundancy as satisfied and no
+      # wildcards present, all of which described `.` rather than the asset.
+      # The root cause is upstream (initDns substitutes an empty fqdn for an IP
+      # target); this guard is what protects users until they pick that up, since
+      # the network provider versions independently of cnspec.
       - title: Networking
-        filters: asset.family.contains('network')
+        filters: |
+          asset.family.contains('network') && dns.fqdn != empty
         checks:
           - uid: mondoo-dns-security-google-workspaces-mx-records
           - uid: mondoo-dns-security-no-cname-for-root-domain

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -28,18 +28,34 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # Two different gates below, on purpose.
+      #
+      # Checks about how a domain *handles* mail need a real mail exchanger, and
+      # `dns.mx != empty` was not that test: RFC 7505 lets a domain publish a
+      # null MX (a single "." target) to declare that it handles no mail at all,
+      # and that satisfies `!= empty`. example.com does exactly this, so every
+      # check here ran against a domain that had explicitly opted out of email.
+      # `dns.mx.where(domainName != ".")` excludes it.
+      #
+      # Checks that stop someone *spoofing* a domain must not depend on MX at
+      # all — a domain with no mail servers is the easiest to forge and the most
+      # important to cover, yet the old gate skipped it entirely. Those groups
+      # gate on the apex instead. The apex restriction is required because
+      # dns.dmarc resolves `_dmarc.<fqdn>` with no organizational-domain
+      # fallback, so it is null on any subdomain; without it, scanning
+      # www.example.com would report spurious DMARC failures. `dns.fqdn != empty`
+      # comes first so && short-circuits before domainName is dereferenced,
+      # which errors on an IP target and on a name that is itself a public suffix.
       - title: DNS Configuration
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.mx.where(domainName != ".") != empty
         checks:
           - uid: mondoo-email-security-txt-record
           - uid: mondoo-email-security-a-record
           - uid: mondoo-email-security-reverse-ip-ptr-record-set
       - title: SPF (Sender Policy Framework)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.fqdn != empty && domainName.fqdn == domainName.effectiveTLDPlusOne
         checks:
           - uid: mondoo-email-security-spf
           - uid: mondoo-email-security-single-spf
@@ -50,14 +66,12 @@ policies:
           - uid: mondoo-email-security-spf-dns-record
       - title: DKIM (DomainKeys Identified Mail)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.mx.where(domainName != ".") != empty
         checks:
           - uid: mondoo-email-security-dkim
       - title: DMARC (Domain-based Message Authentication)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.fqdn != empty && domainName.fqdn == domainName.effectiveTLDPlusOne
         checks:
           - uid: mondoo-email-security-dmarc
           - uid: mondoo-email-security-dmarc-version

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.6
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -43,9 +43,13 @@ policies:
           - uid: mondoo-http-security-x-frame-options
           - uid: mondoo-http-security-referrer-policy
       - title: Headers for HTTPS communication
+        # Joined with && rather than left as two lines of a block scalar. Both
+        # forms select the same assets, but a block scalar is a single Mquery
+        # whose statements become independent datapoints that are all evaluated,
+        # so the TLS handshake was attempted against every asset this filter ran
+        # against instead of short-circuiting on the platform test.
         filters: |
-          asset.platform == 'host'
-          tls.certificates != empty
+          asset.platform == 'host' && tls.certificates != empty
         checks:
           - uid: mondoo-http-security-strict-transport-security
           - uid: mondoo-http-security-hsts-max-age


### PR DESCRIPTION
Group filter changes only — **no check logic is touched**. Three gating defects, each letting checks run against assets they don't apply to, or skip assets that most need them.

## 1. email: `dns.mx != empty` was wrong in *both* directions

RFC 7505 lets a domain publish a **null MX** — a single `.` target — to declare it handles no mail at all. That satisfies `!= empty`:

```
cnquery run host example.com -c 'dns.mx { domainName preference }'
  -> [{domainName: ".", preference: 0}]
```

So `example.com` had all 16 email checks run against it, including DKIM signing and reverse-DNS for a mail server it doesn't have.

Meanwhile a domain with genuinely **zero** MX records failed the gate and got *nothing* — and those are the domains most worth checking. With no mail infrastructure to point at, anyone can forge mail as them, and SPF/DMARC are the only defence. `neverssl.com` is a live example: apex domain, no MX, **no SPF record, no DMARC record**, and the policy reported nothing at all.

The groups now use two gates for two different questions:

| Question | Gate |
|---|---|
| How a domain *handles* mail (supporting records, DKIM) | `dns.mx.where(domainName != ".") != empty` |
| Whether a domain can be *spoofed* (SPF, DMARC) | apex, independent of MX |

The apex restriction is **required, not incidental**: `dns.dmarc` resolves `_dmarc.<fqdn>` with no organizational-domain fallback, so it's null on any subdomain. Without it, loosening the MX gate would report spurious DMARC failures for every `www.*` host. `dns.fqdn != empty` comes first so `&&` short-circuits before `domainName` is dereferenced — that errors on an IP target and on a name that is itself a public suffix.

**Verified:**

| Target | Before | After |
|---|---|---|
| `neverssl.com` (apex, 0 MX) | no applicable policy | **4 HIGH findings**, scores HIGH (80) |
| `example.com` (null MX) | all 16 checks | 12 anti-spoofing; drops the 4 assuming a mail server |
| `mondoo.com` (real MX) | 15 pass / 1 fail | unchanged |

The `neverssl.com` findings are no SPF record, no DMARC record, no DMARC policy, no DMARC version — all real, all previously invisible.

## 2. dns: an IP-scanned asset was scored against the DNS **root zone**

The group gated only on `asset.family.contains('network')`. When the target is an IP, `initDns` substitutes an empty fqdn, and the `dns` resource answers an empty fqdn with the root zone:

```
cnquery run host 1.1.1.1 -c 'dns.fqdn'                  -> ""
cnquery run host 1.1.1.1 -c 'dns.records { name type }' -> name: "."  DNSKEY / NS / NSEC / SOA / ZONEMD
```

So `cnspec scan host 1.1.1.1 -f content/mondoo-dns-security.mql.yaml` reported DNSSEC enabled, NS redundancy satisfied, and no wildcards present — 6 passing checks and 1 failure describing `.` rather than the asset.

Added `dns.fqdn != empty`. The asset now matches no group in this policy, and in a normal multi-policy scan still picks up TLS and HTTP as before (verified).

The root cause is upstream — the provider shouldn't substitute an empty fqdn at all. This guard is what protects users until that lands, since the network provider versions independently of cnspec.

## 3. http: the HSTS group filter used a block scalar

`asset.platform == 'host'` and `tls.certificates != empty` were two lines of a `|` block. Both forms select the same assets, but a block scalar is a single Mquery whose statements become independent datapoints that are **all** evaluated — so the TLS handshake was attempted against every asset the filter ran against, instead of short-circuiting on the platform test. Same issue fixed in #3109 for the sibling group.

All nine group filters across the four policies now use `&&` on one line:

```
dns    | asset.family.contains('network') && dns.fqdn != empty
http   | asset.platform == 'host' && http.get.header != empty
http   | asset.platform == 'host' && tls.certificates != empty
email  | asset.platform == "host" && dns.mx.where(domainName != ".") != empty     (x2)
email  | asset.platform == "host" && dns.fqdn != empty && domainName.fqdn == domainName.effectiveTLDPlusOne   (x2)
tls    | asset.platform == 'host' && tls.params != empty                          (x2)
```

## Known limitation worth a reviewer's eye

The apex filter drops domains that are themselves on the Public Suffix List — `domainName` raises `publicsuffix: cannot derive eTLD+1` for `herokuapp.com`, so the SPF/DMARC groups won't apply there. The check is skipped rather than erroring, so it fails safe, and such domains are an odd email-scanning target anyway. Calling it out because it's a deliberate trade rather than an oversight.

## Verification

- `cnspec policy lint ./content` clean.
- Scans re-run against `neverssl.com`, `example.com`, `mondoo.com`, `1.1.1.1`, plus `1.1.1.1` with dns+tls together to confirm the asset isn't left with no applicable policy.

Version bumps: dns 1.5.0, http 1.3.0, email 1.4.0. TLS untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
