### PR TITLE
🐛 aws: fix lambda public-access false positive on named service principals

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -5899,7 +5899,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that the resource-based policy attached to each AWS Lambda function contains no statements that grant unscoped invocation rights to the wildcard principal (`*`). By default, Lambda functions have no resource-based policy, but policies added for service integrations or cross-account access can inadvertently include a wildcard principal that exposes the function to any AWS identity or unauthenticated caller unless constrained by a condition such as `AWS:SourceArn`, `AWS:SourceAccount`, or `aws:PrincipalOrgID`. Source conditions should be specific; avoid wildcard source ARN values that effectively grant broad invoke access.
+        This check ensures that the resource-based policy attached to each AWS Lambda function contains no statements that grant unscoped invocation rights to the wildcard principal (`*`). By default, Lambda functions have no resource-based policy, but policies added for service integrations or cross-account access can inadvertently include a wildcard principal that exposes the function to any AWS identity or unauthenticated caller unless constrained by a condition such as `AWS:SourceArn`, `AWS:SourceAccount`, or `aws:PrincipalOrgID`. Named service principals such as `events.amazonaws.com` are not wildcard principals and do not make a function public, whether or not the statement carries a source condition. Source conditions should be specific; avoid wildcard source ARN values that effectively grant broad invoke access.
 
         **Why this matters**
 
@@ -6035,29 +6035,13 @@ queries:
     filters: |
       asset.platform == "aws-lambda-function"
     mql: |
-      # Null covers functions without a resource policy; empty covers empty policy documents.
-      # MQL short-circuits before Statement access when the policy is absent.
-      aws.lambda.function.policy == null ||
-      aws.lambda.function.policy == empty ||
-      aws.lambda.function.policy.Statement == null ||
-      aws.lambda.function.policy.Statement == empty ||
-      aws.lambda.function.policy.Statement.where(Effect == "Allow").where(
-        # AWS principals can be encoded as a string or a list; contains(/^\*$/) covers list entries exactly equal to "*".
-        Principal == "*" ||
-        Principal['AWS'] == "*" ||
-        Principal['AWS'].contains(/^\*$/) ||
-        Principal['Service'] == "*" ||
-        Principal['Service'].contains(/^\*$/)
-      ).all(
-        # Require at least one recognized source condition without a bare wildcard value.
-        Condition != null &&
-        Condition.values.any(
-          _.where(key == /aws:(SourceArn|SourceAccount|PrincipalOrgID)/i) != empty &&
-          # values.contains catches scalar values; values.any catches list-valued condition values.
-          _.where(key == /aws:(SourceArn|SourceAccount|PrincipalOrgID)/i).values.contains(/^\*$/) == false &&
-          _.where(key == /aws:(SourceArn|SourceAccount|PrincipalOrgID)/i).values.any(_.contains(/^\*$/)) == false
-        )
-      )
+      # allowsPublicAccess is the provider-side verdict shared with the EFS, SNS, SQS, KMS and
+      # ECR resource-policy checks: an Allow statement granting the `*` principal without a
+      # scoping condition on aws:SourceArn, aws:SourceAccount, or aws:PrincipalOrgID. It matches
+      # the wildcard structurally, so a named service principal such as events.amazonaws.com is
+      # never a candidate, and a function with no resource policy is not public. Function URL
+      # auth type is covered separately by mondoo-aws-security-lambda-function-url-auth-required.
+      aws.lambda.function.allowsPublicAccess == false
   - uid: mondoo-aws-security-lambda-function-public-access-prohibited-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_permission")
     mql: |


### PR DESCRIPTION
## Summary

The AWS variant of **"Ensure the policy attached to the lambda function prohibits public access"** fails **every** Lambda function that has a resource-based policy — including policies that grant only a named service principal (`events.amazonaws.com`) or a single named AWS account.

## Root cause

Two independent defects combine.

**1. The candidate filter admits every statement.**

```mql
.where(
  Principal == "*" ||
  Principal['AWS'] == "*" ||
  Principal['AWS'].contains(/^\*$/) ||
  Principal['Service'] == "*" ||
  Principal['Service'].contains(/^\*$/)
)
```

