### PR TITLE
feat(upload): report why a scan-result upload failed

### DIFF
--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -170,17 +171,63 @@ func fileSizeBytes(path string) int64 {
 	return info.Size()
 }
 
+// uploadFailureReportKind is the value sent on the "reportKind" tag to mark a
+// report as an upload failure. The platform dispatches on it to record the
+// failure with its structured fields, so the literal is part of the wire
+// contract and must stay in sync with the server side.
+const uploadFailureReportKind = "upload_failure"
+
+// uploadFailureTags builds the tag set for an upload-failure report. Numeric
+// values are rendered as strings because health.SendError tags are
+// map[string]string; httpStatus and uploadSessionId are omitted rather than
+// sent as zero/empty so the server can tell "absent" from "actually zero".
+func uploadFailureTags(sessionID, assetMrn string, kind upload.FailureKind, httpStatus int, res upload.Result, bytesTotal int64) map[string]string {
+	tags := map[string]string{
+		"reportKind":  uploadFailureReportKind,
+		"failureKind": string(kind),
+		"bytesSent":   strconv.FormatInt(res.BytesSent, 10),
+		"bytesTotal":  strconv.FormatInt(bytesTotal, 10),
+		"durationMs":  strconv.FormatInt(res.Duration.Milliseconds(), 10),
+	}
+	if sessionID != "" {
+		tags["uploadSessionId"] = sessionID
+	}
+	if assetMrn != "" {
+		tags["assetMrn"] = assetMrn
+	}
+	if httpStatus != 0 {
+		tags["httpStatus"] = strconv.Itoa(httpStatus)
+	}
+	return tags
+}
+
+// reportUploadFailure sends one upload-failure report. Best-effort by
+// construction: health.ReportError swallows its own errors and returns
+// nothing, so a reporting problem can never fail the scan.
+func reportUploadFailure(msg string, tags map[string]string) {
+	health.ReportError("cnspec", cnspec.Version, cnspec.Build, msg, health.WithTags(tags))
+}
+
 func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMrn string, scanDataPath string, stats *scanstats.Collector) error {
+	bytesTotal := fileSizeBytes(scanDataPath)
+
 	urlResp, err := services.GetUploadURL(ctx, &policy.GetUploadURLReq{
 		Kind:     policy.UploadURLKind_UPLOAD_URL_KIND_SCAN_DATABASE_V0,
 		ScopeMrn: assetMrn,
 	})
 	if err != nil {
+		// No upload session exists yet, so the platform has nothing to
+		// correlate this with — but a client that cannot even obtain a URL is
+		// still worth surfacing.
+		reportUploadFailure("upload failed: could not get upload URL: "+err.Error(),
+			uploadFailureTags("", assetMrn, upload.FailureURLRequest, 0, upload.Result{}, bytesTotal))
 		return err
 	}
 
 	uploadUrl := urlResp.UploadUrl
 	if uploadUrl == nil {
+		reportUploadFailure("upload failed: no upload URL for scan data store",
+			uploadFailureTags(urlResp.UploadSessionId, assetMrn, upload.FailureURLRequest, 0, upload.Result{}, bytesTotal))
 		return errors.New("no upload URL for scan data store")
 	}
 
@@ -189,6 +236,12 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 
 	res, err := upload.UploadFile(ctx, url, headers, scanDataPath, "application/octet-stream")
 	if err != nil {
+		// Previously a bare return with no telemetry at all, which made a
+		// client that fails here invisible: the platform sees only an upload
+		// session that never completed, with no reason attached.
+		kind := upload.ClassifyFailure(err)
+		reportUploadFailure("upload failed: "+err.Error(),
+			uploadFailureTags(urlResp.UploadSessionId, assetMrn, kind, 0, res, bytesTotal))
 		return err
 	}
 	defer res.Response.Body.Close()
@@ -197,14 +250,18 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 		// Read a limited amount of the response body for diagnostics.
 		// Truncate to 512 bytes to avoid leaking sensitive details in Sentry tags.
 		body, _ := io.ReadAll(io.LimitReader(res.Response.Body, 512))
-		health.ReportError("cnspec", cnspec.Version, cnspec.Build,
-			fmt.Sprintf("upload failed with status %d", res.Response.StatusCode),
-			health.WithTags(map[string]string{
-				"assetMrn":     assetMrn,
-				"responseBody": string(body),
-			}),
-		)
+		tags := uploadFailureTags(urlResp.UploadSessionId, assetMrn,
+			upload.FailureHTTPStatus, res.Response.StatusCode, res, bytesTotal)
+		tags["responseBody"] = string(body)
+		reportUploadFailure(fmt.Sprintf("upload failed with status %d", res.Response.StatusCode), tags)
 		return fmt.Errorf("upload failed with status %d", res.Response.StatusCode)
+	}
+
+	// Success-path baseline: without these, a slow failing upload cannot be
+	// compared against the normal distribution.
+	stats.AddDuration(scanstats.MetricUploadDuration, res.Duration)
+	if secs := res.Duration.Seconds(); secs > 0 {
+		stats.AddDouble(scanstats.MetricUploadThroughput, "bps", float64(res.BytesSent*8)/secs)
 	}
 
 	// Confirm the upload, attaching scan statistics as the completion payload.
