### PR TITLE
🐛 linux-security: stop pinning auditd checks to one literal audit key

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -6804,7 +6804,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
     docs:
@@ -7125,7 +7125,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
@@ -7135,7 +7135,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
@@ -7145,7 +7145,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
   - uid: mondoo-linux-security-session-initiation-information-is-collected
@@ -7169,14 +7169,14 @@ queries:
       // Check utmp is watched with a non-empty audit key
       auditd.rules.files.contains( f:
         f.path == "/var/run/utmp" && f.permissions == "wa"
-        && f.keyname != ""
+        && f.keyname != empty
       )
       // Check wtmp and btmp are watched with a non-empty audit key
       sessionPaths = ["/var/log/wtmp", "/var/log/btmp"]
       sessionPaths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
     docs:
@@ -7322,7 +7322,7 @@ queries:
         syscalls.in(syscalls_64bit)
         && arch == "b64"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7332,7 +7332,7 @@ queries:
         syscalls.in(syscalls_32bit)
         && arch == "b32"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7340,7 +7340,7 @@ queries:
       auditd.rules.files.contains(
         path == "/etc/localtime"
         && permissions == "wa"
-        && keyname != ""
+        && keyname != empty
       )
     docs:
       desc: |
@@ -7497,7 +7497,7 @@ queries:
           f.path.in([p, p + "/"])
           && f.permissions.contains("w")
           && f.permissions.contains("a")
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
 
@@ -7507,7 +7507,7 @@ queries:
           f.path.in([p, p + "/"])
           && f.permissions.contains("w")
           && f.permissions.contains("a")
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
 
@@ -7875,7 +7875,7 @@ queries:
         syscalls.in(syscalls_64bit)
         && arch == "b64"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7885,7 +7885,7 @@ queries:
         syscalls.in(syscalls_32bit)
         && arch == "b32"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7894,7 +7894,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
 
@@ -7903,7 +7903,7 @@ queries:
       networkDirPaths.any(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
   - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-other
@@ -7915,7 +7915,7 @@ queries:
         syscalls.in(syscalls_64bit)
         && arch == "b64"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7925,7 +7925,7 @@ queries:
         syscalls.in(syscalls_32bit)
         && arch == "b32"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7934,7 +7934,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
   - uid: mondoo-linux-security-discretionary-access-control-permission-modification-events-are-collected
@@ -7963,7 +7963,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7975,7 +7975,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
     docs:
@@ -8190,7 +8190,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRulesEperm64.containsAll(syscalls_64bit)
 
@@ -8202,7 +8202,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRulesEacces64.containsAll(syscalls_64bit)
 
@@ -8214,7 +8214,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRulesEperm32.containsAll(syscalls_32bit)
 
@@ -8226,7 +8226,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
       desiredRulesEacces32.containsAll(syscalls_32bit)
     docs:
@@ -8418,7 +8418,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
     docs:
@@ -8575,14 +8575,14 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ) || auditd.rules.syscalls.contains(
         syscalls.contains("mount")
         && arch == "b32"
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       )
     docs:
       desc: |
@@ -8730,7 +8730,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
 
       deleteRules32 = auditd.rules.syscalls.where(
@@ -8738,7 +8738,7 @@ queries:
         && auidMin == 1000
         && excludesUnsetAuid
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       ).map(syscalls).flat
 
       // Base syscalls must be present on all architectures
@@ -8939,7 +8939,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "x"
-          && f.keyname != ""
+          && f.keyname != empty
         )
       )
 
@@ -8948,7 +8948,7 @@ queries:
         syscalls.containsAll(["init_module", "delete_module"])
         && arch == "b64"
         && action == "always"
-        && fields.contains(key == "key" && value != "")
+        && fields.contains(key == "key" && value != empty)
       )
     docs:
       desc: |
@@ -9092,7 +9092,7 @@ queries:
     mql: |
       auditd.rules.files.contains( f:
         f.path == "/var/log/sudo.log" && f.permissions == "wa"
-        && f.keyname != ""
+        && f.keyname != empty
       )
     docs:
       desc: |

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -6804,7 +6804,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "scope"
+          && f.keyname != ""
         )
       )
     docs:
@@ -6828,10 +6828,10 @@ queries:
         Run this command to confirm the audit rules for changes to the sudoers configuration are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k scope'
