### PR TITLE
Arista EOS security: use typed AAA, logging, NTP, and banner resources

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -478,7 +478,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      arista.eos.runningConfig.content.lines.one(_ == "aaa authorization console")
+      arista.eos.aaa.authorizationConsoleCommands != empty
     docs:
       desc: |
         This check verifies that AAA authorization is enabled for console access. Console authorization controls which commands users can execute after they authenticate, enforcing the principle of least privilege.
@@ -1209,7 +1209,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.any(_ == /^logging host/)
+      arista.eos.logging.hosts.length > 0
     docs:
       desc: |
         This check verifies that logs are sent to a remote syslog server for centralized management. Sending logs off-device protects them from loss due to device failure or compromise and enables correlation across the network.
@@ -1338,8 +1338,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      arista.eos.runningConfig.content.lines.any(_ == /^banner login/)
-      arista.eos.runningConfig.content.contains("no banner login") == false
+      arista.eos.loginBanner.length > 0
     docs:
       desc: |
         This check verifies that a login banner is configured to display legal notice. A login banner communicates that the device is for authorized use only and that activity may be monitored, which is important for legal protection.
@@ -1481,8 +1480,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      arista.eos.runningConfig.content.lines.any(_ == /^banner motd/)
-      arista.eos.runningConfig.content.contains("no banner motd") == false
+      arista.eos.motdBanner.length > 0
     docs:
       desc: |
         This check verifies that a message-of-the-day (MOTD) banner is configured. An MOTD banner communicates important information to users upon login, including security policies, support contacts, and maintenance schedules.
@@ -1750,7 +1748,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
     mql: |
-      arista.eos.runningConfig.content.lines.any(_ == /^ntp server/)
+      arista.eos.ntp.servers.length > 0
     docs:
       desc: |
         This check verifies that NTP servers are configured for time synchronization. Having explicitly configured NTP servers ensures the device synchronizes with trusted, reliable time sources.


### PR DESCRIPTION
Improves five checks in `mondoo-arista-eos-security` using typed Arista EOS resources added to mql in the last two weeks.

- **aaa-authorization-console** → `arista.eos.aaa.authorizationConsoleCommands`
- **logging-host-configured** → `arista.eos.logging.hosts`
- **ntp-servers-configured** → `arista.eos.ntp.servers`
- **login-banner-configured** / **motd-banner-configured** → `arista.eos.loginBanner` / `motdBanner`

Each migrates off brittle running-config text matching (`runningConfig.content.lines...`) to the typed field, preserving the original presence semantics. Titles unchanged.

---
> **Heads-up on CI:** these checks reference Arista provider fields that landed in mql only recently, so this PR's content-lint will stay red until the `arista` provider release ships these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_