@@ -220,9 +277,17 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 		}
 	}
 	if _, err = services.ReportUploadCompleted(ctx, req); err != nil {
+		// The PUT succeeded, so the object IS in the bucket: this upload is
+		// recoverable, unlike a failed PUT. Worth distinguishing.
+		reportUploadFailure("upload failed: could not report completion: "+err.Error(),
+			uploadFailureTags(urlResp.UploadSessionId, assetMrn, upload.FailureReportRPC, 0, res, bytesTotal))
 		return err
 	}
 
-	log.Info().Str("session", urlResp.UploadSessionId).Msg("successfully uploaded scan data store")
+	log.Info().
+		Str("session", urlResp.UploadSessionId).
+		Int64("bytes", res.BytesSent).
+		Dur("duration", res.Duration).
+		Msg("successfully uploaded scan data store")
 	return nil
 }

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -187,24 +187,24 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 	headers := uploadUrl.Headers
 	url := uploadUrl.Url
 
-	resp, err := upload.UploadFile(ctx, url, headers, scanDataPath, "application/octet-stream")
+	res, err := upload.UploadFile(ctx, url, headers, scanDataPath, "application/octet-stream")
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer res.Response.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if res.Response.StatusCode != http.StatusOK && res.Response.StatusCode != http.StatusCreated {
 		// Read a limited amount of the response body for diagnostics.
 		// Truncate to 512 bytes to avoid leaking sensitive details in Sentry tags.
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		body, _ := io.ReadAll(io.LimitReader(res.Response.Body, 512))
 		health.ReportError("cnspec", cnspec.Version, cnspec.Build,
-			fmt.Sprintf("upload failed with status %d", resp.StatusCode),
+			fmt.Sprintf("upload failed with status %d", res.Response.StatusCode),
 			health.WithTags(map[string]string{
 				"assetMrn":     assetMrn,
 				"responseBody": string(body),
 			}),
 		)
-		return fmt.Errorf("upload failed with status %d", resp.StatusCode)
+		return fmt.Errorf("upload failed with status %d", res.Response.StatusCode)
 	}
 
 	// Confirm the upload, attaching scan statistics as the completion payload.

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -219,7 +219,7 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 		// No upload session exists yet, so the platform has nothing to
 		// correlate this with — but a client that cannot even obtain a URL is
 		// still worth surfacing.
-		reportUploadFailure("upload failed: could not get upload URL: "+err.Error(),
+		reportUploadFailure("upload failed: could not get upload URL: "+upload.RedactError(err),
 			uploadFailureTags("", assetMrn, upload.FailureURLRequest, 0, upload.Result{}, bytesTotal))
 		return err
 	}
@@ -240,7 +240,7 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 		// client that fails here invisible: the platform sees only an upload
 		// session that never completed, with no reason attached.
 		kind := upload.ClassifyFailure(err)
-		reportUploadFailure("upload failed: "+err.Error(),
+		reportUploadFailure("upload failed: "+upload.RedactError(err),
 			uploadFailureTags(urlResp.UploadSessionId, assetMrn, kind, 0, res, bytesTotal))
 		return err
 	}
