### PR TITLE
🐛 email: check reverse DNS on the mail exchangers, not the domain's web address

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.4.0
+    version: 1.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -27,8 +27,17 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # `dns.fqdn != empty` keeps these checks off assets that have no domain
+      # name. Scanning by IP leaves the fqdn empty, and the dns resource answers
+      # an empty fqdn with the DNS ROOT ZONE — so `cnspec scan host 1.1.1.1`
+      # previously reported DNSSEC as enabled, NS redundancy as satisfied and no
+      # wildcards present, all of which described `.` rather than the asset.
+      # The root cause is upstream (initDns substitutes an empty fqdn for an IP
+      # target); this guard is what protects users until they pick that up, since
+      # the network provider versions independently of cnspec.
       - title: Networking
-        filters: asset.family.contains('network')
+        filters: |
+          asset.family.contains('network') && dns.fqdn != empty
         checks:
           - uid: mondoo-dns-security-google-workspaces-mx-records
           - uid: mondoo-dns-security-no-cname-for-root-domain

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.4.0
+    version: 1.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -81,7 +81,7 @@ policies:
     scoring_system: highest impact
 queries:
   - uid: mondoo-email-security-reverse-ip-ptr-record-set
-    title: Ensure Reverse IP Lookup PTR record is set (DNS Forward confirmed)
+    title: Ensure mail exchangers have reverse DNS that resolves back
     impact: 60
     tags:
       compliance/bsi-sys-1-5: false
@@ -98,68 +98,111 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
+    # Checks the mail exchangers, not the domain's own address. `dns.reverse`
+    # resolves the *domain's* A/AAAA records, which for most organizations is a
+    # web host on a CDN, not a mail server — so the previous query examined the
+    # wrong addresses entirely and then required the PTR name to sit inside the
+    # scanned domain. That is not what forward-confirmed reverse DNS means, and
+    # it is impossible for hosted mail: Google Workspace mail leaves an IP whose
+    # PTR is in 1e100.net and Microsoft 365 from outlook.com, neither of which a
+    # customer controls. Both are correctly configured. The round trip is what
+    # matters, not who owns the name.
     mql: |
-      dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
+      dns.mx.all( dns(fqdn: _.domainName).reverse != empty )
+      dns.mx.all( dns(fqdn: _.domainName).reverse.all( rdata.all( dns(fqdn: _).records.where(type == "A") != empty ) ) )
     docs:
       desc: |
-        A reverse DNS PTR record maps the sending mail server's IP address back to a fully qualified domain name within your domain. Reverse DNS queries for IPv4 addresses use the special domain `in-addr.arpa`, where the IPv4 address is represented in reverse octet order followed by the `.in-addr.arpa` suffix. When the PTR record resolves to a hostname whose forward A record points back to the original IP address, the domain is in a forward-confirmed reverse DNS state, which receiving mail servers treat as a reliable signal that the sender is legitimate.
+        This check verifies that every mail exchanger listed for the domain has reverse DNS in place: the address behind each MX host resolves to a PTR record, and that PTR name itself resolves back to an address. Receiving mail servers use this round trip as a basic signal that a sender is a legitimate, deliberately operated mail host rather than a compromised machine or a transient cloud instance.
 
         **Why this matters**
 
-        - Validates sender identity and prevents spam classification.
-        - Reduces phishing and spoofing by verifying legitimate email servers.
-        - Forward-confirmed reverse DNS provides authentication strong enough to be used for allowlisting email servers.
+        - **Deliverability:** Large providers, including Gmail and Outlook, treat a sending address with no PTR record as a strong spam signal and may reject or silently drop the mail.
+        - **Sender accountability:** A resolvable PTR ties the sending address to a named host, which is what allows receivers and abuse desks to attribute traffic.
+        - **Operational hygiene:** A missing PTR usually means a mail server was brought up on an address nobody configured reverse DNS for, which is exactly the pattern of an unmanaged or hijacked sender.
 
-        **If you don't fix this**
+        **What this does not require**
 
