### PR TITLE
🧹 ci: bump pinned CLIs in the remediation validator job

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -57,8 +57,8 @@ jobs:
         # `doctl-<version>-checksums.sha256` file. No auth needed for
         # `doctl --help` introspection.
         env:
-          DOCTL_VERSION: "1.163.0"
-          DOCTL_SHA256: "04413587db80236f80b02b586db094ffa94096891b14c2b4883b623ff3d59b48"
+          DOCTL_VERSION: "1.166.0"
+          DOCTL_SHA256: "1596424b64091a7939bde561daf2402ca8a141966429928e688d20d17091ec89"
         run: |
           # --fail makes curl exit non-zero on HTTP 4xx/5xx (default -sSL silently
           # writes the error body to disk and trips the sha256 check below).
@@ -85,8 +85,8 @@ jobs:
         # registry. Bump GLAB_VERSION and GLAB_SHA256 in lockstep when
         # GitLab ships new commands or flags.
         env:
-          GLAB_VERSION: "1.109.0"
-          GLAB_SHA256: "67b4a8557727a058f44e0839babdcf214ea6f6f829062cf0bae02f7b25814e5d"
+          GLAB_VERSION: "1.112.0"
+          GLAB_SHA256: "f1c52907558b665f2032b615787d353cd06e54240b501a81f9489bfc8f6a8ebf"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/${GLAB_VERSION}/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
@@ -103,8 +103,8 @@ jobs:
         # and HCLOUD_SHA256 in lockstep when Hetzner ships new commands or
         # flags — the SHA-256 is published in the per-release checksums.txt.
         env:
-          HCLOUD_VERSION: "1.66.0"
-          HCLOUD_SHA256: "8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86"
+          HCLOUD_VERSION: "1.67.0"
+          HCLOUD_SHA256: "7164483e05a1abef492768db429a28c21d579dc70e807558cb140debc2971477"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz" \
@@ -123,8 +123,8 @@ jobs:
         # `databricks_cli_<version>_SHA256SUMS` file. No auth needed for the
         # `__complete` / `--help` introspection the validator performs.
         env:
-          DATABRICKS_VERSION: "1.9.0"
-          DATABRICKS_SHA256: "10938da31db7f89e6e90f6be41d340e3387231e5da5125cfc97ecb8cb66f6394"
+          DATABRICKS_VERSION: "1.11.0"
+          DATABRICKS_SHA256: "bddad9e2d830dd7ea00292203c00088f3efe6f940f1ecdad59a3dc25bc28bca9"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/databricks/cli/releases/download/v${DATABRICKS_VERSION}/databricks_cli_${DATABRICKS_VERSION}_linux_amd64.zip" \


### PR DESCRIPTION
Bumps the four SHA-pinned CLI tarballs installed by the `validate-cli` job in `validate-remediation.yaml`. That job is a grammar oracle: `validate_remediation_commands.py` introspects each CLI's real command tree, so stale pins mean newly added commands get reported as invalid and removed ones slip through.

| CLI | Old | New |
| --- | --- | --- |
| doctl | 1.163.0 | 1.166.0 |
| glab | 1.109.0 | 1.112.0 |
| hcloud | 1.66.0 | 1.67.0 |
| databricks | 1.9.0 | 1.11.0 |

Each SHA-256 was taken from the vendor's published per-release checksum file, then verified against a local download of the exact asset URL the workflow fetches. Archive layouts are unchanged (`doctl`, `bin/glab`, `hcloud`, `databricks`), so the extract and install steps needed no edits.

The unpinned installs in the same job (aws, gcloud, oci-cli) already track latest and were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)