@@ -279,7 +279,7 @@ func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMr
 	if _, err = services.ReportUploadCompleted(ctx, req); err != nil {
 		// The PUT succeeded, so the object IS in the bucket: this upload is
 		// recoverable, unlike a failed PUT. Worth distinguishing.
-		reportUploadFailure("upload failed: could not report completion: "+err.Error(),
+		reportUploadFailure("upload failed: could not report completion: "+upload.RedactError(err),
 			uploadFailureTags(urlResp.UploadSessionId, assetMrn, upload.FailureReportRPC, 0, res, bytesTotal))
 		return err
 	}

--- a/internal/datalakes/sqlite/upload_report_test.go
+++ b/internal/datalakes/sqlite/upload_report_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sqlite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/upload"
+)
+
+func TestUploadFailureTags_TransportError(t *testing.T) {
+	tags := uploadFailureTags(
+		"sess-1",
+		"//assets.api.mondoo.app/spaces/s1/assets/a1",
+		upload.FailureTimeout,
+		0,
+		upload.Result{BytesSent: 1_441_792, Duration: 30_857 * time.Millisecond},
+		3_621_572,
+	)
+
+	assert.Equal(t, "upload_failure", tags["reportKind"])
+	assert.Equal(t, "sess-1", tags["uploadSessionId"])
+	assert.Equal(t, "timeout", tags["failureKind"])
+	assert.Equal(t, "1441792", tags["bytesSent"])
+	assert.Equal(t, "3621572", tags["bytesTotal"])
+	assert.Equal(t, "30857", tags["durationMs"])
+	assert.Equal(t, "//assets.api.mondoo.app/spaces/s1/assets/a1", tags["assetMrn"])
+	// No response => no httpStatus tag at all, rather than "0".
+	_, ok := tags["httpStatus"]
+	require.False(t, ok)
+}
+
+func TestUploadFailureTags_HTTPStatusIncluded(t *testing.T) {
+	tags := uploadFailureTags("sess-2", "//assets/a2", upload.FailureHTTPStatus, 408,
+		upload.Result{BytesSent: 3_621_572, Duration: 30_900 * time.Millisecond}, 3_621_572)
+
+	assert.Equal(t, "408", tags["httpStatus"])
+	assert.Equal(t, "http_status", tags["failureKind"])
+}
+
+func TestUploadFailureTags_EmptySessionOmitted(t *testing.T) {
+	// url_request_failed happens before a session exists.
+	tags := uploadFailureTags("", "//assets/a3", upload.FailureURLRequest, 0, upload.Result{}, 0)
+
+	_, ok := tags["uploadSessionId"]
+	assert.False(t, ok, "no session id exists yet for url_request_failed")
+	assert.Equal(t, "url_request_failed", tags["failureKind"])
+}

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -42,6 +42,12 @@ type Collector struct {
 func New() *Collector { return &Collector{} }
 
 func (c *Collector) add(m *policy.Metric) {
+	// Nil-tolerant, matching ToProto below: recording a metric should never
+	// panic a scan just because a caller had no collector. Metrics added to a
+	// nil collector are dropped.
+	if c == nil {
+		return
+	}
 	c.mu.Lock()
 	c.metrics = append(c.metrics, m)
 	c.mu.Unlock()

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -17,6 +17,11 @@ import (
 const (
 	MetricScanDuration = "cnspec.scan.duration"    // unit: ms
 	MetricUploadSize   = "cnspec.scan.upload_size" // unit: bytes
+	// MetricUploadDuration / MetricUploadThroughput give the success-path
+	// baseline for upload latency. Without them a slow failing upload cannot
+	// be compared against the normal distribution.
+	MetricUploadDuration   = "cnspec.scan.upload_duration"       // unit: ms
+	MetricUploadThroughput = "cnspec.scan.upload_throughput_bps" // unit: bps
 
 	MetricChecks             = "cnspec.scan.checks"               // unit: count
 	MetricDataQueries        = "cnspec.scan.data_queries"         // unit: count

--- a/policy/scanstats/collector_test.go
+++ b/policy/scanstats/collector_test.go
@@ -48,3 +48,15 @@ func TestCollector_ErroredAndUploadSizeConstants(t *testing.T) {
 	require.Equal(t, "cnspec.scan.upload_size", stats.Metrics[1].Name)
 	require.Equal(t, int64(4096), stats.Metrics[1].GetIntValue())
 }
+
+// A nil collector must not panic: add() is nil-tolerant like ToProto.
+func TestCollector_NilReceiverDoesNotPanic(t *testing.T) {
+	var c *Collector
+	require.NotPanics(t, func() {
+		c.AddInt(MetricUploadSize, "bytes", 1)
+		c.AddDuration(MetricUploadDuration, time.Second)
+		c.AddDouble(MetricUploadThroughput, "bps", 1.5)
+		c.AddBool("x", true)
+	})
+	require.Nil(t, c.ToProto())
+}

--- a/upload/failurekind.go
+++ b/upload/failurekind.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"syscall"
+)
+
+// FailureKind is a closed taxonomy describing why an upload attempt failed.
+// It is sent to the platform as the "failureKind" tag on a health.SendError
+// report, so the values are part of the wire contract: add to them freely, but
+// do not rename or repurpose an existing one.
+type FailureKind string
+
+const (
+	FailureTimeout         FailureKind = "timeout"
+	FailureConnectionReset FailureKind = "connection_reset"
+	FailureDNS             FailureKind = "dns"
+	FailureTLS             FailureKind = "tls"
+	FailureContextCanceled FailureKind = "context_canceled"
+	FailureHTTPStatus      FailureKind = "http_status"
+	FailureReportRPC       FailureKind = "report_rpc_failed"
+	FailureURLRequest      FailureKind = "url_request_failed"
+	// FailureOther is the catch-all. An unrecognised error is still reported —
+	// with its message intact — rather than dropped.
+	FailureOther FailureKind = "other"
+)
+
+// ClassifyFailure maps a transport error to a FailureKind. It inspects the
+// error tree with errors.Is/As rather than matching strings, so it survives
+// message changes in the standard library.
+//
+// Order matters: context.Canceled is checked before the net.Error timeout
+// branch because a canceled request often surfaces as both, and the DNS/TLS
+// cases are checked before it because those errors are also net.Errors.
+func ClassifyFailure(err error) FailureKind {
+	if err == nil {
+		return FailureOther
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return FailureTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return FailureContextCanceled
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return FailureDNS
+	}
+
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return FailureTLS
+	}
+	var recordErr tls.RecordHeaderError
+	if errors.As(err, &recordErr) {
+		return FailureTLS
+	}
+
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EPIPE) {
+		return FailureConnectionReset
+	}
+
+	// Checked after the specific cases above: a DNS or TLS failure is also a
+	// net.Error, and a timeout is the least specific useful answer.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return FailureTimeout
+	}
+
+	return FailureOther
+}

