### PR TITLE
✨ content(aws,gcp): retarget 14 checks to per-resource asset platforms

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -39447,7 +39447,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Model
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-model-network-isolation-terraform-hcl
         tags:
@@ -39559,8 +39559,8 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/mkt-algo-model-internet-free.html
         title: Amazon SageMaker - Network Isolation
   - uid: mondoo-aws-security-sagemaker-model-network-isolation-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.models.all(enableNetworkIsolation == true)
+    filters: asset.platform == "aws-sagemaker-model"
+    mql: aws.sagemaker.model.enableNetworkIsolation == true
   - uid: mondoo-aws-security-sagemaker-model-network-isolation-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_model")
     mql: |
@@ -39605,7 +39605,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Model
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-hcl
         tags:
@@ -39727,8 +39727,8 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html
         title: Amazon SageMaker - Give SageMaker Hosted Endpoints Access to Resources in Your VPC
   - uid: mondoo-aws-security-sagemaker-model-vpc-configured-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.models.all(vpc != empty)
+    filters: asset.platform == "aws-sagemaker-model"
+    mql: aws.sagemaker.model.vpc != empty
   - uid: mondoo-aws-security-sagemaker-model-vpc-configured-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_model")
     mql: |
@@ -40370,7 +40370,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Domain
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-terraform-hcl
         tags:
@@ -40502,8 +40502,8 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/encryption-at-rest.html
         title: Amazon SageMaker - Encryption at Rest
   - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-aws
-    filters: asset.platform == "aws"
-    mql: aws.sagemaker.domains.all(kmsKey != empty)
+    filters: asset.platform == "aws-sagemaker-domain"
+    mql: aws.sagemaker.domain.kmsKey != empty
   - uid: mondoo-aws-security-sagemaker-domain-kms-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_domain")
     mql: |
@@ -41223,7 +41223,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-sagemaker-domain-default-role-not-admin-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Domain
           mondoo.com/filter-icon: aws
     docs:
       desc: |
@@ -41332,11 +41332,10 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege
         title: AWS IAM - Apply Least-Privilege Permissions
   - uid: mondoo-aws-security-sagemaker-domain-default-role-not-admin-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sagemaker-domain"
     mql: |
-      aws.sagemaker.domains
-        .where(defaultExecutionRole != empty)
-        .all(defaultExecutionRole.attachedPolicies.none(name == "AdministratorAccess"))
+      aws.sagemaker.domain.defaultExecutionRole == empty ||
+      aws.sagemaker.domain.defaultExecutionRole.attachedPolicies.none(name == "AdministratorAccess")
   # No Terraform variants: Verifying that the role does not attach `AdministratorAccess` requires resolving an IAM role and walking `aws_iam_role_policy_attachment` resources — a multi-resource correlation that the variant pattern does not express.
   - uid: mondoo-aws-security-sagemaker-notebook-role-not-admin
     title: Ensure SageMaker notebook instance IAM role is not AdministratorAccess
@@ -41480,9 +41479,13 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     variants:
-      - uid: mondoo-aws-security-sagemaker-job-role-not-admin-aws
+      - uid: mondoo-aws-security-sagemaker-job-role-not-admin-trainingjob
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Training Job
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-sagemaker-job-role-not-admin-processingjob
+        tags:
+          mondoo.com/filter-title: AWS SageMaker Processing Job
           mondoo.com/filter-icon: aws
     docs:
       desc: |
@@ -41555,16 +41558,16 @@ queries:
         title: Amazon SageMaker - Execution Roles
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege
         title: AWS IAM - Apply Least-Privilege Permissions
-  - uid: mondoo-aws-security-sagemaker-job-role-not-admin-aws
-    filters: asset.platform == "aws"
+  - uid: mondoo-aws-security-sagemaker-job-role-not-admin-trainingjob
+    filters: asset.platform == "aws-sagemaker-trainingjob"
     mql: |
-      aws.sagemaker.trainingJobs
-        .where(iamRole != empty)
-        .all(iamRole.attachedPolicies.none(name == "AdministratorAccess"))
-      &&
-      aws.sagemaker.processingJobs
-        .where(iamRole != empty)
-        .all(iamRole.attachedPolicies.none(name == "AdministratorAccess"))
+      aws.sagemaker.trainingjob.iamRole == empty ||
+      aws.sagemaker.trainingjob.iamRole.attachedPolicies.none(name == "AdministratorAccess")
+  - uid: mondoo-aws-security-sagemaker-job-role-not-admin-processingjob
+    filters: asset.platform == "aws-sagemaker-processingjob"
+    mql: |
+      aws.sagemaker.processingjob.iamRole == empty ||
+      aws.sagemaker.processingjob.iamRole.attachedPolicies.none(name == "AdministratorAccess")
   - uid: mondoo-aws-security-mq-audit-logging
     title: Ensure Amazon MQ brokers have audit logging enabled
     impact: 60
@@ -82672,7 +82675,7 @@ queries:
     variants:
       - uid: mondoo-aws-security-sagemaker-domain-vpc-only-aws
         tags:
