### PR TITLE
✨ querypacks: gate Linux runtime probes on the data source, not run-c…

### DIFF
--- a/content/querypacks/mondoo-linux-inventory.mql.yaml
+++ b/content/querypacks/mondoo-linux-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-linux-inventory
     name: Linux Inventory Pack
-    version: 1.9.0
+    version: 1.10.0
     license: BUSL-1.1
     require:
       - provider: os
@@ -87,13 +87,13 @@ packs:
             title: Installed kernels
             docs:
               desc: Lists all installed kernel packages and versions.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/version").exists
             mql: kernel.installed
           - uid: mondoo-linux-kernel-info
             title: Running kernel versions
             docs:
               desc: Returns details about the currently running kernel.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/version").exists
             mql: kernel.info
           - uid: mondoo-linux-kernel-modules
             title: Kernel modules
@@ -105,7 +105,7 @@ packs:
             title: Kernel parameters
             docs:
               desc: Returns runtime kernel parameters (sysctl values).
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/sys/kernel/ostype").exists
             mql: kernel.parameters
       - uid: mondoo-linux-inventory-processes-services-group
         title: Processes & Services
@@ -115,7 +115,7 @@ packs:
             title: Running processes
             docs:
               desc: Lists running processes with their PID, command, and flags.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/1/status").exists
             mql: processes { pid command flags }
           - uid: mondoo-linux-running-services
             title: Running services
@@ -158,19 +158,19 @@ packs:
             title: Listening ports
             docs:
               desc: Lists listening network ports with their protocol, address, state, and owning process.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/net/tcp").exists
             mql: ports.listening { user state port address protocol process remoteAddress remotePort }
           - uid: mondoo-linux-all-connections
             title: All network connections
             docs:
               desc: Lists all retained network connections with their protocol, address, state, and owning process.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/net/tcp").exists
             mql: ports { user state port address protocol process remoteAddress remotePort }
           - uid: mondoo-linux-active-connections
             title: Active network connections
             docs:
               desc: Lists network connections that are not closed, with their protocol, address, state, and owning process.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/net/tcp").exists
             mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
           - uid: mondoo-linux-interface-configuration
             title: Network interface configuration
@@ -237,7 +237,7 @@ packs:
             title: Mounted devices
             docs:
               desc: Lists mounted filesystems with path, type, device, options, and total, used, and available space.
-            filters: mondoo.capabilities.contains("run-command")
+            filters: mondoo.capabilities.contains("run-command") || file("/proc/mounts").exists
             mql: mount.list { path fstype device options size used available }
           - uid: mondoo-linux-root-volume
             title: Root volume size and filesystem type


### PR DESCRIPTION

Eight queries in the Linux Inventory Pack were gated on `mondoo.capabilities.contains("run-command")`, but their Linux implementations read the data out of procfs via conn.FileSystem() and never shell out. Only local/SSH/WinRM/docker-exec connections report run-command, so every agentless scan (filesystem, tar, device/EBS snapshot) dropped these queries even where the data was present and readable.

The capability check was a proxy for "can we obtain this data". Replace it with the actual precondition -- the presence of the procfs file the implementation reads -- keeping the run-command disjunct so agent-based scans are unchanged:

  listening-ports/all-connections/active-connections  /proc/net/tcp
  processes                                           /proc/1/status
  kernel-info, installed-kernel                       /proc/version
  kernel-parameters                                   /proc/sys/kernel/ostype
  mounts                                              /proc/mounts

Why a precondition rather than simply dropping the filter: procfs is populated by a running kernel, so it does not exist in a container image or on a mounted disk snapshot -- there `/proc` is an empty mountpoint. parseProcNet() returns (nil, nil) for a missing file ("no ports are open then") and LinuxProcManager.List() enumerates an empty /proc without error. Dropping the gate outright would therefore report zero listening ports and zero processes on snapshot-scanned hosts: a false negative worse than no data, because a consumer cannot distinguish "measured, nothing listening" from "never measured". Gating on the data source keeps that distinction honest -- the query runs only when the answer is real.

Follows the existing precedent in this pack, where mondoo-linux-docker-containers gates on file("/var/run/docker.sock").exists rather than a capability.

Verified by running cnspec against a filesystem connection inside a Linux container (capabilities: file, find-file -- no run-command): ports.listening returned both live listeners with process attribution and the correct bind addresses (0.0.0.0:8080 and 127.0.0.1:9443), processes and kernel.info returned real data, and kernel.modules correctly failed with "provider does not implement RunCommand". In the same image exported as a rootfs tarball, all five procfs discriminators are absent and proc/ is an empty directory, so the queries are skipped there as intended.

Left gated on run-command, since these shell out with no filesystem fallback: uptime (uptime), kernel-modules (/sbin/lsmod), iptables-input, iptables-output, nftables-ruleset, network-neighbors, the systemd-* queries, and running-services -- the systemd FS manager deliberately ignores /run, so it can report `enabled` but never `running`, and `services.where(running == true)` would silently yield nothing.