--- a/upload/failurekind.go
+++ b/upload/failurekind.go
@@ -18,8 +18,20 @@ import (
 type FailureKind string
 
 const (
-	FailureTimeout         FailureKind = "timeout"
+	FailureTimeout FailureKind = "timeout"
+	// FailureConnectionRefused means the peer never accepted the connection, so
+	// nothing was established and nothing was sent. Deliberately distinct from
+	// FailureConnectionReset: refused points at "cannot reach this destination
+	// at all" (egress policy, firewall, DNS pointing somewhere dead), reset at
+	// "the connection existed and was dropped". For a client that can reach the
+	// API host but not the ingest host, this is the kind that says so.
+	FailureConnectionRefused FailureKind = "connection_refused"
+	// FailureConnectionReset is an established connection dropped by the peer or
+	// the network (ECONNRESET).
 	FailureConnectionReset FailureKind = "connection_reset"
+	// FailureBrokenPipe is a local write to a connection the peer had already
+	// closed (EPIPE) — typically mid-body, after some bytes went out.
+	FailureBrokenPipe      FailureKind = "broken_pipe"
 	FailureDNS             FailureKind = "dns"
 	FailureTLS             FailureKind = "tls"
 	FailureContextCanceled FailureKind = "context_canceled"
@@ -27,7 +39,8 @@ const (
 	FailureReportRPC       FailureKind = "report_rpc_failed"
 	FailureURLRequest      FailureKind = "url_request_failed"
 	// FailureOther is the catch-all. An unrecognised error is still reported —
-	// with its message intact — rather than dropped.
+	// with its message intact — rather than dropped. A nil error also maps here;
+	// see ClassifyFailure.
 	FailureOther FailureKind = "other"
 )
 
@@ -38,6 +51,11 @@ const (
 // Order matters: context.Canceled is checked before the net.Error timeout
 // branch because a canceled request often surfaces as both, and the DNS/TLS
 // cases are checked before it because those errors are also net.Errors.
+//
+// A nil error maps to FailureOther. Callers only classify on a failure, so nil
+// here means a caller bug; FailureOther keeps that from inventing a wire value
+// that downstream queries would have to know about, and the accompanying error
+// message will be empty, which makes the mistake obvious in the data.
 func ClassifyFailure(err error) FailureKind {
 	if err == nil {
 		return FailureOther
@@ -64,10 +82,14 @@ func ClassifyFailure(err error) FailureKind {
 		return FailureTLS
 	}
 
-	if errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.ECONNREFUSED) ||
-		errors.Is(err, syscall.EPIPE) {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return FailureConnectionRefused
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
 		return FailureConnectionReset
+	}
+	if errors.Is(err, syscall.EPIPE) {
+		return FailureBrokenPipe
 	}
 
 	// Checked after the specific cases above: a DNS or TLS failure is also a

--- a/upload/failurekind_test.go
+++ b/upload/failurekind_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want FailureKind
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, FailureTimeout},
+		{"wrapped deadline", fmt.Errorf("put failed: %w", context.DeadlineExceeded), FailureTimeout},
+		{"canceled", context.Canceled, FailureContextCanceled},
+		{"net timeout", &net.OpError{Op: "dial", Err: &timeoutErr{}}, FailureTimeout},
+		{"connection reset", &net.OpError{Op: "write", Err: syscall.ECONNRESET}, FailureConnectionReset},
+		{"connection refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, FailureConnectionReset},
+		{"dns", &net.DNSError{Err: "no such host", Name: "ingest.example.com"}, FailureDNS},
+		{"tls", &tls.CertificateVerificationError{}, FailureTLS},
+		{"unknown", errors.New("something odd"), FailureOther},
+		{"nil", nil, FailureOther},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassifyFailure(tc.err))
+		})
+	}
+}
+
+// timeoutErr is a net.Error that reports Timeout() == true.
+type timeoutErr struct{}
+
+func (*timeoutErr) Error() string   { return "i/o timeout" }
+func (*timeoutErr) Timeout() bool   { return true }
+func (*timeoutErr) Temporary() bool { return true }

