### PR TITLE
STACKIT security: prefer private SKE control plane

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -1516,15 +1516,18 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
-      stackit.ske.cluster.apiServerAclEnabled == true
+      stackit.ske.cluster.controlPlaneAccessScope == "SNA" ||
+      stackit.ske.cluster.apiServerAclEnabled == true &&
+      stackit.ske.cluster.apiServerAclAllowedCidrs.none(_ == "0.0.0.0/0" || _ == "::/0")
     docs:
       desc: |
-        This check ensures that a STACKIT Kubernetes Engine (SKE) cluster has the API-server access-control list (ACL) enabled. With the ACL disabled, the cluster's Kubernetes API server is reachable from any source address, exposing the control plane to the entire internet.
+        This check ensures that a STACKIT Kubernetes Engine (SKE) cluster does not leave its Kubernetes API server open to the internet. The strongest posture is a private control plane: when `controlPlaneAccessScope` is `SNA`, the API server answers only from inside the attached STACKIT network and is never reachable from the internet. When the control plane is `PUBLIC`, the API server is published on the internet and is only as restricted as its access-control list (ACL) makes it, so the check then requires the ACL to be enabled and its allowed source ranges to exclude `0.0.0.0/0` and `::/0`. A PUBLIC control plane with the ACL disabled, or an ACL that admits any address, exposes the control plane to the entire internet.
 
         **Why this matters**
 
-        - **Control-plane exposure:** An unrestricted API server is continuously scanned and is a primary target for credential and exploit attacks.
-        - **Defense in depth:** An IP allow-list ensures only known networks can even attempt to authenticate to the cluster.
+        - **Private is stronger than filtered:** An `SNA` control plane is not published on the internet at all, which removes the API server from internet-wide scanning entirely rather than relying on an allow-list to filter it.
+        - **Control-plane exposure:** A PUBLIC, unrestricted API server is continuously scanned and is a primary target for credential and exploit attacks.
+        - **Defense in depth:** Where the control plane must remain public, an IP allow-list that excludes the open-internet ranges ensures only known networks can even attempt to authenticate to the cluster.
       remediation:
         - id: console
           desc: |


### PR DESCRIPTION
Improves one check in `mondoo-stackit-security` using a STACKIT provider field added to mql in the last two weeks.

- **ske-apiserver-acl-enabled** — pass when `controlPlaneAccessScope == "SNA"` (the API server answers only from inside the attached STACKIT network, the strongest posture); otherwise, for a `PUBLIC` control plane, require the ACL enabled with its allowed CIDRs excluding `0.0.0.0/0` and `::/0`. `apiServerAclEnabled` alone couldn't tell you whether the API server was published to the internet at all. Description updated.

---
> **Heads-up on CI:** this check references a STACKIT provider field that landed in mql only recently, so this PR's content-lint will stay red until the `stackit` provider release ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk

---
_Generated by [Claude Code](https://claude.ai/code/session_014b3xEcxLyvaRwmFzoazLuk)_