### PR TITLE
Snowflake security: count effective ACCOUNTADMIN users

### DIFF
--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -239,10 +239,12 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      snowflake.account.roles.where(name == "ACCOUNTADMIN").all(assignedToUsers <= 3)
+      snowflake.account.roles.where(name == "ACCOUNTADMIN").all(effectiveUsers.length <= 3)
     docs:
       desc: |
-        This check ensures that the ACCOUNTADMIN role is configured to be granted to no more than three users. ACCOUNTADMIN holds the highest privilege level in Snowflake, so keeping its membership small enforces the principle of least privilege and shrinks the attack surface.
+        This check ensures that the ACCOUNTADMIN role is effectively held by no more than three users. ACCOUNTADMIN holds the highest privilege level in Snowflake, so keeping its membership small enforces the principle of least privilege and shrinks the attack surface.
+
+        The count includes every user who reaches ACCOUNTADMIN, whether granted the role directly or through an intermediate role in the role hierarchy. Because Snowflake roles can be nested, a user granted a custom role that has in turn been granted ACCOUNTADMIN holds the role in full even though no direct assignment records it. Counting only direct grants would undercount the true set of account administrators.
 
         **Why this matters**
 


### PR DESCRIPTION
Improves one check in `mondoo-snowflake-security` using a Snowflake provider field added to mql in the last two weeks.

- **accountadmin-role-limited** — count `role.effectiveUsers` instead of `assignedToUsers`. Because Snowflake roles nest, a user granted a custom role that has in turn been granted ACCOUNTADMIN holds the role in full even with no direct assignment; the direct count undercounts the true set of account administrators.

Description updated.

---
> **Heads-up on CI:** this check references a Snowflake provider field that landed in mql only recently, so this PR's content-lint will stay red until the `snowflake` provider release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_