-        - Major providers like Gmail and Outlook may reject or silently drop your emails.
+        The PTR name does **not** have to sit inside your own domain. Reverse DNS for an address is controlled by whoever owns the IP range, so a domain using hosted email cannot influence it: Google Workspace mail arrives from addresses whose PTR is in `1e100.net`, and Microsoft 365 from `outlook.com`. Both are correct configurations, and requiring the name to match the sending domain would fail every hosted-email tenant. What matters is that the round trip resolves.
 
-        Example:
-        IP `123.123.123.123` should have a PTR record pointing to `mail.example.com`, and a forward lookup of `mail.example.com` should resolve back to `123.123.123.123`.
+        **Risk mitigation**
+
+        - **Hosted email:** Nothing to do. Your provider maintains reverse DNS for its sending infrastructure.
+        - **Self-hosted mail:** Ask whoever owns the IP range, usually your hosting or cloud provider, to publish a PTR for each sending address, and publish a matching forward record for the name it returns.
       audit: |
-        Run the `dig -t PTR <special-reverse-domain>` command and verify that it points to your mail domain.
+        ### Audit via dig
 
-        Example:
-        For the IP address `123.123.123.123`, the reverse domain would be `123.123.123.123.in-addr.arpa`. The output should show:
+        Check each mail exchanger in turn. The round trip has two halves.
 
-        ```text
-        123.123.123.123.in-addr.arpa  name = mail.example.com.
-        ```
+        1. List the mail exchangers:
+
+            ```bash
+            dig +short lunalectric.com MX
+            ```
+
+        2. For each MX host, resolve its address and look up the PTR:
+
+            ```bash
+            dig +short aspmx.l.google.com A
+            dig +short -x 142.250.153.27
+            ```
+
+            A configured host returns a name, for example `ea-in-f27.1e100.net.` An empty result is the finding.
+
+        3. Confirm the name the PTR returned resolves back:
+
+            ```bash
+            dig +short ea-in-f27.1e100.net A
+            ```
+
+            A correctly configured host returns the address you started from, completing the round trip.
+
+        The check passes when every mail exchanger clears both halves. Note that the PTR name belonging to your mail provider rather than to your own domain is expected and is not a finding.
       remediation:
         - id: console
           desc: |
-            A PTR record lives in the reverse zone for the IP address, which is controlled by whoever owns the IP range, not by your domain registrar. To publish one:
+            Reverse DNS for an address is published by whoever owns the IP range, not by your domain registrar, so where you go depends on how you send mail.
 
-            1. Identify the public IP addresses your outbound mail servers send from.
+            **If you use hosted email** (Google Workspace, Microsoft 365, or similar), there is nothing to configure. The provider maintains reverse DNS for its own sending infrastructure, and the PTR name will belong to the provider rather than to you. That is correct and satisfies this check. If the check is failing, verify the MX records themselves are right before looking any further.
+
+            **If you run your own mail servers:**
+
+            1. List the mail exchangers for the domain and resolve each to its address.
             2. Sign in to the control panel of the hosting or cloud provider that owns those addresses and open its reverse DNS or PTR settings. On most clouds this is a property of the instance or the allocated public IP, not of your DNS zone.
-            3. Set the PTR for each address to a fully qualified hostname in your own domain, such as `mail.lunalectric.com`.
-            4. In your own DNS zone, publish a matching forward `A` record so `mail.lunalectric.com` resolves back to the same address. Without both halves the lookup is not forward-confirmed.
+            3. Set a PTR for each sending address to a hostname you control, such as `mail.lunalectric.com`.
+            4. In your own DNS zone, publish a matching forward `A` record for that hostname so the round trip completes.
             5. Where the provider does not expose PTR settings, open a support request naming the address and the desired hostname.
         - id: cli
           desc: |
-            To confirm the round trip resolves in both directions:
+            To confirm the round trip for every mail exchanger:
 
-            1. Look up the PTR for the sending address:
-
-                ```bash
-                dig -x 203.0.113.10 +short
-                ```
-
-                A configured address returns a hostname such as `mail.lunalectric.com.`
-
-            2. Look up the forward record for that hostname:
+            1. List the mail exchangers:
 
                 ```bash
-                dig +short A mail.lunalectric.com
+                dig +short lunalectric.com MX
                 ```
 
