### PR TITLE
🐛 windows: stop SMB v1 filters from running a DISM enumeration on every asset

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3643,9 +3643,13 @@ queries:
     # a missing property yields `data = null`, and `null == 4` evaluates to false,
     # so an unguarded check would report a FALSE failure wherever SMB v1 was never
     # installed.
+    #
+    # The two conditions are joined with `&&`, NOT written on separate lines: each
+    # statement in a filter block compiles to its own entrypoint (mqlc.go), so
+    # newline-separated conditions are resolved independently and the platform check
+    # would NOT gate the registry read.
     filters: |
-      asset.family.contains('windows')
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists
+      asset.family.contains('windows') && registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3751,9 +3755,10 @@ queries:
     # already reads instead of running a DISM enumeration on every asset. Keeping a
     # guard at all matters here: an absent `SMB1` value does not by itself prove the
     # SMB v1 server is off, so not-applicable is more honest than a blanket pass.
+    # `&&` rather than separate lines: filter statements compile to independent
+    # entrypoints, so a newline-separated platform check would not gate the registry read.
     filters: |
-      asset.family.contains('windows')
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).exists
+      asset.family.contains('windows') && registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).exists
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3632,6 +3632,20 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-client-driver-is-set-to-enabled-disable-driver-recommended
     title: "Ensure SMB v1 client driver is disabled"
     impact: 100
+    # Applicability stays in `filters` — it is the mechanism built for it, and it
+    # keeps the previous reporting exactly: a host with no SMB v1 client driver is
+    # not-applicable and is not reported at all (an `if` guard in the query would
+    # instead surface it as "skipped"). What changed is only the COST: the previous
+    # filter was `windows.optionalFeatures.where(name == "SMB1Protocol")...`, which
+    # forced `Get-WindowsOptionalFeature -Online -FeatureName *` — a DISM image
+    # enumeration — on EVERY asset just to decide this cheap registry read applies.
+    # This reads the same key the check reads. The guard cannot simply be dropped:
+    # a missing property yields `data = null`, and `null == 4` evaluates to false,
+    # so an unguarded check would report a FALSE failure wherever SMB v1 was never
+    # installed.
+    filters: |
+      asset.family.contains('windows')
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3646,20 +3660,8 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    # The applicability guard lives in the query, not in `filters`, on purpose. A
-    # filter runs on EVERY asset, and the previous filter
-    # (`windows.optionalFeatures.where(name == "SMB1Protocol")...`) forced
-    # `Get-WindowsOptionalFeature -Online -FeatureName *` — a DISM image
-    # enumeration — fleet-wide just to decide this cheap registry read applies.
-    # The `if` guard reads the same key the check already reads, and keeps the
-    # previous reporting behavior: no SMB v1 client driver -> check is skipped,
-    # not failed. Without a guard the check would report a FALSE failure on those
-    # hosts, because a missing property yields `data = null` and `null == 4`
-    # evaluates to false rather than erroring.
     mql: |
-      if ( registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists ) {
-        registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).data == 4
-      }
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).data == 4
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-security
@@ -3744,6 +3746,14 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-server-is-set-to-disabled
     title: Ensure 'Configure SMB v1 server' is set to 'Disabled'
     impact: 100
+    # Same rationale as the SMB v1 client-driver check above: the guard stays in
+    # `filters` (preserving not-applicable reporting) but reads the key the check
+    # already reads instead of running a DISM enumeration on every asset. Keeping a
+    # guard at all matters here: an absent `SMB1` value does not by itself prove the
+    # SMB v1 server is off, so not-applicable is more honest than a blanket pass.
+    filters: |
+      asset.family.contains('windows')
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).exists
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3758,16 +3768,8 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    # Same rationale as the SMB v1 client-driver check above: the guard moves out
-    # of `filters` (where it ran a DISM enumeration on every asset) and into the
-    # query, reading the same key the check already reads. Keeping the guard —
-    # rather than treating a missing value as compliant — matters more here: an
-    # absent `SMB1` value does not by itself prove the SMB v1 server is off, so
-    # this reports "skipped" rather than a possibly-wrong "pass".
     mql: |
-      if ( registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).exists ) {
-        registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).data == 0
-      }
+      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).data == 0
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-security

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3632,8 +3632,6 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-client-driver-is-set-to-enabled-disable-driver-recommended
     title: "Ensure SMB v1 client driver is disabled"
     impact: 100
