### PR TITLE
🐛 scan: stop a failed upstream sync from segfaulting the scanner

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -26,7 +26,6 @@ import (
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/cnspec/v13/policy/executor"
 	"go.mondoo.com/mql/v13"
-	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/cli/execruntime"
 	"go.mondoo.com/mql/v13/discovery"
 	"go.mondoo.com/mql/v13/llx"
@@ -41,7 +40,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/gql"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/health"
 	"go.mondoo.com/mql/v13/utils/multierr"
-	ranger "go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"google.golang.org/protobuf/proto"
@@ -497,11 +495,26 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	connSem := make(chan struct{}, maxConn)
 	var scannedAssets atomic.Int64
 
+	// scanRunCtx bounds every scan goroutine. Cancelling it lets assets that
+	// are still queued for a worker slot be dropped instead of scanned, so the
+	// dispatcher drains promptly when we bail out early.
+	scanRunCtx, cancelScanRun := context.WithCancel(ctx)
+
 	dispatcher := newScanDispatcher(
 		parallelism, connSem, s, explorer, job, upstream,
 		reporter, multiprogress, services, spaceMrn, &scannedAssets,
 	)
 	batcher := newSyncBatcher(dispatcher, services, spaceMrn, s.recording, multiprogress)
+
+	// Drain in-flight scans before returning. Registered after the
+	// explorer.Shutdown defer above so it runs before it (defers are LIFO):
+	// Shutdown closes every asset runtime and sets it to nil, which races with
+	// scans that are still queued or running whenever an early return — e.g. a
+	// failed upstream sync — skips the normal drain at the end of scanSubtree.
+	defer func() {
+		cancelScanRun()
+		dispatcher.Wait()
+	}()
 
 	scanCtx := &scanContext{
 		explorer:           explorer,
@@ -529,7 +542,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			}
 		}
 
-		if err := scanCtx.scanSubtree(ctx, root); err != nil {
+		if err := scanCtx.scanSubtree(scanRunCtx, root); err != nil {
 			return nil, err
 		}
 	}
@@ -728,6 +741,21 @@ func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedA
 	return nil
 }
 
