### PR TITLE
MongoDB Atlas security: cover Flex clusters

### DIFF
--- a/content/mondoo-mongodbatlas-security.mql.yaml
+++ b/content/mondoo-mongodbatlas-security.mql.yaml
@@ -1198,9 +1198,12 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       mongodbatlas.clusters.all(backupEnabled == true)
+      mongodbatlas.flexClusters.all(backupEnabled == true)
     docs:
       desc: |
-        This check verifies that cloud backup is enabled on every database deployment in the project. When `backupEnabled` is false, Atlas takes no managed snapshots of the cluster, so there is no restore point if data is corrupted, deleted, or lost. Enabling cloud backup lets the team recover a cluster to a recent snapshot and is a foundational control for data availability and resilience.
+        This check verifies that cloud backup is enabled on every database deployment in the project, covering both standard clusters and Flex clusters. When `backupEnabled` is false, Atlas takes no managed snapshots of the deployment, so there is no restore point if data is corrupted, deleted, or lost. Enabling cloud backup lets the team recover a deployment to a recent snapshot and is a foundational control for data availability and resilience.
+
+        Flex clusters are a separate deployment type from standard clusters and are reported through their own collection, so a deployment left as Flex is only evaluated when Flex clusters are checked explicitly.
 
         **Why this matters**
 
@@ -1344,9 +1347,12 @@ queries:
       compliance/vda-isa-5: false
     mql: |
       mongodbatlas.clusters.all(terminationProtectionEnabled == true)
+      mongodbatlas.flexClusters.all(terminationProtectionEnabled == true)
     docs:
       desc: |
-        This check verifies that termination protection is enabled on every database deployment. When `terminationProtectionEnabled` is true, Atlas blocks a delete request for the cluster until protection is explicitly removed first, which prevents accidental or unauthorized destruction of a live data store. Without this guardrail, a single mistaken action or a compromised credential can permanently remove a cluster and its data.
+        This check verifies that termination protection is enabled on every database deployment, covering both standard clusters and Flex clusters. When `terminationProtectionEnabled` is true, Atlas blocks a delete request for the deployment until protection is explicitly removed first, which prevents accidental or unauthorized destruction of a live data store. Without this guardrail, a single mistaken action or a compromised credential can permanently remove a deployment and its data.
+
+        Flex clusters are a separate deployment type from standard clusters and are reported through their own collection, so a deployment left as Flex is only evaluated when Flex clusters are checked explicitly.
 
         **Why this matters**
 


### PR DESCRIPTION
Improves two checks in `mondoo-mongodbatlas-security` using a MongoDB Atlas provider field added to mql in the last two weeks.

- **project-cluster-backup-enabled** and **project-cluster-termination-protection** — also evaluate `mongodbatlas.flexClusters`, a separate deployment collection that the standard `mongodbatlas.clusters` checks never saw, so a deployment left as Flex was silently unevaluated.

Descriptions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
