### PR TITLE
🐛 content: resolve deprecated provider field warnings

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -27247,6 +27247,7 @@ queries:
       asset.platform == "azure-mysql-flexible-server"
     mql: |
       azure.subscription.mySql.flexibleServer.dataEncryptionKey != empty
+  # No runtime variant: customer-managed key encryption is only available on the Enterprise/Managed Redis tier, and the Azure Cache for Redis management API exposes no encryption model on Microsoft.Cache/Redis, so the mql azure provider has no field to assert against. Revisit once the provider models Microsoft.Cache/redisEnterprise.
   - uid: mondoo-azure-security-redis-cmk-encryption
     title: Ensure Azure Cache for Redis uses CMK encryption
     impact: 70
@@ -27265,10 +27266,6 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
     variants:
-      - uid: mondoo-azure-security-redis-cmk-encryption-azure
-        tags:
-          mondoo.com/filter-title: Azure Cache for Redis
-          mondoo.com/filter-icon: azure
       - uid: mondoo-azure-security-redis-cmk-encryption-terraform-hcl
         tags:
           mondoo.com/filter-title: Terraform HCL
@@ -27285,30 +27282,39 @@ queries:
 
         **Risk mitigation**
 
-        - Configure customer-managed key encryption on Azure Cache for Redis instances.
+        - Configure customer-managed key encryption on Enterprise tier caches.
         - Implement key rotation policies in Azure Key Vault.
       audit: |
         ### Audit via Portal
 
         1. Navigate to **Azure Cache for Redis** in the Azure Portal.
-        2. Select the cache instance.
+        2. Select an **Enterprise** tier cache.
         3. Under **Settings**, select **Encryption**.
-        4. Review the **Encryption key** setting.
+        4. Review the **Customer-managed key** setting.
 
-        A passing resource shows a configured **Customer-managed key**. A failing resource shows no customer-managed key configured.
+        A passing cluster shows a Key Vault key together with the user-assigned managed identity used to reach it. A failing cluster shows Microsoft-managed key encryption only.
 
         ### Audit via CLI
 
-        1. Run the following command, substituting your resource group and cache name:
+        1. List the Enterprise clusters in the subscription:
 
         ```bash
-        az redis show \
-          --resource-group <ResourceGroupName> \
-          --name <CacheName> \
-          --query "redisConfiguration" -o json
+        az redisenterprise list \
+          --query "[].{name:name, resourceGroup:resourceGroup}" -o table
         ```
 
-        A passing resource returns a `redisConfiguration` object containing `customer-managed-key-encryption` with a configured key URI. A failing resource returns no `customer-managed-key-encryption` field.
+        2. Inspect the encryption settings of each cluster:
+
+        ```bash
+        az redisenterprise show \
+          --cluster-name <ClusterName> \
+          --resource-group-name <ResourceGroupName> \
+          --query "encryption.customerManagedKeyEncryption" -o json
+        ```
+
+        A passing cluster returns a `keyEncryptionKeyUrl` pointing at a Key Vault key. A failing cluster returns `null`.
+
+        The Basic, Standard, and Premium tiers expose no encryption model at all, so a cache on those tiers cannot satisfy this control without migrating to the Enterprise tier.
       remediation:
         - id: portal
           desc: |
@@ -27378,11 +27384,6 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-customer-managed-keys
         title: Configure customer-managed keys for Azure Cache for Redis
-  - uid: mondoo-azure-security-redis-cmk-encryption-azure
-    filters: |
-      asset.platform == "azure-cache-redis-instance"
-    mql: |
-      azure.subscription.cacheService.redisInstance.encryptionKey != empty
   # Customer-managed key encryption is only available on the Enterprise/Managed Redis
   # tier, which Terraform models as azurerm_managed_redis with a customer_managed_key
   # block. The classic azurerm_redis_cache resource has no CMK argument.

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -1631,7 +1631,7 @@ queries:
   - uid: mondoo-snowflake-security-no-accountadmin-default-role-snowflake
     filters: asset.platform == 'snowflake'
     mql: |