Evaluated standalone, every one of these terms is `false` for a non-wildcard principal. Used as a `where` predicate, the `.contains(/^\*$/)` terms admit the row anyway. Measured with `mql` 13.30.0 against the reported policy:

```
Statement.where(Effect == "Allow").length                          -> 1
where(Principal == "*").length                                     -> 0
where(Principal['AWS'] == "*").length                              -> 0
where(Principal['AWS'].contains(/^\*$/)).length                    -> 1   # no AWS key at all
where(Principal['Service'] == "*").length                          -> 0
where(Principal['Service'].contains(/^\*$/)).length                -> 1   # ["events.amazonaws.com"]
```

**2. The assertion can never be satisfied on shipped providers.**

Every admitted statement must then carry a source-scoping `Condition`. On the AWS provider builds released today, the Lambda resource policy is unmarshalled into a struct with no `Condition` field, so the condition block is dropped before MQL sees it. `mondoohq/cnquery#9435` (2026-07-25) fixes the drop, but it is not yet in a released provider.

**Reproduction** — current `main` MQL, customer policies rendered the way the shipped provider renders them:

| fixture | policy | current `main` | correct |
|---|---|---|---|
| `AlertSetupOnNewLb` | `Principal {Service: events.amazonaws.com}` + `ArnLike AWS:SourceArn` | **FAIL** | PASS |
| `backup-tag-change` | `Principal {Service: events.amazonaws.com}` + `ArnLike AWS:SourceArn` | **FAIL** | PASS |
| named account | `Principal {AWS: arn:aws:iam::123456789012:root}` | **FAIL** | PASS |
| API Gateway | `Principal {Service: apigateway.amazonaws.com}` | **FAIL** | PASS |
| S3 | `Principal {Service: s3.amazonaws.com}` | **FAIL** | PASS |

## Fix

```mql
aws.lambda.function.allowsPublicAccess == false
```

`allowsPublicAccess` is the provider-side verdict already shared by the EFS, SNS, SQS, KMS and ECR resource-policy checks (`statementsAllowPublic`, unit-tested in `aws_iam_policy_statement_test.go`): an `Allow` statement granting the `*` principal without a scoping condition on `aws:SourceArn`, `aws:SourceAccount`, or `aws:PrincipalOrgID`.

It matches the wildcard **structurally**, so a named service principal is never a candidate and the verdict does not depend on whether the provider preserved the condition block. That makes the check correct on today's provider *and* after cnquery#9435 ships.

`allowsPublicAccess` is policy-only by design. Function URL auth type stays with the dedicated `mondoo-aws-security-lambda-function-url-auth-required` check (same asset platform, same impact) rather than being double-counted here — which also avoids taking a new `lambda:GetFunctionUrlConfig` dependency whose `AccessDenied` would turn the check into a hard error.

Still correctly flagged as public: `Principal: "*"` with no condition, `Principal: {"AWS": "*"}`, and a wildcard principal whose only condition does not scope the caller.

## Docs

One sentence added to `desc`, stating that named service principals are not wildcard principals. No other doc change — the check's scope is unchanged.

## Verification

- `cnspec policy lint content/mondoo-aws-security.mql.yaml` → valid. Negative control (bogus field) → `failed to compile: cannot find field ... in aws.lambda.function`, confirming lint resolves provider fields, so `allowsPublicAccess` genuinely compiles against the installed AWS provider (13.49.0; field minimum is 13.33.2).
- Behaviour measured with the `mql` binary against JSON fixtures of the two reported policies in **both** provider renderings (with and without `Condition`).

## Not included

The issue also reports **"Ensure all RDS clusters are not publicly accessible"** on `sen-kong-nonprod-ec1-postgres-rds`. I could not reproduce a defect from the supplied evidence, so I deliberately left that check alone rather than loosen an impact-100 control on an unproven hypothesis:

- The finding predates the current query — the deployed check description mentions internet-gateway route checking, which #2602 removed on 2026-06-19.
- The supplied evidence does not discriminate. Per AWS, a `PubliclyAccessible=true` instance's endpoint resolves to its **private** IP from inside the VPC, and security groups are orthogonal to the flag — so neither the private-CIDR security group nor `nslookup -> 172.16.27.92` establishes that the members are private.

Detail and the two artifacts needed to settle it are in the issue comment.