--- a/upload/failurekind_test.go
+++ b/upload/failurekind_test.go
@@ -26,7 +26,10 @@ func TestClassifyFailure(t *testing.T) {
 		{"canceled", context.Canceled, FailureContextCanceled},
 		{"net timeout", &net.OpError{Op: "dial", Err: &timeoutErr{}}, FailureTimeout},
 		{"connection reset", &net.OpError{Op: "write", Err: syscall.ECONNRESET}, FailureConnectionReset},
-		{"connection refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, FailureConnectionReset},
+		// Distinct from reset on purpose: refused is the signature of a host
+		// that cannot reach the ingest destination at all.
+		{"connection refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, FailureConnectionRefused},
+		{"broken pipe", &net.OpError{Op: "write", Err: syscall.EPIPE}, FailureBrokenPipe},
 		{"dns", &net.DNSError{Err: "no such host", Name: "ingest.example.com"}, FailureDNS},
 		{"tls", &tls.CertificateVerificationError{}, FailureTLS},
 		{"unknown", errors.New("something odd"), FailureOther},

--- a/upload/redact.go
+++ b/upload/redact.go
@@ -1,0 +1,57 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+)
+
+// redactedErrorMax bounds a reported error message. Mirrors the 512-byte cap
+// already applied to upload response bodies before they are reported.
+const redactedErrorMax = 512
+
+// signedURLQueryRe matches the query string of any URL embedded in an error
+// message. For a signed upload that query carries the signature — a
+// time-limited write credential for the object — so it must never leave the
+// host inside telemetry.
+var signedURLQueryRe = regexp.MustCompile(`(https?://[^\s"?]*)\?[^\s"]*`)
+
+// RedactError renders err for reporting to the platform with any URL removed.
+//
+// Transport errors from net/http arrive wrapped in *url.Error, which embeds the
+// full request URL — and for a signed upload that URL's query string contains
+// the signature granting write access to the object. Reporting it verbatim
+// would copy a credential into error telemetry.
+//
+// Dropping the URL costs nothing diagnostically: the upload session id and
+// asset MRN are already reported alongside as tags, and they identify the
+// request far better than a single-use URL does.
+//
+// The result is truncated to redactedErrorMax bytes.
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var msg string
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		// Keep the operation and the underlying cause, drop the URL entirely.
+		msg = fmt.Sprintf("%s: %v", urlErr.Op, urlErr.Err)
+	} else {
+		msg = err.Error()
+	}
+
+	// Belt and braces: an error that is not a *url.Error can still have had a
+	// URL formatted into it by an intermediate layer.
+	msg = signedURLQueryRe.ReplaceAllString(msg, "$1?<redacted>")
+
+	if len(msg) > redactedErrorMax {
+		msg = msg[:redactedErrorMax] + "…"
+	}
+	return msg
+}