-            3. The check passes only when step 2 returns the address used in step 1. A PTR that points at a hostname which resolves elsewhere, or not at all, is not forward-confirmed and receiving mail servers treat it as unverified.
+            2. For each one, resolve the address and look up its PTR:
+
+                ```bash
+                dig +short mail.lunalectric.com A
+                dig +short -x 203.0.113.10
+                ```
+
+                An empty PTR result is the finding.
+
+            3. Confirm the name the PTR returned resolves back to the same address:
+
+                ```bash
+                dig +short mail.lunalectric.com A
+                ```
+
+            The PTR name belonging to your mail provider rather than to your own domain is expected for hosted email and is not a finding.
         - id: terraform
           desc: |
-            To publish the forward record and, where the provider supports it, the PTR:
+            Terraform can manage the forward record in your own zone, and the PTR only where the provider exposes reverse DNS as a resource:
 
             ```hcl
-            # Forward record in your own zone
+            # Forward record for the mail host, in your own zone
             resource "aws_route53_record" "mail" {
               zone_id = aws_route53_zone.primary.zone_id
               name    = "mail.lunalectric.com"
@@ -184,7 +227,7 @@ queries:
             }
             ```
 
-            AWS does not expose EC2 reverse DNS through Terraform; request the PTR for an Elastic IP through AWS Support and manage only the forward record here.
+            AWS does not expose EC2 reverse DNS through Terraform; request the PTR for an Elastic IP through AWS Support and manage only the forward record here. Nothing to manage at all when using hosted email.
     refs:
       - url: https://en.wikipedia.org/wiki/Reverse_DNS_lookup
         title: Reverse DNS Lookup

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -28,18 +28,34 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # Two different gates below, on purpose.
+      #
+      # Checks about how a domain *handles* mail need a real mail exchanger, and
+      # `dns.mx != empty` was not that test: RFC 7505 lets a domain publish a
+      # null MX (a single "." target) to declare that it handles no mail at all,
+      # and that satisfies `!= empty`. example.com does exactly this, so every
+      # check here ran against a domain that had explicitly opted out of email.
+      # `dns.mx.where(domainName != ".")` excludes it.
+      #
+      # Checks that stop someone *spoofing* a domain must not depend on MX at
+      # all — a domain with no mail servers is the easiest to forge and the most
+      # important to cover, yet the old gate skipped it entirely. Those groups
+      # gate on the apex instead. The apex restriction is required because
+      # dns.dmarc resolves `_dmarc.<fqdn>` with no organizational-domain
+      # fallback, so it is null on any subdomain; without it, scanning
+      # www.example.com would report spurious DMARC failures. `dns.fqdn != empty`
+      # comes first so && short-circuits before domainName is dereferenced,
+      # which errors on an IP target and on a name that is itself a public suffix.
       - title: DNS Configuration
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.mx.where(domainName != ".") != empty
         checks:
           - uid: mondoo-email-security-txt-record
           - uid: mondoo-email-security-a-record
           - uid: mondoo-email-security-reverse-ip-ptr-record-set
       - title: SPF (Sender Policy Framework)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.fqdn != empty && domainName.fqdn == domainName.effectiveTLDPlusOne
         checks:
           - uid: mondoo-email-security-spf
           - uid: mondoo-email-security-single-spf
@@ -50,14 +66,12 @@ policies:
           - uid: mondoo-email-security-spf-dns-record
       - title: DKIM (DomainKeys Identified Mail)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.mx.where(domainName != ".") != empty
         checks:
           - uid: mondoo-email-security-dkim
       - title: DMARC (Domain-based Message Authentication)
         filters: |
-          asset.platform == "host" &&
-          dns.mx != empty
+          asset.platform == "host" && dns.fqdn != empty && domainName.fqdn == domainName.effectiveTLDPlusOne
         checks:
           - uid: mondoo-email-security-dmarc
           - uid: mondoo-email-security-dmarc-version

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.2.6
+    version: 1.3.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -43,9 +43,13 @@ policies:
           - uid: mondoo-http-security-x-frame-options
           - uid: mondoo-http-security-referrer-policy
       - title: Headers for HTTPS communication