+// isPermanentUpstreamError reports whether an upstream RPC error will fail the
+// same way on every attempt — expired or rejected credentials, missing
+// permissions, or a request the server refuses outright — as opposed to a
+// transient network, timeout or backend fault that a retry can recover from.
+func isPermanentUpstreamError(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		switch status.Code(e) {
+		case codes.Unauthenticated, codes.PermissionDenied, codes.InvalidArgument,
+			codes.NotFound, codes.Unimplemented:
+			return true
+		}
+	}
+	return false
+}
+
 // syncBatchWithUpstream synchronizes a batch of connected assets with the
 // upstream Mondoo Platform, or assigns local MRNs when running in incognito mode.
 func syncBatchWithUpstream(
@@ -754,6 +782,13 @@ func syncBatchWithUpstream(
 			})
 			if err == nil {
 				break
+			}
+			// Bad credentials, missing permissions or a rejected request fail
+			// identically on every attempt. Retrying only burns the backoff
+			// before reporting the same error.
+			if isPermanentUpstreamError(err) {
+				log.Error().Err(err).Msg("SynchronizeAssets failed with a permanent error, not retrying")
+				return err
 			}
 			if attempt < maxSyncRetries {
 				backoff := time.Duration(attempt) * 2 * time.Second
@@ -1442,35 +1477,6 @@ func (s *localAssetScanner) UpdateFilters(filters *policy.Mqueries, timeout time
 	}
 
 	return queries, err
-}
-
-func sendErrorToMondooPlatform(serviceAccount *upstream.ServiceAccountCredentials, event *health.SendErrorReq) {
-	// 3. send error to mondoo platform
-	proxy, err := config.GetAPIProxy()
-	if err != nil {
-		log.Error().Err(err).Msg("failed to parse proxy setting")
-		return
-	}
-	httpClient := ranger.NewHttpClient(ranger.WithProxy(proxy))
-
-	plugins := []ranger.ClientPlugin{}
-	certAuth, err := upstream.NewServiceAccountRangerPlugin(serviceAccount)
-	if err != nil {
-		return
-	}
-	plugins = append(plugins, certAuth)
-
-	cl, err := health.NewErrorReportingClient(serviceAccount.ApiEndpoint, httpClient, plugins...)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to create error reporting client")
-		return
-	}
-
-	_, err = cl.SendError(context.Background(), event)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to send error to Mondoo Platform")
-		return
-	}
 }
 
 func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Asset, upstreamClient *upstream.UpstreamClient, f func(context.Context, *policy.LocalServices) error) error {

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -741,21 +741,6 @@ func (sc *scanContext) scanSubtree(ctx context.Context, node *discovery.TrackedA
 	return nil
 }
 
-// isPermanentUpstreamError reports whether an upstream RPC error will fail the
-// same way on every attempt — expired or rejected credentials, missing
-// permissions, or a request the server refuses outright — as opposed to a
-// transient network, timeout or backend fault that a retry can recover from.
-func isPermanentUpstreamError(err error) bool {
-	for e := err; e != nil; e = errors.Unwrap(e) {
-		switch status.Code(e) {
-		case codes.Unauthenticated, codes.PermissionDenied, codes.InvalidArgument,
-			codes.NotFound, codes.Unimplemented:
-			return true
-		}
-	}
-	return false
-}
-
 // syncBatchWithUpstream synchronizes a batch of connected assets with the
 // upstream Mondoo Platform, or assigns local MRNs when running in incognito mode.
 func syncBatchWithUpstream(
@@ -782,13 +767,6 @@ func syncBatchWithUpstream(
 			})
 			if err == nil {
 				break
-			}
-			// Bad credentials, missing permissions or a rejected request fail
-			// identically on every attempt. Retrying only burns the backoff
-			// before reporting the same error.
-			if isPermanentUpstreamError(err) {
-				log.Error().Err(err).Msg("SynchronizeAssets failed with a permanent error, not retrying")
-				return err
 			}
 			if attempt < maxSyncRetries {
 				backoff := time.Duration(attempt) * 2 * time.Second

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -5,7 +5,6 @@ package scan
 
 import (
 	"context"
-	"fmt"
 	"os"
 	goruntime "runtime"
 	"runtime/debug"
@@ -14,11 +13,11 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13"
 	"go.mondoo.com/cnspec/v13/cli/progress"
 	"go.mondoo.com/cnspec/v13/policy"
-	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/discovery"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -189,21 +188,22 @@ func (d *scanDispatcher) Submit(ctx context.Context, tracked *discovery.TrackedA
 	go func() {
 		defer d.wg.Done()
 		defer func() { <-d.connSem }()
-		defer d.reportPanic(tracked)
+		defer d.recoverAssetPanic(tracked)
 
 		// Acquire worker slot, respecting context cancellation.
 		select {
 		case d.scanSem <- struct{}{}:
 			defer func() { <-d.scanSem }()
 		case <-ctx.Done():
-			assetName := ""
-			if tracked.Asset != nil {
-				assetName = tracked.Asset.Name
-			}
-			if err := d.explorer.CloseAsset(tracked); err != nil {
-				log.Error().Err(err).Str("asset", assetName).Msg("failed to close asset")
-			}
-			tracked.Asset = nil
+			d.abandon(tracked)
+			return
+		}
+
+		// The scan run can be cancelled while we wait for a slot, and select
+		// picks at random when both cases are ready — so check again before
+		// starting work whose results we are about to throw away.
+		if ctx.Err() != nil {
+			d.abandon(tracked)
 			return
 		}
 
@@ -222,11 +222,45 @@ func (d *scanDispatcher) Wait() {
 	d.wg.Wait()
 }
 
+// abandon releases an asset that will not be scanned because the scan run was
+// cancelled before a worker slot came free. It resolves the asset's progress
+// task so the TODO list does not wait on it, and closes the connection.
+func (d *scanDispatcher) abandon(tracked *discovery.TrackedAsset) {
+	assetName := ""
+	if tracked.Asset != nil {
+		assetName = tracked.Asset.Name
+		if len(tracked.Asset.PlatformIds) > 0 {
+			d.multiprogress.Errored(tracked.Asset.PlatformIds[0])
+		}
+	}
+	if err := d.explorer.CloseAsset(tracked); err != nil {
+		log.Debug().Err(err).Str("asset", assetName).Msg("could not close abandoned asset")
+	}
+	tracked.Asset = nil
+}
+
 // scanSingleAsset handles the full lifecycle of scanning one asset: delayed
 // discovery, validation, scanning, error reporting, and closing.
 func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery.TrackedAsset) {
 	asset := tracked.Asset
 	runtime := tracked.Runtime
+
+	// The asset can be closed between Submit and the moment a worker slot
+	// frees up: the explorer shuts down when the scan returns early, and
+	// dedup evicts assets whose platform IDs turn out to be a subset of a
+	// newly connected asset. Both clear Runtime, so there is nothing left
+	// to scan here.
+	if asset == nil || runtime == nil {
+		assetName := ""
+		if asset != nil {
+			assetName = asset.Name
+			if len(asset.PlatformIds) > 0 {
+				d.multiprogress.Errored(asset.PlatformIds[0])
+			}
+		}
+		log.Debug().Str("asset", assetName).Msg("asset was closed before its scan started, skipping")
+		return
+	}
 
 	if err := runtime.EnsureProvidersConnected(); err != nil {
 		log.Error().Err(err).Msg("could not connect to providers")
@@ -356,53 +390,67 @@ func (d *scanDispatcher) logMemoryStats(asset *inventory.Asset) {
 	}
 }
 
-// reportPanic captures panics from scan goroutines and reports them.
-func (d *scanDispatcher) reportPanic(tracked *discovery.TrackedAsset) {
-	health.ReportPanic("cnspec", cnspec.Version, cnspec.Build, func(product, version, build string, r any, stacktrace []byte) {
-		opts, err := config.Read()
-		if err != nil {
-			log.Error().Err(err).Msg("failed to read config")
-			return
-		}
+// recoverAssetPanic recovers a panic raised while scanning a single asset,
+// reports it to the Mondoo Platform with asset context, and records it as a
+// scan error so the asset is reported as failed instead of silently missing.
+// One bad asset no longer takes the whole scan process down with it.
+//
+// It must be deferred directly. recover() only takes effect in the deferred
+// function itself, which is why this cannot delegate to health.ReportPanic:
+// that function's recover() would sit one frame too deep, catch nothing, and
+// the panic would kill the process before any report was sent.
+func (d *scanDispatcher) recoverAssetPanic(tracked *discovery.TrackedAsset) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	stacktrace := debug.Stack()
 
-		serviceAccount := opts.GetServiceCredential()
-		if serviceAccount == nil {
-			log.Error().Msg("no service account configured")
-			return
-		}
+	var asset *inventory.Asset
+	if tracked != nil {
+		asset = tracked.Asset
+	}
 
-		tags := map[string]string{
-			"spaceMrn": d.spaceMrn,
+	// Send asset identification as structured tags so the platform can
+	// attribute the panic to a specific asset, rather than burying the map
+	// in the message string.
+	tags := map[string]string{
+		"spaceMrn": d.spaceMrn,
+	}
+	assetName := ""
+	if asset != nil {
+		assetName = asset.Name
+		tags["assetMrn"] = asset.Mrn
+		tags["assetName"] = asset.Name
+		tags["platformIDs"] = strings.Join(asset.PlatformIds, ",")
+		if asset.Platform != nil {
+			tags["assetPlatform"] = asset.Platform.Name
+			tags["assetPlatformVersion"] = asset.Platform.Version
 		}
-		if tracked != nil && tracked.Asset != nil {
-			tags["assetMrn"] = tracked.Asset.Mrn
-			tags["assetName"] = tracked.Asset.Name
-			tags["platformIDs"] = strings.Join(tracked.Asset.PlatformIds, ",")
-			if tracked.Asset.Platform != nil {
-				tags["assetPlatform"] = tracked.Asset.Platform.Name
-				tags["assetPlatformVersion"] = tracked.Asset.Platform.Version
-			}
-		}
+	}
 
-		event := &health.SendErrorReq{
-			ServiceAccountMrn: opts.ServiceAccountMrn,
-			AgentMrn:          opts.AgentMrn,
-			Product: &health.ProductInfo{
-				Name:    product,
-				Version: version,
-				Build:   build,
-			},
-			Error: &health.ErrorInfo{
-				Message:    "panic: " + fmt.Sprintf("%v", r),
-				Stacktrace: string(stacktrace),
-			},
-			// Send asset identification as structured tags so the platform
-			// can attribute the panic to a specific asset, rather than
-			// burying the map in the message string.
-			Tags: tags,
-		}
+	log.Error().
+		Interface("panic", r).
+		Str("asset", assetName).
+		Str("stacktrace", string(stacktrace)).
+		Msg("recovered panic while scanning asset")
 
-		sendErrorToMondooPlatform(serviceAccount, event)
-		log.Info().Msg("reported panic to Mondoo Platform")
-	})
+	health.ReportRecoveredPanic("cnspec", cnspec.Version, cnspec.Build, r, stacktrace, tags)
+
+	if asset == nil {
+		return
+	}
+
+	d.reporter.AddScanError(asset, errors.Newf("panic while scanning asset: %v", r))
+	if len(asset.PlatformIds) > 0 {
+		d.multiprogress.Errored(asset.PlatformIds[0])
+	}
+
+	// Release the connection the panicking scan left open. The asset may
+	// already be closed (a panic after CloseAsset), which is not an error
+	// worth surfacing here.
+	if err := d.explorer.CloseAsset(tracked); err != nil {
+		log.Debug().Err(err).Str("asset", assetName).Msg("could not close asset after panic")
+	}
+	tracked.Asset = nil
 }

--- a/policy/scan/scan_pipeline_test.go
+++ b/policy/scan/scan_pipeline_test.go
@@ -7,14 +7,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnspec/v13/cli/progress"
 	"go.mondoo.com/mql/v13/discovery"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/ranger-rpc/codes"
-	"go.mondoo.com/ranger-rpc/status"
 )
 
 // Assets are submitted to the dispatcher before a worker slot is free, so they
@@ -90,28 +87,4 @@ func TestRecoverAssetPanic(t *testing.T) {
 			defer d.recoverAssetPanic(nil)
 		})
 	})
-}
-
-func TestIsPermanentUpstreamError(t *testing.T) {
-	tests := []struct {
-		name      string
-		err       error
-		permanent bool
-	}{
-		{"nil", nil, false},
-		{"unauthenticated", status.Error(codes.Unauthenticated, "request permission unauthenticated"), true},
-		{"permission denied", status.Error(codes.PermissionDenied, "request permission denied"), true},
-		{"wrapped unauthenticated", errors.Wrap(status.Error(codes.Unauthenticated, "nope"), "sync failed"), true},
-		{"unavailable", status.Error(codes.Unavailable, "try again"), false},
-		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "too slow"), false},
-		{"internal", status.Error(codes.Internal, "backend fault"), false},
-		{"plain error", errors.New("connection reset by peer"), false},
-		{"context canceled", context.Canceled, false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.permanent, isPermanentUpstreamError(test.err))
-		})
-	}
 }