-      snowflake.account.users.where(disabled == false).none(defaultRole == "ACCOUNTADMIN")
+      snowflake.account.users.where(disabled == false).none(defaultRoleRef != empty && defaultRoleRef.name == "ACCOUNTADMIN")
   - uid: mondoo-snowflake-security-no-accountadmin-default-role-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'snowflake_user')

--- a/content/querypacks/mondoo-hetzner-inventory.mql.yaml
+++ b/content/querypacks/mondoo-hetzner-inventory.mql.yaml
@@ -87,14 +87,14 @@ queries:
     filters: asset.platform == "hetzner-project"
     docs:
       desc: |
-        Returns each cloud server with its type, status, datacenter, and network configuration.
+        Returns each cloud server with its type, status, location, and network configuration.
     mql: |
       hetzner.servers {
         id
         name
         status
         serverType
-        datacenter
+        location
         image
         publicIpv4
         publicIpv6


### PR DESCRIPTION
Clears the three `query-deprecated-symbol` lint warnings. They look alike but are three different classes of deprecation, so each needed a different fix.

### `hetzner.server.datacenter` → `location`

The provider marks this deprecated because *"Hetzner removed the datacenter association from servers, so this always resolves to null."* The inventory query was emitting a null column. Straight swap to `location`, plus the query description.

### `snowflake.user.defaultRole` → `defaultRoleRef`

A rename to a richer type: the bare `string` becomes a `snowflake.role` resource.

```diff
- snowflake.account.users.where(disabled == false).none(defaultRole == "ACCOUNTADMIN")
+ snowflake.account.users.where(disabled == false).none(defaultRoleRef != empty && defaultRoleRef.name == "ACCOUNTADMIN")
```

`resolveOwnerRole` reports the ref as null when the user has no default role, or when the role is not a listable account role, hence the `!= empty` guard before the name comparison. It does *not* mask a permissions failure: `snowflakeRoleByName` propagates an error if `SHOW ROLES` fails, so the check errors rather than silently passing.

### `azure.subscription.cacheService.redisInstance.encryptionKey` — no replacement

This one is not a field swap. CMK encryption is not available on Azure Cache for Redis at all, only on Redis Enterprise / Azure Managed Redis, and the provider hardcodes the field to `nil`:

```go
// encryptionKey always resolves to null for Azure Cache for Redis. Customer-
// managed key encryption is not available on this resource...
func (a *mqlAzureSubscriptionCacheServiceRedisInstance) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
```

So `mondoo-azure-security-redis-cmk-encryption-azure` (`encryptionKey != empty`) **failed on every Azure Cache for Redis instance scanned** — a guaranteed false positive, not just a lint warning.

The rest of the check already knew this. The Terraform variant targets `azurerm_managed_redis`, the Bicep remediation uses `Microsoft.Cache/redisEnterprise`, and the Terraform remediation states that `azurerm_redis_cache` has no CMK field. The runtime variant was the lone holdout.

Removed it and recorded why in a `# No runtime variant:` comment, matching the convention already used ~9 times in this file. Left it removed rather than made vacuously passing, per `content/CLAUDE.md`: *"don't paper over the mismatch with a vacuous variant."* The parent check keeps its compliance tags and still runs via the Terraform variant.

Also fixed the `audit:` steps as collateral. They told an auditor to open the classic cache's **Encryption** blade and run `az redis show --query redisConfiguration` looking for a `customer-managed-key-encryption` key that surface never returns. With the runtime variant gone these are the only manual guidance, so they now use `az redisenterprise list` / `show`.

### Verification

- `cnspec policy lint` on all three files: valid, **0 deprecation warnings** (3 before).
- `validate_remediation_commands.py azure`: 419 pass, 0 fail. The Azure target validates `id: cli` remediation only, so the new `audit:` commands were checked by hand against `cmd_data/azure_commands.json` — note `redisenterprise show` takes `--resource-group-name`, not `--resource-group`.
- `go test ./policy/... ./internal/bundle/...` passes. `policy/scan/pdque -run TestNextAvailableFilename` is flaky on unmodified `main` under `-count=5` (nanosecond-timestamp filename collisions) and is untouched by these content-only changes.
- No stale references to the removed variant UID anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)