### PR TITLE
✨ content: add AWS IAM trust policy, RDS patching/logging, and EKS access checks

### DIFF
--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation/fail/system-masters/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation/fail/system-masters/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ClusterAdminAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Properties:
+      ClusterName: example
+      PrincipalArn: arn:aws:iam::111122223333:role/ClusterAdmin
+      Type: STANDARD
+      KubernetesGroups:
+        - system:masters

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation/pass/yaml/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation/pass/yaml/template.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ClusterAdminAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Properties:
+      ClusterName: example
+      PrincipalArn: arn:aws:iam::111122223333:role/ClusterAdmin
+      Type: STANDARD
+      AccessPolicies:
+        - PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy
+          AccessScope:
+            Type: namespace
+            Namespaces:
+              - team-a

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/fail/system-masters/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/fail/system-masters/main.tf
@@ -1,0 +1,7 @@
+# Non-compliant: the access entry grants unbounded cluster-admin via system:masters.
+resource "aws_eks_access_entry" "fail_system_masters" {
+  cluster_name      = "example"
+  principal_arn     = "arn:aws:iam::111122223333:role/ClusterAdmin"
+  type              = "STANDARD"
+  kubernetes_groups = ["system:masters"]
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/pass/no-groups/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/pass/no-groups/main.tf
@@ -1,0 +1,7 @@
+# Compliant: the access entry declares no Kubernetes groups, so authorization comes
+# from a scoped EKS access policy association instead of a group binding.
+resource "aws_eks_access_entry" "pass_no_groups" {
+  cluster_name  = "example"
+  principal_arn = "arn:aws:iam::111122223333:role/ClusterAdmin"
+  type          = "STANDARD"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/pass/scoped-group/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl/pass/scoped-group/main.tf
@@ -1,0 +1,8 @@
+# Compliant: the access entry maps the principal to a project group bound to a
+# scoped ClusterRole rather than to system:masters.
+resource "aws_eks_access_entry" "pass_scoped_group" {
+  cluster_name      = "example"
+  principal_arn     = "arn:aws:iam::111122223333:role/TeamAViewer"
+  type              = "STANDARD"
+  kubernetes_groups = ["team-a-viewers"]
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/fail/disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/fail/disabled/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ExampleDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: fail-disabled
+      Engine: postgres
+      DBInstanceClass: db.t3.medium
+      AllocatedStorage: "20"
+      AutoMinorVersionUpgrade: false

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/pass/default/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/pass/default/template.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ExampleDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: pass-default
+      Engine: postgres
+      DBInstanceClass: db.t3.medium
+      AllocatedStorage: "20"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/pass/yaml/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation/pass/yaml/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ExampleDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: pass-example
+      Engine: postgres
+      DBInstanceClass: db.t3.medium
+      AllocatedStorage: "20"
+      AutoMinorVersionUpgrade: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/fail/disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,8 @@
+# Non-compliant: RDS DB instance explicitly disables automatic minor version upgrades.
+resource "aws_db_instance" "fail_disabled" {
+  identifier                 = "fail-disabled"
+  engine                     = "postgres"
+  instance_class             = "db.t3.medium"
+  allocated_storage          = 20
+  auto_minor_version_upgrade = false
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/pass/default/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/pass/default/main.tf
@@ -1,0 +1,8 @@
+# Compliant: auto_minor_version_upgrade is omitted, and both the AWS API and the
+# Terraform provider default it to true, so the instance still receives patches.
+resource "aws_db_instance" "pass_default" {
+  identifier        = "pass-default"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/pass/explicit/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl/pass/explicit/main.tf
@@ -1,0 +1,8 @@
+# Compliant: RDS DB instance explicitly enables automatic minor version upgrades.
+resource "aws_db_instance" "pass_explicit" {
+  identifier                 = "pass-explicit"
+  engine                     = "postgres"
+  instance_class             = "db.t3.medium"
+  allocated_storage          = 20
+  auto_minor_version_upgrade = true
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation/fail/absent/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation/fail/absent/template.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ExampleDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: fail-absent
+      Engine: postgres
+      DBInstanceClass: db.t3.medium
+      AllocatedStorage: "20"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation/pass/yaml/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation/pass/yaml/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ExampleDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: pass-example
+      Engine: postgres
+      DBInstanceClass: db.t3.medium
+      AllocatedStorage: "20"
+      EnableCloudwatchLogsExports:
+        - postgresql
+        - upgrade

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/fail/absent/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,7 @@
+# Non-compliant: no log types are exported, so engine logs stay on the instance.
+resource "aws_db_instance" "fail_absent" {
+  identifier        = "fail-absent"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/fail/empty/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/fail/empty/main.tf
@@ -1,0 +1,9 @@
+# Non-compliant: the log export list is declared but empty.
+resource "aws_db_instance" "fail_empty" {
+  identifier        = "fail-empty"
+  engine            = "mysql"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+
+  enabled_cloudwatch_logs_exports = []
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/pass/basic/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl/pass/basic/main.tf
@@ -1,0 +1,9 @@
+# Compliant: RDS DB instance publishes PostgreSQL engine logs to CloudWatch Logs.
+resource "aws_db_instance" "pass_example" {
+  identifier        = "pass-example"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+}

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.7.0
+    version: 12.8.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -120,6 +120,8 @@ policies:
           - uid: mondoo-aws-security-iam-support-role
           - uid: mondoo-aws-security-iam-unused-credentials-disabled
           - uid: mondoo-aws-security-iam-instance-role-no-admin-access
+          - uid: mondoo-aws-security-iam-role-trust-policy-no-public-principals
+          - uid: mondoo-aws-security-iam-role-cross-account-trust-scoped
       - title: AWS Lambda Function
         checks:
           - uid: mondoo-aws-security-lambda-concurrency-check
@@ -207,6 +209,8 @@ policies:
           - uid: mondoo-aws-security-rds-instance-not-internet-reachable
           - uid: mondoo-aws-security-rds-snapshot-not-public
           - uid: mondoo-aws-security-rds-snapshot-not-shared
+          - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade
+          - uid: mondoo-aws-security-rds-instance-log-exports-enabled
       - title: Amazon RDS Proxy
         checks:
           - uid: mondoo-aws-security-rds-proxy-tls-required
@@ -412,6 +416,8 @@ policies:
           - uid: mondoo-aws-security-eks-cluster-iam-auth-mode
           - uid: mondoo-aws-security-eks-addon-healthy
           - uid: mondoo-aws-security-eks-control-plane-egress-customer-routed
+          - uid: mondoo-aws-security-eks-access-entry-no-system-masters
+          - uid: mondoo-aws-security-eks-pod-identity-role-no-admin-access
       - title: Amazon GuardDuty
         checks:
           - uid: mondoo-aws-security-guardduty-enabled
@@ -27261,6 +27267,432 @@ queries:
         title: AWS Documentation - Amazon EKS networking requirements
       - url: https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html
         title: AWS Documentation - Amazon EKS cluster networking
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters
+    title: Ensure EKS access entries do not grant the system:masters group
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-eks-access-entry-no-system-masters-aws
+        tags:
+          mondoo.com/filter-title: AWS EKS Cluster
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that no Amazon EKS access entry maps an IAM principal into the `system:masters` Kubernetes group. Membership in `system:masters` is bound to the built-in `cluster-admin` ClusterRole, which grants unconditional access to every resource in the cluster and cannot be narrowed, audited by RBAC review, or revoked without editing the access entry itself.
+
+        AWS provides scoped EKS access policies such as `AmazonEKSAdminPolicy` and `AmazonEKSClusterAdminPolicy` for administrative access. Those policies can be limited to specific namespaces and are visible through the EKS API, which makes them the supported alternative to the `system:masters` shortcut.
+
+        **Why this matters**
+
+        - **Unbounded and unreviewable:** `system:masters` bypasses RBAC evaluation entirely, so a `kubectl auth can-i` review or a ClusterRoleBinding audit will not reveal what the principal is able to do.
+        - **Defeats the surrounding controls:** Private endpoints, authorized CIDR ranges, and network policies restrict how the API server is reached, not what a `system:masters` caller may do once connected.
+        - **Escape to the AWS account:** A cluster-admin can read every Kubernetes secret and mount any service account, which typically yields IAM role credentials and turns cluster access into account access.
+        - **No namespace scoping:** Unlike an EKS access policy, the group grants nothing less than the whole cluster, so it cannot express the access a team actually needs.
+
+        **Risk mitigation**
+
+        - **Scoped administrative access:** Associating `AmazonEKSAdminPolicy` with a namespace scope grants day-to-day administration without whole-cluster authority.
+        - **Auditable grants:** Access policy associations are recorded through the EKS API and CloudTrail, so privilege grants and revocations leave an audit trail.
+        - **Reviewable permissions:** Principals authorized through RBAC-backed policies can be evaluated with standard Kubernetes authorization tooling.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EKS** console.
+        2. In the left navigation pane, choose **Clusters** and select a cluster.
+        3. Choose the **Access** tab and review the **IAM access entries** list.
+        4. Select each access entry and review its **Kubernetes groups**.
+
+        A passing access entry lists no Kubernetes groups, or lists only groups bound to scoped RBAC roles. A failing access entry lists `system:masters`.
+
+        ### Audit via CLI
+
+        1. List the access entries for a cluster:
+
+        ```bash
+        aws eks list-access-entries --cluster-name <cluster-name>
+        ```
+
+        2. Inspect the Kubernetes groups on each access entry:
+
+        ```bash
+        aws eks describe-access-entry \
+          --cluster-name <cluster-name> \
+          --principal-arn <principal-arn> \
+          --query 'accessEntry.kubernetesGroups'
+        ```
+
+        A passing access entry returns a list that does not contain `system:masters`. A failing access entry returns a list containing `system:masters`.
+      remediation:
+        - id: console
+          desc: |
+            To ensure EKS access entries do not grant the system:masters group using the AWS Console:
+
+            1. Navigate to the **EKS** console and select the cluster.
+            2. Choose the **Access** tab and select the access entry that lists `system:masters`.
+            3. Choose **Edit** and remove `system:masters` from **Kubernetes groups**.
+            4. Choose **Add access policy** and associate a scoped policy such as `AmazonEKSAdminPolicy`, selecting a namespace scope where whole-cluster access is not required.
+            5. Save the access entry.
+        - id: cli
+          desc: |
+            To ensure EKS access entries do not grant the system:masters group using the AWS CLI, remove the group and grant a scoped access policy instead.
+
+            Clear the Kubernetes groups on the access entry:
+
+            ```bash
+            aws eks update-access-entry \
+              --cluster-name <cluster-name> \
+              --principal-arn <principal-arn> \
+              --kubernetes-groups
+            ```
+
+            Associate a scoped access policy:
+
+            ```bash
+            aws eks associate-access-policy \
+              --cluster-name <cluster-name> \
+              --principal-arn <principal-arn> \
+              --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy \
+              --access-scope type=namespace,namespaces=team-a
+            ```
+
+            Verify the result:
+
+            ```bash
+            aws eks describe-access-entry \
+              --cluster-name <cluster-name> \
+              --principal-arn <principal-arn> \
+              --query 'accessEntry.kubernetesGroups'
+            ```
+        - id: terraform
+          desc: |
+            To ensure EKS access entries do not grant the system:masters group in Terraform, omit `kubernetes_groups` and grant a scoped access policy association:
+
+            ```hcl
+            resource "aws_eks_access_entry" "admin" {
+              cluster_name  = aws_eks_cluster.example.name
+              principal_arn = aws_iam_role.cluster_admin.arn
+              type          = "STANDARD"
+            }
+
+            resource "aws_eks_access_policy_association" "admin" {
+              cluster_name  = aws_eks_cluster.example.name
+              principal_arn = aws_iam_role.cluster_admin.arn
+              policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+
+              access_scope {
+                type       = "namespace"
+                namespaces = ["team-a"]
+              }
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure EKS access entries do not grant the system:masters group in CloudFormation, omit `KubernetesGroups` and use `AccessPolicies`:
+
+            ```yaml
+            Resources:
+              ClusterAdminAccessEntry:
+                Type: AWS::EKS::AccessEntry
+                Properties:
+                  ClusterName: !Ref EKSCluster
+                  PrincipalArn: !GetAtt ClusterAdminRole.Arn
+                  Type: STANDARD
+                  AccessPolicies:
+                    - PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy
+                      AccessScope:
+                        Type: namespace
+                        Namespaces:
+                          - team-a
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html
+        title: Manage access entries
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/access-policies.html
+        title: Associate access policies with access entries
+
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters-aws
+    filters: asset.platform == "aws-eks-cluster"
+    mql: |
+      aws.eks.cluster.accessEntries.all(
+        kubernetesGroups == empty || kubernetesGroups.none(_ == "system:masters")
+      )
+
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_eks_access_entry")
+    mql: |
+      terraform.resources("aws_eks_access_entry").all(
+        arguments['kubernetes_groups'] == empty ||
+        arguments['kubernetes_groups'].none(_ == "system:masters")
+      )
+
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_eks_access_entry")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_eks_access_entry").all(
+        change.after['kubernetes_groups'] == empty ||
+        change.after['kubernetes_groups'].none(_ == "system:masters")
+      )
+
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_eks_access_entry")
+    mql: |
+      terraform.state.resources.where(type == "aws_eks_access_entry").all(
+        values['kubernetes_groups'] == empty ||
+        values['kubernetes_groups'].none(_ == "system:masters")
+      )
+
+  - uid: mondoo-aws-security-eks-access-entry-no-system-masters-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EKS::AccessEntry")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::EKS::AccessEntry").all(
+        properties['KubernetesGroups'] == empty ||
+        properties['KubernetesGroups'].none(_ == "system:masters")
+      )
+
+  # No Terraform variants: the check resolves the IAM role referenced by the association and inspects the policies attached to it. In Terraform the association carries only a role_arn, and the attached policies live in separate aws_iam_role_policy_attachment resources that may be defined in another module or state, so no single-resource variant can decide whether the role is administrative.
+  - uid: mondoo-aws-security-eks-pod-identity-role-no-admin-access
+    title: Ensure EKS pod identity associations do not use administrator roles
+    impact: 85
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-2
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-2
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-eks-pod-identity-role-no-admin-access-aws
+        tags:
+          mondoo.com/filter-title: AWS EKS Cluster
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that no EKS pod identity association maps a Kubernetes service account to an IAM role carrying the `AdministratorAccess` managed policy. A pod identity association makes the role's credentials available to every pod that uses the service account, so an administrator role turns any workload in that namespace into a full-privilege AWS principal.
+
+        **Why this matters**
+
+        - **Container escape becomes account takeover:** A single vulnerable container or a malicious dependency in the image can read the pod identity credentials and use them against every service in the account.
+        - **Broad blast radius by design:** Every pod using the service account receives the same credentials, so the privilege is shared across replicas, namespaces sharing the account, and future workloads.
+        - **Bypasses cluster controls:** RBAC and network policies restrict what a pod can do inside Kubernetes, not what its AWS credentials can do outside it.
+        - **Convenience turns permanent:** Administrator roles are frequently attached during initial setup to unblock a deployment and then never narrowed, because nothing fails to remind the team.
+
+        **Risk mitigation**
+
+        - **Least privilege per workload:** A dedicated role per service account, scoped to the specific APIs and resource ARNs the workload needs, contains the impact of a compromised pod.
+        - **Contained escape:** A workload that can only read one bucket cannot pivot to IAM, KMS, or EC2 even if the container is fully compromised.
+        - **Meaningful audit trail:** Purpose-built roles make CloudTrail activity attributable to a specific workload rather than to a shared administrator identity.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **EKS** console.
+        2. In the left navigation pane, choose **Clusters** and select a cluster.
+        3. Choose the **Access** tab and review the **Pod Identity associations** list.
+        4. For each association, note the IAM role, then open the **IAM** console, choose **Roles**, select that role, and review the **Permissions** tab.
+
+        A passing association references a role whose attached policies are scoped to the APIs the workload needs. A failing association references a role with the `AdministratorAccess` policy attached.
+
+        ### Audit via CLI
+
+        1. List the pod identity associations for a cluster:
+
+        ```bash
+        aws eks list-pod-identity-associations --cluster-name <cluster-name>
+        ```
+
+        2. Resolve the role for an association:
+
+        ```bash
+        aws eks describe-pod-identity-association \
+          --cluster-name <cluster-name> \
+          --association-id <association-id> \
+          --query 'association.roleArn'
+        ```
+
+        3. List the managed policies attached to that role:
+
+        ```bash
+        aws iam list-attached-role-policies --role-name <role-name>
+        ```
+
+        A passing role returns no policy named `AdministratorAccess`. A failing role returns `AdministratorAccess` in the attached policy list.
+      remediation:
+        - id: console
+          desc: |
+            To ensure EKS pod identity associations do not use administrator roles using the AWS Console:
+
+            1. Navigate to the **IAM** console and choose **Policies**, then create a policy granting only the actions and resource ARNs the workload requires.
+            2. Choose **Roles** and create a role trusted by `pods.eks.amazonaws.com`, attaching the new policy.
+            3. Navigate to the **EKS** console, select the cluster, and open the **Access** tab.
+            4. Select the pod identity association and choose **Edit**, then select the new role.
+            5. Save the association and detach `AdministratorAccess` from the previous role once no workload depends on it.
+        - id: cli
+          desc: |
+            To ensure EKS pod identity associations do not use administrator roles using the AWS CLI, point the association at a least-privilege role.
+
+            Create the trust policy for a pod identity role:
+
+            ```json
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Principal": { "Service": "pods.eks.amazonaws.com" },
+                  "Action": ["sts:AssumeRole", "sts:TagSession"]
+                }
+              ]
+            }
+            ```
+
+            Create the role and attach a scoped policy:
+
+            ```bash
+            aws iam create-role \
+              --role-name eks-workload-role \
+              --assume-role-policy-document file://pod-identity-trust.json
+
+            aws iam attach-role-policy \
+              --role-name eks-workload-role \
+              --policy-arn <scoped-policy-arn>
+            ```
+
+            Repoint the association and verify:
+
+            ```bash
+            aws eks update-pod-identity-association \
+              --cluster-name <cluster-name> \
+              --association-id <association-id> \
+              --role-arn <new-role-arn>
+
+            aws iam list-attached-role-policies --role-name eks-workload-role
+            ```
+        - id: terraform
+          desc: |
+            To ensure EKS pod identity associations do not use administrator roles in Terraform, attach a scoped policy to the role the association references:
+
+            ```hcl
+            data "aws_iam_policy_document" "pod_identity_trust" {
+              statement {
+                effect  = "Allow"
+                actions = ["sts:AssumeRole", "sts:TagSession"]
+
+                principals {
+                  type        = "Service"
+                  identifiers = ["pods.eks.amazonaws.com"]
+                }
+              }
+            }
+
+            resource "aws_iam_role" "workload" {
+              name               = "eks-workload-role"
+              assume_role_policy = data.aws_iam_policy_document.pod_identity_trust.json
+            }
+
+            resource "aws_iam_role_policy" "workload" {
+              role = aws_iam_role.workload.name
+
+              policy = jsonencode({
+                Version = "2012-10-17"
+                Statement = [{
+                  Effect   = "Allow"
+                  Action   = ["s3:GetObject"]
+                  Resource = ["${aws_s3_bucket.app.arn}/*"]
+                }]
+              })
+            }
+
+            resource "aws_eks_pod_identity_association" "workload" {
+              cluster_name    = aws_eks_cluster.example.name
+              namespace       = "team-a"
+              service_account = "app"
+              role_arn        = aws_iam_role.workload.arn
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure EKS pod identity associations do not use administrator roles in CloudFormation, reference a role whose inline policy is scoped to the workload:
+
+            ```yaml
+            Resources:
+              WorkloadRole:
+                Type: AWS::IAM::Role
+                Properties:
+                  RoleName: eks-workload-role
+                  AssumeRolePolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Effect: Allow
+                        Principal:
+                          Service: pods.eks.amazonaws.com
+                        Action:
+                          - sts:AssumeRole
+                          - sts:TagSession
+                  Policies:
+                    - PolicyName: workload-access
+                      PolicyDocument:
+                        Version: "2012-10-17"
+                        Statement:
+                          - Effect: Allow
+                            Action: s3:GetObject
+                            Resource: !Sub "${AppBucket.Arn}/*"
+
+              WorkloadPodIdentity:
+                Type: AWS::EKS::PodIdentityAssociation
+                Properties:
+                  ClusterName: !Ref EKSCluster
+                  Namespace: team-a
+                  ServiceAccount: app
+                  RoleArn: !GetAtt WorkloadRole.Arn
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html
+        title: Learn how EKS Pod Identity grants pods access to AWS services
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege
+        title: IAM security best practices - Grant least privilege
+
+  - uid: mondoo-aws-security-eks-pod-identity-role-no-admin-access-aws
+    filters: asset.platform == "aws-eks-cluster"
+    mql: |
+      aws.eks.cluster.podIdentityAssociations.where(iamRole != empty).all(
+        iamRole.attachedPolicies.none(name == "AdministratorAccess")
+      )
+
   - uid: mondoo-aws-security-ecs-cluster-container-insights
     title: Ensure ECS clusters have Container Insights enabled
     impact: 60
@@ -47205,6 +47637,359 @@ queries:
       aws.iam.roles.where(usedByInstances.length > 0).all(
         attachedPolicies.none(name == "AdministratorAccess")
       )
+  # No Terraform variants: the trust policy is an opaque JSON string in HCL, normally produced by jsonencode() or data.aws_iam_policy_document, so it is unresolved at parse time. The runtime field also exempts wildcard principals that carry a source-scoping condition, a distinction a string or regex match on the encoded document cannot make.
+  - uid: mondoo-aws-security-iam-role-trust-policy-no-public-principals
+    title: Ensure IAM role trust policies do not allow any principal
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-iam-role-trust-policy-no-public-principals-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that no IAM role trust policy grants `sts:AssumeRole` to the wildcard principal `"*"` without a condition that scopes who may use it. A role whose trust policy names a wildcard principal can be assumed by any AWS account on the internet, which hands the caller temporary credentials carrying every permission attached to that role.
+
+        Wildcard principals paired with a scoping condition such as `aws:PrincipalOrgID`, `aws:SourceAccount`, or `aws:SourceArn` are not reported, because the condition restores the boundary the wildcard removed.
+
+        **Why this matters**
+
+        - **Credential issuance, not just data access:** Unlike a permissive bucket or queue policy that leaks one resource, an open trust policy issues STS credentials, so the caller inherits everything the role can do across every service.
+        - **Silent and low-friction:** Assuming a role leaves no trace in the target account until the credentials are used, and requires no exploit, only the role ARN.
+        - **Privilege escalation chain:** Roles are commonly granted broad service permissions on the assumption that only trusted principals can assume them, so an open trust policy often escalates directly to administrative access.
+        - **Attached policies are not a backstop:** Permission boundaries and attached policies limit what the role can do, not who can become it.
+
+        **Risk mitigation**
+
+        - **Explicit trust boundary:** Naming concrete account IDs, role ARNs, or service principals keeps role assumption inside identities you control.
+        - **Organization scoping:** An `aws:PrincipalOrgID` condition keeps assumption inside your AWS organization even when the principal list is broad.
+        - **Third-party hardening:** Vendor roles scoped with `sts:ExternalId` resist the confused deputy problem, where another of the vendor's customers assumes your role.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **IAM** console.
+        2. In the left navigation pane, choose **Roles**.
+        3. Select a role and choose the **Trust relationships** tab.
+        4. Review the **Trusted entities** policy document.
+
+        A passing role names specific accounts, role ARNs, or AWS service principals under `Principal`. A failing role shows `"Principal": {"AWS": "*"}` or `"Principal": "*"` with no `Condition` block that scopes the grant.
+
+        ### Audit via CLI
+
+        1. List every role together with its trust policy:
+
+        ```bash
+        aws iam list-roles --query 'Roles[*].[RoleName,AssumeRolePolicyDocument]'
+        ```
+
+        2. Inspect a single role in detail:
+
+        ```bash
+        aws iam get-role --role-name <role-name> --query 'Role.AssumeRolePolicyDocument'
+        ```
+
+        A passing role has no `Allow` statement whose `Principal` is `"*"`, or has one that is constrained by a `Condition`. A failing role has an unconditioned wildcard principal.
+      remediation:
+        - id: console
+          desc: |
+            To ensure IAM role trust policies do not allow any principal using the AWS Console:
+
+            1. Navigate to the **IAM** console and choose **Roles**.
+            2. Select the affected role and open the **Trust relationships** tab.
+            3. Choose **Edit trust policy**.
+            4. Replace the wildcard `Principal` with the specific accounts, role ARNs, or service principals that need to assume the role.
+            5. If a broad principal is genuinely required, add a `Condition` that scopes it with `aws:PrincipalOrgID`, `aws:SourceAccount`, `aws:SourceArn`, or `sts:ExternalId`.
+            6. Choose **Update policy**.
+        - id: cli
+          desc: |
+            To ensure IAM role trust policies do not allow any principal using the AWS CLI, replace the trust policy with one that names concrete principals.
+
+            Write the corrected trust policy to a file:
+
+            ```json
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Principal": { "AWS": "arn:aws:iam::111122223333:root" },
+                  "Action": "sts:AssumeRole",
+                  "Condition": {
+                    "StringEquals": { "sts:ExternalId": "<unique-external-id>" }
+                  }
+                }
+              ]
+            }
+            ```
+
+            Apply it to the role:
+
+            ```bash
+            aws iam update-assume-role-policy \
+              --role-name <role-name> \
+              --policy-document file://trust-policy.json
+            ```
+
+            Verify the result:
+
+            ```bash
+            aws iam get-role --role-name <role-name> --query 'Role.AssumeRolePolicyDocument'
+            ```
+        - id: terraform
+          desc: |
+            To ensure IAM role trust policies do not allow any principal in Terraform, build the trust policy from an explicit principal list:
+
+            ```hcl
+            data "aws_iam_policy_document" "assume_role" {
+              statement {
+                effect  = "Allow"
+                actions = ["sts:AssumeRole"]
+
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:root"]
+                }
+
+                condition {
+                  test     = "StringEquals"
+                  variable = "aws:PrincipalOrgID"
+                  values   = [data.aws_organizations_organization.current.id]
+                }
+              }
+            }
+
+            resource "aws_iam_role" "example" {
+              name               = "example"
+              assume_role_policy = data.aws_iam_policy_document.assume_role.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure IAM role trust policies do not allow any principal in CloudFormation, name concrete principals in `AssumeRolePolicyDocument`:
+
+            ```yaml
+            Resources:
+              ExampleRole:
+                Type: AWS::IAM::Role
+                Properties:
+                  AssumeRolePolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Effect: Allow
+                        Principal:
+                          Service: ec2.amazonaws.com
+                        Action: sts:AssumeRole
+                        Condition:
+                          StringEquals:
+                            aws:SourceAccount: !Ref AWS::AccountId
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+        title: AWS JSON policy elements - Principal
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+        title: The confused deputy problem
+
+  - uid: mondoo-aws-security-iam-role-trust-policy-no-public-principals-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.iam.roles.none(assumableByPublic)
+
+  # No Terraform variants: the trust policy is an opaque JSON string in HCL, normally produced by jsonencode() or data.aws_iam_policy_document, so neither the trusted account IDs nor the condition keys are readable at parse time. Determining that a principal belongs to an external account also requires knowing the scanned account ID, which no Terraform asset carries.
+  - uid: mondoo-aws-security-iam-role-cross-account-trust-scoped
+    title: Ensure cross-account IAM role trust policies use a scoping condition
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    variants:
+      - uid: mondoo-aws-security-iam-role-cross-account-trust-scoped-aws
+        tags:
+          mondoo.com/filter-title: AWS Account
+          mondoo.com/filter-icon: aws
+    docs:
+      desc: |
+        This check ensures that every IAM role whose trust policy names an AWS account outside the scanned account also constrains that grant with a condition. A trust policy that lists an external account with no condition allows any principal in that account to assume the role, so the security of your role depends entirely on the access controls of an account you do not administer.
+
+        Roles that trust only principals inside the scanned account, or that trust AWS service principals, are not evaluated by this check.
+
+        **Why this matters**
+
+        - **Trust is transitive:** Naming an external account root grants assumption to every current and future IAM identity in that account, including ones created after the trust was established.
+        - **Confused deputy exposure:** A vendor role without `sts:ExternalId` can be assumed on behalf of a different customer of that vendor, letting an unrelated third party reach your account.
+        - **Blast radius from a partner breach:** If the trusted account is compromised, an unconditioned trust policy turns their incident into yours with no additional step.
+        - **Organization drift:** As accounts are added, removed, or sold, a bare account ID in a trust policy silently outlives the business relationship that justified it.
+
+        **Risk mitigation**
+
+        - **Organization scoping:** An `aws:PrincipalOrgID` condition keeps assumption inside your own AWS organization even when the principal is an account root.
+        - **Third-party secrets:** An `sts:ExternalId` condition ties assumption to a value only you and the vendor know, defeating the confused deputy problem.
+        - **Step-up authentication:** An `aws:MultiFactorAuthPresent` condition requires the assuming identity to have authenticated with MFA.
+        - **Narrower principals:** Naming specific role ARNs instead of the account root reduces the trusted surface to identities the partner has explicitly designated.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **IAM** console.
+        2. In the left navigation pane, choose **Roles**.
+        3. Select a role and choose the **Trust relationships** tab.
+        4. Compare each account ID under `Principal` against your own account ID, then check whether the statement carries a `Condition`.
+
+        A passing role either trusts only your own account and AWS services, or constrains external principals with a `Condition` such as `aws:PrincipalOrgID`, `sts:ExternalId`, or `aws:MultiFactorAuthPresent`. A failing role names an external account with no `Condition`.
+
+        ### Audit via CLI
+
+        1. Confirm the account ID being audited:
+
+        ```bash
+        aws sts get-caller-identity --query 'Account'
+        ```
+
+        2. List every role with its trust policy and look for account IDs that do not match:
+
+        ```bash
+        aws iam list-roles --query 'Roles[*].[RoleName,AssumeRolePolicyDocument]'
+        ```
+
+        A passing role has a `Condition` on every `Allow` statement that names an external account. A failing role has an external account principal with no `Condition`.
+      remediation:
+        - id: console
+          desc: |
+            To ensure cross-account IAM role trust policies use a scoping condition using the AWS Console:
+
+            1. Navigate to the **IAM** console and choose **Roles**.
+            2. Select the affected role and open the **Trust relationships** tab.
+            3. Choose **Edit trust policy**.
+            4. Add a `Condition` to each statement that names an external account. Use `aws:PrincipalOrgID` for accounts inside your organization and `sts:ExternalId` for third-party vendors.
+            5. Where possible, replace the account root principal with the specific role ARNs that need access.
+            6. Choose **Update policy**.
+        - id: cli
+          desc: |
+            To ensure cross-account IAM role trust policies use a scoping condition using the AWS CLI, add a condition to the trust policy.
+
+            For a vendor role, pin the grant to an external ID:
+
+            ```json
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Principal": { "AWS": "arn:aws:iam::111122223333:role/VendorRole" },
+                  "Action": "sts:AssumeRole",
+                  "Condition": {
+                    "StringEquals": { "sts:ExternalId": "<unique-external-id>" }
+                  }
+                }
+              ]
+            }
+            ```
+
+            Apply the updated policy:
+
+            ```bash
+            aws iam update-assume-role-policy \
+              --role-name <role-name> \
+              --policy-document file://trust-policy.json
+            ```
+
+            Verify the result:
+
+            ```bash
+            aws iam get-role --role-name <role-name> --query 'Role.AssumeRolePolicyDocument'
+            ```
+        - id: terraform
+          desc: |
+            To ensure cross-account IAM role trust policies use a scoping condition in Terraform, attach a condition block to the cross-account statement:
+
+            ```hcl
+            data "aws_iam_policy_document" "cross_account" {
+              statement {
+                effect  = "Allow"
+                actions = ["sts:AssumeRole"]
+
+                principals {
+                  type        = "AWS"
+                  identifiers = ["arn:aws:iam::111122223333:role/VendorRole"]
+                }
+
+                condition {
+                  test     = "StringEquals"
+                  variable = "sts:ExternalId"
+                  values   = [var.external_id]
+                }
+              }
+            }
+
+            resource "aws_iam_role" "cross_account" {
+              name               = "cross-account-access"
+              assume_role_policy = data.aws_iam_policy_document.cross_account.json
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure cross-account IAM role trust policies use a scoping condition in CloudFormation, add a `Condition` to the cross-account statement:
+
+            ```yaml
+            Resources:
+              CrossAccountRole:
+                Type: AWS::IAM::Role
+                Properties:
+                  AssumeRolePolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                      - Effect: Allow
+                        Principal:
+                          AWS: arn:aws:iam::111122223333:role/VendorRole
+                        Action: sts:AssumeRole
+                        Condition:
+                          StringEquals:
+                            sts:ExternalId: !Ref ExternalId
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+        title: How to use an external ID when granting access to your AWS resources to a third party
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid
+        title: AWS global condition context keys - aws:PrincipalOrgID
+
+  - uid: mondoo-aws-security-iam-role-cross-account-trust-scoped-aws
+    filters: asset.platform == "aws"
+    mql: |
+      aws.iam.roles.where(assumableByExternalAccounts != empty).all(
+        assumeRolePolicyStatements.where(effect == "Allow" && principals["AWS"] != empty).all(
+          conditions["StringEquals"]["aws:PrincipalOrgID"] != empty ||
+          conditions["StringLike"]["aws:PrincipalOrgID"] != empty ||
+          conditions["StringEquals"]["sts:ExternalId"] != empty ||
+          conditions["StringLike"]["sts:ExternalId"] != empty ||
+          conditions["StringEquals"]["aws:PrincipalArn"] != empty ||
+          conditions["ArnLike"]["aws:PrincipalArn"] != empty ||
+          conditions["Bool"]["aws:MultiFactorAuthPresent"] != empty
+        )
+      )
+
   - uid: mondoo-aws-security-lambda-xray-tracing
     title: Ensure Lambda functions have X-Ray tracing enabled
     impact: 30
@@ -79731,6 +80516,363 @@ queries:
     mql: |
       aws.rds.snapshot.attributes.where(_["AttributeName"] == "restore").all(_["AttributeValues"] == empty)
   # No Terraform variants: RADIUS status is operational telemetry reported by the service, not a configuration value with a Terraform or CloudFormation analog.
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade
+    title: Ensure RDS DB instances have automatic minor version upgrades enabled
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-12
+      compliance/nist-csf-2: nist-csf-2-pr-ps-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-5
+    variants:
+      - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-aws
+        tags:
+          mondoo.com/filter-title: AWS RDS DB Instance
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon RDS DB instances have automatic minor version upgrades enabled, so security patches to the database engine are applied during the next maintenance window. Amazon RDS enables this setting for new instances by default, which means a failing instance had it deliberately turned off and has stopped receiving engine patches.
+
+        **Why this matters**
+
+        - **Engine vulnerabilities are remotely reachable:** Flaws in MySQL, PostgreSQL, Oracle, and SQL Server are patched in minor releases and are exploitable by anyone who can open a connection to the instance.
+        - **Disabling is permanent until reversed:** Once automatic upgrades are off, no patch is ever applied without an operator scheduling it, so instances drift years behind the current minor release.
+        - **Manual patching does not happen on time:** The gap between a CVE becoming public and a manual upgrade window is the exposure window, and it is usually measured in months.
+        - **Consistency with the rest of the estate:** DocumentDB, Neptune, ElastiCache, MemoryDB, and Amazon MQ are already held to this standard, and RDS is the most widely deployed of the managed database services.
+
+        **Risk mitigation**
+
+        - **Automatic patch application:** Security fixes land in the next maintenance window without operator action.
+        - **Bounded exposure window:** The time between patch availability and patch application is capped by the maintenance schedule rather than by team capacity.
+        - **Predictable change:** Minor version upgrades are backward compatible within the same major version, so patching does not require an application compatibility review.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Databases**.
+        3. Select a DB instance and choose the **Maintenance & backups** tab.
+        4. Locate the **Auto minor version upgrade** field.
+
+        A passing instance shows **Auto minor version upgrade: Enabled**. A failing instance shows **Disabled**.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances with their automatic minor version upgrade setting:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{Instance:DBInstanceIdentifier,AutoUpgrade:AutoMinorVersionUpgrade}"
+        ```
+
+        A passing instance returns `"AutoUpgrade": true`. A failing instance returns `"AutoUpgrade": false`.
+      remediation:
+        - id: console
+          desc: |
+            To ensure RDS DB instances have automatic minor version upgrades enabled using the AWS Console:
+
+            1. Navigate to the **RDS** console and choose **Databases**.
+            2. Select the DB instance to modify and choose **Modify**.
+            3. Under **Maintenance**, enable **Auto minor version upgrade**.
+            4. Choose whether to apply the change immediately or during the next scheduled maintenance window.
+            5. Choose **Modify DB instance**.
+        - id: cli
+          desc: |
+            To ensure RDS DB instances have automatic minor version upgrades enabled using the AWS CLI, enable the setting on the instance:
+
+            ```bash
+            aws rds modify-db-instance \
+              --db-instance-identifier <instance-id> \
+              --auto-minor-version-upgrade \
+              --apply-immediately
+            ```
+
+            Verify the setting:
+
+            ```bash
+            aws rds describe-db-instances \
+              --db-instance-identifier <instance-id> \
+              --query "DBInstances[*].{Instance:DBInstanceIdentifier,AutoUpgrade:AutoMinorVersionUpgrade}"
+            ```
+        - id: terraform
+          desc: |
+            To ensure RDS DB instances have automatic minor version upgrades enabled in Terraform, set `auto_minor_version_upgrade` to `true`:
+
+            ```hcl
+            resource "aws_db_instance" "example" {
+              identifier                 = "example"
+              engine                     = "postgres"
+              instance_class             = "db.t3.medium"
+              allocated_storage          = 20
+              auto_minor_version_upgrade = true
+              maintenance_window         = "sun:03:00-sun:04:00"
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure RDS DB instances have automatic minor version upgrades enabled in CloudFormation, set `AutoMinorVersionUpgrade` to `true`:
+
+            ```yaml
+            Resources:
+              ExampleDBInstance:
+                Type: AWS::RDS::DBInstance
+                Properties:
+                  DBInstanceIdentifier: example
+                  Engine: postgres
+                  DBInstanceClass: db.t3.medium
+                  AllocatedStorage: "20"
+                  AutoMinorVersionUpgrade: true
+                  PreferredMaintenanceWindow: sun:03:00-sun:04:00
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html
+        title: Upgrading a DB instance engine version
+
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-aws
+    filters: asset.platform == "aws-rds-dbinstance"
+    mql: |
+      aws.rds.dbinstance.autoMinorVersionUpgrade == true
+
+  # The Terraform and CloudFormation defaults for this attribute are both `true`, so the variants
+  # assert it is not explicitly disabled rather than requiring it to be spelled out.
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_db_instance")
+    mql: |
+      terraform.resources("aws_db_instance").all(
+        arguments['auto_minor_version_upgrade'] != false
+      )
+
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_db_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_db_instance").all(
+        change.after['auto_minor_version_upgrade'] != false
+      )
+
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_db_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_db_instance").all(
+        values['auto_minor_version_upgrade'] != false
+      )
+
+  - uid: mondoo-aws-security-rds-instance-auto-minor-version-upgrade-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::RDS::DBInstance")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::RDS::DBInstance").all(
+        properties['AutoMinorVersionUpgrade'] != false
+      )
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled
+    title: Ensure RDS DB instances export database logs to CloudWatch Logs
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    variants:
+      - uid: mondoo-aws-security-rds-instance-log-exports-enabled-aws
+        tags:
+          mondoo.com/filter-title: AWS RDS DB Instance
+          mondoo.com/filter-icon: aws
+      - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation
+        tags:
+          mondoo.com/filter-title: CloudFormation
+          mondoo.com/filter-icon: cloudformation
+    docs:
+      desc: |
+        This check ensures that Amazon RDS DB instances publish at least one database log type to Amazon CloudWatch Logs. By default RDS keeps engine logs on the instance, where they are rotated on a fixed schedule and are unreachable by monitoring and incident response tooling.
+
+        The set of log types RDS can export is engine specific. MySQL and MariaDB offer `audit`, `error`, `general`, and `slowquery`; PostgreSQL offers `postgresql` and `upgrade`; Oracle offers `alert`, `audit`, `listener`, and `trace`; SQL Server offers `agent` and `error`. This check requires at least one type to be exported rather than naming a specific one, so it holds across every engine without demanding a log type the engine does not have.
+
+        **Why this matters**
+
+        - **On-instance logs disappear:** RDS rotates and deletes engine logs on the instance, so by the time an incident is investigated the relevant entries are frequently gone.
+        - **No alerting surface:** Failed authentication bursts, privilege changes, and bulk reads cannot trigger a CloudWatch metric filter or alarm if the logs never leave the instance.
+        - **Deleting the instance destroys the evidence:** An attacker who drops the DB instance also destroys every log that was only stored on it, whereas exported logs survive in CloudWatch.
+        - **Query visibility for detection:** Slow query and general logs reveal bulk extraction patterns that no other RDS telemetry exposes.
+
+        **Risk mitigation**
+
+        - **Durable retention:** Exported logs persist in CloudWatch under a retention policy that outlives the instance.
+        - **Automated detection:** CloudWatch metric filters and Logs Insights queries can alert on authentication failures and anomalous statements without manual review.
+        - **SIEM integration:** CloudWatch log groups can be subscribed to and forwarded to a central SIEM, bringing database activity into the same correlation pipeline as the rest of the estate.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the AWS Management Console and open the **RDS** console.
+        2. In the left navigation pane, choose **Databases**.
+        3. Select a DB instance and choose the **Logs & events** tab.
+        4. Review the **Log exports** section, or open **Modify** and review **Log exports** under **Additional configuration**.
+
+        A passing instance has at least one log type selected for export to CloudWatch Logs. A failing instance has none selected.
+
+        ### Audit via CLI
+
+        1. List all RDS DB instances with their enabled log exports:
+
+        ```bash
+        aws rds describe-db-instances \
+          --query "DBInstances[*].{Instance:DBInstanceIdentifier,Engine:Engine,LogExports:EnabledCloudwatchLogsExports}"
+        ```
+
+        A passing instance returns a non-empty `"LogExports"` list. A failing instance returns `null` or an empty list.
+      remediation:
+        - id: console
+          desc: |
+            To ensure RDS DB instances export database logs to CloudWatch Logs using the AWS Console:
+
+            1. Navigate to the **RDS** console and choose **Databases**.
+            2. Select the DB instance to modify and choose **Modify**.
+            3. Expand **Additional configuration** and locate **Log exports**.
+            4. Select the log types to publish. Choose the audit log where the engine offers one, plus the error and slow query logs.
+            5. Choose **Continue**, then choose whether to apply immediately or during the next maintenance window.
+            6. Choose **Modify DB instance**.
+        - id: cli
+          desc: |
+            To ensure RDS DB instances export database logs to CloudWatch Logs using the AWS CLI, enable the log types the engine supports.
+
+            For a MySQL or MariaDB instance:
+
+            ```bash
+            aws rds modify-db-instance \
+              --db-instance-identifier <instance-id> \
+              --cloudwatch-logs-export-configuration '{"EnableLogTypes":["audit","error","general","slowquery"]}' \
+              --apply-immediately
+            ```
+
+            For a PostgreSQL instance:
+
+            ```bash
+            aws rds modify-db-instance \
+              --db-instance-identifier <instance-id> \
+              --cloudwatch-logs-export-configuration '{"EnableLogTypes":["postgresql","upgrade"]}' \
+              --apply-immediately
+            ```
+
+            Verify the configuration:
+
+            ```bash
+            aws rds describe-db-instances \
+              --db-instance-identifier <instance-id> \
+              --query "DBInstances[*].{Instance:DBInstanceIdentifier,LogExports:EnabledCloudwatchLogsExports}"
+            ```
+        - id: terraform
+          desc: |
+            To ensure RDS DB instances export database logs to CloudWatch Logs in Terraform, set `enabled_cloudwatch_logs_exports` to the log types the engine supports:
+
+            ```hcl
+            resource "aws_db_instance" "example" {
+              identifier        = "example"
+              engine            = "postgres"
+              instance_class    = "db.t3.medium"
+              allocated_storage = 20
+
+              enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+            }
+            ```
+        - id: cloudformation
+          desc: |
+            To ensure RDS DB instances export database logs to CloudWatch Logs in CloudFormation, set `EnableCloudwatchLogsExports`:
+
+            ```yaml
+            Resources:
+              ExampleDBInstance:
+                Type: AWS::RDS::DBInstance
+                Properties:
+                  DBInstanceIdentifier: example
+                  Engine: postgres
+                  DBInstanceClass: db.t3.medium
+                  AllocatedStorage: "20"
+                  EnableCloudwatchLogsExports:
+                    - postgresql
+                    - upgrade
+            ```
+    refs:
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html
+        title: Monitoring Amazon RDS log files
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/publishing_cloudwatchlogs.html
+        title: Publishing database logs to Amazon CloudWatch Logs
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled-aws
+    filters: asset.platform == "aws-rds-dbinstance"
+    mql: |
+      aws.rds.dbinstance.enabledCloudwatchLogsExports != empty
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_db_instance")
+    mql: |
+      terraform.resources("aws_db_instance").all(
+        arguments['enabled_cloudwatch_logs_exports'] != empty
+      )
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_db_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "aws_db_instance").all(
+        change.after['enabled_cloudwatch_logs_exports'] != empty
+      )
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_db_instance")
+    mql: |
+      terraform.state.resources.where(type == "aws_db_instance").all(
+        values['enabled_cloudwatch_logs_exports'] != empty
+      )
+
+  - uid: mondoo-aws-security-rds-instance-log-exports-enabled-cloudformation
+    filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::RDS::DBInstance")
+    mql: |
+      cloudformation.template.resources.where(type == "AWS::RDS::DBInstance").all(
+        properties['EnableCloudwatchLogsExports'] != empty
+      )
+
   - uid: mondoo-aws-security-directoryservice-radius-status-completed
     title: Ensure Directory Service RADIUS MFA setup is completed when configured
     impact: 60


### PR DESCRIPTION
## What

Adds six checks to `mondoo-aws-security` for three gaps found by diffing the AWS provider schema against the policy content. In every case the provider already exposed a purpose-built field that **no check referenced**.

### IAM role trust policies

| Check | Assertion | Impact |
|---|---|---|
| `iam-role-trust-policy-no-public-principals` | No role is assumable by the wildcard principal `"*"` without a source-scoping condition | 90 |
| `iam-role-cross-account-trust-scoped` | Roles trusted by an external AWS account carry a scoping condition | 80 |

The policy had 18 IAM checks and not one inspected a trust policy. `aws.iam.role.assumableByPublic`, `assumableByExternalAccounts`, and `assumeRolePolicyStatements` were all unused.

`assumableByPublic` is the low-false-positive form: the provider's `statementsAllowPublic` helper only reports a wildcard principal when the statement has **no** restricting source-scoping condition, so `aws:PrincipalOrgID` / `aws:SourceArn` / `sts:ExternalId` grants are correctly exempt.

### RDS DB instances

| Check | Assertion | Impact |
|---|---|---|
| `rds-instance-auto-minor-version-upgrade` | Engine minor patches are applied automatically | 60 |
| `rds-instance-log-exports-enabled` | At least one log type is published to CloudWatch Logs | 60 |

DocumentDB, Neptune, ElastiCache, MemoryDB, and Amazon MQ all have auto-minor-upgrade and log-export checks. RDS, the most widely deployed of them, had neither.

The log-export check asserts **at least one** log type rather than naming a specific one, because the exportable set is engine specific: MySQL/MariaDB have `audit`/`error`/`general`/`slowquery`, PostgreSQL has `postgresql`/`upgrade`, Oracle has `alert`/`audit`/`listener`/`trace`, SQL Server has `agent`/`error`. Requiring `audit` would false-positive on every PostgreSQL instance.

### EKS access

| Check | Assertion | Impact |
|---|---|---|
| `eks-access-entry-no-system-masters` | No access entry maps a principal into `system:masters` | 85 |
| `eks-pod-identity-role-no-admin-access` | Pod identity associations do not reference `AdministratorAccess` roles | 85 |

The nine existing EKS checks cover how the API server is reached, never who is authorized once connected. `accessEntries` and `podIdentityAssociations` were unused.

## Variants

Full runtime + `terraform-hcl` / `terraform-plan` / `terraform-state` / `cloudformation` coverage for both RDS checks and the EKS access entry check.

Runtime-only, with a `# No Terraform variants:` comment explaining the specific limitation, for:

- **Both IAM checks** — the trust policy is an opaque JSON string in HCL, normally produced by `jsonencode()` or `data.aws_iam_policy_document`, so it is unresolved at parse time. The runtime field also exempts conditioned wildcards, a distinction a regex on the encoded document cannot make. Deciding an account is *external* additionally requires the scanned account ID, which no Terraform asset carries.
- **`eks-pod-identity-role-no-admin-access`** — the association carries only a `role_arn`; the attached policies live in separate `aws_iam_role_policy_attachment` resources possibly in another module or state.

All four still ship `- id: terraform` remediation, since the fix *is* expressible in HCL even where the assertion is not.

### A note on the Terraform default

`auto_minor_version_upgrade` defaults to `true` in both the AWS API and the Terraform provider, so the IaC variants assert `!= false` rather than `== true`. Asserting `== true` would fail every instance that correctly relies on the default. The `pass/default` fixtures lock this behavior in. (The existing DocumentDB sibling uses `== true` and treats an omitted attribute as failing; that looks like a false positive worth a separate look.)

## Compliance tags

All 13 frameworks, each control read from `cnspec-enterprise-policies/frameworks/` rather than copied from a neighbor:

- **Trust policy / public principal** → `ac-3` *Access Enforcement* ("Enforce approved authorizations for logical access") and `800-171 3.1.1` ("Limit system access to authorized users, processes acting on behalf of authorized users, and devices").
- **Cross-account / EKS access / pod identity** → `ac-6` *Least Privilege* and `800-171 3.1.5`. The two EKS checks use `iso-27001-2022-a-8-2` *Privileged access rights* and `pcidss-requirement-7-2-2` ("least privileges necessary") since both are specifically about privileged access; the IAM checks use `a-8-3` *Information access restriction* and `7-2-1` (access control model).
- **RDS patching** → `si-2` *Flaw Remediation*, `a-8-8`, `pcidss 6.3.3`, `tvm-03`, `nis-2 21.2(e)`; `hipaa: false` since §164.312 has no patch-management control.
- **RDS log export** → the policy's established logging mapping (`au-6`, `a-8-15`, `pcidss 10.2.1`, `cc7-2-1`, `nis-2 21.2(b)`, `log-08`), which 24 of the 25 existing logging checks already use.

One deliberate consistency call: `soc2-control-cc7-1-1` is used for RDS patching to match the seven existing auto-minor-version-upgrade siblings, even though `cc7-4-8` *Remediates Identified Vulnerabilities* is the better fit. Worth remapping the whole family in a follow-up rather than leaving one divergent check here.

## Verification

- `cnspec policy lint content/mondoo-aws-security.mql.yaml` — valid bundle; the only warnings are pre-existing on `main` (identical counts).
- `python3 content/validation/validate_remediation_commands.py aws` — **1002 passed, 0 failed**.
- `typos content/mondoo-aws-security.mql.yaml` — clean.
- `go test ./content` — ok.
- `go test -tags iac_variants -run '^TestTerraformVariants$|^TestCloudFormationVariants$' ./content` — **5147 PASS, 0 FAIL**, including all 16 new fixture scenarios.
- Provider semantics for `assumableByPublic`, `statementsAllowPublic`, `hasSourceScopingCondition`, and `podIdentityAssociation.iamRole` were read from the mql source rather than inferred.

Policy bumped 12.7.0 → 12.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)