--- a/policy/scan/scan_pipeline_test.go
+++ b/policy/scan/scan_pipeline_test.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/cli/progress"
+	"go.mondoo.com/mql/v13/discovery"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+// Assets are submitted to the dispatcher before a worker slot is free, so they
+// can be closed while they wait: the explorer shuts down when the scan returns
+// early, and dedup evicts assets that turn out to be a subset of a newly
+// connected one. Both clear the runtime, which used to segfault in
+// EnsureProvidersConnected as soon as the queued scan started.
+func TestScanSingleAssetSkipsClosedAsset(t *testing.T) {
+	d := &scanDispatcher{multiprogress: progress.NoopMultiProgress{}}
+
+	t.Run("runtime cleared", func(t *testing.T) {
+		tracked := &discovery.TrackedAsset{
+			Asset: &inventory.Asset{Name: "closed", PlatformIds: []string{"//platformid/1"}},
+			State: discovery.AssetClosed,
+		}
+		require.NotPanics(t, func() {
+			d.scanSingleAsset(context.Background(), tracked)
+		})
+	})
+
+	t.Run("asset and runtime cleared", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			d.scanSingleAsset(context.Background(), &discovery.TrackedAsset{State: discovery.AssetClosed})
+		})
+	})
+}
+
+// recoverAssetPanic must recover the panic itself. It previously delegated to
+// health.ReportPanic, whose recover() sat one frame too deep to catch anything,
+// so a single bad asset crashed the whole scan process.
+func TestRecoverAssetPanic(t *testing.T) {
+	t.Run("records the asset as failed", func(t *testing.T) {
+		reporter := NewAggregateReporter()
+		d := &scanDispatcher{
+			multiprogress: progress.NoopMultiProgress{},
+			// A zero-value explorer tracks no assets, so CloseAsset reports
+			// the asset as untracked instead of touching a live connection.
+			explorer: &discovery.AssetExplorer{},
+			reporter: reporter,
+			spaceMrn: "//captain.api.mondoo.app/spaces/test",
+		}
+		assetMrn := "//assets.api.mondoo.app/spaces/test/assets/1"
+		tracked := &discovery.TrackedAsset{
+			Asset: &inventory.Asset{
+				Name:        "panicky",
+				Mrn:         assetMrn,
+				PlatformIds: []string{"//platformid/1"},
+			},
+		}
+
+		require.NotPanics(t, func() {
+			defer d.recoverAssetPanic(tracked)
+			panic("boom")
+		})
+
+		assert.Nil(t, tracked.Asset, "asset reference should be released")
+		res := reporter.Reports()
+		assert.False(t, res.Ok)
+		assert.Contains(t, res.GetFull().Errors[assetMrn], "boom")
+	})
+
+	t.Run("without an asset", func(t *testing.T) {
+		d := &scanDispatcher{multiprogress: progress.NoopMultiProgress{}}
+		require.NotPanics(t, func() {
+			defer d.recoverAssetPanic(nil)
+			panic("boom")
+		})
+	})
+
+	t.Run("no panic", func(t *testing.T) {
+		d := &scanDispatcher{multiprogress: progress.NoopMultiProgress{}}
+		require.NotPanics(t, func() {
+			defer d.recoverAssetPanic(nil)
+		})
+	})
+}
+
+func TestIsPermanentUpstreamError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		permanent bool
+	}{
+		{"nil", nil, false},
+		{"unauthenticated", status.Error(codes.Unauthenticated, "request permission unauthenticated"), true},
+		{"permission denied", status.Error(codes.PermissionDenied, "request permission denied"), true},
+		{"wrapped unauthenticated", errors.Wrap(status.Error(codes.Unauthenticated, "nope"), "sync failed"), true},
+		{"unavailable", status.Error(codes.Unavailable, "try again"), false},
+		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "too slow"), false},
+		{"internal", status.Error(codes.Internal, "backend fault"), false},
+		{"plain error", errors.New("connection reset by peer"), false},
+		{"context canceled", context.Canceled, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.permanent, isPermanentUpstreamError(test.err))
+		})
+	}
+}