-          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-title: AWS SageMaker Domain
           mondoo.com/filter-icon: aws
       - uid: mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl
         tags:
@@ -82780,11 +82783,9 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/studio-notebooks-and-internet-access.html
         title: Connect SageMaker Studio notebooks in a VPC to external resources
   - uid: mondoo-aws-security-sagemaker-domain-vpc-only-aws
-    filters: asset.platform == "aws"
+    filters: asset.platform == "aws-sagemaker-domain"
     mql: |
-      aws.sagemaker.domains.all(
-        appNetworkAccessType == "VpcOnly"
-      )
+      aws.sagemaker.domain.appNetworkAccessType == "VpcOnly"
   - uid: mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_sagemaker_domain")
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -21483,7 +21483,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Endpoint
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-terraform-hcl
         tags:
@@ -21582,11 +21582,9 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-endpoint'
     mql: |
-      gcp.project.vertexai.endpoints.all(
-        encryptionSpec != empty
-      )
+      gcp.project.vertexaiService.endpoint.encryptionSpec != empty
   - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_vertex_ai_endpoint')
@@ -21631,7 +21629,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Endpoint
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-terraform-hcl
         tags:
@@ -21730,11 +21728,9 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/predictions/using-private-service-connect
         title: Using Private Service Connect with Vertex AI
   - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-endpoint'
     mql: |
-      gcp.project.vertexai.endpoints.all(
-        enablePrivateServiceConnect == true
-      )
+      gcp.project.vertexaiService.endpoint.enablePrivateServiceConnect == true
   - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_vertex_ai_endpoint')
@@ -22061,7 +22057,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Pipeline Job
           mondoo.com/filter-icon: gcp
     docs:
       desc: |
@@ -22136,11 +22132,9 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-pipeline-job-cmek-encryption-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-pipelinejob'
     mql: |
-      gcp.project.vertexai.pipelineJobs.all(
-        encryptionSpec != empty
-      )
+      gcp.project.vertexaiService.pipelineJob.encryptionSpec != empty
   # No Terraform variants: Vertex AI pipeline jobs are imperative API executions with no
   # Terraform resource analog; the provider has no resource for pipeline jobs or custom
   # jobs, so a variant cannot be written against pipeline jobs.
@@ -22167,7 +22161,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-vpc-network-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Pipeline Job
           mondoo.com/filter-icon: gcp
     docs:
       desc: |
@@ -22239,11 +22233,9 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/general/vpc-peering
         title: VPC Network Peering for Vertex AI
   - uid: mondoo-gcp-security-vertexai-pipeline-job-vpc-network-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-pipelinejob'
     mql: |
-      gcp.project.vertexai.pipelineJobs.all(
-        networkRef != null
-      )
+      gcp.project.vertexaiService.pipelineJob.networkRef != null
   # No Terraform variants: Vertex AI pipeline jobs are imperative API executions with no
   # Terraform resource analog (no google_vertex_ai_pipeline_job), so the service-account
   # configuration cannot be evaluated from HCL/plan/state.
@@ -22270,7 +22262,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-pipeline-job-no-default-service-account-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Pipeline Job
           mondoo.com/filter-icon: gcp
     docs:
       desc: |
@@ -22355,13 +22347,11 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/pipelines/configure-project#service-account
         title: Configure a service account for Vertex AI Pipelines
   - uid: mondoo-gcp-security-vertexai-pipeline-job-no-default-service-account-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-pipelinejob'
     mql: |
-      gcp.project.vertexai.pipelineJobs.all(
-        serviceAccountRef != null &&
-        serviceAccountRef.email != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
-        serviceAccountRef.email != /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
-      )
+      gcp.project.vertexaiService.pipelineJob.serviceAccountRef != null &&
+      gcp.project.vertexaiService.pipelineJob.serviceAccountRef.email != /^\d+-compute@developer\.gserviceaccount\.com$/ &&
+      gcp.project.vertexaiService.pipelineJob.serviceAccountRef.email != /^[a-z0-9\-]+@appspot\.gserviceaccount\.com$/
   - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption
     title: Ensure Vertex AI feature online stores use CMEK
     impact: 60
@@ -42519,7 +42509,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Notebook Runtime Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl
         tags:
@@ -42611,11 +42601,9 @@ queries:
       - url: https://cloud.google.com/vertex-ai/docs/general/cmek
         title: Customer-managed encryption keys (CMEK) for Vertex AI
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
     mql: |
-      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
-        kmsKey != null
-      )
+      gcp.project.vertexaiService.notebookRuntimeTemplate.kmsKey != null
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
     mql: |
@@ -42657,7 +42645,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Notebook Runtime Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl
         tags:
@@ -42746,11 +42734,10 @@ queries:
       - url: https://cloud.google.com/security/shielded-cloud/shielded-vm
         title: Shielded VM
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
     mql: |
-      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
-        shieldedVmConfig != empty && shieldedVmConfig['enableSecureBoot'] == true
-      )
+      gcp.project.vertexaiService.notebookRuntimeTemplate.shieldedVmConfig != empty &&
+      gcp.project.vertexaiService.notebookRuntimeTemplate.shieldedVmConfig['enableSecureBoot'] == true
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
     mql: |
