### PR TITLE
Vercel security: detect firewall bypass rules

### DIFF
--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -870,7 +870,7 @@ queries:
         title: Vercel Web Application Firewall documentation
 
   - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow
-    title: Ensure no firewall IP rule allows all source addresses
+    title: Ensure no firewall IP or bypass rule allows all source addresses
     impact: 80
     tags:
       compliance/bsi-sys-1-5: false
@@ -889,28 +889,31 @@ queries:
     mql: |
       vercel.project.firewall.ipRules.none(action == "allow" && ip == "0.0.0.0/0")
       vercel.project.firewall.ipRules.none(action == "allow" && ip == "::/0")
+      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "0.0.0.0/0")
+      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "::/0")
     docs:
       desc: |
-        This check ensures that the project's firewall has no IP rule that allows every source address. An allow rule matching `0.0.0.0/0` or `::/0` waves through all traffic from that address family, which can override deny rules and managed protections and effectively neutralize the firewall.
+        This check ensures that the project's firewall has no IP rule or system bypass rule that applies to every source address. An IP allow rule matching `0.0.0.0/0` or `::/0` waves through all traffic from that address family, which can override deny rules and managed protections. A system bypass rule is even stronger: it short-circuits every firewall rule for the traffic it matches, so a bypass entry covering all addresses neutralizes the firewall regardless of how the rest of it is configured.
 
         **Why this matters**
 
         - **An allow-all rule bypasses protections:** A rule that permits every address can take precedence over deny rules and rulesets.
-        - **It hides as a specific exception:** A broad allow entry looks like a scoped exception in a rule list but matches everyone.
-        - **Attack traffic is explicitly welcomed:** Allowing all sources removes the firewall's ability to block known-bad clients by IP.
+        - **A broad bypass entry disables the firewall:** A system bypass rule skips all rule evaluation for matching traffic, so one covering every address exempts everyone from filtering.
+        - **It hides as a specific exception:** A broad allow or bypass entry looks like a scoped exception in a rule list but matches everyone.
+        - **Attack traffic is explicitly welcomed:** Allowing or exempting all sources removes the firewall's ability to block known-bad clients by IP.
 
         **Risk mitigation**
 
-        - **Remove blanket allow rules:** Delete any IP allow rule matching `0.0.0.0/0` or `::/0`.
-        - **Scope allow rules narrowly:** Replace broad entries with the specific ranges that genuinely need to bypass filtering.
+        - **Remove blanket allow and bypass rules:** Delete any IP allow rule or system bypass rule matching `0.0.0.0/0` or `::/0`.
+        - **Scope exceptions narrowly:** Replace broad entries with the specific ranges that genuinely need to bypass filtering.
       audit: |
         ### Audit via Dashboard
 
         1. Sign in to the Vercel dashboard at vercel.com.
         2. Open the project, then go to the **Firewall** tab.
-        3. Review the IP rules for any allow entry covering all addresses.
+        3. Review the IP rules for any allow entry covering all addresses, and review the system bypass rules for any bypass entry covering all addresses.
 
-        A passing result shows no allow rule matching `0.0.0.0/0` or `::/0`; a failing result shows such a rule.
+        A passing result shows no allow rule and no bypass rule matching `0.0.0.0/0` or `::/0`; a failing result shows such a rule.
 
         ### Audit via API
 
@@ -924,11 +927,11 @@ queries:
       remediation:
         - id: console
           desc: |
-            To remove a broad allow rule using the Vercel dashboard:
+            To remove a broad allow or bypass rule using the Vercel dashboard:
 
             1. Open the project and go to the **Firewall** tab.
-            2. Locate any IP allow rule matching `0.0.0.0/0` or `::/0`.
-            3. Delete the rule, or narrow it to the specific ranges that need to bypass filtering.
+            2. Locate any IP allow rule matching `0.0.0.0/0` or `::/0`, and any system bypass rule matching `0.0.0.0/0` or `::/0`.
+            3. Delete the rule, or narrow it to the specific ranges that genuinely need to bypass filtering.
         - id: api
           desc: |
             To remove a broad IP allow rule through the REST API, delete it by its rule identifier:


### PR DESCRIPTION
Improves one check in `mondoo-vercel-security` using a Vercel provider field added to mql in the last two weeks.

- **project-firewall-no-broad-ip-allow** — in addition to the IP allow rules, also flag `firewall.bypassRules` that match all source addresses (`0.0.0.0/0` / `::/0`). A system bypass rule short-circuits *all* firewall evaluation for its traffic, so a broad one neutralizes the firewall regardless of the IP rules. **Retitled**; description, audit, and remediation updated.

---
> **Heads-up on CI:** this check references a Vercel provider field that landed in mql only recently, so this PR's content-lint will stay red until the `vercel` provider release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_