+        auditctl -l | grep -E -- '-w /etc/sudoers(\.d)? '
         ```
 
-        A passing result lists the expected audit rules with the `scope` key. A failing result returns no matching rules.
+        A passing result lists both watch rules with `wa` permissions and a non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -6968,7 +6968,7 @@ queries:
           mondoo.com/filter-icon: linux
     docs:
       desc: |
-        This check verifies that auditd is configured to monitor the files that record login and logout activity, with all audit records tagged with the identifier "logins". On every system it requires watches on `/var/log/lastlog`, which tracks the last login of each user, and `/var/log/tallylog`, which tracks failed login attempts. On Debian-based systems it additionally requires a watch on `/var/log/faillog`, which records failed login counts. On Red Hat and Amazon Linux systems it additionally requires a watch on `/var/run/faillock`, which is used by the `pam_faillock` module to track failed authentication attempts.
+        This check verifies that auditd is configured to monitor the files that record login and logout activity, with every matching audit rule carrying an audit key so the events can be grouped and searched. On every system it requires watches on `/var/log/lastlog`, which tracks the last login of each user, and `/var/log/tallylog`, which tracks failed login attempts. On Debian-based systems it additionally requires a watch on `/var/log/faillog`, which records failed login counts. On Red Hat and Amazon Linux systems it additionally requires a watch on `/var/run/faillock`, which is used by the `pam_faillock` module to track failed authentication attempts.
 
         **Why this matters**
 
@@ -6984,10 +6984,10 @@ queries:
         Run this command to confirm the audit rules for login and logout events are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k logins'
+        auditctl -l | grep -E -- '/var/log/(lastlog|tallylog|faillog)|/var/run/faillock'
         ```
 
-        A passing result lists the expected audit rules with the `logins` key. A failing result returns no matching rules.
+        A passing result lists watch rules on those files with `wa` permissions and a non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -7125,7 +7125,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "logins"
+          && f.keyname != ""
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-rhel
@@ -7135,7 +7135,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "logins"
+          && f.keyname != ""
         )
       )
   - uid: mondoo-linux-security-login-and-logout-events-are-collected-other
@@ -7145,7 +7145,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "logins"
+          && f.keyname != ""
         )
       )
   - uid: mondoo-linux-security-session-initiation-information-is-collected
@@ -7166,17 +7166,17 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      // Check utmp with session key
+      // Check utmp is watched with a non-empty audit key
       auditd.rules.files.contains( f:
         f.path == "/var/run/utmp" && f.permissions == "wa"
-        && f.keyname == "session"
+        && f.keyname != ""
       )
-      // Check wtmp and btmp with logins or session key
+      // Check wtmp and btmp are watched with a non-empty audit key
       sessionPaths = ["/var/log/wtmp", "/var/log/btmp"]
       sessionPaths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname.in(["logins", "session"])
+          && f.keyname != ""
         )
       )
     docs:
@@ -7197,10 +7197,10 @@ queries:
         Run this command to confirm the session audit rules are loaded:
 
         ```bash
-        auditctl -l | grep -E -- '-k (session|logins)'
+        auditctl -l | grep -E -- '-w (/var/run/utmp|/var/log/wtmp|/var/log/btmp).*-p wa'
         ```
 
-        A passing result lists watch rules on `/var/run/utmp`, `/var/log/wtmp`, and `/var/log/btmp` with the `session` or `logins` key. A failing result returns no matching rules.
+        A passing result lists watch rules on `/var/run/utmp`, `/var/log/wtmp`, and `/var/log/btmp` with `-p wa` permissions and a non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -7321,7 +7321,8 @@ queries:
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
         && arch == "b64"
-        && keyname == "time-change"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7330,7 +7331,8 @@ queries:
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
         && arch == "b32"
-        && keyname == "time-change"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7338,7 +7340,7 @@ queries:
       auditd.rules.files.contains(
         path == "/etc/localtime"
         && permissions == "wa"
-        && keyname == "time-change"
+        && keyname != ""
       )
     docs:
       desc: |
@@ -7358,10 +7360,10 @@ queries:
         Run this command to confirm the audit rules for date and time modification events are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k time-change'