-    filters: |
-      windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3648,8 +3646,20 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
+    # The applicability guard lives in the query, not in `filters`, on purpose. A
+    # filter runs on EVERY asset, and the previous filter
+    # (`windows.optionalFeatures.where(name == "SMB1Protocol")...`) forced
+    # `Get-WindowsOptionalFeature -Online -FeatureName *` — a DISM image
+    # enumeration — fleet-wide just to decide this cheap registry read applies.
+    # The `if` guard reads the same key the check already reads, and keeps the
+    # previous reporting behavior: no SMB v1 client driver -> check is skipped,
+    # not failed. Without a guard the check would report a FALSE failure on those
+    # hosts, because a missing property yields `data = null` and `null == 4`
+    # evaluates to false rather than erroring.
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).data == 4
+      if ( registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists ) {
+        registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).data == 4
+      }
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-security
@@ -3734,8 +3744,6 @@ queries:
   - uid: mondoo-windows-security-configure-smb-v1-server-is-set-to-disabled
     title: Ensure 'Configure SMB v1 server' is set to 'Disabled'
     impact: 100
-    filters: |
-      windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
@@ -3750,8 +3758,16 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
+    # Same rationale as the SMB v1 client-driver check above: the guard moves out
+    # of `filters` (where it ran a DISM enumeration on every asset) and into the
+    # query, reading the same key the check already reads. Keeping the guard —
+    # rather than treating a missing value as compliant — matters more here: an
+    # absent `SMB1` value does not by itself prove the SMB v1 server is off, so
+    # this reports "skipped" rather than a possibly-wrong "pass".
     mql: |
-      registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).data == 0
+      if ( registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).exists ) {
+        registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters', name: 'SMB1' ).data == 0
+      }
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-security


### PR DESCRIPTION
## What

Both SMB v1 checks in `mondoo-windows-security` were gated on:

```yaml
filters: |
  windows.optionalFeatures.where(name == "SMB1Protocol").any(enabled == true)
```

This keeps the guard in `filters` — where applicability belongs — but points it at the registry key the check already reads:

```yaml
filters: |
  asset.family.contains('windows')
  registrykey.property( path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10', name: 'Start' ).exists
```

## Why

A **filter runs on every asset** to decide whether a check applies. This one forced `Get-WindowsOptionalFeature -Online -FeatureName *` — a DISM image enumeration that routinely takes seconds — on every Windows asset, purely to decide whether to perform a single cheap registry read. Both check bodies are one `registrykey.property` lookup, so the gate cost far more than the thing it gated.

That cost lands on the provider heartbeat. The runtime tolerates `interval (2s) + grace (3s) = 5s`, and providers-sdk `Service.Heartbeat` arms a dead-man's switch that calls `os.Exit(4)` when a beat is missed — so any resolver that stalls the process past that window is torn down and every in-flight field RPC is reported as `provider.crashed`. Grouping those reports into bursts (one stall = one burst, rather than one per field in flight), `windows.optionalFeatures` is the **largest single driver of heartbeat-timeout provider crashes on Windows at ~44% of bursts** — versus ~3% for the port collector addressed in mondoohq/mql#9309, which is why that fix measured as no change.

## Why the guard cannot just be deleted

A missing registry property yields `exists = false, data = null` and does **not** error. MQL then evaluates `null == 4` as a plain **failure**:

```
$ cnspec run -c 'parse.json(content: "{}").params["missing"] == 4'
[failed] ... actual: _
```

So an unguarded check would report **false non-compliance on every host where SMB v1 was never installed** — the most secure state.

Keeping a guard also matters for the server check specifically: an absent `LanmanServer\Parameters\SMB1` value does not by itself prove the SMB v1 server is off, so *not applicable* is more honest than a blanket pass.

## Reporting behavior is unchanged

Keeping the guard in `filters` (rather than moving it into the query as an `if`) is what preserves this exactly — a filtered-out check is **not applicable and not reported**, whereas an `if` guard would surface those hosts as **skipped**, adding two visible entries per affected asset. Both are unscored, but only the filter form is a no-op for reporting. Verified with `cnspec scan` across the full matrix:

| guard state | `filters` (this PR) | `if` in query |
|---|---|---|
| property absent | **not reported** — matches previous behavior | Skipped |
| present, `Start = 2` | Fail | Fail |
| present, `Start = 4` | Pass | Pass |

`asset.family.contains('windows')` is now stated explicitly in the filter so each check is correct on its own terms rather than relying on the group filter.

## Compatibility

`registrykey.property.exists` has existed since v13.5.0 (added 2023-08-29), so this takes effect on the deployed fleet without any client upgrade — no new resource field, no provider or server release needed.

## Testing

- `cnspec policy lint content/mondoo-windows-security.mql.yaml` → `valid policy bundle(s)`
- `cnspec scan local` against a scratch bundle covering the full matrix above, for both guard forms
- `make test/lint/content` fails only on pre-existing, unrelated Snowflake resource mismatches (reproduced on unmodified `main`); zero errors reference this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)