### PR TITLE
✨ content: attribute internet exposure to the hosts behind load balan…

### DIFF
--- a/content/querypacks/mondoo-aws-inventory.mql.yaml
+++ b/content/querypacks/mondoo-aws-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-asset-inventory-aws
     name: AWS Asset Inventory Pack
-    version: 1.2.0
+    version: 1.3.0
     license: BUSL-1.1
     require:
       - provider: aws
@@ -349,11 +349,19 @@ queries:
       desc: |
         Lists Elastic Load Balancers with their scheme (internet-facing vs.
         internal), listeners, security groups, internet-exposure breakdown, and the
-        targets they route to (EC2 instances / Lambda functions, plus registered
-        instances for classic load balancers).
+        targets they route to (EC2 instances / Lambda functions / registered IP
+        addresses, plus registered instances for classic load balancers).
 
         Scoped to the AWS account scan (no `-single` variant): target groups and
         their registered targets are enumerated account-wide.
+
+        `ipTargets` matters for container workloads. An `ip`-type target group
+        registers pod or task IP addresses rather than instances, so `ec2Targets`
+        is empty and the load balancer appears to route nowhere even though it
+        fronts live workloads. The registered IPs join to the pod IPs collected by
+        the Kubernetes inventory pack, which resolve to a node and its cloud
+        instance, so the hosts behind an internet-facing load balancer stay
+        attributable.
     variants:
       - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
   - uid: mondoo-asset-inventory-aws-elb-loadbalancers-all
@@ -374,6 +382,7 @@ queries:
           port
           ec2Targets { instanceId }
           lambdaTargets { name }
+          ipTargets
         }
         instances { instanceId }
         exposure { internetReachable publiclyAccessible securityGroupAllowsIngress }

--- a/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
+++ b/content/querypacks/mondoo-kubernetes-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-kubernetes-inventory
     name: Kubernetes Inventory Pack
-    version: 1.3.0
+    version: 1.4.0
     license: BUSL-1.1
     require:
       - provider: k8s
@@ -62,8 +62,55 @@ packs:
                 Maps each pod to the node it runs on, tracing workloads behind an
                 internet-facing ingress or load balancer down to a specific node
                 and, via the node provider ID, the underlying cloud instance.
+
+                The pod IP is included so that the registered targets of an
+                ip-type cloud load balancer target group (see the AWS inventory
+                pack's `ipTargets`) resolve to a pod, and from there to a node
+                and its cloud instance, without relying on Service or Ingress
+                relations.
             mql: |
-              k8s.pods { namespace name nodeName }
+              k8s.pods { namespace name nodeName podIP }
+          - uid: k8s-cluster-internet-exposed-pod-nodes
+            title: Nodes hosting internet-exposed workloads
+            docs:
+              desc: |
+                Lists every pod that a Service, Ingress, or Gateway routes to from
+                the public internet, together with the node it runs on and that
+                node's cloud provider ID.
+
+                This is the load-balancer half of host internet exposure. A node
+                can have no public IP, sit in a private subnet, and carry no
+                security group that admits `0.0.0.0/0`, yet still serve internet
+                traffic because an internet-facing load balancer forwards to a pod
+                scheduled on it. Cloud-side instance exposure analysis cannot see
+                that path: with `ip`-type target groups the registered targets are
+                pod IPs, so the instance is never a load balancer target. Each
+                entry names the exposing object and the reason, so a reviewer can
+                tell deliberate exposure from accidental.
+
+                Join `nodeName` to the `Cluster node cloud provider IDs` query in
+                this group to reach the cloud instance. The pod's own `node`
+                relation is deliberately not used here: nodes are cluster-scoped,
+                so it resolves to null on namespace-scoped assets and manifest
+                scans, whereas `nodeName` is always set for a scheduled pod.
+            mql: |
+              k8s.pods.where(exposures.any(internetExposed == true)) {
+                namespace
+                name
+                nodeName
+                podIP
+                exposures {
+                  sourceKind
+                  sourceRef
+                  namespace
+                  name
+                  internetExposed
+                  exposureReason
+                  addresses
+                  ports
+                  protocols
+                }
+              }
           - uid: k8s-cluster-clusterroles
             title: Cluster RBAC ClusterRoles
             docs:
@@ -226,3 +273,20 @@ packs:
               desc: Returns the Ingress rules and backend service configuration.
             mql: |
               k8s.ingress { * }
+      - title: Services inventory
+        filters: asset.platform == "k8s-service"
+        queries:
+          - uid: k8s-service
+            title: Service information
+            docs:
+              desc: |
+                Returns the Service type, selector, ports, load balancer addresses,
+                the pods it routes to, and its network exposures.
+
+                Ingress alone does not describe the full public surface of a
+                cluster. A `type: LoadBalancer` Service provisions its own cloud
+                load balancer with no Ingress object involved, so without this
+                query those workloads, and the nodes they run on, cannot be tied
+                back to the load balancer that publishes them.
+            mql: |
+              k8s.service { * }


### PR DESCRIPTION
A host can have no public IP, sit in a private subnet, and carry no security group admitting 0.0.0.0/0, yet still serve internet traffic because an internet-facing load balancer forwards to a pod scheduled on it. The AWS Load Balancer Controller defaults to `ip`-type target groups, which register pod IPs rather than instances, so the load balancer has no instance target and aws.ec2.instance.exposure.internetReachable stays false. Cloud-side analysis alone therefore reports these hosts as unexposed.

Wire up the provider fields that close that gap:

- kubernetes: add a Services inventory group. Ingress alone does not describe a cluster's public surface; a `type: LoadBalancer` Service provisions its own cloud load balancer with no Ingress object involved, and nothing collected the Service spec or its network exposures.
- kubernetes: add `Nodes hosting internet-exposed workloads`, listing every pod a Service, Ingress, or Gateway routes to from the internet together with its node, so `nodeName` joins to the existing node provider IDs and on to the cloud instance. The pod's `node` relation is deliberately unused: nodes are cluster-scoped, so it resolves to null on namespace-scoped assets and manifest scans, whereas `nodeName` is always set for a scheduled pod.
- kubernetes: add `podIP` to pod-to-node placement so an ip-type target group's registered targets resolve to a pod without relying on Service or Ingress relations.
- aws: add `ipTargets` to the load balancer target groups, exposing the registered IPs that `ec2Targets` cannot represent.

Verified against manifest fixtures: a LoadBalancer Service published on a public ELB hostname reports internetExposed with reason publicLoadBalancerAddress and resolves through its pod's nodeName to the node providerID; the same Service restricted by loadBalancerSourceRanges to RFC1918 reports internetExposed=false (restrictedLoadBalancerSourceRange); a ClusterIP Service reports no exposure.