+        auditctl -l | grep -E -- '(adjtimex|settimeofday|stime|clock_settime|/etc/localtime)'
         ```
 
-        A passing result lists the expected audit rules with the `time-change` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules with any non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -7495,7 +7497,7 @@ queries:
           f.path.in([p, p + "/"])
           && f.permissions.contains("w")
           && f.permissions.contains("a")
-          && f.keyname == "MAC-policy"
+          && f.keyname != ""
         )
       )
 
@@ -7505,7 +7507,7 @@ queries:
           f.path.in([p, p + "/"])
           && f.permissions.contains("w")
           && f.permissions.contains("a")
-          && f.keyname == "MAC-policy"
+          && f.keyname != ""
         )
       )
 
@@ -7530,10 +7532,10 @@ queries:
         Confirm the rules are written to a persistent rules file:
 
         ```bash
-        grep -rs -- '-k MAC-policy' /etc/audit/rules.d/ /etc/audit/audit.rules
+        grep -rsE -- '^-w.*(selinux|apparmor).*-p[[:blank:]]*([rx]*w[rx]*a|[rx]*a[rx]*w)' /etc/audit/rules.d/ /etc/audit/audit.rules
         ```
 
-        The check passes when the persistent rules define a complete Mandatory Access Control set with the `MAC-policy` key and `wa` permissions — either both AppArmor paths:
+        The check passes when the persistent rules define a complete Mandatory Access Control set with `wa` permissions and any non-empty audit key — either both AppArmor paths:
 
         ```
         -w /etc/apparmor -p wa -k MAC-policy
@@ -7550,7 +7552,7 @@ queries:
         You can also confirm the rules are active in the running kernel:
 
         ```bash
-        auditctl -l | grep -- '-k MAC-policy'
+        auditctl -l | grep -E -- '^-w.*(selinux|apparmor).*-p[[:blank:]]*([rx]*w[rx]*a|[rx]*a[rx]*w)'
         ```
 
         Note that `auditctl -l` reports the *running* ruleset, which can differ from what is stored on disk. If `auditctl -l` lists the rules but this check still reports a failure, the rules were loaded into the kernel but are not persisted in a `.rules` file under `/etc/audit/rules.d/` (or in `/etc/audit/audit.rules`). Persist them to a rules file and reload — see the remediation below.
@@ -7707,10 +7709,10 @@ queries:
         Run this command to confirm the audit rules for network environment modification events are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k system-locale'
+        auditctl -l | grep -E -- 'sethostname|setdomainname|/etc/(issue|issue\.net|hosts)|/etc/(sysconfig/)?network'
         ```
 
-        A passing result lists the expected audit rules with the `system-locale` key. A failing result returns no matching rules.
+        A passing result lists the expected syscall and watch rules, each with a non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -7872,7 +7874,8 @@ queries:
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
         && arch == "b64"
-        && keyname == "system-locale"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7881,7 +7884,8 @@ queries:
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
         && arch == "b32"
-        && keyname == "system-locale"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7890,7 +7894,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "system-locale"
+          && f.keyname != ""
         )
       )
 
@@ -7899,7 +7903,7 @@ queries:
       networkDirPaths.any(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "system-locale"
+          && f.keyname != ""
         )
       )
   - uid: mondoo-linux-security-events-that-modify-the-systems-network-environment-are-collected-other
@@ -7910,7 +7914,8 @@ queries:
       desiredRules64 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_64bit)
         && arch == "b64"
-        && keyname == "system-locale"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7919,7 +7924,8 @@ queries:
       desiredRules32 = auditd.rules.syscalls.where(
         syscalls.in(syscalls_32bit)
         && arch == "b32"
-        && keyname == "system-locale"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
 
@@ -7928,7 +7934,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "system-locale"
+          && f.keyname != ""
         )
       )
   - uid: mondoo-linux-security-discretionary-access-control-permission-modification-events-are-collected
@@ -7956,7 +7962,8 @@ queries:
         && arch == "b64"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "perm_mod"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules64.containsAll(syscalls_64bit)
 
@@ -7967,7 +7974,8 @@ queries:
         && arch == "b32"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "perm_mod"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRules32.containsAll(syscalls_32bit)
     docs:
@@ -7988,10 +7996,10 @@ queries:
         Run this command to confirm the audit rules for discretionary access control permission changes are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k perm_mod'
+        auditctl -l | grep -E -- '(chmod|chown|xattr)'
         ```
 
