### PR TITLE
OpenStack security: address-group-aware public-source detection

### DIFF
--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -934,7 +934,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on port 22 from the public internet at `0.0.0.0/0` or `::/0`. SSH exposed to the entire internet is a primary target for automated attacks against the SSH daemon.
+        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on port 22 from a public source. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). SSH exposed to the entire internet is a primary target for automated attacks against the SSH daemon.
 
         **Why this matters**
 
@@ -1002,14 +1002,14 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 22 && portRangeMax >= 22
         )
       )
   - uid: mondoo-openstack-security-no-unrestricted-ssh-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
         portRangeMin <= 22 && portRangeMax >= 22
       )
   - uid: mondoo-openstack-security-no-unrestricted-ssh-terraform-hcl
@@ -1193,7 +1193,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on port 3389 from the public internet at `0.0.0.0/0` or `::/0`. RDP exposed to the entire internet is one of the most actively exploited remote-management surfaces.
+        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on port 3389 from a public source. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). RDP exposed to the entire internet is one of the most actively exploited remote-management surfaces.
 
         **Why this matters**
 
@@ -1261,14 +1261,14 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 3389 && portRangeMax >= 3389
         )
       )
   - uid: mondoo-openstack-security-no-unrestricted-rdp-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
         portRangeMin <= 3389 && portRangeMax >= 3389
       )
   - uid: mondoo-openstack-security-no-unrestricted-rdp-terraform-hcl
@@ -1330,7 +1330,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on the Windows Remote Management ports 5985 (HTTP) or 5986 (HTTPS) from the public internet at `0.0.0.0/0` or `::/0`. WinRM drives PowerShell Remoting and remote administration on Windows hosts, so an internet-exposed listener is a direct path to remote command execution.
+        This check ensures that no Neutron security group has an ingress rule that allows TCP traffic on the Windows Remote Management ports 5985 (HTTP) or 5986 (HTTPS) from a public source. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). WinRM drives PowerShell Remoting and remote administration on Windows hosts, so an internet-exposed listener is a direct path to remote command execution.
 
         **Why this matters**
 
@@ -1398,7 +1398,7 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 5985 && portRangeMax >= 5985 ||
           portRangeMin <= 5986 && portRangeMax >= 5986
         )
@@ -1406,7 +1406,7 @@ queries:
   - uid: mondoo-openstack-security-no-unrestricted-winrm-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
         portRangeMin <= 5985 && portRangeMax >= 5985 ||
         portRangeMin <= 5986 && portRangeMax >= 5986
       )
@@ -1472,7 +1472,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows traffic from the public internet at `0.0.0.0/0` or `::/0` to common database ports, covering MySQL and MariaDB on 3306, PostgreSQL on 5432, MongoDB on 27017, Redis on 6379, Memcached on 11211, Elasticsearch on 9200, Microsoft SQL Server on 1433, and Oracle on 1521. Database services assume a private network for their authentication, encryption defaults, and patching cadence.
+        This check ensures that no Neutron security group has an ingress rule that allows traffic from a public source to common database ports, covering MySQL and MariaDB on 3306, PostgreSQL on 5432, MongoDB on 27017, Redis on 6379, Memcached on 11211, Elasticsearch on 9200, Microsoft SQL Server on 1433, and Oracle on 1521. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). Database services assume a private network for their authentication, encryption defaults, and patching cadence.
 
         **Why this matters**
 
@@ -1540,7 +1540,7 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 3306 && portRangeMax >= 3306 ||
           portRangeMin <= 5432 && portRangeMax >= 5432 ||
           portRangeMin <= 27017 && portRangeMax >= 27017 ||
@@ -1554,7 +1554,7 @@ queries:
   - uid: mondoo-openstack-security-no-unrestricted-db-ports-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
         portRangeMin <= 3306 && portRangeMax >= 3306 ||
         portRangeMin <= 5432 && portRangeMax >= 5432 ||
         portRangeMin <= 27017 && portRangeMax >= 27017 ||
