### PR TITLE
🐛 aws: skip CloudTrail bucket checks when the bucket is unreadable cr…

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -42862,7 +42862,12 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
         title: Blocking public access to your Amazon S3 storage
   - uid: mondoo-aws-security-cloudtrail-s3-bucket-not-public-aws
-    filters: asset.platform == "aws-cloudtrail-trail"
+    # public is null when the bucket lives in another account (e.g. an organization
+    # trail delivering to a Log Archive account) and its policy/ACL can't be read from
+    # the scanned account. Scoring that unknown would fail with no evidence, so the
+    # check only applies when the bucket is readable; the bucket's own account covers
+    # it directly via mondoo-aws-security-s3-bucket-level-public-access-prohibited.
+    filters: asset.platform == "aws-cloudtrail-trail" && aws.cloudtrail.trail.s3bucket.public != null
     mql: |
       aws.cloudtrail.trail.s3bucket.public == false
   # No Terraform variants: This check follows a CloudTrail trail's `S3BucketName` to the referenced bucket and inspects its logging configuration — a cross-resource correlation. The general `s3-bucket-server-access-logging-enabled` check covers the bucket directly in Terraform.
@@ -42993,7 +42998,12 @@ queries:
       - url: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html
         title: Amazon S3 Bucket Policy for CloudTrail
   - uid: mondoo-aws-security-cloudtrail-s3-bucket-logging-aws
-    filters: asset.platform == "aws-cloudtrail-trail"
+    # logging is null when the bucket lives in another account (e.g. an organization
+    # trail delivering to a Log Archive account) and can't be read from the scanned
+    # account — a readable bucket with logging disabled returns an empty dict, not
+    # null, so this filter only skips the no-data case; the bucket's own account
+    # covers it directly via mondoo-aws-security-s3-bucket-logging-enabled.
+    filters: asset.platform == "aws-cloudtrail-trail" && aws.cloudtrail.trail.s3bucket.logging != null
     mql: |
       aws.cloudtrail.trail.s3bucket.logging['TargetBucket'] != empty
   - uid: mondoo-aws-security-dynamodb-pitr-enabled


### PR DESCRIPTION
…oss-account

An organization trail delivers logs to a bucket in another account (typically a Log Archive account). Scanned from the trail's account, the bucket's policy/ACL/logging can't be read, the provider deliberately reports null instead of a confident answer, and the null assertion scored as a failed finding with empty evidence.

Guard the two bucket-dereferencing variants so they only apply when the bucket data is readable:

- cloudtrail-s3-bucket-not-public: public != null (readable buckets always yield true/false; null only means no data)
- cloudtrail-s3-bucket-logging: logging != null (a readable bucket with logging disabled returns an empty dict, not null, so genuine misconfigurations still fail)

The bucket's own account covers both controls directly via s3-bucket-level-public-access-prohibited and s3-bucket-logging-enabled.