### PR TITLE
✨ Add AI-service security policies (Wave 1: OpenAI, Anthropic, Hugging Face, Together)

### DIFF
--- a/content/mondoo-anthropic-security.mql.yaml
+++ b/content/mondoo-anthropic-security.mql.yaml
@@ -1,0 +1,290 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# PROTOTYPE - AI service coverage concept (Wave 1)
+# Foundation-model SaaS (Anthropic Claude). Provider providers/claude v13.0.12 (GA).
+# Field references from providers/claude/resources/claude.lr. Organization
+# resources require an admin API key. SaaS admin settings have no Terraform
+# resource, so no IaC variants apply. Add verified compliance/* tags before GA.
+
+policies:
+  - uid: mondoo-anthropic-security
+    name: Mondoo Anthropic Claude Security
+    version: 0.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: claude,ai
+    require:
+      - provider: claude
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Anthropic Claude organization identity, API keys, data residency, and audit visibility
+    docs:
+      desc: |
+        The Mondoo Anthropic Claude Security policy assesses the security posture
+        of an Anthropic organization through the Claude admin API: organization
+        membership and least privilege, API key lifecycle, workspace data
+        residency, and audit activity visibility. The organization checks require
+        an **admin API key**.
+
+        ## Scan an Anthropic organization
+
+        ```bash
+        cnspec scan claude -f mondoo-anthropic-security.mql.yaml
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    props:
+      - uid: mondooAnthropicMaxAdmins
+        title: Maximum number of organization admins permitted
+        mql: |
+          return 3
+    groups:
+      - title: Identity and Access Management
+        filters: asset.family.contains("claude")
+        checks:
+          - uid: mondoo-anthropic-security-limit-org-admins
+          - uid: mondoo-anthropic-security-no-pending-admin-invites
+          - uid: mondoo-anthropic-security-no-expired-pending-invites
+      - title: Credential Hygiene
+        filters: asset.family.contains("claude")
+        checks:
+          - uid: mondoo-anthropic-security-api-keys-expire
+          - uid: mondoo-anthropic-security-no-orphaned-active-keys
+      - title: Data Residency
+        filters: asset.family.contains("claude")
+        checks:
+          - uid: mondoo-anthropic-security-workspace-inference-geo-pinned
+      - title: Audit and Monitoring
+        filters: asset.family.contains("claude")
+        checks:
+          - uid: mondoo-anthropic-security-activity-log-available
+    scoring_system: highest impact
+
+queries:
+  - uid: mondoo-anthropic-security-limit-org-admins
+    title: Ensure the number of organization admins is limited
+    impact: 70
+    props:
+      - uid: mondooAnthropicMaxAdmins
+    mql: |
+      claude.organization.members.where(role == "admin").length <= props.mondooAnthropicMaxAdmins
+    docs:
+      desc: |
+        This check ensures the Anthropic organization keeps the number of admins
+        small. The admin role grants full control over members, workspaces, and
+        API keys, so a large admin set widens the blast radius of a compromised
+        or careless privileged account.
+
+        **Why this matters**
+
+        - **Least privilege:** Admin is the highest privilege level and should be rare.
+        - **Blast radius:** Each admin is another full-control path.
+      audit: |
+        ### Audit via Console
+
+        1. Open the Anthropic Console and go to **Settings > Members**.
+        2. Count the members whose role is **Admin**.
+
+        A passing result shows the admin count at or below the approved threshold; a failing result shows more.
+      remediation:
+        - id: console
+          desc: |
+            To reduce organization admins:
+
+            1. Open **Settings > Members** in the Anthropic Console.
+            2. Downgrade admins who do not need full control to `developer`, `billing`, or `user`.
+
+  - uid: mondoo-anthropic-security-no-pending-admin-invites
+    title: Ensure no pending invitations grant admin access
+    impact: 60
+    mql: |
+      claude.organization.invites.where(status == "pending" && role == "admin").length == 0
+    docs:
+      desc: |
+        This check ensures no outstanding invitation would grant the admin role
+        on acceptance. Unclaimed admin invites are an easily overlooked
+        privilege-escalation path.
+
+        **Why this matters**
+
+        - **Latent privilege:** A pending admin invite becomes full control the moment it is accepted.
+
+        **Risk mitigation**
+
+        - **Deferred elevation:** Invite at a low role and elevate after verification.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Members** in the Anthropic Console.
+        2. Review pending invitations for any with the **Admin** role.
+
+        A passing result shows no pending admin invitations; a failing result shows one or more.
+      remediation:
+        - id: console
+          desc: |
+            To remove pending admin invitations:
+
+            1. Open **Settings > Members** in the Anthropic Console.
+            2. Revoke each pending invitation with the **Admin** role, or reissue it at a lower role.
+
+  - uid: mondoo-anthropic-security-no-expired-pending-invites
+    title: Ensure stale pending invitations are cleaned up
+    impact: 30
+    mql: |
+      claude.organization.invites.where(status == "pending").all(expiresAt > time.now)
+    docs:
+      desc: |
+        This check ensures pending invitations have not passed their expiration.
+        Expired-but-present invites are dead weight in the access model and blur
+        the true membership surface.
+
+        **Why this matters**
+
+        - **Accurate inventory:** Cleared invites keep the membership picture honest.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Members** in the Anthropic Console.
+        2. Review pending invitations for any past their expiration date.
+
+        A passing result shows no expired pending invitations; a failing result shows one or more.
+      remediation:
+        - id: console
+          desc: |
+            To clean up stale invitations:
+
+            1. Open **Settings > Members** in the Anthropic Console.
+            2. Remove expired pending invitations and resend fresh ones where still needed.
+
+  - uid: mondoo-anthropic-security-api-keys-expire
+    title: Ensure active API keys have an expiration date
+    impact: 60
+    mql: |
+      claude.organization.apiKeys.where(status == "active").all(expiresAt != empty)
+    docs:
+      desc: |
+        This check ensures active API keys have an expiration date. Keys without
+        one remain valid indefinitely, extending the window in which a leaked
+        credential can be abused.
+
+        **Why this matters**
+
+        - **Exposure window:** Non-expiring keys never force re-issuance or review.
+
+        **Risk mitigation**
+
+        - **Forced rotation:** An expiration date guarantees periodic renewal.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > API keys** in the Anthropic Console.
+        2. For each active key, confirm an expiration date is set.
+
+        A passing result shows every active key with an expiration; a failing result shows a non-expiring active key.
+      remediation:
+        - id: console
+          desc: |
+            To add expirations to keys:
+
+            1. Create a replacement key with an expiration date in **Settings > API keys**.
+            2. Migrate consumers, then deactivate the non-expiring key.
+
+  - uid: mondoo-anthropic-security-no-orphaned-active-keys
+    title: Ensure active API keys have a known creator
+    impact: 40
+    mql: |
+      claude.organization.apiKeys.where(status == "active").all(createdBy != empty)
+    docs:
+      desc: |
+        This check ensures every active API key is attributable to a member. A
+        key whose creator cannot be resolved is unowned credential material that
+        no one is accountable for rotating or revoking.
+
+        **Why this matters**
+
+        - **Accountability:** Every credential needs an owner responsible for it.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > API keys** in the Anthropic Console.
+        2. Confirm each active key shows a creating member.
+
+        A passing result shows every active key attributed to a member; a failing result shows an unattributed key.
+      remediation:
+        - id: console
+          desc: |
+            To resolve unattributed keys:
+
+            1. Identify keys with no known creator in **Settings > API keys**.
+            2. Confirm whether they are still needed, then rotate them under a named owner or deactivate them.
+
+  - uid: mondoo-anthropic-security-workspace-inference-geo-pinned
+    title: Ensure workspaces pin a default inference region
+    impact: 40
+    mql: |
+      claude.organization.workspaces.where(archivedAt == empty).all(defaultInferenceGeo != empty)
+    docs:
+      desc: |
+        This check ensures each active workspace pins a default inference region.
+        Pinning constrains where prompts and completions are processed, enforcing
+        data-residency requirements. Workspaces without a pinned region may
+        process data outside an approved jurisdiction.
+
+        **Why this matters**
+
+        - **Data residency:** Regulated data must stay in approved regions.
+
+        **Risk mitigation**
+
+        - **Explicit geo:** A pinned region removes ambiguity about where data flows.
+      audit: |
+        ### Audit via Console
+
+        1. Open each workspace's settings in the Anthropic Console.
+        2. Confirm a default inference region is configured.
+
+        A passing result shows every active workspace with a pinned region; a failing result shows one without.
+      remediation:
+        - id: console
+          desc: |
+            To pin inference regions:
+
+            1. Open each active workspace's settings in the Anthropic Console.
+            2. Set a default inference region consistent with your data-residency obligations and restrict the allowed regions.
+
+  - uid: mondoo-anthropic-security-activity-log-available
+    title: Ensure organization activity logs are accessible
+    impact: 50
+    mql: |
+      claude.organization.activities.length > 0
+    docs:
+      desc: |
+        This check ensures the organization activity feed is reachable. The feed
+        records security-relevant events such as logins, permission changes, and
+        API key changes. An empty result indicates no privileged monitoring
+        identity is configured or activity is not being collected.
+
+        **Why this matters**
+
+        - **Detection:** Investigations depend on a retained activity record.
+
+        **Risk mitigation**
+
+        - **Central ingestion:** Shipping activity to a SIEM preserves it for review.
+      audit: |
+        ### Audit via Console
+
+        1. Open the organization's activity/audit view in the Anthropic Console.
+        2. Confirm activity events are present and an admin key exists for retrieval.
+
+        A passing result shows activity events available; a failing result shows none or no admin access.
+      remediation:
+        - id: console
+          desc: |
+            To enable activity visibility:
+
+            1. Provision an **admin API key** scoped for security monitoring.
+            2. Ingest the organization activity feed into your SIEM for retention and review.

--- a/content/mondoo-huggingface-security.mql.yaml
+++ b/content/mondoo-huggingface-security.mql.yaml
@@ -1,0 +1,190 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# PROTOTYPE - AI service coverage concept (Wave 1)
+# Model hub / ML platform archetype. Provider providers/huggingface v13.1.12 (GA).
+# Field references from providers/huggingface/resources/huggingface.lr. The
+# provider exposes only the current auth token (huggingface.user.accessToken).
+# SaaS settings have no Terraform resource, so no IaC variants apply.
+
+policies:
+  - uid: mondoo-huggingface-security
+    name: Mondoo Hugging Face Security
+    version: 0.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: huggingface,ai
+    require:
+      - provider: huggingface
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Hugging Face access tokens, organization governance, webhooks, and model supply chain
+    docs:
+      desc: |
+        The Mondoo Hugging Face Security policy assesses the security posture of a
+        Hugging Face account and its organizations: credential scoping of the
+        access token in use, organization governance (Enterprise controls),
+        webhook transport security, and model supply-chain hygiene.
+
+        ## Scan a Hugging Face account
+
+        ```bash
+        cnspec scan huggingface -f mondoo-huggingface-security.mql.yaml
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Credential Hygiene
+        filters: asset.family.contains("huggingface")
+        checks:
+          - uid: mondoo-huggingface-security-access-token-fine-grained
+      - title: Organization Governance
+        filters: asset.family.contains("huggingface")
+        checks:
+          - uid: mondoo-huggingface-security-org-enterprise
+      - title: Integrations
+        filters: asset.family.contains("huggingface")
+        checks:
+          - uid: mondoo-huggingface-security-webhooks-use-https
+      - title: Model Supply Chain
+        filters: asset.family.contains("huggingface")
+        checks:
+          - uid: mondoo-huggingface-security-no-disabled-models
+    scoring_system: highest impact
+
+queries:
+  - uid: mondoo-huggingface-security-access-token-fine-grained
+    title: Ensure the access token uses fine-grained permissions
+    impact: 70
+    mql: |
+      huggingface.user.accessToken.role == "fineGrained"
+    docs:
+      desc: |
+        This check ensures the access token in use is fine-grained. Classic
+        `read` and especially `write` tokens grant broad, account-wide access;
+        fine-grained tokens scope access to specific repositories and actions, so
+        a leaked token exposes far less.
+
+        **Why this matters**
+
+        - **Least privilege:** Fine-grained scoping limits what a leaked token can do.
+
+        **Risk mitigation**
+
+        - **Narrow blast radius:** A compromised scoped token cannot touch unrelated repos.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Access Tokens** on the Hugging Face website.
+        2. Confirm the token used for automation is a **Fine-grained** token, not a classic read/write token.
+
+        A passing result shows a fine-grained token; a failing result shows a classic read or write token.
+      remediation:
+        - id: console
+          desc: |
+            To move to a fine-grained token:
+
+            1. In **Settings > Access Tokens**, create a fine-grained token limited to the repositories and permissions the workload needs.
+            2. Migrate consumers to it and revoke the broad classic token.
+    refs:
+      - url: https://huggingface.co/docs/hub/security-tokens
+        title: Hugging Face user access tokens
+
+  - uid: mondoo-huggingface-security-org-enterprise
+    title: Ensure organizations use Enterprise governance controls
+    impact: 40
+    mql: |
+      huggingface.organizations.all(isEnterprise == true)
+    docs:
+      desc: |
+        This check ensures organizations are on the Enterprise tier, which
+        unlocks governance controls such as SSO, audit logging, and resource-group
+        access management. Lower tiers lack the centralized identity and audit
+        capabilities expected for proprietary models and datasets.
+
+        **Why this matters**
+
+        - **Governance:** SSO and audit logging require the Enterprise tier.
+      audit: |
+        ### Audit via Console
+
+        1. Open each organization's **Settings** on the Hugging Face website.
+        2. Confirm the organization is on the **Enterprise** plan with SSO and audit logging enabled.
+
+        A passing result shows Enterprise governance; a failing result shows a lower tier.
+      remediation:
+        - id: console
+          desc: |
+            To enable Enterprise governance:
+
+            1. Upgrade organizations that host proprietary or regulated assets to the **Enterprise** tier.
+            2. Enable SSO and audit logging in the organization settings.
+
+  - uid: mondoo-huggingface-security-webhooks-use-https
+    title: Ensure webhooks deliver over HTTPS
+    impact: 50
+    mql: |
+      huggingface.webhooks.all(webhookUrl == /^https/)
+    docs:
+      desc: |
+        This check ensures webhooks deliver over HTTPS. Webhooks carry repository
+        events and can include secrets in headers; a plaintext HTTP target
+        exposes that traffic to interception and tampering.
+
+        **Why this matters**
+
+        - **Confidentiality:** HTTP delivery leaks event payloads and secrets.
+
+        **Risk mitigation**
+
+        - **Encrypted transport:** HTTPS protects webhook traffic in transit.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Webhooks** on the Hugging Face website.
+        2. Confirm each webhook target URL begins with `https://`.
+
+        A passing result shows only HTTPS targets; a failing result shows an HTTP target.
+      remediation:
+        - id: console
+          desc: |
+            To secure webhook delivery:
+
+            1. Reconfigure each webhook to an HTTPS endpoint in **Settings > Webhooks**.
+            2. Rotate any webhook secret previously transmitted over HTTP.
+
+  - uid: mondoo-huggingface-security-no-disabled-models
+    title: Ensure no account models have been disabled by Hugging Face
+    impact: 60
+    mql: |
+      huggingface.models.where(disabled == true).length == 0
+    docs:
+      desc: |
+        This check ensures no models in the account have been disabled by Hugging
+        Face. Hugging Face disables repositories that violate policy or are
+        flagged for malware or abuse; a disabled model signals a supply-chain or
+        compliance problem to investigate before the artifact is used downstream.
+
+        **Why this matters**
+
+        - **Supply chain:** A disabled model may be malicious or non-compliant.
+
+        **Risk mitigation**
+
+        - **Early containment:** Investigating promptly prevents downstream reuse.
+      audit: |
+        ### Audit via Console
+
+        1. Open the account's or organization's model repositories on the Hugging Face website.
+        2. Look for any repository marked **disabled**.
+
+        A passing result shows no disabled models; a failing result shows one or more.
+      remediation:
+        - id: console
+          desc: |
+            To handle a disabled model:
+
+            1. Investigate why Hugging Face disabled the repository.
+            2. Remove it from any pipelines that reference it and confirm no downstream system pulled the artifact while it was live.

