### PR TITLE
✨ reporter: bring SARIF output up to the detail level of JUnit detailed

### DIFF
--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -12,10 +12,8 @@ import (
 	"github.com/jstemmer/go-junit-report/v2/junit"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/cli/printer"
-	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/utils/iox"
-	"go.mondoo.com/mql/v13/utils/stringx"
 )
 
 // ConvertToJunit maps the ReportCollection to Junit. Each asset becomes its own Suite.
@@ -59,7 +57,7 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper, detailed b
 		}
 
 		bundle := r.Bundle.ToMap()
-		queries := bundle.QueryMap()
+		queries := reporterQueryMap(bundle)
 
 		// iterate over asset mrns
 		for assetMrn, assetObj := range r.Assets {
@@ -268,7 +266,7 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 	}
 
 	if mql := queryMql(query); mql != "" {
-		writeJunitSection(&b, "Query", mql)
+		writeDetailSection(&b, "Query", mql)
 	}
 
 	// The assessment (expected vs actual) is only available for assertion checks
@@ -281,10 +279,10 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 		if cb := resolved.GetCodeBundle(query); cb != nil {
 			if assessment := policy.Query2Assessment(cb, report); assessment != nil {
 				if text := strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(cb, assessment)); text != "" {
-					writeJunitSection(&b, "Result", text)
+					writeDetailSection(&b, "Result", text)
 				}
 				if locs := failingResourceLocations(cb, assessment); locs != "" {
-					writeJunitSection(&b, "Failing resources", locs)
+					writeDetailSection(&b, "Failing resources", locs)
 				}
 			}
 		}
@@ -293,142 +291,14 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 	// For errored checks the score message carries the failure reason.
 	if score != nil && score.Type == policy.ScoreType_Error {
 		if msg := score.MessageLine(); msg != "" {
-			writeJunitSection(&b, "Error", msg)
+			writeDetailSection(&b, "Error", msg)
 		}
 	}
 
-	if rem := queryRemediation(query, platformKeys); rem != "" {
-		writeJunitSection(&b, "Remediation", rem)
-	}
-
-	if refs := queryReferences(query); refs != "" {
-		writeJunitSection(&b, "References", refs)
-	}
+	writeDetailSection(&b, "Remediation", queryRemediation(query, platformKeys))
+	writeDetailSection(&b, "References", queryReferences(query))
 
 	return strings.TrimSpace(b.String())