-        A passing result lists the expected audit rules with the `perm_mod` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules; the audit key can be any non-empty value. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -8181,7 +8189,8 @@ queries:
         && fields.contains(key == "exit" && value == "-EPERM")
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "access"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRulesEperm64.containsAll(syscalls_64bit)
 
@@ -8192,7 +8201,8 @@ queries:
         && fields.contains(key == "exit" && value == "-EACCES")
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "access"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRulesEacces64.containsAll(syscalls_64bit)
 
@@ -8203,7 +8213,8 @@ queries:
         && fields.contains(key == "exit" && value == "-EPERM")
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "access"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRulesEperm32.containsAll(syscalls_32bit)
 
@@ -8214,12 +8225,13 @@ queries:
         && fields.contains(key == "exit" && value == "-EACCES")
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "access"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
       desiredRulesEacces32.containsAll(syscalls_32bit)
     docs:
       desc: |
-        This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing the `creat`, `open`, `openat`, `truncate`, and `ftruncate` system calls on both 32-bit and 64-bit architectures. These system calls control the creation, opening, and truncation of files. The audit log records events where the user is a non-privileged user with an auid of 1000 or higher, the event is not a daemon event, and the system call returned EACCES for permission denied or EPERM for operation not permitted. All audit records are tagged with the identifier "access."
+        This check verifies that the system is configured to monitor unsuccessful attempts to access files by auditing the `creat`, `open`, `openat`, `truncate`, and `ftruncate` system calls on both 32-bit and 64-bit architectures. These system calls control the creation, opening, and truncation of files. The audit log records events where the user is a non-privileged user with an auid of 1000 or higher, the event is not a daemon event, and the system call returned EACCES for permission denied or EPERM for operation not permitted. Each audit rule must have a non-empty key identifier to be counted as a match.
 
         **Why this matters**
 
@@ -8235,10 +8247,10 @@ queries:
         Run this command to confirm the audit rules for unsuccessful file access attempts are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k access'
+        auditctl -l | grep -E -- '(creat|open|openat|truncate|ftruncate)' | grep -E -- '(exit=-EACCES|exit=-EPERM)'
         ```
 
-        A passing result lists the expected audit rules with the `access` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules with non-empty keys. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -8406,7 +8418,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "wa"
-          && f.keyname == "identity"
+          && f.keyname != ""
         )
       )
     docs:
@@ -8427,10 +8439,10 @@ queries:
         Run this command to confirm the audit rules for user and group information changes are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k identity'
+        auditctl -l | grep -E -- '/(group|passwd|gshadow|shadow|opasswd)'
         ```
 
-        A passing result lists the expected audit rules with the `identity` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules with `wa` permissions and any non-empty key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -8562,17 +8574,19 @@ queries:
         && arch == "b64"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "mounts"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ) || auditd.rules.syscalls.contains(
         syscalls.contains("mount")
         && arch == "b32"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "mounts"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       )
     docs:
       desc: |
-        This check verifies that the system is configured to monitor successful file system mount events by auditing the `mount` system call. The audit log will record events where the user is a non-privileged user `(auid >= 1000)` and is not a daemon event `(auid=4294967295)`. All audit records will be tagged with the identifier "mounts."
+        This check verifies that the system is configured to monitor successful file system mount events by auditing the `mount` system call. The audit log will record events where the user is a non-privileged user `(auid >= 1000)` and is not a daemon event `(auid=4294967295)`. All audit records will be tagged with an audit key identifier.
 
         **Why this matters**
 
@@ -8588,10 +8602,10 @@ queries:
         Run this command to confirm the audit rules for filesystem mount operations are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k mounts'
