### PR TITLE
fix(upload): classify Windows socket errors instead of dumping them in "other"

### DIFF
--- a/upload/failurekind.go
+++ b/upload/failurekind.go
@@ -31,13 +31,21 @@ const (
 	FailureConnectionReset FailureKind = "connection_reset"
 	// FailureBrokenPipe is a local write to a connection the peer had already
 	// closed (EPIPE) — typically mid-body, after some bytes went out.
-	FailureBrokenPipe      FailureKind = "broken_pipe"
-	FailureDNS             FailureKind = "dns"
-	FailureTLS             FailureKind = "tls"
-	FailureContextCanceled FailureKind = "context_canceled"
-	FailureHTTPStatus      FailureKind = "http_status"
-	FailureReportRPC       FailureKind = "report_rpc_failed"
-	FailureURLRequest      FailureKind = "url_request_failed"
+	FailureBrokenPipe FailureKind = "broken_pipe"
+	// FailureConnectionAbortedLocally is Windows WSAECONNABORTED: "an
+	// established connection was aborted by the software in your host machine".
+	// Deliberately NOT folded into FailureConnectionReset — the peer did not
+	// drop this connection, something on the client host did, which in practice
+	// means antivirus, endpoint security, or a local proxy agent. "Our own
+	// machine killed it" and "the far end dropped it" lead to completely
+	// different investigations, so they get different kinds.
+	FailureConnectionAbortedLocally FailureKind = "connection_aborted_locally"
+	FailureDNS                      FailureKind = "dns"
+	FailureTLS                      FailureKind = "tls"
+	FailureContextCanceled          FailureKind = "context_canceled"
+	FailureHTTPStatus               FailureKind = "http_status"
+	FailureReportRPC                FailureKind = "report_rpc_failed"
+	FailureURLRequest               FailureKind = "url_request_failed"
 	// FailureOther is the catch-all. An unrecognised error is still reported —
 	// with its message intact — rather than dropped. A nil error also maps here;
 	// see ClassifyFailure.
@@ -90,6 +98,16 @@ func ClassifyFailure(err error) FailureKind {
 	}
 	if errors.Is(err, syscall.EPIPE) {
 		return FailureBrokenPipe
+	}
+
+	// Windows socket errors do NOT satisfy the checks above: Go defines
+	// syscall.ECONNRESET and friends on Windows as synthetic
+	// APPLICATION_ERROR+iota constants, while the kernel returns WSAE* values
+	// (WSAECONNRESET = 10054). errors.Is against the POSIX names therefore never
+	// matches there, and every Windows connection failure fell through to
+	// FailureOther until this hook existed. See failurekind_windows.go.
+	if kind, ok := classifyPlatform(err); ok {
+		return kind
 	}
 
 	// Checked after the specific cases above: a DNS or TLS failure is also a

--- a/upload/failurekind_notwindows.go
+++ b/upload/failurekind_notwindows.go
@@ -1,0 +1,13 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package upload
+
+// classifyPlatform is the no-op counterpart to the Windows implementation.
+// Everywhere except Windows the POSIX errno checks in ClassifyFailure already
+// match, so there is nothing platform-specific left to recognise.
+func classifyPlatform(error) (FailureKind, bool) {
+	return "", false
+}

--- a/upload/failurekind_windows.go
+++ b/upload/failurekind_windows.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package upload
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// classifyPlatform maps Windows socket errors onto FailureKind.
+//
+// This exists because the POSIX names do not work here. Go defines
+// syscall.ECONNRESET, ECONNREFUSED and friends on Windows as synthetic
+// APPLICATION_ERROR+iota constants, whereas Winsock returns its own numbering
+// (WSAECONNRESET = 10054, WSAECONNREFUSED = 10061, ...). An errors.Is check
+// against the POSIX constant therefore never matches a real Windows socket
+// failure, and every one of them was landing in FailureOther. Windows is a
+// first-class scanning target, so this is not a rare path.
+//
+// golang.org/x/sys/windows is used rather than syscall because syscall only
+// exposes four WSAE* constants (WSAEACCES, WSAENOPROTOOPT, WSAECONNABORTED,
+// WSAECONNRESET); the rest, including WSAECONNREFUSED, live in x/sys.
+func classifyPlatform(err error) (FailureKind, bool) {
+	switch {
+	case errors.Is(err, windows.WSAECONNABORTED):
+		// "An established connection was aborted by the software in your host
+		// machine" — the local side killed it, not the peer. Its own kind; see
+		// FailureConnectionAbortedLocally.
+		return FailureConnectionAbortedLocally, true
+	case errors.Is(err, windows.WSAECONNRESET):
+		return FailureConnectionReset, true
+	case errors.Is(err, windows.WSAECONNREFUSED):
+		return FailureConnectionRefused, true
+	case errors.Is(err, windows.WSAETIMEDOUT):
+		return FailureTimeout, true
+	case errors.Is(err, windows.WSAEHOSTUNREACH), errors.Is(err, windows.WSAENETUNREACH):
+		// No route to the destination at all. Grouped with refused because the
+		// operational question is the same: this host cannot reach that
+		// endpoint, as distinct from reaching it and being dropped.
+		return FailureConnectionRefused, true
+	case errors.Is(err, windows.WSAHOST_NOT_FOUND), errors.Is(err, windows.WSATRY_AGAIN):
+		return FailureDNS, true
+	}
+	return "", false
+}

--- a/upload/failurekind_windows_test.go
+++ b/upload/failurekind_windows_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package upload
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+// TestClassifyFailure_WindowsSocketErrors covers the gap that put every Windows
+// connection failure into FailureOther: Go's syscall.ECONNRESET on Windows is a
+// synthetic APPLICATION_ERROR+iota value, not Winsock's 10054, so errors.Is
+// against the POSIX names never matched here.
+//
+// The errors are shaped the way net/http delivers them — a *net.OpError
+// wrapping the raw Errno — because that wrapping is what errors.Is has to
+// traverse.
+func TestClassifyFailure_WindowsSocketErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want FailureKind
+	}{
+		{
+			// Seen in the field as: "An established connection was aborted by
+			// the software in your host machine."
+			name: "WSAECONNABORTED is local interference, not a peer reset",
+			err:  &net.OpError{Op: "read", Err: windows.WSAECONNABORTED},
+			want: FailureConnectionAbortedLocally,
+		},
+		{
+			// Seen in the field as: "An existing connection was forcibly closed
+			// by the remote host."
+			name: "WSAECONNRESET",
+			err:  &net.OpError{Op: "read", Err: windows.WSAECONNRESET},
+			want: FailureConnectionReset,
+		},
+		{name: "WSAECONNREFUSED", err: &net.OpError{Op: "dial", Err: windows.WSAECONNREFUSED}, want: FailureConnectionRefused},
+		{name: "WSAETIMEDOUT", err: &net.OpError{Op: "dial", Err: windows.WSAETIMEDOUT}, want: FailureTimeout},
+		{name: "WSAEHOSTUNREACH", err: &net.OpError{Op: "dial", Err: windows.WSAEHOSTUNREACH}, want: FailureConnectionRefused},
+		{name: "WSAENETUNREACH", err: &net.OpError{Op: "dial", Err: windows.WSAENETUNREACH}, want: FailureConnectionRefused},
+		{name: "WSAHOST_NOT_FOUND", err: &net.OpError{Op: "dial", Err: windows.WSAHOST_NOT_FOUND}, want: FailureDNS},
+		{name: "wrapped", err: fmt.Errorf("upload failed: %w", &net.OpError{Op: "write", Err: windows.WSAECONNRESET}), want: FailureConnectionReset},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassifyFailure(tc.err))
+		})
+	}
+}
+
+// TestClassifyFailure_WindowsPOSIXNamesDoNotMatch is the regression guard for
+// the root cause. If a future Go release ever makes syscall.ECONNRESET on
+// Windows equal Winsock's value, this test fails and the platform hook can be
+// simplified — but until then it documents WHY the hook has to exist.
+func TestClassifyFailure_WindowsPOSIXNamesDoNotMatch(t *testing.T) {
+	assert.NotEqual(t, syscall.Errno(windows.WSAECONNRESET), syscall.ECONNRESET,
+		"syscall.ECONNRESET now equals WSAECONNRESET — the platform hook may be redundant")
+}