@@ -1644,7 +1644,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows traffic from the public internet at `0.0.0.0/0` or `::/0` to container and cluster orchestration control planes, covering the Kubernetes API server on 6443, the kubelet API on 10250, etcd on 2379 and 2380, and the Docker daemon on 2375 and 2376. These endpoints expose cluster control and container runtimes that assume a private management network.
+        This check ensures that no Neutron security group has an ingress rule that allows traffic from a public source to container and cluster orchestration control planes, covering the Kubernetes API server on 6443, the kubelet API on 10250, etcd on 2379 and 2380, and the Docker daemon on 2375 and 2376. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). These endpoints expose cluster control and container runtimes that assume a private management network.
 
         **Why this matters**
 
@@ -1714,7 +1714,7 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+        rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
           portRangeMin <= 6443 && portRangeMax >= 6443 ||
           portRangeMin <= 10250 && portRangeMax >= 10250 ||
           portRangeMin <= 2379 && portRangeMax >= 2379 ||
@@ -1726,7 +1726,7 @@ queries:
   - uid: mondoo-openstack-security-no-unrestricted-mgmt-ports-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").where(protocol == "tcp" || protocol == "").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).where(protocol == "tcp" || protocol == "").none(
         portRangeMin <= 6443 && portRangeMax >= 6443 ||
         portRangeMin <= 10250 && portRangeMax >= 10250 ||
         portRangeMin <= 2379 && portRangeMax >= 2379 ||
@@ -1808,7 +1808,7 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no Neutron security group has an ingress rule that allows the full port range from the public internet at `0.0.0.0/0` or `::/0`. In Neutron, leaving `port_range_min` and `port_range_max` unset means the rule matches every port.
+        This check ensures that no Neutron security group has an ingress rule that allows the full port range from a public source. A source counts as public when it is a broad prefix such as `0.0.0.0/0` or `::/0`, when it is a remote address group that holds such a range, or when the rule is left unscoped with no remote at all (which Neutron treats as any source). In Neutron, leaving `port_range_min` and `port_range_max` unset means the rule matches every port.
 
         **Why this matters**
 
@@ -1878,7 +1878,7 @@ queries:
     filters: asset.platform == "openstack-project"
     mql: |
       openstack.securityGroups.all(
-        rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").none(
+        rules.where(direction == "ingress").where(includesPublicSource).none(
           portRangeMin == 0 && portRangeMax == 0 ||
           portRangeMin <= 1 && portRangeMax >= 65535
         )
@@ -1886,7 +1886,7 @@ queries:
   - uid: mondoo-openstack-security-no-all-ports-open-openstack-security-group
     filters: asset.platform == "openstack-security-group"
     mql: |
-      openstack.securityGroup.rules.where(direction == "ingress").where(remoteIpPrefix == "0.0.0.0/0" || remoteIpPrefix == "::/0").none(
+      openstack.securityGroup.rules.where(direction == "ingress").where(includesPublicSource).none(
         portRangeMin == 0 && portRangeMax == 0 ||
         portRangeMin <= 1 && portRangeMax >= 65535
       )


### PR DESCRIPTION
Improves the public-ingress security-group checks in `mondoo-openstack-security` using an OpenStack provider field added to mql in the last two weeks.

- **no-unrestricted ssh / rdp / winrm / db-ports / mgmt-ports / all-ports-open** — match the rule's `includesPublicSource` verdict instead of `remoteIpPrefix`. This closes a failed-open gap: a rule whose source is a **remote address group** containing `0.0.0.0/0`, or a rule left unscoped with no remote at all (which Neutron treats as any source), was previously read as non-public and passed.

Both the project-scoped and per-security-group variants are updated; descriptions updated to describe the broadened source detection. Terraform variants untouched.

---
> **Heads-up on CI:** these checks reference an OpenStack provider field that landed in mql only recently, so this PR's content-lint will stay red until the `openstack` provider release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_