--- a/upload/redact.go
+++ b/upload/redact.go
@@ -18,6 +18,19 @@ const redactedErrorMax = 512
 // message. For a signed upload that query carries the signature — a
 // time-limited write credential for the object — so it must never leave the
 // host inside telemetry.
+//
+// DELIBERATELY NOT ANCHORED, and it must stay that way. Static analysis flags
+// unanchored hostname patterns because an unanchored regex is unsafe when it
+// *validates* a URL in a security decision — an attacker embeds the trusted
+// host in a longer string and slips past the check. This regex makes no such
+// decision: it is a redaction sweep over free-form error text, and the URL it
+// must find is always mid-string. net/http renders a failed request as
+//
+//	Put "https://host/obj?X-Goog-Signature=…": dial tcp …: connection refused
+//
+// so anchoring with ^/$ matches nothing, silently disables redaction, and ships
+// the signature to the platform — the exact leak this file exists to stop.
+// TestRedactError_RedactsURLMidMessage is the regression test for that.
 var signedURLQueryRe = regexp.MustCompile(`(https?://[^\s"?]*)\?[^\s"]*`)
 
 // RedactError renders err for reporting to the platform with any URL removed.

--- a/upload/redact_test.go
+++ b/upload/redact_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package upload
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shape net/http actually produces for a failed signed PUT: the signature
+// lives in the query string, so it must not survive redaction.
+const signedURL = "https://storage.googleapis.com/mondoo-ingest/ingest/scans/sess-1?" +
+	"X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=svc%40proj.iam.gserviceaccount.com" +
+	"&X-Goog-Signature=8a1f3c9d2b7e4f60a1b2c3d4e5f60718293a4b5c6d7e8f90"
+
+func TestRedactError_DropsSignedURL(t *testing.T) {
+	err := &url.Error{Op: "Put", URL: signedURL, Err: context.DeadlineExceeded}
+
+	got := RedactError(err)
+
+	assert.NotContains(t, got, "X-Goog-Signature")
+	assert.NotContains(t, got, "8a1f3c9d2b7e4f60")
+	assert.NotContains(t, got, "storage.googleapis.com")
+	// The diagnostically useful part survives.
+	assert.Contains(t, got, "Put")
+	assert.Contains(t, got, "context deadline exceeded")
+}
+
+func TestRedactError_StripsQueryFromEmbeddedURL(t *testing.T) {
+	// Not a *url.Error — a URL formatted into the message by another layer.
+	err := fmt.Errorf("upload to %s failed", signedURL)
+
+	got := RedactError(err)
+
+	assert.NotContains(t, got, "X-Goog-Signature")
+	assert.Contains(t, got, "<redacted>")
+	// The host/path is retained in this branch; only the credential-bearing
+	// query is removed.
+	assert.Contains(t, got, "storage.googleapis.com")
+}
+
+func TestRedactError_Truncates(t *testing.T) {
+	got := RedactError(errors.New(strings.Repeat("a", redactedErrorMax*2)))
+
+	assert.Len(t, got, redactedErrorMax+len("…"))
+	assert.True(t, strings.HasSuffix(got, "…"))
+}
+
+func TestRedactError_PassesThroughPlainError(t *testing.T) {
+	assert.Equal(t, "connection reset by peer", RedactError(errors.New("connection reset by peer")))
+}
+
+func TestRedactError_Nil(t *testing.T) {
+	require.Equal(t, "", RedactError(nil))
+}

--- a/upload/redact_test.go
+++ b/upload/redact_test.go
@@ -47,6 +47,24 @@ func TestRedactError_StripsQueryFromEmbeddedURL(t *testing.T) {
 	assert.Contains(t, got, "storage.googleapis.com")
 }
 
+// TestRedactError_RedactsURLMidMessage guards signedURLQueryRe against being
+// "hardened" with ^/$ anchors, which static analysis periodically suggests for
+// unanchored hostname patterns. The URL is always mid-string in a real net/http
+// error, so anchoring matches nothing and ships the signature verbatim. This
+// exact string is what net/http produces for a failed PUT.
+func TestRedactError_RedactsURLMidMessage(t *testing.T) {
+	msg := `Put "` + signedURL + `": dial tcp 10.0.0.1:443: connect: connection refused`
+
+	got := RedactError(errors.New(msg))
+
+	require.NotContains(t, got, "X-Goog-Signature",
+		"signature survived redaction — is signedURLQueryRe anchored?")
+	require.NotContains(t, got, "8a1f3c9d2b7e4f60")
+	assert.Contains(t, got, "<redacted>")
+	// Surrounding diagnostic context is preserved.
+	assert.Contains(t, got, "connection refused")
+}
+
 func TestRedactError_Truncates(t *testing.T) {
 	got := RedactError(errors.New(strings.Repeat("a", redactedErrorMax*2)))
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -5,11 +5,45 @@ package upload
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"os"
+	"sync/atomic"
+	"time"
 
 	"go.mondoo.com/mql/v13/cli/config"
 )
