### PR TITLE
OCI security: parsed IAM statements and typed security rules

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -475,7 +475,9 @@ queries:
   - uid: mondoo-oci-security-iam-no-overly-permissive-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policy.statements.none(_ == /allow.*manage\s+all-resources\s+in\s+tenancy/i)
+      oci.identity.policy.parsedStatements.none(
+        effect == "allow" && verb == "manage" && resourceType == "all-resources" && scopeType == "tenancy"
+      )
   - uid: mondoo-oci-security-iam-no-overly-permissive-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -1842,7 +1844,9 @@ queries:
   - uid: mondoo-oci-security-iam-no-broad-compartment-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policy.statements.none(_ == /allow.*manage\s+all-resources\s+in\s+compartment/i)
+      oci.identity.policy.parsedStatements.none(
+        effect == "allow" && verb == "manage" && resourceType == "all-resources" && scopeType == "compartment"
+      )
   - uid: mondoo-oci-security-iam-no-broad-compartment-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -2256,10 +2260,10 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "6"
       ).none(
-        _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 22 && _['tcpOptions']['destinationPortRange']['max'] >= 22
+        destinationPortMin == empty || destinationPortMin <= 22 && destinationPortMax >= 22
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -2415,10 +2419,10 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "6"
       ).none(
-        _['tcpOptions'] == empty || _['tcpOptions']['destinationPortRange']['min'] <= 3389 && _['tcpOptions']['destinationPortRange']['max'] >= 3389
+        destinationPortMin == empty || destinationPortMin <= 3389 && destinationPortMax >= 3389
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -2568,9 +2572,9 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-udp-ingress-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "17"
-      ).none(_['udpOptions'] == empty)
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "17"
+      ).none(destinationPortMin == empty)
   - uid: mondoo-oci-security-vcn-no-unrestricted-udp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -3335,20 +3339,16 @@ queries:
     filters: asset.platform == 'oci'
     mql: |
       oci.network.networkSecurityGroups.all(
-        ingressSecurityRules.where(
-          _['source'] == "0.0.0.0/0" || _['source'] == "::/0"
-        ).where(_['protocol'] == "6").none(_['tcpOptions'] == empty)
-        &&
-        ingressSecurityRules.where(
-          _['source'] == "0.0.0.0/0" || _['source'] == "::/0"
-        ).where(_['protocol'] == "6" && _['tcpOptions'] != empty).none(
-          _['tcpOptions']['destinationPortRange']['min'] <= 22 && _['tcpOptions']['destinationPortRange']['max'] >= 22
+        ingressRules.where(
+          source == "0.0.0.0/0" || source == "::/0"
+        ).where(protocol == "6").none(
+          destinationPortMin == empty || destinationPortMin <= 22 && destinationPortMax >= 22
         )
         &&
-        ingressSecurityRules.where(
-          _['source'] == "0.0.0.0/0" || _['source'] == "::/0"
-        ).where(_['protocol'] == "6" && _['tcpOptions'] != empty).none(
-          _['tcpOptions']['destinationPortRange']['min'] <= 3389 && _['tcpOptions']['destinationPortRange']['max'] >= 3389
+        ingressRules.where(
+          source == "0.0.0.0/0" || source == "::/0"
+        ).where(protocol == "6").none(
+          destinationPortMin == empty || destinationPortMin <= 3389 && destinationPortMax >= 3389
         )
       )
   - uid: mondoo-oci-security-nsg-no-unrestricted-admin-ports-terraform-hcl
@@ -6628,7 +6628,7 @@ queries:
   - uid: mondoo-oci-security-iam-no-any-user-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policy.statements.none(_ == /\ballow\s+(dynamic-group\s+|service\s+)?any-user\b/i)
+      oci.identity.policy.parsedStatements.none(effect == "allow" && subjectType == "any-user")
   - uid: mondoo-oci-security-iam-no-any-user-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -6780,7 +6780,7 @@ queries:
   - uid: mondoo-oci-security-iam-no-cross-tenant-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |
-      oci.identity.policy.statements.none(_ == /^\s*(endorse|admit)\s+/i)
+      oci.identity.policy.parsedStatements.none(effect == "endorse" || effect == "admit")
   - uid: mondoo-oci-security-iam-no-cross-tenant-policies-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_identity_policy")
     mql: |
@@ -6926,17 +6926,17 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "6" && _['tcpOptions'] != empty
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "6" && destinationPortMin != empty
       ).none(
-        _['tcpOptions']['destinationPortRange']['min'] <= 1521 && _['tcpOptions']['destinationPortRange']['max'] >= 1521 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 1522 && _['tcpOptions']['destinationPortRange']['max'] >= 1522 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 1433 && _['tcpOptions']['destinationPortRange']['max'] >= 1433 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 3306 && _['tcpOptions']['destinationPortRange']['max'] >= 3306 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 5432 && _['tcpOptions']['destinationPortRange']['max'] >= 5432 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 6379 && _['tcpOptions']['destinationPortRange']['max'] >= 6379 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 9200 && _['tcpOptions']['destinationPortRange']['max'] >= 9200 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 27017 && _['tcpOptions']['destinationPortRange']['max'] >= 27017
+        destinationPortMin <= 1521 && destinationPortMax >= 1521 ||
+        destinationPortMin <= 1522 && destinationPortMax >= 1522 ||
+        destinationPortMin <= 1433 && destinationPortMax >= 1433 ||
+        destinationPortMin <= 3306 && destinationPortMax >= 3306 ||
+        destinationPortMin <= 5432 && destinationPortMax >= 5432 ||
+        destinationPortMin <= 6379 && destinationPortMax >= 6379 ||
+        destinationPortMin <= 9200 && destinationPortMax >= 9200 ||
+        destinationPortMin <= 27017 && destinationPortMax >= 27017
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -7109,16 +7109,16 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "6" && _['tcpOptions'] != empty
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "6" && destinationPortMin != empty
       ).none(
-        _['tcpOptions']['destinationPortRange']['min'] <= 21 && _['tcpOptions']['destinationPortRange']['max'] >= 21 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 23 && _['tcpOptions']['destinationPortRange']['max'] >= 23 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 135 && _['tcpOptions']['destinationPortRange']['max'] >= 135 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 137 && _['tcpOptions']['destinationPortRange']['max'] >= 137 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 138 && _['tcpOptions']['destinationPortRange']['max'] >= 138 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 139 && _['tcpOptions']['destinationPortRange']['max'] >= 139 ||
-        _['tcpOptions']['destinationPortRange']['min'] <= 445 && _['tcpOptions']['destinationPortRange']['max'] >= 445
+        destinationPortMin <= 21 && destinationPortMax >= 21 ||
+        destinationPortMin <= 23 && destinationPortMax >= 23 ||
+        destinationPortMin <= 135 && destinationPortMax >= 135 ||
+        destinationPortMin <= 137 && destinationPortMax >= 137 ||
+        destinationPortMin <= 138 && destinationPortMax >= 138 ||
+        destinationPortMin <= 139 && destinationPortMax >= 139 ||
+        destinationPortMin <= 445 && destinationPortMax >= 445
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")


### PR DESCRIPTION
Improves two families of checks in `mondoo-oci-security` using OCI provider fields added to mql in the last two weeks.

- **iam-no-overly-permissive / broad-compartment / any-user / cross-tenant policies** — match parsed `policy.parsedStatements` (`verb`, `resourceType`, `scopeType`, `subjectType`, `effect`) instead of raw-text regexes, removing false negatives from reordered wording, comma-separated principals, nested compartment paths, and the `endorse`/`admit` cross-tenant forms.
- **vcn/nsg unrestricted-ingress checks** — use the typed `oci.network` security rules (`source`, `protocol`, `destinationPortMin`/`destinationPortMax`) with uniform null-bound = all-ports semantics, replacing the deep `tcpOptions` dict navigation and its hand-rolled special cases.

Terraform variants untouched.

---
> **Heads-up on CI:** these checks reference OCI provider fields that landed in mql only recently, so this PR's content-lint will stay red until the `oci` provider release ships these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_