### PR TITLE
🧹 azure: follow the azauth chained-token signature change

### DIFF
--- a/cli/reporter/azure_service_bus_handler.go
+++ b/cli/reporter/azure_service_bus_handler.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13/policy"
@@ -33,7 +32,7 @@ func (h *azureSbusHandler) WriteReport(ctx context.Context, report *policy.Repor
 	senderName := parts[len(parts)-1]
 	sbusUrl := strings.TrimSuffix(trimmedUrl, "/"+senderName)
 
-	cred, err := azauth.GetDefaultChainedToken(&azidentity.DefaultAzureCredentialOptions{})
+	cred, err := azauth.GetDefaultChainedToken(nil)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.5
 // replace go.mondoo.com/mql/v13 => ../mql
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/Masterminds/semver v1.5.0
@@ -49,7 +48,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260723123104-e6509982da98
-	go.mondoo.com/mql/v13 v13.31.0
+	go.mondoo.com/mql/v13 v13.31.1-0.20260728113358-eae664e3a4c8
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0
@@ -80,6 +79,7 @@ require (
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Azure/azure-amqp-common-go/v3 v3.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-amqp v1.5.1 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1082,8 +1082,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260723123104-e6509982da98 h1:KEDs+FZDvATZu+FWER9c1xDMUE/bNUfjRdo7v5kGoC4=
 go.mondoo.com/mondoo-go v0.0.0-20260723123104-e6509982da98/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.31.0 h1:rwLTyUZFk/ES8qp7qYiImcwCq++eM9IEgNlvJ7/5RNQ=
-go.mondoo.com/mql/v13 v13.31.0/go.mod h1:h/PSSizGM78QLucyJE73cLtNFRmd1ez0VCg+eHGef4M=
+go.mondoo.com/mql/v13 v13.31.1-0.20260728113358-eae664e3a4c8 h1:PAqPWJUETYa/uwb7MAIU0khYSsdQlwi0d6LEtDBm0ek=
+go.mondoo.com/mql/v13 v13.31.1-0.20260728113358-eae664e3a4c8/go.mod h1:h/PSSizGM78QLucyJE73cLtNFRmd1ez0VCg+eHGef4M=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Consumer-side update for [mondoohq/mql#9468](https://github.com/mondoohq/mql/pull/9468), which is merged.

`azauth.GetDefaultChainedToken` takes an `azauth.ChainedTokenOptions` now, so that it can carry a client ID, a federated token file, and a restricted sign-in method list — none of which `azidentity.DefaultAzureCredentialOptions` has anywhere to put. That's what lets a keyless deployment skip probing sign-in methods that cannot work, which was costing ~15s per connection on the managed identity probe alone.

This is the only call site in the repo. It passed an empty options struct, so `nil` is equivalent — it wants the full default chain either way — and the `azidentity` import goes with it.

Also bumps mql to main (`eae664e3a`), which is where that change landed.

## Why now

`server` cannot build against merged mql until this ships: it depends on both, and `cnspec v13.30.1` still calls the old signature. [mondoohq/server#17900](https://github.com/mondoohq/server/pull/17900) is red on exactly this, so this needs a cnspec release before that one can go green.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cli/reporter/` passes
- [x] `gofmt` clean, `go mod tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)