+        auditctl -l | grep -- '-S mount' | grep -- '-F auid'
         ```
 
-        A passing result lists the expected audit rules with the `mounts` key. A failing result returns no matching rules.
+        A passing result lists audit rules for the mount syscall with the correct auid filters and any non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -8710,19 +8724,21 @@ queries:
       syscalls_base = ["unlinkat", "renameat"]
       syscalls_nonarm = ["unlink", "rename"]
 
-      // Get rules with delete key and proper auid filtering
+      // Get audited syscall rules with proper auid filtering and a non-empty audit key
       deleteRules64 = auditd.rules.syscalls.where(
         arch == "b64"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "delete"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
 
       deleteRules32 = auditd.rules.syscalls.where(
         arch == "b32"
         && auidMin == 1000
         && excludesUnsetAuid
-        && keyname == "delete"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       ).map(syscalls).flat
 
       // Base syscalls must be present on all architectures
@@ -8761,10 +8777,10 @@ queries:
         Run this command to confirm the audit rules for file deletion events are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k delete'
+        auditctl -l | grep -E -- '(unlink|rename)'
         ```
 
-        A passing result lists the expected audit rules with the `delete` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules with the appropriate syscalls, auid filters, and any non-empty key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -8923,7 +8939,7 @@ queries:
       paths.all(p:
         auditd.rules.files.contains( f:
           f.path == p && f.permissions == "x"
-          && f.keyname == "modules"
+          && f.keyname != ""
         )
       )
 
@@ -8931,7 +8947,8 @@ queries:
       auditd.rules.syscalls.contains(
         syscalls.containsAll(["init_module", "delete_module"])
         && arch == "b64"
-        && keyname == "modules"
+        && action == "always"
+        && fields.contains(key == "key" && value != "")
       )
     docs:
       desc: |
@@ -8949,10 +8966,10 @@ queries:
         Run this command to confirm the audit rules for kernel module loading and unloading are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k modules'
+        auditctl -l | grep -E -- '\-w /sbin/(insmod|rmmod|modprobe)|init_module|delete_module'
         ```
 
-        A passing result lists the expected audit rules with the `modules` key. A failing result returns no matching rules.
+        A passing result lists the expected audit rules with the proper paths and permissions (any non-empty key is acceptable). A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |
@@ -9075,7 +9092,7 @@ queries:
     mql: |
       auditd.rules.files.contains( f:
         f.path == "/var/log/sudo.log" && f.permissions == "wa"
-        && f.keyname == "actions"
+        && f.keyname != ""
       )
     docs:
       desc: |
@@ -9093,10 +9110,10 @@ queries:
         Run this command to confirm the audit rules for administrator actions recorded in the sudo log are loaded:
 
         ```bash
-        auditctl -l | grep -- '-k actions'
+        auditctl -l | grep -- '/var/log/sudo.log'
         ```
 
-        A passing result lists the expected audit rules with the `actions` key. A failing result returns no matching rules.
+        A passing result lists the audit rule for `/var/log/sudo.log` with write and append permissions (`-p wa`) and a non-empty audit key. A failing result returns no matching rules.
       remediation:
         - id: cli
           desc: |

--- a/skills/mql/mql-reference.md
+++ b/skills/mql/mql-reference.md
@@ -366,11 +366,11 @@ queries:
       asset.family.contains("linux") &&
       (kernel.info['machine'] == 'i386' || kernel.info['machine'] == 'i686')
     mql: |
-      auditd.rules.files.where(path == '/etc/localtime' && keyname != '').length > 0 &&
+      auditd.rules.files.where(path == '/etc/localtime' && keyname != empty).length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b32') &&
         syscalls.contains('adjtimex') &&
-        fields.any(key == 'key' && value != '')
+        fields.any(key == 'key' && value != empty)
       ).length > 0
 
   # 64-bit specific rules
@@ -379,16 +379,16 @@ queries:
       asset.family.contains("linux") &&
       (kernel.info['machine'] == 'x86_64' || kernel.info['machine'].contains('64'))
     mql: |
-      auditd.rules.files.where(path == '/etc/localtime' && keyname != '').length > 0 &&
+      auditd.rules.files.where(path == '/etc/localtime' && keyname != empty).length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b64') &&
         syscalls.contains('adjtimex') &&
-        fields.any(key == 'key' && value != '')
+        fields.any(key == 'key' && value != empty)
       ).length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b32') &&
         syscalls.contains('stime') &&
-        fields.any(key == 'key' && value != '')
+        fields.any(key == 'key' && value != empty)
       ).length > 0
 
   # Comprehensive check (if architecture detection is complex)
@@ -399,31 +399,31 @@ queries:
       is_64bit = machine_arch == 'x86_64' || machine_arch.contains('64')
 
       localtime_rule = auditd.rules.files.where(
-        path == '/etc/localtime' && keyname != ''
+        path == '/etc/localtime' && keyname != empty
       ).length > 0
 
       if (is_64bit) {
         localtime_rule &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b64') &&
-          fields.any(key == 'key' && value != '')
+          fields.any(key == 'key' && value != empty)
         ).length > 0 &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b32') &&
-          fields.any(key == 'key' && value != '')
+          fields.any(key == 'key' && value != empty)
         ).length > 0
       } else {
         localtime_rule &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b32') &&
-          fields.any(key == 'key' && value != '')
+          fields.any(key == 'key' && value != empty)
         ).length > 0
       }
 ```
 
 > **Note:** the auditd key (`-k <key>`, equivalently `-F key=<key>`) is only a label used to
 > group and search audit events — the kernel emits the record either way. Assert that a key is
