### PR TITLE
⚡ perf(scan): snapshot assets before report aggregation

### DIFF
--- a/policy/scan/reporter_aggregate.go
+++ b/policy/scan/reporter_aggregate.go
@@ -4,6 +4,8 @@
 package scan
 
 import (
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 
@@ -53,7 +55,7 @@ func (r *AggregateReporter) AddReport(asset *inventory.Asset, results *AssetRepo
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.assets[asset.Mrn] = asset
+	r.assets[asset.Mrn] = snapshotAsset(asset)
 	r.assetReports[asset.Mrn] = results.Report
 	r.resolvedPolicies[asset.Mrn] = results.ResolvedPolicy
 
@@ -71,7 +73,7 @@ func (r *AggregateReporter) AddVulnReport(asset *inventory.Asset, vulnReport *gq
 	mvdVulnReport := gql.ConvertToMvdVulnReport(vulnReport)
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.assets[asset.Mrn] = asset
+	r.assets[asset.Mrn] = snapshotAsset(asset)
 	r.assetVulnReports[asset.Mrn] = mvdVulnReport
 }
 
@@ -82,8 +84,40 @@ func (r *AggregateReporter) AddScanError(asset *inventory.Asset, err error) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.assets[asset.Mrn] = asset
+	r.assets[asset.Mrn] = snapshotAsset(asset)
 	r.assetErrors[asset.Mrn] = err
+}
+
+func snapshotAsset(asset *inventory.Asset) *inventory.Asset {
+	if asset == nil {
+		return nil
+	}
+
+	snapshot := &inventory.Asset{
+		Id:          asset.Id,
+		Mrn:         asset.Mrn,
+		Name:        asset.Name,
+		PlatformIds: slices.Clone(asset.PlatformIds),
+		State:       asset.State,
+		Labels:      maps.Clone(asset.Labels),
+		Annotations: maps.Clone(asset.Annotations),
+		Options:     maps.Clone(asset.Options),
+		IdDetector:  slices.Clone(asset.IdDetector),
+		Category:    asset.Category,
+		ManagedBy:   asset.ManagedBy,
+		Url:         asset.Url,
+		KindString:  asset.KindString,
+		Fqdn:        asset.Fqdn,
+		TraceId:     asset.TraceId,
+	}
+
+	if asset.Platform != nil {
+		snapshot.Platform = asset.Platform.CloneVT()
+	}
+
+	// Connections and related assets are not needed in scan reports and can
+	// retain large provider configs and discovery trees in memory.
+	return snapshot
 }
 
 func (r *AggregateReporter) Reports() *ScanResult {

--- a/policy/scan/reporter_aggregate_test.go
+++ b/policy/scan/reporter_aggregate_test.go
@@ -4,10 +4,13 @@
 package scan
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
 
 func TestAggregateReport(t *testing.T) {
@@ -35,4 +38,82 @@ func TestAggregateReport(t *testing.T) {
 
 	r.AddBundle(b2)
 	assert.Equal(t, r.bundle, policy.Merge(b, b2))
+}
+
+func TestAggregateReporterAssetSnapshot(t *testing.T) {
+	r := NewAggregateReporter()
+	asset := &inventory.Asset{
+		Mrn:         "//assets.api.mondoo.app/assets/abc",
+		Name:        "target",
+		PlatformIds: []string{"//platformid.api.mondoo.app/runtime/linux/host/abc"},
+		Platform: &inventory.Platform{
+			Name:    "linux",
+			Version: "6.6",
+		},
+		Connections: []*inventory.Config{
+			{
+				Type: "ssh",
+				Options: map[string]string{
+					"host": "10.0.0.1",
+					"key":  strings.Repeat("k", 2048),
+				},
+			},
+		},
+		RelatedAssets: []*inventory.Asset{
+			{Mrn: "//assets.api.mondoo.app/assets/child", Name: "child"},
+		},
+		Labels: map[string]string{
+			"env": "prod",
+		},
+		Url: "https://app.mondoo.com/assets/abc",
+	}
+
+	r.AddReport(asset, &AssetReport{
+		ResolvedPolicy: &policy.ResolvedPolicy{},
+		Report: &policy.Report{
+			Score: &policy.Score{Value: 100},
+		},
+	})
+
+	asset.Name = "mutated"
+	asset.Labels["env"] = "dev"
+
+	full := r.Reports().GetFull()
+	requireAsset := full.Assets[asset.Mrn]
+
+	assert.NotNil(t, requireAsset)
+	assert.Equal(t, "target", requireAsset.Name)
+	assert.Equal(t, "prod", requireAsset.Labels["env"])
+	assert.Nil(t, requireAsset.Connections)
+	assert.Nil(t, requireAsset.RelatedAssets)
+}
+
+func BenchmarkSnapshotAsset_TrimmedRetention(b *testing.B) {
+	asset := &inventory.Asset{
+		Mrn:  "//assets.api.mondoo.app/assets/abc",
+		Name: "target",
+		Connections: []*inventory.Config{
+			{
+				Type: "ssh",
+				Options: map[string]string{
+					"payload": strings.Repeat("x", 4096),
+				},
+			},
+		},
+		RelatedAssets: []*inventory.Asset{
+			{Mrn: "//assets.api.mondoo.app/assets/child", Name: "child"},
+		},
+		Labels: map[string]string{"scope": "bench"},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s := snapshotAsset(asset)
+		if i == 0 {
+			if s.SizeVT() >= asset.SizeVT() {
+				b.Fatalf("expected snapshot to retain less data: snapshot=%d original=%d", s.SizeVT(), asset.SizeVT())
+			}
+		}
+		s.Mrn = fmt.Sprintf("%s-%d", s.Mrn, i)
+	}
 }


### PR DESCRIPTION
## Summary

- Store compact asset snapshots in `AggregateReporter` instead of retaining live provider connections and related-asset trees.
- Preserve report-visible identity, platform, labels, annotations, and metadata while releasing discovery-heavy references earlier.
- Add retention tests and a synthetic benchmark.

## Rough data

- Snapshot benchmark: ~243 ns/op, 728 B/op, 6 allocs/op.
- The retained snapshot omits `Connections` and `RelatedAssets`, which can pin large provider/discovery graphs across many assets.

## Validation

- Focused `policy/scan` tests pass.
- Docker/OrbStack benchmarking was unavailable because no daemon was running; local synthetic validation was used instead.