### PR TITLE
Okta security: flag group owners on admin groups

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -121,11 +121,14 @@ queries:
       desc: |
         This check ensures that the number of super admins in your Okta org is kept to the minimum required for operations. The super admin role holds the highest permissions of any admin role, so a large pool of super admins greatly widens the blast radius of a compromised account.
 
+        The check also confirms that groups carrying the super admin role have no group owners. Group ownership is an indirect grant: an owner can add members, and those members inherit every administrator role the group carries. A super admin group with owners therefore has a hidden set of principals who can expand super admin access at will, which the member count alone does not capture.
+
         **Why this matters**
 
         - **Least privilege:** Restricting super admin assignments keeps broad control of the org in the hands of only those who genuinely need it.
         - **Reduced attack surface:** Fewer super admin accounts means fewer high-value targets for attackers to phish or take over.
         - **Clear accountability:** A small, well-defined set of super admins makes it easier to audit who can change critical org settings.
+        - **No hidden expansion:** Blocking owners on super admin groups stops principals outside the counted membership from silently granting themselves or others super admin.
         - **Containment:** Most administrative tasks can be performed with scoped roles, leaving super admin access reserved for exceptional needs.
 
         **Risk mitigation**
@@ -178,7 +181,7 @@ queries:
         title: Super Administrators
   - uid: mondoo-okta-security-limit-super-admins-api
     filters: asset.platform == "okta-org"
-    mql: okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < props.mondooOktaSecurityMaxOktaSuperAdmins )
+    mql: okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < props.mondooOktaSecurityMaxOktaSuperAdmins && owners.length == 0)
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses
     title: Enable Okta ThreatInsight to block suspicious IP addresses
     impact: 100
@@ -3806,11 +3809,14 @@ queries:
       desc: |
         This check ensures that the number of users holding the Organization Administrator role stays within a safe threshold. The Organization Administrator role grants nearly the same access as the Super Administrator, covering management of users, groups, applications, and most organizational settings.
 
+        The check also confirms that groups carrying the org admin role have no group owners. Group ownership is an indirect grant: an owner can add members, and those members inherit every administrator role the group carries. An org admin group with owners therefore has a hidden set of principals who can expand org admin access beyond the counted membership.
+
         **Why this matters**
 
         - **Broad access:** Org admins can modify user accounts, reset credentials, assign applications, and change group memberships across the whole organization.
         - **High-value targets:** The breadth of org admin access makes these accounts attractive targets for attackers seeking maximum impact.
         - **Lateral movement:** A compromised org admin account lets an attacker escalate privileges and create backdoor accounts.
+        - **No hidden expansion:** Blocking owners on org admin groups stops principals outside the counted membership from silently granting org admin.
 
         **Risk mitigation**
 
@@ -3854,4 +3860,4 @@ queries:
         title: Administrator Role Comparison
   - uid: mondoo-okta-security-limit-org-admins-api
     filters: asset.platform == "okta-org"
-    mql: okta.groups.where(roles.contains(type == "ORG_ADMIN")).all(members.length < props.maxOrgAdmins)
+    mql: okta.groups.where(roles.contains(type == "ORG_ADMIN")).all(members.length < props.maxOrgAdmins && owners.length == 0)


### PR DESCRIPTION
Improves two checks in `mondoo-okta-security` using an Okta provider field added to mql in the last two weeks.

- **limit-super-admins-api** and **limit-org-admins-api** — in addition to bounding the member count, require groups carrying the super-admin / org-admin role to have no group **owners** (`okta.group.owners`). Group ownership is an indirect grant: an owner can add members, and those members inherit every admin role the group carries, so a member-count check alone under-bounds who really holds the role.

Descriptions updated. API variant only (the Terraform siblings cannot observe runtime ownership).

---
> **Heads-up on CI:** these checks reference an Okta provider field that landed in mql only recently, so this PR's content-lint will stay red until the `okta` provider release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_