### PR TITLE
✨ content: add Mondoo MariaDB Security policy

### DIFF
--- a/content/mondoo-mariadb-security.mql.yaml
+++ b/content/mondoo-mariadb-security.mql.yaml
@@ -1,0 +1,4529 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-mariadb-security
+    name: Mondoo MariaDB Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: linux,mariadb
+    require:
+      - provider: os
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden MariaDB server networking, authentication, encryption, and audit logging
+    docs:
+      desc: |
+        The Mondoo MariaDB Security policy assesses the on-disk option files of a self-managed MariaDB installation. It reads the option file chain, resolving the `!include` and `!includedir` directives so every fragment contributes, and normalizes option names so `-` and `_` are interchangeable exactly as the server treats them.
+
+        This policy provides security checks across eight areas:
+
+        - Connection surface and network exposure
+        - Transport encryption and certificate material
+        - Password policy enforced by the MariaDB password plugins
+        - Filesystem privileges and server-side code execution
+        - Error logging and the server audit plugin
+        - Encryption at rest for tables, logs, and temporary files
+        - Galera cluster replication security
+        - Protection of option files and the credentials they hold
+
+        **Scope and limitations**
+
+        This policy reads configuration as it is written to disk. It does not open a SQL connection to the server, so it cannot assess accounts, granted privileges, or the effective value of a dynamic variable. Checks describe the configuration the server would load on its next restart.
+
+        MySQL and Percona Server are covered by the Mondoo MySQL Security policy instead. Although the two products share an option file format, their security options differ substantially: MariaDB enforces password rules through the `simple_password_check` and `password_reuse_check` plugins rather than a `validate_password` component, audits through the `server_audit` plugin rather than an audit log plugin, and adds encryption and Galera cluster options that have no MySQL equivalent. The underlying resource returns nothing on a host running MySQL, so the checks here do not apply to those servers.
+
+        Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Connection and Network Exposure
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-bind-address-restricted
+          - uid: mondoo-mariadb-security-skip-name-resolve-enabled
+          - uid: mondoo-mariadb-security-skip-show-database-enabled
+      - title: Transport Encryption
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-require-secure-transport-enabled
+          - uid: mondoo-mariadb-security-tls-version-modern
+          - uid: mondoo-mariadb-security-server-certificate-configured
+          - uid: mondoo-mariadb-security-client-ca-configured
+      - title: Authentication and Password Policy
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-skip-grant-tables-disabled
+          - uid: mondoo-mariadb-security-simple-password-check-plugin-loaded
+          - uid: mondoo-mariadb-security-simple-password-check-length-sufficient
+          - uid: mondoo-mariadb-security-simple-password-check-composition-required
+          - uid: mondoo-mariadb-security-password-reuse-check-configured
+      - title: Filesystem Privileges and Code Execution
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-runs-as-dedicated-account
+          - uid: mondoo-mariadb-security-local-infile-disabled
+          - uid: mondoo-mariadb-security-secure-file-priv-restricted
+          - uid: mondoo-mariadb-security-symbolic-links-disabled
+          - uid: mondoo-mariadb-security-allow-suspicious-udfs-disabled
+          - uid: mondoo-mariadb-security-log-bin-trust-function-creators-disabled
+          - uid: mondoo-mariadb-security-automatic-sp-privileges-disabled
+      - title: Logging and Audit
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-error-log-configured
+          - uid: mondoo-mariadb-security-log-warnings-includes-warnings
+          - uid: mondoo-mariadb-security-log-output-retained
+          - uid: mondoo-mariadb-security-general-log-disabled
+          - uid: mondoo-mariadb-security-server-audit-logging-enabled
+          - uid: mondoo-mariadb-security-server-audit-events-cover-connect-and-query
+          - uid: mondoo-mariadb-security-server-audit-no-excluded-users
+      - title: Encryption at Rest
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-innodb-encrypt-tables-enforced
+          - uid: mondoo-mariadb-security-innodb-encrypt-log-enabled
+          - uid: mondoo-mariadb-security-encrypt-binlog-enabled
+          - uid: mondoo-mariadb-security-encrypt-tmp-disk-tables-enabled
+          - uid: mondoo-mariadb-security-file-key-management-configured
+          - uid: mondoo-mariadb-security-file-key-management-key-file-protected
+      - title: Galera Cluster Replication
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-galera-replication-encrypted
+          - uid: mondoo-mariadb-security-galera-sst-method-secure
+      - title: Credential and Option File Protection
+        filters: |
+          asset.family.contains("linux") &&
+          mariadb.conf.file.exists
+        checks:
+          - uid: mondoo-mariadb-security-client-options-no-plaintext-password
+          - uid: mondoo-mariadb-security-option-files-restricted-permissions
+          - uid: mondoo-mariadb-security-user-option-files-protected
+queries:
+  - uid: mondoo-mariadb-security-bind-address-restricted
+    title: Ensure bind_address does not expose MariaDB on every interface
+    impact: 75
+    mql: |
+      mariadb.conf.bindAddress.none(_ == "*" || _ == "0.0.0.0" || _ == "::")
+    docs:
+      desc: |
+        This check ensures that `bind_address` names specific addresses instead of accepting connections on every interface. MariaDB binds to every interface when the option is unset, so an installation that never sets it is reachable from every network the host is attached to.
+
+        Where the database only serves applications on the same host, `skip_networking` removes the TCP listener entirely and is stronger still. Where remote access is required, naming the addresses keeps the listener off networks the database was never meant to serve.
+
+        **Why this matters**
+
+        - **Smaller network surface:** Only the addresses you name can accept a connection attempt.
+        - **Defense in depth behind the firewall:** Binding narrowly means a firewall change does not immediately expose the database.
+        - **Explicit intent:** A named address documents which network the server is expected to serve.
+
+        **Risk mitigation**
+
+        - **Blocks opportunistic scanning:** Scanners probing port 3306 cannot fingerprint a server that never answers them.
+        - **Contains credential attacks:** Password guessing cannot begin against an address the server does not accept.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'bind_address';"
+        ```
+
+        2. Confirm which addresses the server is actually bound to:
+
+        ```bash
+        sudo ss -lntp | grep mariadbd
+        ```
+
+        A passing result names specific addresses such as `127.0.0.1` or a private address. A failing result reports `*`, `0.0.0.0`, or `::`, or shows the server listening on `0.0.0.0:3306`.
+      remediation:
+        - id: cli
+          desc: |
+            To bind MariaDB to specific addresses using the CLI:
+
+            1. Set `bind-address` in the server option file.
+            2. Restart MariaDB, because this option cannot be changed at runtime.
+            3. Confirm the resulting listeners.
+
+            ```bash
+            sudo sed -i "s/^#*\s*bind-address.*/bind-address = 127.0.0.1,10.0.0.5/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo ss -lntp | grep mariadbd
+            ```
+        - id: script
+          desc: |
+            To bind MariaDB to specific addresses using a bash script:
+
+            1. Set the addresses the server must serve.
+            2. Replace an existing option or append one under the server group.
+            3. Restart MariaDB and report the resulting listeners.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            ADDRESSES="127.0.0.1,10.0.0.5"
+
+            if grep -qE "^\s*bind[-_]address" "$MYCNF"; then
+              sed -i "s|^\s*bind[-_]address.*|bind-address = ${ADDRESSES}|" "$MYCNF"
+            else
+              printf "bind-address = %s\n" "$ADDRESSES" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ss -lntp | grep mariadbd
+            ```
+        - id: ansible
+          desc: |
+            To bind MariaDB to specific addresses using Ansible:
+
+            1. Set `bind-address` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Restrict the MariaDB bind address
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_bind_address: "127.0.0.1,10.0.0.5"
+              tasks:
+                - name: Set bind-address
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: bind-address
+                    value: "{{ mariadb_bind_address }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-skip-name-resolve-enabled
+    title: Ensure skip_name_resolve is enabled
+    impact: 60
+    mql: |
+      mariadb.conf.skipNameResolve == true
+    docs:
+      desc: |
+        This check ensures that `skip_name_resolve` is enabled so the server matches accounts by IP address rather than resolving client hostnames. With name resolution active, an account defined for a hostname is authorized based on the answer a reverse lookup returns at connection time.
+
+        That makes an external naming service part of the authorization decision. An attacker who can influence reverse DNS for an address they control can cause the server to match a host pattern that was meant for a trusted machine.
+
+        **Why this matters**
+
+        - **Authorization stops depending on DNS:** Host matching uses the address the connection actually came from.
+        - **Removes a spoofable input:** Reverse lookup answers cannot be manipulated into matching a trusted pattern.
+        - **Predictable connection handling:** Connections are not delayed when a naming service is slow or unavailable.
+
+        **Risk mitigation**
+
+        - **Blocks DNS-based authorization bypass:** A forged reverse record cannot satisfy a hostname-scoped account.
+        - **Removes a denial of service path:** A failing resolver cannot prevent clients from connecting.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'skip_name_resolve';"
+        ```
+
+        2. Identify accounts still defined against a hostname rather than an address:
+
+        ```bash
+        sudo mariadb -e "SELECT user, host FROM mysql.global_priv WHERE host NOT REGEXP '^[0-9a-fA-F:.%]+$';"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF`, and the second query lists accounts that must be redefined against addresses before the option is enabled.
+      remediation:
+        - id: cli
+          desc: |
+            To disable client hostname resolution using the CLI:
+
+            1. Redefine any account scoped to a hostname so it names an address or address pattern.
+            2. Set `skip_name_resolve` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "SELECT user, host FROM mysql.global_priv WHERE host NOT REGEXP '^[0-9a-fA-F:.%]+$';"
+            sudo sed -i "s/^#*\s*skip[-_]name[-_]resolve.*/skip_name_resolve = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'skip_name_resolve';"
+            ```
+        - id: script
+          desc: |
+            To disable client hostname resolution using a bash script:
+
+            1. Refuse to proceed while accounts are still scoped to hostnames, because they would stop matching.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            hostname_accounts=$(mariadb -N -B -e \
+              "SELECT count(*) FROM mysql.global_priv WHERE host NOT REGEXP '^[0-9a-fA-F:.%]+\$';")
+
+            if [ "$hostname_accounts" -gt 0 ]; then
+              echo "$hostname_accounts account(s) are scoped to hostnames; redefine them first" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*skip[-_]name[-_]resolve" "$MYCNF"; then
+              sed -i "s|^\s*skip[-_]name[-_]resolve.*|skip_name_resolve = ON|" "$MYCNF"
+            else
+              printf "skip_name_resolve = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To disable client hostname resolution using Ansible:
+
+            1. Set `skip_name_resolve` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Disable MariaDB client hostname resolution
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set skip_name_resolve
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: skip_name_resolve
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-skip-show-database-enabled
+    title: Ensure skip_show_database is enabled
+    impact: 55
+    mql: |
+      mariadb.conf.skipShowDatabase == true
+    docs:
+      desc: |
+        This check ensures that `skip_show_database` is enabled so `SHOW DATABASES` is restricted to accounts holding the `SHOW DATABASES` privilege. Without it, every authenticated account can enumerate every schema name on the server, including schemas it has no privilege to read.
+
+        Schema names routinely disclose which applications, tenants, and environments share a server. That information shapes an attacker's next step after obtaining any low-privilege credential.
+
+        **Why this matters**
+
+        - **Limits enumeration:** An account sees only the schemas it is entitled to know about.
+        - **Reduces tenant disclosure:** Shared servers do not reveal the names of unrelated applications.
+        - **Least privilege for metadata:** Catalog visibility becomes a privilege rather than a default.
+
+        **Risk mitigation**
+
+        - **Slows lateral movement:** A compromised application account cannot map the rest of the server.
+        - **Reduces targeting information:** Attackers cannot identify high-value schemas to pursue.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'skip_show_database';"
+        ```
+
+        2. Review which accounts hold the privilege that grants enumeration anyway:
+
+        ```bash
+        sudo mariadb -e "SELECT user, host FROM mysql.user WHERE Show_db_priv = 'Y';"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF`, meaning every authenticated account can enumerate all schemas.
+      remediation:
+        - id: cli
+          desc: |
+            To restrict schema enumeration using the CLI:
+
+            1. Grant `SHOW DATABASES` to the administrative accounts that genuinely need it.
+            2. Set `skip_show_database` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "GRANT SHOW DATABASES ON *.* TO 'dba'@'10.0.0.%';"
+            sudo sed -i "s/^#*\s*skip[-_]show[-_]database.*/skip_show_database = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'skip_show_database';"
+            ```
+        - id: script
+          desc: |
+            To restrict schema enumeration using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            if grep -qE "^\s*skip[-_]show[-_]database" "$MYCNF"; then
+              sed -i "s|^\s*skip[-_]show[-_]database.*|skip_show_database = ON|" "$MYCNF"
+            else
+              printf "skip_show_database = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'skip_show_database';"
+            ```
+        - id: ansible
+          desc: |
+            To restrict schema enumeration using Ansible:
+
+            1. Set `skip_show_database` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Restrict MariaDB schema enumeration
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set skip_show_database
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: skip_show_database
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-require-secure-transport-enabled
+    title: Ensure require_secure_transport is enabled
+    impact: 85
+    mql: |
+      mariadb.conf.requireSecureTransport == true
+    docs:
+      desc: |
+        This check ensures that `require_secure_transport` is enabled so the server refuses connections that are neither encrypted nor made over a local socket. Configuring certificate material makes TLS available, but MariaDB still accepts unencrypted TCP connections unless this option forces the requirement.
+
+        Enforcing the requirement server-side is what closes the gap. Per-account `REQUIRE SSL` clauses achieve the same for individual accounts, but they must be applied to every account and are easy to omit when a new one is created.
+
+        **Why this matters**
+
+        - **Encryption becomes mandatory:** A client cannot connect by declining TLS.
+        - **Applies to every account:** The requirement does not depend on remembering a per-account clause.
+        - **Credentials protected in transit:** Authentication exchanges are never observable on the network.
+
+        **Risk mitigation**
+
+        - **Defeats passive interception:** Captured traffic yields no readable queries or credentials.
+        - **Prevents accidental cleartext:** A misconfigured client library cannot silently connect without TLS.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'require_secure_transport';"
+        ```
+
+        2. Confirm the server has usable TLS material:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'have_ssl';"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF`, meaning unencrypted TCP connections are still accepted.
+      remediation:
+        - id: cli
+          desc: |
+            To require encrypted connections using the CLI:
+
+            1. Confirm TLS material is configured and the server reports it is available.
+            2. Set `require_secure_transport` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "SHOW VARIABLES LIKE 'have_ssl';"
+            sudo sed -i "s/^#*\s*require[-_]secure[-_]transport.*/require_secure_transport = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'require_secure_transport';"
+            ```
+        - id: script
+          desc: |
+            To require encrypted connections using a bash script:
+
+            1. Refuse to proceed unless the server has usable TLS material, because enabling the requirement would lock out every remote client.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            tls_state=$(mariadb -N -B -e "SELECT @@have_ssl;" 2>/dev/null || echo "UNKNOWN")
+            if [ "$tls_state" != "YES" ]; then
+              echo "server reports TLS availability as $tls_state; configure certificates first" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*require[-_]secure[-_]transport" "$MYCNF"; then
+              sed -i "s|^\s*require[-_]secure[-_]transport.*|require_secure_transport = ON|" "$MYCNF"
+            else
+              printf "require_secure_transport = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To require encrypted connections using Ansible:
+
+            1. Verify the server has usable TLS material.
+            2. Set `require_secure_transport` in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Require encrypted MariaDB connections
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Read TLS availability
+                  ansible.builtin.command:
+                    cmd: mariadb -N -B -e "SELECT @@have_ssl;"
+                  changed_when: false
+                  register: have_ssl
+
+                - name: Fail when TLS material is missing
+                  ansible.builtin.fail:
+                    msg: "Configure ssl_cert and ssl_key before requiring secure transport."
+                  when: have_ssl.stdout | trim != "YES"
+
+                - name: Set require_secure_transport
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: require_secure_transport
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-tls-version-modern
+    title: Ensure tls_version excludes TLS 1.0 and TLS 1.1
+    impact: 75
+    mql: |
+      mariadb.conf.tlsVersion != empty
+      mariadb.conf.tlsVersion.none(_.downcase == "tlsv1" || _.downcase == "tlsv1.1")
+    docs:
+      desc: |
+        This check ensures that `tls_version` is set explicitly and names only TLS 1.2 and TLS 1.3. TLS 1.0 and TLS 1.1 are deprecated, depend on obsolete hashing and cipher constructions, and are no longer adequate for protecting authentication material.
+
+        Leaving the option unset falls back to the versions the server was compiled to accept, which varies by build and by MariaDB release. Setting it explicitly makes the accepted set verifiable from the option file and keeps it from widening when the server is upgraded.
+
+        **Why this matters**
+
+        - **Removes downgrade room:** A client cannot negotiate a protocol version the server refuses to offer.
+        - **Modern cipher suites only:** TLS 1.2 and above provide authenticated encryption modes older versions lack.
+        - **Verifiable from configuration:** The accepted set does not depend on a compiled-in default.
+
+        **Risk mitigation**
+
+        - **Blocks protocol downgrade attacks:** An attacker influencing the handshake cannot force a deprecated version.
+        - **Removes weak-cipher exposure:** Attacks against obsolete constructions in TLS 1.0 and 1.1 no longer apply.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'tls_version';"
+        ```
+
+        2. Confirm which version connections actually negotiate:
+
+        ```bash
+        sudo mariadb -e "SHOW SESSION STATUS LIKE 'Ssl_version';"
+        ```
+
+        A passing result names only `TLSv1.2` and `TLSv1.3`. A failing result includes `TLSv1` or `TLSv1.1`, or is unset so the compiled-in default applies.
+      remediation:
+        - id: cli
+          desc: |
+            To restrict accepted TLS versions using the CLI:
+
+            1. Confirm every client library supports TLS 1.2 or above.
+            2. Set `tls_version` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*tls[-_]version.*/tls_version = TLSv1.2,TLSv1.3/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'tls_version';"
+            ```
+        - id: script
+          desc: |
+            To restrict accepted TLS versions using a bash script:
+
+            1. Define the accepted versions.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            VERSIONS="TLSv1.2,TLSv1.3"
+
+            if grep -qE "^\s*tls[-_]version" "$MYCNF"; then
+              sed -i "s|^\s*tls[-_]version.*|tls_version = ${VERSIONS}|" "$MYCNF"
+            else
+              printf "tls_version = %s\n" "$VERSIONS" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'tls_version';"
+            ```
+        - id: ansible
+          desc: |
+            To restrict accepted TLS versions using Ansible:
+
+            1. Set `tls_version` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Restrict accepted MariaDB TLS versions
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_tls_versions: "TLSv1.2,TLSv1.3"
+              tasks:
+                - name: Set tls_version
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: tls_version
+                    value: "{{ mariadb_tls_versions }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-server-certificate-configured
+    title: Ensure ssl_cert and ssl_key are configured
+    impact: 70
+    mql: |
+      mariadb.conf.sslCertFile != empty
+      mariadb.conf.sslKeyFile != empty
+    docs:
+      desc: |
+        This check ensures that `ssl_cert` and `ssl_key` name the server certificate and its private key. Without both, the server cannot present a verifiable identity, and clients configured to verify it will refuse to connect.
+
+        Naming the material explicitly means the certificate is one you issued and can rotate. It is also the prerequisite for requiring secure transport, since a server with no usable certificate that refuses unencrypted connections refuses every remote connection.
+
+        **Why this matters**
+
+        - **Server identity is verifiable:** Clients can confirm they reached the intended database rather than an interposed listener.
+        - **Certificates become manageable:** Explicit paths give you a place to rotate and monitor expiry.
+        - **Enables strict client verification:** Clients using verify-identity modes have a chain they can validate.
+
+        **Risk mitigation**
+
+        - **Defeats machine-in-the-middle:** An attacker cannot present substitute material that clients will accept.
+        - **Prevents a lockout during hardening:** Requiring TLS on a server with no certificate is caught before it breaks access.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the configured paths from a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('ssl_cert','ssl_key','ssl_ca');"
+        ```
+
+        2. Confirm the certificate is valid and note its expiry:
+
+        ```bash
+        sudo openssl x509 -in /etc/mysql/ssl/server-cert.pem -noout -subject -issuer -dates
+        ```
+
+        A passing result names both files and shows a certificate issued by your authority with a future expiry. A failing result leaves either option empty.
+      remediation:
+        - id: cli
+          desc: |
+            To configure server certificate material using the CLI:
+
+            1. Install the certificate and key where the server account can read them.
+            2. Set `ssl_cert` and `ssl_key` in the server option file.
+            3. Restart MariaDB and confirm the paths.
+
+            ```bash
+            sudo install -o mysql -g mysql -m 0600 server-key.pem /etc/mysql/ssl/server-key.pem
+            sudo install -o mysql -g mysql -m 0644 server-cert.pem /etc/mysql/ssl/server-cert.pem
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            ssl_cert = /etc/mysql/ssl/server-cert.pem
+            ssl_key  = /etc/mysql/ssl/server-key.pem
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('ssl_cert','ssl_key');"
+            ```
+        - id: script
+          desc: |
+            To configure server certificate material using a bash script:
+
+            1. Verify the key matches the certificate before changing configuration.
+            2. Set both options, replacing any existing values.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            CERT="/etc/mysql/ssl/server-cert.pem"
+            KEY="/etc/mysql/ssl/server-key.pem"
+
+            cert_mod=$(openssl x509 -in "$CERT" -noout -modulus)
+            key_mod=$(openssl rsa -in "$KEY" -noout -modulus)
+            if [ "$cert_mod" != "$key_mod" ]; then
+              echo "private key does not match the certificate" >&2
+              exit 1
+            fi
+
+            chown mysql:mysql "$KEY" "$CERT"
+            chmod 0600 "$KEY"
+            chmod 0644 "$CERT"
+
+            set_option() {
+              local key="$1" value="$2"
+              if grep -qE "^\s*${key}\b" "$MYCNF"; then
+                sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
+              else
+                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+              fi
+            }
+
+            set_option ssl_cert "$CERT"
+            set_option ssl_key "$KEY"
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To configure server certificate material using Ansible:
+
+            1. Place the certificate and key with ownership the server can read.
+            2. Set `ssl_cert` and `ssl_key` in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Configure MariaDB server certificate material
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_ssl_cert: /etc/mysql/ssl/server-cert.pem
+                mariadb_ssl_key: /etc/mysql/ssl/server-key.pem
+              tasks:
+                - name: Protect the private key
+                  ansible.builtin.file:
+                    path: "{{ mariadb_ssl_key }}"
+                    owner: mysql
+                    group: mysql
+                    mode: "0600"
+
+                - name: Set the certificate options
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: "{{ item.option }}"
+                    value: "{{ item.value }}"
+                    mode: "0640"
+                  loop:
+                    - { option: "ssl_cert", value: "{{ mariadb_ssl_cert }}" }
+                    - { option: "ssl_key", value: "{{ mariadb_ssl_key }}" }
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-client-ca-configured
+    title: Ensure a certificate authority is configured for client verification
+    impact: 65
+    mql: |
+      mariadb.conf.sslCaFile != empty || mariadb.conf.sslCaPath != empty
+    docs:
+      desc: |
+        This check ensures that either `ssl_ca` or `ssl_capath` names a trust anchor. The server needs one to validate client certificates, so accounts created with `REQUIRE X509`, `REQUIRE ISSUER`, or `REQUIRE SUBJECT` cannot be enforced without it.
+
+        A configured authority also completes the chain that clients verify. Clients using verify modes need the same authority to validate the certificate the server presents, so publishing it alongside the server material is what makes strict client verification workable.
+
+        **Why this matters**
+
+        - **Client certificates become enforceable:** Account-level X.509 requirements have something to validate against.
+        - **Controls who can issue identities:** Only certificates chaining to the configured authority are accepted.
+        - **Supports revocation:** A managed authority gives you a place to distrust compromised certificates.
+
+        **Risk mitigation**
+
+        - **Rejects untrusted certificates:** A self-issued client certificate cannot satisfy an X.509 account requirement.
+        - **Prevents a false sense of assurance:** Account requirements that could never validate are surfaced before they are relied upon.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the configured trust anchor:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('ssl_ca','ssl_capath','ssl_crl');"
+        ```
+
+        2. Identify accounts that depend on client certificates:
+
+        ```bash
+        sudo mariadb -e "SELECT user, host, ssl_type FROM mysql.user WHERE ssl_type <> '';"
+        ```
+
+        A passing result names an authority file or directory. A failing result leaves both empty, in which case any account requiring X.509 cannot be validated.
+      remediation:
+        - id: cli
+          desc: |
+            To configure a client certificate authority using the CLI:
+
+            1. Install the issuing authority certificate where the server can read it.
+            2. Set `ssl_ca` in the server option file.
+            3. Restart MariaDB and confirm the value.
+
+            ```bash
+            sudo install -o mysql -g mysql -m 0644 ca.pem /etc/mysql/ssl/ca.pem
+            sudo sed -i "s|^#*\s*ssl[-_]ca\b.*|ssl_ca = /etc/mysql/ssl/ca.pem|" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'ssl_ca';"
+            ```
+        - id: script
+          desc: |
+            To configure a client certificate authority using a bash script:
+
+            1. Verify the authority certificate is present and parseable.
+            2. Set `ssl_ca`, replacing any existing value.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            CA_FILE="/etc/mysql/ssl/ca.pem"
+
+            if ! openssl x509 -in "$CA_FILE" -noout >/dev/null 2>&1; then
+              echo "authority certificate missing or unparseable: $CA_FILE" >&2
+              exit 1
+            fi
+
+            chown mysql:mysql "$CA_FILE"
+            chmod 0644 "$CA_FILE"
+
+            if grep -qE "^\s*ssl[-_]ca\b" "$MYCNF"; then
+              sed -i "s|^\s*ssl[-_]ca\b.*|ssl_ca = ${CA_FILE}|" "$MYCNF"
+            else
+              printf "ssl_ca = %s\n" "$CA_FILE" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To configure a client certificate authority using Ansible:
+
+            1. Place the authority certificate with ownership the server can read.
+            2. Set `ssl_ca` in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Configure the MariaDB client certificate authority
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_ssl_ca: /etc/mysql/ssl/ca.pem
+              tasks:
+                - name: Install the authority certificate
+                  ansible.builtin.copy:
+                    src: ca.pem
+                    dest: "{{ mariadb_ssl_ca }}"
+                    owner: mysql
+                    group: mysql
+                    mode: "0644"
+
+                - name: Set ssl_ca
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: ssl_ca
+                    value: "{{ mariadb_ssl_ca }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-skip-grant-tables-disabled
+    title: Ensure skip_grant_tables is not enabled
+    impact: 95
+    mql: |
+      mariadb.conf.skipGrantTables == false
+    docs:
+      desc: |
+        This check ensures that `skip_grant_tables` is not present in any option file. The option starts the server with the privilege system switched off entirely: every connection is accepted without a password and acts with full privileges on every schema.
+
+        The option exists to recover a server whose administrative password has been lost, and it is meant to be used briefly with networking disabled. Left in an option file, it survives every restart and turns the database into an unauthenticated service. Because the resource reports an option written with no value as enabled, a bare `skip_grant_tables` line is detected as well as an explicit `ON`.
+
+        **Why this matters**
+
+        - **Access control is switched off:** No password is required and no privilege is checked.
+        - **Recovery settings must not persist:** A recovery option left in place becomes a permanent bypass.
+        - **A bare flag counts:** The option is enabled by its presence alone, without a value.
+
+        **Risk mitigation**
+
+        - **Prevents unauthenticated full access:** Nobody reaching the server obtains administrative control without a credential.
+        - **Blocks credential exfiltration:** The privilege tables cannot be read and cracked offline.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm the privilege system is active on a running server:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'skip_grant_tables';"
+        ```
+
+        2. Search every option file for the option, including include fragments:
+
+        ```bash
+        sudo grep -rniE "^\s*skip[-_]grant[-_]tables" /etc/mysql/ /etc/my.cnf /etc/my.cnf.d/ 2>/dev/null
+        ```
+
+        A passing result reports `OFF` and finds no matching line. A failing result reports `ON`, or finds the option written as a bare flag.
+      remediation:
+        - id: cli
+          desc: |
+            To restore the privilege system using the CLI:
+
+            1. Remove the option from every option file that declares it.
+            2. Restart MariaDB so the privilege system is loaded.
+            3. Confirm the option is off.
+
+            ```bash
+            sudo sed -i -E "/^\s*skip[-_]grant[-_]tables/d" /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'skip_grant_tables';"
+            ```
+        - id: script
+          desc: |
+            To restore the privilege system using a bash script:
+
+            1. Remove the option from the main file and every include fragment.
+            2. Restart MariaDB.
+            3. Fail if the option survives anywhere.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            for dir in /etc/mysql /etc/my.cnf.d; do
+              [ -d "$dir" ] || continue
+              find "$dir" -type f -name "*.cnf" -exec \
+                sed -i -E "/^[[:space:]]*skip[-_]grant[-_]tables/d" {} +
+            done
+
+            if [ -f /etc/my.cnf ]; then
+              sed -i -E "/^[[:space:]]*skip[-_]grant[-_]tables/d" /etc/my.cnf
+            fi
+
+            systemctl restart mariadb
+
+            state=$(mariadb -N -B -e "SELECT @@skip_grant_tables;")
+            if [ "$state" != "0" ] && [ "$state" != "OFF" ]; then
+              echo "privilege system still disabled" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To restore the privilege system using Ansible:
+
+            1. Remove the option from every option file.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Restore the MariaDB privilege system
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find option files
+                  ansible.builtin.find:
+                    paths:
+                      - /etc/mysql
+                      - /etc/my.cnf.d
+                    patterns: "*.cnf"
+                    recurse: true
+                  register: option_files
+                  failed_when: false
+
+                - name: Remove skip_grant_tables
+                  ansible.builtin.lineinfile:
+                    path: "{{ item.path }}"
+                    regexp: '^\s*skip[-_]grant[-_]tables'
+                    state: absent
+                  loop: "{{ option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-simple-password-check-plugin-loaded
+    title: Ensure the simple_password_check plugin is loaded at startup
+    impact: 70
+    mql: |
+      mariadb.conf.pluginLoad.any(_ == /simple_password_check/)
+    docs:
+      desc: |
+        This check ensures that `simple_password_check` is named in `plugin_load` or `plugin_load_add` so password strength rules are enforced from the moment the server starts. MariaDB accepts any password without this plugin, including single characters and the account name itself.
+
+        Loading the plugin at runtime instead leaves a window after every restart during which any password is accepted, and a runtime installation is easy to lose during a host rebuild. The length and composition options in this group have no effect until the plugin is loaded.
+
+        **Why this matters**
+
+        - **Rules apply from startup:** There is no interval after a restart where weak passwords are accepted.
+        - **Survives host rebuilds:** The requirement lives in configuration rather than in server state.
+        - **Prerequisite for the policy options:** Length and composition minimums depend on it.
+
+        **Risk mitigation**
+
+        - **Blocks trivial passwords:** Short and simple strings are rejected at the point an account is created.
+        - **Closes the post-restart gap:** Accounts cannot be created with weak passwords immediately after a restart.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm the plugin is active:
+
+        ```bash
+        sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE 'simple_password%';"
+        ```
+
+        2. Confirm the resulting policy variables are present:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+        ```
+
+        A passing result shows the plugin `ACTIVE` and the policy variables present. A failing result returns no rows, meaning no password rules are enforced.
+      remediation:
+        - id: cli
+          desc: |
+            To load password validation at startup using the CLI:
+
+            1. Install the plugin so it is registered with the server.
+            2. Add it to the option file so it loads on every start.
+            3. Restart MariaDB and confirm the policy variables appear.
+
+            ```bash
+            sudo mariadb -e "INSTALL SONAME 'simple_password_check';"
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            plugin_load_add = simple_password_check.so
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+            ```
+        - id: script
+          desc: |
+            To load password validation at startup using a bash script:
+
+            1. Install the plugin when it is not already active.
+            2. Add the load option when it is absent.
+            3. Restart MariaDB and confirm the policy variables are present.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            active=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE 'simple_password%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$active" -eq 0 ]; then
+              mariadb -e "INSTALL SONAME 'simple_password_check';"
+            fi
+
+            if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*simple_password_check" "$MYCNF"; then
+              printf "plugin_load_add = simple_password_check.so\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+            ```
+        - id: ansible
+          desc: |
+            To load password validation at startup using Ansible:
+
+            1. Install the plugin.
+            2. Add the load option to the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Load MariaDB password validation at startup
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Install the simple_password_check plugin
+                  ansible.builtin.command:
+                    cmd: mariadb -e "INSTALL SONAME 'simple_password_check';"
+                  register: install_plugin
+                  changed_when: install_plugin.rc == 0
+                  failed_when: >-
+                    install_plugin.rc != 0 and
+                    'already' not in install_plugin.stderr
+
+                - name: Load the plugin on every start
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: plugin_load_add
+                    value: simple_password_check.so
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-simple-password-check-length-sufficient
+    title: Ensure simple_password_check_minimal_length is at least 14
+    impact: 65
+    mql: |
+      mariadb.conf.simplePasswordCheckMinimalLength >= 14
+    docs:
+      desc: |
+        This check ensures that `simple_password_check_minimal_length` requires at least 14 characters. The plugin defaults this to 8, which is short enough that a stolen hash can be recovered by exhaustive search on commodity hardware.
+
+        Length contributes more to resistance against offline cracking than composition rules do, because each additional character multiplies the search space. The resource reports 0 when the option is unset, so an unset value fails this check and prompts an explicit minimum to be configured.
+
+        **Why this matters**
+
+        - **Exponential cost growth:** Each additional character multiplies the work an attacker must do.
+        - **Outlasts hardware gains:** A 14 character minimum remains defensible as cracking speeds increase.
+        - **Explicit rather than inherited:** The minimum is visible in configuration rather than left at a short default.
+
+        **Risk mitigation**
+
+        - **Defeats exhaustive search:** Full keyspace attacks against a stolen hash become impractical.
+        - **Limits credential stuffing success:** Longer passwords are less likely to appear in breach corpora.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective minimum length:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check_minimal_length';"
+        ```
+
+        2. Confirm the minimum is enforced by attempting a short password on a test account:
+
+        ```bash
+        sudo mariadb -e "CREATE USER 'pwtest'@'localhost' IDENTIFIED BY 'Short1!';" 2>&1 | head -n 2
+        ```
+
+        A passing result reports 14 or greater. A failing result reports a smaller number such as 8, or returns no row because the plugin is not loaded.
+      remediation:
+        - id: cli
+          desc: |
+            To raise the minimum password length using the CLI:
+
+            1. Set the option in the server option file.
+            2. Restart MariaDB.
+            3. Confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*simple_password_check_minimal_length.*/simple_password_check_minimal_length = 14/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check_minimal_length';"
+            ```
+        - id: script
+          desc: |
+            To raise the minimum password length using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            MIN_LENGTH=14
+
+            if grep -qE "^\s*simple_password_check_minimal_length" "$MYCNF"; then
+              sed -i "s|^\s*simple_password_check_minimal_length.*|simple_password_check_minimal_length = ${MIN_LENGTH}|" "$MYCNF"
+            else
+              printf "simple_password_check_minimal_length = %s\n" "$MIN_LENGTH" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'simple_password_check_minimal_length';"
+            ```
+        - id: ansible
+          desc: |
+            To raise the minimum password length using Ansible:
+
+            1. Set the option in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Raise the MariaDB minimum password length
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_password_min_length: 14
+              tasks:
+                - name: Set simple_password_check_minimal_length
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: simple_password_check_minimal_length
+                    value: "{{ mariadb_password_min_length }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-simple-password-check-composition-required
+    title: Ensure simple_password_check requires mixed character classes
+    impact: 60
+    mql: |
+      mariadb.conf.simplePasswordCheckDigits >= 1
+      mariadb.conf.simplePasswordCheckLetters >= 1
+      mariadb.conf.simplePasswordCheckOtherCharacters >= 1
+    docs:
+      desc: |
+        This check ensures that the `simple_password_check` plugin requires at least one digit, at least one letter of each case, and at least one non-alphanumeric character. Setting any of these to 0 removes that class from the requirement, so a password made entirely of lowercase letters can satisfy the policy on length alone.
+
+        The three options are evaluated together because each covers a different part of the character space. All three must be at least 1 for the composition requirement to be meaningful, and the resource reports 0 for any option left unset.
+
+        **Why this matters**
+
+        - **Larger effective character set:** Requiring several classes multiplies the search space for any given length.
+        - **Rejects patterned passwords:** All-letter or all-digit passwords fail the requirement.
+        - **Each class covers a gap:** Digits, letter case, and symbols each expand a different part of the keyspace.
+
+        **Risk mitigation**
+
+        - **Defeats dictionary attacks:** Plain words and their simple mutations are rejected.
+        - **Slows offline cracking:** A stolen hash takes substantially longer to recover.
+      audit: |
+        ### Audit via CLI
+
+        1. Read all three effective values:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+        ```
+
+        2. Confirm the composition requirement is enforced:
+
+        ```bash
+        sudo mariadb -e "CREATE USER 'pwtest'@'localhost' IDENTIFIED BY 'alllowercaseletters';" 2>&1 | head -n 2
+        ```
+
+        A passing result reports 1 or greater for digits, letters, and other characters. A failing result reports 0 for any of them, or returns no rows because the plugin is not loaded.
+      remediation:
+        - id: cli
+          desc: |
+            To require mixed character classes using the CLI:
+
+            1. Set all three options in the server option file.
+            2. Restart MariaDB.
+            3. Confirm the effective values.
+
+            ```bash
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            simple_password_check_digits            = 2
+            simple_password_check_letters_same_case = 2
+            simple_password_check_other_characters  = 2
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+            ```
+        - id: script
+          desc: |
+            To require mixed character classes using a bash script:
+
+            1. Set each option, replacing any existing value.
+            2. Restart MariaDB and report the effective values.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            set_option() {
+              local key="$1" value="$2"
+              if grep -qE "^\s*${key}\b" "$MYCNF"; then
+                sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
+              else
+                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+              fi
+            }
+
+            set_option simple_password_check_digits 2
+            set_option simple_password_check_letters_same_case 2
+            set_option simple_password_check_other_characters 2
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'simple_password_check%';"
+            ```
+        - id: ansible
+          desc: |
+            To require mixed character classes using Ansible:
+
+            1. Set all three options in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Require mixed character classes in MariaDB passwords
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set the composition options
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: "{{ item.option }}"
+                    value: "{{ item.value }}"
+                    mode: "0640"
+                  loop:
+                    - { option: "simple_password_check_digits", value: "2" }
+                    - { option: "simple_password_check_letters_same_case", value: "2" }
+                    - { option: "simple_password_check_other_characters", value: "2" }
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-password-reuse-check-configured
+    title: Ensure password_reuse_check_interval prevents password reuse
+    impact: 55
+    mql: |
+      mariadb.conf.passwordReuseCheckInterval > 0
+    docs:
+      desc: |
+        This check ensures that `password_reuse_check_interval` sets a number of days during which a previous password cannot be reused. The option comes from the `password_reuse_check` plugin and defaults to 0, which means an account prompted to change its password can set it back to the value it just replaced.
+
+        Without an interval, rotation produces no new secret. An account can alternate between two familiar passwords indefinitely, so a credential that leaked once stays in circulation.
+
+        **Why this matters**
+
+        - **Rotation becomes meaningful:** A forced change produces a genuinely new credential.
+        - **Defeats alternation:** Accounts cannot cycle between two familiar passwords.
+        - **Bounded history:** The interval defines how far back the server remembers.
+
+        **Risk mitigation**
+
+        - **Prevents restoring a leaked password:** A credential known to an attacker cannot be reinstated.
+        - **Makes expiry effective:** Rotation cannot be satisfied without changing the secret.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm the plugin is active and read the interval:
+
+        ```bash
+        sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE 'password_reuse%';"
+        sudo mariadb -e "SHOW VARIABLES LIKE 'password_reuse_check_interval';"
+        ```
+
+        2. Confirm history is being recorded:
+
+        ```bash
+        sudo mariadb -e "SELECT count(*) FROM mysql.password_reuse_check_history;"
+        ```
+
+        A passing result reports a positive number of days. A failing result reports 0, or returns no row because the plugin is not loaded.
+      remediation:
+        - id: cli
+          desc: |
+            To prevent password reuse using the CLI:
+
+            1. Install the plugin and add it to the option file so it loads on every start.
+            2. Set the interval.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "INSTALL SONAME 'password_reuse_check';"
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            plugin_load_add               = password_reuse_check.so
+            password_reuse_check_interval = 365
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'password_reuse_check_interval';"
+            ```
+        - id: script
+          desc: |
+            To prevent password reuse using a bash script:
+
+            1. Install the plugin when it is not already active.
+            2. Set the load option and the interval.
+            3. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            INTERVAL=365
+
+            active=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE 'password_reuse%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$active" -eq 0 ]; then
+              mariadb -e "INSTALL SONAME 'password_reuse_check';"
+            fi
+
+            if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*password_reuse_check" "$MYCNF"; then
+              printf "plugin_load_add = password_reuse_check.so\n" >>"$MYCNF"
+            fi
+
+            if grep -qE "^\s*password_reuse_check_interval" "$MYCNF"; then
+              sed -i "s|^\s*password_reuse_check_interval.*|password_reuse_check_interval = ${INTERVAL}|" "$MYCNF"
+            else
+              printf "password_reuse_check_interval = %s\n" "$INTERVAL" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'password_reuse_check_interval';"
+            ```
+        - id: ansible
+          desc: |
+            To prevent password reuse using Ansible:
+
+            1. Install the plugin.
+            2. Set the load option and the interval in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Prevent MariaDB password reuse
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_password_reuse_interval: 365
+              tasks:
+                - name: Install the password_reuse_check plugin
+                  ansible.builtin.command:
+                    cmd: mariadb -e "INSTALL SONAME 'password_reuse_check';"
+                  register: install_plugin
+                  changed_when: install_plugin.rc == 0
+                  failed_when: >-
+                    install_plugin.rc != 0 and
+                    'already' not in install_plugin.stderr
+
+                - name: Configure the plugin and interval
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: "{{ item.option }}"
+                    value: "{{ item.value }}"
+                    mode: "0640"
+                  loop:
+                    - { option: "plugin_load_add", value: "password_reuse_check.so" }
+                    - { option: "password_reuse_check_interval", value: "{{ mariadb_password_reuse_interval }}" }
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-runs-as-dedicated-account
+    title: Ensure the server does not run as the root account
+    impact: 85
+    mql: |
+      mariadb.conf.serverOptions["user"] != empty && mariadb.conf.serverOptions["user"].downcase != "root"
+    docs:
+      desc: |
+        This check ensures that the `user` option names a dedicated unprivileged account rather than `root`. The account named here is the identity the server drops to after binding its port, and it is the identity every file operation the server performs runs under.
+
+        A server running as `root` turns any file write primitive into full host compromise. MariaDB exposes several such primitives to sufficiently privileged accounts, including `SELECT ... INTO OUTFILE` and user-defined function libraries, so the account boundary is what keeps a database compromise from becoming a host compromise. The check also fails when the option is unset, because the server then keeps the identity of whichever account started it.
+
+        **Why this matters**
+
+        - **Blast radius containment:** File writes are limited to what the database account can reach.
+        - **Data directory ownership is meaningful:** Files are owned by an account that owns nothing else.
+        - **Explicit rather than inherited:** Naming the account means the identity does not depend on how the service was started.
+
+        **Risk mitigation**
+
+        - **Prevents privilege escalation to the host:** A file write primitive cannot overwrite system files or authorized keys.
+        - **Limits damage from a UDF loaded by an attacker:** Library code executes without host administrative rights.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the account the server is configured to use:
+
+        ```bash
+        sudo grep -rniE "^\s*user\s*=" /etc/mysql/ /etc/my.cnf 2>/dev/null
+        ```
+
+        2. Confirm the identity the running process actually holds:
+
+        ```bash
+        ps -o user= -C mariadbd
+        ```
+
+        3. Confirm the data directory is owned by that account:
+
+        ```bash
+        sudo ls -ld "$(sudo mariadb -N -B -e 'SELECT @@datadir;')"
+        ```
+
+        A passing result names a dedicated account such as `mysql`, and the process runs as that account. A failing result names `root`, leaves the option unset, or shows the process running as `root`.
+      remediation:
+        - id: cli
+          desc: |
+            To run the server as a dedicated account using the CLI:
+
+            1. Create the account when it does not exist.
+            2. Transfer ownership of the data directory and log directory to it.
+            3. Set the `user` option, restart the server, and confirm the running identity.
+
+            ```bash
+            sudo useradd --system --no-create-home --shell /usr/sbin/nologin mysql || true
+            sudo chown -R mysql:mysql /var/lib/mysql /var/log/mysql
+            sudo sed -i "s/^#*\s*user\s*=.*/user = mysql/" /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            ps -o user= -C mariadbd
+            ```
+        - id: script
+          desc: |
+            To run the server as a dedicated account using a bash script:
+
+            1. Create the account when it is missing.
+            2. Transfer ownership of the data directory reported by the server.
+            3. Set the option, restart, and fail if the process still runs as root.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            ACCOUNT="mysql"
+
+            if ! id "$ACCOUNT" >/dev/null 2>&1; then
+              useradd --system --no-create-home --shell /usr/sbin/nologin "$ACCOUNT"
+            fi
+
+            datadir=$(mariadb -N -B -e "SELECT @@datadir;")
+            chown -R "${ACCOUNT}:${ACCOUNT}" "$datadir"
+
+            if grep -qE "^\s*user\s*=" "$MYCNF"; then
+              sed -i "s|^\s*user\s*=.*|user = ${ACCOUNT}|" "$MYCNF"
+            else
+              printf "user = %s\n" "$ACCOUNT" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            running_as=$(ps -o user= -C mariadbd | tr -d ' ' | head -n1)
+            if [ "$running_as" = "root" ]; then
+              echo "mariadbd is still running as root" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To run the server as a dedicated account using Ansible:
+
+            1. Create the dedicated account.
+            2. Transfer ownership of the data directory.
+            3. Set the `user` option and restart the server.
+
+            ```yaml
+            - name: Run MariaDB as a dedicated account
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_account: mysql
+                mariadb_datadir: /var/lib/mysql
+              tasks:
+                - name: Create the dedicated account
+                  ansible.builtin.user:
+                    name: "{{ mariadb_account }}"
+                    system: true
+                    create_home: false
+                    shell: /usr/sbin/nologin
+
+                - name: Own the data directory
+                  ansible.builtin.file:
+                    path: "{{ mariadb_datadir }}"
+                    owner: "{{ mariadb_account }}"
+                    group: "{{ mariadb_account }}"
+                    recurse: true
+
+                - name: Set the user option
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: user
+                    value: "{{ mariadb_account }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-local-infile-disabled
+    title: Ensure local_infile is disabled
+    impact: 80
+    mql: |
+      mariadb.conf.localInfile == false
+    docs:
+      desc: |
+        This check ensures that `local_infile` is disabled so the server does not accept `LOAD DATA LOCAL INFILE` statements. That statement makes the server ask the connecting client to send the contents of a file from the client's own filesystem.
+
+        The direction of that transfer is what makes the option dangerous. A malicious or compromised server, or an attacker who can inject a statement into an application's connection, can request any file the client process can read, including application configuration holding credentials. The read happens on the client, so no privilege on the server is required.
+
+        **Why this matters**
+
+        - **Clients stop honoring file requests:** The server never asks a client to upload local files.
+        - **No server privilege is needed to abuse it:** Disabling the feature is the control, not restricting grants.
+        - **Bulk loading has safer alternatives:** Server-side `LOAD DATA INFILE` confined by `secure_file_priv` covers legitimate use.
+
+        **Risk mitigation**
+
+        - **Prevents client-side file disclosure:** An injected statement cannot exfiltrate files from application hosts.
+        - **Blocks a credential theft path:** Application configuration files cannot be read through the database connection.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'local_infile';"
+        ```
+
+        2. Confirm the statement is refused:
+
+        ```bash
+        sudo mariadb -e "LOAD DATA LOCAL INFILE '/etc/hostname' INTO TABLE mysql.help_topic;" 2>&1 | head -n 2
+        ```
+
+        A passing result reports `OFF` and the statement is rejected. A failing result reports `ON`.
+      remediation:
+        - id: cli
+          desc: |
+            To disable local file loading using the CLI:
+
+            1. Confirm no bulk load job depends on the client-side form.
+            2. Set `local_infile` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*local[-_]infile.*/local_infile = OFF/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'local_infile';"
+            ```
+        - id: script
+          desc: |
+            To disable local file loading using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            if grep -qE "^\s*local[-_]infile" "$MYCNF"; then
+              sed -i "s|^\s*local[-_]infile.*|local_infile = OFF|" "$MYCNF"
+            else
+              printf "local_infile = OFF\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'local_infile';"
+            ```
+        - id: ansible
+          desc: |
+            To disable local file loading using Ansible:
+
+            1. Set `local_infile` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Disable MariaDB client-side file loading
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set local_infile
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: local_infile
+                    value: "OFF"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-secure-file-priv-restricted
+    title: Ensure secure_file_priv confines server-side file access
+    impact: 80
+    mql: |
+      mariadb.conf.secureFilePriv != empty
+    docs:
+      desc: |
+        This check ensures that `secure_file_priv` is not set to an empty value. An empty value removes the restriction entirely, which lets `LOAD DATA INFILE` read and `SELECT ... INTO OUTFILE` write anywhere on the filesystem the server account can reach.
+
+        Set to a directory, the option confines both statements to that directory. Set to `NULL`, it disables the statements outright, which is the strongest setting where no bulk file exchange is needed. Either satisfies this check; only an empty value fails it.
+
+        **Why this matters**
+
+        - **File access is confined:** Reads and writes are limited to a directory you designate.
+        - **Sensitive files are unreachable:** Server configuration and key material fall outside the permitted path.
+        - **NULL is available:** Servers with no bulk load requirement can disable the statements completely.
+
+        **Risk mitigation**
+
+        - **Blocks arbitrary file read:** An attacker with `FILE` privilege cannot read files outside the directory.
+        - **Prevents arbitrary file write:** Writing a web shell or a cron entry through the database is not possible.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'secure_file_priv';"
+        ```
+
+        2. Identify accounts holding the privilege the option constrains:
+
+        ```bash
+        sudo mariadb -e "SELECT user, host FROM mysql.user WHERE File_priv = 'Y';"
+        ```
+
+        A passing result reports a directory path or `NULL`. A failing result reports an empty value, meaning file statements are unrestricted.
+      remediation:
+        - id: cli
+          desc: |
+            To confine server-side file access using the CLI:
+
+            1. Create a directory owned by the server account for file exchange, or choose `NULL` to disable the statements.
+            2. Set `secure_file_priv` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo install -d -o mysql -g mysql -m 0750 /var/lib/mysql-files
+            sudo sed -i "s|^#*\s*secure[-_]file[-_]priv.*|secure_file_priv = /var/lib/mysql-files|" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'secure_file_priv';"
+            ```
+        - id: script
+          desc: |
+            To confine server-side file access using a bash script:
+
+            1. Create the exchange directory with restrictive ownership.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and fail if the value is still empty.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            FILE_DIR="/var/lib/mysql-files"
+
+            install -d -o mysql -g mysql -m 0750 "$FILE_DIR"
+
+            if grep -qE "^\s*secure[-_]file[-_]priv" "$MYCNF"; then
+              sed -i "s|^\s*secure[-_]file[-_]priv.*|secure_file_priv = ${FILE_DIR}|" "$MYCNF"
+            else
+              printf "secure_file_priv = %s\n" "$FILE_DIR" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            value=$(mariadb -N -B -e "SELECT @@secure_file_priv;")
+            if [ -z "$value" ]; then
+              echo "secure_file_priv is still unrestricted" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To confine server-side file access using Ansible:
+
+            1. Create the exchange directory owned by the server account.
+            2. Set `secure_file_priv` in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Confine MariaDB server-side file access
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_file_dir: /var/lib/mysql-files
+              tasks:
+                - name: Create the file exchange directory
+                  ansible.builtin.file:
+                    path: "{{ mariadb_file_dir }}"
+                    state: directory
+                    owner: mysql
+                    group: mysql
+                    mode: "0750"
+
+                - name: Set secure_file_priv
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: secure_file_priv
+                    value: "{{ mariadb_file_dir }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-symbolic-links-disabled
+    title: Ensure symbolic_links is disabled
+    impact: 70
+    mql: |
+      mariadb.conf.symbolicLinks == false
+    docs:
+      desc: |
+        This check ensures that `symbolic_links` is disabled so table files cannot be redirected outside the data directory. With the feature enabled, a table's data file may be a symbolic link pointing anywhere the server account can write.
+
+        That breaks the assumption that the data directory bounds where the server reads and writes. An account able to create a table with a `DATA DIRECTORY` clause, or an attacker who can place a link inside the data directory, can cause the server to write through it to a path of their choosing.
+
+        **Why this matters**
+
+        - **The data directory becomes a real boundary:** Table storage stays inside the directory the server owns.
+        - **Backups and snapshots stay complete:** Tools that copy the data directory capture everything.
+        - **Removes an indirection:** File paths cannot be redirected after a table is created.
+
+        **Risk mitigation**
+
+        - **Prevents writes outside the data directory:** A symbolic link cannot be used to overwrite unrelated files.
+        - **Blocks a privilege escalation path:** Table creation cannot be turned into an arbitrary file write.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'have_symlink';"
+        ```
+
+        2. Look for existing links inside the data directory:
+
+        ```bash
+        sudo find "$(sudo mariadb -N -B -e 'SELECT @@datadir;')" -type l -ls
+        ```
+
+        A passing result reports `DISABLED` and finds no links. A failing result reports `YES`, and any link found should be investigated before the option is changed.
+      remediation:
+        - id: cli
+          desc: |
+            To disable symbolic link support using the CLI:
+
+            1. Confirm no table currently relies on a link, because those tables become unreadable.
+            2. Set `symbolic_links` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo find "$(sudo mariadb -N -B -e 'SELECT @@datadir;')" -type l -ls
+            sudo sed -i "s/^#*\s*symbolic[-_]links.*/symbolic_links = OFF/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'have_symlink';"
+            ```
+        - id: script
+          desc: |
+            To disable symbolic link support using a bash script:
+
+            1. Refuse to proceed while links exist in the data directory.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            datadir=$(mariadb -N -B -e "SELECT @@datadir;")
+            links=$(find "$datadir" -type l -print)
+
+            if [ -n "$links" ]; then
+              echo "symbolic links present in the data directory; relocate these tables first:" >&2
+              printf '%s\n' "$links" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*symbolic[-_]links" "$MYCNF"; then
+              sed -i "s|^\s*symbolic[-_]links.*|symbolic_links = OFF|" "$MYCNF"
+            else
+              printf "symbolic_links = OFF\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To disable symbolic link support using Ansible:
+
+            1. Set `symbolic_links` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Disable MariaDB symbolic link support
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set symbolic_links
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: symbolic_links
+                    value: "OFF"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-allow-suspicious-udfs-disabled
+    title: Ensure allow_suspicious_udfs is disabled
+    impact: 80
+    mql: |
+      mariadb.conf.allowSuspiciousUdfs == false
+    docs:
+      desc: |
+        This check ensures that `allow_suspicious_udfs` is disabled. The option controls whether the server accepts a user-defined function library that exports only the main function symbol, without the auxiliary initialization and deinitialization symbols a legitimate UDF provides.
+
+        A library exporting only that one symbol is characteristic of a shared object that was not written as a MariaDB UDF at all, which is exactly the shape of a library repurposed to gain code execution inside the server process. Refusing such libraries removes a well-established post-exploitation technique.
+
+        **Why this matters**
+
+        - **Libraries must look like real UDFs:** The server rejects shared objects that lack the expected symbols.
+        - **Code runs in the server process:** A loaded library executes with the server account's full access.
+        - **Legitimate UDFs are unaffected:** Properly written functions export the required symbols.
+
+        **Risk mitigation**
+
+        - **Blocks a code execution technique:** An attacker with `INSERT` on `mysql.func` cannot load an arbitrary shared object.
+        - **Raises the bar after compromise:** Turning database access into host code execution requires more work.
+      audit: |
+        ### Audit via CLI
+
+        1. Search the option files for the option:
+
+        ```bash
+        sudo grep -rniE "^\s*allow[-_]suspicious[-_]udfs" /etc/mysql/ /etc/my.cnf /etc/my.cnf.d/ 2>/dev/null
+        ```
+
+        2. Review the functions currently registered and the plugin directory they load from:
+
+        ```bash
+        sudo mariadb -e "SELECT * FROM mysql.func;"
+        sudo ls -l "$(sudo mariadb -N -B -e 'SELECT @@plugin_dir;')"
+        ```
+
+        A passing result finds no matching line and shows only expected functions. A failing result finds the option enabled, in which case the registered functions and the plugin directory contents should be reviewed for unexpected libraries.
+      remediation:
+        - id: cli
+          desc: |
+            To reject suspicious function libraries using the CLI:
+
+            1. Remove the option from every option file that declares it.
+            2. Review the registered functions for anything unexpected.
+            3. Restart MariaDB.
+
+            ```bash
+            sudo sed -i -E "/^\s*allow[-_]suspicious[-_]udfs/d" /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo mariadb -e "SELECT * FROM mysql.func;"
+            sudo systemctl restart mariadb
+            ```
+        - id: script
+          desc: |
+            To reject suspicious function libraries using a bash script:
+
+            1. Remove the option from the main file and every include fragment.
+            2. Report the registered functions so unexpected entries are visible.
+            3. Restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            for dir in /etc/mysql /etc/my.cnf.d; do
+              [ -d "$dir" ] || continue
+              find "$dir" -type f -name "*.cnf" -exec \
+                sed -i -E "/^[[:space:]]*allow[-_]suspicious[-_]udfs/d" {} +
+            done
+
+            if [ -f /etc/my.cnf ]; then
+              sed -i -E "/^[[:space:]]*allow[-_]suspicious[-_]udfs/d" /etc/my.cnf
+            fi
+
+            echo "registered user-defined functions:"
+            mariadb -N -B -e "SELECT name, dl FROM mysql.func;"
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To reject suspicious function libraries using Ansible:
+
+            1. Remove the option from every option file.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Reject suspicious MariaDB function libraries
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find option files
+                  ansible.builtin.find:
+                    paths:
+                      - /etc/mysql
+                      - /etc/my.cnf.d
+                    patterns: "*.cnf"
+                    recurse: true
+                  register: option_files
+                  failed_when: false
+
+                - name: Remove allow_suspicious_udfs
+                  ansible.builtin.lineinfile:
+                    path: "{{ item.path }}"
+                    regexp: '^\s*allow[-_]suspicious[-_]udfs'
+                    state: absent
+                  loop: "{{ option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-log-bin-trust-function-creators-disabled
+    title: Ensure log_bin_trust_function_creators is disabled
+    impact: 70
+    mql: |
+      mariadb.conf.logBinTrustFunctionCreators == false
+    docs:
+      desc: |
+        This check ensures that `log_bin_trust_function_creators` is disabled so creating a stored function requires the `SUPER` privilege in addition to `CREATE ROUTINE` when binary logging is active. Enabling the option removes that additional requirement.
+
+        The safety check exists because stored functions can be nondeterministic, which makes statement-based replication diverge between a primary and its replicas. Its security value is that it keeps routine creation, a form of persistent server-side code, behind a privilege that is granted sparingly.
+
+        **Why this matters**
+
+        - **Routine creation stays privileged:** Adding server-side code requires more than routine-level grants.
+        - **Replication consistency is preserved:** Nondeterministic routines cannot silently diverge replicas.
+        - **Fewer accounts can persist code:** The set of accounts able to install a routine stays small.
+
+        **Risk mitigation**
+
+        - **Limits persistence mechanisms:** A compromised application account cannot install a routine to maintain access.
+        - **Prevents replica divergence:** An attacker cannot use a nondeterministic routine to corrupt replicas.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'log_bin_trust_function_creators';"
+        ```
+
+        2. Review the routines that exist and who defined them:
+
+        ```bash
+        sudo mariadb -e "SELECT db, name, type, definer FROM mysql.proc;"
+        ```
+
+        A passing result reports `OFF`. A failing result reports `ON`, and the routine list should be reviewed for definers that are not administrative accounts.
+      remediation:
+        - id: cli
+          desc: |
+            To restore the routine creation safety check using the CLI:
+
+            1. Confirm no deployment process depends on creating routines without `SUPER`.
+            2. Set the option in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*log[-_]bin[-_]trust[-_]function[-_]creators.*/log_bin_trust_function_creators = OFF/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'log_bin_trust_function_creators';"
+            ```
+        - id: script
+          desc: |
+            To restore the routine creation safety check using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            if grep -qE "^\s*log[-_]bin[-_]trust[-_]function[-_]creators" "$MYCNF"; then
+              sed -i "s|^\s*log[-_]bin[-_]trust[-_]function[-_]creators.*|log_bin_trust_function_creators = OFF|" "$MYCNF"
+            else
+              printf "log_bin_trust_function_creators = OFF\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'log_bin_trust_function_creators';"
+            ```
+        - id: ansible
+          desc: |
+            To restore the routine creation safety check using Ansible:
+
+            1. Set `log_bin_trust_function_creators` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Restore the MariaDB routine creation safety check
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set log_bin_trust_function_creators
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: log_bin_trust_function_creators
+                    value: "OFF"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-automatic-sp-privileges-disabled
+    title: Ensure automatic_sp_privileges is disabled
+    impact: 60
+    mql: |
+      mariadb.conf.automaticSpPrivileges == false
+    docs:
+      desc: |
+        This check ensures that `automatic_sp_privileges` is disabled so creating a stored routine does not automatically grant its creator `EXECUTE` and `ALTER ROUTINE` on it. The option is enabled by default, which means routine privileges appear without anyone granting them.
+
+        Automatic grants make the privilege model harder to reason about, because the grants recorded for an account no longer reflect only deliberate decisions. Disabling the option means every routine privilege is explicit and reviewable.
+
+        **Why this matters**
+
+        - **Privileges stay deliberate:** Every grant appears because someone issued it.
+        - **Reviews are meaningful:** The grant tables reflect intended access rather than side effects.
+        - **Separation of duties:** Creating a routine and being able to execute it can be split between accounts.
+
+        **Risk mitigation**
+
+        - **Prevents unintended privilege accumulation:** An account does not gain execute rights simply by creating routines.
+        - **Makes privilege audits reliable:** Unexpected routine access is visible rather than explained away as automatic.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'automatic_sp_privileges';"
+        ```
+
+        2. Review the routine-level grants that currently exist:
+
+        ```bash
+        sudo mariadb -e "SELECT user, host, db, routine_name, proc_priv FROM mysql.procs_priv;"
+        ```
+
+        A passing result reports `OFF`. A failing result reports `ON`, meaning routine creators receive privileges automatically.
+      remediation:
+        - id: cli
+          desc: |
+            To require explicit routine privileges using the CLI:
+
+            1. Grant `EXECUTE` explicitly to the accounts that need to call existing routines.
+            2. Set `automatic_sp_privileges` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "GRANT EXECUTE ON PROCEDURE appdb.sync_orders TO 'app'@'10.0.0.%';"
+            sudo sed -i "s/^#*\s*automatic[-_]sp[-_]privileges.*/automatic_sp_privileges = OFF/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'automatic_sp_privileges';"
+            ```
+        - id: script
+          desc: |
+            To require explicit routine privileges using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the existing routine grants for review.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            if grep -qE "^\s*automatic[-_]sp[-_]privileges" "$MYCNF"; then
+              sed -i "s|^\s*automatic[-_]sp[-_]privileges.*|automatic_sp_privileges = OFF|" "$MYCNF"
+            else
+              printf "automatic_sp_privileges = OFF\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            echo "existing routine-level grants:"
+            mariadb -N -B -e "SELECT concat(user,'@',host), db, routine_name, proc_priv FROM mysql.procs_priv;"
+            ```
+        - id: ansible
+          desc: |
+            To require explicit routine privileges using Ansible:
+
+            1. Set `automatic_sp_privileges` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Require explicit MariaDB routine privileges
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set automatic_sp_privileges
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: automatic_sp_privileges
+                    value: "OFF"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-error-log-configured
+    title: Ensure log_error names a dedicated error log destination
+    impact: 70
+    mql: |
+      mariadb.conf.logError != empty
+    docs:
+      desc: |
+        This check ensures that `log_error` names a destination for the error log. When the option is empty, the server writes diagnostics to its standard error stream, where they depend entirely on how the service was started and are frequently discarded.
+
+        The error log records startup and shutdown, failed connection attempts, and plugin load failures. It is the record that shows whether the security settings in this policy actually took effect, and it is usually the first artifact examined during an incident.
+
+        **Why this matters**
+
+        - **Durable diagnostics:** Messages are written to a file that survives a restart.
+        - **Failed authentication is recorded:** Repeated connection failures become visible.
+        - **Confirms configuration took effect:** Plugin load failures are reported rather than silent.
+
+        **Risk mitigation**
+
+        - **Preserves incident evidence:** Authentication failures and errors remain available for investigation.
+        - **Surfaces silent security failures:** A password plugin that failed to load is visible.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective destination:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'log_error';"
+        ```
+
+        2. Confirm the file exists and is being written:
+
+        ```bash
+        sudo ls -l /var/log/mysql/error.log && sudo tail -n 20 /var/log/mysql/error.log
+        ```
+
+        A passing result names a path and shows recent entries. A failing result reports an empty value, meaning diagnostics go to the standard error stream.
+      remediation:
+        - id: cli
+          desc: |
+            To configure a dedicated error log using the CLI:
+
+            1. Create the log directory owned by the server account.
+            2. Set `log_error` in the server option file.
+            3. Restart MariaDB and confirm the destination.
+
+            ```bash
+            sudo install -d -o mysql -g mysql -m 0750 /var/log/mysql
+            sudo sed -i "s|^#*\s*log[-_]error\b.*|log_error = /var/log/mysql/error.log|" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'log_error';"
+            ```
+        - id: script
+          desc: |
+            To configure a dedicated error log using a bash script:
+
+            1. Create the log directory with restrictive ownership.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and fail if the destination is still empty.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            LOG_FILE="/var/log/mysql/error.log"
+
+            install -d -o mysql -g mysql -m 0750 "$(dirname "$LOG_FILE")"
+
+            if grep -qE "^\s*log[-_]error\b" "$MYCNF"; then
+              sed -i "s|^\s*log[-_]error\b.*|log_error = ${LOG_FILE}|" "$MYCNF"
+            else
+              printf "log_error = %s\n" "$LOG_FILE" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            value=$(mariadb -N -B -e "SELECT @@log_error;")
+            if [ -z "$value" ] || [ "$value" = "stderr" ]; then
+              echo "error log destination is still not a file" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To configure a dedicated error log using Ansible:
+
+            1. Create the log directory owned by the server account.
+            2. Set `log_error` in the server option group.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Configure a dedicated MariaDB error log
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_log_dir: /var/log/mysql
+              tasks:
+                - name: Create the log directory
+                  ansible.builtin.file:
+                    path: "{{ mariadb_log_dir }}"
+                    state: directory
+                    owner: mysql
+                    group: mysql
+                    mode: "0750"
+
+                - name: Set log_error
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: log_error
+                    value: "{{ mariadb_log_dir }}/error.log"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-log-warnings-includes-warnings
+    title: Ensure log_warnings records warnings and aborted connections
+    impact: 60
+    mql: |
+      mariadb.conf.logWarnings >= 2
+    docs:
+      desc: |
+        This check ensures that `log_warnings` is at least 2 so aborted connections are recorded in the error log. MariaDB uses a numeric verbosity here rather than the named levels MySQL uses, and at level 1 the messages that report aborted connections and failed authentication attempts are suppressed.
+
+        Level 2 is the threshold at which aborted connection notes appear, which is where most security-relevant signal lives. An attacker probing credentials produces aborted connections rather than errors, so a server at level 1 can be attacked continuously without the error log showing anything.
+
+        **Why this matters**
+
+        - **Failed authentication becomes visible:** Aborted connection notes record unsuccessful attempts.
+        - **Configuration problems surface:** Options the server ignored are reported rather than silently dropped.
+        - **Small volume increase:** Warnings add far less volume than statement logging while carrying most of the signal.
+
+        **Risk mitigation**
+
+        - **Detects credential attacks:** Repeated aborted connections from one address become apparent.
+        - **Reveals ineffective hardening:** An option the server rejected is reported instead of assumed active.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'log_warnings';"
+        ```
+
+        2. Confirm aborted connection notes are present in the log:
+
+        ```bash
+        sudo grep -ciE "aborted connection|access denied" /var/log/mysql/error.log
+        ```
+
+        A passing result reports 2 or greater. A failing result reports 1 or 0, meaning aborted connections are not recorded.
+      remediation:
+        - id: cli
+          desc: |
+            To record warnings in the error log using the CLI:
+
+            1. Set `log_warnings` in the server option file.
+            2. Restart MariaDB.
+            3. Confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*log[-_]warnings.*/log_warnings = 2/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'log_warnings';"
+            ```
+        - id: script
+          desc: |
+            To record warnings in the error log using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            LEVEL=2
+
+            if grep -qE "^\s*log[-_]warnings" "$MYCNF"; then
+              sed -i "s|^\s*log[-_]warnings.*|log_warnings = ${LEVEL}|" "$MYCNF"
+            else
+              printf "log_warnings = %s\n" "$LEVEL" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'log_warnings';"
+            ```
+        - id: ansible
+          desc: |
+            To record warnings in the error log using Ansible:
+
+            1. Set `log_warnings` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Record warnings in the MariaDB error log
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_log_warnings: 2
+              tasks:
+                - name: Set log_warnings
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: log_warnings
+                    value: "{{ mariadb_log_warnings }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-log-output-retained
+    title: Ensure log_output is not set to NONE
+    impact: 60
+    mql: |
+      mariadb.conf.logOutput != empty
+      mariadb.conf.logOutput.none(_.downcase == "none")
+    docs:
+      desc: |
+        This check ensures that `log_output` names a real destination rather than `NONE`. The option controls where the general and slow query logs are written, and setting it to `NONE` discards their contents even while the logs themselves are enabled.
+
+        That combination is misleading during a review, because `slow_query_log` reads as `ON` while nothing is retained anywhere. Naming `FILE` or `TABLE` explicitly means an enabled log actually produces records.
+
+        **Why this matters**
+
+        - **Enabled logs produce output:** A log that is on is written somewhere.
+        - **Removes a misleading configuration:** The log state and the retained data agree.
+        - **Slow query analysis stays possible:** Long-running statements are recorded for review.
+
+        **Risk mitigation**
+
+        - **Prevents silent loss of query records:** Statements are retained rather than discarded.
+        - **Avoids false assurance during audit:** An enabled log cannot appear compliant while retaining nothing.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'log_output';"
+        ```
+
+        2. Confirm the slow query log is producing records:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('slow_query_log','slow_query_log_file');"
+        ```
+
+        A passing result names `FILE`, `TABLE`, or both. A failing result reports `NONE`, or is unset.
+      remediation:
+        - id: cli
+          desc: |
+            To retain query log output using the CLI:
+
+            1. Set `log_output` in the server option file.
+            2. Restart MariaDB.
+            3. Confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*log[-_]output.*/log_output = FILE/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'log_output';"
+            ```
+        - id: script
+          desc: |
+            To retain query log output using a bash script:
+
+            1. Set the option, replacing any existing value.
+            2. Restart MariaDB and fail if the value is still `NONE`.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            if grep -qE "^\s*log[-_]output" "$MYCNF"; then
+              sed -i "s|^\s*log[-_]output.*|log_output = FILE|" "$MYCNF"
+            else
+              printf "log_output = FILE\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            value=$(mariadb -N -B -e "SELECT @@log_output;")
+            if [ "$value" = "NONE" ]; then
+              echo "log output is still discarded" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To retain query log output using Ansible:
+
+            1. Set `log_output` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Retain MariaDB query log output
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set log_output
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: log_output
+                    value: FILE
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-general-log-disabled
+    title: Ensure the general query log is disabled
+    impact: 60
+    mql: |
+      mariadb.conf.generalLog == false
+    docs:
+      desc: |
+        This check ensures that `general_log` is disabled. Unlike the other logging checks in this policy, the secure state here is off, because the general query log records every statement the server receives in cleartext, including the statements that set passwords.
+
+        A `CREATE USER` or `SET PASSWORD` statement is written to the general log with the password in plain text, so an enabled general log turns the log file into a credential store. Use the `server_audit` plugin for a durable record of activity, since it can record connections and queries without capturing password arguments the same way.
+
+        **Why this matters**
+
+        - **Passwords are written in cleartext:** Statements that set a password are recorded verbatim.
+        - **Log readers become credential holders:** Anyone able to read the log obtains those passwords.
+        - **A purpose-built alternative exists:** The `server_audit` plugin records activity for audit retention.
+
+        **Risk mitigation**
+
+        - **Prevents credential disclosure through logs:** Passwords are not persisted to disk in readable form.
+        - **Limits damage from log exfiltration:** A copied log file does not yield working credentials.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('general_log','general_log_file');"
+        ```
+
+        2. When the log is enabled, check whether it already contains credentials:
+
+        ```bash
+        sudo grep -ciE "identified by|set password" "$(sudo mariadb -N -B -e 'SELECT @@general_log_file;')"
+        ```
+
+        A passing result reports `OFF`. A failing result reports `ON`, and any existing log file should be treated as a credential exposure and rotated.
+      remediation:
+        - id: cli
+          desc: |
+            To disable the general query log using the CLI:
+
+            1. Set `general_log` in the server option file.
+            2. Restart MariaDB.
+            3. Remove or rotate any existing general log, because it may contain passwords.
+
+            ```bash
+            sudo sed -i "s/^#*\s*general[-_]log\b.*/general_log = OFF/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo shred -u /var/log/mysql/general.log
+            ```
+        - id: script
+          desc: |
+            To disable the general query log using a bash script:
+
+            1. Capture the current log path before changing the option.
+            2. Set the option and restart MariaDB.
+            3. Securely remove the previous log, since it may hold cleartext passwords.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            log_path=$(mariadb -N -B -e "SELECT @@general_log_file;" 2>/dev/null || true)
+
+            if grep -qE "^\s*general[-_]log\b" "$MYCNF"; then
+              sed -i "s|^\s*general[-_]log\b.*|general_log = OFF|" "$MYCNF"
+            else
+              printf "general_log = OFF\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            if [ -n "$log_path" ] && [ -f "$log_path" ]; then
+              echo "removing previous general log, which may contain cleartext passwords: $log_path"
+              shred -u "$log_path"
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To disable the general query log using Ansible:
+
+            1. Set `general_log` in the server option group.
+            2. Notify a handler that restarts the server.
+            3. Remove any existing general log file.
+
+            ```yaml
+            - name: Disable the MariaDB general query log
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_general_log_file: /var/log/mysql/general.log
+              tasks:
+                - name: Set general_log
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: general_log
+                    value: "OFF"
+                    mode: "0640"
+                  notify: Restart mariadb
+
+                - name: Remove the previous general log
+                  ansible.builtin.file:
+                    path: "{{ mariadb_general_log_file }}"
+                    state: absent
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-server-audit-logging-enabled
+    title: Ensure server_audit_logging is enabled
+    impact: 80
+    mql: |
+      mariadb.conf.serverAuditLogging == true
+    docs:
+      desc: |
+        This check ensures that `server_audit_logging` is enabled so the MariaDB `server_audit` plugin actually writes records. Loading the plugin is not sufficient: with logging off it is installed and idle, which is easy to mistake for working auditing during a review.
+
+        The plugin is the mechanism MariaDB provides for a durable activity record. It captures connections and statements in a consistent format suitable for a log pipeline, and it is the alternative to the general query log, which cannot be used for audit retention because it records passwords in cleartext.
+
+        **Why this matters**
+
+        - **Loaded is not the same as active:** The plugin records nothing until logging is switched on.
+        - **Durable activity record:** Connections and statements are captured in a parseable format.
+        - **Retention without credential exposure:** Auditing does not require the general query log.
+
+        **Risk mitigation**
+
+        - **Supports incident reconstruction:** Responders can establish which accounts acted and when.
+        - **Detects credential misuse:** Connections from unexpected accounts or addresses are recorded.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm the plugin is installed and active:
+
+        ```bash
+        sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE 'SERVER_AUDIT%';"
+        ```
+
+        2. Read the logging state and destination:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit%';"
+        ```
+
+        3. Confirm records are being written:
+
+        ```bash
+        sudo tail -n 5 /var/log/mysql/server_audit.log
+        ```
+
+        A passing result reports `ON` and shows recent records. A failing result reports `OFF`, meaning nothing is recorded even if the plugin is loaded.
+      remediation:
+        - id: cli
+          desc: |
+            To enable server auditing using the CLI:
+
+            1. Install the plugin and add it to the option file so it loads on every start.
+            2. Enable logging and set the destination.
+            3. Restart MariaDB and confirm records appear.
+
+            ```bash
+            sudo mariadb -e "INSTALL SONAME 'server_audit';"
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            plugin_load_add        = server_audit.so
+            server_audit_logging   = ON
+            server_audit_events    = CONNECT,QUERY,TABLE
+            server_audit_file_path = /var/log/mysql/server_audit.log
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_logging';"
+            ```
+        - id: script
+          desc: |
+            To enable server auditing using a bash script:
+
+            1. Install the plugin when it is not already active.
+            2. Create the log directory, then set the load option, the logging state, and the destination.
+            3. Restart MariaDB and confirm logging is on.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            AUDIT_LOG="/var/log/mysql/server_audit.log"
+
+            active=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE 'SERVER_AUDIT%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$active" -eq 0 ]; then
+              mariadb -e "INSTALL SONAME 'server_audit';"
+            fi
+
+            install -d -o mysql -g mysql -m 0750 "$(dirname "$AUDIT_LOG")"
+
+            set_option() {
+              local key="$1" value="$2"
+              if grep -qE "^\s*${key}\b" "$MYCNF"; then
+                sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
+              else
+                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+              fi
+            }
+
+            if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*server_audit" "$MYCNF"; then
+              printf "plugin_load_add = server_audit.so\n" >>"$MYCNF"
+            fi
+
+            set_option server_audit_logging "ON"
+            set_option server_audit_file_path "$AUDIT_LOG"
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'server_audit_logging';"
+            ```
+        - id: ansible
+          desc: |
+            To enable server auditing using Ansible:
+
+            1. Install the plugin.
+            2. Set the load option, the logging state, and the destination.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Enable MariaDB server auditing
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_audit_log: /var/log/mysql/server_audit.log
+              tasks:
+                - name: Install the server_audit plugin
+                  ansible.builtin.command:
+                    cmd: mariadb -e "INSTALL SONAME 'server_audit';"
+                  register: install_plugin
+                  changed_when: install_plugin.rc == 0
+                  failed_when: >-
+                    install_plugin.rc != 0 and
+                    'already' not in install_plugin.stderr
+
+                - name: Create the log directory
+                  ansible.builtin.file:
+                    path: "{{ mariadb_audit_log | dirname }}"
+                    state: directory
+                    owner: mysql
+                    group: mysql
+                    mode: "0750"
+
+                - name: Configure the audit plugin
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: "{{ item.option }}"
+                    value: "{{ item.value }}"
+                    mode: "0640"
+                  loop:
+                    - { option: "plugin_load_add", value: "server_audit.so" }
+                    - { option: "server_audit_logging", value: "ON" }
+                    - { option: "server_audit_file_path", value: "{{ mariadb_audit_log }}" }
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-server-audit-events-cover-connect-and-query
+    title: Ensure server_audit_events records connections and queries
+    impact: 70
+    mql: |
+      mariadb.conf.serverAuditEvents.any(_.downcase == "connect")
+      mariadb.conf.serverAuditEvents.any(_.downcase == "query")
+    docs:
+      desc: |
+        This check ensures that `server_audit_events` includes both `CONNECT` and `QUERY`. The option selects which classes of activity the audit plugin records, and a plugin that is logging but recording neither class produces a file with almost nothing useful in it.
+
+        The two classes answer different questions. `CONNECT` records who authenticated, from where, and whether the attempt succeeded, which is the basis for detecting credential misuse. `QUERY` records the statements that were run, which is what establishes what an attacker actually did. Adding `TABLE` narrows attribution further by recording the objects each statement touched.
+
+        **Why this matters**
+
+        - **Attribution and activity together:** Connection records identify the actor and query records show the actions.
+        - **Failed authentication is captured:** The `CONNECT` class records unsuccessful attempts, not just successful ones.
+        - **Explicit selection:** The recorded classes are visible in configuration rather than left to a default.
+
+        **Risk mitigation**
+
+        - **Detects credential attacks:** Repeated failed connections from one address are recorded.
+        - **Supports incident scoping:** Responders can determine which statements ran under a compromised account.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective event classes:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_events';"
+        ```
+
+        2. Confirm both classes appear in the audit file:
+
+        ```bash
+        sudo awk -F, '{ print $3 }' /var/log/mysql/server_audit.log | sort | uniq -c
+        ```
+
+        A passing result names at least `CONNECT` and `QUERY`. A failing result omits either class, or is empty so only the plugin default applies.
+      remediation:
+        - id: cli
+          desc: |
+            To record connections and queries using the CLI:
+
+            1. Set `server_audit_events` in the server option file.
+            2. Restart MariaDB.
+            3. Confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*server[-_]audit[-_]events.*/server_audit_events = CONNECT,QUERY,TABLE/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_events';"
+            ```
+        - id: script
+          desc: |
+            To record connections and queries using a bash script:
+
+            1. Define the event classes to record.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            EVENTS="CONNECT,QUERY,TABLE"
+
+            if grep -qE "^\s*server[-_]audit[-_]events" "$MYCNF"; then
+              sed -i "s|^\s*server[-_]audit[-_]events.*|server_audit_events = ${EVENTS}|" "$MYCNF"
+            else
+              printf "server_audit_events = %s\n" "$EVENTS" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'server_audit_events';"
+            ```
+        - id: ansible
+          desc: |
+            To record connections and queries using Ansible:
+
+            1. Set `server_audit_events` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Record MariaDB connections and queries in the audit log
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_audit_events: "CONNECT,QUERY,TABLE"
+              tasks:
+                - name: Set server_audit_events
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: server_audit_events
+                    value: "{{ mariadb_audit_events }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-server-audit-no-excluded-users
+    title: Ensure server_audit_excl_users does not exempt accounts from auditing
+    impact: 60
+    mql: |
+      mariadb.conf.serverAuditExclUsers == empty
+    docs:
+      desc: |
+        This check ensures that `server_audit_excl_users` is empty so no account is exempt from the audit log. Every account named in this option has its activity omitted from the audit record entirely, which creates a blind spot precisely where an attacker would want one.
+
+        The option is usually populated for volume reasons, most often to silence a busy application or monitoring account. That is also the account most likely to be targeted, because it holds broad access and its traffic is expected. Where volume is genuinely a problem, narrow `server_audit_events` rather than exempting an identity.
+
+        **Why this matters**
+
+        - **No exempt identities:** Every account's activity appears in the record.
+        - **Busy accounts are high value:** An application account with broad access is the most attractive target to hide behind.
+        - **Volume has a better remedy:** Restricting event classes reduces volume without creating a blind spot.
+
+        **Risk mitigation**
+
+        - **Removes a hiding place:** An attacker who obtains an exempt account cannot act unrecorded.
+        - **Keeps the audit record complete:** Investigations do not have gaps for specific identities.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the excluded account list:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_excl_users';"
+        ```
+
+        2. Confirm whether an inclusion list is in use instead, which has the same effect of narrowing coverage:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_incl_users';"
+        ```
+
+        A passing result reports an empty list. A failing result names one or more accounts whose activity is not recorded.
+      remediation:
+        - id: cli
+          desc: |
+            To audit every account using the CLI:
+
+            1. Remove the exclusion list from the server option file.
+            2. Narrow `server_audit_events` instead if the change produces too much volume.
+            3. Restart MariaDB and confirm the list is empty.
+
+            ```bash
+            sudo sed -i -E "/^\s*server[-_]audit[-_]excl[-_]users/d" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_excl_users';"
+            ```
+        - id: script
+          desc: |
+            To audit every account using a bash script:
+
+            1. Report which accounts are currently exempt before changing anything.
+            2. Remove the exclusion list from every option file.
+            3. Restart MariaDB and confirm the list is empty.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            current=$(mariadb -N -B -e "SELECT @@server_audit_excl_users;" 2>/dev/null || true)
+            if [ -n "$current" ]; then
+              echo "removing audit exemptions for: $current"
+            fi
+
+            for dir in /etc/mysql /etc/my.cnf.d; do
+              [ -d "$dir" ] || continue
+              find "$dir" -type f -name "*.cnf" -exec \
+                sed -i -E "/^[[:space:]]*server[-_]audit[-_]excl[-_]users/d" {} +
+            done
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'server_audit_excl_users';"
+            ```
+        - id: ansible
+          desc: |
+            To audit every account using Ansible:
+
+            1. Remove the exclusion list from every option file.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Audit every MariaDB account
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find option files
+                  ansible.builtin.find:
+                    paths:
+                      - /etc/mysql
+                      - /etc/my.cnf.d
+                    patterns: "*.cnf"
+                    recurse: true
+                  register: option_files
+                  failed_when: false
+
+                - name: Remove audit exemptions
+                  ansible.builtin.lineinfile:
+                    path: "{{ item.path }}"
+                    regexp: '^\s*server[-_]audit[-_]excl[-_]users'
+                    state: absent
+                  loop: "{{ option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-innodb-encrypt-tables-enforced
+    title: Ensure innodb_encrypt_tables is set to ON or FORCE
+    impact: 75
+    mql: |
+      mariadb.conf.innodbEncryptTables.downcase == "on" || mariadb.conf.innodbEncryptTables.downcase == "force"
+    docs:
+      desc: |
+        This check ensures that `innodb_encrypt_tables` is set to `ON` or `FORCE` so InnoDB tables are encrypted at rest. Unlike the boolean options elsewhere in this policy, this one takes three values: `OFF` encrypts nothing, `ON` encrypts tables unless a statement opts out with `ENCRYPTED=NO`, and `FORCE` refuses to create an unencrypted table at all.
+
+        `FORCE` is the stronger setting because it removes the per-table opt-out, so no migration script or application can create an unencrypted table by accident. Either value satisfies this check, and enabling encryption also requires a configured key management plugin.
+
+        **Why this matters**
+
+        - **Tables are covered by default:** Encryption does not depend on per-statement clauses.
+        - **FORCE removes the opt-out:** No statement can create an unencrypted table.
+        - **Protects data at rest:** Files copied from the data directory are unreadable without the keys.
+
+        **Risk mitigation**
+
+        - **Limits exposure from stolen media:** A lost disk or backup does not disclose table contents.
+        - **Contains filesystem-level access:** An account able to read data files cannot read table data directly.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_tables';"
+        ```
+
+        2. Identify tables that are not encrypted:
+
+        ```bash
+        sudo mariadb -e "SELECT name, encryption_scheme FROM information_schema.innodb_tablespaces_encryption WHERE encryption_scheme = 0;"
+        ```
+
+        A passing result reports `ON` or `FORCE`. A failing result reports `OFF`, and the second query lists tablespaces that need converting.
+      remediation:
+        - id: cli
+          desc: |
+            To encrypt InnoDB tables using the CLI:
+
+            1. Confirm a key management plugin is configured, because encryption cannot work without one.
+            2. Set `innodb_encrypt_tables` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE '%key_management%';"
+            sudo sed -i "s/^#*\s*innodb[-_]encrypt[-_]tables.*/innodb_encrypt_tables = FORCE/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_tables';"
+            ```
+        - id: script
+          desc: |
+            To encrypt InnoDB tables using a bash script:
+
+            1. Refuse to proceed when no key management plugin is active, because table creation would fail.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and report tables that remain unencrypted.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            keyplugin=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE '%key_management%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$keyplugin" -eq 0 ]; then
+              echo "no key management plugin is active; configure one before enabling encryption" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*innodb[-_]encrypt[-_]tables" "$MYCNF"; then
+              sed -i "s|^\s*innodb[-_]encrypt[-_]tables.*|innodb_encrypt_tables = FORCE|" "$MYCNF"
+            else
+              printf "innodb_encrypt_tables = FORCE\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+
+            echo "tablespaces still unencrypted:"
+            mariadb -N -B -e "SELECT name FROM information_schema.innodb_tablespaces_encryption
+              WHERE encryption_scheme = 0;"
+            ```
+        - id: ansible
+          desc: |
+            To encrypt InnoDB tables using Ansible:
+
+            1. Set `innodb_encrypt_tables` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Encrypt MariaDB InnoDB tables
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_encrypt_tables: FORCE
+              tasks:
+                - name: Set innodb_encrypt_tables
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: innodb_encrypt_tables
+                    value: "{{ mariadb_encrypt_tables }}"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-innodb-encrypt-log-enabled
+    title: Ensure innodb_encrypt_log is enabled
+    impact: 70
+    mql: |
+      mariadb.conf.innodbEncryptLog == true
+    docs:
+      desc: |
+        This check ensures that `innodb_encrypt_log` is enabled so the InnoDB redo log is encrypted at rest. The redo log holds recently modified page contents, so encrypted tables can still leave readable copies of their most recent data in it.
+
+        Table encryption alone therefore leaves a gap. The redo log is written continuously and lives inside the data directory, so anything able to read the data directory can recover recent changes to encrypted tables from it.
+
+        **Why this matters**
+
+        - **Closes a recent-data gap:** Modified page contents are protected as well as the tables.
+        - **Covers the whole data directory:** Encryption is consistent across the files InnoDB writes.
+        - **Protects crash recovery data:** Content retained for recovery is not readable.
+
+        **Risk mitigation**
+
+        - **Prevents recovery of recent changes:** The redo log cannot be read to reconstruct encrypted table data.
+        - **Limits exposure from filesystem access:** Reading the data directory does not reveal recent writes.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_log';"
+        ```
+
+        2. Confirm the key management plugin backing the encryption is active:
+
+        ```bash
+        sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE '%key_management%';"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF`, meaning recent changes to encrypted tables remain readable in the redo log.
+      remediation:
+        - id: cli
+          desc: |
+            To encrypt the InnoDB redo log using the CLI:
+
+            1. Confirm a key management plugin is active.
+            2. Set `innodb_encrypt_log` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*innodb[-_]encrypt[-_]log.*/innodb_encrypt_log = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_log';"
+            ```
+        - id: script
+          desc: |
+            To encrypt the InnoDB redo log using a bash script:
+
+            1. Refuse to proceed when no key management plugin is active.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            keyplugin=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE '%key_management%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$keyplugin" -eq 0 ]; then
+              echo "no key management plugin is active; configure one before enabling encryption" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*innodb[-_]encrypt[-_]log" "$MYCNF"; then
+              sed -i "s|^\s*innodb[-_]encrypt[-_]log.*|innodb_encrypt_log = ON|" "$MYCNF"
+            else
+              printf "innodb_encrypt_log = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_log';"
+            ```
+        - id: ansible
+          desc: |
+            To encrypt the InnoDB redo log using Ansible:
+
+            1. Set `innodb_encrypt_log` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Encrypt the MariaDB InnoDB redo log
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set innodb_encrypt_log
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: innodb_encrypt_log
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-encrypt-binlog-enabled
+    title: Ensure encrypt_binlog is enabled
+    impact: 70
+    mql: |
+      mariadb.conf.encryptBinlog == true
+    docs:
+      desc: |
+        This check ensures that `encrypt_binlog` is enabled so binary and relay log files are encrypted at rest. The binary log records the row images of every change, which means it contains the same data as the tables themselves.
+
+        Encrypting tables while leaving the binary log in cleartext leaves the data readable in a second location. Binary logs are also frequently retained longer than expected and copied to replicas and backup hosts, which widens the number of places the unencrypted content exists.
+
+        **Why this matters**
+
+        - **Closes a parallel copy of the data:** Row images in the log are protected like the tables.
+        - **Covers replicas and backups:** Log files copied elsewhere remain encrypted.
+        - **Consistent encryption posture:** Table encryption is not undermined by an unprotected log.
+
+        **Risk mitigation**
+
+        - **Prevents data recovery from log files:** A copied binary log does not disclose table contents.
+        - **Limits exposure from long retention:** Historical changes stay protected for as long as the log exists.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('encrypt_binlog','log_bin');"
+        ```
+
+        2. Confirm the current log files exist and are being rotated:
+
+        ```bash
+        sudo mariadb -e "SHOW BINARY LOGS;"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF` while binary logging is active, meaning the log files are readable.
+      remediation:
+        - id: cli
+          desc: |
+            To encrypt binary logs using the CLI:
+
+            1. Confirm a key management plugin is active.
+            2. Set `encrypt_binlog` in the server option file.
+            3. Restart MariaDB, then rotate the logs so new files are encrypted.
+
+            ```bash
+            sudo sed -i "s/^#*\s*encrypt[-_]binlog.*/encrypt_binlog = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "FLUSH BINARY LOGS;"
+            sudo mariadb -e "SHOW VARIABLES LIKE 'encrypt_binlog';"
+            ```
+        - id: script
+          desc: |
+            To encrypt binary logs using a bash script:
+
+            1. Refuse to proceed when no key management plugin is active.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and rotate the logs so new files are written encrypted.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            keyplugin=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE '%key_management%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$keyplugin" -eq 0 ]; then
+              echo "no key management plugin is active; configure one before enabling encryption" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*encrypt[-_]binlog" "$MYCNF"; then
+              sed -i "s|^\s*encrypt[-_]binlog.*|encrypt_binlog = ON|" "$MYCNF"
+            else
+              printf "encrypt_binlog = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "FLUSH BINARY LOGS;"
+            ```
+        - id: ansible
+          desc: |
+            To encrypt binary logs using Ansible:
+
+            1. Set `encrypt_binlog` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Encrypt MariaDB binary logs
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set encrypt_binlog
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: encrypt_binlog
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-encrypt-tmp-disk-tables-enabled
+    title: Ensure encrypt_tmp_disk_tables is enabled
+    impact: 70
+    mql: |
+      mariadb.conf.encryptTmpDiskTables == true
+    docs:
+      desc: |
+        This check ensures that `encrypt_tmp_disk_tables` is enabled so internal temporary tables written to disk are encrypted. The server spills a temporary table to disk whenever a sort, join, or aggregate exceeds the in-memory limit, and that spilled table holds real row data drawn from the tables being queried.
+
+        This is the encryption gap that is easiest to overlook, because temporary files are transient and live outside the tables an operator thinks of as sensitive. A query against an encrypted table can still write its intermediate results to an unencrypted file in `tmpdir`.
+
+        **Why this matters**
+
+        - **Query intermediates hold real data:** Spilled temporary tables contain rows from the source tables.
+        - **Transient files are still readable:** A file only has to exist briefly to be copied.
+        - **Completes the encryption picture:** Tables, logs, and temporary files are all covered.
+
+        **Risk mitigation**
+
+        - **Prevents disclosure through temporary files:** Data from encrypted tables is not written in cleartext.
+        - **Closes a query-time gap:** Large sorts and joins do not bypass the encryption posture.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the effective value:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'encrypt_tmp_disk_tables';"
+        ```
+
+        2. Confirm where temporary files are written and how often the server spills to disk:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'tmpdir';"
+        sudo mariadb -e "SHOW GLOBAL STATUS LIKE 'Created_tmp_disk_tables';"
+        ```
+
+        A passing result reports `ON`. A failing result reports `OFF`, and a nonzero disk temporary table count shows the gap is actively being used.
+      remediation:
+        - id: cli
+          desc: |
+            To encrypt temporary disk tables using the CLI:
+
+            1. Confirm a key management plugin is active.
+            2. Set `encrypt_tmp_disk_tables` in the server option file.
+            3. Restart MariaDB and confirm the effective value.
+
+            ```bash
+            sudo sed -i "s/^#*\s*encrypt[-_]tmp[-_]disk[-_]tables.*/encrypt_tmp_disk_tables = ON/" \
+              /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'encrypt_tmp_disk_tables';"
+            ```
+        - id: script
+          desc: |
+            To encrypt temporary disk tables using a bash script:
+
+            1. Refuse to proceed when no key management plugin is active.
+            2. Set the option, replacing any existing value.
+            3. Restart MariaDB and report the effective value.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+
+            keyplugin=$(mariadb -N -B -e "SELECT count(*) FROM information_schema.plugins
+              WHERE plugin_name LIKE '%key_management%' AND plugin_status = 'ACTIVE';")
+
+            if [ "$keyplugin" -eq 0 ]; then
+              echo "no key management plugin is active; configure one before enabling encryption" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*encrypt[-_]tmp[-_]disk[-_]tables" "$MYCNF"; then
+              sed -i "s|^\s*encrypt[-_]tmp[-_]disk[-_]tables.*|encrypt_tmp_disk_tables = ON|" "$MYCNF"
+            else
+              printf "encrypt_tmp_disk_tables = ON\n" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            mariadb -e "SHOW VARIABLES LIKE 'encrypt_tmp_disk_tables';"
+            ```
+        - id: ansible
+          desc: |
+            To encrypt temporary disk tables using Ansible:
+
+            1. Set `encrypt_tmp_disk_tables` in the server option group.
+            2. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Encrypt MariaDB temporary disk tables
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+              tasks:
+                - name: Set encrypt_tmp_disk_tables
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: encrypt_tmp_disk_tables
+                    value: "ON"
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-file-key-management-configured
+    title: Ensure file_key_management_filename names an encryption key file
+    impact: 70
+    mql: |
+      mariadb.conf.fileKeyManagementFilename != empty
+    docs:
+      desc: |
+        This check ensures that `file_key_management_filename` names the key file the `file_key_management` plugin reads. Every encryption option in this policy depends on a key source, and without one the server cannot encrypt anything regardless of how the encryption options are set.
+
+        Naming the key file explicitly is what makes the encryption settings effective rather than aspirational. Where a dedicated key management service is used instead of the file-based plugin, this check will fail and the exception should be recorded, since the resource reports only the file-based plugin's option.
+
+        **Why this matters**
+
+        - **Encryption needs a key source:** The encryption options have no effect without one.
+        - **Explicit key location:** The file is a known artifact that can be backed up and rotated deliberately.
+        - **Makes encryption verifiable:** A configured key source shows the encryption settings can actually work.
+
+        **Risk mitigation**
+
+        - **Prevents silently ineffective encryption:** Encryption options that could never apply are surfaced.
+        - **Supports key rotation:** A named key file gives you a place to add new key versions.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the configured key file:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'file_key_management%';"
+        ```
+
+        2. Confirm the plugin is active:
+
+        ```bash
+        sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE '%key_management%';"
+        ```
+
+        A passing result names a key file and shows the plugin `ACTIVE`. A failing result leaves the option empty, meaning no key source is configured for the file-based plugin.
+      remediation:
+        - id: cli
+          desc: |
+            To configure the encryption key file using the CLI:
+
+            1. Generate a key file containing at least one key identifier and a hex key.
+            2. Restrict it to the server account, then name it in the option file along with the plugin.
+            3. Restart MariaDB and confirm the plugin is active.
+
+            ```bash
+            sudo install -d -o mysql -g mysql -m 0750 /etc/mysql/encryption
+            printf '1;%s\n' "$(openssl rand -hex 32)" | sudo tee /etc/mysql/encryption/keyfile.enc >/dev/null
+            sudo chown mysql:mysql /etc/mysql/encryption/keyfile.enc
+            sudo chmod 0600 /etc/mysql/encryption/keyfile.enc
+            sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            plugin_load_add              = file_key_management.so
+            file_key_management_filename = /etc/mysql/encryption/keyfile.enc
+            EOF
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'file_key_management%';"
+            ```
+        - id: script
+          desc: |
+            To configure the encryption key file using a bash script:
+
+            1. Create the key file only when it does not already exist, so an existing key is never overwritten.
+            2. Restrict it to the server account.
+            3. Set the plugin and filename options, then restart MariaDB.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+            KEY_FILE="/etc/mysql/encryption/keyfile.enc"
+
+            install -d -o mysql -g mysql -m 0750 "$(dirname "$KEY_FILE")"
+
+            if [ -s "$KEY_FILE" ]; then
+              echo "key file already present, leaving it unchanged: $KEY_FILE"
+            else
+              printf '1;%s\n' "$(openssl rand -hex 32)" >"$KEY_FILE"
+            fi
+
+            chown mysql:mysql "$KEY_FILE"
+            chmod 0600 "$KEY_FILE"
+
+            if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*file_key_management" "$MYCNF"; then
+              printf "plugin_load_add = file_key_management.so\n" >>"$MYCNF"
+            fi
+
+            if grep -qE "^\s*file[-_]key[-_]management[-_]filename" "$MYCNF"; then
+              sed -i "s|^\s*file[-_]key[-_]management[-_]filename.*|file_key_management_filename = ${KEY_FILE}|" "$MYCNF"
+            else
+              printf "file_key_management_filename = %s\n" "$KEY_FILE" >>"$MYCNF"
+            fi
+
+            systemctl restart mariadb
+            ```
+        - id: ansible
+          desc: |
+            To configure the encryption key file using Ansible:
+
+            1. Create the key directory and generate a key file only when one is absent.
+            2. Set the plugin and filename options.
+            3. Notify a handler that restarts the server.
+
+            ```yaml
+            - name: Configure the MariaDB encryption key file
+              hosts: mariadb
+              become: true
+              vars:
+                mariadb_conf: /etc/mysql/mariadb.conf.d/50-server.cnf
+                mariadb_key_file: /etc/mysql/encryption/keyfile.enc
+              tasks:
+                - name: Create the key directory
+                  ansible.builtin.file:
+                    path: "{{ mariadb_key_file | dirname }}"
+                    state: directory
+                    owner: mysql
+                    group: mysql
+                    mode: "0750"
+
+                - name: Check whether a key file already exists
+                  ansible.builtin.stat:
+                    path: "{{ mariadb_key_file }}"
+                  register: key_file
+
+                - name: Generate a key file when absent
+                  ansible.builtin.shell:
+                    cmd: printf '1;%s\n' "$(openssl rand -hex 32)" > {{ mariadb_key_file }}
+                  when: not key_file.stat.exists
+
+                - name: Restrict the key file
+                  ansible.builtin.file:
+                    path: "{{ mariadb_key_file }}"
+                    owner: mysql
+                    group: mysql
+                    mode: "0600"
+
+                - name: Configure the plugin and key file
+                  community.general.ini_file:
+                    path: "{{ mariadb_conf }}"
+                    section: mysqld
+                    option: "{{ item.option }}"
+                    value: "{{ item.value }}"
+                    mode: "0640"
+                  loop:
+                    - { option: "plugin_load_add", value: "file_key_management.so" }
+                    - { option: "file_key_management_filename", value: "{{ mariadb_key_file }}" }
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-file-key-management-key-file-protected
+    title: Ensure the encryption key file is readable only by the server account
+    impact: 90
+    mql: |
+      mariadb.conf.fileKeyManagementFilename == empty || file(mariadb.conf.fileKeyManagementFilename).permissions.group_readable == false && file(mariadb.conf.fileKeyManagementFilename).permissions.other_readable == false
+    docs:
+      desc: |
+        This check ensures that the key file named by `file_key_management_filename` is readable only by the account that runs the server. The file holds the encryption keys themselves, so any account that can read it can decrypt every encrypted table, log, and temporary file the server produces.
+
+        A readable key file collapses the entire encryption-at-rest posture. Backups, snapshots, and the data directory all remain encrypted, but the key sits alongside them, so an attacker who obtains both has plaintext. Servers using a key management service rather than the file-based plugin pass this check, because there is no key file on disk to protect.
+
+        **Why this matters**
+
+        - **The key is the whole secret:** Reading it defeats every encryption option at once.
+        - **Keys and data often travel together:** A backup that captures the data directory and the key file yields plaintext.
+        - **File mode is the only boundary:** The plugin does not refuse to start on a permissive key file.
+
+        **Risk mitigation**
+
+        - **Prevents local key theft:** An unprivileged account cannot read the encryption keys.
+        - **Preserves encryption value after filesystem access:** Reading data files without the key yields nothing useful.
+      audit: |
+        ### Audit via CLI
+
+        1. Read the configured key file path:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'file_key_management_filename';"
+        ```
+
+        2. Inspect its ownership and permissions:
+
+        ```bash
+        sudo ls -l "$(sudo mariadb -N -B -e 'SELECT @@file_key_management_filename;')"
+        ```
+
+        3. Confirm the directory holding it is not traversable by other accounts:
+
+        ```bash
+        sudo ls -ld /etc/mysql/encryption
+        ```
+
+        A passing result shows the file owned by the server account as `-rw-------`, or reports no key file because a key management service is used instead. A failing result shows a mode such as `-rw-r--r--` or `-rw-r-----`.
+      remediation:
+        - id: cli
+          desc: |
+            To protect the encryption key file using the CLI:
+
+            1. Set ownership to the server account and remove group and world access.
+            2. Restrict the directory holding it as well.
+            3. Confirm the resulting permissions.
+
+            ```bash
+            KEY_FILE=$(sudo mariadb -N -B -e 'SELECT @@file_key_management_filename;')
+            sudo chown mysql:mysql "$KEY_FILE"
+            sudo chmod 0600 "$KEY_FILE"
+            sudo chmod 0750 "$(dirname "$KEY_FILE")"
+            sudo ls -l "$KEY_FILE"
+            ```
+        - id: script
+          desc: |
+            To protect the encryption key file using a bash script:
+
+            1. Resolve the key file path from the server rather than assuming a location.
+            2. Apply ownership and mode to the file and its directory.
+            3. Fail if group or world access remains.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            KEY_FILE=$(mariadb -N -B -e "SELECT @@file_key_management_filename;")
+
+            if [ -z "$KEY_FILE" ]; then
+              echo "no file-based key management configured; nothing to protect"
+              exit 0
+            fi
+
+            if [ ! -f "$KEY_FILE" ]; then
+              echo "configured key file does not exist: $KEY_FILE" >&2
+              exit 1
+            fi
+
+            chown mysql:mysql "$KEY_FILE"
+            chmod 0600 "$KEY_FILE"
+            chmod 0750 "$(dirname "$KEY_FILE")"
+
+            if find "$KEY_FILE" -perm /0077 | grep -q .; then
+              echo "group or world access remains on $KEY_FILE" >&2
+              exit 1
+            fi
+
+            ls -l "$KEY_FILE"
+            ```
+        - id: ansible
+          desc: |
+            To protect the encryption key file using Ansible:
+
+            1. Resolve the key file path from the server.
+            2. Apply ownership and mode to the file and its directory.
+
+            ```yaml
+            - name: Protect the MariaDB encryption key file
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Resolve the key file path
+                  ansible.builtin.command:
+                    cmd: mariadb -N -B -e "SELECT @@file_key_management_filename;"
+                  changed_when: false
+                  register: key_path
+
+                - name: Restrict the key directory
+                  ansible.builtin.file:
+                    path: "{{ key_path.stdout | trim | dirname }}"
+                    state: directory
+                    owner: mysql
+                    group: mysql
+                    mode: "0750"
+                  when: key_path.stdout | trim | length > 0
+
+                - name: Restrict the key file
+                  ansible.builtin.file:
+                    path: "{{ key_path.stdout | trim }}"
+                    owner: mysql
+                    group: mysql
+                    mode: "0600"
+                  when: key_path.stdout | trim | length > 0
+            ```
+
+  - uid: mondoo-mariadb-security-galera-replication-encrypted
+    title: Ensure Galera replication traffic is encrypted
+    impact: 85
+    mql: |
+      mariadb.conf.wsrepOn == false || mariadb.conf.wsrepProviderOptions == /socket\.ssl/
+    docs:
+      desc: |
+        This check ensures that a Galera cluster node configures TLS for the replication channel through `wsrep_provider_options`. The `socket.ssl_key`, `socket.ssl_cert`, and `socket.ssl_ca` entries are what secure traffic between nodes. Without them, write set replication crosses the network in cleartext.
+
+        The replication channel carries the row images of every committed change, so an unencrypted cluster link exposes the same data as the tables themselves. Requiring TLS on client connections does nothing for this channel, because it is a separate transport between nodes. The check applies only to nodes with `wsrep_on` enabled, so a standalone server is not asked to configure cluster options.
+
+        **Why this matters**
+
+        - **The cluster link carries table data:** Write sets contain the rows being changed.
+        - **A separate transport from client TLS:** Client encryption settings do not cover node-to-node traffic.
+        - **Nodes often span failure domains:** Cluster members are frequently in different racks or availability zones.
+
+        **Risk mitigation**
+
+        - **Prevents interception between nodes:** Captured replication traffic yields no readable data.
+        - **Blocks a rogue node joining unencrypted:** Requiring TLS means a joiner must present valid material.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm whether the node is part of a cluster:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'wsrep_on';"
+        ```
+
+        2. Read the provider options and look for the TLS entries:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES LIKE 'wsrep_provider_options'\G" | tr ';' '\n' | grep -i ssl
+        ```
+
+        3. Confirm the negotiated cluster state:
+
+        ```bash
+        sudo mariadb -e "SHOW STATUS WHERE Variable_name IN ('wsrep_cluster_size','wsrep_connected');"
+        ```
+
+        A passing result either reports `wsrep_on` as `OFF`, or shows `socket.ssl_key`, `socket.ssl_cert`, and `socket.ssl_ca` populated. A failing result shows a cluster node with no TLS entries.
+      remediation:
+        - id: cli
+          desc: |
+            To encrypt Galera replication traffic using the CLI:
+
+            1. Install certificate material readable by the server account on every node.
+            2. Add the TLS entries to `wsrep_provider_options`.
+            3. Restart the cluster in a rolling fashion, because all nodes must agree on the transport.
+
+            ```bash
+            sudo install -o mysql -g mysql -m 0600 galera.key /etc/mysql/ssl/galera.key
+            sudo install -o mysql -g mysql -m 0644 galera.crt /etc/mysql/ssl/galera.crt
+            sudo sed -i "s|^#*\s*wsrep_provider_options.*|wsrep_provider_options = socket.ssl_key=/etc/mysql/ssl/galera.key;socket.ssl_cert=/etc/mysql/ssl/galera.crt;socket.ssl_ca=/etc/mysql/ssl/ca.pem|" \
+              /etc/mysql/mariadb.conf.d/60-galera.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW STATUS LIKE 'wsrep_cluster_size';"
+            ```
+        - id: script
+          desc: |
+            To encrypt Galera replication traffic using a bash script:
+
+            1. Verify the certificate material is present before changing configuration.
+            2. Set the provider options in the Galera option file.
+            3. Report that every node needs the same change before the cluster will re-form.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            GALERA_CNF="/etc/mysql/mariadb.conf.d/60-galera.cnf"
+            SSL_KEY="/etc/mysql/ssl/galera.key"
+            SSL_CERT="/etc/mysql/ssl/galera.crt"
+            SSL_CA="/etc/mysql/ssl/ca.pem"
+
+            for f in "$SSL_KEY" "$SSL_CERT" "$SSL_CA"; do
+              if [ ! -s "$f" ]; then
+                echo "missing Galera TLS material: $f" >&2
+                exit 1
+              fi
+            done
+
+            chown mysql:mysql "$SSL_KEY" "$SSL_CERT" "$SSL_CA"
+            chmod 0600 "$SSL_KEY"
+
+            options="socket.ssl_key=${SSL_KEY};socket.ssl_cert=${SSL_CERT};socket.ssl_ca=${SSL_CA}"
+
+            if grep -qE "^\s*wsrep_provider_options" "$GALERA_CNF"; then
+              sed -i "s|^\s*wsrep_provider_options.*|wsrep_provider_options = ${options}|" "$GALERA_CNF"
+            else
+              printf "wsrep_provider_options = %s\n" "$options" >>"$GALERA_CNF"
+            fi
+
+            echo "apply this change on every node, then restart them in a rolling fashion" >&2
+            ```
+        - id: ansible
+          desc: |
+            To encrypt Galera replication traffic using Ansible:
+
+            1. Place the certificate material on every node.
+            2. Set the provider options in the Galera option file.
+            3. Restart nodes one at a time using a serial play so the cluster stays available.
+
+            ```yaml
+            - name: Encrypt Galera replication traffic
+              hosts: mariadb_galera
+              become: true
+              serial: 1
+              vars:
+                galera_conf: /etc/mysql/mariadb.conf.d/60-galera.cnf
+                galera_ssl_key: /etc/mysql/ssl/galera.key
+                galera_ssl_cert: /etc/mysql/ssl/galera.crt
+                galera_ssl_ca: /etc/mysql/ssl/ca.pem
+              tasks:
+                - name: Protect the Galera private key
+                  ansible.builtin.file:
+                    path: "{{ galera_ssl_key }}"
+                    owner: mysql
+                    group: mysql
+                    mode: "0600"
+
+                - name: Set the provider TLS options
+                  community.general.ini_file:
+                    path: "{{ galera_conf }}"
+                    section: galera
+                    option: wsrep_provider_options
+                    value: >-
+                      socket.ssl_key={{ galera_ssl_key }};socket.ssl_cert={{ galera_ssl_cert
+                      }};socket.ssl_ca={{ galera_ssl_ca }}
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-galera-sst-method-secure
+    title: Ensure wsrep_sst_method does not use unencrypted rsync
+    impact: 75
+    mql: |
+      mariadb.conf.wsrepOn == false || mariadb.conf.wsrepSstMethod.downcase != "rsync"
+    docs:
+      desc: |
+        This check ensures that a Galera node does not use `rsync` for state snapshot transfer. A state snapshot transfer sends the entire dataset from an existing node to a joining one, and the `rsync` method carries it over an unauthenticated, unencrypted connection on a separate port.
+
+        A snapshot transfer is the single largest data exposure in a cluster's lifetime, because it moves everything at once rather than incremental changes. The `mariabackup` method supports encryption and authentication for the transfer, which is why it is the appropriate choice for a cluster handling sensitive data. The check applies only to nodes with `wsrep_on` enabled.
+
+        **Why this matters**
+
+        - **A snapshot transfer moves everything:** The full dataset crosses the network in one operation.
+        - **The rsync method has no transport security:** The transfer is neither encrypted nor authenticated.
+        - **A supported alternative exists:** The `mariabackup` method can encrypt and authenticate the transfer.
+
+        **Risk mitigation**
+
+        - **Prevents bulk interception:** An observer on the network cannot capture the whole dataset during a node join.
+        - **Blocks unauthorized snapshot requests:** An authenticated transfer method cannot be triggered by an arbitrary host.
+      audit: |
+        ### Audit via CLI
+
+        1. Confirm whether the node is part of a cluster and read the transfer method:
+
+        ```bash
+        sudo mariadb -e "SHOW VARIABLES WHERE Variable_name IN ('wsrep_on','wsrep_sst_method');"
+        ```
+
+        2. Review the transfer account configuration used by the method:
+
+        ```bash
+        sudo grep -rniE "^\s*wsrep_sst_(method|auth)" /etc/mysql/ 2>/dev/null
+        ```
+
+        3. Confirm recent transfer activity and its outcome:
+
+        ```bash
+        sudo mariadb -e "SHOW STATUS WHERE Variable_name IN ('wsrep_local_state_comment','wsrep_cluster_status');"
+        ```
+
+        A passing result either reports `wsrep_on` as `OFF`, or names a method such as `mariabackup`. A failing result names `rsync`.
+      remediation:
+        - id: cli
+          desc: |
+            To use an encrypted snapshot transfer method using the CLI:
+
+            1. Install the `mariadb-backup` package on every node.
+            2. Create the transfer account and set `wsrep_sst_method` and `wsrep_sst_auth`.
+            3. Restart nodes in a rolling fashion and confirm the method took effect.
+
+            ```bash
+            sudo apt-get install -y mariadb-backup
+            sudo mariadb -e "CREATE USER 'sst'@'localhost' IDENTIFIED BY 'changeme';"
+            sudo mariadb -e "GRANT RELOAD, PROCESS, LOCK TABLES, BINLOG MONITOR ON *.* TO 'sst'@'localhost';"
+            sudo sed -i "s/^#*\s*wsrep_sst_method.*/wsrep_sst_method = mariabackup/" \
+              /etc/mysql/mariadb.conf.d/60-galera.cnf
+            sudo systemctl restart mariadb
+            sudo mariadb -e "SHOW VARIABLES LIKE 'wsrep_sst_method';"
+            ```
+        - id: script
+          desc: |
+            To use an encrypted snapshot transfer method using a bash script:
+
+            1. Refuse to proceed unless the backup tool is installed, because the method would fail on the next node join.
+            2. Set the method in the Galera option file.
+            3. Report that every node needs the same change.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            GALERA_CNF="/etc/mysql/mariadb.conf.d/60-galera.cnf"
+
+            if ! command -v mariabackup >/dev/null 2>&1; then
+              echo "mariabackup is not installed; install mariadb-backup first" >&2
+              exit 1
+            fi
+
+            if grep -qE "^\s*wsrep_sst_method" "$GALERA_CNF"; then
+              sed -i "s|^\s*wsrep_sst_method.*|wsrep_sst_method = mariabackup|" "$GALERA_CNF"
+            else
+              printf "wsrep_sst_method = mariabackup\n" >>"$GALERA_CNF"
+            fi
+
+            echo "apply this change on every node, then restart them in a rolling fashion" >&2
+            ```
+        - id: ansible
+          desc: |
+            To use an encrypted snapshot transfer method using Ansible:
+
+            1. Install the backup package on every node.
+            2. Set `wsrep_sst_method` in the Galera option file.
+            3. Restart nodes one at a time using a serial play so the cluster stays available.
+
+            ```yaml
+            - name: Use an encrypted Galera snapshot transfer method
+              hosts: mariadb_galera
+              become: true
+              serial: 1
+              vars:
+                galera_conf: /etc/mysql/mariadb.conf.d/60-galera.cnf
+              tasks:
+                - name: Install the backup tool
+                  ansible.builtin.package:
+                    name: mariadb-backup
+                    state: present
+
+                - name: Set wsrep_sst_method
+                  community.general.ini_file:
+                    path: "{{ galera_conf }}"
+                    section: galera
+                    option: wsrep_sst_method
+                    value: mariabackup
+                    mode: "0640"
+                  notify: Restart mariadb
+              handlers:
+                - name: Restart mariadb
+                  ansible.builtin.service:
+                    name: mariadb
+                    state: restarted
+            ```
+
+  - uid: mondoo-mariadb-security-client-options-no-plaintext-password
+    title: Ensure no plaintext password is stored in the client option groups
+    impact: 85
+    mql: |
+      mariadb.conf.clientOptions["password"] == empty
+    docs:
+      desc: |
+        This check ensures that no `password` option appears in the client option groups. The `[client]`, `[mysql]`, and `[client-server]` groups are read by every client program MariaDB ships, so a password written there is available to every account that can read the option file.
+
+        A password in a system-wide option file is a durable credential in a file that is often more readable than intended and is frequently captured by configuration management, backups, and container images. Supply the credential from a secret store at run time, or use a per-user option file restricted to its owner.
+
+        **Why this matters**
+
+        - **Option files are widely readable:** System option files are commonly readable beyond the database account.
+        - **Credentials spread with copies:** Backups, images, and configuration repositories carry the password with them.
+        - **Better mechanisms exist:** Secret stores and per-user files keep the credential out of a shared file.
+
+        **Risk mitigation**
+
+        - **Prevents credential harvesting:** A local account cannot read a database password from a shared file.
+        - **Limits exposure from leaked configuration:** A copied option file does not include a working credential.
+      audit: |
+        ### Audit via CLI
+
+        1. Search the option files for a password option:
+
+        ```bash
+        sudo grep -rniE "^\s*password\s*=" /etc/mysql/ /etc/my.cnf /etc/my.cnf.d/ 2>/dev/null
+        ```
+
+        2. Check the permissions on any file that declares one:
+
+        ```bash
+        sudo ls -l /etc/mysql/my.cnf
+        ```
+
+        A passing result finds no password option in the client groups. A failing result shows a `password` line, and that credential should be treated as exposed and rotated.
+      remediation:
+        - id: cli
+          desc: |
+            To remove plaintext client passwords using the CLI:
+
+            1. Move the credential into a per-user option file restricted to its owner, or supply it from a secret store.
+            2. Remove the password option from the shared option file.
+            3. Rotate the exposed password, because it must be assumed compromised.
+
+            ```bash
+            printf '[client]\npassword = new-password\n' | install -m 0600 /dev/stdin ~/.my.cnf
+            sudo sed -i -E "/^\s*password\s*=/d" /etc/mysql/my.cnf
+            sudo mariadb -e "SET PASSWORD FOR 'app'@'localhost' = PASSWORD('new-password');"
+            sudo grep -rniE "^\s*password\s*=" /etc/mysql/ || echo "no plaintext passwords remain"
+            ```
+        - id: script
+          desc: |
+            To remove plaintext client passwords using a bash script:
+
+            1. Report every file and line that declares a password before changing anything.
+            2. Remove the option from each file, keeping a backup.
+            3. Remind the operator to rotate the exposed credentials.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            found=0
+
+            for dir in /etc/mysql /etc/my.cnf.d; do
+              [ -d "$dir" ] || continue
+              while IFS= read -r file; do
+                if grep -qE "^[[:space:]]*password[[:space:]]*=" "$file"; then
+                  echo "removing plaintext password from $file"
+                  grep -nE "^[[:space:]]*password[[:space:]]*=" "$file"
+                  cp -a "$file" "${file}.bak"
+                  sed -i -E "/^[[:space:]]*password[[:space:]]*=/d" "$file"
+                  found=1
+                fi
+              done < <(find "$dir" -type f -name "*.cnf")
+            done
+
+            if [ "$found" -eq 1 ]; then
+              echo "rotate every password that was stored in these files; treat them as compromised" >&2
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To remove plaintext client passwords using Ansible:
+
+            1. Find the option files.
+            2. Remove any password option they declare.
+            3. Report that the credentials need rotating.
+
+            ```yaml
+            - name: Remove plaintext MariaDB client passwords
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find option files
+                  ansible.builtin.find:
+                    paths:
+                      - /etc/mysql
+                      - /etc/my.cnf.d
+                    patterns: "*.cnf"
+                    recurse: true
+                  register: option_files
+                  failed_when: false
+
+                - name: Remove password options
+                  ansible.builtin.lineinfile:
+                    path: "{{ item.path }}"
+                    regexp: '^\s*password\s*='
+                    state: absent
+                  loop: "{{ option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+                  register: removed
+
+                - name: Report credentials that must be rotated
+                  ansible.builtin.debug:
+                    msg: "A stored password was removed. Rotate the affected accounts."
+                  when: removed is changed
+            ```
+
+  - uid: mondoo-mariadb-security-option-files-restricted-permissions
+    title: Ensure option files are not group or world accessible
+    impact: 75
+    mql: |
+      mariadb.conf.files != empty
+      mariadb.conf.files.all(permissions.group_writeable == false && permissions.other_readable == false && permissions.other_writeable == false)
+    docs:
+      desc: |
+        This check ensures that every file in the option file chain is readable only by its owner and the server account. MariaDB does not refuse to start when an option file is world readable, so a permissive mode goes unnoticed.
+
+        Include fragments deserve the same protection as the main file. MariaDB packages ship several fragments under `mariadb.conf.d`, and configuration management tooling adds more with whatever permissions wrote them, which leaves a fragment world readable even when the main file is correctly restricted. This check evaluates every contributing file rather than only the entry point.
+
+        **Why this matters**
+
+        - **Option files describe the server:** Data directory paths, TLS material, and encryption key locations are all disclosed.
+        - **Write access is server control:** An account able to modify a fragment can disable authentication on the next restart.
+        - **Fragments are numerous:** A packaged MariaDB install reads several files, any of which can be permissive.
+
+        **Risk mitigation**
+
+        - **Blocks local reconnaissance:** An unprivileged account cannot learn where keys and data live.
+        - **Prevents configuration tampering:** An attacker cannot add an option that weakens the server.
+      audit: |
+        ### Audit via CLI
+
+        1. List the option files the server actually reads, in order:
+
+        ```bash
+        mariadbd --verbose --help 2>/dev/null | grep -A1 "Default options are read from"
+        ```
+
+        2. Inspect the permissions on the main file and every fragment:
+
+        ```bash
+        sudo ls -l /etc/mysql/my.cnf
+        sudo ls -lR /etc/mysql/mariadb.conf.d/ /etc/mysql/conf.d/ 2>/dev/null
+        ```
+
+        A passing result shows each file with no group write bit and no world access, which is `-rw-------` or `-rw-r-----`. A failing result shows a mode such as `-rw-r--r--` on the main file or any fragment.
+      remediation:
+        - id: cli
+          desc: |
+            To restrict option file permissions using the CLI:
+
+            1. Set ownership so the server account can read the files.
+            2. Remove group write and world access from every file in the chain.
+            3. Confirm the resulting permissions.
+
+            ```bash
+            sudo chown -R root:mysql /etc/mysql
+            sudo find /etc/mysql -type f -name "*.cnf" -exec chmod 0640 {} +
+            sudo find /etc/mysql -type d -exec chmod 0750 {} +
+            sudo ls -lR /etc/mysql
+            ```
+        - id: script
+          desc: |
+            To restrict option file permissions using a bash script:
+
+            1. Apply ownership and mode across the configuration directory.
+            2. Include the traditional single-file location when present.
+            3. Report any file that still allows world access.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            for target in /etc/mysql /etc/my.cnf.d; do
+              [ -d "$target" ] || continue
+              chown -R root:mysql "$target"
+              find "$target" -type f -name "*.cnf" -exec chmod 0640 {} +
+              find "$target" -type d -exec chmod 0750 {} +
+            done
+
+            if [ -f /etc/my.cnf ]; then
+              chown root:mysql /etc/my.cnf
+              chmod 0640 /etc/my.cnf
+            fi
+
+            remaining=$(find /etc/mysql /etc/my.cnf /etc/my.cnf.d -name "*.cnf" -perm /0007 -print 2>/dev/null || true)
+            if [ -n "$remaining" ]; then
+              echo "files still world accessible:" >&2
+              printf '%s\n' "$remaining" >&2
+              exit 1
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To restrict option file permissions using Ansible:
+
+            1. Find every option file in the chain.
+            2. Apply ownership and mode to each of them.
+
+            ```yaml
+            - name: Restrict MariaDB option file permissions
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find option files
+                  ansible.builtin.find:
+                    paths:
+                      - /etc/mysql
+                      - /etc/my.cnf.d
+                    patterns: "*.cnf"
+                    recurse: true
+                  register: option_files
+                  failed_when: false
+
+                - name: Protect option files
+                  ansible.builtin.file:
+                    path: "{{ item.path }}"
+                    owner: root
+                    group: mysql
+                    mode: "0640"
+                  loop: "{{ option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+            ```
+
+  - uid: mondoo-mariadb-security-user-option-files-protected
+    title: Ensure per-user option files are not readable by other accounts
+    impact: 85
+    mql: |
+      mariadb.conf.userFiles.all(file.permissions.group_readable == false && file.permissions.other_readable == false)
+    docs:
+      desc: |
+        This check ensures that every per-user option file found in a home directory is readable only by its owner. These files are `.my.cnf` and the obfuscated `.mylogin.cnf` credential store, and both routinely hold the credentials a person or a service uses to reach the database.
+
+        A `.my.cnf` holds its password in plain text. A `.mylogin.cnf` is obfuscated rather than encrypted, so its contents can be recovered by anyone who can read the file. In both cases the file mode is the only thing separating the credential from other accounts on the host. Servers with no per-user option files pass this check, because there is nothing to protect.
+
+        **Why this matters**
+
+        - **These files hold working credentials:** Their contents authenticate directly to the database.
+        - **Obfuscation is not encryption:** A readable `.mylogin.cnf` can be decoded by any account that reads it.
+        - **File mode is the only boundary:** Nothing else prevents another local account from reading them.
+
+        **Risk mitigation**
+
+        - **Prevents local credential theft:** A compromised service account cannot read another user's database password.
+        - **Contains lateral movement:** A foothold on a shared host does not yield database credentials.
+      audit: |
+        ### Audit via CLI
+
+        1. Find per-user option files and check their permissions:
+
+        ```bash
+        sudo find /home /root -maxdepth 2 \( -name ".my.cnf" -o -name ".mylogin.cnf" \) -ls 2>/dev/null
+        ```
+
+        2. Inspect the contents of a plain-text file to confirm whether it holds a credential:
+
+        ```bash
+        sudo grep -l "password" /home/*/.my.cnf 2>/dev/null
+        ```
+
+        A passing result shows every file as `-rw-------`, or finds no such files. A failing result shows a mode such as `-rw-r--r--` or `-rw-r-----`, meaning other accounts can read the credential.
+      remediation:
+        - id: cli
+          desc: |
+            To protect per-user option files using the CLI:
+
+            1. Restrict every per-user option file to its owner.
+            2. Confirm the resulting permissions.
+            3. Rotate any credential that was readable, because it must be assumed exposed.
+
+            ```bash
+            sudo find /home /root -maxdepth 2 \( -name ".my.cnf" -o -name ".mylogin.cnf" \) \
+              -exec chmod 0600 {} +
+            sudo find /home /root -maxdepth 2 \( -name ".my.cnf" -o -name ".mylogin.cnf" \) -ls
+            sudo mariadb -e "SET PASSWORD FOR 'app'@'localhost' = PASSWORD('new-password');"
+            ```
+        - id: script
+          desc: |
+            To protect per-user option files using a bash script:
+
+            1. Report each file that is readable beyond its owner before changing it.
+            2. Restrict the mode.
+            3. Remind the operator to rotate credentials that were exposed.
+
+            ```bash
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            exposed=0
+
+            while IFS= read -r file; do
+              mode=$(stat -c "%a" "$file")
+              if [ "$mode" != "600" ]; then
+                echo "restricting $file (was mode $mode)"
+                chmod 0600 "$file"
+                exposed=1
+              fi
+            done < <(find /home /root -maxdepth 2 \( -name ".my.cnf" -o -name ".mylogin.cnf" \) 2>/dev/null)
+
+            if [ "$exposed" -eq 1 ]; then
+              echo "rotate the credentials stored in these files; treat them as compromised" >&2
+            fi
+            ```
+        - id: ansible
+          desc: |
+            To protect per-user option files using Ansible:
+
+            1. Find per-user option files under the home directories.
+            2. Restrict each of them to its owner.
+
+            ```yaml
+            - name: Protect per-user MariaDB option files
+              hosts: mariadb
+              become: true
+              tasks:
+                - name: Find per-user option files
+                  ansible.builtin.find:
+                    paths:
+                      - /home
+                      - /root
+                    patterns:
+                      - ".my.cnf"
+                      - ".mylogin.cnf"
+                    hidden: true
+                    recurse: true
+                    depth: 2
+                  register: user_option_files
+                  failed_when: false
+
+                - name: Restrict them to their owner
+                  ansible.builtin.file:
+                    path: "{{ item.path }}"
+                    mode: "0600"
+                  loop: "{{ user_option_files.files | default([]) }}"
+                  loop_control:
+                    label: "{{ item.path }}"
+            ```

--- a/content/mondoo-mariadb-security.mql.yaml
+++ b/content/mondoo-mariadb-security.mql.yaml
@@ -120,6 +120,20 @@ queries:
   - uid: mondoo-mariadb-security-bind-address-restricted
     title: Ensure bind_address does not expose MariaDB on every interface
     impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       mariadb.conf.bindAddress.none(_ == "*" || _ == "0.0.0.0" || _ == "::")
     docs:
@@ -226,6 +240,20 @@ queries:
   - uid: mondoo-mariadb-security-skip-name-resolve-enabled
     title: Ensure skip_name_resolve is enabled
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.skipNameResolve == true
     docs:
@@ -338,6 +366,20 @@ queries:
   - uid: mondoo-mariadb-security-skip-show-database-enabled
     title: Ensure skip_show_database is enabled
     impact: 55
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.skipShowDatabase == true
     docs:
@@ -442,6 +484,20 @@ queries:
   - uid: mondoo-mariadb-security-require-secure-transport-enabled
     title: Ensure require_secure_transport is enabled
     impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       mariadb.conf.requireSecureTransport == true
     docs:
@@ -564,6 +620,20 @@ queries:
   - uid: mondoo-mariadb-security-tls-version-modern
     title: Ensure tls_version excludes TLS 1.0 and TLS 1.1
     impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       mariadb.conf.tlsVersion != empty
       mariadb.conf.tlsVersion.none(_.downcase == "tlsv1" || _.downcase == "tlsv1.1")
@@ -671,6 +741,20 @@ queries:
   - uid: mondoo-mariadb-security-server-certificate-configured
     title: Ensure ssl_cert and ssl_key are configured
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       mariadb.conf.sslCertFile != empty
       mariadb.conf.sslKeyFile != empty
@@ -811,6 +895,20 @@ queries:
   - uid: mondoo-mariadb-security-client-ca-configured
     title: Ensure a certificate authority is configured for client verification
     impact: 65
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.sslCaFile != empty || mariadb.conf.sslCaPath != empty
     docs:
@@ -934,6 +1032,20 @@ queries:
   - uid: mondoo-mariadb-security-skip-grant-tables-disabled
     title: Ensure skip_grant_tables is not enabled
     impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.skipGrantTables == false
     docs:
@@ -1053,6 +1165,20 @@ queries:
   - uid: mondoo-mariadb-security-simple-password-check-plugin-loaded
     title: Ensure the simple_password_check plugin is loaded at startup
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.pluginLoad.any(_ == /simple_password_check/)
     docs:
@@ -1174,6 +1300,20 @@ queries:
   - uid: mondoo-mariadb-security-simple-password-check-length-sufficient
     title: Ensure simple_password_check_minimal_length is at least 14
     impact: 65
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.simplePasswordCheckMinimalLength >= 14
     docs:
@@ -1279,6 +1419,20 @@ queries:
   - uid: mondoo-mariadb-security-simple-password-check-composition-required
     title: Ensure simple_password_check requires mixed character classes
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/pci-dss-4: pcidss-requirement-8-3-6
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.simplePasswordCheckDigits >= 1
       mariadb.conf.simplePasswordCheckLetters >= 1
@@ -1398,6 +1552,20 @@ queries:
   - uid: mondoo-mariadb-security-password-reuse-check-configured
     title: Ensure password_reuse_check_interval prevents password reuse
     impact: 55
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-d-security-awareness-training-and-tools-password-management
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-8
+      compliance/pci-dss-4: pcidss-requirement-8-3-7
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.passwordReuseCheckInterval > 0
     docs:
@@ -1532,6 +1700,20 @@ queries:
   - uid: mondoo-mariadb-security-runs-as-dedicated-account
     title: Ensure the server does not run as the root account
     impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.serverOptions["user"] != empty && mariadb.conf.serverOptions["user"].downcase != "root"
     docs:
@@ -1673,6 +1855,20 @@ queries:
   - uid: mondoo-mariadb-security-local-infile-disabled
     title: Ensure local_infile is disabled
     impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.localInfile == false
     docs:
@@ -1776,6 +1972,20 @@ queries:
   - uid: mondoo-mariadb-security-secure-file-priv-restricted
     title: Ensure secure_file_priv confines server-side file access
     impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.secureFilePriv != empty
     docs:
@@ -1899,6 +2109,20 @@ queries:
   - uid: mondoo-mariadb-security-symbolic-links-disabled
     title: Ensure symbolic_links is disabled
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.symbolicLinks == false
     docs:
@@ -2012,6 +2236,20 @@ queries:
   - uid: mondoo-mariadb-security-allow-suspicious-udfs-disabled
     title: Ensure allow_suspicious_udfs is disabled
     impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-19
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.allowSuspiciousUdfs == false
     docs:
@@ -2129,6 +2367,20 @@ queries:
   - uid: mondoo-mariadb-security-log-bin-trust-function-creators-disabled
     title: Ensure log_bin_trust_function_creators is disabled
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.logBinTrustFunctionCreators == false
     docs:
@@ -2232,6 +2484,20 @@ queries:
   - uid: mondoo-mariadb-security-automatic-sp-privileges-disabled
     title: Ensure automatic_sp_privileges is disabled
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-4-i-information-access-management
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-1-2
     mql: |
       mariadb.conf.automaticSpPrivileges == false
     docs:
@@ -2338,6 +2604,20 @@ queries:
   - uid: mondoo-mariadb-security-error-log-configured
     title: Ensure log_error names a dedicated error log destination
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.logError != empty
     docs:
@@ -2461,6 +2741,20 @@ queries:
   - uid: mondoo-mariadb-security-log-warnings-includes-warnings
     title: Ensure log_warnings records warnings and aborted connections
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-2
+      compliance/pci-dss-4: pcidss-requirement-10-2-2
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.logWarnings >= 2
     docs:
@@ -2566,6 +2860,20 @@ queries:
   - uid: mondoo-mariadb-security-log-output-retained
     title: Ensure log_output is not set to NONE
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.logOutput != empty
       mariadb.conf.logOutput.none(_.downcase == "none")
@@ -2675,6 +2983,20 @@ queries:
   - uid: mondoo-mariadb-security-general-log-disabled
     title: Ensure the general query log is disabled
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.generalLog == false
     docs:
@@ -2792,6 +3114,20 @@ queries:
   - uid: mondoo-mariadb-security-server-audit-logging-enabled
     title: Ensure server_audit_logging is enabled
     impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.serverAuditLogging == true
     docs:
@@ -2950,6 +3286,20 @@ queries:
   - uid: mondoo-mariadb-security-server-audit-events-cover-connect-and-query
     title: Ensure server_audit_events records connections and queries
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.serverAuditEvents.any(_.downcase == "connect")
       mariadb.conf.serverAuditEvents.any(_.downcase == "query")
@@ -3057,6 +3407,20 @@ queries:
   - uid: mondoo-mariadb-security-server-audit-no-excluded-users
     title: Ensure server_audit_excl_users does not exempt accounts from auditing
     impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
       mariadb.conf.serverAuditExclUsers == empty
     docs:
@@ -3173,6 +3537,20 @@ queries:
   - uid: mondoo-mariadb-security-innodb-encrypt-tables-enforced
     title: Ensure innodb_encrypt_tables is set to ON or FORCE
     impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.innodbEncryptTables.downcase == "on" || mariadb.conf.innodbEncryptTables.downcase == "force"
     docs:
@@ -3290,6 +3668,20 @@ queries:
   - uid: mondoo-mariadb-security-innodb-encrypt-log-enabled
     title: Ensure innodb_encrypt_log is enabled
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.innodbEncryptLog == true
     docs:
@@ -3402,6 +3794,20 @@ queries:
   - uid: mondoo-mariadb-security-encrypt-binlog-enabled
     title: Ensure encrypt_binlog is enabled
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.encryptBinlog == true
     docs:
@@ -3515,6 +3921,20 @@ queries:
   - uid: mondoo-mariadb-security-encrypt-tmp-disk-tables-enabled
     title: Ensure encrypt_tmp_disk_tables is enabled
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-10
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.encryptTmpDiskTables == true
     docs:
@@ -3628,6 +4048,20 @@ queries:
   - uid: mondoo-mariadb-security-file-key-management-configured
     title: Ensure file_key_management_filename names an encryption key file
     impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.fileKeyManagementFilename != empty
     docs:
@@ -3783,6 +4217,20 @@ queries:
   - uid: mondoo-mariadb-security-file-key-management-key-file-protected
     title: Ensure the encryption key file is readable only by the server account
     impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-12
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/pci-dss-4: pcidss-requirement-3-6-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
     mql: |
       mariadb.conf.fileKeyManagementFilename == empty || file(mariadb.conf.fileKeyManagementFilename).permissions.group_readable == false && file(mariadb.conf.fileKeyManagementFilename).permissions.other_readable == false
     docs:
@@ -3913,6 +4361,20 @@ queries:
   - uid: mondoo-mariadb-security-galera-replication-encrypted
     title: Ensure Galera replication traffic is encrypted
     impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       mariadb.conf.wsrepOn == false || mariadb.conf.wsrepProviderOptions == /socket\.ssl/
     docs:
@@ -4053,6 +4515,20 @@ queries:
   - uid: mondoo-mariadb-security-galera-sst-method-secure
     title: Ensure wsrep_sst_method does not use unencrypted rsync
     impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       mariadb.conf.wsrepOn == false || mariadb.conf.wsrepSstMethod.downcase != "rsync"
     docs:
@@ -4177,6 +4653,20 @@ queries:
   - uid: mondoo-mariadb-security-client-options-no-plaintext-password
     title: Ensure no plaintext password is stored in the client option groups
     impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.clientOptions["password"] == empty
     docs:
@@ -4299,6 +4789,20 @@ queries:
   - uid: mondoo-mariadb-security-option-files-restricted-permissions
     title: Ensure option files are not group or world accessible
     impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-5
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       mariadb.conf.files != empty
       mariadb.conf.files.all(permissions.group_writeable == false && permissions.other_readable == false && permissions.other_writeable == false)
@@ -4417,6 +4921,20 @@ queries:
   - uid: mondoo-mariadb-security-user-option-files-protected
     title: Ensure per-user option files are not readable by other accounts
     impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-5-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-9
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       mariadb.conf.userFiles.all(file.permissions.group_readable == false && file.permissions.other_readable == false)
     docs:


### PR DESCRIPTION
Adds `content/mondoo-mariadb-security.mql.yaml`, a security policy for self-managed MariaDB installations, built on the `mariadb.conf` resource in the `os` provider. Completes the set with #3150 (PostgreSQL) and #3151 (MySQL).

## What it checks

37 checks in eight groups, all filtered on `asset.family.contains("linux") && mariadb.conf.file.exists`:

| Group | Checks | Impact range |
|---|---|---|
| Connection and Network Exposure | 3 | 55–75 |
| Transport Encryption | 4 | 65–85 |
| Authentication and Password Policy | 5 | 55–95 |
| Filesystem Privileges and Code Execution | 7 | 60–85 |
| Logging and Audit | 7 | 60–80 |
| Encryption at Rest | 6 | 70–90 |
| Galera Cluster Replication | 2 | 75–85 |
| Credential and Option File Protection | 3 | 75–85 |

The encryption key file check is the highest non-`skip_grant_tables` item at 90: it holds the keys for every encrypted table, log, and temporary file, so a readable key file collapses the whole encryption-at-rest posture at once.

## Why this is a separate policy, not MySQL variants

The two products share an option file format, which makes them look interchangeable. Their security surfaces are not:

| Concern | MySQL | MariaDB |
|---|---|---|
| Password rules | `validate_password` component | `simple_password_check` + `password_reuse_check` plugins |
| Audit | `audit_log_*` | `server_audit_*` |
| Error verbosity | `log_error_verbosity` (named levels) | `log_warnings` (numeric) |
| Table encryption | `default_table_encryption` (boolean) | `innodb_encrypt_tables` (OFF/ON/**FORCE**) |
| Keyring | keyring components | `file_key_management` + key file on disk |
| Clustering | none in the option file | Galera `wsrep_*` in a separate `[galera]` group |

`innodb_encrypt_tables` is worth calling out: it is tri-state, not boolean, so the check accepts `ON` or `FORCE` rather than testing a boolean. `FORCE` is the stronger value because it removes the per-table `ENCRYPTED=NO` opt-out.

MariaDB also has no `default_password_lifetime`, `password_history`, or `password_require_current`, so the three corresponding MySQL checks have no analog here and are not present.

## Verification

Same approach as the previous two: every check runs against a deliberately weak fixture and a hardened one, and is only accepted if it **fails** on the weak one and **passes** on the hardened one.

```
37 checks assigned, 37 verified clean
```

The fixtures exercise `!includedir` resolution, bare-flag options, option-name normalization, and the separate `[galera]` group merge, which I confirmed populates `galeraOptions` independently of `serverOptions`.

One check needed a **third fixture**. The weak file has to *set* `file_key_management_filename` so `file-key-management-key-file-protected` has an actual 0644 key file to inspect. That makes the option present, so `file-key-management-configured` could not fail against the same fixture. Rather than drop a check or accept an unverified one, I added a `nokey` variant with the option absent and verified that check against it. I also confirmed the `== empty ||` guard on the permission check short-circuits correctly when no key file is configured, so a server using an external key management service passes rather than erroring.

`cnspec policy lint` is valid, `go test ./content/...` passes, and `typos` is clean.

## Galera checks

Two checks cover the cluster transport, both guarded on `wsrep_on` so a standalone server is not asked to configure cluster options:

- **`galera-replication-encrypted`** requires the `socket.ssl*` entries in `wsrep_provider_options`. This is a *separate transport* from client TLS: `require_secure_transport` does nothing for node-to-node traffic, and the replication channel carries the row images of every committed change.
- **`galera-sst-method-secure`** rejects `rsync`. A state snapshot transfer moves the entire dataset in one operation, and the `rsync` method carries it unencrypted and unauthenticated on a separate port. `mariabackup` supports encryption and authentication.

Their Ansible remediations use `serial: 1` so nodes restart one at a time and the cluster stays available, and the `script` variants explicitly report that every node needs the same change before the cluster will re-form.

## Design notes

Consistent with the other two policies: remediation edits the option file directly rather than using `SET PERSIST` (which writes to `mysqld-auto.cnf`, applied after the option files and not parsed by this resource), `runs-as-dedicated-account` asserts on `serverOptions["user"]` rather than the typed `runAsUser` field so it stays fixture-verifiable, and the general query log check asserts **off** because it records `SET PASSWORD` statements in cleartext.

`server-audit-no-excluded-users` is a check I have not seen elsewhere and is worth a look: `server_audit_excl_users` is usually populated to silence a busy application account, which is precisely the account most likely to be targeted. The `audit:` step also surfaces `server_audit_incl_users`, which narrows coverage the same way from the other direction.

## Requires

`mariadb.conf` first ships in **os provider 13.39.0**. The resource returns nothing on a MySQL host, so these checks correctly do not apply to those servers.

## Deliberately out of scope

- **Compliance tags are now included** (see the follow-up commit). All 37 checks carry `compliance/*` tags across the 13 frameworks the content repo tags.
- **Anything requiring a SQL connection.** No accounts, grants, or `mysql.global_priv` inspection. `audit:` steps use `mariadb -e` so an auditor gets a vendor-native path that reflects runtime state.
- **One check not fixture-verified in the failing direction.** `user-option-files-protected` reads `userFiles`, which enumerates real home directories rather than accepting a path.

## Compliance mapping method

Tags were not copied from neighboring checks. Every control uid was read from the framework definitions in `cnspec-enterprise-policies/frameworks`, and a validator confirms each one exists under the framework it is claimed for before anything is written. Checks were grouped by control objective into 19 families and each family mapped once, so two checks share a control only when they genuinely share an objective.

Two mechanical traps worth knowing about, both handled:

- **The tag key is not always the framework uid.** The CSA framework declares `uid: cloud-controls-matrix-4`, but content tags it as `compliance/csa-cloud-controls-matrix-4` while the control uid values are prefixed `cloud-controls-matrix-4-`. A key that matches no real framework produces a dangling `framework_owner` and fails bundle migration.
- **Control uid prefixes are irregular.** PCI DSS controls are `pcidss-requirement-*`, SOC 2 are `soc2-control-*`, and NIST SP 800-171 uses a double hyphen (`nist-sp-800-171--3-13-8`). None of these are derivable from the framework key, so all 1049 mapped values were validated against the catalog rather than constructed.

Erring toward a null mapping, per the guidance that a missing mapping beats a wrong one: **20% of cells are the unquoted YAML boolean `false`**.

| Framework | null cells |
|---|---|
| bsi-sys-1-5 | all |
| nis-2 | ~half |
| soc2-2017 | ~a third |
| hipaa | ~a quarter |
| vda-isa-5, csa, pci-dss-4, nist-csf-1/2 | a few |
| iso-27001-2022, nist-sp-800-53-rev5 | none |

BSI SYS.1.5 is `false` throughout: it is a virtualization baustein covering virtual IT systems, virtual networks, and hypervisor administration, with no database-configuration nexus. NIS2 has only 21 broad articles, of which only 21.2(h) Cryptography and 21.2(i) Access control reach these checks, so the logging, password-policy, and file-permission checks are `false` there.

A few mappings are deliberately narrower than their group:

- Password checks split three ways rather than sharing one control: length and composition to NIST SP 800-171 3.5.7 / PCI 8.3.6, reuse to 3.5.8 / PCI 8.3.7, and expiry to PCI 8.3.9 with **800-171 `false`** because rev2 has no forced-rotation requirement.
- The general-query-log and credential-file checks map to credential-protection controls (800-171 3.5.10 "Store and transmit only cryptographically-protected passwords", PCI 8.3.2), not to the logging controls, because their objective is keeping cleartext passwords off disk.
- The encryption-key checks map to key management (SC-12, 3.13.10, PCI 3.6.1, SOC 2 CC6.1.11), not data-at-rest. CSA is `false` there: its CEK domain covers key lifecycle stages but has no key-storage-protection control.
- Config-file permissions map to configuration/change-restriction controls (CM-5, 3.4.5, ISO A.8.9), with PCI and SOC 2 `false` rather than stretched to their broad "configuration standards" requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)