+
+// Result carries the outcome of an upload attempt. BytesSent and Duration are
+// populated even when err is non-nil, so a caller can tell a connection that
+// never established (BytesSent == 0) from one that stalled mid-body
+// (0 < BytesSent < ContentLength). The receiving end cannot make that
+// distinction on its own — a stalled upload and one that never started look
+// identical from there — which is why it is measured here.
+type Result struct {
+	// Response is nil when the request failed before a response was received.
+	// The caller is responsible for closing its body.
+	Response  *http.Response
+	BytesSent int64
+	Duration  time.Duration
+}
+
+// countingReader counts the bytes read out of it. http.Client reads the request
+// body as it writes it to the wire, so the count is a lower bound on bytes that
+// reached the network — good enough to classify a stall.
+//
+// The count is atomic because http.Client may read the body on a different
+// goroutine than the one that returns from Do.
+type countingReader struct {
+	r io.Reader
+	n atomic.Int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n.Add(int64(n))
+	return n, err
+}
 
 // UploadFile uploads a file to a pre-signed URL via HTTP PUT.
 //
@@ -22,34 +56,43 @@ import (
 // It sets the provided headers and Content-Type to application/octet-stream.
 // The caller is responsible for checking the response status code and closing
 // the response body.
-func UploadFile(ctx context.Context, url string, headers map[string]string, filePath string, contentType string) (*http.Response, error) {
+//
+// The returned Result reports bytes sent and elapsed time on both the success
+// and the error path — see Result.
+func UploadFile(ctx context.Context, url string, headers map[string]string, filePath string, contentType string) (Result, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 	defer file.Close()
 
-	req, err := http.NewRequestWithContext(ctx, "PUT", url, file)
+	fileInfo, err := file.Stat()
 	if err != nil {
-		return nil, err
+		return Result{}, err
+	}
+
+	counter := &countingReader{r: file}
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, counter)
+	if err != nil {
+		return Result{}, err
 	}
 
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
 
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
 	req.ContentLength = fileInfo.Size()
 	req.Header.Set("Content-Type", contentType)
 
 	client, err := newHTTPClient()
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
-	return client.Do(req)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	// BytesSent/Duration are filled in on both paths on purpose.
+	return Result{Response: resp, BytesSent: counter.n.Load(), Duration: time.Since(start)}, err
 }
 
 // newHTTPClient builds the HTTP client used by UploadFile. When api_proxy is

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -81,6 +81,12 @@ func UploadFile(ctx context.Context, url string, headers map[string]string, file
 		req.Header.Set(key, value)
 	}
 
+	// This assignment is REQUIRED — do not drop it or move it above the request
+	// construction. net/http only infers ContentLength for *bytes.Buffer,
+	// *bytes.Reader and *strings.Reader; for anything else it leaves the length
+	// unset and falls back to chunked transfer encoding, which signed-URL
+	// endpoints commonly reject. countingReader also masks the concrete body
+	// type, so nothing downstream can recover the size on its own.
 	req.ContentLength = fileInfo.Size()
 	req.Header.Set("Content-Type", contentType)
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -55,7 +55,7 @@ func TestUploadFile_PUTsContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resp, err := UploadFile(
+	res, err := UploadFile(
 		context.Background(),
 		server.URL,
 		map[string]string{"X-Test-Header": "header-value"},
@@ -63,10 +63,55 @@ func TestUploadFile_PUTsContent(t *testing.T) {
 		"application/octet-stream",
 	)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer res.Response.Body.Close()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, res.Response.StatusCode)
 	assert.Equal(t, "hello-world", received)
+}
+
+// writeTempFileSize writes a file of exactly size zero bytes. Distinct from
+// writeTempFile above, which takes literal content — the counting-reader tests
+// need a payload large enough to fail partway through.
+func writeTempFileSize(t *testing.T, size int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scan.db")
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o600))
+	return path
+}
+
+func TestUploadFile_ReportsBytesSentOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res, err := UploadFile(context.Background(), srv.URL, nil, writeTempFileSize(t, 4096), "application/octet-stream")
+	require.NoError(t, err)
+	defer res.Response.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+	assert.Equal(t, int64(4096), res.BytesSent)
+	assert.Positive(t, res.Duration)
+}
+
+func TestUploadFile_ReportsPartialBytesWhenServerHangsUp(t *testing.T) {
+	// Hijack and close the connection mid-body so the client's write fails
+	// after some bytes have gone out — the "stalled mid-body" case.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	res, err := UploadFile(context.Background(), srv.URL, nil, writeTempFileSize(t, 8<<20), "application/octet-stream")
+	require.Error(t, err)
+	assert.Nil(t, res.Response)
+	// Bytes sent is reported even on failure, and is short of the total.
+	assert.Less(t, res.BytesSent, int64(8<<20))
 }
 
 // TestNewHTTPClient_HonorsAPIProxy is the regression test for the