-> present, never that it equals a particular literal, or the check reports a false negative on
+> present (`!= empty`, which rejects both an absent and a blank key), never that it equals a particular literal, or the check reports a false negative on
 > hosts that use a different naming convention. On watch rules (`-w`) read `keyname`; on syscall
 > rules (`-a`) read the normalized `fields` entry, which covers both spellings.
 

--- a/skills/mql/mql-reference.md
+++ b/skills/mql/mql-reference.md
@@ -366,11 +366,11 @@ queries:
       asset.family.contains("linux") &&
       (kernel.info['machine'] == 'i386' || kernel.info['machine'] == 'i686')
     mql: |
-      auditd.rules.files.where(path == '/etc/localtime' && keyname == 'time-change').length > 0 &&
+      auditd.rules.files.where(path == '/etc/localtime' && keyname != '').length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b32') &&
         syscalls.contains('adjtimex') &&
-        keyname == 'time-change'
+        fields.any(key == 'key' && value != '')
       ).length > 0
 
   # 64-bit specific rules
@@ -379,16 +379,16 @@ queries:
       asset.family.contains("linux") &&
       (kernel.info['machine'] == 'x86_64' || kernel.info['machine'].contains('64'))
     mql: |
-      auditd.rules.files.where(path == '/etc/localtime' && keyname == 'time-change').length > 0 &&
+      auditd.rules.files.where(path == '/etc/localtime' && keyname != '').length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b64') &&
         syscalls.contains('adjtimex') &&
-        keyname == 'time-change'
+        fields.any(key == 'key' && value != '')
       ).length > 0 &&
       auditd.rules.syscalls.where(
         fields.any(key == 'arch' && value == 'b32') &&
         syscalls.contains('stime') &&
-        keyname == 'time-change'
+        fields.any(key == 'key' && value != '')
       ).length > 0
 
   # Comprehensive check (if architecture detection is complex)
@@ -399,27 +399,33 @@ queries:
       is_64bit = machine_arch == 'x86_64' || machine_arch.contains('64')
 
       localtime_rule = auditd.rules.files.where(
-        path == '/etc/localtime' && keyname == 'time-change'
+        path == '/etc/localtime' && keyname != ''
       ).length > 0
 
       if (is_64bit) {
         localtime_rule &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b64') &&
-          keyname == 'time-change'
+          fields.any(key == 'key' && value != '')
         ).length > 0 &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b32') &&