### PR DESCRIPTION
Once upload-failure reporting from #3148 started arriving, several records came back as `failure_kind="other"` — and every one of them was a Windows socket error:

```
wsarecv: An established connection was aborted by the software in your host machine.
wsarecv: An existing connection was forcibly closed by the remote host.
wsasend: An existing connection was forcibly closed by the remote host.
```

Those are `WSAECONNABORTED` (10053) and `WSAECONNRESET` (10054), and the classifier could never have matched them.

## Why

On Windows, Go defines `syscall.ECONNRESET` and friends as **synthetic `APPLICATION_ERROR + iota` constants** — not Winsock's numbering. Verified in the Go 1.26.4 source:

```
syscall/zerrors_windows.go:  ECONNRESET   (APPLICATION_ERROR + iota)
syscall/types_windows.go:    WSAECONNRESET   Errno = 10054
```

So `errors.Is(err, syscall.ECONNRESET)` **never matches a real Windows socket failure**, and every Windows connection error was falling through to `other`. Windows is a first-class scanning target, so this is not a rare path.

## What changed

A build-tagged `classifyPlatform` hook (`failurekind_windows.go` / `failurekind_notwindows.go`) mapping `WSAECONNRESET`, `WSAECONNREFUSED`, `WSAETIMEDOUT`, `WSAE{HOST,NET}UNREACH` and `WSAHOST_NOT_FOUND` onto the existing kinds.

Uses `golang.org/x/sys/windows` — already a direct dependency — because `syscall` exposes only four `WSAE*` constants and `WSAECONNREFUSED` isn't one of them.

## One new kind, deliberately

`WSAECONNABORTED` gets its own `connection_aborted_locally` rather than being folded into `connection_reset`.

*"An established connection was aborted by the software in your host machine"* means **the local side killed it** — in practice antivirus, endpoint security, or a proxy agent — not the peer. Diagnosing "our own machine killed the connection" is a different exercise from "the far end dropped it", and it's a plausible explanation for a host that can reach one endpoint but not another. Collapsing the two would hide that distinction at exactly the point it's most useful.

## Testing

- `GOOS=windows go vet ./upload/` — the only thing that compiles the Windows files and their test, since neither is built on a dev host. Clean.
- Windows-tagged table test covering all six mappings plus a wrapped error, with the errors shaped as `*net.OpError` wrapping the raw `Errno`, which is how `net/http` actually delivers them and what `errors.Is` has to traverse.
- A guard asserting `syscall.ECONNRESET` still differs from `WSAECONNRESET` — if a future Go release unifies them, it fails and the hook can be deleted.
- Host tests unchanged and passing.

## Worth noting

The catch-all worked as intended. `other` keeps the raw message, and that is the only reason this was visible at all rather than quietly miscounted as a handled case. Had unknown errors mapped to a bare `"unknown"` with the message dropped, this would have gone unnoticed until someone wondered why Windows never fails.

Timing: worth landing before affected clients upgrade, so the data arrives already classified rather than needing to be re-read from message text later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