### PR DESCRIPTION
When a scan-result upload fails, cnspec currently tells the platform almost nothing — so an upload that never completes is indistinguishable from one that was never attempted. This adds structured reporting for every upload failure a running client can observe.

## The gap

In `uploadScanDataStore`, only a **non-2xx PUT status** was reported. Everything else returned a bare error:

| failure | before | after |
|---|---|---|
| `GetUploadURL` fails | silent | `url_request_failed` |
| **PUT transport error** (timeout, reset, DNS, TLS, ctx cancel) | **silent** | classified `failureKind` |
| PUT non-2xx | reported | reported + structured fields |
| **`ReportUploadCompleted` fails** | **silent** | `report_rpc_failed` |

The silent cases turn out to be the common ones, and they are exactly the cases the server cannot diagnose on its own: from the receiving end, a client that stalled mid-upload and a client that never connected look identical.

## What this adds

**`bytes_sent`, via a counting `io.Reader`** — the useful field, because it separates causes the server cannot:

- `0` → connection never established (refused, DNS, TLS, blocked egress)
- `0 < n < total` → **stalled mid-body**, e.g. a proxy or load balancer request timeout on a multi-MB PUT
- `== total`, no response → the body landed and the response was dropped; **the object may exist and be recoverable**

`UploadFile` now returns a `Result` reporting `BytesSent` and `Duration` on **both** the success and error paths. The counter is `atomic.Int64` because `http.Client` may read the request body on a different goroutine than the one returning from `Do`.

**A closed `failureKind` taxonomy** (`upload/failurekind.go`), classified with `errors.Is`/`errors.As` against the error tree rather than string matching, so it survives stdlib message changes. An unrecognised error maps to `other` **and keeps its message** — a failure is never dropped because the classifier doesn't recognise it yet.

**Success baseline** — `cnspec.scan.upload_duration` and `cnspec.scan.upload_throughput_bps` on the existing `ScanStatistics` payload (already `repeated Metric`, so **no proto change**). Without a baseline you can't tell whether failing uploads are the tail of the normal latency distribution or a distinct mode.

Reporting goes through the **existing** `health.SendError` RPC with a `reportKind=upload_failure` discriminator tag — no new RPC, no proto change. It's best-effort by construction: `health.ReportError` swallows its own errors and returns nothing, so reporting can never fail a scan.

A matching platform-side change records these reports with their structured fields; until it ships, the reports degrade gracefully to the existing generic error-report path.

## Scope

This makes upload failures **diagnosable**. It does **not** change what happens on failure — a failed bucket upload still gives up, and the scan result is lost. Adding a retry or a fallback to the `StoreResults` path is deliberately left for separate work.

Also noticed and deliberately not changed here: `newHTTPClient()` returns a bare `&http.Client{}` with **no timeout** when no proxy is configured, so the scan-db PUT is unbounded — unlike the findings upload path, which sets an explicit 2-minute timeout. Worth fixing, but it changes behaviour rather than observability.

## Testing

`go build ./...`, `go vet`, and `go test -race` clean across `./upload/`, `./internal/datalakes/sqlite/`, `./policy/scanstats/`.

- `ClassifyFailure`: one case per taxonomy entry, plus a wrapped error and an unrecognised error → `other`
- counting reader: exact count on success; partial count when the server hijacks the connection and closes mid-body
- tag builder: `httpStatus` omitted when there was no response; `uploadSessionId` omitted for `url_request_failed`, since no session exists yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
