### PR TITLE
🐛 policy: deterministic query compile order

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -706,10 +706,17 @@ func topologicalSortQueries(queries []*Mquery) ([]*Mquery, error) {
 		queriesMap[q.Mrn] = q
 	}
 
-	// Topologically sort the queries
+	// Topologically sort the queries. Seed the DFS from the input slice, NOT
+	// the map: map iteration would make the compile order — and everything
+	// that accumulates in compile order, like a shared property's For list
+	// built by QueryPropsResolver — a per-run dice roll. The slice keeps the
+	// bundle's own order wherever the topology doesn't force otherwise.
 	sorted := &Mqueries{}
 	visited := map[string]struct{}{}
-	for _, q := range queriesMap {
+	for _, q := range queries {
+		if q == nil {
+			continue
+		}
 		err := topologicalSortQueriesDFS(q.Mrn, queriesMap, visited, sorted)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## The bug

`topologicalSortQueries` seeded its DFS **by ranging over the queries map**, so — absent variant constraints — query *compile order* was Go's randomized map-iteration order.

Compile order is load-bearing: `QueryPropsResolver` appends each query's implicit-property reference to the shared property's `For` list *at compile time*, so the same bundle produced differently-ordered `For` lists run to run.

This is also exactly what made `TestProps_ImplicitPropsOnSharedQueries` flaky — its assertion couples `For` order to bundle query order, which was correct to demand and randomly violated. Measured locally on pristine main: **4/30 failures**; it is currently blocking CI on #3179 by dice roll.

## The fix

Seed the DFS from the input **slice** instead of the map — the bundle's own order wins wherever the topology doesn't force otherwise, and variants still compile before their includers (the DFS itself is unchanged). Flake rate after the fix: **0/40**; full `./policy/` suite green.

## Context

Fourth ordering-nondeterminism found via the scan-content digest work (server repo, draft ADR `unchanged-scan-short-circuit`): content digests over otherwise-identical scans/compilations flag byte-level churn, and every source so far has been map iteration. Same disease family as #3179 (score error messages) and mondoohq/mql#9652 (`Deduplicate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HHX819u6q9PngxJfpCaST