-          keyname == 'time-change'
+          fields.any(key == 'key' && value != '')
         ).length > 0
       } else {
         localtime_rule &&
         auditd.rules.syscalls.where(
           fields.any(key == 'arch' && value == 'b32') &&
-          keyname == 'time-change'
+          fields.any(key == 'key' && value != '')
         ).length > 0
       }
 ```
+
+> **Note:** the auditd key (`-k <key>`, equivalently `-F key=<key>`) is only a label used to
+> group and search audit events — the kernel emits the record either way. Assert that a key is
+> present, never that it equals a particular literal, or the check reports a false negative on
+> hosts that use a different naming convention. On watch rules (`-w`) read `keyname`; on syscall
+> rules (`-a`) read the normalized `fields` entry, which covers both spellings.
 
 **When to Use Query Variants:**
 - Different system architectures (32-bit vs 64-bit)


### PR DESCRIPTION
## Problem

The 16 auditd checks in **Mondoo Linux Security** each required an exact audit key — `-k scope`, `-k logins`, `-k time-change`, `-k perm_mod`, and so on.

The auditd key is only a label used to group and search audit events. The kernel emits the record either way. What actually matters is the watched path plus its permissions (watch rules), or the syscall list plus the arch/exit/auid filters (syscall rules).

Pinning the literal produces false negatives on correctly hardened hosts. Reported downstream against a RHEL 9.8 server (cnspec 13.29.1) whose rules are correct:

```
# auditctl -l | grep sudoers
-w /etc/sudoers -p wa -k sudoers
-w /etc/sudoers.d -p wa -k sudoers
```

The check failed purely because the key read `sudoers` rather than `scope`.

CIS agrees. Every generation of the CIS Linux benchmarks verifies these rules with

```
awk '/^ *-w/ && /\/etc\/sudoers/ && / +-p *wa/ && (/ key= *[!-~]* *$/ || / -k *[!-~]* *$/)'
```

`[!-~]*` accepts any run of printable characters, so CIS requires a **non-empty** key and never a specific one. The named key in the benchmark text is example output, not an assertion.

## Change

All 32 keyname constraints across the 16 checks now assert that a key is *present* instead of that it equals a literal.

| rule kind | before | after |
|---|---|---|
| watch (`-w`) | `f.keyname == "scope"` | `f.keyname != ""` |
| syscall (`-a`) | `keyname == "time-change"` | `action == "always"` + `fields.contains(key == "key" && value != "")` |

Two details worth review:

**Syscall rules use `fields`, not `keyname`.** `keyname` is populated only from `-k` (`providers/os/resources/auditd.go:349`). The provider deliberately normalizes `-k` into `fields` as `key=<name>` — its own comment says *"-k is shorthand for -F key=; normalize into fields so queries don't need to check both representations."* Reading the field therefore also matches rules written as `-F key=<name>`, which `keyname` alone silently misses.

**`action == "always"` is new and load-bearing.** No syscall selector constrained `action`, so `-a never,exit` suppression rules were already eligible to satisfy these checks; the literal key was only an accidental guard, since nobody tags a suppression rule `-k time-change`. Relaxing the key would have widened that hole, so the guard is now explicit. Verified below.

Untouched on purpose: every `uid`, `title`, `impact`, `filters`, `variants` and `compliance/*` tag, so framework mappings and customer exceptions are unaffected. Remediation snippets keep recommending the conventional key — that is still good practice.

Docs follow the code. Every `audit:` procedure that told the user to `grep -- '-k <key>'` now verifies what the check actually asserts, and no `desc:` still claims records carry a specific identifier. The auditd example in `skills/mql/mql-reference.md` taught the same anti-pattern and is updated with a note.

## Verification

`cnspec policy lint` clean; `go test ./content -run TestBundles` passes.

Behaviour was measured, not assumed — five mock RHEL 9.8 roots scanned with `cnspec run fs`:

| query | reported host<sup>1</sup> | CIS host<sup>2</sup> | no key at all<sup>3</sup> | no rules | `-a never`<sup>4</sup> |
|---|---|---|---|---|---|
| sudoers **before** | ❌ FAIL | ✅ PASS | ❌ FAIL | ❌ FAIL | – |
| sudoers **after** | ✅ **PASS** | ✅ PASS | ❌ FAIL | ❌ FAIL | – |
| time-change **before** | ❌ FAIL | – | – | ❌ FAIL | ⚠️ PASS |
| time-change **after** | ✅ **PASS** | – | – | ❌ FAIL | ✅ FAIL |
| time-change, key fix only | ✅ PASS | – | – | ❌ FAIL | ⚠️ PASS |

<sup>1</sup> `-k sudoers` watch rules + a syscall rule spelled `-F key=`, exactly as reported.
<sup>2</sup> conventional `-k scope`.
<sup>3</sup> `-w /etc/sudoers -p wa` with no key — **still fails**; the requirement was relaxed, not dropped.
<sup>4</sup> `-a never,exit … -k time-change`; the last row is the same fix without the `action` guard, showing the guard is what closes the hole.

Reported downstream: mondoo-community/workspace-telekom#203