### PR DESCRIPTION
## What happened

A production Azure scan crashed with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
go.mondoo.com/mql/v13/providers.(*Runtime).EnsureProvidersConnected(...)
	providers/runtime.go:326
go.mondoo.com/cnspec/v13/policy/scan.(*scanDispatcher).scanSingleAsset(...)
	policy/scan/scan_pipeline.go:231
go.mondoo.com/cnspec/v13/policy/scan.(*scanDispatcher).Submit.func1()
	policy/scan/scan_pipeline.go:216
```

The receiver itself was nil, not one of its fields. Working backwards from the logs:

1. `SynchronizeAssets` returned `Unauthenticated`. All three attempts failed, so `syncBatchWithUpstream` returned the error.
2. `syncBatcher.Flush` propagated it up through `scanSubtree`, and `distributeJob` returned.
3. Nothing drains the dispatcher on that path — `dispatcher.Wait()` only runs on the success path and at branch boundaries — so the deferred `explorer.Shutdown()` closed every asset and set each `Runtime` to nil while scan goroutines were still alive.
4. Assets submitted by earlier, successful batches were parked waiting for a worker slot (`connSem` is 50, parallelism is much lower, so queueing is the normal state). ~6s later a slot freed, one resumed into `scanSingleAsset`, and dereferenced its now-nil runtime.

## Changes

- **Drain in-flight scans before returning.** A cancellable `scanRunCtx` bounds every scan goroutine, and a defer registered after the `explorer.Shutdown` one (defers are LIFO, so it runs first) cancels it and waits for the dispatcher. `Submit` rechecks `ctx.Err()` after acquiring a slot, since `select` picks at random when both cases are ready. This is the fix for the crash.
- **Guard `scanSingleAsset` against a closed asset.** Defence in depth for the exact deref, and it also covers a second race: `AssetExplorer.dedup` evicts already-submitted assets whose platform IDs turn out to be a subset of a newly connected one, clearing their runtime the same way.
- **Make the per-asset panic handler actually recover.** It delegated to `health.ReportPanic`, whose `recover()` sat one frame too deep to catch anything — so panics killed the process *and* no report was ever sent. Panics are now recovered, reported with the same asset tags, recorded as a scan error, and contained to the one asset. This also makes `sendErrorToMondooPlatform` dead code (mql's `sendPanic` does the same work), so it's removed.

Retry behaviour for `SynchronizeAssets` is unchanged — every failure still retries, pending a proper assessment of which upstream codes are genuinely non-retryable.

## Testing

New `policy/scan/scan_pipeline_test.go` covers the nil-runtime path that segfaulted, and that the panic handler swallows the panic and records the asset as failed.

`go test -race ./policy/...` passes and `golangci-lint run ./policy/scan/...` is clean.

## Note

This fixes the crash, not the trigger. The scan still fails on `Unauthenticated` from `SynchronizeAssets` — now with a clean error instead of a SIGSEGV — so that credential rejection still needs looking at on the platform side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
