### PR TITLE
🐛 Fix auditd checks failing on stricter-than-required syscall rules

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7319,7 +7319,7 @@ queries:
       // 64-bit syscall rules for time modification
       syscalls_64bit = ["adjtimex", "settimeofday", "clock_settime"]
       desiredRules64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && keyname == "time-change"
       ).map(syscalls).flat
@@ -7328,7 +7328,7 @@ queries:
       // 32-bit syscall rules for time modification (includes stime)
       syscalls_32bit = ["adjtimex", "settimeofday", "clock_settime", "stime"]
       desiredRules32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && keyname == "time-change"
       ).map(syscalls).flat
@@ -7870,7 +7870,7 @@ queries:
       // Syscall rules for network changes (64-bit)
       syscalls_64bit = ["sethostname", "setdomainname"]
       desiredRules64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && keyname == "system-locale"
       ).map(syscalls).flat
@@ -7879,7 +7879,7 @@ queries:
       // Syscall rules for network changes (32-bit)
       syscalls_32bit = ["sethostname", "setdomainname"]
       desiredRules32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && keyname == "system-locale"
       ).map(syscalls).flat
@@ -7908,7 +7908,7 @@ queries:
       // Syscall rules for network changes (64-bit)
       syscalls_64bit = ["sethostname", "setdomainname"]
       desiredRules64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && keyname == "system-locale"
       ).map(syscalls).flat
@@ -7917,7 +7917,7 @@ queries:
       // Syscall rules for network changes (32-bit)
       syscalls_32bit = ["sethostname", "setdomainname"]
       desiredRules32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && keyname == "system-locale"
       ).map(syscalls).flat
@@ -7952,7 +7952,7 @@ queries:
       // Syscalls for DAC permission modification (64-bit)
       syscalls_64bit = ["chmod", "fchmod", "fchmodat", "chown", "fchown", "fchownat", "lchown", "setxattr", "lsetxattr", "fsetxattr", "removexattr", "lremovexattr", "fremovexattr"]
       desiredRules64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && auidMin == 1000
         && excludesUnsetAuid
@@ -7963,7 +7963,7 @@ queries:
       // Syscalls for DAC permission modification (32-bit)
       syscalls_32bit = ["chmod", "fchmod", "fchmodat", "chown", "fchown", "fchownat", "lchown", "setxattr", "lsetxattr", "fsetxattr", "removexattr", "lremovexattr", "fremovexattr"]
       desiredRules32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && auidMin == 1000
         && excludesUnsetAuid
@@ -8176,7 +8176,7 @@ queries:
 
       // Check for EPERM exit code rules (64-bit)
       desiredRulesEperm64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && fields.contains(key == "exit" && value == "-EPERM")
         && auidMin == 1000
@@ -8187,7 +8187,7 @@ queries:
 
       // Check for EACCES exit code rules (64-bit)
       desiredRulesEacces64 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_64bit)
+        syscalls.any(_.in(syscalls_64bit))
         && arch == "b64"
         && fields.contains(key == "exit" && value == "-EACCES")
         && auidMin == 1000
@@ -8198,7 +8198,7 @@ queries:
 
       // Check for EPERM exit code rules (32-bit)
       desiredRulesEperm32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && fields.contains(key == "exit" && value == "-EPERM")
         && auidMin == 1000
@@ -8209,7 +8209,7 @@ queries:
 
       // Check for EACCES exit code rules (32-bit)
       desiredRulesEacces32 = auditd.rules.syscalls.where(
-        syscalls.in(syscalls_32bit)
+        syscalls.any(_.in(syscalls_32bit))
         && arch == "b32"
         && fields.contains(key == "exit" && value == "-EACCES")
         && auidMin == 1000


### PR DESCRIPTION
## Problem

Five auditd checks in **Mondoo Linux Security** filtered syscall rules like this:

```mql
syscalls_64bit = ["creat", "open", "openat", "truncate", "ftruncate"]
desiredRulesEacces64 = auditd.rules.syscalls.where(
  syscalls.in(syscalls_64bit)        // <-- bug
  && arch == "b64"
  && fields.contains(key == "exit" && value == "-EACCES")
  && auidMin == 1000 && excludesUnsetAuid
  && keyname == "access"
).map(syscalls).flat
desiredRulesEacces64.containsAll(syscalls_64bit)
```

`syscalls` is the `[]string` of `-S` entries belonging to **one** rule, so
`syscalls.in(LIST)` evaluates as a **subset test** — true only when *every*
syscall of the rule is a member of `LIST`.

A host that audits the required syscalls **plus extras** — a *stricter*, more
compliant configuration — is therefore dropped by the filter. `.map(syscalls).flat`
returns `[]` and `containsAll()` fails, producing the customer's reported output:

```
[failed] [].containsAll()
  expected: == []
  actual:   [creat, open, openat, truncate, ftruncate]
```

The check reports a violation on a system that is configured *more* strictly than
the benchmark requires.

## Fix

`syscalls.in(LIST)` → `syscalls.any(_.in(LIST))` at all 12 sites — "this rule audits
at least one syscall I care about", so the rule is kept, its syscalls join the union,
and `containsAll()` decides pass/fail on **presence**, which is the intent.

Affected checks:

- `…-events-that-modify-date-and-time-information-are-collected`
- `…-events-that-modify-the-systems-network-environment-are-collected-debian-rhel`
- `…-events-that-modify-the-systems-network-environment-are-collected-other`
- `…-discretionary-access-control-permission-modification-events-are-collected`
- `…-unsuccessful-unauthorized-file-access-attempts-are-collected`

## Verification

Fixtures built with `auditd.rules(path:)` and executed with `cnspec run local`, comparing `HEAD` against the branch:

| Scenario | Expected | Before | After |
|---|---|---|---|
| `time-change`, customer's exact rules from the issue | pass | pass | pass |
| `access`, stricter-than-required (`+open_by_handle_at`) | pass | **fail** | **pass** |
| `access`, non-compliant (`truncate` absent) | fail | fail | fail |
| `time-change`, syscalls split across several rules | pass | pass | pass |
| `time-change`, rule carrying no `-S` list at all | no error | n/a | no error |

Detection power is unchanged: a genuinely non-compliant configuration still fails.
`cnspec policy lint content/mondoo-linux-security.mql.yaml` → *valid policy bundle(s)*.

## Notes for the reporter

The issue also reported that "test compares only against `syscalls_64bit` set". That part
is **already fixed** on `main`: each 32-bit block now compares against its own
`syscalls_32bit` (and for `time-change` that set correctly includes `stime`, which does not
exist on `b64`). The customer was on cnspec 13.1.1, which predates both that correction and
the `arch` / `auidMin` / `excludesUnsetAuid` convenience fields on `auditd.rule.syscall`.
The superset false-negative fixed here is the part that survived on current `main`.

One adjacent behaviour was reviewed and deliberately **not** changed: rules written without
`-F arch=` (which parse as `arch == ""`) are still not credited. CIS mandates the
arch-qualified form and the checks' own remediation installs it, so this is intentional.