-}
-
-// writeJunitSection appends an indented "Title:\n  body" section to b.
-func writeJunitSection(b *strings.Builder, title, body string) {
-	if b.Len() > 0 {
-		b.WriteString("\n")
-	}
-	b.WriteString(title)
-	b.WriteString(":\n")
-	b.WriteString(stringx.Indent(2, strings.TrimSpace(body)))
-	b.WriteString("\n")
-}
-
-// queryMql returns the MQL source for a query, preferring the current field and
-// falling back to the deprecated one (which the compact reporter still reads).
-func queryMql(query *policy.Mquery) string {
-	if query.Mql != "" {
-		return query.Mql
-	}
-	return query.Query
-}
-
-// platformRemediationKeys returns the set of remediation ids relevant to an
-// asset's platform: the platform name, its family entries (e.g. "terraform" for
-// the "terraform-hcl" platform), and the platform-agnostic "default"/"" ids. It
-// is used to filter remediation down to the platform being scanned so a Terraform
-// scan shows Terraform remediation rather than every IaC/tool variant.
-func platformRemediationKeys(platform *inventory.Platform) map[string]bool {
-	keys := map[string]bool{"": true, "default": true}
-	if platform != nil {
-		if platform.Name != "" {
-			keys[strings.ToLower(platform.Name)] = true
-		}
-		for _, f := range platform.Family {
-			if f != "" {
-				keys[strings.ToLower(f)] = true
-			}
-		}
-	}
-	return keys
-}
-
-// queryRemediation renders the remediation for a query, labeling each item with
-// its platform/tool id (e.g. "[terraform]") when present. Items are filtered to
-// those matching the asset's platform (name/family) or that are platform-agnostic;
-// if none match, all items are shown so remediation is never dropped entirely.
-func queryRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
-	if query.Docs == nil || query.Docs.Remediation == nil {
-		return ""
-	}
-
-	// Collect non-empty items, splitting into platform matches and the rest.
-	var matched, all []*policy.TypedDoc
-	for _, item := range query.Docs.Remediation.Items {
-		if item == nil || strings.TrimSpace(item.Desc) == "" {
-			continue
-		}
-		all = append(all, item)
-		if platformKeys[strings.ToLower(item.Id)] {
-			matched = append(matched, item)
-		}
-	}
-
-	items := matched
-	if len(items) == 0 {
-		items = all // fallback: no platform-specific match, show everything
-	}
-
-	var b strings.Builder
-	for _, item := range items {
-		if b.Len() > 0 {
-			b.WriteString("\n")
-		}
-		if item.Id != "" && item.Id != "default" {
-			b.WriteString("[" + item.Id + "] ")
-		}
-		b.WriteString(strings.TrimSpace(item.Desc))
-	}
-	return b.String()
-}
-
-// queryReferences renders a query's references as "Title: URL" lines. It prefers
-// docs.refs (the canonical location) and falls back to the deprecated refs field.
-func queryReferences(query *policy.Mquery) string {
-	refs := query.Refs
-	if query.Docs != nil && len(query.Docs.Refs) > 0 {
-		refs = query.Docs.Refs
-	}
-	var b strings.Builder
-	for _, ref := range refs {
-		if ref == nil || ref.Url == "" {
-			continue
-		}
-		if b.Len() > 0 {
-			b.WriteString("\n")
-		}
-		if ref.Title != "" {
-			b.WriteString(ref.Title + ": ")
-		}
-		b.WriteString(ref.Url)
-	}
-	return b.String()
-}
-
-// failingResourceLocations lists the source locations (path:line) of the resources
-// that caused a check to fail. It is populated for resources that carry source
-// context (e.g. Terraform/HCL) and empty for scalar checks.
-func failingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) string {
-	var b strings.Builder
-	for _, sc := range cb.FailingResourceContexts(assessment) {
-		if sc.Path == "" {
-			continue
-		}
-		loc := sc.Path
-		if startLine, _, _, _, _, ok := sc.Range.Bounds(); ok && startLine >= 1 {
-			loc += ":" + strconv.FormatInt(int64(startLine), 10)
-		}
-		if b.Len() > 0 {
-			b.WriteString("\n")
-		}
-		b.WriteString(loc)
-	}
-	return b.String()
 }
 
 func iota32(i int32) string {

--- a/cli/reporter/query_docs.go
+++ b/cli/reporter/query_docs.go
@@ -1,0 +1,315 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/utils/stringx"
+)
+
+// Helpers that extract the human-readable documentation of a check (description,
+// MQL, audit steps, remediation, references, compliance mappings) and the severity
+// derived from its impact. They are shared by the JUnit and SARIF reporters so both
+// surface the same content.
+
+// reporterQueryMap indexes a bundle's queries the way the reporters look them up:
+// by code id, falling back to the MRN. Several queries can share a code id (e.g.
+// variants that compile to the same MQL), so the one with the lowest MRN wins.
+// policy.PolicyBundleMap.QueryMap picks an arbitrary one instead - it iterates a
+// map - which makes SARIF rule ids and JUnit test names flip between runs of the
+// same report.
+func reporterQueryMap(bundle *policy.PolicyBundleMap) map[string]*policy.Mquery {
+	res := make(map[string]*policy.Mquery, len(bundle.Queries))
+	for _, key := range sortedKeys(bundle.Queries) {
+		query := bundle.Queries[key]
+		if query == nil {
+			continue
+		}
+		id := query.CodeId
+		if id == "" {
+			id = query.Mrn
+		}
+		if id == "" {
+			continue
+		}
+		if _, ok := res[id]; ok {
+			continue
+		}
+		res[id] = query
+	}
+	return res
+}
+
+// queryDescription extracts a description from a query
+func queryDescription(query *policy.Mquery) string {
+	if query.Docs != nil && query.Docs.Desc != "" {
+		return query.Docs.Desc
+	}
+	if query.Desc != "" {
+		return query.Desc
+	}
+	return ""
+}
+
+// queryMql returns the MQL source for a query, preferring the current field and
+// falling back to the deprecated one (which the compact reporter still reads).
+func queryMql(query *policy.Mquery) string {
+	if query.Mql != "" {
+		return query.Mql
+	}
+	return query.Query
+}
+
+// queryAudit returns the manual audit instructions of a check, if it has any.
+func queryAudit(query *policy.Mquery) string {
+	if query.Docs == nil {
+		return ""
+	}
+	return strings.TrimSpace(query.Docs.Audit)
+}
+
+// platformRemediationKeys returns the set of remediation ids relevant to an
+// asset's platform: the platform name, its family entries (e.g. "terraform" for
+// the "terraform-hcl" platform), and the platform-agnostic "default"/"" ids. It
+// is used to filter remediation down to the platform being scanned so a Terraform
+// scan shows Terraform remediation rather than every IaC/tool variant.
+func platformRemediationKeys(platform *inventory.Platform) map[string]bool {
+	keys := map[string]bool{"": true, "default": true}
+	if platform != nil {
+		if platform.Name != "" {
+			keys[strings.ToLower(platform.Name)] = true
+		}
+		for _, f := range platform.Family {
+			if f != "" {
+				keys[strings.ToLower(f)] = true
+			}
+		}
+	}
+	return keys
+}
+
+// remediationItems returns the remediation entries of a query that apply to the
+// asset's platform (name/family) or that are platform-agnostic. If none match, all
+// items are returned so remediation is never dropped entirely.
+func remediationItems(query *policy.Mquery, platformKeys map[string]bool) []*policy.TypedDoc {
+	if query.Docs == nil || query.Docs.Remediation == nil {
+		return nil
+	}
+
+	var matched, all []*policy.TypedDoc
+	for _, item := range query.Docs.Remediation.Items {
+		if item == nil || strings.TrimSpace(item.Desc) == "" {
+			continue
+		}
+		all = append(all, item)
+		if platformKeys[strings.ToLower(item.Id)] {
+			matched = append(matched, item)
+		}
+	}
+
+	if len(matched) == 0 {
+		return all // fallback: no platform-specific match, show everything
+	}
+	return matched
+}
+
+// queryRemediation renders the remediation for a query as plain text, labeling
+// each item with its platform/tool id (e.g. "[terraform]") when present.
+func queryRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
+	var b strings.Builder
+	for _, item := range remediationItems(query, platformKeys) {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		if item.Id != "" && item.Id != "default" {
+			b.WriteString("[" + item.Id + "] ")
+		}
+		b.WriteString(strings.TrimSpace(item.Desc))
+	}
+	return b.String()
+}
+
+// queryRefs returns the references of a query. It prefers docs.refs (the canonical
+// location) and falls back to the deprecated refs field.
+func queryRefs(query *policy.Mquery) []*policy.MqueryRef {
+	refs := query.Refs
+	if query.Docs != nil && len(query.Docs.Refs) > 0 {
+		refs = query.Docs.Refs
+	}
+
+	res := make([]*policy.MqueryRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref == nil || ref.Url == "" {
+			continue
+		}
+		res = append(res, ref)
+	}
+	return res
+}
+
+// queryReferences renders a query's references as "Title: URL" lines.
+func queryReferences(query *policy.Mquery) string {
+	var b strings.Builder
+	for _, ref := range queryRefs(query) {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		if ref.Title != "" {
+			b.WriteString(ref.Title + ": ")
+		}
+		b.WriteString(ref.Url)
+	}
+	return b.String()
+}
+
+// queryComplianceTags returns the compliance framework mappings of a check, keyed
+// by framework (e.g. "compliance/iso-27001-2022" -> "iso-27001-2022-a-8-24").
+// Entries that are explicitly turned off (value "false") are dropped.
+func queryComplianceTags(query *policy.Mquery) map[string]string {
+	res := map[string]string{}
+	for k, v := range query.Tags {
+		if !strings.HasPrefix(k, "compliance/") || v == "" || v == "false" {
+			continue
+		}
+		res[k] = v
+	}
+	return res
+}
+
+// failingResourceLocations lists the source locations (path:line) of the resources
+// that caused a check to fail. It is populated for resources that carry source
+// context (e.g. Terraform/HCL) and empty for scalar checks.
+func failingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) string {
+	var b strings.Builder
+	for _, sc := range cb.FailingResourceContexts(assessment) {
+		if sc.Path == "" {
+			continue
+		}
+		loc := sc.Path
+		if startLine, _, _, _, _, ok := sc.Range.Bounds(); ok && startLine >= 1 {
+			loc += ":" + strconv.FormatInt(int64(startLine), 10)
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(loc)
+	}
+	return b.String()
+}
+
+// writeDetailSection appends an indented "Title:\n  body" section to b. It is the
+// plain-text section format used in JUnit failure bodies and SARIF rule help.
+func writeDetailSection(b *strings.Builder, title, body string) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return
+	}
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString(title)
+	b.WriteString(":\n")
+	b.WriteString(stringx.Indent(2, body))
+	b.WriteString("\n")
+}
+
+// policyTitlesByQuery maps a check MRN to the titles of the policies that include
+// it, so a finding can be attributed to the policy it came from.
+func policyTitlesByQuery(bundle *policy.PolicyBundleMap) map[string][]string {
+	res := map[string][]string{}
+	if bundle == nil {
+		return res
+	}
+
+	for _, p := range bundle.Policies {
+		if p == nil {
+			continue
+		}
+		title := p.Name
+		if title == "" {
+			title = p.Mrn
+		}
+		if title == "" {
+			continue
+		}
+
+		for _, group := range p.Groups {
+			if group == nil {
+				continue
+			}
+			for _, check := range group.Checks {
+				if check == nil || check.Mrn == "" {
+					continue
+				}
+				if !stringx.Contains(res[check.Mrn], title) {
+					res[check.Mrn] = append(res[check.Mrn], title)
+				}
+			}
+		}
+	}
+
+	for k := range res {
+		sort.Strings(res[k])
+	}
+	return res
+}
+
+// queryImpact returns the configured impact of a check (0-100, where 100 is the
+// most impactful) and whether it is set at all.
+func queryImpact(query *policy.Mquery) (int32, bool) {
+	if query == nil || query.Impact == nil || query.Impact.Value == nil {
+		return 0, false
+	}
+	return query.Impact.Value.Value, true
+}
+
+// riskSeverityLabel maps a cnspec risk value (0-100, the inverse of a score value)
+// to the severity label cnspec uses everywhere else. The bands mirror
+// policy.ScoreRatingsText:
+//
+//	90 .. 100 → CRITICAL
+//	70 ..  89 → HIGH
+//	40 ..  69 → MEDIUM
+//	 1 ..  39 → LOW
+//	        0 → NONE
+func riskSeverityLabel(risk int32) string {
+	switch {
+	case risk >= 90:
+		return policy.ScoreRatingTextCritical
+	case risk >= 70:
+		return policy.ScoreRatingTextHigh
+	case risk >= 40:
+		return policy.ScoreRatingTextMedium
+	case risk >= 1:
+		return policy.ScoreRatingTextLow
+	default:
+		return policy.ScoreRatingTextNone
+	}
+}
+
+// riskSarifLevel maps a cnspec risk value to a SARIF level. The bands are the same
+// ones GitHub code scanning uses for security-severity (>= 7.0 error, >= 4.0
+// warning), which keeps level and security-severity consistent.
+func riskSarifLevel(risk int32) string {
+	switch {
+	case risk >= 70:
+		return "error"
+	case risk >= 40:
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+// securitySeverity renders a cnspec risk value (0-100) as the 0.0-10.0 string that
+// GitHub code scanning reads from the "security-severity" rule property.
+func securitySeverity(risk int32) string {
+	return strconv.FormatFloat(float64(risk)/10, 'f', 1, 64)
+}

--- a/cli/reporter/sarif.go
+++ b/cli/reporter/sarif.go
@@ -8,18 +8,25 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
+	"go.mondoo.com/cnspec/v13"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13/cli/printer"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/mrn"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/mql/v13/utils/iox"
 )
 
-const sarifAssetErrorRuleID = "asset-error"
+const (
+	sarifAssetErrorRuleID  = "asset-error"
+	sarifVulnPackageRuleID = "vulnerable-package"
+	sarifInformationURI    = "https://cnspec.io"
+)
 
 // sarifFingerprintKey is the key under which cnspec stores its stable
 // per-finding fingerprint in SARIF partialFingerprints. It uses a URI-style
@@ -27,6 +34,35 @@ const sarifAssetErrorRuleID = "asset-error"
 // tooling (e.g. GitHub code scanning's primaryLocationLineHash). The trailing
 // version lets us evolve the fingerprint algorithm without remapping old runs.
 const sarifFingerprintKey = "https://cnspec.io/fingerprint/v1"
+
+// The SARIF report carries the same content as the detailed JUnit report, split
+// along the lines the SARIF spec (and its consumers) expect:
+//
+//	rule.shortDescription   check title
+//	rule.fullDescription    check description
+//	rule.help               description, MQL, audit steps, remediation, references,
+//	                        compliance mappings — as text and as markdown
+//	rule.helpUri            first reference of the check
+//	rule.properties         severity, impact, security-severity, tags, policies,
+//	                        compliance mappings, MQL
+//	result.message          title, status, score, assessment (expected vs actual)
+//	result.locations        source location of each failing resource, plus the
+//	                        asset as a logical location
+//	result.properties       score, risk, severity, status, asset
+//
+// Vulnerabilities from the scan's vulnerability report are emitted alongside the
+// policy findings, one result per affected package (per advisory when the report
+// carries advisories), which mirrors the JUnit vulnerability test suite.
+
+// sarifRunContext carries everything a single asset's run needs while its rules
+// and results are built.
+type sarifRunContext struct {
+	assetMrn     string
+	asset        *inventory.Asset
+	logicalLoc   *sarif.LogicalLocation
+	platformKeys map[string]bool
+	policyTitles map[string][]string
+}
 
 // ConvertToSarif converts a ReportCollection into a SARIF 2.1.0 report.
 // Each scanned asset is represented as a separate SARIF run.
@@ -45,27 +81,42 @@ func ConvertToSarif(r *policy.ReportCollection, out iox.OutputHelper) error {
 	}
 
 	bundle := r.Bundle.ToMap()
-	queries := bundle.QueryMap()
+	queries := reporterQueryMap(bundle)
+	policyTitles := policyTitlesByQuery(bundle)
 
 	// Create one run per asset (deterministic order via sorted keys)
 	assetMrns := sortedKeys(r.Assets)
 	for _, assetMrn := range assetMrns {
 		assetObj := r.Assets[assetMrn]
-		run := newAssetRun(assetObj)
+		ctx := &sarifRunContext{
+			assetMrn:     assetMrn,
+			asset:        assetObj,
+			logicalLoc:   assetLogicalLocation(assetObj),
+			platformKeys: platformRemediationKeys(assetObj.Platform),
+			policyTitles: policyTitles,
+		}
+		run := newAssetRun(r, ctx)
 
 		// Register the asset-error rule if this asset has an error
 		if _, hasErr := r.Errors[assetMrn]; hasErr {
 			run.AddRule(sarifAssetErrorRuleID).
 				WithName("Asset scan error").
-				WithDescription("The asset could not be scanned successfully")
+				WithDescription("The asset could not be scanned successfully").
+				WithFullDescription(sarif.NewMultiformatMessageString(
+					"cnspec could not complete the scan of this asset. No policy results are available for it.")).
+				WithDefaultConfiguration(sarif.NewReportingConfiguration().WithLevel("error")).
+				WithProperties(sarif.Properties{
+					"tags": []string{"cnspec", "scan"},
+				})
 		}
 
 		// Register reporting queries applicable to this asset as SARIF rules
-		registerAssetRules(run, r, assetMrn, queries)
+		registerAssetRules(run, r, ctx, queries)
 
 		// Emit results for this asset
-		addAssetErrors(run, r, assetMrn, assetObj)
-		addAssetResults(run, r, assetMrn, assetObj, queries)
+		addAssetErrors(run, r, ctx)
+		addAssetResults(run, r, ctx, queries)
+		addAssetVulnerabilities(run, r.VulnReports[assetMrn], ctx)
 
 		report.AddRun(run)
 	}
@@ -74,23 +125,119 @@ func ConvertToSarif(r *policy.ReportCollection, out iox.OutputHelper) error {
 }
 
 // newAssetRun creates a new SARIF run for a given asset
-func newAssetRun(asset *inventory.Asset) *sarif.Run {
-	run := sarif.NewRunWithInformationURI("cnspec", "https://cnspec.io")
-	// Tag the run with asset metadata so consumers can identify which asset it covers
-	props := sarif.Properties{"asset": asset.Name}
-	if asset.Platform != nil {
-		platformName := getPlatformNameForAsset(asset)
-		if platformName != "" {
+func newAssetRun(r *policy.ReportCollection, ctx *sarifRunContext) *sarif.Run {
+	run := sarif.NewRunWithInformationURI("cnspec", sarifInformationURI)
+	run.Tool.Driver.
+		WithVersion(cnspec.GetVersion()).
+		WithFullName("cnspec " + cnspec.GetVersion()).
+		WithShortDescription(sarif.NewMultiformatMessageString(
+			"cnspec is an open source, cloud-native security and policy scanner"))
+	run.Tool.Driver.Organization = strPtr("Mondoo")
+	// cnspec reports 1-based line and column numbers on source locations.
+	run.ColumnKind = "utf16CodeUnits"
+
+	// Tag the run with asset metadata so consumers can identify which asset it
+	// covers, and correlate re-scans of the same asset across uploads.
+	run.AutomationDetails = sarif.NewRunAutomationDetails().
+		WithID("cnspec/" + ctx.asset.Name).
+		WithDescriptionText("cnspec scan of " + ctx.asset.Name)
+
+	props := sarif.Properties{"asset": ctx.asset.Name}
+	if ctx.assetMrn != "" {
+		props["assetMrn"] = ctx.assetMrn
+	}
+	if ctx.asset.Platform != nil {
+		if platformName := getPlatformNameForAsset(ctx.asset); platformName != "" {
 			props["platform"] = platformName
 		}
+		if ctx.asset.Platform.Version != "" {
+			props["platformVersion"] = ctx.asset.Platform.Version
+		}
+		if ctx.asset.Platform.Arch != "" {
+			props["platformArch"] = ctx.asset.Platform.Arch
+		}
 	}
+	addRunScoreProperties(props, r, ctx.assetMrn)
+	addRunVulnProperties(props, r.VulnReports[ctx.assetMrn])
 	run.Properties = props
+
 	return run
 }
 
-// registerAssetRules registers the reporting queries for a single asset as SARIF rules on the run
-func registerAssetRules(run *sarif.Run, r *policy.ReportCollection, assetMrn string, queries map[string]*policy.Mquery) {
+// addRunScoreProperties summarizes the asset's policy results (overall score and
+// per-status counts) into the run's property bag.
+func addRunScoreProperties(props sarif.Properties, r *policy.ReportCollection, assetMrn string) {
+	report, ok := r.Reports[assetMrn]
+	if !ok || report == nil {
+		return
+	}
+
+	if report.Score != nil {
+		props["score"] = report.Score.Value
+		props["grade"] = report.Score.Rating().Letter()
+	}
+
 	resolved, ok := r.ResolvedPolicies[assetMrn]
+	if !ok || resolved == nil || resolved.CollectorJob == nil {
+		return
+	}
+
+	var total, passed, failed, errored, skipped int
+	for id, score := range report.Scores {
+		if _, ok := resolved.CollectorJob.ReportingQueries[id]; !ok {
+			continue
+		}
+		total++
+		switch scoreToSarifKind(score) {
+		case "pass":
+			passed++
+		case "fail":
+			if score != nil && score.Type == policy.ScoreType_Error {
+				errored++
+			} else {
+				failed++
+			}
+		case "notApplicable":
+			skipped++
+		}
+	}
+
+	props["checksTotal"] = total
+	props["checksPassed"] = passed
+	props["checksFailed"] = failed
+	props["checksErrored"] = errored
+	props["checksSkipped"] = skipped
+}
+
+// addRunVulnProperties summarizes the asset's vulnerability report into the run's
+// property bag, mirroring the properties of the JUnit vulnerability test suite.
+func addRunVulnProperties(props sarif.Properties, vulnReport *mvd.VulnReport) {
+	if vulnReport == nil || vulnReport.Stats == nil {
+		return
+	}
+
+	// Platforms without a package inventory (Terraform, cloud APIs, ...) report
+	// empty stats; don't clutter their runs with zeros.
+	if pkgs := vulnReport.Stats.Packages; pkgs != nil && pkgs.Total > 0 {
+		props["packagesTotal"] = pkgs.Total
+		props["packagesAffected"] = pkgs.Affected
+		props["packagesCritical"] = pkgs.Critical
+		props["packagesHigh"] = pkgs.High
+		props["packagesMedium"] = pkgs.Medium
+		props["packagesLow"] = pkgs.Low
+		props["packagesNone"] = pkgs.None
+	}
+	if advisories := vulnReport.Stats.Advisories; advisories != nil && advisories.Total > 0 {
+		props["advisoriesTotal"] = advisories.Total
+	}
+	if cves := vulnReport.Stats.Cves; cves != nil && cves.Total > 0 {
+		props["cvesTotal"] = cves.Total
+	}
+}
+
+// registerAssetRules registers the reporting queries for a single asset as SARIF rules on the run
+func registerAssetRules(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRunContext, queries map[string]*policy.Mquery) {
+	resolved, ok := r.ResolvedPolicies[ctx.assetMrn]
 	if !ok || resolved.CollectorJob == nil {
 		return
 	}
@@ -100,49 +247,158 @@ func registerAssetRules(run *sarif.Run, r *policy.ReportCollection, assetMrn str
 		if !ok {
 			continue
 		}
-
-		ruleID := queryRuleID(query)
-		rb := run.AddRule(ruleID)
-		if query.Title != "" {
-			rb.WithName(query.Title)
-		}
-		desc := queryDescription(query)
-		if desc != "" {
-			rb.WithDescription(desc)
-		}
-		if query.Impact != nil && query.Impact.Value != nil {
-			rb.WithProperties(sarif.Properties{
-				"impact": query.Impact.Value.GetValue(),
-			})
-		}
+		registerCheckRule(run, query, ctx)
 	}
 }
 
-func addAssetErrors(run *sarif.Run, r *policy.ReportCollection, assetMrn string, assetObj *inventory.Asset) {
-	errMsg, ok := r.Errors[assetMrn]
+// registerCheckRule turns a check into a SARIF rule that carries everything a
+// consumer needs to render and act on the finding: title, description, help
+// (query, audit steps, remediation, references, compliance mappings), severity
+// and the policies it belongs to.
+func registerCheckRule(run *sarif.Run, query *policy.Mquery, ctx *sarifRunContext) {
+	ruleID := queryRuleID(query)
+	rb := run.AddRule(ruleID)
+
+	title := query.Title
+	if title == "" {
+		title = ruleID
+	}
+	rb.WithName(title).WithDescription(title)
+
+	if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+		rb.WithFullDescription(sarif.NewMultiformatMessageString(desc).WithMarkdown(desc))
+	}
+
+	if text, markdown := checkHelp(query, ctx); text != "" {
+		rb.WithHelp(sarif.NewMultiformatMessageString(text).WithMarkdown(markdown))
+	}
+
+	if refs := queryRefs(query); len(refs) > 0 {
+		rb.WithHelpURI(refs[0].Url)
+	}
+
+	props := sarif.Properties{"tags": checkRuleTags(query, ctx)}
+	if impact, ok := queryImpact(query); ok {
+		props["impact"] = impact
+		props["severity"] = riskSeverityLabel(impact)
+		// GitHub code scanning reads the alert severity from this property.
+		props["security-severity"] = securitySeverity(impact)
+		rb.WithDefaultConfiguration(sarif.NewReportingConfiguration().WithLevel(riskSarifLevel(impact)))
+	}
+	if query.Mrn != "" {
+		props["queryMrn"] = query.Mrn
+	}
+	if mql := strings.TrimSpace(queryMql(query)); mql != "" {
+		props["mql"] = mql
+	}
+	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
+		props["policies"] = titles
+	}
+	if compliance := queryComplianceTags(query); len(compliance) > 0 {
+		props["compliance"] = compliance
+	}
+	if rem := queryRemediation(query, ctx.platformKeys); rem != "" {
+		props["remediation"] = rem
+	}
+	rb.WithProperties(props)
+}
+
+// checkRuleTags builds the rule tags. Consumers use them to group and filter
+// findings; "security" in particular is what makes GitHub code scanning treat the
+// rule as a security alert.
+func checkRuleTags(query *policy.Mquery, ctx *sarifRunContext) []string {
+	tags := []string{"security", "cnspec"}
+	for _, title := range ctx.policyTitles[query.Mrn] {
+		tags = append(tags, "policy/"+title)
+	}
+	compliance := queryComplianceTags(query)
+	for _, framework := range sortedKeys(compliance) {
+		tags = append(tags, framework)
+	}
+	return tags
+}
+
+// checkHelp renders the static documentation of a check as plain text and as
+// markdown. SARIF consumers show this next to every finding of the rule, so it
+// carries the same sections as the detailed JUnit failure body.
+func checkHelp(query *policy.Mquery, ctx *sarifRunContext) (string, string) {
+	var text, md strings.Builder
+
+	desc := strings.TrimSpace(queryDescription(query))
+	if desc != "" {
+		text.WriteString(desc + "\n")
+		md.WriteString(desc + "\n")
+	}
+
+	if impact, ok := queryImpact(query); ok {
+		severity := riskSeverityLabel(impact) + " (impact " + strconv.Itoa(int(impact)) + ")"
+		writeDetailSection(&text, "Severity", severity)
+		writeMarkdownSection(&md, "Severity", severity)
+	}
+
+	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
+		writeDetailSection(&text, "Policies", strings.Join(titles, "\n"))
+		writeMarkdownSection(&md, "Policies", markdownList(titles))
+	}
+
+	if mql := strings.TrimSpace(queryMql(query)); mql != "" {
+		writeDetailSection(&text, "Query", mql)
+		writeMarkdownSection(&md, "Query", markdownCode(mql))
+	}
+
+	if audit := queryAudit(query); audit != "" {
+		writeDetailSection(&text, "Audit", audit)
+		writeMarkdownSection(&md, "Audit", audit)
+	}
+
+	writeDetailSection(&text, "Remediation", queryRemediation(query, ctx.platformKeys))
+	writeMarkdownSection(&md, "Remediation", markdownRemediation(query, ctx.platformKeys))
+
+	writeDetailSection(&text, "References", queryReferences(query))
+	writeMarkdownSection(&md, "References", markdownReferences(query))
+
+	if compliance := queryComplianceTags(query); len(compliance) > 0 {
+		var lines []string
+		for _, framework := range sortedKeys(compliance) {
+			lines = append(lines, strings.TrimPrefix(framework, "compliance/")+": "+compliance[framework])
+		}
+		writeDetailSection(&text, "Compliance", strings.Join(lines, "\n"))
+		writeMarkdownSection(&md, "Compliance", markdownList(lines))
+	}
+
+	return strings.TrimSpace(text.String()), strings.TrimSpace(md.String())
+}
+
+func addAssetErrors(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRunContext) {
+	errMsg, ok := r.Errors[ctx.assetMrn]
 	if !ok {
 		return
 	}
+	text := fmt.Sprintf("Asset %s: %s", ctx.asset.Name, errMsg)
+	markdown := "**" + ctx.asset.Name + "** could not be scanned\n\n" + markdownCode(errMsg)
 	result := sarif.NewRuleResult(sarifAssetErrorRuleID).
 		WithLevel("error").
-		WithMessage(sarif.NewTextMessage(fmt.Sprintf("Asset %s: %s", assetObj.Name, errMsg)))
+		WithKind("fail").
+		WithMessage(sarif.NewTextMessage(text).WithMarkdown(markdown)).
+		WithLocations([]*sarif.Location{
+			sarif.NewLocation().WithLogicalLocations([]*sarif.LogicalLocation{ctx.logicalLoc}),
+		}).
+		WithPartialFingerPrints(map[string]interface{}{
+			sarifFingerprintKey: sarifFingerprint(sarifAssetErrorRuleID, ctx.assetMrn),
+		})
 	run.AddResult(result)
 }
 
-func addAssetResults(run *sarif.Run, r *policy.ReportCollection, assetMrn string, assetObj *inventory.Asset, queries map[string]*policy.Mquery) {
-	report, ok := r.Reports[assetMrn]
+func addAssetResults(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRunContext, queries map[string]*policy.Mquery) {
+	report, ok := r.Reports[ctx.assetMrn]
 	if !ok {
 		return
 	}
 
-	resolved, ok := r.ResolvedPolicies[assetMrn]
+	resolved, ok := r.ResolvedPolicies[ctx.assetMrn]
 	if !ok || resolved.CollectorJob == nil {
 		return
 	}
-
-	// The asset is recorded as a logical location on every result so consumers
-	// can still tell which asset a finding belongs to.
-	logicalLoc := assetLogicalLocation(assetObj)
 
 	// Sort score IDs for deterministic output
 	scoreIDs := sortedKeys(report.Scores)
@@ -160,14 +416,7 @@ func addAssetResults(run *sarif.Run, r *policy.ReportCollection, assetMrn string
 
 		ruleID := queryRuleID(query)
 		level := scoreToSarifLevel(score)
-
-		msg := query.Title
-		if msg == "" {
-			msg = ruleID
-		}
-		if score != nil && score.Message != "" {
-			msg += ": " + score.MessageLine()
-		}
+		kind := scoreToSarifKind(score)
 
 		// Build the assessment once and reuse it for both the human-readable
 		// detail and the structured source locations.
@@ -179,6 +428,12 @@ func addAssetResults(run *sarif.Run, r *policy.ReportCollection, assetMrn string
 				assessment = policy.Query2Assessment(codeBundle, report)
 			}
 		}
+
+		var detail string
+		if assessment != nil && codeBundle != nil {
+			detail = strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(codeBundle, assessment))
+		}
+		props := checkResultProperties(query, score, ctx)
 
 		// Source locations of the failing resources. This covers terraform and
 		// any resource that carries @context data; it is empty for scalar checks
@@ -192,40 +447,394 @@ func addAssetResults(run *sarif.Run, r *policy.ReportCollection, assetMrn string
 			}
 		}
 
+		// The assessment covers all failing resources at once, so repeating it on
+		// every location of a check that fails on many resources would grow the
+		// report quadratically. Those results carry the offending source snippet in
+		// their own region instead.
+		if len(locations) > 1 {
+			detail = ""
+		}
+		text, markdown := checkResultMessage(query, score, detail)
+
 		if len(locations) == 0 {
-			// No source context: anchor a single result to the asset and keep the
-			// full assessment detail (expected vs actual) in the message.
-			detail := msg
-			if assessment != nil {
-				if text := strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(codeBundle, assessment)); text != "" {
-					detail += "\n\n" + text
-				}
-			}
+			// No source context: anchor a single result to the asset. The full
+			// assessment detail (expected vs actual) travels in the message.
 			result := sarif.NewRuleResult(ruleID).
 				WithLevel(level).
-				WithMessage(sarif.NewTextMessage(detail)).
+				WithKind(kind).
+				WithMessage(sarif.NewTextMessage(text).WithMarkdown(markdown)).
 				WithLocations([]*sarif.Location{
-					sarif.NewLocation().WithLogicalLocations([]*sarif.LogicalLocation{logicalLoc}),
+					sarif.NewLocation().WithLogicalLocations([]*sarif.LogicalLocation{ctx.logicalLoc}),
+				}).
+				WithPartialFingerPrints(map[string]interface{}{
+					sarifFingerprintKey: sarifFingerprint(ruleID, ctx.assetMrn),
 				})
+			result.Properties = props
+			withRiskRank(result, score)
 			run.AddResult(result)
 			continue
 		}
 
 		// One result per failing resource, each pointing at its exact source.
-		// The code snippet travels in the region; the message stays concise.
+		// The code snippet travels in the region.
 		for i := range locations {
 			loc := sarif.NewLocationWithPhysicalLocation(physicalLocationFromContext(locations[i])).
-				WithLogicalLocations([]*sarif.LogicalLocation{logicalLoc})
+				WithLogicalLocations([]*sarif.LogicalLocation{ctx.logicalLoc})
 			result := sarif.NewRuleResult(ruleID).
 				WithLevel(level).
-				WithMessage(sarif.NewTextMessage(msg)).
+				WithKind(kind).
+				WithMessage(sarif.NewTextMessage(text).WithMarkdown(markdown)).
 				WithLocations([]*sarif.Location{loc}).
 				WithPartialFingerPrints(map[string]interface{}{
 					sarifFingerprintKey: sarifLocationFingerprint(ruleID, locations[i]),
 				})
+			result.Properties = props
+			withRiskRank(result, score)
 			run.AddResult(result)
 		}
 	}
+}
+
+// checkResultMessage renders the dynamic part of a finding — what the check is,
+// whether it passed, and how the actual state differed from the expected one — as
+// plain text and as markdown.
+func checkResultMessage(query *policy.Mquery, score *policy.Score, detail string) (string, string) {
+	title := query.Title
+	if title == "" {
+		title = queryRuleID(query)
+	}
+
+	// "FAIL · CRITICAL · score 0/100 · <what the check reported>"
+	status := scoreStatusLabel(score)
+	var details string
+	if score != nil && score.Type == policy.ScoreType_Result {
+		details += " · " + riskSeverityLabel(scoreRisk(score)) + " · score " + strconv.Itoa(int(score.Value)) + "/100"
+	}
+	if msg := score.MessageLine(); msg != "" {
+		details += " · " + msg
+	}
+
+	text := title + ": " + status + details
+	markdown := "**" + title + "**\n\n" + scoreStatusIcon(score) + " **" + status + "**" + details
+
+	if detail != "" {
+		text += "\n\n" + detail
+		markdown += "\n\n" + markdownCode(detail)
+	}
+
+	return text, markdown
+}
+
+// checkResultProperties captures the scoring outcome of a single check so
+// consumers can filter and sort findings without re-deriving it from the level.
+func checkResultProperties(query *policy.Mquery, score *policy.Score, ctx *sarifRunContext) sarif.Properties {
+	props := sarif.Properties{
+		"asset":  ctx.asset.Name,
+		"status": strings.ToLower(scoreStatusLabel(score)),
+	}
+	if ctx.assetMrn != "" {
+		props["assetMrn"] = ctx.assetMrn
+	}
+	if score != nil {
+		props["scoreType"] = score.TypeLabel()
+		props["completion"] = score.Completion()
+		if score.Type == policy.ScoreType_Result {
+			props["score"] = score.Value
+			props["risk"] = scoreRisk(score)
+			props["severity"] = riskSeverityLabel(scoreRisk(score))
+		}
+	}
+	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
+		props["policies"] = titles
+	}
+	return props
+}
+
+// withRiskRank sets the SARIF rank (0-100, higher is more important) of failing
+// results to the check's risk, so viewers that sort by rank show the most
+// dangerous findings first.
+func withRiskRank(result *sarif.Result, score *policy.Score) {
+	if score == nil || score.Type != policy.ScoreType_Result || score.Value == 100 {
+		return
+	}
+	result.WithRank(float32(scoreRisk(score)))
+}
+
+// addAssetVulnerabilities emits the asset's vulnerability findings: one result per
+// affected package and advisory, falling back to a single rule for affected
+// packages that no advisory in the report accounts for.
+func addAssetVulnerabilities(run *sarif.Run, vulnReport *mvd.VulnReport, ctx *sarifRunContext) {
+	if vulnReport == nil {
+		return
+	}
+
+	// Index the packages the asset is actually affected by. Advisories carry
+	// their own package lists, which we intersect with this set.
+	affected := map[string]*mvd.Package{}
+	byName := map[string]*mvd.Package{}
+	for _, pkg := range vulnReport.Packages {
+		if pkg == nil || !pkg.Affected {
+			continue
+		}
+		affected[vulnPackageKey(pkg)] = pkg
+		byName[pkg.Name] = pkg
+	}
+	if len(affected) == 0 {
+		return
+	}
+
+	covered := map[string]bool{}
+
+	advisories := make([]*mvd.Advisory, 0, len(vulnReport.Advisories))
+	for _, advisory := range vulnReport.Advisories {
+		if advisory != nil && advisory.ID != "" {
+			advisories = append(advisories, advisory)
+		}
+	}
+	sort.Slice(advisories, func(i, j int) bool { return advisories[i].ID < advisories[j].ID })
+
+	for _, advisory := range advisories {
+		pkgs := advisoryPackages(advisory, affected, byName)
+		if len(pkgs) == 0 {
+			continue
+		}
+
+		registerAdvisoryRule(run, advisory)
+		for _, pkg := range pkgs {
+			covered[vulnPackageKey(pkg)] = true
+			run.AddResult(vulnResult(advisory.ID, advisory, pkg, ctx))
+		}
+	}
+
+	// Affected packages that no advisory in this report accounts for.
+	var remaining []string
+	for key := range affected {
+		if !covered[key] {
+			remaining = append(remaining, key)
+		}
+	}
+	if len(remaining) == 0 {
+		return
+	}
+	sort.Strings(remaining)
+
+	run.AddRule(sarifVulnPackageRuleID).
+		WithName("Vulnerable package").
+		WithDescription("An installed package has known vulnerabilities").
+		WithFullDescription(sarif.NewMultiformatMessageString(
+			"An installed package is affected by known vulnerabilities. Update it to a fixed version.")).
+		WithProperties(sarif.Properties{"tags": []string{"security", "cnspec", "vulnerability"}})
+
+	for _, key := range remaining {
+		run.AddResult(vulnResult(sarifVulnPackageRuleID, nil, affected[key], ctx))
+	}
+}
+
+// advisoryPackages returns the packages of an advisory that the asset is actually
+// affected by, in deterministic order.
+func advisoryPackages(advisory *mvd.Advisory, affected, byName map[string]*mvd.Package) []*mvd.Package {
+	var res []*mvd.Package
+	seen := map[string]bool{}
+	for _, pkg := range advisory.Affected {
+		if pkg == nil {
+			continue
+		}
+		match, ok := affected[vulnPackageKey(pkg)]
+		if !ok {
+			// the advisory may carry a different version than the installed one
+			match, ok = byName[pkg.Name]
+			if !ok {
+				continue
+			}
+		}
+		key := vulnPackageKey(match)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		res = append(res, match)
+	}
+	sort.Slice(res, func(i, j int) bool { return vulnPackageKey(res[i]) < vulnPackageKey(res[j]) })
+	return res
+}
+
+// registerAdvisoryRule registers an advisory (e.g. USN-5825-1) as a SARIF rule,
+// carrying its description, CVEs and references.
+func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
+	title := advisory.Title
+	if title == "" {
+		title = advisory.ID
+	}
+
+	rb := run.AddRule(advisory.ID).WithName(title).WithDescription(title)
+	if desc := strings.TrimSpace(advisory.Description); desc != "" {
+		rb.WithFullDescription(sarif.NewMultiformatMessageString(desc).WithMarkdown(desc))
+	}
+
+	var text, md strings.Builder
+	if desc := strings.TrimSpace(advisory.Description); desc != "" {
+		text.WriteString(desc + "\n")
+		md.WriteString(desc + "\n")
+	}
+
+	severity := riskSeverityLabel(advisory.Score) + " (score " + securitySeverity(advisory.Score) + ")"
+	writeDetailSection(&text, "Severity", severity)
+	writeMarkdownSection(&md, "Severity", severity)
+
+	cves := advisoryCves(advisory)
+	if len(cves) > 0 {
+		var textLines, mdLines []string
+		for _, cve := range cves {
+			line := cve.ID
+			if cve.Score > 0 {
+				line += " (CVSS " + strconv.FormatFloat(float64(cve.Score), 'f', 1, 32) + ")"
+			}
+			textLines = append(textLines, strings.TrimSpace(line+" "+cve.Url))
+			if cve.Url != "" {
+				line = "[" + line + "](" + cve.Url + ")"
+			}
+			mdLines = append(mdLines, line)
+		}
+		writeDetailSection(&text, "CVEs", strings.Join(textLines, "\n"))
+		writeMarkdownSection(&md, "CVEs", markdownList(mdLines))
+	}
+
+	var refLines, refMdLines []string
+	for _, ref := range advisory.Refs {
+		if ref == nil || ref.Url == "" {
+			continue
+		}
+		refTitle := ref.Title
+		if refTitle == "" {
+			refTitle = ref.Url
+		}
+		refLines = append(refLines, refTitle+": "+ref.Url)
+		refMdLines = append(refMdLines, "["+refTitle+"]("+ref.Url+")")
+	}
+	writeDetailSection(&text, "References", strings.Join(refLines, "\n"))
+	writeMarkdownSection(&md, "References", markdownList(refMdLines))
+
+	if help := strings.TrimSpace(text.String()); help != "" {
+		rb.WithHelp(sarif.NewMultiformatMessageString(help).WithMarkdown(strings.TrimSpace(md.String())))
+	}
+	if len(advisory.Refs) > 0 && advisory.Refs[0] != nil && advisory.Refs[0].Url != "" {
+		rb.WithHelpURI(advisory.Refs[0].Url)
+	} else if len(cves) > 0 && cves[0].Url != "" {
+		rb.WithHelpURI(cves[0].Url)
+	}
+
+	props := sarif.Properties{
+		"tags":              []string{"security", "cnspec", "vulnerability", "advisory"},
+		"security-severity": securitySeverity(advisory.Score),
+		"severity":          riskSeverityLabel(advisory.Score),
+		"advisory":          advisory.ID,
+	}
+	if len(cves) > 0 {
+		ids := make([]string, 0, len(cves))
+		for _, cve := range cves {
+			ids = append(ids, cve.ID)
+		}
+		props["cves"] = ids
+	}
+	if advisory.Published != "" {
+		props["published"] = advisory.Published
+	}
+	if advisory.Modified != "" {
+		props["modified"] = advisory.Modified
+	}
+	rb.WithProperties(props)
+	rb.WithDefaultConfiguration(sarif.NewReportingConfiguration().WithLevel(riskSarifLevel(advisory.Score)))
+}
+
+// advisoryCves returns the CVEs of an advisory in deterministic order.
+func advisoryCves(advisory *mvd.Advisory) []*mvd.CVE {
+	res := make([]*mvd.CVE, 0, len(advisory.Cves))
+	for _, cve := range advisory.Cves {
+		if cve != nil && cve.ID != "" {
+			res = append(res, cve)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
+	return res
+}
+
+// vulnResult builds the finding for one affected package. When advisory is set the
+// finding is attributed to it, otherwise it reports the package on its own.
+func vulnResult(ruleID string, advisory *mvd.Advisory, pkg *mvd.Package, ctx *sarifRunContext) *sarif.Result {
+	score := pkg.Score
+	if advisory != nil && advisory.Score > 0 {
+		score = advisory.Score
+	}
+
+	update := "No fixed version is available yet."
+	if pkg.Available != "" {
+		update = "Update to " + pkg.Available + "."
+	}
+
+	text := pkg.Name + " " + pkg.Version + " has known vulnerabilities"
+	markdown := "**" + pkg.Name + "** " + pkg.Version + " has known vulnerabilities"
+	if advisory != nil {
+		title := advisory.Title
+		if title == "" {
+			title = advisory.ID
+		}
+		text = pkg.Name + " " + pkg.Version + " is affected by " + advisory.ID + " (" + title + ")"
+		markdown = "**" + pkg.Name + "** " + pkg.Version + " is affected by **" + advisory.ID + "** — " + title
+	}
+	text += " · " + riskSeverityLabel(score) + " (score " + securitySeverity(score) + ") · " + update
+	markdown += "\n\n" + scoreIcon(score) + " **" + riskSeverityLabel(score) + "**" +
+		" · score " + securitySeverity(score) + " · " + update
+
+	logicalLocs := []*sarif.LogicalLocation{
+		ctx.logicalLoc,
+		sarif.NewLogicalLocation().WithName(pkg.Name).WithKind("package").
+			WithFullyQualifiedName(pkg.Name + "@" + pkg.Version),
+	}
+
+	props := sarif.Properties{
+		"asset":             ctx.asset.Name,
+		"package":           pkg.Name,
+		"installedVersion":  pkg.Version,
+		"severity":          riskSeverityLabel(score),
+		"security-severity": securitySeverity(score),
+		"status":            "fail",
+	}
+	if ctx.assetMrn != "" {
+		props["assetMrn"] = ctx.assetMrn
+	}
+	if pkg.Available != "" {
+		props["fixedVersion"] = pkg.Available
+	}
+	if pkg.Arch != "" {
+		props["arch"] = pkg.Arch
+	}
+	if pkg.Format != "" {
+		props["format"] = pkg.Format
+	}
+	if pkg.Namespace != "" {
+		props["namespace"] = pkg.Namespace
+	}
+	if advisory != nil {
+		props["advisory"] = advisory.ID
+	}
+
+	result := sarif.NewRuleResult(ruleID).
+		WithLevel(riskSarifLevel(score)).
+		WithKind("fail").
+		WithMessage(sarif.NewTextMessage(text).WithMarkdown(markdown)).
+		WithLocations([]*sarif.Location{
+			sarif.NewLocation().WithLogicalLocations(logicalLocs),
+		}).
+		WithPartialFingerPrints(map[string]interface{}{
+			sarifFingerprintKey: sarifFingerprint(ruleID, ctx.assetMrn, vulnPackageKey(pkg)),
+		}).
+		WithRank(float32(score))
+	result.Properties = props
+	return result
+}
+
+func vulnPackageKey(pkg *mvd.Package) string {
+	return pkg.Name + "@" + pkg.Version
 }
 
 // assetLogicalLocation builds the SARIF logical location that identifies an asset.
@@ -273,8 +882,22 @@ func physicalLocationFromContext(ctx llx.SourceContext) *sarif.PhysicalLocation 
 // sarifLocationFingerprint produces a stable fingerprint for a (rule, location)
 // pair so code-scanning consumers can dedup the same finding across runs.
 func sarifLocationFingerprint(ruleID string, ctx llx.SourceContext) string {
-	h := sha256.Sum256([]byte(ruleID + "\n" + ctx.Path + "#" + ctx.Range.String()))
+	return sarifFingerprint(ruleID, ctx.Path+"#"+ctx.Range.String())
+}
+
+// sarifFingerprint hashes the parts that identify a finding into a stable
+// fingerprint. Callers must pass the parts in a fixed order.
+func sarifFingerprint(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(h[:])
+}
+
+// scoreRisk is the inverse of a score value: 0 (no risk) to 100 (critical).
+func scoreRisk(score *policy.Score) int32 {
+	if score == nil {
+		return 0
+	}
+	return 100 - int32(score.Value)
 }
 
 // scoreToSarifLevel maps a cnspec Score to a SARIF level using cnspec's
@@ -300,16 +923,83 @@ func scoreToSarifLevel(score *policy.Score) string {
 		if score.Value == 100 {
 			return "none" // pass
 		}
-		if score.Value >= 61 {
-			return "note" // Low severity
-		}
-		if score.Value >= 31 {
-			return "warning" // Medium severity
-		}
-		return "error" // High/Critical severity
+		return riskSarifLevel(scoreRisk(score))
 	default:
 		return "none"
 	}
+}
+
+// scoreToSarifKind maps a cnspec Score to a SARIF result kind. The kind tells
+// consumers what the result means; the level only says how loud it is. SARIF
+// requires the level to be "none" for every kind other than "fail", which
+// scoreToSarifLevel guarantees.
+func scoreToSarifKind(score *policy.Score) string {
+	if score == nil {
+		return "review"
+	}
+
+	switch score.Type {
+	case policy.ScoreType_Error:
+		return "fail"
+	case policy.ScoreType_Skip, policy.ScoreType_OutOfScope, policy.ScoreType_Disabled:
+		return "notApplicable"
+	case policy.ScoreType_Unscored:
+		return "informational"
+	case policy.ScoreType_Unknown:
+		return "review"
+	case policy.ScoreType_Result:
+		if score.Value == 100 {
+			return "pass"
+		}
+		return "fail"
+	default:
+		return "review"
+	}
+}
+
+// scoreStatusLabel is the human-readable outcome of a check.
+func scoreStatusLabel(score *policy.Score) string {
+	switch scoreToSarifKind(score) {
+	case "pass":
+		return "PASS"
+	case "fail":
+		if score != nil && score.Type == policy.ScoreType_Error {
+			return "ERROR"
+		}
+		return "FAIL"
+	case "notApplicable":
+		return "SKIPPED"
+	case "informational":
+		return "UNSCORED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func scoreStatusIcon(score *policy.Score) string {
+	switch scoreToSarifKind(score) {
+	case "pass":
+		return "✅"
+	case "fail":
+		if score != nil && score.Type == policy.ScoreType_Error {
+			return "⚠️"
+		}
+		return "❌"
+	case "notApplicable":
+		return "⏭️"
+	default:
+		return "ℹ️"
+	}
+}
+
+func scoreIcon(risk int32) string {
+	if risk >= 70 {
+		return "❌"
+	}
+	if risk >= 40 {
+		return "⚠️"
+	}
+	return "ℹ️"
 }
 
 // queryRuleID returns a stable, human-readable rule ID for a query.
@@ -329,15 +1019,71 @@ func queryRuleID(query *policy.Mquery) string {
 	return query.CodeId
 }
 
-// queryDescription extracts a description from a query
-func queryDescription(query *policy.Mquery) string {
-	if query.Docs != nil && query.Docs.Desc != "" {
-		return query.Docs.Desc
+// writeMarkdownSection appends a "**Title**\n\nbody" section to b.
+func writeMarkdownSection(b *strings.Builder, title, body string) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return
 	}
-	if query.Desc != "" {
-		return query.Desc
+	if b.Len() > 0 {
+		b.WriteString("\n")
 	}
-	return ""
+	b.WriteString("**" + title + "**\n\n")
+	b.WriteString(body)
+	b.WriteString("\n")
+}
+
+func markdownList(items []string) string {
+	var b strings.Builder
+	for _, item := range items {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString("- " + item)
+	}
+	return b.String()
+}
+
+// markdownCode wraps content in a fenced block, growing the fence if the content
+// itself contains one.
+func markdownCode(content string) string {
+	fence := "```"
+	for strings.Contains(content, fence) {
+		fence += "`"
+	}
+	return fence + "\n" + strings.TrimSpace(content) + "\n" + fence
+}
+
+// markdownRemediation renders the platform-relevant remediation of a check, with
+// each variant introduced by its platform/tool id.
+func markdownRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
+	var b strings.Builder
+	for _, item := range remediationItems(query, platformKeys) {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		if item.Id != "" && item.Id != "default" {
+			b.WriteString("_" + item.Id + "_\n\n")
+		}
+		b.WriteString(strings.TrimSpace(item.Desc))
+	}
+	return b.String()
+}
+
+func markdownReferences(query *policy.Mquery) string {
+	var items []string
+	for _, ref := range queryRefs(query) {
+		title := ref.Title
+		if title == "" {
+			title = ref.Url
+		}
+		items = append(items, "["+title+"]("+ref.Url+")")
+	}
+	return markdownList(items)
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 func writeSarif(report *sarif.Report, out iox.OutputHelper) error {

--- a/cli/reporter/sarif.go
+++ b/cli/reporter/sarif.go
@@ -311,11 +311,8 @@ func checkRuleTags(query *policy.Mquery, ctx *sarifRunContext) []string {
 	for _, title := range ctx.policyTitles[query.Mrn] {
 		tags = append(tags, "policy/"+title)
 	}
-	compliance := queryComplianceTags(query)
-	for _, framework := range sortedKeys(compliance) {
-		tags = append(tags, framework)
-	}
-	return tags
+	// the compliance tag keys are already namespaced, e.g. "compliance/iso-27001-2022"
+	return append(tags, sortedKeys(queryComplianceTags(query))...)
 }
 
 // checkHelp renders the static documentation of a check as plain text and as

--- a/cli/reporter/sarif_test.go
+++ b/cli/reporter/sarif_test.go
@@ -6,15 +6,65 @@ package reporter
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/cli/printer"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/mql/v13/utils/iox"
+	"go.mondoo.com/mql/v13/utils/stringx"
 )
+
+// toSarif runs the converter and parses the result back into the SARIF types.
+func toSarif(t *testing.T, r *policy.ReportCollection) *sarif.Report {
+	t.Helper()
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	require.NoError(t, ConvertToSarif(r, &writer))
+
+	report, err := sarif.FromBytes(buf.Bytes())
+	require.NoError(t, err)
+	return report
+}
+
+func findRule(run *sarif.Run, id string) *sarif.ReportingDescriptor {
+	for _, rule := range run.Tool.Driver.Rules {
+		if rule.ID == id {
+			return rule
+		}
+	}
+	return nil
+}
+
+func resultsForRule(run *sarif.Run, id string) []*sarif.Result {
+	var res []*sarif.Result
+	for _, result := range run.Results {
+		if result.RuleID != nil && *result.RuleID == id {
+			res = append(res, result)
+		}
+	}
+	return res
+}
+
+// indented renders a help section body the way writeDetailSection does, so tests
+// can look for it verbatim inside the rendered help.
+func indented(body string) string {
+	return strings.TrimRight(stringx.Indent(2, body), "\n")
+}
+
+func ruleHelpText(rule *sarif.ReportingDescriptor) string {
+	if rule == nil || rule.Help == nil || rule.Help.Text == nil {
+		return ""
+	}
+	return *rule.Help.Text
+}
 
 func TestSarifConverter(t *testing.T) {
 	yr := sampleReportCollection()
@@ -92,6 +142,31 @@ func TestSarifDeterministicOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, buf1.String(), buf2.String())
+}
+
+// TestSarifDeterministicRuleIDs guards the deterministic query lookup: the ubuntu
+// fixture has several checks that share a code id, and picking an arbitrary one
+// would make rule ids (and with them the fingerprints consumers dedup on) flip
+// between runs of the same report.
+func TestSarifDeterministicRuleIDs(t *testing.T) {
+	raw, err := os.ReadFile("./testdata/report-ubuntu.json")
+	require.NoError(t, err)
+
+	var first string
+	for i := 0; i < 5; i++ {
+		yr := &policy.ReportCollection{}
+		require.NoError(t, json.Unmarshal(raw, yr))
+
+		buf := bytes.Buffer{}
+		writer := iox.IOWriter{Writer: &buf}
+		require.NoError(t, ConvertToSarif(yr, &writer))
+
+		if i == 0 {
+			first = buf.String()
+			continue
+		}
+		assert.Equal(t, first, buf.String())
+	}
 }
 
 func TestSarifNilReport(t *testing.T) {
@@ -287,6 +362,334 @@ func TestSarifLocationFingerprint(t *testing.T) {
 	other := llx.SourceContext{Path: "other.tf", Range: ctx.Range}
 	assert.NotEqual(t, sarifLocationFingerprint("rule-a", ctx), sarifLocationFingerprint("rule-b", ctx))
 	assert.NotEqual(t, sarifLocationFingerprint("rule-a", ctx), sarifLocationFingerprint("rule-a", other))
+}
+
+func TestSarifRunMetadata(t *testing.T) {
+	report := toSarif(t, sampleReportCollection())
+	require.Len(t, report.Runs, 1)
+	run := report.Runs[0]
+
+	require.NotNil(t, run.Tool.Driver.Version)
+	assert.NotEmpty(t, *run.Tool.Driver.Version)
+	require.NotNil(t, run.Tool.Driver.Organization)
+	assert.Equal(t, "Mondoo", *run.Tool.Driver.Organization)
+	assert.Equal(t, "utf16CodeUnits", run.ColumnKind)
+
+	require.NotNil(t, run.AutomationDetails)
+	require.NotNil(t, run.AutomationDetails.ID)
+	assert.Equal(t, "cnspec/X1", *run.AutomationDetails.ID)
+
+	// the run carries the asset identity and a summary of its results
+	assert.Equal(t, "X1", run.Properties["asset"])
+	assert.Equal(t, "ubuntu", run.Properties["platform"])
+	assert.Equal(t, "22.04", run.Properties["platformVersion"])
+	assert.EqualValues(t, 3, run.Properties["checksTotal"])
+	assert.EqualValues(t, 1, run.Properties["checksPassed"])
+	assert.EqualValues(t, 1, run.Properties["checksErrored"])
+	assert.EqualValues(t, 1, run.Properties["checksSkipped"])
+
+	// vulnerability stats mirror the JUnit vulnerability suite properties
+	assert.EqualValues(t, 1, run.Properties["packagesTotal"])
+	assert.EqualValues(t, 1, run.Properties["packagesCritical"])
+	assert.EqualValues(t, 1, run.Properties["packagesAffected"])
+}
+
+func TestSarifResultKinds(t *testing.T) {
+	report := toSarif(t, sampleReportCollection())
+	run := report.Runs[0]
+
+	kinds := map[string]string{}
+	levels := map[string]string{}
+	for _, result := range run.Results {
+		if result.Kind == nil || result.RuleID == nil {
+			continue
+		}
+		kinds[*result.RuleID] = *result.Kind
+		levels[*result.RuleID] = *result.Level
+	}
+
+	// passed check
+	assert.Equal(t, "pass", kinds["mondoo-linux-security-snmp-server-is-not-enabled"])
+	assert.Equal(t, "none", levels["mondoo-linux-security-snmp-server-is-not-enabled"])
+	// errored check
+	assert.Equal(t, "fail", kinds["mondoo-kubernetes-security-kubelet-event-record-qps"])
+	assert.Equal(t, "error", levels["mondoo-kubernetes-security-kubelet-event-record-qps"])
+	// skipped check
+	assert.Equal(t, "notApplicable", kinds["mondoo-kubernetes-security-secure-scheduler_conf"])
+	assert.Equal(t, "none", levels["mondoo-kubernetes-security-secure-scheduler_conf"])
+}
+
+func TestSarifDetailedRuleContent(t *testing.T) {
+	report := toSarif(t, detailedReportCollection())
+	require.Len(t, report.Runs, 1)
+	run := report.Runs[0]
+
+	rule := findRule(run, "test-check")
+	require.NotNil(t, rule)
+
+	require.NotNil(t, rule.Name)
+	assert.Equal(t, "Ensure the thing is configured", *rule.Name)
+	require.NotNil(t, rule.FullDescription)
+	require.NotNil(t, rule.FullDescription.Text)
+	assert.Equal(t, "Root login over SSH should be disabled.", *rule.FullDescription.Text)
+
+	// the help carries query, remediation and references, as text and markdown
+	require.NotNil(t, rule.Help)
+	require.NotNil(t, rule.Help.Markdown)
+	help := ruleHelpText(rule)
+	assert.Contains(t, help, "Query:")
+	assert.Contains(t, help, "sshd.config.params['PermitRootLogin']")
+	assert.Contains(t, help, "Remediation:")
+	assert.Contains(t, help, "References:")
+	assert.Contains(t, help, "CIS Benchmark: https://example.com/cis")
+
+	markdown := *rule.Help.Markdown
+	assert.Contains(t, markdown, "**Query**")
+	assert.Contains(t, markdown, "```")
+	assert.Contains(t, markdown, "**Remediation**")
+	assert.Contains(t, markdown, "[CIS Benchmark](https://example.com/cis)")
+
+	// remediation is filtered to the asset platform, like the JUnit reporter does
+	assert.Contains(t, help, "Set PermitRootLogin to no in your TF config.")
+	assert.NotContains(t, help, "Use the AWS console to fix it.")
+	assert.NotContains(t, markdown, "Use CloudFormation to fix it.")
+
+	require.NotNil(t, rule.HelpURI)
+	assert.Equal(t, "https://example.com/cis", *rule.HelpURI)
+
+	// severity and tags drive rendering and filtering in SARIF consumers
+	assert.Contains(t, rule.Properties["tags"], "security")
+	assert.Contains(t, rule.Properties["remediation"], "[terraform]")
+	assert.Equal(t, "sshd.config.params['PermitRootLogin'] == \"no\"", rule.Properties["mql"])
+
+	// the finding itself reports the outcome
+	results := resultsForRule(run, "test-check")
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Message.Text)
+	assert.Contains(t, *results[0].Message.Text, "Ensure the thing is configured: FAIL")
+	require.NotNil(t, results[0].Message.Markdown)
+	assert.Contains(t, *results[0].Message.Markdown, "**FAIL**")
+	assert.Equal(t, "fail", results[0].Properties["status"])
+	assert.EqualValues(t, 100, results[0].Properties["risk"])
+	assert.Equal(t, "CRITICAL", results[0].Properties["severity"])
+	require.NotNil(t, results[0].Rank)
+	assert.EqualValues(t, 100, *results[0].Rank)
+}
+
+func TestSarifRuleSeverity(t *testing.T) {
+	yr := detailedReportCollection()
+	yr.Bundle.Queries[0].Impact = &policy.Impact{Value: &policy.ImpactValue{Value: 80}}
+
+	run := toSarif(t, yr).Runs[0]
+	rule := findRule(run, "test-check")
+	require.NotNil(t, rule)
+
+	assert.EqualValues(t, 80, rule.Properties["impact"])
+	assert.Equal(t, "HIGH", rule.Properties["severity"])
+	// GitHub code scanning reads the alert severity from this property
+	assert.Equal(t, "8.0", rule.Properties["security-severity"])
+	require.NotNil(t, rule.DefaultConfiguration)
+	assert.Equal(t, "error", rule.DefaultConfiguration.Level)
+	assert.Contains(t, ruleHelpText(rule), "HIGH (impact 80)")
+}
+
+func TestSarifComplianceTags(t *testing.T) {
+	yr := detailedReportCollection()
+	yr.Bundle.Queries[0].Tags = map[string]string{
+		"compliance/iso-27001-2022": "iso-27001-2022-a-8-24",
+		"compliance/bsi-sys-1-5":    "false", // explicitly turned off, must be dropped
+		"mondoo.com/platform":       "aws,cloud",
+	}
+
+	run := toSarif(t, yr).Runs[0]
+	rule := findRule(run, "test-check")
+	require.NotNil(t, rule)
+
+	compliance, ok := rule.Properties["compliance"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "iso-27001-2022-a-8-24", compliance["compliance/iso-27001-2022"])
+	assert.NotContains(t, compliance, "compliance/bsi-sys-1-5")
+	assert.NotContains(t, compliance, "mondoo.com/platform")
+
+	assert.Contains(t, rule.Properties["tags"], "compliance/iso-27001-2022")
+	assert.Contains(t, ruleHelpText(rule), "iso-27001-2022: iso-27001-2022-a-8-24")
+}
+
+func TestSarifVulnerabilities(t *testing.T) {
+	yr := detailedReportCollection()
+	assetMrn := "//assets.api.mondoo.app/spaces/test/assets/abc"
+	yr.VulnReports = map[string]*mvd.VulnReport{
+		assetMrn: {
+			Packages: []*mvd.Package{
+				{Name: "libssl3", Version: "3.0.2-0ubuntu1.10", Available: "3.0.2-0ubuntu1.15", Affected: true, Score: 95, Arch: "amd64", Format: "deb"},
+				{Name: "curl", Version: "7.81.0-1ubuntu1.4", Available: "7.81.0-1ubuntu1.15", Affected: true, Score: 50},
+				{Name: "bash", Version: "5.1-6ubuntu1", Affected: false},
+			},
+			Advisories: []*mvd.Advisory{
+				{
+					ID:          "USN-1234-1",
+					Title:       "OpenSSL vulnerabilities",
+					Description: "Several security issues were fixed in OpenSSL.",
+					Score:       95,
+					Affected:    []*mvd.Package{{Name: "libssl3", Version: "3.0.2-0ubuntu1.10"}},
+					Cves:        []*mvd.CVE{{ID: "CVE-2023-0286", Score: 7.4, Url: "https://nvd.nist.gov/vuln/detail/CVE-2023-0286"}},
+				},
+			},
+		},
+	}
+
+	run := toSarif(t, yr).Runs[0]
+
+	// the advisory becomes its own rule, with CVEs and severity
+	advisoryRule := findRule(run, "USN-1234-1")
+	require.NotNil(t, advisoryRule)
+	assert.Equal(t, "9.5", advisoryRule.Properties["security-severity"])
+	assert.Equal(t, "CRITICAL", advisoryRule.Properties["severity"])
+	assert.Contains(t, advisoryRule.Properties["tags"], "vulnerability")
+	assert.Contains(t, ruleHelpText(advisoryRule), "CVE-2023-0286")
+	require.NotNil(t, advisoryRule.HelpURI)
+	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2023-0286", *advisoryRule.HelpURI)
+
+	advisoryResults := resultsForRule(run, "USN-1234-1")
+	require.Len(t, advisoryResults, 1)
+	assert.Contains(t, *advisoryResults[0].Message.Text, "libssl3 3.0.2-0ubuntu1.10 is affected by USN-1234-1")
+	assert.Contains(t, *advisoryResults[0].Message.Text, "Update to 3.0.2-0ubuntu1.15.")
+	assert.Equal(t, "libssl3", advisoryResults[0].Properties["package"])
+	assert.Equal(t, "3.0.2-0ubuntu1.15", advisoryResults[0].Properties["fixedVersion"])
+	// the package shows up as a logical location next to the asset
+	require.Len(t, advisoryResults[0].Locations, 1)
+	require.Len(t, advisoryResults[0].Locations[0].LogicalLocations, 2)
+	assert.Equal(t, "package", *advisoryResults[0].Locations[0].LogicalLocations[1].Kind)
+
+	// affected packages no advisory accounts for fall back to a generic rule
+	pkgResults := resultsForRule(run, sarifVulnPackageRuleID)
+	require.Len(t, pkgResults, 1)
+	assert.Contains(t, *pkgResults[0].Message.Text, "curl 7.81.0-1ubuntu1.4 has known vulnerabilities")
+	assert.Equal(t, "MEDIUM", pkgResults[0].Properties["severity"])
+
+	// packages that are not affected produce no findings
+	assert.NotContains(t, resultMessages(run), "bash")
+}
+
+func resultMessages(run *sarif.Run) string {
+	var b strings.Builder
+	for _, result := range run.Results {
+		if result.Message.Text != nil {
+			b.WriteString(*result.Message.Text)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// TestSarifMatchesDetailedJunitContent verifies the promise of the SARIF reporter:
+// everything the detailed JUnit failure body renders for a check is present in the
+// SARIF report too - the static documentation on the rule, the dynamic outcome on
+// the result.
+func TestSarifMatchesDetailedJunitContent(t *testing.T) {
+	raw, err := os.ReadFile("./testdata/report-ubuntu.json")
+	require.NoError(t, err)
+	yr := &policy.ReportCollection{}
+	require.NoError(t, json.Unmarshal(raw, yr))
+
+	report := toSarif(t, yr)
+	runs := map[string]*sarif.Run{}
+	for _, run := range report.Runs {
+		runs[run.Properties["asset"].(string)] = run
+	}
+
+	bundle := yr.Bundle.ToMap()
+	queries := reporterQueryMap(bundle)
+
+	checked := 0
+	for assetMrn, asset := range yr.Assets {
+		run := runs[asset.Name]
+		require.NotNil(t, run)
+
+		policyReport := yr.Reports[assetMrn]
+		resolved := yr.ResolvedPolicies[assetMrn]
+		require.NotNil(t, policyReport)
+		require.NotNil(t, resolved)
+		platformKeys := platformRemediationKeys(asset.Platform)
+
+		for id, score := range policyReport.Scores {
+			if _, ok := resolved.CollectorJob.ReportingQueries[id]; !ok {
+				continue
+			}
+			query, ok := queries[id]
+			if !ok {
+				continue
+			}
+			// the JUnit body is only rendered for failed and errored checks
+			if score == nil || (score.Type != policy.ScoreType_Error && !(score.Type == policy.ScoreType_Result && score.Value != 100)) {
+				continue
+			}
+			if detailedCheckBody(resolved, policyReport, query, score, platformKeys) == "" {
+				continue
+			}
+			checked++
+
+			ruleID := queryRuleID(query)
+			rule := findRule(run, ruleID)
+			require.NotNil(t, rule, "no SARIF rule for %s", ruleID)
+			results := resultsForRule(run, ruleID)
+			require.NotEmpty(t, results, "no SARIF result for %s", ruleID)
+
+			var messages strings.Builder
+			for _, result := range results {
+				if result.Message.Text != nil {
+					messages.WriteString(*result.Message.Text)
+				}
+			}
+
+			help := ruleHelpText(rule)
+			if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+				require.NotNil(t, rule.FullDescription)
+				assert.Equal(t, desc, *rule.FullDescription.Text, "description missing for %s", ruleID)
+				assert.Contains(t, help, desc, "description missing from help of %s", ruleID)
+			}
+			// help sections are indented by two spaces, exactly like the JUnit body
+			if mql := strings.TrimSpace(queryMql(query)); mql != "" {
+				assert.Contains(t, help, indented(mql), "query missing from help of %s", ruleID)
+				assert.Equal(t, mql, rule.Properties["mql"])
+			}
+			if rem := queryRemediation(query, platformKeys); rem != "" {
+				assert.Contains(t, help, indented(rem), "remediation missing from help of %s", ruleID)
+				assert.Equal(t, rem, rule.Properties["remediation"])
+			}
+			if refs := queryReferences(query); refs != "" {
+				assert.Contains(t, help, indented(refs), "references missing from help of %s", ruleID)
+			}
+			if msg := score.MessageLine(); msg != "" {
+				assert.Contains(t, messages.String(), msg, "score message missing from results of %s", ruleID)
+			}
+			// checks that fail on several source locations get one result per
+			// location and carry the offending snippet there instead of repeating
+			// the whole assessment on each of them
+			if assessment := checkAssessmentText(resolved, policyReport, query); assessment != "" && len(results) == 1 {
+				assert.Contains(t, messages.String(), assessment, "assessment missing from results of %s", ruleID)
+			}
+		}
+	}
+
+	assert.Greater(t, checked, 0, "fixture has no failing checks to compare")
+}
+
+// checkAssessmentText renders the expected-vs-actual assessment the way both
+// reporters do, for use in the content parity test.
+func checkAssessmentText(resolved *policy.ResolvedPolicy, report *policy.Report, query *policy.Mquery) string {
+	if resolved == nil || resolved.ExecutionJob == nil {
+		return ""
+	}
+	cb := resolved.GetCodeBundle(query)
+	if cb == nil {
+		return ""
+	}
+	assessment := policy.Query2Assessment(cb, report)
+	if assessment == nil {
+		return ""
+	}
+	return strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(cb, assessment))
 }
 
 func TestSarifScoreLevels(t *testing.T) {

--- a/cli/reporter/sarif_test.go
+++ b/cli/reporter/sarif_test.go
@@ -621,7 +621,9 @@ func TestSarifMatchesDetailedJunitContent(t *testing.T) {
 				continue
 			}
 			// the JUnit body is only rendered for failed and errored checks
-			if score == nil || (score.Type != policy.ScoreType_Error && !(score.Type == policy.ScoreType_Result && score.Value != 100)) {
+			failed := score != nil && (score.Type == policy.ScoreType_Error ||
+				(score.Type == policy.ScoreType_Result && score.Value != 100))
+			if !failed {
 				continue
 			}
 			if detailedCheckBody(resolved, policyReport, query, score, platformKeys) == "" {


### PR DESCRIPTION
The SARIF reporter emitted a rule title, a short description and a one-line message per finding. `--output junit,detailed` carried the full check documentation, so SARIF consumers (GitHub code scanning, GitLab, the VS Code SARIF viewer, DefectDojo) had far less to render than JUnit did.

SARIF now carries the same content, placed where the spec and its consumers expect it rather than in one message blob.

## Content mapping

| JUnit detailed | SARIF |
| --- | --- |
| description | `rule.fullDescription` + `rule.help` |
| query (MQL) | `rule.help` (fenced code block in markdown), `rule.properties.mql` |
| result / assessment | `result.message` (text + markdown) |
| failing resources | `result.locations` physical location + snippet |
| error | `result.message` status line |
| remediation (platform-filtered) | `rule.help`, `rule.properties.remediation` |
| references | `rule.help`, `rule.helpUri` |
| vulnerability test suite | advisory rules + per-package results, stats in `run.properties` |

## Beyond parity

- `result.kind` (`pass` / `fail` / `notApplicable` / `informational` / `review`), so passing and skipped checks are no longer indistinguishable from findings.
- `security-severity` and `tags` on rules — GitHub code scanning reads the alert severity from `security-severity`, and the `security` tag is what makes it file the rule as a security alert. The cnspec risk bands line up exactly with GitHub's (CRITICAL ≥ 9.0, HIGH ≥ 7.0, MEDIUM ≥ 4.0).
- `defaultConfiguration.level` derived from the check impact, and `rank` from the risk, so viewers sort the dangerous findings first.
- Audit steps, compliance framework mappings and owning policies in the help and properties.
- `partialFingerprints` on every result, not just the located ones.
- Run-level metadata: tool version, asset MRN and platform, overall grade, check counts, package/advisory counts.

## Vulnerabilities

Vulnerabilities from the scan report are emitted alongside the policy findings, mirroring the JUnit vulnerability suite: one rule per advisory (description, CVEs with CVSS links, references, severity) with one result per affected package, plus a `vulnerable-package` fallback rule for affected packages that no advisory in the report accounts for. The affected package shows up as a logical location next to the asset.

## Two fixes along the way

- **Rule IDs were nondeterministic.** Several checks share a code id (variants that compile to the same MQL — 26 of them in the ubuntu test fixture) and `policy.PolicyBundleMap.QueryMap` picks an arbitrary one, because it iterates a map. That made SARIF rule ids — and the fingerprints consumers dedup on — flip between runs of the same report. Both reporters now resolve queries through a deterministic map. This also stabilizes JUnit test names for those checks, which were previously random.
- **Quadratic growth.** A check failing on N source locations would have repeated the full aggregate assessment in all N messages. Those results keep their own region snippet instead.

The shared check documentation helpers moved out of `junit.go` into `query_docs.go` so both reporters render the same content from one place; that accounts for most of the churn in the JUnit diff.

## Verification

- Output validates against the official SARIF 2.1.0 JSON schema — on the test fixtures (including a grafted vulnerability report exercising both the advisory and fallback paths), on the asset-error path, and on a real `cnspec scan terraform --output sarif` run, which produced correct physical locations with line/column ranges and code snippets.
- New `TestSarifMatchesDetailedJunitContent` asserts the parity claim directly: for every failing check in the fixture, each piece the JUnit detailed body renders must be present in the SARIF rule or result.
- New tests cover result kinds, run metadata, rule severity, compliance tags, vulnerability findings, and deterministic rule ids across repeated conversions.
- `go test ./cli/...` passes, `golangci-lint run ./cli/reporter/...` is clean.

## Example

A failing Terraform check, as it now appears:

```json
{
  "ruleId": "mondoo-aws-security-s3-bucket-versioning-enabled-terraform-hcl",
  "kind": "fail",
  "level": "error",
  "rank": 100,
  "message": {
    "text": "Ensure S3 bucket versioning is enabled: FAIL · CRITICAL · score 0/100\n\n[failed] terraform.resources.all() ...",
    "markdown": "**Ensure S3 bucket versioning is enabled**\n\n❌ **FAIL** · CRITICAL · score 0/100\n\n```\n[failed] ...\n```"
  },
  "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "tf/main.tf" },
    "region": { "startLine": 1, "startColumn": 1, "endLine": 3, "snippet": { "text": "resource \"aws_s3_bucket\" \"b\" {" } } } }],
  "properties": { "severity": "CRITICAL", "score": 0, "risk": 100, "status": "fail", "asset": "Terraform HCL directory tf" }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