@@ -42792,7 +42779,7 @@ queries:
     variants:
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-gcp
         tags:
-          mondoo.com/filter-title: GCP Vertex AI
+          mondoo.com/filter-title: GCP Vertex AI Notebook Runtime Template
           mondoo.com/filter-icon: gcp
       - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl
         tags:
@@ -42885,11 +42872,11 @@ queries:
       - url: https://cloud.google.com/colab/docs/runtimes
         title: Colab Enterprise runtimes
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-gcp
-    filters: asset.platform == 'gcp-project'
+    filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
     mql: |
-      gcp.project.vertexaiService.notebookRuntimeTemplates.all(
-        networkSpec != empty && networkSpec['network'] != null && networkSpec['network'] != ""
-      )
+      gcp.project.vertexaiService.notebookRuntimeTemplate.networkSpec != empty &&
+      gcp.project.vertexaiService.notebookRuntimeTemplate.networkSpec['network'] != null &&
+      gcp.project.vertexaiService.notebookRuntimeTemplate.networkSpec['network'] != ""
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl
     filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_colab_runtime_template')
     mql: |


### PR DESCRIPTION
## What

14 checks in the AWS and GCP policies still iterated an account/project-wide collection even though mql now discovers each of those resources as its own asset platform. This retargets each runtime variant at the fine-grained platform and rewrites the MQL to the singular resource.

Scoring one aggregate datapoint per account means a single bad SageMaker model sinks the whole account's score with no indication of which model failed. Per-resource assets score each one independently.

### AWS (6 checks)

| Check | New platform |
|---|---|
| `sagemaker-model-network-isolation`, `sagemaker-model-vpc-configured` | `aws-sagemaker-model` |
| `sagemaker-domain-kms-encryption`, `sagemaker-domain-default-role-not-admin`, `sagemaker-domain-vpc-only` | `aws-sagemaker-domain` |
| `sagemaker-job-role-not-admin` **(split into 2 variants)** | `aws-sagemaker-trainingjob` + `aws-sagemaker-processingjob` |

`sagemaker-job-role-not-admin` AND-ed `aws.sagemaker.trainingJobs` and `aws.sagemaker.processingJobs` in one query. Both now have their own platform, so it becomes two runtime variants under the same parent check — the control objective and compliance mappings stay in one place. This follows the existing `mondoo-azure-security-no-sql-databases-allow-ingress-0-0-0-0-0` pattern of several runtime variants under one parent.

### GCP (8 checks)

| Check | New platform |
|---|---|
| `vertexai-endpoint-cmek-encryption`, `vertexai-endpoint-private-service-connect` | `gcp-vertexai-endpoint` |
| `vertexai-pipeline-job-cmek-encryption`, `-vpc-network`, `-no-default-service-account` | `gcp-vertexai-pipelinejob` |
| `vertexai-notebook-runtime-template-cmek-encryption`, `-shielded-vm`, `-private-network` | `gcp-vertexai-notebookruntimetemplate` |

## Rewrite rules applied

- `COLL.all(pred)` → `SINGULAR.pred`, repeating the full singular path per field.
- `COLL.where(P).all(Q)` → the guard `!P || Q`. The where-predicate becomes a guard rather than being dropped, which would silently rescope scoring.
- Each parent's `mondoo.com/filter-title` moves off the generic `AWS Account` / `GCP Vertex AI` to the provider's canonical platform title (`AWS SageMaker Domain`, `GCP Vertex AI Pipeline Job`, …), sourced from `providers/<cloud>/connection/platform.go`.
- Terraform/CloudFormation sibling variants are untouched.

## Deliberately left on the broad platform

Four families look like candidates but would regress if moved:

- **15 CloudWatch metric-filter/alarm checks** (`cloudwatch-*-alarm-aws`). Their `aws.cloudwatch.logGroups.any(...)` is an account-level existence assertion — CIS 4.x asks whether *a* log group has the filter. On `aws-cloudwatch-loggroup` the semantics invert to "every log group must carry every filter," which fails essentially every account.
- **8 EC2-instance and 4 ECS-container checks.** `DiscoveryEC2InstanceAPI` and `DiscoveryECSContainersAPI` are commented out of `AllAPIResources` in the AWS provider, so `aws-ec2-instance` / `aws-ecs-container` are never emitted by a default scan. Retargeting would make these checks silently never run.
- **`gke-backup-plan-exists`.** `clusters.length == 0 || gkeBackupService.backupPlans.where(...).length > 0` is a project-level assertion gated on clusters existing, not a per-cluster property.
- **`route53-resolver-query-logging-enabled`.** Needs the account-level resolver query-log association list, which is not reachable from a per-VPC asset.

Azure and OCI had zero remaining candidates — the earlier per-resource passes covered both completely.

## Testing

- `cnspec policy lint ./content` → valid (the 2 `terraform.resources` warnings and 3 deprecated-symbol warnings are pre-existing on `main`).
- `go test ./content/...` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)