### PR TITLE
🐛 policy: make query compile order deterministic

### DIFF
--- a/policy/bundle.go
+++ b/policy/bundle.go
@@ -706,10 +706,17 @@ func topologicalSortQueries(queries []*Mquery) ([]*Mquery, error) {
 		queriesMap[q.Mrn] = q
 	}
 
-	// Topologically sort the queries
+	// Topologically sort the queries. Seed the traversal from the input slice,
+	// not from queriesMap: Go randomizes map iteration order, so seeding from
+	// the map makes the resulting compile order differ between runs. Compile
+	// order is observable, because compiling a query appends to the `for` list
+	// of any policy property it implicitly references.
 	sorted := &Mqueries{}
 	visited := map[string]struct{}{}
-	for _, q := range queriesMap {
+	for _, q := range queries {
+		if q == nil {
+			continue
+		}
 		err := topologicalSortQueriesDFS(q.Mrn, queriesMap, visited, sorted)
 		if err != nil {
 			return nil, err

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -876,3 +876,57 @@ queries:
 		require.Equal(t, string(llxtypes.String), query.Props[0].Type)
 	}
 }
+
+func TestProps_ImplicitPropsOrderIsDeterministic(t *testing.T) {
+	// Compiling a query appends to the `for` list of every policy property it
+	// implicitly references, so the `for` order is a function of the order in
+	// which queries get compiled. That order used to be seeded from a map, which
+	// Go deliberately randomizes, so the same bundle compiled twice could produce
+	// two different `for` orders. Repeat the compile to catch a reintroduction:
+	// a single run reproduced the old bug only about one time in ten.
+	bundleYaml := `
+policies:
+  - uid: example1
+    name: Example policy 1
+    version: "1.0.0"
+    groups:
+      - title: group1
+        filters: return true
+        checks:
+          - uid: check-1
+          - uid: check-2
+          - uid: check-3
+    props:
+      - uid: crontabDir
+        mql: return "/etc/cron.d"
+
+queries:
+  - uid: check-1
+    mql: props.crontabDir != ""
+  - uid: check-2
+    mql: props.crontabDir == "/etc/cron.d"
+  - uid: check-3
+    mql: props.crontabDir != "/tmp"`
+
+	compileOrder := func() []string {
+		b, err := policy.BundleFromYAML([]byte(bundleYaml))
+		require.NoError(t, err)
+		_, err = b.CompileExt(context.Background(), policy.BundleCompileConf{
+			CompilerConfig: conf,
+		})
+		require.NoError(t, err)
+
+		require.Len(t, b.Policies[0].Props, 1)
+		order := []string{}
+		for _, ref := range b.Policies[0].Props[0].For {
+			order = append(order, ref.Mrn)
+		}
+		return order
+	}
+
+	want := compileOrder()
+	require.Len(t, want, 3)
+	for i := 0; i < 25; i++ {
+		require.Equal(t, want, compileOrder(), "property `for` order changed between compiles of the same bundle")
+	}
+}


### PR DESCRIPTION
## Problem

`TestProps_ImplicitPropsOnSharedQueries` fails intermittently, blocking unrelated PRs (seen on #2735 and #3219 in the last day). Measured locally at **~8%** (23/25 passing).

```
Error: Not equal:
  expected: ".../queries/check-2/properties/crontabDir"
  actual  : ".../queries/check-1/properties/crontabDir"
```

## Root cause

`topologicalSortQueries` seeded its DFS by ranging over `queriesMap`:

```go
for _, q := range queriesMap {   // Go randomizes map iteration order
    err := topologicalSortQueriesDFS(q.Mrn, queriesMap, visited, sorted)
```

The sorted result drives the order `compileQueries` compiles queries in, and compiling a query appends to the `for` list of every policy property it *implicitly* references (`bundle.go`, in the implicit-property path: `found.prop.For = append(found.prop.For, ...)`).

So query compile order is observable in the output, and the same bundle compiled twice could yield two different orderings of `Property.For`. The test pairs `policyProp.For[i]` with `b.Queries[i]` **by index**, so it fails whenever the two disagree.

Worth noting the visible symptom is misleading: `b.Queries` is stable across compiles. Instrumenting 40 compiles showed `b.Queries` identical 40/40 while `prop.For` varied 36/4 — the topologically sorted slice is local to `compileQueries` and never replaces `b.Queries`. It leaks out only through compile order.

## Fix

Seed the traversal from the input slice, which is already in stable declaration order. Variant ordering is unaffected: the DFS still emits every variant before the query that includes it, since that ordering comes from the recursion, not the seed order.

## Verification

- Flaky test: **23/25 → 40/40** passing.
- Instrumented harness: `prop.For` order went from 2 distinct orderings over 40 compiles to 1.
- New regression test fails on unfixed code, passes on fixed code (verified by stashing the fix).
- `go test ./policy/... -count=3` passes.

The regression test repeats the compile 25 times because a single compile reproduced the old bug only about one in ten runs.

## Not addressed here

`TestNextAvailableFilename` (`policy/scan/pdque`) is *also* flaky — a timestamp-collision issue, ~45% locally. Confirmed pre-existing and unrelated: it fails at statistically identical rates with and without this change (7/15 on main vs 6/15 here). Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)