+        # Joined with && rather than left as two lines of a block scalar. Both
+        # forms select the same assets, but a block scalar is a single Mquery
+        # whose statements become independent datapoints that are all evaluated,
+        # so the TLS handshake was attempted against every asset this filter ran
+        # against instead of short-circuiting on the platform test.
         filters: |
-          asset.platform == 'host'
-          tls.certificates != empty
+          asset.platform == 'host' && tls.certificates != empty
         checks:
           - uid: mondoo-http-security-strict-transport-security
           - uid: mondoo-http-security-hsts-max-age


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #3135** — targets `fix/network-policy-asset-gating`, not `main`, because it touches the same file and its version bump follows that one. Review/merge #3135 first; this will retarget to `main` automatically.

Found while asking why `mondoo.com` still failed one check after #3135. It wasn't a real finding — the check could not pass for most correctly-configured domains.

## The defect

```coffee
dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
```

**It looked at the wrong addresses.** `dns.reverse` resolves the *domain's* A/AAAA records and PTRs those. For most organizations that's a web host, not a mail server:

```
mondoo.com  A  -> 216.150.1.1        -> PTR: <none>            # web host
mondoo.com  MX -> aspmx.l.google.com -> 142.250.153.27
                                     -> PTR: ea-in-f27.1e100.net.
```

The check failed on the web address, having never examined the mail path at all.

**The assertion was wrong in principle.** Requiring the PTR name to contain the scanned domain isn't what forward-confirmed reverse DNS means. FCrDNS is a round-trip consistency test and says nothing about who owns the name. Google's mail address passes it properly:

```
PTR(142.250.153.27)     = ea-in-f27.1e100.net.
A(ea-in-f27.1e100.net.) = 142.250.153.27      -> consistent
```

**And it was unachievable.** Reverse DNS is published by whoever owns the IP range, so a tenant cannot influence it — Google Workspace mail leaves `1e100.net` addresses, Microsoft 365 `outlook.com` ones. Every hosted-email domain (the majority) failed a check it had no way to satisfy, as did every domain whose web address sits behind a CDN without a PTR. Same shape as the OCSP defect in #3134: penalising the normal configuration.

## The fix

Checks the mail exchangers, and tests the round trip rather than ownership:

```coffee
dns.mx.all( dns(fqdn: _.domainName).reverse != empty )
dns.mx.all( dns(fqdn: _.domainName).reverse.all( rdata.all( dns(fqdn: _).records.where(type == "A") != empty ) ) )
```

Two datapoints so the halves report independently: every mail exchanger's address has a PTR, and every name that PTR returns resolves back to an address.

**Known limitation, stated rather than hidden:** MQL can't carry the original address through that nesting to assert the PTR name resolves to the *same* IP. This is the achievable approximation — it catches a missing or dangling PTR, which is the failure mode that actually breaks deliverability, but it won't catch a PTR that resolves to an unrelated address.

Also worth knowing: MX records describe *inbound* mail. Outbound may leave from entirely different IPs (SendGrid, app servers), which is what SPF enumerates. Verifying those would mean walking `dns.spf.mechanisms` through `include:` chains, which isn't cleanly expressible. So this check is narrower than "all your sending IPs have reverse DNS" — the docs no longer claim otherwise.

Title, `desc`, `audit`, and all three remediation entries rewritten. The docs now say explicitly that a PTR name belonging to your mail provider is expected and not a finding, and the remediation tells hosted-email users there is nothing to configure — it previously told them to point the PTR at their own domain, which they cannot do.

## Verification

- `mondoo.com` goes from 15 passing / 1 failing to **16 / 0**.
- The predicate still discriminates: `dns(fqdn: "aspmx.l.google.com").reverse != empty` passes, while the same query against a host with no PTR fails — so an MX pointing at an address without reverse DNS is still caught.
- `cnspec policy lint` clean.

**One honest caveat on test coverage:** I could not find a live domain whose MX host lacks a PTR, across ~25 sampled including self-hosted mail operators (postfix.org, exim.org, dovecot.org, kernel.org, debian.org, sourcehut, …). That's expected — a sending address without reverse DNS gets its mail rejected, so operators fix it. It means this is a genuine but rare finding, and the negative case is demonstrated at the predicate level rather than against a whole live domain.

Version bump: email 1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
