### PR TITLE
🐛 content(linux): fix SSH idle timeout check failing on unrelated Match blocks

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -12409,9 +12409,15 @@ queries:
 
       userBlocks = sshd.config.blocks.where(criteria.contains(props.excludedMatchBlocks) == false && criteria != "");
 
-      userBlocks.all(params.ClientAliveInterval >= 1)
-      userBlocks.all(params.ClientAliveInterval <= 300)
-      userBlocks.all(params.ClientAliveCountMax > 0) && userBlocks.all(params.ClientAliveCountMax <= 3)
+      // A Match block only carries the parameters it sets itself; anything it does not set is
+      // inherited from the default block. Only check the blocks that override these settings,
+      // otherwise every Match block that leaves them alone is reported as unset.
+      intervalBlocks = userBlocks.where(params["ClientAliveInterval"] != null);
+      countMaxBlocks = userBlocks.where(params["ClientAliveCountMax"] != null);
+
+      intervalBlocks.all(params.ClientAliveInterval >= 1)
+      intervalBlocks.all(params.ClientAliveInterval <= 300)
+      countMaxBlocks.all(params.ClientAliveCountMax > 0) && countMaxBlocks.all(params.ClientAliveCountMax <= 3)
 
       defaultBlock.all(params.ClientAliveInterval >= 1)
       defaultBlock.all(params.ClientAliveInterval <= 300)
@@ -12430,13 +12436,22 @@ queries:
 
         By configuring `ClientAliveInterval` within 1-300 seconds and `ClientAliveCountMax` within 1-3, organizations can enforce predictable session timeouts, reduce the risk of unauthorized access from abandoned sessions, and balance usability with security.
       audit: |
-        Run this command to inspect the SSH idle timeout settings:
+        Run this command to inspect the effective SSH idle timeout settings:
 
         ```bash
         sshd -T | grep -iE 'clientalive(interval|countmax)'
         ```
 
         A passing result shows `clientaliveinterval` between `1` and `300` and `clientalivecountmax` between `1` and `3`. A failing result shows either value outside these ranges or absent.
+
+        `Match` blocks are evaluated as well: a block that overrides these settings with a
+        non-compliant value also fails the check, while a block that does not set them at all
+        inherits the global values and is ignored. Run this command to inspect the settings that
+        apply inside a `Match` block:
+
+        ```bash
+        sshd -T -C user=<user>,host=<host>,addr=<addr> | grep -iE 'clientalive(interval|countmax)'
+        ```
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## Problem

```
$ sshd -T | grep -iE 'clientalive(interval|countmax)'
clientaliveinterval 300
clientalivecountmax 2
```

The values live in a file under `/etc/ssh/sshd_config.d/` pulled in via `Include`, identical across the customer's fleet — yet the check fails on the one host that also has a `Match` block.

## Root cause

An `sshd_config` `Match` block only carries the parameters set inside its own stanza; it does **not** inherit the default block. This is by design in the resource parser — `mergeIncludedBlocks` / `ParseBlocks` in `cnquery/providers/os/resources/sshd/params.go` keep each block's `params` map to the keys that block sets itself.

The check asserted `userBlocks.all(params.ClientAliveInterval >= 1)` across every `Match` block, so a block that simply leaves the setting alone evaluates `null >= 1` → false and fails the whole check. Confirmed against the parser output:

```
$ cnspec run local -c 'sshd.config("…").blocks { criteria params["ClientAliveInterval"] }' --json
[{"criteria":"",                "params[ClientAliveInterval]":"300"},
 {"criteria":"Group sftponly",  "params[ClientAliveInterval]":null}]
```

Any `Match Group sftponly` with just a `ChrootDirectory`, or a bare `Match all`, was enough to fail a compliant host.

## Fix

Restrict the `Match`-block assertions to the blocks that actually override these parameters:

```mql
intervalBlocks = userBlocks.where(params["ClientAliveInterval"] != null);
countMaxBlocks = userBlocks.where(params["ClientAliveCountMax"] != null);

intervalBlocks.all(params.ClientAliveInterval >= 1)
intervalBlocks.all(params.ClientAliveInterval <= 300)
countMaxBlocks.all(params.ClientAliveCountMax > 0) && countMaxBlocks.all(params.ClientAliveCountMax <= 3)
```

`defaultBlock` deliberately keeps `all(...)`, so a host with no setting at all still fails. A `Match` block that *weakens* the setting still fails.

### Why not the inverted `none(...)` form

The CIS variants of this control in `cnspec-enterprise-policies` use `userBlocks.none(params.ClientAliveInterval < 1)`. That also fixes this report, but it is fail-open: `params` values are strings, and the parser leaves values real `sshd` honours but Go's duration parser doesn't (`1d`, `1w`) and double-quoted values (`\"0\"`) as non-numeric strings. Both `< 1` and `> 300` are then false, so a `Match` block that disables the idle timeout with `ClientAliveInterval \"0\"` or stretches it to `1d` would silently pass. Measured:

| `Match User bad` sets | real `sshd -T -C user=bad` | `all()` (before) | `none()` | this PR |
|---|---|---|---|---|
| `ClientAliveInterval 1d` | 86400 | fail | **pass** | fail |
| `ClientAliveInterval \"0\"` | 0 | fail | **pass** | fail |
| `ClientAliveCountMax \"0\"` | 0 | fail | **pass** | fail |

The presence filter keeps those fail-closed.

## Verification

Each scenario is an `sshd_config` tree scanned with a bundle containing this check verbatim (`cnspec scan local -f … --incognito`):

| scenario | expected | before | after |
|---|---|---|---|
| Include sets 300/2, `Match Group sftponly` sets neither (**the report**) | pass | **fail** | pass |
| `Match` sets only `ClientAliveCountMax 3` | pass | **fail** | pass |
| `Match all` with no ClientAlive params | pass | **fail** | pass |
| no `Match` blocks, 300/2 global | pass | pass | pass |
| `Match` sets compliant 120/3 | pass | pass | pass |
| interval and countmax split across main file + Include | pass | pass | pass |
| global `ClientAliveInterval 5m` | pass | pass | pass |
| nothing set anywhere | fail | fail | fail |
| global `0` / `301` | fail | fail | fail |
| `Match` sets interval `0` / `600` | fail | fail | fail |
| `Match` sets countmax `0` / `5` | fail | fail | fail |
| two `Match` blocks, one weakening | fail | fail | fail |
| `Match` sets `1d` / `"0"` / countmax `"0"` | fail | fail | fail |

18/18 scenarios match expectations; no scenario that should fail passes. `cnspec policy lint content/mondoo-linux-security.mql.yaml` → `valid policy bundle(s)`.

## Docs

The `audit:` section now states that `Match` blocks are evaluated — a weakening override fails, a block that does not set the parameters inherits the global values and is ignored — and shows `sshd -T -C user=…` for inspecting a specific `Match` context.

## Out of scope

Two adjacent issues surfaced while verifying, both pre-existing and untouched here:

- The parser leaves `ClientAliveInterval 1d` / `1w` and double-quoted values as non-numeric strings (`time.ParseDuration` has no `d`/`w` unit; `parseQuotedArg` keeps the quotes). This PR is fail-closed on them, but they cannot be range-checked. Resource-side fix belongs in cnquery.
- An `Include` placed *after* a `Match` stanza attributes the included global settings to that `Match` block. Also cnquery-side.
- The CIS variants of this control in `cnspec-enterprise-policies` still use the `none(...)` form and carry the fail-open gap described above.