### PR TITLE
🐛 scan: contain progress-bar goroutine panic

### DIFF
--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
@@ -488,11 +489,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	scanGroups.Add(1)
 	go func() {
 		defer scanGroups.Done()
-		defer health.ReportPanic("cnspec", cnspec.Version, cnspec.Build)
-
-		if err := multiprogress.Open(); err != nil {
-			log.Error().Err(err).Msg("failed to open progress bar")
-		}
+		runProgressBar(multiprogress)
 	}()
 	// Make sure the progress bar is closed when we exit early. Calling this multiple times
 	// is safe
@@ -1536,4 +1533,28 @@ func createProgressBar(disableProgressBar bool) (progress.MultiProgress, error) 
 		return progress.NewTodoList(progress.WithScore())
 	}
 	return progress.NoopMultiProgress{}, nil
+}
+
+// runProgressBar opens the progress bar and contains any panic from the UI so a
+// bug in the progress renderer can never crash the scan process. The panic is
+// reported upstream WITHOUT re-raising it (unlike health.ReportPanic), and the
+// scan continues without the progress bar — subsequent progress updates become
+// safe no-ops because the underlying tea.Program stops accepting sends once its
+// context is done. This is the progress-bar counterpart to the per-asset panic
+// containment in scanDispatcher.
+func runProgressBar(mp progress.MultiProgress) {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			health.ReportRecoveredPanic("cnspec", cnspec.Version, cnspec.Build, r, stack,
+				map[string]string{"component": "progressbar"})
+			log.Error().
+				Interface("panic", r).
+				Bytes("stacktrace", stack).
+				Msg("recovered from panic in progress bar; continuing scan without it")
+		}
+	}()
+	if err := mp.Open(); err != nil {
+		log.Error().Err(err).Msg("failed to open progress bar")
+	}
 }

--- a/policy/scan/progressbar_panic_test.go
+++ b/policy/scan/progressbar_panic_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnspec/v13/cli/progress"
+)
+
+// panicProgress is a MultiProgress whose Open panics, standing in for a bug in
+// the progress renderer.
+type panicProgress struct {
+	progress.NoopMultiProgress
+}
+
+func (panicProgress) Open() error { panic("progress bar exploded") }
+
+// TestRunProgressBar_ContainsPanic verifies that a panic while opening the
+// progress bar is contained and does not propagate, so a UI bug can't crash the
+// scan process.
+func TestRunProgressBar_ContainsPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		runProgressBar(panicProgress{})
+	})
+}
+
+// TestRunProgressBar_NoPanicPath ensures the normal path is a clean pass-through.
+func TestRunProgressBar_NoPanicPath(t *testing.T) {
+	assert.NotPanics(t, func() {
+		runProgressBar(progress.NoopMultiProgress{})
+	})
+}


### PR DESCRIPTION
**Stacked on #3175** (1 of 3).

## Problem
The progress-bar goroutine deferred `health.ReportPanic`, which re-raises the panic after reporting it. Escaping the bare `go func()`, a panic in the progress renderer would crash the entire cnspec process — the same class of "one failure takes down the run" bug already fixed for per-asset scan goroutines in the base PR.

## Fix
Extract the goroutine body into `runProgressBar`, which:
- recovers the panic **directly** (recover only works in a function the panicking goroutine deferred),
- reports it via `health.ReportRecoveredPanic` (no re-raise), tagged `component=progressbar`,
- lets the scan continue without the progress bar.

Continuing is safe, not a hang risk: bubbletea's `Program.Send` selects on the program's context, so once the program stops all subsequent progress updates (`AddTask`, `OnProgress`, …) become no-ops rather than blocking.

## Test
`TestRunProgressBar_ContainsPanic` asserts a panicking `MultiProgress.Open` is contained.