--- a/content/mondoo-openai-security.mql.yaml
+++ b/content/mondoo-openai-security.mql.yaml
@@ -1,0 +1,346 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# PROTOTYPE - AI service coverage concept (Wave 1)
+# Foundation-model SaaS (OpenAI). Provider providers/openai v13.0.11 (@maturity preview).
+# Field references from providers/openai/resources/openai.lr.
+# SaaS admin settings have no Terraform resource, so no IaC variants apply.
+# Compliance tags omitted intentionally on this standalone prototype (no tagged
+# siblings); add verified compliance/* tags before GA per content/CLAUDE.md.
+
+policies:
+  - uid: mondoo-openai-security
+    name: Mondoo OpenAI Security
+    version: 0.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: openai,ai
+    require:
+      - provider: openai
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden OpenAI organization identity, API keys, data governance, and audit visibility
+    docs:
+      desc: |
+        The Mondoo OpenAI Security policy assesses the security posture of an
+        OpenAI organization through the OpenAI management API: organization
+        membership and least privilege, API key and service-account hygiene, data
+        governance over uploaded files and vector stores, and audit log
+        visibility.
+
+        Several checks require an **admin API key** (organization users, invites,
+        audit logs, project API keys, and service accounts).
+
+        ## Scan an OpenAI organization
+
+        ```bash
+        cnspec scan openai -f mondoo-openai-security.mql.yaml
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    props:
+      - uid: mondooOpenaiMaxOrgOwners
+        title: Maximum number of organization owners permitted
+        mql: |
+          return 3
+      - uid: mondooOpenaiMaxApiKeyAgeDays
+        title: Maximum API key age in days before rotation is expected
+        mql: |
+          return 90
+    groups:
+      - title: Identity and Access Management
+        filters: asset.family.contains("openai")
+        checks:
+          - uid: mondoo-openai-security-limit-org-owners
+          - uid: mondoo-openai-security-no-pending-owner-invites
+          - uid: mondoo-openai-security-service-accounts-not-owner
+      - title: Credential Hygiene
+        filters: asset.family.contains("openai")
+        checks:
+          - uid: mondoo-openai-security-no-keys-in-archived-projects
+          - uid: mondoo-openai-security-rotate-project-api-keys
+      - title: Data Governance
+        filters: asset.family.contains("openai")
+        checks:
+          - uid: mondoo-openai-security-vector-stores-expire
+      - title: Audit and Monitoring
+        filters: asset.family.contains("openai")
+        checks:
+          - uid: mondoo-openai-security-audit-logs-available
+    scoring_system: highest impact
+
+queries:
+  - uid: mondoo-openai-security-limit-org-owners
+    title: Ensure the number of organization owners is limited
+    impact: 70
+    props:
+      - uid: mondooOpenaiMaxOrgOwners
+    mql: |
+      openai.users.where(role == "owner").length <= props.mondooOpenaiMaxOrgOwners
+    docs:
+      desc: |
+        This check ensures the OpenAI organization keeps the number of owners
+        small. Owners hold full control over billing, member management, and
+        project configuration, so a large owner set widens the blast radius of
+        any single compromised or careless account.
+
+        **Why this matters**
+
+        - **Least privilege:** Owner is the highest privilege level; few identities should hold it.
+        - **Blast radius:** Each additional owner is another full-takeover path.
+
+        **Risk mitigation**
+
+        - **Accountability:** A small owner set is easier to review and attest.
+      audit: |
+        ### Audit via Console
+
+        1. Open the OpenAI dashboard and go to **Settings > Members**.
+        2. Count the members whose role is **Owner**.
+
+        A passing result shows the owner count at or below the approved threshold; a failing result shows more owners than permitted.
+      remediation:
+        - id: console
+          desc: |
+            To reduce the number of organization owners:
+
+            1. Open **Settings > Members** in the OpenAI dashboard.
+            2. For each owner who does not need full control, change the role to **Reader**.
+    refs:
+      - url: https://platform.openai.com/docs/guides/your-data
+        title: OpenAI platform data controls
+
+  - uid: mondoo-openai-security-no-pending-owner-invites
+    title: Ensure no pending invitations grant owner access
+    impact: 60
+    mql: |
+      openai.invites.where(status == "pending" && role == "owner").length == 0
+    docs:
+      desc: |
+        This check ensures there are no outstanding invitations that would grant
+        the owner role on acceptance. Unclaimed owner invites are an
+        often-forgotten privilege-escalation path, especially when sent to
+        personal or shared mailboxes.
+
+        **Why this matters**
+
+        - **Latent privilege:** A pending owner invite becomes full control the moment it is accepted.
+        - **Weak delivery targets:** Invites to shared inboxes can be accepted by unintended parties.
+
+        **Risk mitigation**
+
+        - **Deferred elevation:** Invite at a low role and elevate only after the member is verified.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Members** in the OpenAI dashboard.
+        2. Review the **Pending invitations** list for any with the **Owner** role.
+
+        A passing result shows no pending owner invitations; a failing result shows one or more.
+      remediation:
+        - id: console
+          desc: |
+            To remove pending owner invitations:
+
+            1. Open **Settings > Members** in the OpenAI dashboard.
+            2. Revoke each pending invitation with the **Owner** role, or reissue it as **Reader**.
+
+  - uid: mondoo-openai-security-service-accounts-not-owner
+    title: Ensure project service accounts do not hold the owner role
+    impact: 70
+    mql: |
+      openai.projects.all(serviceAccounts.all(role != "owner"))
+    docs:
+      desc: |
+        This check ensures automation service accounts are not granted the
+        project owner role. An owner-level service account lets automated
+        workloads (and anyone holding the key) change project configuration and
+        manage other credentials, violating least privilege.
+
+        **Why this matters**
+
+        - **Non-human privilege:** Machine identities rarely need to manage a project.
+        - **Key exposure:** A leaked owner service-account key is a project takeover.
+
+        **Risk mitigation**
+
+        - **Scoped automation:** The member role is sufficient for typical automation.
+      audit: |
+        ### Audit via Console
+
+        1. Open the OpenAI dashboard and select each project under **Settings > Projects**.
+        2. Open **Service accounts** and review each account's role.
+
+        A passing result shows every service account at the **Member** role; a failing result shows a service account with **Owner**.
+      remediation:
+        - id: console
+          desc: |
+            To downgrade over-privileged service accounts:
+
+            1. Open the affected project's **Service accounts** page.
+            2. Change any service account with the **Owner** role to **Member**.
+
+  - uid: mondoo-openai-security-no-keys-in-archived-projects
+    title: Ensure archived projects do not retain active API keys
+    impact: 80
+    mql: |
+      openai.projects.where(status == "archived").all(apiKeys.length == 0)
+    docs:
+      desc: |
+        This check ensures archived projects contain no API keys. Keys in an
+        archived project remain valid credentials against the OpenAI API but are
+        rarely monitored, making them a common source of long-lived, forgotten
+        access.
+
+        **Why this matters**
+
+        - **Shadow credentials:** Archived projects are assumed inactive, yet their keys still work.
+        - **Low visibility:** Nobody watches an archived project for key misuse.
+
+        **Risk mitigation**
+
+        - **Clean teardown:** Deleting keys before archiving removes the credential entirely.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Projects** in the OpenAI dashboard and filter to **Archived**.
+        2. For each archived project, open **API keys** and confirm the list is empty.
+
+        A passing result shows no API keys in any archived project; a failing result shows one or more.
+      remediation:
+        - id: console
+          desc: |
+            To remove keys from archived projects:
+
+            1. Open each archived project's **API keys** page.
+            2. Delete every remaining key and rotate any that may have been exposed.
+
+  - uid: mondoo-openai-security-rotate-project-api-keys
+    title: Ensure project API keys are rotated regularly
+    impact: 60
+    props:
+      - uid: mondooOpenaiMaxApiKeyAgeDays
+    mql: |
+      openai.projects.all(
+        apiKeys.all(createdAt > time.now - props.mondooOpenaiMaxApiKeyAgeDays * time.day)
+      )
+    docs:
+      desc: |
+        This check ensures project API keys are not older than the approved
+        rotation window. Long-lived keys extend the window in which a leaked
+        credential can be abused and let stale automations retain access.
+
+        **Why this matters**
+
+        - **Exposure window:** The longer a key lives, the longer a leak stays exploitable.
+        - **Drift:** Old keys accumulate for automations no one owns anymore.
+
+        **Risk mitigation**
+
+        - **Scheduled rotation:** Periodic re-issuance forces review of who still needs access.
+      audit: |
+        ### Audit via Console
+
+        1. Open each project's **API keys** page in the OpenAI dashboard.
+        2. Review the **Created** date of each key against your rotation window.
+
+        A passing result shows every key created within the approved window; a failing result shows a key older than it.
+      remediation:
+        - id: console
+          desc: |
+            To rotate an aging API key:
+
+            1. Create a replacement key in the project's **API keys** page.
+            2. Migrate consumers to the new key, then delete the old key.
+
+  - uid: mondoo-openai-security-vector-stores-expire
+    title: Ensure vector stores have an expiration policy
+    impact: 40
+    mql: |
+      openai.vectorStores.all(expiresAt != empty)
+    docs:
+      desc: |
+        This check ensures every vector store has an expiration policy. Vector
+        stores hold embeddings of uploaded files and can retain sensitive
+        organizational data indefinitely; an expiration policy enforces data
+        minimization by clearing stores that are no longer actively used.
+
+        **Why this matters**
+
+        - **Data minimization:** Embeddings of sensitive documents should not live forever.
+        - **Forgotten data:** Unused stores accumulate silently.
+
+        **Risk mitigation**
+
+        - **Automatic cleanup:** An expiration policy purges idle stores without manual effort.
+      audit: |
+        ### Audit via Console
+
+        1. Open the **Storage > Vector stores** area of the OpenAI dashboard.
+        2. Review each store for a configured expiration policy.
+
+        A passing result shows every store with an expiration policy; a failing result shows a store with none.
+      remediation:
+        - id: console
+          desc: |
+            To set an expiration policy:
+
+            1. Open each vector store in the OpenAI dashboard.
+            2. Configure an **expires after** policy appropriate to its use.
+        - id: api
+          desc: |
+            To set an expiration policy through the API, provide `expires_after`
+            when creating or updating the vector store:
+
+            ```bash
+            curl https://api.openai.com/v1/vector_stores/<id> \
+              -H "Authorization: Bearer $OPENAI_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"expires_after":{"anchor":"last_active_at","days":30}}'
+            ```
+
+  - uid: mondoo-openai-security-audit-logs-available
+    title: Ensure organization audit logs are accessible
+    impact: 50
+    mql: |
+      openai.auditLogs.length > 0
+    docs:
+      desc: |
+        This check ensures the OpenAI organization audit log is reachable. Audit
+        logs record security-relevant activity such as API key creation, role
+        changes, and login events; the audit log API requires an admin API key,
+        so an empty result indicates no privileged monitoring identity is
+        configured or audit activity is not being collected.
+
+        **Why this matters**
+
+        - **Accountability:** Without audit logs there is no record of who changed what.
+        - **Detection:** Incident investigation depends on retained activity.
+
+        **Risk mitigation**
+
+        - **Central ingestion:** Shipping logs to a SIEM preserves them for review.
+      audit: |
+        ### Audit via Console
+
+        1. Open **Settings > Logs** (audit logs) in the OpenAI dashboard.
+        2. Confirm audit events are present and that an admin key exists for retrieval.
+
+        A passing result shows audit events available; a failing result shows none or no admin access.
+      remediation:
+        - id: console
+          desc: |
+            To enable audit visibility:
+
+            1. Create an **admin API key** scoped for security monitoring.
+            2. Confirm audit logs are visible under **Settings > Logs**.
+        - id: api
+          desc: |
+            To ingest audit logs, poll the audit log API with an admin key:
+
+            ```bash
+            curl https://api.openai.com/v1/organization/audit_logs \
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY"
+            ```

--- a/content/mondoo-together-security.mql.yaml
+++ b/content/mondoo-together-security.mql.yaml
@@ -1,0 +1,149 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# PROTOTYPE - AI service coverage concept (Wave 1)
+# ML/inference platform archetype. Provider providers/together v13.0.11 (@maturity preview).
+# Field references from providers/together/resources/together.lr. Ships as
+# preview (0.x) until the together provider graduates. SaaS settings have no
+# Terraform resource, so no IaC variants apply.
+
+policies:
+  - uid: mondoo-together-security
+    name: Mondoo Together AI Security
+    version: 0.1.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: together,ai
+    require:
+      - provider: together
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Together AI cluster identity federation, secret attribution, and endpoint ownership
+    docs:
+      desc: |
+        The Mondoo Together AI Security policy assesses the security posture of a
+        Together AI organization, focusing on the surfaces the provider exposes:
+        identity federation on GPU clusters, ownership attribution of stored
+        secrets, and ownership of inference endpoints.
+
+        ## Scan a Together AI organization
+
+        ```bash
+        cnspec scan together -f mondoo-together-security.mql.yaml
+        ```
+
+        Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
+    groups:
+      - title: Identity Federation
+        filters: asset.family.contains("together")
+        checks:
+          - uid: mondoo-together-security-clusters-use-oidc
+      - title: Credential Hygiene
+        filters: asset.family.contains("together")
+        checks:
+          - uid: mondoo-together-security-secrets-attributable
+      - title: Endpoint Ownership
+        filters: asset.family.contains("together")
+        checks:
+          - uid: mondoo-together-security-endpoints-have-owner
+    scoring_system: highest impact
+
+queries:
+  - uid: mondoo-together-security-clusters-use-oidc
+    title: Ensure GPU clusters use OIDC identity federation
+    impact: 60
+    mql: |
+      together.clusters.all(oidcIssuer != empty)
+    docs:
+      desc: |
+        This check ensures GPU clusters federate identity through OIDC. Federation
+        delegates authentication to the organization's identity provider,
+        inheriting MFA and lifecycle deprovisioning. Clusters without an OIDC
+        issuer rely on static credentials that are harder to rotate and govern.
+
+        **Why this matters**
+
+        - **Central identity:** Cluster access follows the IdP's controls.
+
+        **Risk mitigation**
+
+        - **Fewer static keys:** Workloads authenticate through federation.
+      audit: |
+        ### Audit via Console
+
+        1. Open the Together AI console and review each cluster's authentication settings.
+        2. Confirm an OIDC issuer and client are configured.
+
+        A passing result shows every cluster with an OIDC issuer; a failing result shows a cluster without one.
+      remediation:
+        - id: console
+          desc: |
+            To federate cluster identity:
+
+            1. Open each cluster's settings in the Together AI console.
+            2. Configure an OIDC issuer and client so workloads authenticate through your identity provider.
+
+  - uid: mondoo-together-security-secrets-attributable
+    title: Ensure stored secrets are attributable to a creator
+    impact: 40
+    mql: |
+      together.secrets.all(createdBy != empty)
+    docs:
+      desc: |
+        This check ensures every stored secret traces back to a responsible
+        identity. A secret with no recorded creator is unowned material that no
+        one is accountable for rotating or removing.
+
+        **Why this matters**
+
+        - **Accountability:** Every secret needs a named owner.
+      audit: |
+        ### Audit via Console
+
+        1. Open the Together AI console and review the stored secrets list.
+        2. Confirm each secret shows a creator.
+
+        A passing result shows every secret attributed to a creator; a failing result shows an unattributed secret.
+      remediation:
+        - id: console
+          desc: |
+            To resolve unattributed secrets:
+
+            1. Review secrets without a recorded owner in the Together AI console.
+            2. Confirm they are still needed, rotate them under a named identity, and delete any that cannot be accounted for.
+
+  - uid: mondoo-together-security-endpoints-have-owner
+    title: Ensure inference endpoints have a recorded owner
+    impact: 40
+    mql: |
+      together.endpoints.all(owner != empty)
+    docs:
+      desc: |
+        This check ensures dedicated inference endpoints have a recorded owner.
+        Endpoints consume GPU capacity and expose a model over the network; an
+        endpoint with no owner is unaccounted-for infrastructure that may be
+        forgotten, left running, or left exposed.
+
+        **Why this matters**
+
+        - **Accountability:** Every exposed model surface needs an owner.
+
+        **Risk mitigation**
+
+        - **Lifecycle control:** Owned endpoints get decommissioned when no longer needed.
+      audit: |
+        ### Audit via Console
+
+        1. Open the Together AI console and review the inference endpoints list.
+        2. Confirm each endpoint shows an owner.
+
+        A passing result shows every endpoint with an owner; a failing result shows an unowned endpoint.
+      remediation:
+        - id: console
+          desc: |
+            To attribute and clean up endpoints:
+
+            1. Assign an owner to each endpoint in the Together AI console.
+            2. Decommission endpoints that are no longer needed so idle model surfaces are not left running.


### PR DESCRIPTION
## Summary

Adds cnspec security policies for four AI services that already have mql providers but no policy coverage. This closes the highest-leverage gap in AI-service coverage: the data-gathering layer already exists, only the policy was missing.

| Policy | Provider | Maturity |
|---|---|---|
| `mondoo-openai-security` | openai | preview |
| `mondoo-anthropic-security` | claude | GA |
| `mondoo-huggingface-security` | huggingface | GA |
| `mondoo-together-security` | together | preview |

Each policy maps existing provider resources to a normalized AI security control framework: identity & least privilege, credential hygiene, data governance, and audit visibility.

## Checks by policy

- **OpenAI** — limit org owners, no pending owner invites, service accounts not owner, no keys in archived projects, key rotation, vector-store expiry, audit-log availability
- **Anthropic Claude** — limit admins, no pending/expired admin invites, API key expiry & creator attribution, workspace inference-region pinning (data residency), activity-log availability
- **Hugging Face** — fine-grained access token, Enterprise org governance, HTTPS webhooks, no Hugging Face-disabled models
- **Together AI** — cluster OIDC federation, secret creator attribution, endpoint ownership

## Validation

- ✅ `cnspec policy lint` passes on all four (`valid policy bundle(s)`) against the installed providers
- Field references verified against each provider's `.lr`; MQL idioms cross-checked against existing content
- Each check includes the required `desc` / `audit` / `remediation` docs sections with id-based remediation methods

## Notes / follow-ups

- **`mondoo-weaviate-security` was dropped from this PR**: the `weaviate` provider (v13.0.0, brand new) is not yet published to the release channel that CI policy-lint resolves against, so its checks cannot compile in CI. It will follow once the provider is published.
- `compliance/*` tags to be added before GA (verified against each framework's control text, per `content/CLAUDE.md`)
- Policies for preview-maturity providers (`openai`, `together`) ship as preview (`0.1.0`)
- SaaS admin settings have no Terraform resource, so no IaC variants apply
- **Mistral** and **Ollama** are intentionally deferred: their providers currently expose no RBAC/key/audit/exposure surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)