### PR TITLE
🌟 scandb content checksums + upload wire surface (unchanged-scan short-circuit)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260808001139-ef2a665833b7
-	go.mondoo.com/mql/v13 v13.34.1
+	go.mondoo.com/mql/v13 v13.34.2-0.20260818034035-c1b8ec01406c
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1080,8 +1080,12 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260808001139-ef2a665833b7 h1:4XvjK+Hng0qCDb2i4LkniOgjS/vioUUxl9wnHDU5RFc=
 go.mondoo.com/mondoo-go v0.0.0-20260808001139-ef2a665833b7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.34.1 h1:d6vma34ttZVUNVicSqWOUgkbHTEbHb2egVV4b5idWyA=
-go.mondoo.com/mql/v13 v13.34.1/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
+go.mondoo.com/mql/v13 v13.34.0 h1:3yccoUH+NSJPiKNTqPmRJOf+U5ymOgLkPn9QqWZR2P0=
+go.mondoo.com/mql/v13 v13.34.0/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
+go.mondoo.com/mql/v13 v13.34.2-0.20260818032626-ced5daaf19ec h1:7Up+Rgsn+UOOefhBmQAHeRFiIPQCJhT4GNKXu/ndmpg=
+go.mondoo.com/mql/v13 v13.34.2-0.20260818032626-ced5daaf19ec/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
+go.mondoo.com/mql/v13 v13.34.2-0.20260818034035-c1b8ec01406c h1:2Cj8WDWHOZm9Q3PiePtBYWKVM1EfXv2g21sSsSS8CTw=
+go.mondoo.com/mql/v13 v13.34.2-0.20260818034035-c1b8ec01406c/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -17,6 +17,7 @@ import (
 	"go.mondoo.com/cnspec/v13/policy/scandb"
 	"go.mondoo.com/cnspec/v13/policy/scanstats"
 	"go.mondoo.com/cnspec/v13/upload"
+	mql "go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
@@ -59,7 +60,19 @@ func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Ass
 	if asset != nil {
 		assetMrn = asset.Mrn
 	}
-	err := withSqliteDataStore(ctx, assetMrn, func(scanDataStore *scandb.SqliteScanDataStore) error {
+	// Write-time scan-content checksums: every row is hashed as it is
+	// written (no second pass over the database). Gated by the
+	// server-activated ScanContentMode* features (layered onto ctx from
+	// ScanParameters.enabled_features) — zero checksum work when the scope
+	// hasn't opted in — and on the file having somewhere to go: a temp
+	// database with no upstream and no --output-scan-db directory is
+	// deleted moments later, so checksumming it is pure waste. Checksum
+	// work can never fail a scan: hash errors are counted (and leave the
+	// file unstamped, fail-open), reported below, never propagated.
+	checksumsEnabled := (upstreamClient != nil || outputDirFromCtx(ctx) != "") &&
+		mql.GetFeatures(ctx).ScanContentChecksumsActive()
+
+	err := withSqliteDataStore(ctx, assetMrn, checksumsEnabled, func(scanDataStore *scandb.SqliteScanDataStore) error {
 		// Persist the inventory.Asset proto so the scan database is self-contained
 		// (consumed by the cnspec loadtest tool to replay against SynchronizeAssets).
 		if asset != nil {
@@ -98,8 +111,37 @@ func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Ass
 		}
 		stats.AddDuration(scanstats.MetricScanDuration, time.Since(scanStart))
 
-		// Snapshot process memory as of this asset's completion. The values
-		// are process-wide, not this asset's cost — see ADR-0004.
+		// Report the write-time checksum activity. The cost rides the
+		// uploaded statistics — shadow mode exists to measure exactly this,
+		// so a local log line is not enough — and so does the failure count:
+		// hash errors never fail a scan (the row is stored without a
+		// checksum and Finalize leaves the file unstamped, fail-open), which
+		// makes the uploaded error metric the only way a silent hashing
+		// problem becomes visible fleet-wide.
+		if checksumsEnabled {
+			// The one stamp call: this seam runs for every scan — with an
+			// upstream (before Finalize/upload) and without one (kept
+			// --output-scan-db files never see Finalize) — so stamping here,
+			// and only here, covers both paths.
+			scanDataStore.StampChecksums()
+			cs := scanDataStore.WriteChecksumStats()
+			stats.AddDuration(scanstats.MetricChecksumDuration, cs.Duration)
+			stats.AddInt(scanstats.MetricChecksumErrors, "count", cs.Errors)
+			evt := log.Info()
+			if cs.Errors > 0 {
+				evt = log.Warn()
+			}
+			evt.
+				Str("checksummedRows", cs.Counts.String()).
+				Int64("failures", cs.Errors).
+				Dur("hashDuration", cs.Duration).
+				Msg("scan content checksums computed at write time")
+		}
+
+		// Snapshot process memory and CPU as of this asset's completion —
+		// after the checksum pass, so the pass's cost shows up in the
+		// snapshot instead of hiding behind it. The values are process-wide,
+		// not this asset's cost — see ADR-0004.
 		recordResourceStats(scanCtx, stats)
 
 		if upstream != nil {
@@ -121,7 +163,7 @@ func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Ass
 	return nil
 }
 
-func withSqliteDataStore(ctx context.Context, assetMrn string, f func(scanDataStore *scandb.SqliteScanDataStore) error) error {
+func withSqliteDataStore(ctx context.Context, assetMrn string, enableChecksums bool, f func(scanDataStore *scandb.SqliteScanDataStore) error) error {
 	// When the scan ctx carries an output dir (set via WithOutputDir from the
 	// `cnspec scan --output-scan-db` flag), write the scan db there and keep
 	// it after upload. Otherwise create a temp file we delete.
@@ -159,7 +201,11 @@ func withSqliteDataStore(ctx context.Context, assetMrn string, f func(scanDataSt
 		}
 	}()
 
-	scanDataStore, err := scandb.NewSqliteScanDataStore(tmpFile.Name(), assetMrn)
+	var opts []scandb.StoreOption
+	if enableChecksums {
+		opts = append(opts, scandb.WithWriteTimeChecksums())
+	}
+	scanDataStore, err := scandb.NewSqliteScanDataStore(tmpFile.Name(), assetMrn, opts...)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to create scan data store")
 		return err

--- a/policy/checksum/checksum.go
+++ b/policy/checksum/checksum.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package checksum computes the scan-content checksums for the row types
+// that live in cnspec — scores and scored risk factors. It builds on mql's
+// llx/checksum, which owns the hash writer, the llx canonicalization, and
+// the data/resource row checksums; this package adds exactly what cannot
+// live there without a dependency cycle (mql cannot import cnspec's policy
+// protos). The server imports both packages and re-implements neither.
+//
+// The canonicalization rules (explicit canon, no reflection, multiset
+// lists, length-prefixed writes) and the AlgoVersion are llx/checksum's;
+// see that package's doc.
+package checksum
+
+import (
+	"go.mondoo.com/cnspec/v13/policy"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
+)
+
+// canonScoredRiskFactor hashes one ScoredRiskFactor message, in full —
+// unlike HashRiskRow, which hashes only the four scandb table columns.
+func canonScoredRiskFactor(h *llxchecksum.Hasher, r *policy.ScoredRiskFactor) error {
+	if r == nil {
+		h.Str("<nil>")
+		return nil
+	}
+	h.Str(r.Mrn).F64(float64(r.Risk)).Bool(r.IsToxic).Bool(r.IsDetected)
+	return llxchecksum.CanonResultMap(h, r.Data)
+}
+
+// canonScoredRiskFactors folds on emptiness, not pointer presence: the
+// scandb round trip marshals an empty container to zero bytes and reads it
+// back as nil (writeScore / convertScore), so nil and empty MUST hash
+// identically or the same logical row would checksum differently before
+// and after storage. Empty collapses to the nil encoding — the form every
+// stored row round-trips to — so hashing an in-memory row and hashing its
+// stored self always agree.
+func canonScoredRiskFactors(h *llxchecksum.Hasher, rf *policy.ScoredRiskFactors) error {
+	if rf == nil || len(rf.Items) == 0 {
+		h.Str("<nil>")
+		return nil
+	}
+	h.Str("risk_factors")
+	return llxchecksum.Multiset(h, "risk_factor", rf.Items, canonScoredRiskFactor)
+}
+
+// canonSource hashes a score source's identity, scanner fields, and fixed
+// state. FirstDetectedAt and LastUpdatedAt are wall-clock noise and
+// deliberately excluded — the same rationale as HashResourceRow dropping
+// Created/Updated: a re-scan that changes nothing but observation times
+// must not read as changed content. FixedAt is NOT observation noise: it
+// flips once, when the source marks the finding fixed, and a scan whose
+// only difference is that flip must read as changed so the server learns
+// the fixed state instead of keeping a stale un-fixed copy.
+func canonSource(h *llxchecksum.Hasher, s *policy.Source) error {
+	if s == nil {
+		h.Str("<nil>")
+		return nil
+	}
+	h.Str(s.Name).Str(s.Url).Str(s.Version).I64(int64(s.Vendor)).Str(s.FixedAt)
+	return nil
+}
+
+// canonSources folds on emptiness for the same reason as
+// canonScoredRiskFactors: nil and empty are one value after the storage
+// round trip, so they must be one value in the hash.
+func canonSources(h *llxchecksum.Hasher, s *policy.Sources) error {
+	if s == nil || len(s.Items) == 0 {
+		h.Str("<nil>")
+		return nil
+	}
+	h.Str("sources")
+	return llxchecksum.Multiset(h, "source", s.Items, canonSource)
+}
+
+// HashScoreRow computes the row checksum for a scores row.
+func HashScoreRow(s *policy.Score) (uint64, error) {
+	h := llxchecksum.NewHasher("row:score")
+	if s == nil {
+		h.Str("<nil>")
+		if err := h.Err(); err != nil {
+			return 0, err
+		}
+		return h.Sum64(), nil
+	}
+	h.Str(s.QrId).U32(s.RiskScore).U32(s.Type).U32(s.Value).U32(s.Weight).Str(s.Message)
+	if err := canonScoredRiskFactors(h, s.RiskFactors); err != nil {
+		return 0, err
+	}
+	if err := canonSources(h, s.Sources); err != nil {
+		return 0, err
+	}
+	if err := h.Err(); err != nil {
+		return 0, err
+	}
+	return h.Sum64(), nil
+}
+
+// HashRiskRow computes the row checksum for a scored_risk_factors row. Only
+// the four table columns are content here — the Data map is not stored in
+// the table.
+//
+// Float canonicalization: the canonical width is the proto field's float32.
+// The risk column is REAL (float64) on disk, so every hasher must narrow
+// the column value to float32 and re-widen before folding — cnspec's
+// readers do exactly that (StreamRisks/GetRisk build a float32
+// ScoredRiskFactor, and this function folds float64(float32)). A server
+// recomputing from the column must narrow the same way; hashing the raw
+// REAL diverges permanently for any stored value that is not exactly
+// float32-representable.
+func HashRiskRow(r *policy.ScoredRiskFactor) (uint64, error) {
+	h := llxchecksum.NewHasher("row:risk")
+	if r == nil {
+		h.Str("<nil>")
+		if err := h.Err(); err != nil {
+			return 0, err
+		}
+		return h.Sum64(), nil
+	}
+	h.Str(r.Mrn).F64(float64(r.Risk)).Bool(r.IsToxic).Bool(r.IsDetected)
+	if err := h.Err(); err != nil {
+		return 0, err
+	}
+	return h.Sum64(), nil
+}

--- a/policy/checksum/checksum_bench_test.go
+++ b/policy/checksum/checksum_bench_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package checksum
+
+import (
+	"fmt"
+	"testing"
+
+	"go.mondoo.com/cnspec/v13/policy"
+)
+
+// The score/risk checksum pass runs over every scored row of every scan, on
+// the client (C0 emission) and the server (backfill + verification
+// recompute), so per-row cost is fleet-wide cost. Together with mql's
+// llx/checksum benchmarks (data and resource rows), these pin the shapes
+// this package owns: the bare score (the floor — most checks carry no risk
+// factors or sources), the loaded score (risk factors + sources, the
+// realistic ceiling), and the four-column risk row.
+
+// benchScore returns a bare score row: scalars only.
+func benchScore() *policy.Score {
+	return &policy.Score{
+		QrId:      "//policy.api.mondoo.app/queries/mondoo-linux-security-permissions-on-etc-shadow",
+		RiskScore: 25,
+		Type:      2,
+		Value:     80,
+		Weight:    1,
+		Message:   "expected file permissions 0o640, got 0o644",
+	}
+}
+
+// benchLoadedScore returns a score carrying risk factors and sources — the
+// shape a finding-bearing score takes on a real asset.
+func benchLoadedScore() *policy.Score {
+	s := benchScore()
+	items := make([]*policy.ScoredRiskFactor, 5)
+	for i := range items {
+		items[i] = &policy.ScoredRiskFactor{
+			Mrn:        fmt.Sprintf("//policy.api.mondoo.app/risks/internet-facing-%d", i),
+			Risk:       0.4,
+			IsToxic:    i%2 == 0,
+			IsDetected: true,
+		}
+	}
+	s.RiskFactors = &policy.ScoredRiskFactors{Items: items}
+	s.Sources = &policy.Sources{Items: []*policy.Source{
+		{Name: "scanner", Url: "https://example.com/scan", Version: "13.0.0"},
+		{Name: "integration", Url: "https://example.com/aws", Version: "2.1.0"},
+	}}
+	return s
+}
+
+func BenchmarkHashScoreRow_Bare(b *testing.B) {
+	score := benchScore()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := HashScoreRow(score); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashScoreRow_Loaded(b *testing.B) {
+	score := benchLoadedScore()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := HashScoreRow(score); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashRiskRow(b *testing.B) {
+	risk := &policy.ScoredRiskFactor{
+		Mrn:        "//policy.api.mondoo.app/risks/internet-facing",
+		Risk:       0.4,
+		IsToxic:    true,
+		IsDetected: true,
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := HashRiskRow(risk); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/policy/checksum/checksum_test.go
+++ b/policy/checksum/checksum_test.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package checksum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+)
+
+func TestHashScoreRow(t *testing.T) {
+	score := &policy.Score{
+		QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m",
+	}
+	d1, err := HashScoreRow(score)
+	require.NoError(t, err)
+
+	// Every scalar field is a fold input.
+	changed := &policy.Score{QrId: "qr-1", RiskScore: 25, Type: 2, Value: 81, Weight: 1, Message: "m"}
+	d2, err := HashScoreRow(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, d1, d2)
+
+	// Risk factors are content...
+	withRisks := &policy.Score{
+		QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m",
+		RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{
+			{Mrn: "//risk/1", Risk: 0.5},
+			{Mrn: "//risk/2", Risk: 0.7},
+		}},
+	}
+	d3, err := HashScoreRow(withRisks)
+	require.NoError(t, err)
+	assert.NotEqual(t, d1, d3)
+
+	// ...and a multiset: item order is not.
+	reordered := &policy.Score{
+		QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m",
+		RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{
+			{Mrn: "//risk/2", Risk: 0.7},
+			{Mrn: "//risk/1", Risk: 0.5},
+		}},
+	}
+	d4, err := HashScoreRow(reordered)
+	require.NoError(t, err)
+	assert.Equal(t, d3, d4, "risk factor order is not content")
+}
+
+// TestSourceTimestampsAreNotContent pins the wall-clock exclusion: a re-scan
+// that changes nothing but source observation times must not read as changed
+// content.
+func TestSourceTimestampsAreNotContent(t *testing.T) {
+	src := func(first, last string) *policy.Score {
+		return &policy.Score{
+			QrId: "qr-1", Value: 80,
+			Sources: &policy.Sources{Items: []*policy.Source{{
+				Name: "scanner", Url: "https://example.com", Version: "1.0",
+				FirstDetectedAt: first, LastUpdatedAt: last,
+			}}},
+		}
+	}
+
+	d1, err := HashScoreRow(src("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"))
+	require.NoError(t, err)
+	d2, err := HashScoreRow(src("2026-01-01T00:00:00Z", "2026-08-12T00:00:00Z"))
+	require.NoError(t, err)
+	assert.Equal(t, d1, d2, "source timestamps are wall-clock noise, not content")
+
+	// The identity fields ARE content.
+	other := src("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z")
+	other.Sources.Items[0].Name = "other-scanner"
+	d3, err := HashScoreRow(other)
+	require.NoError(t, err)
+	assert.NotEqual(t, d1, d3)
+
+	// FixedAt is content, not observation noise: a scan whose only change is
+	// the fixed-state flip must read as changed.
+	fixed := src("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z")
+	fixed.Sources.Items[0].FixedAt = "2026-08-12T00:00:00Z"
+	d4, err := HashScoreRow(fixed)
+	require.NoError(t, err)
+	assert.NotEqual(t, d1, d4, "a fixed_at flip alone is a content change")
+}
+
+func TestHashRiskRow(t *testing.T) {
+	risk := &policy.ScoredRiskFactor{Mrn: "//risk/1", Risk: 0.5, IsToxic: true, IsDetected: false}
+	r1, err := HashRiskRow(risk)
+	require.NoError(t, err)
+	r1again, err := HashRiskRow(risk)
+	require.NoError(t, err)
+	assert.Equal(t, r1, r1again)
+
+	risk.IsDetected = true
+	r2, err := HashRiskRow(risk)
+	require.NoError(t, err)
+	assert.NotEqual(t, r1, r2)
+}
+
+// TestEmptyContainersHashAsNil pins the round-trip normalization: the scandb
+// writer marshals an empty-but-non-nil RiskFactors/Sources to zero bytes and
+// the reader materializes it back as nil, so emptiness — not pointer
+// presence — is the content. A score hashed in memory (write-time emission)
+// and the same score hashed after the storage round trip must agree.
+func TestEmptyContainersHashAsNil(t *testing.T) {
+	base := &policy.Score{QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m"}
+	dNil, err := HashScoreRow(base)
+	require.NoError(t, err)
+
+	emptied := &policy.Score{
+		QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m",
+		RiskFactors: &policy.ScoredRiskFactors{},
+		Sources:     &policy.Sources{},
+	}
+	dEmpty, err := HashScoreRow(emptied)
+	require.NoError(t, err)
+	assert.Equal(t, dNil, dEmpty,
+		"nil and empty containers are one value after the storage round trip, so they must be one value in the hash")
+
+	// A single element still changes the checksum — the collapse is only of
+	// the empty forms.
+	withItem := &policy.Score{
+		QrId: "qr-1", RiskScore: 25, Type: 2, Value: 80, Weight: 1, Message: "m",
+		RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{{Mrn: "//r/1", Risk: 0.5}}},
+	}
+	dItem, err := HashScoreRow(withItem)
+	require.NoError(t, err)
+	assert.NotEqual(t, dNil, dItem)
+}

--- a/policy/checksum/golden_test.go
+++ b/policy/checksum/golden_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package checksum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// Golden vectors, mirroring mql's llx/checksum goldens for the row kinds it
+// owns. These pinned bits ARE the shared contract with every consumer that
+// recomputes score/risk checksums (the scandb pass here, the server's
+// backfill and verification recompute): all the other tests in this package
+// are relative — both sides of every comparison move together under an
+// algorithm change — so without these, an innocent refactor (reordered
+// folds, a renamed domain string, a changed sentinel) ships silently and
+// every stored checksum stops comparing without the AlgoVersion bump the
+// change requires.
+//
+// If one of these tests fails, you changed the canonicalization: either
+// revert, or bump llx/checksum's AlgoVersion (coordinating with every
+// consumer) and re-pin.
+
+func TestHashScoreRowGolden(t *testing.T) {
+	bare := &policy.Score{
+		QrId: "golden-check", RiskScore: 25, Type: 2, Value: 80, Weight: 1,
+		Message: "expected file permissions 0o640, got 0o644",
+	}
+	d, err := HashScoreRow(bare)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0xb925ffea8e783082), d, "bare score golden moved — see the package comment above")
+
+	// The loaded shape exercises every fold this package owns: risk factors
+	// (with a Data result map), sources with vendor and fixed state, and the
+	// timestamp exclusions (FirstDetectedAt/LastUpdatedAt are set but must
+	// not contribute; FixedAt is set and must).
+	loaded := &policy.Score{
+		QrId: "golden-check", RiskScore: 25, Type: 2, Value: 80, Weight: 1,
+		Message: "expected file permissions 0o640, got 0o644",
+		RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{
+			{
+				Mrn: "//policy.api.mondoo.app/risks/internet-facing", Risk: -0.4,
+				IsToxic: true, IsDetected: true,
+				Data: map[string]*llx.Result{
+					"data-query-1": {CodeId: "data-query-1", Data: llx.StringPrimitive("exposed")},
+				},
+			},
+			{Mrn: "//policy.api.mondoo.app/risks/eol", Risk: 0.2},
+		}},
+		Sources: &policy.Sources{Items: []*policy.Source{{
+			Name: "scanner", Url: "https://example.com/scan", Version: "13.0.0",
+			Vendor:          policy.Source_MONDOO,
+			FirstDetectedAt: "2026-01-01T00:00:00Z",
+			LastUpdatedAt:   "2026-08-12T00:00:00Z",
+			FixedAt:         "2026-08-15T00:00:00Z",
+		}}},
+	}
+	dl, err := HashScoreRow(loaded)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0x8c82ebc76368d08c), dl, "loaded score golden moved — see the package comment above")
+
+	// The observation timestamps are excluded from the fold, so changing
+	// them must not move the golden.
+	loaded.Sources.Items[0].LastUpdatedAt = "2026-08-16T00:00:00Z"
+	dl2, err := HashScoreRow(loaded)
+	require.NoError(t, err)
+	assert.Equal(t, dl, dl2)
+}
+
+func TestHashRiskRowGolden(t *testing.T) {
+	risk := &policy.ScoredRiskFactor{
+		Mrn: "//policy.api.mondoo.app/risks/internet-facing", Risk: 0.4,
+		IsToxic: true, IsDetected: true,
+	}
+	d, err := HashRiskRow(risk)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0xc618f726fd50c75a), d, "risk row golden moved — see the package comment above")
+}

--- a/policy/checksum/manifest.go
+++ b/policy/checksum/manifest.go
@@ -1,0 +1,37 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package checksum
+
+// The manifest is the comparison artifact of the unchanged-scan
+// short-circuit: a trimmed-down scandb — the same four tables, keyed
+// identically, every payload column dropped — holding nothing but each row's
+// key and its 8-byte checksum, plus a metadata table naming the producing
+// algorithm and asset. The server stages one next to every processed scan;
+// in client_compare the client pulls it back and diffs its own rows against
+// it before deciding to upload. The schema is declared here, with the
+// client, because both sides read and write the same file format — the
+// server builds manifests today, the client reads them tomorrow.
+//
+// WITHOUT ROWID: the tables are pure key → checksum maps, so the declared
+// primary key IS the clustering key — one B-tree per table, no hidden rowid,
+// no shadow index. Smaller files, and single-descent lookups for the
+// key-addressed diff queries (EXCEPT / JOIN USING(key)).
+const ManifestSchema = `
+CREATE TABLE data                (code_id TEXT PRIMARY KEY, checksum INTEGER NOT NULL) WITHOUT ROWID;
+CREATE TABLE scores              (qr_id   TEXT PRIMARY KEY, checksum INTEGER NOT NULL) WITHOUT ROWID;
+CREATE TABLE scored_risk_factors (mrn     TEXT PRIMARY KEY, checksum INTEGER NOT NULL) WITHOUT ROWID;
+CREATE TABLE resources           (name TEXT NOT NULL, id TEXT NOT NULL, checksum INTEGER NOT NULL,
+                                  PRIMARY KEY (name, id)) WITHOUT ROWID;
+CREATE TABLE metadata            (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+`
+
+// Manifest metadata keys.
+const (
+	// ManifestMetaAlgoVersion reports the AlgoVersion that produced every
+	// checksum in the file. Checksums across versions never compare: a
+	// reader whose own algorithm differs treats the manifest as absent.
+	ManifestMetaAlgoVersion = "checksum_algo_version"
+	// ManifestMetaAssetMrn names the asset the manifest describes.
+	ManifestMetaAssetMrn = "asset_mrn"
+)

--- a/policy/checksum/manifest_test.go
+++ b/policy/checksum/manifest_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package checksum
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	// The same driver the cnspec binary registers (apps/cnspec/cnspec.go):
+	// modernc.org/sqlite and glebarez both claim the driver name "sqlite",
+	// so linking both into one binary panics at init — never import modernc
+	// here or in anything the cnspec binary may grow to include.
+	_ "github.com/glebarez/go-sqlite"
+)
+
+// TestManifestSchema pins that the declared schema is executable and shaped
+// as every reader assumes: four checksum tables plus metadata, all
+// key-addressable, checksums surviving the int64 bit-pattern round trip.
+func TestManifestSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m.manifest.db")
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	_, err = db.Exec(ManifestSchema)
+	require.NoError(t, err)
+
+	// High bit set: the uint64 → int64 storage convention must round-trip.
+	cs := uint64(0xffffffffffffffff)
+	_, err = db.Exec(`INSERT INTO data (code_id, checksum) VALUES (?, ?)`, "c1", int64(cs))
+	require.NoError(t, err)
+	var got int64
+	require.NoError(t, db.QueryRow(`SELECT checksum FROM data WHERE code_id = ?`, "c1").Scan(&got))
+	assert.Equal(t, cs, uint64(got))
+
+	// Resources are keyed by the (name, id) pair.
+	_, err = db.Exec(`INSERT INTO resources (name, id, checksum) VALUES (?, ?, ?)`, "user", "root", int64(1))
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO resources (name, id, checksum) VALUES (?, ?, ?)`, "user", "root", int64(2))
+	assert.Error(t, err, "the composite key is the identity")
+
+	for _, kv := range [][2]string{
+		{ManifestMetaAlgoVersion, "1"},
+		{ManifestMetaAssetMrn, "//assets/a1"},
+	} {
+		_, err = db.Exec(`INSERT INTO metadata (key, value) VALUES (?, ?)`, kv[0], kv[1])
+		require.NoError(t, err)
+	}
+	var algo string
+	require.NoError(t, db.QueryRow(`SELECT value FROM metadata WHERE key = ?`, ManifestMetaAlgoVersion).Scan(&algo))
+	assert.Equal(t, "1", algo)
+}

--- a/policy/cnspec_policy.pb.go
+++ b/policy/cnspec_policy.pb.go
@@ -462,6 +462,59 @@ func (UploadURLKind) EnumDescriptor() ([]byte, []int) {
 	return file_cnspec_policy_proto_rawDescGZIP(), []int{6}
 }
 
+// DownloadKind addresses the artifact GetDownloadURL serves. Kind-addressed
+// so future artifacts slot in without another RPC.
+type DownloadKind int32
+
+const (
+	DownloadKind_DOWNLOAD_KIND_UNSPECIFIED DownloadKind = 0
+	// The slim scan manifest: a trimmed-down scan database carrying only each
+	// row's key and content digest per kind, plus the digest metadata of the
+	// last processed upload. The client compares the manifest's kind digests
+	// against its own to decide whether an upload can be skipped, and diffs
+	// row digests for change attribution.
+	DownloadKind_DOWNLOAD_KIND_SCAN_MANIFEST DownloadKind = 1
+)
+
+// Enum value maps for DownloadKind.
+var (
+	DownloadKind_name = map[int32]string{
+		0: "DOWNLOAD_KIND_UNSPECIFIED",
+		1: "DOWNLOAD_KIND_SCAN_MANIFEST",
+	}
+	DownloadKind_value = map[string]int32{
+		"DOWNLOAD_KIND_UNSPECIFIED":   0,
+		"DOWNLOAD_KIND_SCAN_MANIFEST": 1,
+	}
+)
+
+func (x DownloadKind) Enum() *DownloadKind {
+	p := new(DownloadKind)
+	*p = x
+	return p
+}
+
+func (x DownloadKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DownloadKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_cnspec_policy_proto_enumTypes[7].Descriptor()
+}
+
+func (DownloadKind) Type() protoreflect.EnumType {
+	return &file_cnspec_policy_proto_enumTypes[7]
+}
+
+func (x DownloadKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DownloadKind.Descriptor instead.
+func (DownloadKind) EnumDescriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{7}
+}
+
 type ScoreRating int32
 
 const (
@@ -534,11 +587,11 @@ func (x ScoreRating) String() string {
 }
 
 func (ScoreRating) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[7].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[8].Descriptor()
 }
 
 func (ScoreRating) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[7]
+	return &file_cnspec_policy_proto_enumTypes[8]
 }
 
 func (x ScoreRating) Number() protoreflect.EnumNumber {
@@ -547,7 +600,7 @@ func (x ScoreRating) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ScoreRating.Descriptor instead.
 func (ScoreRating) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{7}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{8}
 }
 
 type Comparison int32
@@ -580,11 +633,11 @@ func (x Comparison) String() string {
 }
 
 func (Comparison) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[8].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[9].Descriptor()
 }
 
 func (Comparison) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[8]
+	return &file_cnspec_policy_proto_enumTypes[9]
 }
 
 func (x Comparison) Number() protoreflect.EnumNumber {
@@ -593,7 +646,7 @@ func (x Comparison) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Comparison.Descriptor instead.
 func (Comparison) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{8}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{9}
 }
 
 type DateFilterField int32
@@ -629,11 +682,11 @@ func (x DateFilterField) String() string {
 }
 
 func (DateFilterField) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[9].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[10].Descriptor()
 }
 
 func (DateFilterField) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[9]
+	return &file_cnspec_policy_proto_enumTypes[10]
 }
 
 func (x DateFilterField) Number() protoreflect.EnumNumber {
@@ -642,7 +695,7 @@ func (x DateFilterField) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DateFilterField.Descriptor instead.
 func (DateFilterField) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{9}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{10}
 }
 
 // protolint:disable ENUM_FIELD_NAMES_PREFIX
@@ -683,11 +736,11 @@ func (x Migration_Action) String() string {
 }
 
 func (Migration_Action) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[10].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[11].Descriptor()
 }
 
 func (Migration_Action) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[10]
+	return &file_cnspec_policy_proto_enumTypes[11]
 }
 
 func (x Migration_Action) Number() protoreflect.EnumNumber {
@@ -750,11 +803,11 @@ func (x ReportingJob_Type) String() string {
 }
 
 func (ReportingJob_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[11].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[12].Descriptor()
 }
 
 func (ReportingJob_Type) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[11]
+	return &file_cnspec_policy_proto_enumTypes[12]
 }
 
 func (x ReportingJob_Type) Number() protoreflect.EnumNumber {
@@ -796,11 +849,11 @@ func (x PolicyDelta_PolicyAssignmentActionType) String() string {
 }
 
 func (PolicyDelta_PolicyAssignmentActionType) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[12].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[13].Descriptor()
 }
 
 func (PolicyDelta_PolicyAssignmentActionType) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[12]
+	return &file_cnspec_policy_proto_enumTypes[13]
 }
 
 func (x PolicyDelta_PolicyAssignmentActionType) Number() protoreflect.EnumNumber {
@@ -851,11 +904,11 @@ func (x Source_Vendor) String() string {
 }
 
 func (Source_Vendor) Descriptor() protoreflect.EnumDescriptor {
-	return file_cnspec_policy_proto_enumTypes[13].Descriptor()
+	return file_cnspec_policy_proto_enumTypes[14].Descriptor()
 }
 
 func (Source_Vendor) Type() protoreflect.EnumType {
-	return &file_cnspec_policy_proto_enumTypes[13]
+	return &file_cnspec_policy_proto_enumTypes[14]
 }
 
 func (x Source_Vendor) Number() protoreflect.EnumNumber {
@@ -864,7 +917,7 @@ func (x Source_Vendor) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Source_Vendor.Descriptor instead.
 func (Source_Vendor) EnumDescriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{106, 0}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{109, 0}
 }
 
 type ImpactValue struct {
@@ -8181,7 +8234,13 @@ type ReportUploadCompletedReq struct {
 	// details carries an optional, per-upload-kind completion payload. For a
 	// scan-database upload this packs a ScanStatistics. New upload kinds can pack
 	// their own message without changing this message.
-	Details       *anypb.Any `protobuf:"bytes,3,opt,name=details,proto3" json:"details,omitempty"`
+	Details *anypb.Any `protobuf:"bytes,3,opt,name=details,proto3" json:"details,omitempty"`
+	// unchanged reports that no PUT happened for this session: the client
+	// compared its scan content against the last processed upload (via the
+	// manifest served by GetDownloadURL) and found every kind digest equal.
+	// Completion is still the scan signal in both outcomes — statistics ride
+	// details exactly as for a full upload.
+	Unchanged     bool `protobuf:"varint,4,opt,name=unchanged,proto3" json:"unchanged,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8237,6 +8296,193 @@ func (x *ReportUploadCompletedReq) GetDetails() *anypb.Any {
 	return nil
 }
 
+func (x *ReportUploadCompletedReq) GetUnchanged() bool {
+	if x != nil {
+		return x.Unchanged
+	}
+	return false
+}
+
+type GetDownloadURLReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Kind  DownloadKind           `protobuf:"varint,1,opt,name=kind,proto3,enum=cnspec.policy.v1.DownloadKind" json:"kind,omitempty"`
+	// Same addressing as GetUploadURL.
+	ScopeMrn      string `protobuf:"bytes,2,opt,name=scope_mrn,json=scopeMrn,proto3" json:"scope_mrn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDownloadURLReq) Reset() {
+	*x = GetDownloadURLReq{}
+	mi := &file_cnspec_policy_proto_msgTypes[91]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDownloadURLReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDownloadURLReq) ProtoMessage() {}
+
+func (x *GetDownloadURLReq) ProtoReflect() protoreflect.Message {
+	mi := &file_cnspec_policy_proto_msgTypes[91]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDownloadURLReq.ProtoReflect.Descriptor instead.
+func (*GetDownloadURLReq) Descriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{91}
+}
+
+func (x *GetDownloadURLReq) GetKind() DownloadKind {
+	if x != nil {
+		return x.Kind
+	}
+	return DownloadKind_DOWNLOAD_KIND_UNSPECIFIED
+}
+
+func (x *GetDownloadURLReq) GetScopeMrn() string {
+	if x != nil {
+		return x.ScopeMrn
+	}
+	return ""
+}
+
+type GetDownloadURLResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The signed GET for the requested artifact. Absent means nothing is
+	// served — the client proceeds with a full upload, always.
+	DownloadUrl *DownloadURL `protobuf:"bytes,1,opt,name=download_url,json=downloadUrl,proto3" json:"download_url,omitempty"`
+	// There is deliberately no base-identity field: the comparison policy is
+	// always-latest. A delta that raced a concurrent upload fails the
+	// server's row-digest verify and falls back to a full upload.
+	// Explicit "nothing will be served for this request" — the base does not
+	// exist, its stored digests are no longer eligible, or the scope is in a
+	// force-resend state. Reasons stay server-side; client behavior keys on
+	// download_url presence alone. The marker's one job is telemetry
+	// disambiguation of a degenerate success: an intermediary can turn a
+	// response into an empty 200 whose body unmarshals as an all-zero
+	// message, indistinguishable from a genuine decline without this bit.
+	// (A real transport failure surfaces as an RPC error, never as a
+	// response, so it needs no marker.)
+	Unavailable   bool `protobuf:"varint,2,opt,name=unavailable,proto3" json:"unavailable,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDownloadURLResp) Reset() {
+	*x = GetDownloadURLResp{}
+	mi := &file_cnspec_policy_proto_msgTypes[92]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDownloadURLResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDownloadURLResp) ProtoMessage() {}
+
+func (x *GetDownloadURLResp) ProtoReflect() protoreflect.Message {
+	mi := &file_cnspec_policy_proto_msgTypes[92]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDownloadURLResp.ProtoReflect.Descriptor instead.
+func (*GetDownloadURLResp) Descriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{92}
+}
+
+func (x *GetDownloadURLResp) GetDownloadUrl() *DownloadURL {
+	if x != nil {
+		return x.DownloadUrl
+	}
+	return nil
+}
+
+func (x *GetDownloadURLResp) GetUnavailable() bool {
+	if x != nil {
+		return x.Unavailable
+	}
+	return false
+}
+
+// DownloadURL mirrors UploadURL for the opposite direction.
+type DownloadURL struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Headers       map[string]string      `protobuf:"bytes,2,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExpiresAt     int64                  `protobuf:"varint,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DownloadURL) Reset() {
+	*x = DownloadURL{}
+	mi := &file_cnspec_policy_proto_msgTypes[93]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DownloadURL) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DownloadURL) ProtoMessage() {}
+
+func (x *DownloadURL) ProtoReflect() protoreflect.Message {
+	mi := &file_cnspec_policy_proto_msgTypes[93]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DownloadURL.ProtoReflect.Descriptor instead.
+func (*DownloadURL) Descriptor() ([]byte, []int) {
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{93}
+}
+
+func (x *DownloadURL) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *DownloadURL) GetHeaders() map[string]string {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+func (x *DownloadURL) GetExpiresAt() int64 {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return 0
+}
+
 // ScanStatistics is the completion payload for a scan-database upload. Every
 // statistic is a namespaced Metric so new metrics require no proto change.
 type ScanStatistics struct {
@@ -8248,7 +8494,7 @@ type ScanStatistics struct {
 
 func (x *ScanStatistics) Reset() {
 	*x = ScanStatistics{}
-	mi := &file_cnspec_policy_proto_msgTypes[91]
+	mi := &file_cnspec_policy_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8260,7 +8506,7 @@ func (x *ScanStatistics) String() string {
 func (*ScanStatistics) ProtoMessage() {}
 
 func (x *ScanStatistics) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[91]
+	mi := &file_cnspec_policy_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8273,7 +8519,7 @@ func (x *ScanStatistics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanStatistics.ProtoReflect.Descriptor instead.
 func (*ScanStatistics) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{91}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ScanStatistics) GetMetrics() []*Metric {
@@ -8303,7 +8549,7 @@ type Metric struct {
 
 func (x *Metric) Reset() {
 	*x = Metric{}
-	mi := &file_cnspec_policy_proto_msgTypes[92]
+	mi := &file_cnspec_policy_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8315,7 +8561,7 @@ func (x *Metric) String() string {
 func (*Metric) ProtoMessage() {}
 
 func (x *Metric) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[92]
+	mi := &file_cnspec_policy_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8328,7 +8574,7 @@ func (x *Metric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metric.ProtoReflect.Descriptor instead.
 func (*Metric) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{92}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *Metric) GetName() string {
@@ -8426,7 +8672,7 @@ type EntityScoreReq struct {
 
 func (x *EntityScoreReq) Reset() {
 	*x = EntityScoreReq{}
-	mi := &file_cnspec_policy_proto_msgTypes[93]
+	mi := &file_cnspec_policy_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8438,7 +8684,7 @@ func (x *EntityScoreReq) String() string {
 func (*EntityScoreReq) ProtoMessage() {}
 
 func (x *EntityScoreReq) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[93]
+	mi := &file_cnspec_policy_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8451,7 +8697,7 @@ func (x *EntityScoreReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntityScoreReq.ProtoReflect.Descriptor instead.
 func (*EntityScoreReq) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{93}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *EntityScoreReq) GetEntityMrn() string {
@@ -8478,7 +8724,7 @@ type SynchronizeAssetsReq struct {
 
 func (x *SynchronizeAssetsReq) Reset() {
 	*x = SynchronizeAssetsReq{}
-	mi := &file_cnspec_policy_proto_msgTypes[94]
+	mi := &file_cnspec_policy_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8490,7 +8736,7 @@ func (x *SynchronizeAssetsReq) String() string {
 func (*SynchronizeAssetsReq) ProtoMessage() {}
 
 func (x *SynchronizeAssetsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[94]
+	mi := &file_cnspec_policy_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8503,7 +8749,7 @@ func (x *SynchronizeAssetsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SynchronizeAssetsReq.ProtoReflect.Descriptor instead.
 func (*SynchronizeAssetsReq) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{94}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *SynchronizeAssetsReq) GetSpaceMrn() string {
@@ -8533,7 +8779,7 @@ type SynchronizeAssetsRespAssetDetail struct {
 
 func (x *SynchronizeAssetsRespAssetDetail) Reset() {
 	*x = SynchronizeAssetsRespAssetDetail{}
-	mi := &file_cnspec_policy_proto_msgTypes[95]
+	mi := &file_cnspec_policy_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8545,7 +8791,7 @@ func (x *SynchronizeAssetsRespAssetDetail) String() string {
 func (*SynchronizeAssetsRespAssetDetail) ProtoMessage() {}
 
 func (x *SynchronizeAssetsRespAssetDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[95]
+	mi := &file_cnspec_policy_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8558,7 +8804,7 @@ func (x *SynchronizeAssetsRespAssetDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SynchronizeAssetsRespAssetDetail.ProtoReflect.Descriptor instead.
 func (*SynchronizeAssetsRespAssetDetail) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{95}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *SynchronizeAssetsRespAssetDetail) GetPlatformMrn() string {
@@ -8605,7 +8851,7 @@ type SynchronizeAssetsResp struct {
 
 func (x *SynchronizeAssetsResp) Reset() {
 	*x = SynchronizeAssetsResp{}
-	mi := &file_cnspec_policy_proto_msgTypes[96]
+	mi := &file_cnspec_policy_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8617,7 +8863,7 @@ func (x *SynchronizeAssetsResp) String() string {
 func (*SynchronizeAssetsResp) ProtoMessage() {}
 
 func (x *SynchronizeAssetsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[96]
+	mi := &file_cnspec_policy_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8630,7 +8876,7 @@ func (x *SynchronizeAssetsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SynchronizeAssetsResp.ProtoReflect.Descriptor instead.
 func (*SynchronizeAssetsResp) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{96}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *SynchronizeAssetsResp) GetDetails() map[string]*SynchronizeAssetsRespAssetDetail {
@@ -8649,7 +8895,7 @@ type GetScanParametersReq struct {
 
 func (x *GetScanParametersReq) Reset() {
 	*x = GetScanParametersReq{}
-	mi := &file_cnspec_policy_proto_msgTypes[97]
+	mi := &file_cnspec_policy_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8661,7 +8907,7 @@ func (x *GetScanParametersReq) String() string {
 func (*GetScanParametersReq) ProtoMessage() {}
 
 func (x *GetScanParametersReq) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[97]
+	mi := &file_cnspec_policy_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8674,7 +8920,7 @@ func (x *GetScanParametersReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetScanParametersReq.ProtoReflect.Descriptor instead.
 func (*GetScanParametersReq) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{97}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GetScanParametersReq) GetScopeMrn() string {
@@ -8693,7 +8939,7 @@ type ScanParameters struct {
 
 func (x *ScanParameters) Reset() {
 	*x = ScanParameters{}
-	mi := &file_cnspec_policy_proto_msgTypes[98]
+	mi := &file_cnspec_policy_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8705,7 +8951,7 @@ func (x *ScanParameters) String() string {
 func (*ScanParameters) ProtoMessage() {}
 
 func (x *ScanParameters) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[98]
+	mi := &file_cnspec_policy_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8718,7 +8964,7 @@ func (x *ScanParameters) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanParameters.ProtoReflect.Descriptor instead.
 func (*ScanParameters) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{98}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ScanParameters) GetEnabledFeatures() []string {
@@ -8748,7 +8994,7 @@ type PurgeAssetsRequest struct {
 
 func (x *PurgeAssetsRequest) Reset() {
 	*x = PurgeAssetsRequest{}
-	mi := &file_cnspec_policy_proto_msgTypes[99]
+	mi := &file_cnspec_policy_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8760,7 +9006,7 @@ func (x *PurgeAssetsRequest) String() string {
 func (*PurgeAssetsRequest) ProtoMessage() {}
 
 func (x *PurgeAssetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[99]
+	mi := &file_cnspec_policy_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8773,7 +9019,7 @@ func (x *PurgeAssetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeAssetsRequest.ProtoReflect.Descriptor instead.
 func (*PurgeAssetsRequest) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{99}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *PurgeAssetsRequest) GetSpaceMrn() string {
@@ -8843,7 +9089,7 @@ type DateFilter struct {
 
 func (x *DateFilter) Reset() {
 	*x = DateFilter{}
-	mi := &file_cnspec_policy_proto_msgTypes[100]
+	mi := &file_cnspec_policy_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8855,7 +9101,7 @@ func (x *DateFilter) String() string {
 func (*DateFilter) ProtoMessage() {}
 
 func (x *DateFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[100]
+	mi := &file_cnspec_policy_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8868,7 +9114,7 @@ func (x *DateFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DateFilter.ProtoReflect.Descriptor instead.
 func (*DateFilter) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{100}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *DateFilter) GetTimestamp() string {
@@ -8902,7 +9148,7 @@ type PurgeAssetsConfirmation struct {
 
 func (x *PurgeAssetsConfirmation) Reset() {
 	*x = PurgeAssetsConfirmation{}
-	mi := &file_cnspec_policy_proto_msgTypes[101]
+	mi := &file_cnspec_policy_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8914,7 +9160,7 @@ func (x *PurgeAssetsConfirmation) String() string {
 func (*PurgeAssetsConfirmation) ProtoMessage() {}
 
 func (x *PurgeAssetsConfirmation) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[101]
+	mi := &file_cnspec_policy_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8927,7 +9173,7 @@ func (x *PurgeAssetsConfirmation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PurgeAssetsConfirmation.ProtoReflect.Descriptor instead.
 func (*PurgeAssetsConfirmation) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{101}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *PurgeAssetsConfirmation) GetAssetMrns() []string {
@@ -8958,7 +9204,7 @@ type RefreshAssetScoresRequest struct {
 
 func (x *RefreshAssetScoresRequest) Reset() {
 	*x = RefreshAssetScoresRequest{}
-	mi := &file_cnspec_policy_proto_msgTypes[102]
+	mi := &file_cnspec_policy_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8970,7 +9216,7 @@ func (x *RefreshAssetScoresRequest) String() string {
 func (*RefreshAssetScoresRequest) ProtoMessage() {}
 
 func (x *RefreshAssetScoresRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[102]
+	mi := &file_cnspec_policy_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8983,7 +9229,7 @@ func (x *RefreshAssetScoresRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshAssetScoresRequest.ProtoReflect.Descriptor instead.
 func (*RefreshAssetScoresRequest) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{102}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *RefreshAssetScoresRequest) GetScopeMrn() string {
@@ -9038,7 +9284,7 @@ type RefreshAssetScoresResponse struct {
 
 func (x *RefreshAssetScoresResponse) Reset() {
 	*x = RefreshAssetScoresResponse{}
-	mi := &file_cnspec_policy_proto_msgTypes[103]
+	mi := &file_cnspec_policy_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9050,7 +9296,7 @@ func (x *RefreshAssetScoresResponse) String() string {
 func (*RefreshAssetScoresResponse) ProtoMessage() {}
 
 func (x *RefreshAssetScoresResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[103]
+	mi := &file_cnspec_policy_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9063,7 +9309,7 @@ func (x *RefreshAssetScoresResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshAssetScoresResponse.ProtoReflect.Descriptor instead.
 func (*RefreshAssetScoresResponse) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{103}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *RefreshAssetScoresResponse) GetRefreshed() []*AssetRefreshResult {
@@ -9090,7 +9336,7 @@ type AssetRefreshResult struct {
 
 func (x *AssetRefreshResult) Reset() {
 	*x = AssetRefreshResult{}
-	mi := &file_cnspec_policy_proto_msgTypes[104]
+	mi := &file_cnspec_policy_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9102,7 +9348,7 @@ func (x *AssetRefreshResult) String() string {
 func (*AssetRefreshResult) ProtoMessage() {}
 
 func (x *AssetRefreshResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[104]
+	mi := &file_cnspec_policy_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9115,7 +9361,7 @@ func (x *AssetRefreshResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetRefreshResult.ProtoReflect.Descriptor instead.
 func (*AssetRefreshResult) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{104}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *AssetRefreshResult) GetAssetMrn() string {
@@ -9143,7 +9389,7 @@ type Sources struct {
 
 func (x *Sources) Reset() {
 	*x = Sources{}
-	mi := &file_cnspec_policy_proto_msgTypes[105]
+	mi := &file_cnspec_policy_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9155,7 +9401,7 @@ func (x *Sources) String() string {
 func (*Sources) ProtoMessage() {}
 
 func (x *Sources) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[105]
+	mi := &file_cnspec_policy_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9168,7 +9414,7 @@ func (x *Sources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sources.ProtoReflect.Descriptor instead.
 func (*Sources) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{105}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *Sources) GetItems() []*Source {
@@ -9201,7 +9447,7 @@ type Source struct {
 
 func (x *Source) Reset() {
 	*x = Source{}
-	mi := &file_cnspec_policy_proto_msgTypes[106]
+	mi := &file_cnspec_policy_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9213,7 +9459,7 @@ func (x *Source) String() string {
 func (*Source) ProtoMessage() {}
 
 func (x *Source) ProtoReflect() protoreflect.Message {
-	mi := &file_cnspec_policy_proto_msgTypes[106]
+	mi := &file_cnspec_policy_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9226,7 +9472,7 @@ func (x *Source) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Source.ProtoReflect.Descriptor instead.
 func (*Source) Descriptor() ([]byte, []int) {
-	return file_cnspec_policy_proto_rawDescGZIP(), []int{106}
+	return file_cnspec_policy_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *Source) GetName() string {
@@ -10038,11 +10284,26 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"expires_at\x18\x03 \x01(\x03R\texpiresAt\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x93\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x01\n" +
 	"\x18ReportUploadCompletedReq\x12*\n" +
 	"\x11upload_session_id\x18\x01 \x01(\tR\x0fuploadSessionId\x12\x1b\n" +
 	"\tscope_mrn\x18\x02 \x01(\tR\bscopeMrn\x12.\n" +
-	"\adetails\x18\x03 \x01(\v2\x14.google.protobuf.AnyR\adetails\"D\n" +
+	"\adetails\x18\x03 \x01(\v2\x14.google.protobuf.AnyR\adetails\x12\x1c\n" +
+	"\tunchanged\x18\x04 \x01(\bR\tunchanged\"d\n" +
+	"\x11GetDownloadURLReq\x122\n" +
+	"\x04kind\x18\x01 \x01(\x0e2\x1e.cnspec.policy.v1.DownloadKindR\x04kind\x12\x1b\n" +
+	"\tscope_mrn\x18\x02 \x01(\tR\bscopeMrn\"x\n" +
+	"\x12GetDownloadURLResp\x12@\n" +
+	"\fdownload_url\x18\x01 \x01(\v2\x1d.cnspec.policy.v1.DownloadURLR\vdownloadUrl\x12 \n" +
+	"\vunavailable\x18\x02 \x01(\bR\vunavailable\"\xc0\x01\n" +
+	"\vDownloadURL\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12D\n" +
+	"\aheaders\x18\x02 \x03(\v2*.cnspec.policy.v1.DownloadURL.HeadersEntryR\aheaders\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\x03R\texpiresAt\x1a:\n" +
+	"\fHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"D\n" +
 	"\x0eScanStatistics\x122\n" +
 	"\ametrics\x18\x01 \x03(\v2\x18.cnspec.policy.v1.MetricR\ametrics\"\xc3\x01\n" +
 	"\x06Metric\x12\x12\n" +
@@ -10194,7 +10455,10 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x1bUPLOAD_URL_KIND_UNSPECIFIED\x10\x00\x12$\n" +
 	" UPLOAD_URL_KIND_SCAN_DATABASE_V0\x10\x01\x12&\n" +
 	"\"UPLOAD_URL_KIND_SERVERLESS_LOGS_V0\x10\x02\x12(\n" +
-	"$UPLOAD_URL_KIND_THIRD_PARTY_FINDINGS\x10\x03*\xb3\x01\n" +
+	"$UPLOAD_URL_KIND_THIRD_PARTY_FINDINGS\x10\x03*N\n" +
+	"\fDownloadKind\x12\x1d\n" +
+	"\x19DOWNLOAD_KIND_UNSPECIFIED\x10\x00\x12\x1f\n" +
+	"\x1bDOWNLOAD_KIND_SCAN_MANIFEST\x10\x01*\xb3\x01\n" +
 	"\vScoreRating\x12\v\n" +
 	"\aunrated\x10\x00\x12\t\n" +
 	"\x05aPlus\x10\x01\x12\x05\n" +
@@ -10237,7 +10501,7 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x0fDefaultPolicies\x12$.cnspec.policy.v1.DefaultPoliciesReq\x1a\x16.cnspec.policy.v1.URLs\"\x00\x12D\n" +
 	"\fGetFramework\x12\x15.cnspec.policy.v1.Mrn\x1a\x1b.cnspec.policy.v1.Framework\"\x00\x12C\n" +
 	"\x0fDeleteFramework\x12\x15.cnspec.policy.v1.Mrn\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12K\n" +
-	"\x0eListFrameworks\x12\x19.cnspec.policy.v1.ListReq\x1a\x1c.cnspec.policy.v1.Frameworks\"\x002\xc7\f\n" +
+	"\x0eListFrameworks\x12\x19.cnspec.policy.v1.ListReq\x1a\x1c.cnspec.policy.v1.Frameworks\"\x002\xa6\r\n" +
 	"\x0ePolicyResolver\x12G\n" +
 	"\x06Assign\x12\".cnspec.policy.v1.PolicyAssignment\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12I\n" +
 	"\bUnassign\x12\".cnspec.policy.v1.PolicyAssignment\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12A\n" +
@@ -10248,7 +10512,8 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x11GetResolvedPolicy\x12\x15.cnspec.policy.v1.Mrn\x1a .cnspec.policy.v1.ResolvedPolicy\"\x00\x12L\n" +
 	"\fStoreResults\x12!.cnspec.policy.v1.StoreResultsReq\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12W\n" +
 	"\fGetUploadURL\x12!.cnspec.policy.v1.GetUploadURLReq\x1a\".cnspec.policy.v1.GetUploadURLResp\"\x00\x12^\n" +
-	"\x15ReportUploadCompleted\x12*.cnspec.policy.v1.ReportUploadCompletedReq\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12I\n" +
+	"\x15ReportUploadCompleted\x12*.cnspec.policy.v1.ReportUploadCompletedReq\x1a\x17.cnspec.policy.v1.Empty\"\x00\x12]\n" +
+	"\x0eGetDownloadURL\x12#.cnspec.policy.v1.GetDownloadURLReq\x1a$.cnspec.policy.v1.GetDownloadURLResp\"\x00\x12I\n" +
 	"\tGetReport\x12 .cnspec.policy.v1.EntityScoreReq\x1a\x18.cnspec.policy.v1.Report\"\x00\x12[\n" +
 	"\x12GetFrameworkReport\x12 .cnspec.policy.v1.EntityScoreReq\x1a!.cnspec.policy.v1.FrameworkReport\"\x00\x12H\n" +
 	"\bGetScore\x12 .cnspec.policy.v1.EntityScoreReq\x1a\x18.cnspec.policy.v1.Report\"\x00\x12t\n" +
@@ -10270,8 +10535,8 @@ func file_cnspec_policy_proto_rawDescGZIP() []byte {
 	return file_cnspec_policy_proto_rawDescData
 }
 
-var file_cnspec_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 14)
-var file_cnspec_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 146)
+var file_cnspec_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 15)
+var file_cnspec_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 150)
 var file_cnspec_policy_proto_goTypes = []any{
 	(Action)(0),            // 0: cnspec.policy.v1.Action
 	(ScoringSystem)(0),     // 1: cnspec.policy.v1.ScoringSystem
@@ -10280,456 +10545,466 @@ var file_cnspec_policy_proto_goTypes = []any{
 	(ReviewStatus)(0),      // 4: cnspec.policy.v1.ReviewStatus
 	(ServerFeature)(0),     // 5: cnspec.policy.v1.ServerFeature
 	(UploadURLKind)(0),     // 6: cnspec.policy.v1.UploadURLKind
-	(ScoreRating)(0),       // 7: cnspec.policy.v1.ScoreRating
-	(Comparison)(0),        // 8: cnspec.policy.v1.Comparison
-	(DateFilterField)(0),   // 9: cnspec.policy.v1.DateFilterField
-	(Migration_Action)(0),  // 10: cnspec.policy.v1.Migration.Action
-	(ReportingJob_Type)(0), // 11: cnspec.policy.v1.ReportingJob.Type
-	(PolicyDelta_PolicyAssignmentActionType)(0), // 12: cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
-	(Source_Vendor)(0),                          // 13: cnspec.policy.v1.Source.Vendor
-	(*ImpactValue)(nil),                         // 14: cnspec.policy.v1.ImpactValue
-	(*Impact)(nil),                              // 15: cnspec.policy.v1.Impact
-	(*ObjectRef)(nil),                           // 16: cnspec.policy.v1.ObjectRef
-	(*Author)(nil),                              // 17: cnspec.policy.v1.Author
-	(*MqueryRef)(nil),                           // 18: cnspec.policy.v1.MqueryRef
-	(*HumanTime)(nil),                           // 19: cnspec.policy.v1.HumanTime
-	(*TypedDoc)(nil),                            // 20: cnspec.policy.v1.TypedDoc
-	(*Remediation)(nil),                         // 21: cnspec.policy.v1.Remediation
-	(*MqueryDocs)(nil),                          // 22: cnspec.policy.v1.MqueryDocs
-	(*Filters)(nil),                             // 23: cnspec.policy.v1.Filters
-	(*Property)(nil),                            // 24: cnspec.policy.v1.Property
-	(*Mquery)(nil),                              // 25: cnspec.policy.v1.Mquery
-	(*QueryPackDocs)(nil),                       // 26: cnspec.policy.v1.QueryPackDocs
-	(*QueryGroup)(nil),                          // 27: cnspec.policy.v1.QueryGroup
-	(*QueryPack)(nil),                           // 28: cnspec.policy.v1.QueryPack
-	(*PropsReq)(nil),                            // 29: cnspec.policy.v1.PropsReq
-	(*PolicyGroup)(nil),                         // 30: cnspec.policy.v1.PolicyGroup
-	(*Validity)(nil),                            // 31: cnspec.policy.v1.Validity
-	(*PolicyRef)(nil),                           // 32: cnspec.policy.v1.PolicyRef
-	(*Policy)(nil),                              // 33: cnspec.policy.v1.Policy
-	(*Policies)(nil),                            // 34: cnspec.policy.v1.Policies
-	(*Requirement)(nil),                         // 35: cnspec.policy.v1.Requirement
-	(*QueryCounts)(nil),                         // 36: cnspec.policy.v1.QueryCounts
-	(*Bundle)(nil),                              // 37: cnspec.policy.v1.Bundle
-	(*MigrationPolicyRef)(nil),                  // 38: cnspec.policy.v1.MigrationPolicyRef
-	(*MigrationGroup)(nil),                      // 39: cnspec.policy.v1.MigrationGroup
-	(*MigrationConditions)(nil),                 // 40: cnspec.policy.v1.MigrationConditions
-	(*MigrationMetadata)(nil),                   // 41: cnspec.policy.v1.MigrationMetadata
-	(*MigrationStage)(nil),                      // 42: cnspec.policy.v1.MigrationStage
-	(*Migration)(nil),                           // 43: cnspec.policy.v1.Migration
-	(*MigrationSource)(nil),                     // 44: cnspec.policy.v1.MigrationSource
-	(*MigrationTarget)(nil),                     // 45: cnspec.policy.v1.MigrationTarget
-	(*SoftwareSelector)(nil),                    // 46: cnspec.policy.v1.SoftwareSelector
-	(*ResourceSelector)(nil),                    // 47: cnspec.policy.v1.ResourceSelector
-	(*RiskMagnitude)(nil),                       // 48: cnspec.policy.v1.RiskMagnitude
-	(*RiskFactor)(nil),                          // 49: cnspec.policy.v1.RiskFactor
-	(*RiskFactorDocs)(nil),                      // 50: cnspec.policy.v1.RiskFactorDocs
-	(*PolicyGroupDocs)(nil),                     // 51: cnspec.policy.v1.PolicyGroupDocs
-	(*PolicyDocs)(nil),                          // 52: cnspec.policy.v1.PolicyDocs
-	(*Framework)(nil),                           // 53: cnspec.policy.v1.Framework
-	(*Frameworks)(nil),                          // 54: cnspec.policy.v1.Frameworks
-	(*FrameworkGroup)(nil),                      // 55: cnspec.policy.v1.FrameworkGroup
-	(*FrameworkRef)(nil),                        // 56: cnspec.policy.v1.FrameworkRef
-	(*Evidence)(nil),                            // 57: cnspec.policy.v1.Evidence
-	(*Control)(nil),                             // 58: cnspec.policy.v1.Control
-	(*FrameworkMap)(nil),                        // 59: cnspec.policy.v1.FrameworkMap
-	(*ControlMap)(nil),                          // 60: cnspec.policy.v1.ControlMap
-	(*ControlDocs)(nil),                         // 61: cnspec.policy.v1.ControlDocs
-	(*ControlRef)(nil),                          // 62: cnspec.policy.v1.ControlRef
-	(*Asset)(nil),                               // 63: cnspec.policy.v1.Asset
-	(*ResolvedPolicy)(nil),                      // 64: cnspec.policy.v1.ResolvedPolicy
-	(*ExecutionJob)(nil),                        // 65: cnspec.policy.v1.ExecutionJob
-	(*ExecutionQuery)(nil),                      // 66: cnspec.policy.v1.ExecutionQuery
-	(*CollectorJob)(nil),                        // 67: cnspec.policy.v1.CollectorJob
-	(*RiskDataInfo)(nil),                        // 68: cnspec.policy.v1.RiskDataInfo
-	(*StringArray)(nil),                         // 69: cnspec.policy.v1.StringArray
-	(*DataQueryInfo)(nil),                       // 70: cnspec.policy.v1.DataQueryInfo
-	(*ReportingJob)(nil),                        // 71: cnspec.policy.v1.ReportingJob
-	(*Report)(nil),                              // 72: cnspec.policy.v1.Report
-	(*Reports)(nil),                             // 73: cnspec.policy.v1.Reports
-	(*ReportCollection)(nil),                    // 74: cnspec.policy.v1.ReportCollection
-	(*FrameworkReport)(nil),                     // 75: cnspec.policy.v1.FrameworkReport
-	(*ControlScore)(nil),                        // 76: cnspec.policy.v1.ControlScore
-	(*Cvss)(nil),                                // 77: cnspec.policy.v1.Cvss
-	(*CvssStats)(nil),                           // 78: cnspec.policy.v1.CvssStats
-	(*Score)(nil),                               // 79: cnspec.policy.v1.Score
-	(*ScoreDelta)(nil),                          // 80: cnspec.policy.v1.ScoreDelta
-	(*ScoredRiskFactor)(nil),                    // 81: cnspec.policy.v1.ScoredRiskFactor
-	(*ScoredRiskFactors)(nil),                   // 82: cnspec.policy.v1.ScoredRiskFactors
-	(*RiskFactorStats)(nil),                     // 83: cnspec.policy.v1.RiskFactorStats
-	(*RiskFactorsStats)(nil),                    // 84: cnspec.policy.v1.RiskFactorsStats
-	(*Stats)(nil),                               // 85: cnspec.policy.v1.Stats
-	(*ScoreDistribution)(nil),                   // 86: cnspec.policy.v1.ScoreDistribution
-	(*ScoreStats)(nil),                          // 87: cnspec.policy.v1.ScoreStats
-	(*AssetFindingsStats)(nil),                  // 88: cnspec.policy.v1.AssetFindingsStats
-	(*Empty)(nil),                               // 89: cnspec.policy.v1.Empty
-	(*Mrn)(nil),                                 // 90: cnspec.policy.v1.Mrn
-	(*Mqueries)(nil),                            // 91: cnspec.policy.v1.Mqueries
-	(*ListReq)(nil),                             // 92: cnspec.policy.v1.ListReq
-	(*DefaultPoliciesReq)(nil),                  // 93: cnspec.policy.v1.DefaultPoliciesReq
-	(*URLs)(nil),                                // 94: cnspec.policy.v1.URLs
-	(*PolicyAssignment)(nil),                    // 95: cnspec.policy.v1.PolicyAssignment
-	(*PolicyMutationDelta)(nil),                 // 96: cnspec.policy.v1.PolicyMutationDelta
-	(*PolicyDelta)(nil),                         // 97: cnspec.policy.v1.PolicyDelta
-	(*ResolveReq)(nil),                          // 98: cnspec.policy.v1.ResolveReq
-	(*UpdateAssetJobsReq)(nil),                  // 99: cnspec.policy.v1.UpdateAssetJobsReq
-	(*StoreResultsReq)(nil),                     // 100: cnspec.policy.v1.StoreResultsReq
-	(*GetUploadURLReq)(nil),                     // 101: cnspec.policy.v1.GetUploadURLReq
-	(*GetUploadURLResp)(nil),                    // 102: cnspec.policy.v1.GetUploadURLResp
-	(*UploadURL)(nil),                           // 103: cnspec.policy.v1.UploadURL
-	(*ReportUploadCompletedReq)(nil),            // 104: cnspec.policy.v1.ReportUploadCompletedReq
-	(*ScanStatistics)(nil),                      // 105: cnspec.policy.v1.ScanStatistics
-	(*Metric)(nil),                              // 106: cnspec.policy.v1.Metric
-	(*EntityScoreReq)(nil),                      // 107: cnspec.policy.v1.EntityScoreReq
-	(*SynchronizeAssetsReq)(nil),                // 108: cnspec.policy.v1.SynchronizeAssetsReq
-	(*SynchronizeAssetsRespAssetDetail)(nil),    // 109: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
-	(*SynchronizeAssetsResp)(nil),               // 110: cnspec.policy.v1.SynchronizeAssetsResp
-	(*GetScanParametersReq)(nil),                // 111: cnspec.policy.v1.GetScanParametersReq
-	(*ScanParameters)(nil),                      // 112: cnspec.policy.v1.ScanParameters
-	(*PurgeAssetsRequest)(nil),                  // 113: cnspec.policy.v1.PurgeAssetsRequest
-	(*DateFilter)(nil),                          // 114: cnspec.policy.v1.DateFilter
-	(*PurgeAssetsConfirmation)(nil),             // 115: cnspec.policy.v1.PurgeAssetsConfirmation
-	(*RefreshAssetScoresRequest)(nil),           // 116: cnspec.policy.v1.RefreshAssetScoresRequest
-	(*RefreshAssetScoresResponse)(nil),          // 117: cnspec.policy.v1.RefreshAssetScoresResponse
-	(*AssetRefreshResult)(nil),                  // 118: cnspec.policy.v1.AssetRefreshResult
-	(*Sources)(nil),                             // 119: cnspec.policy.v1.Sources
-	(*Source)(nil),                              // 120: cnspec.policy.v1.Source
-	nil,                                         // 121: cnspec.policy.v1.ObjectRef.TagsEntry
-	nil,                                         // 122: cnspec.policy.v1.TypedDoc.TagsEntry
-	nil,                                         // 123: cnspec.policy.v1.Filters.ItemsEntry
-	nil,                                         // 124: cnspec.policy.v1.Mquery.TagsEntry
-	nil,                                         // 125: cnspec.policy.v1.QueryPack.TagsEntry
-	nil,                                         // 126: cnspec.policy.v1.Policy.TagsEntry
-	nil,                                         // 127: cnspec.policy.v1.MigrationMetadata.LabelsEntry
-	nil,                                         // 128: cnspec.policy.v1.RiskFactor.TagsEntry
-	nil,                                         // 129: cnspec.policy.v1.Framework.TagsEntry
-	nil,                                         // 130: cnspec.policy.v1.Control.TagsEntry
-	nil,                                         // 131: cnspec.policy.v1.ExecutionJob.QueriesEntry
-	nil,                                         // 132: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	nil,                                         // 133: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	nil,                                         // 134: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	nil,                                         // 135: cnspec.policy.v1.CollectorJob.DatapointsEntry
-	nil,                                         // 136: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	nil,                                         // 137: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	nil,                                         // 138: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
-	nil,                                         // 139: cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
-	nil,                                         // 140: cnspec.policy.v1.ReportingJob.DatapointsEntry
-	nil,                                         // 141: cnspec.policy.v1.ReportingJob.ChildJobsEntry
-	nil,                                         // 142: cnspec.policy.v1.Report.ScoresEntry
-	nil,                                         // 143: cnspec.policy.v1.Report.DataEntry
-	nil,                                         // 144: cnspec.policy.v1.Report.CvssScoresEntry
-	nil,                                         // 145: cnspec.policy.v1.ReportCollection.AssetsEntry
-	nil,                                         // 146: cnspec.policy.v1.ReportCollection.ReportsEntry
-	nil,                                         // 147: cnspec.policy.v1.ReportCollection.ErrorsEntry
-	nil,                                         // 148: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	nil,                                         // 149: cnspec.policy.v1.ReportCollection.VulnReportsEntry
-	nil,                                         // 150: cnspec.policy.v1.ScoredRiskFactor.DataEntry
-	nil,                                         // 151: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
-	nil,                                         // 152: cnspec.policy.v1.StoreResultsReq.DataEntry
-	nil,                                         // 153: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
-	nil,                                         // 154: cnspec.policy.v1.UploadURL.HeadersEntry
-	nil,                                         // 155: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	nil,                                         // 156: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	nil,                                         // 157: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
-	nil,                                         // 158: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	nil,                                         // 159: cnspec.policy.v1.RefreshAssetScoresRequest.LabelsEntry
-	(*timestamppb.Timestamp)(nil),               // 160: google.protobuf.Timestamp
-	(*inventory.Platform)(nil),                  // 161: cnquery.providers.v1.Platform
-	(*llx.CodeBundle)(nil),                      // 162: mql.llx.CodeBundle
-	(*anypb.Any)(nil),                           // 163: google.protobuf.Any
-	(*inventory.Asset)(nil),                     // 164: cnquery.providers.v1.Asset
-	(*llx.Result)(nil),                          // 165: mql.llx.Result
-	(*mvd.VulnReport)(nil),                      // 166: mondoo.mvd.v1.VulnReport
-	(*llx.ResourceRecording)(nil),               // 167: mql.llx.ResourceRecording
-	(*recording.EntityResourcesReq)(nil),        // 168: mql.providers.v1.recording.EntityResourcesReq
-	(*recording.EntityResourcesRes)(nil),        // 169: mql.providers.v1.recording.EntityResourcesRes
+	(DownloadKind)(0),      // 7: cnspec.policy.v1.DownloadKind
+	(ScoreRating)(0),       // 8: cnspec.policy.v1.ScoreRating
+	(Comparison)(0),        // 9: cnspec.policy.v1.Comparison
+	(DateFilterField)(0),   // 10: cnspec.policy.v1.DateFilterField
+	(Migration_Action)(0),  // 11: cnspec.policy.v1.Migration.Action
+	(ReportingJob_Type)(0), // 12: cnspec.policy.v1.ReportingJob.Type
+	(PolicyDelta_PolicyAssignmentActionType)(0), // 13: cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
+	(Source_Vendor)(0),                          // 14: cnspec.policy.v1.Source.Vendor
+	(*ImpactValue)(nil),                         // 15: cnspec.policy.v1.ImpactValue
+	(*Impact)(nil),                              // 16: cnspec.policy.v1.Impact
+	(*ObjectRef)(nil),                           // 17: cnspec.policy.v1.ObjectRef
+	(*Author)(nil),                              // 18: cnspec.policy.v1.Author
+	(*MqueryRef)(nil),                           // 19: cnspec.policy.v1.MqueryRef
+	(*HumanTime)(nil),                           // 20: cnspec.policy.v1.HumanTime
+	(*TypedDoc)(nil),                            // 21: cnspec.policy.v1.TypedDoc
+	(*Remediation)(nil),                         // 22: cnspec.policy.v1.Remediation
+	(*MqueryDocs)(nil),                          // 23: cnspec.policy.v1.MqueryDocs
+	(*Filters)(nil),                             // 24: cnspec.policy.v1.Filters
+	(*Property)(nil),                            // 25: cnspec.policy.v1.Property
+	(*Mquery)(nil),                              // 26: cnspec.policy.v1.Mquery
+	(*QueryPackDocs)(nil),                       // 27: cnspec.policy.v1.QueryPackDocs
+	(*QueryGroup)(nil),                          // 28: cnspec.policy.v1.QueryGroup
+	(*QueryPack)(nil),                           // 29: cnspec.policy.v1.QueryPack
+	(*PropsReq)(nil),                            // 30: cnspec.policy.v1.PropsReq
+	(*PolicyGroup)(nil),                         // 31: cnspec.policy.v1.PolicyGroup
+	(*Validity)(nil),                            // 32: cnspec.policy.v1.Validity
+	(*PolicyRef)(nil),                           // 33: cnspec.policy.v1.PolicyRef
+	(*Policy)(nil),                              // 34: cnspec.policy.v1.Policy
+	(*Policies)(nil),                            // 35: cnspec.policy.v1.Policies
+	(*Requirement)(nil),                         // 36: cnspec.policy.v1.Requirement
+	(*QueryCounts)(nil),                         // 37: cnspec.policy.v1.QueryCounts
+	(*Bundle)(nil),                              // 38: cnspec.policy.v1.Bundle
+	(*MigrationPolicyRef)(nil),                  // 39: cnspec.policy.v1.MigrationPolicyRef
+	(*MigrationGroup)(nil),                      // 40: cnspec.policy.v1.MigrationGroup
+	(*MigrationConditions)(nil),                 // 41: cnspec.policy.v1.MigrationConditions
+	(*MigrationMetadata)(nil),                   // 42: cnspec.policy.v1.MigrationMetadata
+	(*MigrationStage)(nil),                      // 43: cnspec.policy.v1.MigrationStage
+	(*Migration)(nil),                           // 44: cnspec.policy.v1.Migration
+	(*MigrationSource)(nil),                     // 45: cnspec.policy.v1.MigrationSource
+	(*MigrationTarget)(nil),                     // 46: cnspec.policy.v1.MigrationTarget
+	(*SoftwareSelector)(nil),                    // 47: cnspec.policy.v1.SoftwareSelector
+	(*ResourceSelector)(nil),                    // 48: cnspec.policy.v1.ResourceSelector
+	(*RiskMagnitude)(nil),                       // 49: cnspec.policy.v1.RiskMagnitude
+	(*RiskFactor)(nil),                          // 50: cnspec.policy.v1.RiskFactor
+	(*RiskFactorDocs)(nil),                      // 51: cnspec.policy.v1.RiskFactorDocs
+	(*PolicyGroupDocs)(nil),                     // 52: cnspec.policy.v1.PolicyGroupDocs
+	(*PolicyDocs)(nil),                          // 53: cnspec.policy.v1.PolicyDocs
+	(*Framework)(nil),                           // 54: cnspec.policy.v1.Framework
+	(*Frameworks)(nil),                          // 55: cnspec.policy.v1.Frameworks
+	(*FrameworkGroup)(nil),                      // 56: cnspec.policy.v1.FrameworkGroup
+	(*FrameworkRef)(nil),                        // 57: cnspec.policy.v1.FrameworkRef
+	(*Evidence)(nil),                            // 58: cnspec.policy.v1.Evidence
+	(*Control)(nil),                             // 59: cnspec.policy.v1.Control
+	(*FrameworkMap)(nil),                        // 60: cnspec.policy.v1.FrameworkMap
+	(*ControlMap)(nil),                          // 61: cnspec.policy.v1.ControlMap
+	(*ControlDocs)(nil),                         // 62: cnspec.policy.v1.ControlDocs
+	(*ControlRef)(nil),                          // 63: cnspec.policy.v1.ControlRef
+	(*Asset)(nil),                               // 64: cnspec.policy.v1.Asset
+	(*ResolvedPolicy)(nil),                      // 65: cnspec.policy.v1.ResolvedPolicy
+	(*ExecutionJob)(nil),                        // 66: cnspec.policy.v1.ExecutionJob
+	(*ExecutionQuery)(nil),                      // 67: cnspec.policy.v1.ExecutionQuery
+	(*CollectorJob)(nil),                        // 68: cnspec.policy.v1.CollectorJob
+	(*RiskDataInfo)(nil),                        // 69: cnspec.policy.v1.RiskDataInfo
+	(*StringArray)(nil),                         // 70: cnspec.policy.v1.StringArray
+	(*DataQueryInfo)(nil),                       // 71: cnspec.policy.v1.DataQueryInfo
+	(*ReportingJob)(nil),                        // 72: cnspec.policy.v1.ReportingJob
+	(*Report)(nil),                              // 73: cnspec.policy.v1.Report
+	(*Reports)(nil),                             // 74: cnspec.policy.v1.Reports
+	(*ReportCollection)(nil),                    // 75: cnspec.policy.v1.ReportCollection
+	(*FrameworkReport)(nil),                     // 76: cnspec.policy.v1.FrameworkReport
+	(*ControlScore)(nil),                        // 77: cnspec.policy.v1.ControlScore
+	(*Cvss)(nil),                                // 78: cnspec.policy.v1.Cvss
+	(*CvssStats)(nil),                           // 79: cnspec.policy.v1.CvssStats
+	(*Score)(nil),                               // 80: cnspec.policy.v1.Score
+	(*ScoreDelta)(nil),                          // 81: cnspec.policy.v1.ScoreDelta
+	(*ScoredRiskFactor)(nil),                    // 82: cnspec.policy.v1.ScoredRiskFactor
+	(*ScoredRiskFactors)(nil),                   // 83: cnspec.policy.v1.ScoredRiskFactors
+	(*RiskFactorStats)(nil),                     // 84: cnspec.policy.v1.RiskFactorStats
+	(*RiskFactorsStats)(nil),                    // 85: cnspec.policy.v1.RiskFactorsStats
+	(*Stats)(nil),                               // 86: cnspec.policy.v1.Stats
+	(*ScoreDistribution)(nil),                   // 87: cnspec.policy.v1.ScoreDistribution
+	(*ScoreStats)(nil),                          // 88: cnspec.policy.v1.ScoreStats
+	(*AssetFindingsStats)(nil),                  // 89: cnspec.policy.v1.AssetFindingsStats
+	(*Empty)(nil),                               // 90: cnspec.policy.v1.Empty
+	(*Mrn)(nil),                                 // 91: cnspec.policy.v1.Mrn
+	(*Mqueries)(nil),                            // 92: cnspec.policy.v1.Mqueries
+	(*ListReq)(nil),                             // 93: cnspec.policy.v1.ListReq
+	(*DefaultPoliciesReq)(nil),                  // 94: cnspec.policy.v1.DefaultPoliciesReq
+	(*URLs)(nil),                                // 95: cnspec.policy.v1.URLs
+	(*PolicyAssignment)(nil),                    // 96: cnspec.policy.v1.PolicyAssignment
+	(*PolicyMutationDelta)(nil),                 // 97: cnspec.policy.v1.PolicyMutationDelta
+	(*PolicyDelta)(nil),                         // 98: cnspec.policy.v1.PolicyDelta
+	(*ResolveReq)(nil),                          // 99: cnspec.policy.v1.ResolveReq
+	(*UpdateAssetJobsReq)(nil),                  // 100: cnspec.policy.v1.UpdateAssetJobsReq
+	(*StoreResultsReq)(nil),                     // 101: cnspec.policy.v1.StoreResultsReq
+	(*GetUploadURLReq)(nil),                     // 102: cnspec.policy.v1.GetUploadURLReq
+	(*GetUploadURLResp)(nil),                    // 103: cnspec.policy.v1.GetUploadURLResp
+	(*UploadURL)(nil),                           // 104: cnspec.policy.v1.UploadURL
+	(*ReportUploadCompletedReq)(nil),            // 105: cnspec.policy.v1.ReportUploadCompletedReq
+	(*GetDownloadURLReq)(nil),                   // 106: cnspec.policy.v1.GetDownloadURLReq
+	(*GetDownloadURLResp)(nil),                  // 107: cnspec.policy.v1.GetDownloadURLResp
+	(*DownloadURL)(nil),                         // 108: cnspec.policy.v1.DownloadURL
+	(*ScanStatistics)(nil),                      // 109: cnspec.policy.v1.ScanStatistics
+	(*Metric)(nil),                              // 110: cnspec.policy.v1.Metric
+	(*EntityScoreReq)(nil),                      // 111: cnspec.policy.v1.EntityScoreReq
+	(*SynchronizeAssetsReq)(nil),                // 112: cnspec.policy.v1.SynchronizeAssetsReq
+	(*SynchronizeAssetsRespAssetDetail)(nil),    // 113: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
+	(*SynchronizeAssetsResp)(nil),               // 114: cnspec.policy.v1.SynchronizeAssetsResp
+	(*GetScanParametersReq)(nil),                // 115: cnspec.policy.v1.GetScanParametersReq
+	(*ScanParameters)(nil),                      // 116: cnspec.policy.v1.ScanParameters
+	(*PurgeAssetsRequest)(nil),                  // 117: cnspec.policy.v1.PurgeAssetsRequest
+	(*DateFilter)(nil),                          // 118: cnspec.policy.v1.DateFilter
+	(*PurgeAssetsConfirmation)(nil),             // 119: cnspec.policy.v1.PurgeAssetsConfirmation
+	(*RefreshAssetScoresRequest)(nil),           // 120: cnspec.policy.v1.RefreshAssetScoresRequest
+	(*RefreshAssetScoresResponse)(nil),          // 121: cnspec.policy.v1.RefreshAssetScoresResponse
+	(*AssetRefreshResult)(nil),                  // 122: cnspec.policy.v1.AssetRefreshResult
+	(*Sources)(nil),                             // 123: cnspec.policy.v1.Sources
+	(*Source)(nil),                              // 124: cnspec.policy.v1.Source
+	nil,                                         // 125: cnspec.policy.v1.ObjectRef.TagsEntry
+	nil,                                         // 126: cnspec.policy.v1.TypedDoc.TagsEntry
+	nil,                                         // 127: cnspec.policy.v1.Filters.ItemsEntry
+	nil,                                         // 128: cnspec.policy.v1.Mquery.TagsEntry
+	nil,                                         // 129: cnspec.policy.v1.QueryPack.TagsEntry
+	nil,                                         // 130: cnspec.policy.v1.Policy.TagsEntry
+	nil,                                         // 131: cnspec.policy.v1.MigrationMetadata.LabelsEntry
+	nil,                                         // 132: cnspec.policy.v1.RiskFactor.TagsEntry
+	nil,                                         // 133: cnspec.policy.v1.Framework.TagsEntry
+	nil,                                         // 134: cnspec.policy.v1.Control.TagsEntry
+	nil,                                         // 135: cnspec.policy.v1.ExecutionJob.QueriesEntry
+	nil,                                         // 136: cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	nil,                                         // 137: cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	nil,                                         // 138: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	nil,                                         // 139: cnspec.policy.v1.CollectorJob.DatapointsEntry
+	nil,                                         // 140: cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	nil,                                         // 141: cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	nil,                                         // 142: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
+	nil,                                         // 143: cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
+	nil,                                         // 144: cnspec.policy.v1.ReportingJob.DatapointsEntry
+	nil,                                         // 145: cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	nil,                                         // 146: cnspec.policy.v1.Report.ScoresEntry
+	nil,                                         // 147: cnspec.policy.v1.Report.DataEntry
+	nil,                                         // 148: cnspec.policy.v1.Report.CvssScoresEntry
+	nil,                                         // 149: cnspec.policy.v1.ReportCollection.AssetsEntry
+	nil,                                         // 150: cnspec.policy.v1.ReportCollection.ReportsEntry
+	nil,                                         // 151: cnspec.policy.v1.ReportCollection.ErrorsEntry
+	nil,                                         // 152: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	nil,                                         // 153: cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	nil,                                         // 154: cnspec.policy.v1.ScoredRiskFactor.DataEntry
+	nil,                                         // 155: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	nil,                                         // 156: cnspec.policy.v1.StoreResultsReq.DataEntry
+	nil,                                         // 157: cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	nil,                                         // 158: cnspec.policy.v1.UploadURL.HeadersEntry
+	nil,                                         // 159: cnspec.policy.v1.DownloadURL.HeadersEntry
+	nil,                                         // 160: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	nil,                                         // 161: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	nil,                                         // 162: cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	nil,                                         // 163: cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	nil,                                         // 164: cnspec.policy.v1.RefreshAssetScoresRequest.LabelsEntry
+	(*timestamppb.Timestamp)(nil),               // 165: google.protobuf.Timestamp
+	(*inventory.Platform)(nil),                  // 166: cnquery.providers.v1.Platform
+	(*llx.CodeBundle)(nil),                      // 167: mql.llx.CodeBundle
+	(*anypb.Any)(nil),                           // 168: google.protobuf.Any
+	(*inventory.Asset)(nil),                     // 169: cnquery.providers.v1.Asset
+	(*llx.Result)(nil),                          // 170: mql.llx.Result
+	(*mvd.VulnReport)(nil),                      // 171: mondoo.mvd.v1.VulnReport
+	(*llx.ResourceRecording)(nil),               // 172: mql.llx.ResourceRecording
+	(*recording.EntityResourcesReq)(nil),        // 173: mql.providers.v1.recording.EntityResourcesReq
+	(*recording.EntityResourcesRes)(nil),        // 174: mql.providers.v1.recording.EntityResourcesRes
 }
 var file_cnspec_policy_proto_depIdxs = []int32{
-	14,  // 0: cnspec.policy.v1.Impact.value:type_name -> cnspec.policy.v1.ImpactValue
+	15,  // 0: cnspec.policy.v1.Impact.value:type_name -> cnspec.policy.v1.ImpactValue
 	1,   // 1: cnspec.policy.v1.Impact.scoring:type_name -> cnspec.policy.v1.ScoringSystem
 	0,   // 2: cnspec.policy.v1.Impact.action:type_name -> cnspec.policy.v1.Action
-	121, // 3: cnspec.policy.v1.ObjectRef.tags:type_name -> cnspec.policy.v1.ObjectRef.TagsEntry
-	122, // 4: cnspec.policy.v1.TypedDoc.tags:type_name -> cnspec.policy.v1.TypedDoc.TagsEntry
-	20,  // 5: cnspec.policy.v1.Remediation.items:type_name -> cnspec.policy.v1.TypedDoc
-	18,  // 6: cnspec.policy.v1.MqueryDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
-	21,  // 7: cnspec.policy.v1.MqueryDocs.remediation:type_name -> cnspec.policy.v1.Remediation
-	123, // 8: cnspec.policy.v1.Filters.items:type_name -> cnspec.policy.v1.Filters.ItemsEntry
-	16,  // 9: cnspec.policy.v1.Property.for:type_name -> cnspec.policy.v1.ObjectRef
-	18,  // 10: cnspec.policy.v1.Mquery.refs:type_name -> cnspec.policy.v1.MqueryRef
-	22,  // 11: cnspec.policy.v1.Mquery.docs:type_name -> cnspec.policy.v1.MqueryDocs
-	15,  // 12: cnspec.policy.v1.Mquery.impact:type_name -> cnspec.policy.v1.Impact
-	124, // 13: cnspec.policy.v1.Mquery.tags:type_name -> cnspec.policy.v1.Mquery.TagsEntry
-	23,  // 14: cnspec.policy.v1.Mquery.filters:type_name -> cnspec.policy.v1.Filters
-	24,  // 15: cnspec.policy.v1.Mquery.props:type_name -> cnspec.policy.v1.Property
-	16,  // 16: cnspec.policy.v1.Mquery.variants:type_name -> cnspec.policy.v1.ObjectRef
+	125, // 3: cnspec.policy.v1.ObjectRef.tags:type_name -> cnspec.policy.v1.ObjectRef.TagsEntry
+	126, // 4: cnspec.policy.v1.TypedDoc.tags:type_name -> cnspec.policy.v1.TypedDoc.TagsEntry
+	21,  // 5: cnspec.policy.v1.Remediation.items:type_name -> cnspec.policy.v1.TypedDoc
+	19,  // 6: cnspec.policy.v1.MqueryDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
+	22,  // 7: cnspec.policy.v1.MqueryDocs.remediation:type_name -> cnspec.policy.v1.Remediation
+	127, // 8: cnspec.policy.v1.Filters.items:type_name -> cnspec.policy.v1.Filters.ItemsEntry
+	17,  // 9: cnspec.policy.v1.Property.for:type_name -> cnspec.policy.v1.ObjectRef
+	19,  // 10: cnspec.policy.v1.Mquery.refs:type_name -> cnspec.policy.v1.MqueryRef
+	23,  // 11: cnspec.policy.v1.Mquery.docs:type_name -> cnspec.policy.v1.MqueryDocs
+	16,  // 12: cnspec.policy.v1.Mquery.impact:type_name -> cnspec.policy.v1.Impact
+	128, // 13: cnspec.policy.v1.Mquery.tags:type_name -> cnspec.policy.v1.Mquery.TagsEntry
+	24,  // 14: cnspec.policy.v1.Mquery.filters:type_name -> cnspec.policy.v1.Filters
+	25,  // 15: cnspec.policy.v1.Mquery.props:type_name -> cnspec.policy.v1.Property
+	17,  // 16: cnspec.policy.v1.Mquery.variants:type_name -> cnspec.policy.v1.ObjectRef
 	0,   // 17: cnspec.policy.v1.Mquery.action:type_name -> cnspec.policy.v1.Action
-	25,  // 18: cnspec.policy.v1.QueryGroup.queries:type_name -> cnspec.policy.v1.Mquery
-	23,  // 19: cnspec.policy.v1.QueryGroup.filters:type_name -> cnspec.policy.v1.Filters
-	25,  // 20: cnspec.policy.v1.QueryPack.queries:type_name -> cnspec.policy.v1.Mquery
-	27,  // 21: cnspec.policy.v1.QueryPack.groups:type_name -> cnspec.policy.v1.QueryGroup
-	24,  // 22: cnspec.policy.v1.QueryPack.props:type_name -> cnspec.policy.v1.Property
-	23,  // 23: cnspec.policy.v1.QueryPack.computed_filters:type_name -> cnspec.policy.v1.Filters
-	23,  // 24: cnspec.policy.v1.QueryPack.filters:type_name -> cnspec.policy.v1.Filters
-	35,  // 25: cnspec.policy.v1.QueryPack.require:type_name -> cnspec.policy.v1.Requirement
-	26,  // 26: cnspec.policy.v1.QueryPack.docs:type_name -> cnspec.policy.v1.QueryPackDocs
-	17,  // 27: cnspec.policy.v1.QueryPack.authors:type_name -> cnspec.policy.v1.Author
-	125, // 28: cnspec.policy.v1.QueryPack.tags:type_name -> cnspec.policy.v1.QueryPack.TagsEntry
-	24,  // 29: cnspec.policy.v1.PropsReq.props:type_name -> cnspec.policy.v1.Property
-	32,  // 30: cnspec.policy.v1.PolicyGroup.policies:type_name -> cnspec.policy.v1.PolicyRef
-	25,  // 31: cnspec.policy.v1.PolicyGroup.checks:type_name -> cnspec.policy.v1.Mquery
-	25,  // 32: cnspec.policy.v1.PolicyGroup.queries:type_name -> cnspec.policy.v1.Mquery
+	26,  // 18: cnspec.policy.v1.QueryGroup.queries:type_name -> cnspec.policy.v1.Mquery
+	24,  // 19: cnspec.policy.v1.QueryGroup.filters:type_name -> cnspec.policy.v1.Filters
+	26,  // 20: cnspec.policy.v1.QueryPack.queries:type_name -> cnspec.policy.v1.Mquery
+	28,  // 21: cnspec.policy.v1.QueryPack.groups:type_name -> cnspec.policy.v1.QueryGroup
+	25,  // 22: cnspec.policy.v1.QueryPack.props:type_name -> cnspec.policy.v1.Property
+	24,  // 23: cnspec.policy.v1.QueryPack.computed_filters:type_name -> cnspec.policy.v1.Filters
+	24,  // 24: cnspec.policy.v1.QueryPack.filters:type_name -> cnspec.policy.v1.Filters
+	36,  // 25: cnspec.policy.v1.QueryPack.require:type_name -> cnspec.policy.v1.Requirement
+	27,  // 26: cnspec.policy.v1.QueryPack.docs:type_name -> cnspec.policy.v1.QueryPackDocs
+	18,  // 27: cnspec.policy.v1.QueryPack.authors:type_name -> cnspec.policy.v1.Author
+	129, // 28: cnspec.policy.v1.QueryPack.tags:type_name -> cnspec.policy.v1.QueryPack.TagsEntry
+	25,  // 29: cnspec.policy.v1.PropsReq.props:type_name -> cnspec.policy.v1.Property
+	33,  // 30: cnspec.policy.v1.PolicyGroup.policies:type_name -> cnspec.policy.v1.PolicyRef
+	26,  // 31: cnspec.policy.v1.PolicyGroup.checks:type_name -> cnspec.policy.v1.Mquery
+	26,  // 32: cnspec.policy.v1.PolicyGroup.queries:type_name -> cnspec.policy.v1.Mquery
 	2,   // 33: cnspec.policy.v1.PolicyGroup.type:type_name -> cnspec.policy.v1.GroupType
-	23,  // 34: cnspec.policy.v1.PolicyGroup.filters:type_name -> cnspec.policy.v1.Filters
-	31,  // 35: cnspec.policy.v1.PolicyGroup.valid:type_name -> cnspec.policy.v1.Validity
-	51,  // 36: cnspec.policy.v1.PolicyGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
-	17,  // 37: cnspec.policy.v1.PolicyGroup.authors:type_name -> cnspec.policy.v1.Author
-	17,  // 38: cnspec.policy.v1.PolicyGroup.reviewers:type_name -> cnspec.policy.v1.Author
+	24,  // 34: cnspec.policy.v1.PolicyGroup.filters:type_name -> cnspec.policy.v1.Filters
+	32,  // 35: cnspec.policy.v1.PolicyGroup.valid:type_name -> cnspec.policy.v1.Validity
+	52,  // 36: cnspec.policy.v1.PolicyGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
+	18,  // 37: cnspec.policy.v1.PolicyGroup.authors:type_name -> cnspec.policy.v1.Author
+	18,  // 38: cnspec.policy.v1.PolicyGroup.reviewers:type_name -> cnspec.policy.v1.Author
 	4,   // 39: cnspec.policy.v1.PolicyGroup.review_status:type_name -> cnspec.policy.v1.ReviewStatus
-	19,  // 40: cnspec.policy.v1.Validity.from:type_name -> cnspec.policy.v1.HumanTime
-	19,  // 41: cnspec.policy.v1.Validity.until:type_name -> cnspec.policy.v1.HumanTime
+	20,  // 40: cnspec.policy.v1.Validity.from:type_name -> cnspec.policy.v1.HumanTime
+	20,  // 41: cnspec.policy.v1.Validity.until:type_name -> cnspec.policy.v1.HumanTime
 	0,   // 42: cnspec.policy.v1.PolicyRef.action:type_name -> cnspec.policy.v1.Action
-	15,  // 43: cnspec.policy.v1.PolicyRef.impact:type_name -> cnspec.policy.v1.Impact
+	16,  // 43: cnspec.policy.v1.PolicyRef.impact:type_name -> cnspec.policy.v1.Impact
 	1,   // 44: cnspec.policy.v1.PolicyRef.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	30,  // 45: cnspec.policy.v1.Policy.groups:type_name -> cnspec.policy.v1.PolicyGroup
-	52,  // 46: cnspec.policy.v1.Policy.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	31,  // 45: cnspec.policy.v1.Policy.groups:type_name -> cnspec.policy.v1.PolicyGroup
+	53,  // 46: cnspec.policy.v1.Policy.docs:type_name -> cnspec.policy.v1.PolicyDocs
 	1,   // 47: cnspec.policy.v1.Policy.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	17,  // 48: cnspec.policy.v1.Policy.authors:type_name -> cnspec.policy.v1.Author
-	126, // 49: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
-	24,  // 50: cnspec.policy.v1.Policy.props:type_name -> cnspec.policy.v1.Property
-	49,  // 51: cnspec.policy.v1.Policy.risk_factors:type_name -> cnspec.policy.v1.RiskFactor
-	35,  // 52: cnspec.policy.v1.Policy.require:type_name -> cnspec.policy.v1.Requirement
-	23,  // 53: cnspec.policy.v1.Policy.computed_filters:type_name -> cnspec.policy.v1.Filters
-	36,  // 54: cnspec.policy.v1.Policy.query_counts:type_name -> cnspec.policy.v1.QueryCounts
-	33,  // 55: cnspec.policy.v1.Policies.items:type_name -> cnspec.policy.v1.Policy
-	33,  // 56: cnspec.policy.v1.Bundle.policies:type_name -> cnspec.policy.v1.Policy
-	28,  // 57: cnspec.policy.v1.Bundle.packs:type_name -> cnspec.policy.v1.QueryPack
-	24,  // 58: cnspec.policy.v1.Bundle.props:type_name -> cnspec.policy.v1.Property
-	25,  // 59: cnspec.policy.v1.Bundle.queries:type_name -> cnspec.policy.v1.Mquery
-	53,  // 60: cnspec.policy.v1.Bundle.frameworks:type_name -> cnspec.policy.v1.Framework
-	59,  // 61: cnspec.policy.v1.Bundle.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
-	52,  // 62: cnspec.policy.v1.Bundle.docs:type_name -> cnspec.policy.v1.PolicyDocs
-	39,  // 63: cnspec.policy.v1.Bundle.migration_groups:type_name -> cnspec.policy.v1.MigrationGroup
-	43,  // 64: cnspec.policy.v1.MigrationGroup.migrations:type_name -> cnspec.policy.v1.Migration
-	40,  // 65: cnspec.policy.v1.MigrationGroup.conditions:type_name -> cnspec.policy.v1.MigrationConditions
-	42,  // 66: cnspec.policy.v1.MigrationGroup.stages:type_name -> cnspec.policy.v1.MigrationStage
-	41,  // 67: cnspec.policy.v1.MigrationGroup.metadata:type_name -> cnspec.policy.v1.MigrationMetadata
-	38,  // 68: cnspec.policy.v1.MigrationConditions.source_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
-	38,  // 69: cnspec.policy.v1.MigrationConditions.target_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
-	160, // 70: cnspec.policy.v1.MigrationMetadata.created_at:type_name -> google.protobuf.Timestamp
-	127, // 71: cnspec.policy.v1.MigrationMetadata.labels:type_name -> cnspec.policy.v1.MigrationMetadata.LabelsEntry
-	43,  // 72: cnspec.policy.v1.MigrationStage.query_migrations:type_name -> cnspec.policy.v1.Migration
-	43,  // 73: cnspec.policy.v1.MigrationStage.policy_migrations:type_name -> cnspec.policy.v1.Migration
-	44,  // 74: cnspec.policy.v1.Migration.source:type_name -> cnspec.policy.v1.MigrationSource
-	45,  // 75: cnspec.policy.v1.Migration.target:type_name -> cnspec.policy.v1.MigrationTarget
-	10,  // 76: cnspec.policy.v1.Migration.action:type_name -> cnspec.policy.v1.Migration.Action
-	50,  // 77: cnspec.policy.v1.RiskFactor.docs:type_name -> cnspec.policy.v1.RiskFactorDocs
-	23,  // 78: cnspec.policy.v1.RiskFactor.filters:type_name -> cnspec.policy.v1.Filters
-	25,  // 79: cnspec.policy.v1.RiskFactor.checks:type_name -> cnspec.policy.v1.Mquery
-	25,  // 80: cnspec.policy.v1.RiskFactor.queries:type_name -> cnspec.policy.v1.Mquery
+	18,  // 48: cnspec.policy.v1.Policy.authors:type_name -> cnspec.policy.v1.Author
+	130, // 49: cnspec.policy.v1.Policy.tags:type_name -> cnspec.policy.v1.Policy.TagsEntry
+	25,  // 50: cnspec.policy.v1.Policy.props:type_name -> cnspec.policy.v1.Property
+	50,  // 51: cnspec.policy.v1.Policy.risk_factors:type_name -> cnspec.policy.v1.RiskFactor
+	36,  // 52: cnspec.policy.v1.Policy.require:type_name -> cnspec.policy.v1.Requirement
+	24,  // 53: cnspec.policy.v1.Policy.computed_filters:type_name -> cnspec.policy.v1.Filters
+	37,  // 54: cnspec.policy.v1.Policy.query_counts:type_name -> cnspec.policy.v1.QueryCounts
+	34,  // 55: cnspec.policy.v1.Policies.items:type_name -> cnspec.policy.v1.Policy
+	34,  // 56: cnspec.policy.v1.Bundle.policies:type_name -> cnspec.policy.v1.Policy
+	29,  // 57: cnspec.policy.v1.Bundle.packs:type_name -> cnspec.policy.v1.QueryPack
+	25,  // 58: cnspec.policy.v1.Bundle.props:type_name -> cnspec.policy.v1.Property
+	26,  // 59: cnspec.policy.v1.Bundle.queries:type_name -> cnspec.policy.v1.Mquery
+	54,  // 60: cnspec.policy.v1.Bundle.frameworks:type_name -> cnspec.policy.v1.Framework
+	60,  // 61: cnspec.policy.v1.Bundle.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
+	53,  // 62: cnspec.policy.v1.Bundle.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	40,  // 63: cnspec.policy.v1.Bundle.migration_groups:type_name -> cnspec.policy.v1.MigrationGroup
+	44,  // 64: cnspec.policy.v1.MigrationGroup.migrations:type_name -> cnspec.policy.v1.Migration
+	41,  // 65: cnspec.policy.v1.MigrationGroup.conditions:type_name -> cnspec.policy.v1.MigrationConditions
+	43,  // 66: cnspec.policy.v1.MigrationGroup.stages:type_name -> cnspec.policy.v1.MigrationStage
+	42,  // 67: cnspec.policy.v1.MigrationGroup.metadata:type_name -> cnspec.policy.v1.MigrationMetadata
+	39,  // 68: cnspec.policy.v1.MigrationConditions.source_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
+	39,  // 69: cnspec.policy.v1.MigrationConditions.target_policy:type_name -> cnspec.policy.v1.MigrationPolicyRef
+	165, // 70: cnspec.policy.v1.MigrationMetadata.created_at:type_name -> google.protobuf.Timestamp
+	131, // 71: cnspec.policy.v1.MigrationMetadata.labels:type_name -> cnspec.policy.v1.MigrationMetadata.LabelsEntry
+	44,  // 72: cnspec.policy.v1.MigrationStage.query_migrations:type_name -> cnspec.policy.v1.Migration
+	44,  // 73: cnspec.policy.v1.MigrationStage.policy_migrations:type_name -> cnspec.policy.v1.Migration
+	45,  // 74: cnspec.policy.v1.Migration.source:type_name -> cnspec.policy.v1.MigrationSource
+	46,  // 75: cnspec.policy.v1.Migration.target:type_name -> cnspec.policy.v1.MigrationTarget
+	11,  // 76: cnspec.policy.v1.Migration.action:type_name -> cnspec.policy.v1.Migration.Action
+	51,  // 77: cnspec.policy.v1.RiskFactor.docs:type_name -> cnspec.policy.v1.RiskFactorDocs
+	24,  // 78: cnspec.policy.v1.RiskFactor.filters:type_name -> cnspec.policy.v1.Filters
+	26,  // 79: cnspec.policy.v1.RiskFactor.checks:type_name -> cnspec.policy.v1.Mquery
+	26,  // 80: cnspec.policy.v1.RiskFactor.queries:type_name -> cnspec.policy.v1.Mquery
 	3,   // 81: cnspec.policy.v1.RiskFactor.scope:type_name -> cnspec.policy.v1.ScopeType
-	48,  // 82: cnspec.policy.v1.RiskFactor.magnitude:type_name -> cnspec.policy.v1.RiskMagnitude
-	46,  // 83: cnspec.policy.v1.RiskFactor.software:type_name -> cnspec.policy.v1.SoftwareSelector
-	47,  // 84: cnspec.policy.v1.RiskFactor.resources:type_name -> cnspec.policy.v1.ResourceSelector
+	49,  // 82: cnspec.policy.v1.RiskFactor.magnitude:type_name -> cnspec.policy.v1.RiskMagnitude
+	47,  // 83: cnspec.policy.v1.RiskFactor.software:type_name -> cnspec.policy.v1.SoftwareSelector
+	48,  // 84: cnspec.policy.v1.RiskFactor.resources:type_name -> cnspec.policy.v1.ResourceSelector
 	0,   // 85: cnspec.policy.v1.RiskFactor.action:type_name -> cnspec.policy.v1.Action
-	128, // 86: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
-	55,  // 87: cnspec.policy.v1.Framework.groups:type_name -> cnspec.policy.v1.FrameworkGroup
-	52,  // 88: cnspec.policy.v1.Framework.docs:type_name -> cnspec.policy.v1.PolicyDocs
-	17,  // 89: cnspec.policy.v1.Framework.authors:type_name -> cnspec.policy.v1.Author
-	129, // 90: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
-	56,  // 91: cnspec.policy.v1.Framework.dependencies:type_name -> cnspec.policy.v1.FrameworkRef
-	59,  // 92: cnspec.policy.v1.Framework.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
-	53,  // 93: cnspec.policy.v1.Frameworks.items:type_name -> cnspec.policy.v1.Framework
-	58,  // 94: cnspec.policy.v1.FrameworkGroup.controls:type_name -> cnspec.policy.v1.Control
+	132, // 86: cnspec.policy.v1.RiskFactor.tags:type_name -> cnspec.policy.v1.RiskFactor.TagsEntry
+	56,  // 87: cnspec.policy.v1.Framework.groups:type_name -> cnspec.policy.v1.FrameworkGroup
+	53,  // 88: cnspec.policy.v1.Framework.docs:type_name -> cnspec.policy.v1.PolicyDocs
+	18,  // 89: cnspec.policy.v1.Framework.authors:type_name -> cnspec.policy.v1.Author
+	133, // 90: cnspec.policy.v1.Framework.tags:type_name -> cnspec.policy.v1.Framework.TagsEntry
+	57,  // 91: cnspec.policy.v1.Framework.dependencies:type_name -> cnspec.policy.v1.FrameworkRef
+	60,  // 92: cnspec.policy.v1.Framework.framework_maps:type_name -> cnspec.policy.v1.FrameworkMap
+	54,  // 93: cnspec.policy.v1.Frameworks.items:type_name -> cnspec.policy.v1.Framework
+	59,  // 94: cnspec.policy.v1.FrameworkGroup.controls:type_name -> cnspec.policy.v1.Control
 	2,   // 95: cnspec.policy.v1.FrameworkGroup.type:type_name -> cnspec.policy.v1.GroupType
-	51,  // 96: cnspec.policy.v1.FrameworkGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
-	17,  // 97: cnspec.policy.v1.FrameworkGroup.authors:type_name -> cnspec.policy.v1.Author
-	17,  // 98: cnspec.policy.v1.FrameworkGroup.reviewers:type_name -> cnspec.policy.v1.Author
+	52,  // 96: cnspec.policy.v1.FrameworkGroup.docs:type_name -> cnspec.policy.v1.PolicyGroupDocs
+	18,  // 97: cnspec.policy.v1.FrameworkGroup.authors:type_name -> cnspec.policy.v1.Author
+	18,  // 98: cnspec.policy.v1.FrameworkGroup.reviewers:type_name -> cnspec.policy.v1.Author
 	4,   // 99: cnspec.policy.v1.FrameworkGroup.review_status:type_name -> cnspec.policy.v1.ReviewStatus
 	0,   // 100: cnspec.policy.v1.FrameworkRef.action:type_name -> cnspec.policy.v1.Action
-	25,  // 101: cnspec.policy.v1.Evidence.checks:type_name -> cnspec.policy.v1.Mquery
-	25,  // 102: cnspec.policy.v1.Evidence.queries:type_name -> cnspec.policy.v1.Mquery
-	62,  // 103: cnspec.policy.v1.Evidence.controls:type_name -> cnspec.policy.v1.ControlRef
-	61,  // 104: cnspec.policy.v1.Control.docs:type_name -> cnspec.policy.v1.ControlDocs
-	130, // 105: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
+	26,  // 101: cnspec.policy.v1.Evidence.checks:type_name -> cnspec.policy.v1.Mquery
+	26,  // 102: cnspec.policy.v1.Evidence.queries:type_name -> cnspec.policy.v1.Mquery
+	63,  // 103: cnspec.policy.v1.Evidence.controls:type_name -> cnspec.policy.v1.ControlRef
+	62,  // 104: cnspec.policy.v1.Control.docs:type_name -> cnspec.policy.v1.ControlDocs
+	134, // 105: cnspec.policy.v1.Control.tags:type_name -> cnspec.policy.v1.Control.TagsEntry
 	0,   // 106: cnspec.policy.v1.Control.action:type_name -> cnspec.policy.v1.Action
-	57,  // 107: cnspec.policy.v1.Control.evidence:type_name -> cnspec.policy.v1.Evidence
-	16,  // 108: cnspec.policy.v1.FrameworkMap.framework_dependencies:type_name -> cnspec.policy.v1.ObjectRef
-	16,  // 109: cnspec.policy.v1.FrameworkMap.policy_dependencies:type_name -> cnspec.policy.v1.ObjectRef
-	16,  // 110: cnspec.policy.v1.FrameworkMap.query_pack_dependencies:type_name -> cnspec.policy.v1.ObjectRef
-	60,  // 111: cnspec.policy.v1.FrameworkMap.controls:type_name -> cnspec.policy.v1.ControlMap
-	16,  // 112: cnspec.policy.v1.FrameworkMap.framework_owner:type_name -> cnspec.policy.v1.ObjectRef
-	62,  // 113: cnspec.policy.v1.ControlMap.checks:type_name -> cnspec.policy.v1.ControlRef
-	62,  // 114: cnspec.policy.v1.ControlMap.policies:type_name -> cnspec.policy.v1.ControlRef
-	62,  // 115: cnspec.policy.v1.ControlMap.controls:type_name -> cnspec.policy.v1.ControlRef
-	62,  // 116: cnspec.policy.v1.ControlMap.queries:type_name -> cnspec.policy.v1.ControlRef
-	18,  // 117: cnspec.policy.v1.ControlDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
+	58,  // 107: cnspec.policy.v1.Control.evidence:type_name -> cnspec.policy.v1.Evidence
+	17,  // 108: cnspec.policy.v1.FrameworkMap.framework_dependencies:type_name -> cnspec.policy.v1.ObjectRef
+	17,  // 109: cnspec.policy.v1.FrameworkMap.policy_dependencies:type_name -> cnspec.policy.v1.ObjectRef
+	17,  // 110: cnspec.policy.v1.FrameworkMap.query_pack_dependencies:type_name -> cnspec.policy.v1.ObjectRef
+	61,  // 111: cnspec.policy.v1.FrameworkMap.controls:type_name -> cnspec.policy.v1.ControlMap
+	17,  // 112: cnspec.policy.v1.FrameworkMap.framework_owner:type_name -> cnspec.policy.v1.ObjectRef
+	63,  // 113: cnspec.policy.v1.ControlMap.checks:type_name -> cnspec.policy.v1.ControlRef
+	63,  // 114: cnspec.policy.v1.ControlMap.policies:type_name -> cnspec.policy.v1.ControlRef
+	63,  // 115: cnspec.policy.v1.ControlMap.controls:type_name -> cnspec.policy.v1.ControlRef
+	63,  // 116: cnspec.policy.v1.ControlMap.queries:type_name -> cnspec.policy.v1.ControlRef
+	19,  // 117: cnspec.policy.v1.ControlDocs.refs:type_name -> cnspec.policy.v1.MqueryRef
 	0,   // 118: cnspec.policy.v1.ControlRef.action:type_name -> cnspec.policy.v1.Action
-	161, // 119: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
-	65,  // 120: cnspec.policy.v1.ResolvedPolicy.execution_job:type_name -> cnspec.policy.v1.ExecutionJob
-	67,  // 121: cnspec.policy.v1.ResolvedPolicy.collector_job:type_name -> cnspec.policy.v1.CollectorJob
-	25,  // 122: cnspec.policy.v1.ResolvedPolicy.filters:type_name -> cnspec.policy.v1.Mquery
+	166, // 119: cnspec.policy.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
+	66,  // 120: cnspec.policy.v1.ResolvedPolicy.execution_job:type_name -> cnspec.policy.v1.ExecutionJob
+	68,  // 121: cnspec.policy.v1.ResolvedPolicy.collector_job:type_name -> cnspec.policy.v1.CollectorJob
+	26,  // 122: cnspec.policy.v1.ResolvedPolicy.filters:type_name -> cnspec.policy.v1.Mquery
 	5,   // 123: cnspec.policy.v1.ResolvedPolicy.features:type_name -> cnspec.policy.v1.ServerFeature
-	131, // 124: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
-	132, // 125: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
-	162, // 126: cnspec.policy.v1.ExecutionQuery.code:type_name -> mql.llx.CodeBundle
-	133, // 127: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
-	134, // 128: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
-	135, // 129: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
-	136, // 130: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
-	137, // 131: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
-	138, // 132: cnspec.policy.v1.CollectorJob.risk_data_queries:type_name -> cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
-	139, // 133: cnspec.policy.v1.RiskDataInfo.datapoint_checksums:type_name -> cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
+	135, // 124: cnspec.policy.v1.ExecutionJob.queries:type_name -> cnspec.policy.v1.ExecutionJob.QueriesEntry
+	136, // 125: cnspec.policy.v1.ExecutionQuery.properties:type_name -> cnspec.policy.v1.ExecutionQuery.PropertiesEntry
+	167, // 126: cnspec.policy.v1.ExecutionQuery.code:type_name -> mql.llx.CodeBundle
+	137, // 127: cnspec.policy.v1.CollectorJob.reporting_jobs:type_name -> cnspec.policy.v1.CollectorJob.ReportingJobsEntry
+	138, // 128: cnspec.policy.v1.CollectorJob.reporting_queries:type_name -> cnspec.policy.v1.CollectorJob.ReportingQueriesEntry
+	139, // 129: cnspec.policy.v1.CollectorJob.datapoints:type_name -> cnspec.policy.v1.CollectorJob.DatapointsEntry
+	140, // 130: cnspec.policy.v1.CollectorJob.risk_mrns:type_name -> cnspec.policy.v1.CollectorJob.RiskMrnsEntry
+	141, // 131: cnspec.policy.v1.CollectorJob.risk_factors:type_name -> cnspec.policy.v1.CollectorJob.RiskFactorsEntry
+	142, // 132: cnspec.policy.v1.CollectorJob.risk_data_queries:type_name -> cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry
+	143, // 133: cnspec.policy.v1.RiskDataInfo.datapoint_checksums:type_name -> cnspec.policy.v1.RiskDataInfo.DatapointChecksumsEntry
 	1,   // 134: cnspec.policy.v1.ReportingJob.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	140, // 135: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
-	141, // 136: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
-	11,  // 137: cnspec.policy.v1.ReportingJob.type:type_name -> cnspec.policy.v1.ReportingJob.Type
-	79,  // 138: cnspec.policy.v1.Report.score:type_name -> cnspec.policy.v1.Score
-	142, // 139: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
-	143, // 140: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
-	85,  // 141: cnspec.policy.v1.Report.stats:type_name -> cnspec.policy.v1.Stats
-	82,  // 142: cnspec.policy.v1.Report.risks:type_name -> cnspec.policy.v1.ScoredRiskFactors
-	85,  // 143: cnspec.policy.v1.Report.ignored_stats:type_name -> cnspec.policy.v1.Stats
-	77,  // 144: cnspec.policy.v1.Report.cvss_score:type_name -> cnspec.policy.v1.Cvss
-	144, // 145: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
-	78,  // 146: cnspec.policy.v1.Report.cvss_stats:type_name -> cnspec.policy.v1.CvssStats
-	72,  // 147: cnspec.policy.v1.Reports.reports:type_name -> cnspec.policy.v1.Report
-	145, // 148: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
-	37,  // 149: cnspec.policy.v1.ReportCollection.bundle:type_name -> cnspec.policy.v1.Bundle
-	146, // 150: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
-	147, // 151: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
-	148, // 152: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
-	149, // 153: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
-	76,  // 154: cnspec.policy.v1.FrameworkReport.score:type_name -> cnspec.policy.v1.ControlScore
-	76,  // 155: cnspec.policy.v1.FrameworkReport.controls:type_name -> cnspec.policy.v1.ControlScore
-	76,  // 156: cnspec.policy.v1.ControlScore.assets:type_name -> cnspec.policy.v1.ControlScore
-	86,  // 157: cnspec.policy.v1.ControlScore.scores:type_name -> cnspec.policy.v1.ScoreDistribution
-	82,  // 158: cnspec.policy.v1.Score.risk_factors:type_name -> cnspec.policy.v1.ScoredRiskFactors
-	120, // 159: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
-	119, // 160: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
-	150, // 161: cnspec.policy.v1.ScoredRiskFactor.data:type_name -> cnspec.policy.v1.ScoredRiskFactor.DataEntry
-	81,  // 162: cnspec.policy.v1.ScoredRiskFactors.items:type_name -> cnspec.policy.v1.ScoredRiskFactor
-	83,  // 163: cnspec.policy.v1.RiskFactorsStats.items:type_name -> cnspec.policy.v1.RiskFactorStats
-	86,  // 164: cnspec.policy.v1.Stats.failed:type_name -> cnspec.policy.v1.ScoreDistribution
-	86,  // 165: cnspec.policy.v1.Stats.passed:type_name -> cnspec.policy.v1.ScoreDistribution
-	86,  // 166: cnspec.policy.v1.Stats.errors:type_name -> cnspec.policy.v1.ScoreDistribution
-	87,  // 167: cnspec.policy.v1.AssetFindingsStats.score_stats:type_name -> cnspec.policy.v1.ScoreStats
-	84,  // 168: cnspec.policy.v1.AssetFindingsStats.risk_factors:type_name -> cnspec.policy.v1.RiskFactorsStats
-	25,  // 169: cnspec.policy.v1.Mqueries.items:type_name -> cnspec.policy.v1.Mquery
+	144, // 135: cnspec.policy.v1.ReportingJob.datapoints:type_name -> cnspec.policy.v1.ReportingJob.DatapointsEntry
+	145, // 136: cnspec.policy.v1.ReportingJob.child_jobs:type_name -> cnspec.policy.v1.ReportingJob.ChildJobsEntry
+	12,  // 137: cnspec.policy.v1.ReportingJob.type:type_name -> cnspec.policy.v1.ReportingJob.Type
+	80,  // 138: cnspec.policy.v1.Report.score:type_name -> cnspec.policy.v1.Score
+	146, // 139: cnspec.policy.v1.Report.scores:type_name -> cnspec.policy.v1.Report.ScoresEntry
+	147, // 140: cnspec.policy.v1.Report.data:type_name -> cnspec.policy.v1.Report.DataEntry
+	86,  // 141: cnspec.policy.v1.Report.stats:type_name -> cnspec.policy.v1.Stats
+	83,  // 142: cnspec.policy.v1.Report.risks:type_name -> cnspec.policy.v1.ScoredRiskFactors
+	86,  // 143: cnspec.policy.v1.Report.ignored_stats:type_name -> cnspec.policy.v1.Stats
+	78,  // 144: cnspec.policy.v1.Report.cvss_score:type_name -> cnspec.policy.v1.Cvss
+	148, // 145: cnspec.policy.v1.Report.cvss_scores:type_name -> cnspec.policy.v1.Report.CvssScoresEntry
+	79,  // 146: cnspec.policy.v1.Report.cvss_stats:type_name -> cnspec.policy.v1.CvssStats
+	73,  // 147: cnspec.policy.v1.Reports.reports:type_name -> cnspec.policy.v1.Report
+	149, // 148: cnspec.policy.v1.ReportCollection.assets:type_name -> cnspec.policy.v1.ReportCollection.AssetsEntry
+	38,  // 149: cnspec.policy.v1.ReportCollection.bundle:type_name -> cnspec.policy.v1.Bundle
+	150, // 150: cnspec.policy.v1.ReportCollection.reports:type_name -> cnspec.policy.v1.ReportCollection.ReportsEntry
+	151, // 151: cnspec.policy.v1.ReportCollection.errors:type_name -> cnspec.policy.v1.ReportCollection.ErrorsEntry
+	152, // 152: cnspec.policy.v1.ReportCollection.resolved_policies:type_name -> cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry
+	153, // 153: cnspec.policy.v1.ReportCollection.vuln_reports:type_name -> cnspec.policy.v1.ReportCollection.VulnReportsEntry
+	77,  // 154: cnspec.policy.v1.FrameworkReport.score:type_name -> cnspec.policy.v1.ControlScore
+	77,  // 155: cnspec.policy.v1.FrameworkReport.controls:type_name -> cnspec.policy.v1.ControlScore
+	77,  // 156: cnspec.policy.v1.ControlScore.assets:type_name -> cnspec.policy.v1.ControlScore
+	87,  // 157: cnspec.policy.v1.ControlScore.scores:type_name -> cnspec.policy.v1.ScoreDistribution
+	83,  // 158: cnspec.policy.v1.Score.risk_factors:type_name -> cnspec.policy.v1.ScoredRiskFactors
+	124, // 159: cnspec.policy.v1.Score.source:type_name -> cnspec.policy.v1.Source
+	123, // 160: cnspec.policy.v1.Score.sources:type_name -> cnspec.policy.v1.Sources
+	154, // 161: cnspec.policy.v1.ScoredRiskFactor.data:type_name -> cnspec.policy.v1.ScoredRiskFactor.DataEntry
+	82,  // 162: cnspec.policy.v1.ScoredRiskFactors.items:type_name -> cnspec.policy.v1.ScoredRiskFactor
+	84,  // 163: cnspec.policy.v1.RiskFactorsStats.items:type_name -> cnspec.policy.v1.RiskFactorStats
+	87,  // 164: cnspec.policy.v1.Stats.failed:type_name -> cnspec.policy.v1.ScoreDistribution
+	87,  // 165: cnspec.policy.v1.Stats.passed:type_name -> cnspec.policy.v1.ScoreDistribution
+	87,  // 166: cnspec.policy.v1.Stats.errors:type_name -> cnspec.policy.v1.ScoreDistribution
+	88,  // 167: cnspec.policy.v1.AssetFindingsStats.score_stats:type_name -> cnspec.policy.v1.ScoreStats
+	85,  // 168: cnspec.policy.v1.AssetFindingsStats.risk_factors:type_name -> cnspec.policy.v1.RiskFactorsStats
+	26,  // 169: cnspec.policy.v1.Mqueries.items:type_name -> cnspec.policy.v1.Mquery
 	0,   // 170: cnspec.policy.v1.PolicyAssignment.action:type_name -> cnspec.policy.v1.Action
 	1,   // 171: cnspec.policy.v1.PolicyAssignment.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	151, // 172: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
+	155, // 172: cnspec.policy.v1.PolicyMutationDelta.policy_deltas:type_name -> cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry
 	0,   // 173: cnspec.policy.v1.PolicyMutationDelta.action:type_name -> cnspec.policy.v1.Action
-	12,  // 174: cnspec.policy.v1.PolicyDelta.action:type_name -> cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
+	13,  // 174: cnspec.policy.v1.PolicyDelta.action:type_name -> cnspec.policy.v1.PolicyDelta.PolicyAssignmentActionType
 	1,   // 175: cnspec.policy.v1.PolicyDelta.scoring_system:type_name -> cnspec.policy.v1.ScoringSystem
-	25,  // 176: cnspec.policy.v1.ResolveReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
-	25,  // 177: cnspec.policy.v1.UpdateAssetJobsReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
-	79,  // 178: cnspec.policy.v1.StoreResultsReq.scores:type_name -> cnspec.policy.v1.Score
-	152, // 179: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
-	153, // 180: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
-	81,  // 181: cnspec.policy.v1.StoreResultsReq.risks:type_name -> cnspec.policy.v1.ScoredRiskFactor
-	77,  // 182: cnspec.policy.v1.StoreResultsReq.cvssScores:type_name -> cnspec.policy.v1.Cvss
+	26,  // 176: cnspec.policy.v1.ResolveReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
+	26,  // 177: cnspec.policy.v1.UpdateAssetJobsReq.asset_filters:type_name -> cnspec.policy.v1.Mquery
+	80,  // 178: cnspec.policy.v1.StoreResultsReq.scores:type_name -> cnspec.policy.v1.Score
+	156, // 179: cnspec.policy.v1.StoreResultsReq.data:type_name -> cnspec.policy.v1.StoreResultsReq.DataEntry
+	157, // 180: cnspec.policy.v1.StoreResultsReq.resources:type_name -> cnspec.policy.v1.StoreResultsReq.ResourcesEntry
+	82,  // 181: cnspec.policy.v1.StoreResultsReq.risks:type_name -> cnspec.policy.v1.ScoredRiskFactor
+	78,  // 182: cnspec.policy.v1.StoreResultsReq.cvssScores:type_name -> cnspec.policy.v1.Cvss
 	6,   // 183: cnspec.policy.v1.GetUploadURLReq.kind:type_name -> cnspec.policy.v1.UploadURLKind
-	103, // 184: cnspec.policy.v1.GetUploadURLResp.upload_url:type_name -> cnspec.policy.v1.UploadURL
-	154, // 185: cnspec.policy.v1.UploadURL.headers:type_name -> cnspec.policy.v1.UploadURL.HeadersEntry
-	163, // 186: cnspec.policy.v1.ReportUploadCompletedReq.details:type_name -> google.protobuf.Any
-	106, // 187: cnspec.policy.v1.ScanStatistics.metrics:type_name -> cnspec.policy.v1.Metric
-	164, // 188: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
-	155, // 189: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
-	156, // 190: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
-	114, // 191: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
-	157, // 192: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
-	8,   // 193: cnspec.policy.v1.DateFilter.comparison:type_name -> cnspec.policy.v1.Comparison
-	9,   // 194: cnspec.policy.v1.DateFilter.field:type_name -> cnspec.policy.v1.DateFilterField
-	158, // 195: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
-	159, // 196: cnspec.policy.v1.RefreshAssetScoresRequest.labels:type_name -> cnspec.policy.v1.RefreshAssetScoresRequest.LabelsEntry
-	118, // 197: cnspec.policy.v1.RefreshAssetScoresResponse.refreshed:type_name -> cnspec.policy.v1.AssetRefreshResult
-	118, // 198: cnspec.policy.v1.RefreshAssetScoresResponse.missing:type_name -> cnspec.policy.v1.AssetRefreshResult
-	120, // 199: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
-	13,  // 200: cnspec.policy.v1.Source.vendor:type_name -> cnspec.policy.v1.Source.Vendor
-	25,  // 201: cnspec.policy.v1.Filters.ItemsEntry.value:type_name -> cnspec.policy.v1.Mquery
-	66,  // 202: cnspec.policy.v1.ExecutionJob.QueriesEntry.value:type_name -> cnspec.policy.v1.ExecutionQuery
-	71,  // 203: cnspec.policy.v1.CollectorJob.ReportingJobsEntry.value:type_name -> cnspec.policy.v1.ReportingJob
-	69,  // 204: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry.value:type_name -> cnspec.policy.v1.StringArray
-	70,  // 205: cnspec.policy.v1.CollectorJob.DatapointsEntry.value:type_name -> cnspec.policy.v1.DataQueryInfo
-	69,  // 206: cnspec.policy.v1.CollectorJob.RiskMrnsEntry.value:type_name -> cnspec.policy.v1.StringArray
-	49,  // 207: cnspec.policy.v1.CollectorJob.RiskFactorsEntry.value:type_name -> cnspec.policy.v1.RiskFactor
-	68,  // 208: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry.value:type_name -> cnspec.policy.v1.RiskDataInfo
-	15,  // 209: cnspec.policy.v1.ReportingJob.ChildJobsEntry.value:type_name -> cnspec.policy.v1.Impact
-	79,  // 210: cnspec.policy.v1.Report.ScoresEntry.value:type_name -> cnspec.policy.v1.Score
-	165, // 211: cnspec.policy.v1.Report.DataEntry.value:type_name -> mql.llx.Result
-	77,  // 212: cnspec.policy.v1.Report.CvssScoresEntry.value:type_name -> cnspec.policy.v1.Cvss
-	164, // 213: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
-	72,  // 214: cnspec.policy.v1.ReportCollection.ReportsEntry.value:type_name -> cnspec.policy.v1.Report
-	64,  // 215: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry.value:type_name -> cnspec.policy.v1.ResolvedPolicy
-	166, // 216: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
-	165, // 217: cnspec.policy.v1.ScoredRiskFactor.DataEntry.value:type_name -> mql.llx.Result
-	97,  // 218: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry.value:type_name -> cnspec.policy.v1.PolicyDelta
-	165, // 219: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> mql.llx.Result
-	167, // 220: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> mql.llx.ResourceRecording
-	109, // 221: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry.value:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
-	37,  // 222: cnspec.policy.v1.PolicyHub.SetBundle:input_type -> cnspec.policy.v1.Bundle
-	37,  // 223: cnspec.policy.v1.PolicyHub.ValidateBundle:input_type -> cnspec.policy.v1.Bundle
-	90,  // 224: cnspec.policy.v1.PolicyHub.GetBundle:input_type -> cnspec.policy.v1.Mrn
-	90,  // 225: cnspec.policy.v1.PolicyHub.GetPolicy:input_type -> cnspec.policy.v1.Mrn
-	90,  // 226: cnspec.policy.v1.PolicyHub.DeletePolicy:input_type -> cnspec.policy.v1.Mrn
-	90,  // 227: cnspec.policy.v1.PolicyHub.GetPolicyFilters:input_type -> cnspec.policy.v1.Mrn
-	92,  // 228: cnspec.policy.v1.PolicyHub.List:input_type -> cnspec.policy.v1.ListReq
-	93,  // 229: cnspec.policy.v1.PolicyHub.DefaultPolicies:input_type -> cnspec.policy.v1.DefaultPoliciesReq
-	90,  // 230: cnspec.policy.v1.PolicyHub.GetFramework:input_type -> cnspec.policy.v1.Mrn
-	90,  // 231: cnspec.policy.v1.PolicyHub.DeleteFramework:input_type -> cnspec.policy.v1.Mrn
-	92,  // 232: cnspec.policy.v1.PolicyHub.ListFrameworks:input_type -> cnspec.policy.v1.ListReq
-	95,  // 233: cnspec.policy.v1.PolicyResolver.Assign:input_type -> cnspec.policy.v1.PolicyAssignment
-	95,  // 234: cnspec.policy.v1.PolicyResolver.Unassign:input_type -> cnspec.policy.v1.PolicyAssignment
-	29,  // 235: cnspec.policy.v1.PolicyResolver.SetProps:input_type -> cnspec.policy.v1.PropsReq
-	98,  // 236: cnspec.policy.v1.PolicyResolver.Resolve:input_type -> cnspec.policy.v1.ResolveReq
-	99,  // 237: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
-	99,  // 238: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
-	90,  // 239: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:input_type -> cnspec.policy.v1.Mrn
-	100, // 240: cnspec.policy.v1.PolicyResolver.StoreResults:input_type -> cnspec.policy.v1.StoreResultsReq
-	101, // 241: cnspec.policy.v1.PolicyResolver.GetUploadURL:input_type -> cnspec.policy.v1.GetUploadURLReq
-	104, // 242: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:input_type -> cnspec.policy.v1.ReportUploadCompletedReq
-	107, // 243: cnspec.policy.v1.PolicyResolver.GetReport:input_type -> cnspec.policy.v1.EntityScoreReq
-	107, // 244: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:input_type -> cnspec.policy.v1.EntityScoreReq
-	107, // 245: cnspec.policy.v1.PolicyResolver.GetScore:input_type -> cnspec.policy.v1.EntityScoreReq
-	168, // 246: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> mql.providers.v1.recording.EntityResourcesReq
-	108, // 247: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:input_type -> cnspec.policy.v1.SynchronizeAssetsReq
-	113, // 248: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
-	116, // 249: cnspec.policy.v1.PolicyResolver.RefreshAssetScores:input_type -> cnspec.policy.v1.RefreshAssetScoresRequest
-	111, // 250: cnspec.policy.v1.PolicyResolver.GetScanParameters:input_type -> cnspec.policy.v1.GetScanParametersReq
-	89,  // 251: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
-	89,  // 252: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
-	37,  // 253: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
-	33,  // 254: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
-	89,  // 255: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
-	91,  // 256: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
-	34,  // 257: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
-	94,  // 258: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
-	53,  // 259: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
-	89,  // 260: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
-	54,  // 261: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
-	89,  // 262: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
-	89,  // 263: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
-	89,  // 264: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnspec.policy.v1.Empty
-	64,  // 265: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
-	89,  // 266: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
-	64,  // 267: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
-	64,  // 268: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
-	89,  // 269: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
-	102, // 270: cnspec.policy.v1.PolicyResolver.GetUploadURL:output_type -> cnspec.policy.v1.GetUploadURLResp
-	89,  // 271: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:output_type -> cnspec.policy.v1.Empty
-	72,  // 272: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
-	75,  // 273: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
-	72,  // 274: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
-	169, // 275: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> mql.providers.v1.recording.EntityResourcesRes
-	110, // 276: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
-	115, // 277: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
-	117, // 278: cnspec.policy.v1.PolicyResolver.RefreshAssetScores:output_type -> cnspec.policy.v1.RefreshAssetScoresResponse
-	112, // 279: cnspec.policy.v1.PolicyResolver.GetScanParameters:output_type -> cnspec.policy.v1.ScanParameters
-	251, // [251:280] is the sub-list for method output_type
-	222, // [222:251] is the sub-list for method input_type
-	222, // [222:222] is the sub-list for extension type_name
-	222, // [222:222] is the sub-list for extension extendee
-	0,   // [0:222] is the sub-list for field type_name
+	104, // 184: cnspec.policy.v1.GetUploadURLResp.upload_url:type_name -> cnspec.policy.v1.UploadURL
+	158, // 185: cnspec.policy.v1.UploadURL.headers:type_name -> cnspec.policy.v1.UploadURL.HeadersEntry
+	168, // 186: cnspec.policy.v1.ReportUploadCompletedReq.details:type_name -> google.protobuf.Any
+	7,   // 187: cnspec.policy.v1.GetDownloadURLReq.kind:type_name -> cnspec.policy.v1.DownloadKind
+	108, // 188: cnspec.policy.v1.GetDownloadURLResp.download_url:type_name -> cnspec.policy.v1.DownloadURL
+	159, // 189: cnspec.policy.v1.DownloadURL.headers:type_name -> cnspec.policy.v1.DownloadURL.HeadersEntry
+	110, // 190: cnspec.policy.v1.ScanStatistics.metrics:type_name -> cnspec.policy.v1.Metric
+	169, // 191: cnspec.policy.v1.SynchronizeAssetsReq.list:type_name -> cnquery.providers.v1.Asset
+	160, // 192: cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.annotations:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail.AnnotationsEntry
+	161, // 193: cnspec.policy.v1.SynchronizeAssetsResp.details:type_name -> cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry
+	118, // 194: cnspec.policy.v1.PurgeAssetsRequest.date_filter:type_name -> cnspec.policy.v1.DateFilter
+	162, // 195: cnspec.policy.v1.PurgeAssetsRequest.labels:type_name -> cnspec.policy.v1.PurgeAssetsRequest.LabelsEntry
+	9,   // 196: cnspec.policy.v1.DateFilter.comparison:type_name -> cnspec.policy.v1.Comparison
+	10,  // 197: cnspec.policy.v1.DateFilter.field:type_name -> cnspec.policy.v1.DateFilterField
+	163, // 198: cnspec.policy.v1.PurgeAssetsConfirmation.errors:type_name -> cnspec.policy.v1.PurgeAssetsConfirmation.ErrorsEntry
+	164, // 199: cnspec.policy.v1.RefreshAssetScoresRequest.labels:type_name -> cnspec.policy.v1.RefreshAssetScoresRequest.LabelsEntry
+	122, // 200: cnspec.policy.v1.RefreshAssetScoresResponse.refreshed:type_name -> cnspec.policy.v1.AssetRefreshResult
+	122, // 201: cnspec.policy.v1.RefreshAssetScoresResponse.missing:type_name -> cnspec.policy.v1.AssetRefreshResult
+	124, // 202: cnspec.policy.v1.Sources.items:type_name -> cnspec.policy.v1.Source
+	14,  // 203: cnspec.policy.v1.Source.vendor:type_name -> cnspec.policy.v1.Source.Vendor
+	26,  // 204: cnspec.policy.v1.Filters.ItemsEntry.value:type_name -> cnspec.policy.v1.Mquery
+	67,  // 205: cnspec.policy.v1.ExecutionJob.QueriesEntry.value:type_name -> cnspec.policy.v1.ExecutionQuery
+	72,  // 206: cnspec.policy.v1.CollectorJob.ReportingJobsEntry.value:type_name -> cnspec.policy.v1.ReportingJob
+	70,  // 207: cnspec.policy.v1.CollectorJob.ReportingQueriesEntry.value:type_name -> cnspec.policy.v1.StringArray
+	71,  // 208: cnspec.policy.v1.CollectorJob.DatapointsEntry.value:type_name -> cnspec.policy.v1.DataQueryInfo
+	70,  // 209: cnspec.policy.v1.CollectorJob.RiskMrnsEntry.value:type_name -> cnspec.policy.v1.StringArray
+	50,  // 210: cnspec.policy.v1.CollectorJob.RiskFactorsEntry.value:type_name -> cnspec.policy.v1.RiskFactor
+	69,  // 211: cnspec.policy.v1.CollectorJob.RiskDataQueriesEntry.value:type_name -> cnspec.policy.v1.RiskDataInfo
+	16,  // 212: cnspec.policy.v1.ReportingJob.ChildJobsEntry.value:type_name -> cnspec.policy.v1.Impact
+	80,  // 213: cnspec.policy.v1.Report.ScoresEntry.value:type_name -> cnspec.policy.v1.Score
+	170, // 214: cnspec.policy.v1.Report.DataEntry.value:type_name -> mql.llx.Result
+	78,  // 215: cnspec.policy.v1.Report.CvssScoresEntry.value:type_name -> cnspec.policy.v1.Cvss
+	169, // 216: cnspec.policy.v1.ReportCollection.AssetsEntry.value:type_name -> cnquery.providers.v1.Asset
+	73,  // 217: cnspec.policy.v1.ReportCollection.ReportsEntry.value:type_name -> cnspec.policy.v1.Report
+	65,  // 218: cnspec.policy.v1.ReportCollection.ResolvedPoliciesEntry.value:type_name -> cnspec.policy.v1.ResolvedPolicy
+	171, // 219: cnspec.policy.v1.ReportCollection.VulnReportsEntry.value:type_name -> mondoo.mvd.v1.VulnReport
+	170, // 220: cnspec.policy.v1.ScoredRiskFactor.DataEntry.value:type_name -> mql.llx.Result
+	98,  // 221: cnspec.policy.v1.PolicyMutationDelta.PolicyDeltasEntry.value:type_name -> cnspec.policy.v1.PolicyDelta
+	170, // 222: cnspec.policy.v1.StoreResultsReq.DataEntry.value:type_name -> mql.llx.Result
+	172, // 223: cnspec.policy.v1.StoreResultsReq.ResourcesEntry.value:type_name -> mql.llx.ResourceRecording
+	113, // 224: cnspec.policy.v1.SynchronizeAssetsResp.DetailsEntry.value:type_name -> cnspec.policy.v1.SynchronizeAssetsRespAssetDetail
+	38,  // 225: cnspec.policy.v1.PolicyHub.SetBundle:input_type -> cnspec.policy.v1.Bundle
+	38,  // 226: cnspec.policy.v1.PolicyHub.ValidateBundle:input_type -> cnspec.policy.v1.Bundle
+	91,  // 227: cnspec.policy.v1.PolicyHub.GetBundle:input_type -> cnspec.policy.v1.Mrn
+	91,  // 228: cnspec.policy.v1.PolicyHub.GetPolicy:input_type -> cnspec.policy.v1.Mrn
+	91,  // 229: cnspec.policy.v1.PolicyHub.DeletePolicy:input_type -> cnspec.policy.v1.Mrn
+	91,  // 230: cnspec.policy.v1.PolicyHub.GetPolicyFilters:input_type -> cnspec.policy.v1.Mrn
+	93,  // 231: cnspec.policy.v1.PolicyHub.List:input_type -> cnspec.policy.v1.ListReq
+	94,  // 232: cnspec.policy.v1.PolicyHub.DefaultPolicies:input_type -> cnspec.policy.v1.DefaultPoliciesReq
+	91,  // 233: cnspec.policy.v1.PolicyHub.GetFramework:input_type -> cnspec.policy.v1.Mrn
+	91,  // 234: cnspec.policy.v1.PolicyHub.DeleteFramework:input_type -> cnspec.policy.v1.Mrn
+	93,  // 235: cnspec.policy.v1.PolicyHub.ListFrameworks:input_type -> cnspec.policy.v1.ListReq
+	96,  // 236: cnspec.policy.v1.PolicyResolver.Assign:input_type -> cnspec.policy.v1.PolicyAssignment
+	96,  // 237: cnspec.policy.v1.PolicyResolver.Unassign:input_type -> cnspec.policy.v1.PolicyAssignment
+	30,  // 238: cnspec.policy.v1.PolicyResolver.SetProps:input_type -> cnspec.policy.v1.PropsReq
+	99,  // 239: cnspec.policy.v1.PolicyResolver.Resolve:input_type -> cnspec.policy.v1.ResolveReq
+	100, // 240: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
+	100, // 241: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:input_type -> cnspec.policy.v1.UpdateAssetJobsReq
+	91,  // 242: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:input_type -> cnspec.policy.v1.Mrn
+	101, // 243: cnspec.policy.v1.PolicyResolver.StoreResults:input_type -> cnspec.policy.v1.StoreResultsReq
+	102, // 244: cnspec.policy.v1.PolicyResolver.GetUploadURL:input_type -> cnspec.policy.v1.GetUploadURLReq
+	105, // 245: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:input_type -> cnspec.policy.v1.ReportUploadCompletedReq
+	106, // 246: cnspec.policy.v1.PolicyResolver.GetDownloadURL:input_type -> cnspec.policy.v1.GetDownloadURLReq
+	111, // 247: cnspec.policy.v1.PolicyResolver.GetReport:input_type -> cnspec.policy.v1.EntityScoreReq
+	111, // 248: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:input_type -> cnspec.policy.v1.EntityScoreReq
+	111, // 249: cnspec.policy.v1.PolicyResolver.GetScore:input_type -> cnspec.policy.v1.EntityScoreReq
+	173, // 250: cnspec.policy.v1.PolicyResolver.GetResourcesData:input_type -> mql.providers.v1.recording.EntityResourcesReq
+	112, // 251: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:input_type -> cnspec.policy.v1.SynchronizeAssetsReq
+	117, // 252: cnspec.policy.v1.PolicyResolver.PurgeAssets:input_type -> cnspec.policy.v1.PurgeAssetsRequest
+	120, // 253: cnspec.policy.v1.PolicyResolver.RefreshAssetScores:input_type -> cnspec.policy.v1.RefreshAssetScoresRequest
+	115, // 254: cnspec.policy.v1.PolicyResolver.GetScanParameters:input_type -> cnspec.policy.v1.GetScanParametersReq
+	90,  // 255: cnspec.policy.v1.PolicyHub.SetBundle:output_type -> cnspec.policy.v1.Empty
+	90,  // 256: cnspec.policy.v1.PolicyHub.ValidateBundle:output_type -> cnspec.policy.v1.Empty
+	38,  // 257: cnspec.policy.v1.PolicyHub.GetBundle:output_type -> cnspec.policy.v1.Bundle
+	34,  // 258: cnspec.policy.v1.PolicyHub.GetPolicy:output_type -> cnspec.policy.v1.Policy
+	90,  // 259: cnspec.policy.v1.PolicyHub.DeletePolicy:output_type -> cnspec.policy.v1.Empty
+	92,  // 260: cnspec.policy.v1.PolicyHub.GetPolicyFilters:output_type -> cnspec.policy.v1.Mqueries
+	35,  // 261: cnspec.policy.v1.PolicyHub.List:output_type -> cnspec.policy.v1.Policies
+	95,  // 262: cnspec.policy.v1.PolicyHub.DefaultPolicies:output_type -> cnspec.policy.v1.URLs
+	54,  // 263: cnspec.policy.v1.PolicyHub.GetFramework:output_type -> cnspec.policy.v1.Framework
+	90,  // 264: cnspec.policy.v1.PolicyHub.DeleteFramework:output_type -> cnspec.policy.v1.Empty
+	55,  // 265: cnspec.policy.v1.PolicyHub.ListFrameworks:output_type -> cnspec.policy.v1.Frameworks
+	90,  // 266: cnspec.policy.v1.PolicyResolver.Assign:output_type -> cnspec.policy.v1.Empty
+	90,  // 267: cnspec.policy.v1.PolicyResolver.Unassign:output_type -> cnspec.policy.v1.Empty
+	90,  // 268: cnspec.policy.v1.PolicyResolver.SetProps:output_type -> cnspec.policy.v1.Empty
+	65,  // 269: cnspec.policy.v1.PolicyResolver.Resolve:output_type -> cnspec.policy.v1.ResolvedPolicy
+	90,  // 270: cnspec.policy.v1.PolicyResolver.UpdateAssetJobs:output_type -> cnspec.policy.v1.Empty
+	65,  // 271: cnspec.policy.v1.PolicyResolver.ResolveAndUpdateJobs:output_type -> cnspec.policy.v1.ResolvedPolicy
+	65,  // 272: cnspec.policy.v1.PolicyResolver.GetResolvedPolicy:output_type -> cnspec.policy.v1.ResolvedPolicy
+	90,  // 273: cnspec.policy.v1.PolicyResolver.StoreResults:output_type -> cnspec.policy.v1.Empty
+	103, // 274: cnspec.policy.v1.PolicyResolver.GetUploadURL:output_type -> cnspec.policy.v1.GetUploadURLResp
+	90,  // 275: cnspec.policy.v1.PolicyResolver.ReportUploadCompleted:output_type -> cnspec.policy.v1.Empty
+	107, // 276: cnspec.policy.v1.PolicyResolver.GetDownloadURL:output_type -> cnspec.policy.v1.GetDownloadURLResp
+	73,  // 277: cnspec.policy.v1.PolicyResolver.GetReport:output_type -> cnspec.policy.v1.Report
+	76,  // 278: cnspec.policy.v1.PolicyResolver.GetFrameworkReport:output_type -> cnspec.policy.v1.FrameworkReport
+	73,  // 279: cnspec.policy.v1.PolicyResolver.GetScore:output_type -> cnspec.policy.v1.Report
+	174, // 280: cnspec.policy.v1.PolicyResolver.GetResourcesData:output_type -> mql.providers.v1.recording.EntityResourcesRes
+	114, // 281: cnspec.policy.v1.PolicyResolver.SynchronizeAssets:output_type -> cnspec.policy.v1.SynchronizeAssetsResp
+	119, // 282: cnspec.policy.v1.PolicyResolver.PurgeAssets:output_type -> cnspec.policy.v1.PurgeAssetsConfirmation
+	121, // 283: cnspec.policy.v1.PolicyResolver.RefreshAssetScores:output_type -> cnspec.policy.v1.RefreshAssetScoresResponse
+	116, // 284: cnspec.policy.v1.PolicyResolver.GetScanParameters:output_type -> cnspec.policy.v1.ScanParameters
+	255, // [255:285] is the sub-list for method output_type
+	225, // [225:255] is the sub-list for method input_type
+	225, // [225:225] is the sub-list for extension type_name
+	225, // [225:225] is the sub-list for extension extendee
+	0,   // [0:225] is the sub-list for field type_name
 }
 
 func init() { file_cnspec_policy_proto_init() }
@@ -10737,7 +11012,7 @@ func file_cnspec_policy_proto_init() {
 	if File_cnspec_policy_proto != nil {
 		return
 	}
-	file_cnspec_policy_proto_msgTypes[92].OneofWrappers = []any{
+	file_cnspec_policy_proto_msgTypes[95].OneofWrappers = []any{
 		(*Metric_IntValue)(nil),
 		(*Metric_DoubleValue)(nil),
 		(*Metric_BoolValue)(nil),
@@ -10748,8 +11023,8 @@ func file_cnspec_policy_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cnspec_policy_proto_rawDesc), len(file_cnspec_policy_proto_rawDesc)),
-			NumEnums:      14,
-			NumMessages:   146,
+			NumEnums:      15,
+			NumMessages:   150,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -1213,6 +1213,13 @@ service PolicyResolver {
   // Signed URL upload flow
   rpc GetUploadURL(GetUploadURLReq) returns (GetUploadURLResp) {}
   rpc ReportUploadCompleted(ReportUploadCompletedReq) returns (Empty) {}
+  // GetUploadURL's mirror in the opposite direction: mints a signed GET for
+  // a server-held artifact of this scope (initially the scan manifest, see
+  // DownloadKind). Servers that predate this RPC answer NotFound (ranger's
+  // unknown-method response); in-process local services answer
+  // Unimplemented. Clients must treat any error here exactly like an
+  // absent download_url: upload in full.
+  rpc GetDownloadURL(GetDownloadURLReq) returns (GetDownloadURLResp) {}
 
   rpc GetReport(EntityScoreReq) returns (Report) {}
   rpc GetFrameworkReport(EntityScoreReq) returns (FrameworkReport) {}
@@ -1308,6 +1315,56 @@ message ReportUploadCompletedReq {
   // scan-database upload this packs a ScanStatistics. New upload kinds can pack
   // their own message without changing this message.
   google.protobuf.Any details = 3;
+  // unchanged reports that no PUT happened for this session: the client
+  // compared its scan content against the last processed upload (via the
+  // manifest served by GetDownloadURL) and found every kind digest equal.
+  // Completion is still the scan signal in both outcomes — statistics ride
+  // details exactly as for a full upload.
+  bool unchanged = 4;
+}
+
+// DownloadKind addresses the artifact GetDownloadURL serves. Kind-addressed
+// so future artifacts slot in without another RPC.
+enum DownloadKind {
+  DOWNLOAD_KIND_UNSPECIFIED = 0;
+  // The slim scan manifest: a trimmed-down scan database carrying only each
+  // row's key and content digest per kind, plus the digest metadata of the
+  // last processed upload. The client compares the manifest's kind digests
+  // against its own to decide whether an upload can be skipped, and diffs
+  // row digests for change attribution.
+  DOWNLOAD_KIND_SCAN_MANIFEST = 1;
+}
+
+message GetDownloadURLReq {
+  DownloadKind kind = 1;
+  // Same addressing as GetUploadURL.
+  string scope_mrn = 2;
+}
+
+message GetDownloadURLResp {
+  // The signed GET for the requested artifact. Absent means nothing is
+  // served — the client proceeds with a full upload, always.
+  DownloadURL download_url = 1;
+  // There is deliberately no base-identity field: the comparison policy is
+  // always-latest. A delta that raced a concurrent upload fails the
+  // server's row-digest verify and falls back to a full upload.
+  // Explicit "nothing will be served for this request" — the base does not
+  // exist, its stored digests are no longer eligible, or the scope is in a
+  // force-resend state. Reasons stay server-side; client behavior keys on
+  // download_url presence alone. The marker's one job is telemetry
+  // disambiguation of a degenerate success: an intermediary can turn a
+  // response into an empty 200 whose body unmarshals as an all-zero
+  // message, indistinguishable from a genuine decline without this bit.
+  // (A real transport failure surfaces as an RPC error, never as a
+  // response, so it needs no marker.)
+  bool unavailable = 2;
+}
+
+// DownloadURL mirrors UploadURL for the opposite direction.
+message DownloadURL {
+  string url = 1;
+  map<string, string> headers = 2;
+  int64 expires_at = 3;
 }
 
 // ScanStatistics is the completion payload for a scan-database upload. Every

--- a/policy/cnspec_policy.ranger.go
+++ b/policy/cnspec_policy.ranger.go
@@ -436,6 +436,7 @@ type PolicyResolver interface {
 	StoreResults(context.Context, *StoreResultsReq) (*Empty, error)
 	GetUploadURL(context.Context, *GetUploadURLReq) (*GetUploadURLResp, error)
 	ReportUploadCompleted(context.Context, *ReportUploadCompletedReq) (*Empty, error)
+	GetDownloadURL(context.Context, *GetDownloadURLReq) (*GetDownloadURLResp, error)
 	GetReport(context.Context, *EntityScoreReq) (*Report, error)
 	GetFrameworkReport(context.Context, *EntityScoreReq) (*FrameworkReport, error)
 	GetScore(context.Context, *EntityScoreReq) (*Report, error)
@@ -522,6 +523,11 @@ func (c *PolicyResolverClient) ReportUploadCompleted(ctx context.Context, in *Re
 	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/ReportUploadCompleted"}, ""), in, out)
 	return out, err
 }
+func (c *PolicyResolverClient) GetDownloadURL(ctx context.Context, in *GetDownloadURLReq) (*GetDownloadURLResp, error) {
+	out := new(GetDownloadURLResp)
+	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/GetDownloadURL"}, ""), in, out)
+	return out, err
+}
 func (c *PolicyResolverClient) GetReport(ctx context.Context, in *EntityScoreReq) (*Report, error) {
 	out := new(Report)
 	err := c.DoClientRequest(ctx, c.httpclient, strings.Join([]string{c.prefix, "/GetReport"}, ""), in, out)
@@ -595,6 +601,7 @@ func NewPolicyResolverServer(handler PolicyResolver, opts ...PolicyResolverServe
 			"StoreResults":          srv.StoreResults,
 			"GetUploadURL":          srv.GetUploadURL,
 			"ReportUploadCompleted": srv.ReportUploadCompleted,
+			"GetDownloadURL":        srv.GetDownloadURL,
 			"GetReport":             srv.GetReport,
 			"GetFrameworkReport":    srv.GetFrameworkReport,
 			"GetScore":              srv.GetScore,
@@ -852,6 +859,30 @@ func (p *PolicyResolverServer) ReportUploadCompleted(ctx context.Context, reqByt
 		return nil, err
 	}
 	return p.handler.ReportUploadCompleted(ctx, &req)
+}
+func (p *PolicyResolverServer) GetDownloadURL(ctx context.Context, reqBytes *[]byte) (pb.Message, error) {
+	var req GetDownloadURLReq
+	var err error
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, errors.New("could not access header")
+	}
+
+	switch md.First("Content-Type") {
+	case "application/protobuf", "application/octet-stream", "application/grpc+proto":
+		err = pb.Unmarshal(*reqBytes, &req)
+	default:
+		// handle case of empty object
+		if len(*reqBytes) > 0 {
+			err = jsonpb.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(*reqBytes, &req)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return p.handler.GetDownloadURL(ctx, &req)
 }
 func (p *PolicyResolverServer) GetReport(ctx context.Context, reqBytes *[]byte) (pb.Message, error) {
 	var req EntityScoreReq

--- a/policy/cnspec_policy_vtproto.pb.go
+++ b/policy/cnspec_policy_vtproto.pb.go
@@ -2669,6 +2669,7 @@ func (m *ReportUploadCompletedReq) CloneVT() *ReportUploadCompletedReq {
 	r.UploadSessionId = m.UploadSessionId
 	r.ScopeMrn = m.ScopeMrn
 	r.Details = (*anypb.Any)((*anypb1.Any)(m.Details).CloneVT())
+	r.Unchanged = m.Unchanged
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2677,6 +2678,67 @@ func (m *ReportUploadCompletedReq) CloneVT() *ReportUploadCompletedReq {
 }
 
 func (m *ReportUploadCompletedReq) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetDownloadURLReq) CloneVT() *GetDownloadURLReq {
+	if m == nil {
+		return (*GetDownloadURLReq)(nil)
+	}
+	r := new(GetDownloadURLReq)
+	r.Kind = m.Kind
+	r.ScopeMrn = m.ScopeMrn
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetDownloadURLReq) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetDownloadURLResp) CloneVT() *GetDownloadURLResp {
+	if m == nil {
+		return (*GetDownloadURLResp)(nil)
+	}
+	r := new(GetDownloadURLResp)
+	r.DownloadUrl = m.DownloadUrl.CloneVT()
+	r.Unavailable = m.Unavailable
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetDownloadURLResp) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *DownloadURL) CloneVT() *DownloadURL {
+	if m == nil {
+		return (*DownloadURL)(nil)
+	}
+	r := new(DownloadURL)
+	r.Url = m.Url
+	r.ExpiresAt = m.ExpiresAt
+	if rhs := m.Headers; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Headers = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DownloadURL) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -10600,6 +10662,16 @@ func (m *ReportUploadCompletedReq) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Unchanged {
+		i--
+		if m.Unchanged {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if m.Details != nil {
 		size, err := (*anypb1.Any)(m.Details).MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -10621,6 +10693,168 @@ func (m *ReportUploadCompletedReq) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i -= len(m.UploadSessionId)
 		copy(dAtA[i:], m.UploadSessionId)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UploadSessionId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetDownloadURLReq) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetDownloadURLReq) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetDownloadURLReq) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ScopeMrn) > 0 {
+		i -= len(m.ScopeMrn)
+		copy(dAtA[i:], m.ScopeMrn)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ScopeMrn)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Kind != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Kind))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetDownloadURLResp) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetDownloadURLResp) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetDownloadURLResp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Unavailable {
+		i--
+		if m.Unavailable {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.DownloadUrl != nil {
+		size, err := m.DownloadUrl.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DownloadURL) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DownloadURL) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DownloadURL) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ExpiresAt != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ExpiresAt))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Headers) > 0 {
+		for k := range m.Headers {
+			v := m.Headers[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Url) > 0 {
+		i -= len(m.Url)
+		copy(dAtA[i:], m.Url)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Url)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -14777,6 +15011,68 @@ func (m *ReportUploadCompletedReq) SizeVT() (n int) {
 	if m.Details != nil {
 		l = (*anypb1.Any)(m.Details).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Unchanged {
+		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetDownloadURLReq) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Kind != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Kind))
+	}
+	l = len(m.ScopeMrn)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetDownloadURLResp) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DownloadUrl != nil {
+		l = m.DownloadUrl.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Unavailable {
+		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DownloadURL) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Url)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Headers) > 0 {
+		for k, v := range m.Headers {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if m.ExpiresAt != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ExpiresAt))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -37033,6 +37329,464 @@ func (m *ReportUploadCompletedReq) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Unchanged", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Unchanged = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDownloadURLReq) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDownloadURLReq: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDownloadURLReq: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Kind", wireType)
+			}
+			m.Kind = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Kind |= DownloadKind(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ScopeMrn", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ScopeMrn = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDownloadURLResp) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDownloadURLResp: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDownloadURLResp: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DownloadUrl", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DownloadUrl == nil {
+				m.DownloadUrl = &DownloadURL{}
+			}
+			if err := m.DownloadUrl.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Unavailable", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Unavailable = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DownloadURL) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DownloadURL: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DownloadURL: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Url", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Url = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Headers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Headers == nil {
+				m.Headers = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Headers[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpiresAt", wireType)
+			}
+			m.ExpiresAt = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExpiresAt |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/policy/resolver.go
+++ b/policy/resolver.go
@@ -258,6 +258,18 @@ func (s *LocalServices) ReportUploadCompleted(ctx context.Context, req *ReportUp
 	return globalEmpty, nil
 }
 
+// GetDownloadURL is GetUploadURL's mirror: it provides a signed GET for a
+// server-held artifact of this scope (initially the scan manifest).
+func (s *LocalServices) GetDownloadURL(ctx context.Context, req *GetDownloadURLReq) (*GetDownloadURLResp, error) {
+	// Only forward to upstream if we have one and are not in incognito mode
+	if s.Upstream != nil && !s.Incognito {
+		return s.Upstream.GetDownloadURL(ctx, req)
+	}
+
+	// Local services hold no server-side artifacts — nothing is ever served.
+	return nil, status.Error(codes.Unimplemented, "local services do not support download URLs")
+}
+
 // GetReport retrieves a report for a given asset and policy
 func (s *LocalServices) GetReport(ctx context.Context, req *EntityScoreReq) (*Report, error) {
 	return s.DataLake.GetReport(ctx, req.EntityMrn, req.ScoreMrn)

--- a/policy/scandb/checksum.go
+++ b/policy/scandb/checksum.go
@@ -1,0 +1,407 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scandb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/checksum"
+	"go.mondoo.com/cnspec/v13/policy/scandb/sqlc"
+	"go.mondoo.com/mql/v13/llx"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
+	"google.golang.org/protobuf/proto"
+)
+
+// Scan-content checksums: every checksummed row gets an 8-byte checksum
+// stored in its table's `checksum` column, and the metadata table announces
+// the algorithm via checksum_algo_version. There is no kind- or asset-level
+// fold anywhere: row equality (the manifest diff — server-side today, the
+// client's manifest pull in client_compare later) is the only comparison
+// currency, and checksums from different algorithm versions never compare.
+// The (key, resource_id) pair is derived, never stored: key is the row's
+// own primary key, resource_id is resources' id column ('' for every other
+// kind). The asset and asset_filters tables are exempt (replay-only; ingest
+// never consumes them).
+//
+// The CLIENT hashes at write time (see WithWriteTimeChecksums in
+// scan_data_store.go) — no second pass over the database during a scan.
+// This file is the post-pass over ALREADY-WRITTEN files: server-side
+// stamping and verification, backfill, tooling, benchmarks. Both paths are
+// bit-identical by construction and pinned so by TestWriteTimeChecksumParity.
+//
+// The row checksums come from mql's llx/checksum (data, resources) and
+// cnspec's policy/checksum (scores, risks) — never from local code.
+
+// MetaChecksumAlgoVersion is the metadata key announcing which checksum
+// algorithm wrote the checksum columns. Deliberately the manifest's own
+// key (the manifest is a trimmed scandb), referenced rather than repeated
+// so the two can never diverge.
+const MetaChecksumAlgoVersion = checksum.ManifestMetaAlgoVersion
+
+// ErrNoChecksumColumns reports a scan database whose tables lack the
+// `checksum` columns — one written by a client that predates them. The
+// stamped schema_version is "1.0" either way (see SchemaVersion), so column
+// presence is the only way to tell; callers doing bulk stamping should treat
+// this as "old file, skip or migrate", not corruption.
+var ErrNoChecksumColumns = errors.New("scan database predates checksum columns")
+
+// rowEntry is one checksummed row: its rowid and checksum. The rowid is the
+// one key shape every table shares (all four are ordinary rowid tables —
+// none is WITHOUT ROWID — so even resources' composite (name, id) primary
+// key collapses to a single integer). Rowids are stable for exactly the
+// window this pass uses them: hash phase and update phase run back to back
+// on the same open handle, with no deletes and no VACUUM in between
+// (Finalize's VACUUM comes after).
+type rowEntry struct {
+	rid      int64
+	checksum uint64
+}
+
+// ChecksumCounts reports how many rows were checksummed per table.
+type ChecksumCounts struct {
+	Data      int
+	Scores    int
+	Risks     int
+	Resources int
+}
+
+func (d ChecksumCounts) String() string {
+	return fmt.Sprintf("data=%d scores=%d risks=%d resources=%d",
+		d.Data, d.Scores, d.Risks, d.Resources)
+}
+
+// OpenForChecksums opens an existing scan database read-write without
+// re-initializing the schema — for re-running ComputeChecksums over an
+// already-written file (server-side stamping, tooling, benchmarks). Files
+// from pre-checksum clients open fine but fail ComputeChecksums with
+// ErrNoChecksumColumns. A missing path is an error — this entry point's
+// contract is an EXISTING file, so it must never fabricate one.
+func OpenForChecksums(filePath string) (*SqliteScanDataStore, error) {
+	// Stat first for a clear error (a bare driver error for a missing file
+	// reads like corruption), then open via a file: URI with mode=rw —
+	// read-write without create — so even a race cannot fabricate the file
+	// the way a plain-path DSN (READWRITE|CREATE) silently would.
+	if _, err := os.Stat(filePath); err != nil {
+		return nil, fmt.Errorf("cannot open scan database: %w", err)
+	}
+	sqlDB, err := sql.Open("sqlite", "file:"+filepath.ToSlash(filePath)+"?mode=rw")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sqlite file: %w", err)
+	}
+	queries, err := sqlc.Prepare(context.Background(), sqlDB)
+	if err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("failed to prepare queries: %w", err)
+	}
+	return &SqliteScanDataStore{
+		sqlDB:    sqlDB,
+		queries:  queries,
+		filePath: filePath,
+		readOnly: false,
+	}, nil
+}
+
+// checksumTargets names every checksummed table and its stage-apply
+// statement, in the order the pass processes them. The statements are
+// compile-time literals — no SQL is ever assembled from data (or from
+// anything else: even identifier interpolation via Sprintf trips SQL
+// scanners for no benefit when the full set of tables is known here).
+var checksumTargets = []struct {
+	table     string
+	updateSQL string
+}{
+	{"data", `UPDATE data SET checksum = s.checksum FROM _checksum_stage AS s WHERE data.rowid = s.rid`},
+	{"scores", `UPDATE scores SET checksum = s.checksum FROM _checksum_stage AS s WHERE scores.rowid = s.rid`},
+	{"scored_risk_factors", `UPDATE scored_risk_factors SET checksum = s.checksum FROM _checksum_stage AS s WHERE scored_risk_factors.rowid = s.rid`},
+	{"resources", `UPDATE resources SET checksum = s.checksum FROM _checksum_stage AS s WHERE resources.rowid = s.rid`},
+}
+
+// ensureChecksumColumns fails fast — before any row is read or hashed —
+// when the file predates the checksum columns, so old files can never be
+// half-processed or falsely stamped.
+func (s *SqliteScanDataStore) ensureChecksumColumns(ctx context.Context) error {
+	for _, target := range checksumTargets {
+		var n int
+		if err := s.sqlDB.QueryRowContext(ctx,
+			`SELECT count(*) FROM pragma_table_info(?) WHERE name = 'checksum'`,
+			target.table).Scan(&n); err != nil {
+			return fmt.Errorf("failed to inspect %s schema: %w", target.table, err)
+		}
+		if n == 0 {
+			return fmt.Errorf("table %s has no checksum column: %w", target.table, ErrNoChecksumColumns)
+		}
+	}
+	return nil
+}
+
+// ComputeChecksums computes the per-row checksums for every checksummed
+// table, stores them in each table's `checksum` column, and — only after
+// every row's update has been verified against the streamed row count —
+// announces the algorithm version in the metadata table. Databases written
+// by pre-checksum clients are refused up front with ErrNoChecksumColumns
+// rather than half-processed or falsely stamped.
+//
+// The scanning client does NOT run this: it hashes at write time
+// (WithWriteTimeChecksums), which produces bit-identical columns. This
+// pass exists for already-written files — server-side stamping and
+// verification recompute, backfill, tooling — and reads with row-at-a-time
+// cursors (never whole-table loads), hashing each stored row exactly as a
+// reader decodes it.
+func (s *SqliteScanDataStore) ComputeChecksums(ctx context.Context) (ChecksumCounts, error) {
+	if s.readOnly {
+		return ChecksumCounts{}, fmt.Errorf("cannot compute checksums in read-only mode")
+	}
+	if err := s.ensureChecksumColumns(ctx); err != nil {
+		return ChecksumCounts{}, err
+	}
+
+	dataRows, err := s.hashDataRows(ctx)
+	if err != nil {
+		return ChecksumCounts{}, err
+	}
+	scoreRows, err := s.hashScoreRows(ctx)
+	if err != nil {
+		return ChecksumCounts{}, err
+	}
+	riskRows, err := s.hashRiskRows(ctx)
+	if err != nil {
+		return ChecksumCounts{}, err
+	}
+	resourceRows, err := s.hashResourceRows(ctx)
+	if err != nil {
+		return ChecksumCounts{}, err
+	}
+
+	tx, err := s.sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return ChecksumCounts{}, fmt.Errorf("failed to begin checksum tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	entriesFor := map[string][]rowEntry{
+		"data":                dataRows,
+		"scores":              scoreRows,
+		"scored_risk_factors": riskRows,
+		"resources":           resourceRows,
+	}
+	for _, target := range checksumTargets {
+		if err := applyChecksums(ctx, tx, target.updateSQL, entriesFor[target.table]); err != nil {
+			return ChecksumCounts{}, fmt.Errorf("failed to write %s checksums: %w", target.table, err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)`,
+		MetaChecksumAlgoVersion, llxchecksum.AlgoVersion); err != nil {
+		return ChecksumCounts{}, fmt.Errorf("failed to write metadata %s: %w", MetaChecksumAlgoVersion, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return ChecksumCounts{}, fmt.Errorf("failed to commit checksums: %w", err)
+	}
+
+	return ChecksumCounts{
+		Data:      len(dataRows),
+		Scores:    len(scoreRows),
+		Risks:     len(riskRows),
+		Resources: len(resourceRows),
+	}, nil
+}
+
+// hashDataRows cursors over the data table, holding one row at a time.
+func (s *SqliteScanDataStore) hashDataRows(ctx context.Context) ([]rowEntry, error) {
+	rows, err := s.sqlDB.QueryContext(ctx, `SELECT rowid, code_id, data FROM data`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query data: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var entries []rowEntry
+	for rows.Next() {
+		var rid int64
+		var codeID string
+		var blob []byte
+		if err := rows.Scan(&rid, &codeID, &blob); err != nil {
+			return nil, fmt.Errorf("failed to scan data row: %w", err)
+		}
+		result := &llx.Result{}
+		if err := proto.Unmarshal(blob, result); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal result %s: %w", codeID, err)
+		}
+		d, err := llxchecksum.HashDataRow(codeID, result)
+		if err != nil {
+			return nil, fmt.Errorf("data row %s: %w", codeID, err)
+		}
+		entries = append(entries, rowEntry{rid: rid, checksum: d})
+	}
+	return entries, rows.Err()
+}
+
+// hashScoreRows cursors over the scores table, decoding each row through
+// convertScore so the hashed value is exactly what every reader sees.
+func (s *SqliteScanDataStore) hashScoreRows(ctx context.Context) ([]rowEntry, error) {
+	rows, err := s.sqlDB.QueryContext(ctx,
+		`SELECT rowid, qr_id, risk_score, type, value, weight, message, risk_factors, sources FROM scores`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query scores: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var entries []rowEntry
+	for rows.Next() {
+		var rid int64
+		var row sqlc.StreamScoresRow
+		if err := rows.Scan(&rid, &row.QrID, &row.RiskScore, &row.Type, &row.Value,
+			&row.Weight, &row.Message, &row.RiskFactors, &row.Sources); err != nil {
+			return nil, fmt.Errorf("failed to scan score row: %w", err)
+		}
+		score, err := s.convertScore(&row)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert score %s: %w", row.QrID, err)
+		}
+		d, err := checksum.HashScoreRow(score)
+		if err != nil {
+			return nil, fmt.Errorf("score row %s: %w", score.QrId, err)
+		}
+		entries = append(entries, rowEntry{rid: rid, checksum: d})
+	}
+	return entries, rows.Err()
+}
+
+// hashRiskRows cursors over the scored_risk_factors table, mirroring
+// StreamRisks' column decoding (REAL narrowed to the proto's float32).
+func (s *SqliteScanDataStore) hashRiskRows(ctx context.Context) ([]rowEntry, error) {
+	rows, err := s.sqlDB.QueryContext(ctx,
+		`SELECT rowid, mrn, risk, is_toxic, is_detected FROM scored_risk_factors`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query risk factors: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var entries []rowEntry
+	for rows.Next() {
+		var rid int64
+		var mrn string
+		var riskValue float64
+		var isToxic, isDetected bool
+		if err := rows.Scan(&rid, &mrn, &riskValue, &isToxic, &isDetected); err != nil {
+			return nil, fmt.Errorf("failed to scan risk row: %w", err)
+		}
+		d, err := checksum.HashRiskRow(&policy.ScoredRiskFactor{
+			Mrn:        mrn,
+			Risk:       float32(riskValue),
+			IsToxic:    isToxic,
+			IsDetected: isDetected,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("risk row %s: %w", mrn, err)
+		}
+		entries = append(entries, rowEntry{rid: rid, checksum: d})
+	}
+	return entries, rows.Err()
+}
+
+// hashResourceRows cursors over the resources table. The update key is the
+// physical rowid — never the blob-internal identity — so a row whose
+// payload disagrees with its key columns can never be skipped silently (the
+// row-count verification in applyChecksums would catch it regardless).
+func (s *SqliteScanDataStore) hashResourceRows(ctx context.Context) ([]rowEntry, error) {
+	rows, err := s.sqlDB.QueryContext(ctx, `SELECT rowid, name, id, data FROM resources`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query resources: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var entries []rowEntry
+	for rows.Next() {
+		var rid int64
+		var name, id string
+		var blob []byte
+		if err := rows.Scan(&rid, &name, &id, &blob); err != nil {
+			return nil, fmt.Errorf("failed to scan resource row: %w", err)
+		}
+		rec := &llx.ResourceRecording{}
+		if err := proto.Unmarshal(blob, rec); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource %s/%s: %w", name, id, err)
+		}
+		d, err := llxchecksum.HashResourceRow(rec)
+		if err != nil {
+			return nil, fmt.Errorf("resource row %s/%s: %w", name, id, err)
+		}
+		entries = append(entries, rowEntry{rid: rid, checksum: d})
+	}
+	return entries, rows.Err()
+}
+
+// applyStageChunk is the number of staged rows per INSERT statement. At 2
+// bound parameters per row it stays well under SQLite's most conservative
+// host-parameter limit (999).
+const applyStageChunk = 300
+
+// applyChecksums stages the entries in a temp table and applies them with a
+// single UPDATE ... FROM per table, inside the caller's transaction. The
+// update statement is one of the compile-time literals in checksumTargets.
+// The update's affected-row count must equal the number of streamed entries
+// — a mismatch (a key that matched nothing) aborts the pass so a row can
+// never be reported as checksummed while keeping its DEFAULT 0 sentinel.
+func applyChecksums(ctx context.Context, tx *sql.Tx, updateSQL string, entries []rowEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Self-healing stage lifecycle: reset any leftover stage before creating
+	// (so a previous call's failed drop can never resurface here as a
+	// misleading "table already exists"), and drop error-checked on the
+	// success path. Error paths return without dropping — the caller's
+	// rollback undoes the CREATE TEMP TABLE along with everything else, and
+	// the reset here covers even the case where it somehow does not.
+	if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS _checksum_stage`); err != nil {
+		return fmt.Errorf("failed to reset checksum stage: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`CREATE TEMP TABLE _checksum_stage (rid INTEGER NOT NULL, checksum INTEGER NOT NULL)`); err != nil {
+		return fmt.Errorf("failed to create checksum stage: %w", err)
+	}
+
+	for start := 0; start < len(entries); start += applyStageChunk {
+		end := min(start+applyStageChunk, len(entries))
+		chunk := entries[start:end]
+		query := `INSERT INTO _checksum_stage (rid, checksum) VALUES `
+		args := make([]any, 0, len(chunk)*2)
+		for i, e := range chunk {
+			if i > 0 {
+				query += ","
+			}
+			query += "(?, ?)"
+			// SQLite INTEGER is int64; store the uint64 bit pattern.
+			args = append(args, e.rid, int64(e.checksum))
+		}
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to stage checksums: %w", err)
+		}
+	}
+
+	res, err := tx.ExecContext(ctx, updateSQL)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to read affected rows: %w", err)
+	}
+	if affected != int64(len(entries)) {
+		return fmt.Errorf("checksum update matched %d of %d rows", affected, len(entries))
+	}
+
+	if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS _checksum_stage`); err != nil {
+		return fmt.Errorf("failed to drop checksum stage: %w", err)
+	}
+	return nil
+}

--- a/policy/scandb/checksum.go
+++ b/policy/scandb/checksum.go
@@ -356,15 +356,12 @@ func applyChecksums(ctx context.Context, tx *sql.Tx, updateSQL string, entries [
 		return nil
 	}
 
-	// Self-healing stage lifecycle: reset any leftover stage before creating
-	// (so a previous call's failed drop can never resurface here as a
-	// misleading "table already exists"), and drop error-checked on the
-	// success path. Error paths return without dropping — the caller's
-	// rollback undoes the CREATE TEMP TABLE along with everything else, and
-	// the reset here covers even the case where it somehow does not.
-	if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS _checksum_stage`); err != nil {
-		return fmt.Errorf("failed to reset checksum stage: %w", err)
-	}
+	// Stage lifecycle, resting on two verified SQLite facts: ROLLBACK undoes
+	// CREATE TEMP TABLE, so error paths return without cleanup and a failed
+	// pass can never leave a stage behind; COMMIT does not — a temp table
+	// outlives the transaction on its pooled connection — so the success
+	// path must drop, error-checked, because the next call's CREATE depends
+	// on it.
 	if _, err := tx.ExecContext(ctx,
 		`CREATE TEMP TABLE _checksum_stage (rid INTEGER NOT NULL, checksum INTEGER NOT NULL)`); err != nil {
 		return fmt.Errorf("failed to create checksum stage: %w", err)

--- a/policy/scandb/checksum.go
+++ b/policy/scandb/checksum.go
@@ -32,9 +32,13 @@ import (
 //
 // The CLIENT hashes at write time (see WithWriteTimeChecksums in
 // scan_data_store.go) — no second pass over the database during a scan.
-// This file is the post-pass over ALREADY-WRITTEN files: server-side
-// stamping and verification, backfill, tooling, benchmarks. Both paths are
-// bit-identical by construction and pinned so by TestWriteTimeChecksumParity.
+// This file is the post-pass, and it has exactly one production consumer:
+// SERVER-SIDE BACKFILL of already-written files whose rows carry no
+// checksums (feature-off scans, hash failures; pre-checksum-schema files
+// are refused with ErrNoChecksumColumns). The server imports this package
+// for that rather than reimplementing the algorithm; nothing in cnspec's
+// scan path calls it. Both paths are bit-identical by construction and
+// pinned so by the parity tests — the post-pass's only in-repo callers.
 //
 // The row checksums come from mql's llx/checksum (data, resources) and
 // cnspec's policy/checksum (scores, risks) — never from local code.
@@ -78,9 +82,9 @@ func (d ChecksumCounts) String() string {
 }
 
 // OpenForChecksums opens an existing scan database read-write without
-// re-initializing the schema — for re-running ComputeChecksums over an
-// already-written file (server-side stamping, tooling, benchmarks). Files
-// from pre-checksum clients open fine but fail ComputeChecksums with
+// re-initializing the schema — the server-side backfill entry point for
+// running ComputeChecksums over an already-written file. Files from
+// pre-checksum clients open fine but fail ComputeChecksums with
 // ErrNoChecksumColumns. A missing path is an error — this entry point's
 // contract is an EXISTING file, so it must never fabricate one.
 func OpenForChecksums(filePath string) (*SqliteScanDataStore, error) {
@@ -150,10 +154,10 @@ func (s *SqliteScanDataStore) ensureChecksumColumns(ctx context.Context) error {
 //
 // The scanning client does NOT run this: it hashes at write time
 // (WithWriteTimeChecksums), which produces bit-identical columns. This
-// pass exists for already-written files — server-side stamping and
-// verification recompute, backfill, tooling — and reads with row-at-a-time
-// cursors (never whole-table loads), hashing each stored row exactly as a
-// reader decodes it.
+// pass exists solely for server-side backfill of already-written files
+// whose rows carry no checksums, and reads with row-at-a-time cursors
+// (never whole-table loads), hashing each stored row exactly as a reader
+// decodes it.
 func (s *SqliteScanDataStore) ComputeChecksums(ctx context.Context) (ChecksumCounts, error) {
 	if s.readOnly {
 		return ChecksumCounts{}, fmt.Errorf("cannot compute checksums in read-only mode")

--- a/policy/scandb/checksum_test.go
+++ b/policy/scandb/checksum_test.go
@@ -1,0 +1,253 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scandb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/checksum"
+	"go.mondoo.com/mql/v13/llx"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
+)
+
+// readChecksum reads one row's checksum column back as the uint64 the
+// packages produce (SQLite stores the int64 bit pattern).
+func readChecksum(t *testing.T, path, query string, args ...any) uint64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+	var v int64
+	require.NoError(t, db.QueryRow(query, args...).Scan(&v))
+	return uint64(v)
+}
+
+// TestComputeChecksums pins the writer half of the wire contract: the
+// checksum columns land in every table bit-equal to what the canonical
+// packages produce for the same rows, the metadata announces the algorithm,
+// the pass is deterministic, and it folds final table state (an upsert
+// before the pass is what gets checksummed).
+func TestComputeChecksums(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	score := &policy.Score{
+		QrId: "check1", RiskScore: 25, Type: 2, Value: 100, Weight: 1,
+		RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{{Mrn: "//r/1", Risk: 0.5}}},
+		Sources:     &policy.Sources{Items: []*policy.Source{{Name: "scanner", Version: "1.0"}}},
+	}
+	data := &llx.Result{CodeId: "data1", Data: llx.StringPrimitive("hello")}
+	risk := &policy.ScoredRiskFactor{Mrn: "//r/1", Risk: 0.5, IsToxic: true}
+	res := &llx.ResourceRecording{Resource: "user", Id: "root",
+		Fields: map[string]*llx.Result{"c1": {CodeId: "c1", Data: llx.StringPrimitive("v1")}}}
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1")
+	require.NoError(t, err)
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{score}))
+	require.NoError(t, w.WriteData(ctx, []*llx.Result{data}))
+	require.NoError(t, w.WriteRisk(ctx, risk))
+	require.NoError(t, w.WriteResource(ctx, res))
+	_, err = w.Finalize()
+	require.NoError(t, err)
+
+	cw, err := OpenForChecksums(path)
+	require.NoError(t, err)
+	counts, err := cw.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, ChecksumCounts{Data: 1, Scores: 1, Risks: 1, Resources: 1}, counts)
+
+	// Deterministic: a second pass over unchanged state rewrites the same
+	// values.
+	again, err := cw.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, counts, again)
+	require.NoError(t, cw.Close())
+
+	// Every column is bit-equal to the canonical packages' output for the
+	// same row — the exact values the server's extract-vs-recompute parity
+	// gate compares.
+	wantData, err := llxchecksum.HashDataRow("data1", data)
+	require.NoError(t, err)
+	assert.Equal(t, wantData, readChecksum(t, path, `SELECT checksum FROM data WHERE code_id = ?`, "data1"))
+
+	wantScore, err := checksum.HashScoreRow(score)
+	require.NoError(t, err)
+	assert.Equal(t, wantScore, readChecksum(t, path, `SELECT checksum FROM scores WHERE qr_id = ?`, "check1"))
+
+	wantRisk, err := checksum.HashRiskRow(risk)
+	require.NoError(t, err)
+	assert.Equal(t, wantRisk,
+		readChecksum(t, path, `SELECT checksum FROM scored_risk_factors WHERE mrn = ?`, "//r/1"))
+
+	wantRes, err := llxchecksum.HashResourceRow(res)
+	require.NoError(t, err)
+	assert.Equal(t, wantRes, readChecksum(t, path, `SELECT checksum FROM resources WHERE name = ? AND id = ?`, "user", "root"))
+
+	// The metadata key announces the algorithm the columns were written with.
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	var algo string
+	require.NoError(t, db.QueryRow(`SELECT value FROM metadata WHERE key = ?`, MetaChecksumAlgoVersion).Scan(&algo))
+	require.NoError(t, db.Close())
+	assert.Equal(t, llxchecksum.AlgoVersion, algo)
+}
+
+// TestComputeChecksumsFoldsFinalState: rows are upserted during a scan; the
+// checksum pass must only ever see the final value.
+func TestComputeChecksumsFoldsFinalState(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1")
+	require.NoError(t, err)
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{{QrId: "check1", Value: 40}}))
+	final := &policy.Score{QrId: "check1", Value: 100}
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{final})) // upsert
+	_, err = w.Finalize()
+	require.NoError(t, err)
+
+	cw, err := OpenForChecksums(path)
+	require.NoError(t, err)
+	counts, err := cw.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+	assert.Equal(t, 1, counts.Scores, "one row per qr_id after the upsert")
+
+	want, err := checksum.HashScoreRow(final)
+	require.NoError(t, err)
+	assert.Equal(t, want, readChecksum(t, path, `SELECT checksum FROM scores WHERE qr_id = ?`, "check1"),
+		"the checksum is of the final upserted row, never a stale intermediate")
+}
+
+// TestComputeChecksumsReadOnly: a reader must refuse the pass — checksums
+// are written by the scan owner, never by a consumer.
+func TestComputeChecksumsReadOnly(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+	w, err := NewSqliteScanDataStore(path, "//assets/a1")
+	require.NoError(t, err)
+	_, err = w.Finalize()
+	require.NoError(t, err)
+
+	r, err := NewSqliteScanDataStoreReader(path)
+	require.NoError(t, err)
+	defer r.Close() //nolint:errcheck
+	_, err = r.ComputeChecksums(ctx)
+	assert.Error(t, err)
+}
+
+// TestComputeChecksumsPreChecksumFile: a scan database written by a client
+// that predates the checksum columns must be refused up front — before any
+// row is streamed or hashed — with ErrNoChecksumColumns, and must never be
+// stamped with checksum_algo_version. The stamped schema_version is "1.0"
+// either way, so the column check is the only guard. This covers both an
+// old file with rows and the sharper trap: an old file whose tables are
+// empty, where the row updates would all no-op and (without the guard) the
+// metadata would be committed anyway.
+func TestComputeChecksumsPreChecksumFile(t *testing.T) {
+	ctx := context.Background()
+
+	// The pre-checksum schema exactly as origin/main declared it.
+	oldSchema := `
+CREATE TABLE metadata (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+CREATE TABLE scores (qr_id TEXT PRIMARY KEY, risk_score INTEGER NOT NULL, type INTEGER NOT NULL,
+  value INTEGER NOT NULL, weight INTEGER NOT NULL, message TEXT, risk_factors BLOB, sources BLOB);
+CREATE TABLE data (code_id TEXT PRIMARY KEY, data BLOB NOT NULL);
+CREATE TABLE scored_risk_factors (mrn TEXT PRIMARY KEY, risk REAL NOT NULL, is_toxic BOOLEAN NOT NULL, is_detected BOOLEAN NOT NULL);
+CREATE TABLE resources (name TEXT NOT NULL, id TEXT NOT NULL, data BLOB NOT NULL, PRIMARY KEY (name, id));
+CREATE TABLE asset (id INTEGER PRIMARY KEY CHECK (id = 0), data BLOB NOT NULL);
+CREATE TABLE asset_filters (code_id TEXT NOT NULL PRIMARY KEY);
+`
+
+	for _, tc := range []struct {
+		name    string
+		withRow bool
+	}{
+		{name: "with rows", withRow: true},
+		{name: "empty tables", withRow: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "old.db")
+			db, err := sql.Open("sqlite", path)
+			require.NoError(t, err)
+			_, err = db.Exec(oldSchema)
+			require.NoError(t, err)
+			_, err = db.Exec(`INSERT INTO metadata (key, value) VALUES ('schema_version', '1.0')`)
+			require.NoError(t, err)
+			if tc.withRow {
+				_, err = db.Exec(`INSERT INTO scores (qr_id, risk_score, type, value, weight) VALUES ('q1', 10, 2, 100, 1)`)
+				require.NoError(t, err)
+			}
+			require.NoError(t, db.Close())
+
+			cw, err := OpenForChecksums(path)
+			require.NoError(t, err)
+			defer cw.Close() //nolint:errcheck
+
+			_, err = cw.ComputeChecksums(ctx)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrNoChecksumColumns),
+				"pre-checksum files must fail with the typed sentinel, got: %v", err)
+
+			// The refusal must leave no trace: no algo-version stamp.
+			db, err = sql.Open("sqlite", path)
+			require.NoError(t, err)
+			defer db.Close() //nolint:errcheck
+			var v string
+			scanErr := db.QueryRow(`SELECT value FROM metadata WHERE key = ?`, MetaChecksumAlgoVersion).Scan(&v)
+			assert.ErrorIs(t, scanErr, sql.ErrNoRows,
+				"a refused file must never be stamped with checksum_algo_version")
+		})
+	}
+}
+
+// TestOpenForChecksumsMissingPath: the entry point's contract is an existing
+// file — a wrong path must fail at open with a clear error and must never
+// fabricate an empty database at that path.
+func TestOpenForChecksumsMissingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.db")
+	_, err := OpenForChecksums(path)
+	require.Error(t, err)
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "a failed open must not leave a stray file behind")
+}
+
+// TestReaderIsReadOnlyAtTheDatabase: the checksum ownership contract
+// (checksums are written by the scan owner, never a consumer) must be
+// enforced by SQLite itself, not only by the Go-level readOnly bool — raw
+// SQL through a reader handle must fail, and a reader must never fabricate
+// a missing file.
+func TestReaderIsReadOnlyAtTheDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.db")
+	w, err := NewSqliteScanDataStore(path, "//assets/a1")
+	require.NoError(t, err)
+	_, err = w.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	r, err := NewSqliteScanDataStoreReader(path)
+	require.NoError(t, err)
+	defer r.Close() //nolint:errcheck
+	_, err = r.sqlDB.Exec(`INSERT INTO metadata (key, value) VALUES ('probe', 'x')`)
+	assert.Error(t, err, "writes through a reader handle must be rejected by the database")
+
+	// A reader on a missing path must error, not create the file.
+	missing := filepath.Join(t.TempDir(), "missing.db")
+	r2, err := NewSqliteScanDataStoreReader(missing)
+	if err == nil {
+		_, err = r2.GetMetadata()
+		require.NoError(t, r2.Close())
+	}
+	assert.Error(t, err, "a reader must not open a nonexistent database")
+	_, statErr := os.Stat(missing)
+	assert.True(t, os.IsNotExist(statErr), "a reader must never fabricate the file")
+}

--- a/policy/scandb/checksum_write_test.go
+++ b/policy/scandb/checksum_write_test.go
@@ -1,0 +1,346 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scandb
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/checksum"
+	"go.mondoo.com/mql/v13/llx"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// parityCorpus is the divergence-prone write sequence shared by the parity
+// tests: empty containers, an upsert, unicode+NUL, error rows,
+// rounding-hostile floats, empty resource ids, nil map values. finalScores
+// holds the score rows as they exist after the upsert.
+type parityCorpus struct {
+	finalScores []*policy.Score
+	data        []*llx.Result
+	risks       []*policy.ScoredRiskFactor
+	resources   []*llx.ResourceRecording
+}
+
+// writeParityCorpus performs the identical write sequence against any store.
+func writeParityCorpus(t *testing.T, ctx context.Context, w *SqliteScanDataStore) parityCorpus {
+	t.Helper()
+
+	scores := []*policy.Score{
+		{QrId: "bare", RiskScore: 25, Type: 2, Value: 80, Weight: 1},
+		{QrId: "empty-containers", Value: 100, RiskFactors: &policy.ScoredRiskFactors{}, Sources: &policy.Sources{}},
+		{QrId: "unicode", Value: 1, Message: "žluťoučký kůň 🐎 \x00 with NUL"},
+		{QrId: "loaded", RiskScore: 90, Type: 2, Weight: 3, Message: "m",
+			RiskFactors: &policy.ScoredRiskFactors{Items: []*policy.ScoredRiskFactor{
+				{Mrn: "//r/a", Risk: 0.7, IsToxic: true, Data: map[string]*llx.Result{
+					"q1": {CodeId: "q1", Data: llx.StringPrimitive("v")},
+				}},
+			}},
+			Sources: &policy.Sources{Items: []*policy.Source{{
+				Name: "s", Url: "https://e.com", Version: "1", Vendor: policy.Source_MICROSOFT,
+				FirstDetectedAt: "2026-01-01T00:00:00Z", FixedAt: "2026-02-01T00:00:00Z",
+			}}}},
+	}
+	require.NoError(t, w.WriteScores(ctx, scores))
+	// An upsert's replacement row carries its own checksum — final state wins.
+	upserted := &policy.Score{QrId: "bare", Value: 99, Message: "final"}
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{upserted}))
+
+	data := []*llx.Result{
+		{CodeId: "d-str", Data: llx.StringPrimitive("hello")},
+		{CodeId: "d-nil"},
+		{CodeId: "d-err", Error: "query failed: boom"},
+	}
+	require.NoError(t, w.WriteData(ctx, data))
+
+	risks := []*policy.ScoredRiskFactor{
+		{Mrn: "//r/1", Risk: 0.7, IsToxic: true, IsDetected: true},
+		{Mrn: "//r/2", Risk: float32(math.Copysign(0, -1))},
+	}
+	for _, r := range risks {
+		require.NoError(t, w.WriteRisk(ctx, r))
+	}
+
+	resources := []*llx.ResourceRecording{
+		{Resource: "singleton", Id: "", Fields: map[string]*llx.Result{"f": {CodeId: "f", Data: llx.StringPrimitive("v")}}},
+		// nil map value: folds like the zero Result (mql llx/checksum), so
+		// the write-time hash matches the recompute from the stored row.
+		{Resource: "nilresult", Id: "y", Fields: map[string]*llx.Result{"gone": nil}},
+	}
+	for _, rec := range resources {
+		require.NoError(t, w.WriteResource(ctx, rec))
+	}
+
+	return parityCorpus{
+		finalScores: append([]*policy.Score{upserted}, scores[1:]...),
+		data:        data,
+		risks:       risks,
+		resources:   resources,
+	}
+}
+
+// collectChecksumColumns reads every checksum column of every checksummed
+// table, keyed by the row's natural key.
+func collectChecksumColumns(t *testing.T, path string) map[string]uint64 {
+	t.Helper()
+	dst := map[string]uint64{}
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+	for _, q := range []string{
+		`SELECT 'data:' || code_id, checksum FROM data`,
+		`SELECT 'score:' || qr_id, checksum FROM scores`,
+		`SELECT 'risk:' || mrn, checksum FROM scored_risk_factors`,
+		`SELECT 'res:' || name || '/' || id, checksum FROM resources`,
+	} {
+		rows, err := db.Query(q)
+		require.NoError(t, err)
+		for rows.Next() {
+			var k string
+			var v int64
+			require.NoError(t, rows.Scan(&k, &v))
+			dst[k] = uint64(v)
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+	}
+	return dst
+}
+
+// readAlgoStamp returns the checksum_algo_version metadata value, or "" when
+// the file is unstamped.
+func readAlgoStamp(t *testing.T, path string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+	var v string
+	err = db.QueryRow(`SELECT value FROM metadata WHERE key = ?`, MetaChecksumAlgoVersion).Scan(&v)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	require.NoError(t, err)
+	return v
+}
+
+// TestWriteTimeChecksumParity is the write-time contract: rows hashed as
+// they are written land bit-identical to what the post-pass (and the
+// server's recompute) derives from the stored rows — across the shapes
+// that historically diverged and hostile inputs.
+func TestWriteTimeChecksumParity(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	corpus := writeParityCorpus(t, ctx, w)
+
+	cs := w.WriteChecksumStats()
+	assert.Equal(t, ChecksumCounts{Data: 3, Scores: 5, Risks: 2, Resources: 2}, cs.Counts,
+		"counts are hash operations: the upsert hashes twice for one final row")
+	assert.Zero(t, cs.Errors)
+	assert.Positive(t, cs.Duration)
+
+	// The scan owner stamps once, when writes are complete — the same call
+	// the sqlite datalake makes.
+	w.StampChecksums()
+	_, err = w.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Every stored column is bit-equal to the canonical packages' output
+	// for the in-memory row — for "bare" that is the upserted replacement:
+	// a row's checksum is of the final write.
+	for _, s := range corpus.finalScores {
+		want, err := checksum.HashScoreRow(s)
+		require.NoError(t, err)
+		assert.Equal(t, want, readChecksum(t, path, `SELECT checksum FROM scores WHERE qr_id = ?`, s.QrId), s.QrId)
+	}
+	for _, d := range corpus.data {
+		want, err := llxchecksum.HashDataRow(d.CodeId, d)
+		require.NoError(t, err)
+		assert.Equal(t, want, readChecksum(t, path, `SELECT checksum FROM data WHERE code_id = ?`, d.CodeId), d.CodeId)
+	}
+	for _, r := range corpus.risks {
+		want, err := checksum.HashRiskRow(r)
+		require.NoError(t, err)
+		assert.Equal(t, want, readChecksum(t, path, `SELECT checksum FROM scored_risk_factors WHERE mrn = ?`, r.Mrn), r.Mrn)
+	}
+	for _, rec := range corpus.resources {
+		want, err := llxchecksum.HashResourceRow(rec)
+		require.NoError(t, err)
+		assert.Equal(t, want,
+			readChecksum(t, path, `SELECT checksum FROM resources WHERE name = ? AND id = ?`, rec.Resource, rec.Id), rec.Resource)
+	}
+
+	// The file is stamped: every hash succeeded.
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, path))
+
+	// Re-running the post-pass over this file rewrites every column to the
+	// exact same bits the write path stored — and does not depend on the
+	// pre-existing column state.
+	before := collectChecksumColumns(t, path)
+	cw, err := OpenForChecksums(path)
+	require.NoError(t, err)
+	_, err = cw.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+	assert.Equal(t, before, collectChecksumColumns(t, path),
+		"write-time and post-pass checksums must be bit-identical for every row")
+}
+
+// TestComputeChecksumsMatchesWriteTimePath is the cross-file equivalence:
+// the same content written twice — once through the normal write-time path,
+// once bare and then stamped by ComputeChecksums — carries bit-identical
+// checksum columns and the same algorithm stamp. This is the exact
+// guarantee the server relies on: its recompute over an uploaded file must
+// agree with what the scanning client wrote, without depending on any
+// pre-existing column state (the bare file starts at DEFAULT 0 everywhere).
+func TestComputeChecksumsMatchesWriteTimePath(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	writePath := filepath.Join(dir, "writetime.db")
+	postPath := filepath.Join(dir, "postpass.db")
+
+	// One file checksummed the normal way: at write time, stamped once by
+	// the scan owner.
+	ww, err := NewSqliteScanDataStore(writePath, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	writeParityCorpus(t, ctx, ww)
+	ww.StampChecksums()
+	_, err = ww.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, ww.Close())
+
+	// The identical content written bare, then stamped by the post-pass.
+	wp, err := NewSqliteScanDataStore(postPath, "//assets/a1")
+	require.NoError(t, err)
+	writeParityCorpus(t, ctx, wp)
+	_, err = wp.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, wp.Close())
+
+	cw, err := OpenForChecksums(postPath)
+	require.NoError(t, err)
+	counts, err := cw.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+	assert.Equal(t, ChecksumCounts{Data: 3, Scores: 4, Risks: 2, Resources: 2}, counts,
+		"the post-pass hashes final rows: four scores remain after the upsert")
+
+	assert.Equal(t,
+		collectChecksumColumns(t, writePath),
+		collectChecksumColumns(t, postPath),
+		"the write-time path and ComputeChecksums must produce bit-identical columns for identical content")
+
+	// Both paths announce the same algorithm.
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, writePath))
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, postPath))
+}
+
+// TestWriteTimeChecksumsDisabledByDefault: without the option, writes cost
+// zero checksum work, columns keep the schema default, and Finalize never
+// stamps.
+func TestWriteTimeChecksumsDisabledByDefault(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1")
+	require.NoError(t, err)
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{{QrId: "q1", Value: 100}}))
+	require.NoError(t, w.WriteData(ctx, []*llx.Result{{CodeId: "d1", Data: llx.StringPrimitive("v")}}))
+	cs := w.WriteChecksumStats()
+	assert.Zero(t, cs.Counts)
+	assert.Zero(t, cs.Duration)
+	w.StampChecksums() // no-op on a store without the option
+	_, err = w.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.Zero(t, readChecksum(t, path, `SELECT checksum FROM scores WHERE qr_id = ?`, "q1"))
+	assert.Zero(t, readChecksum(t, path, `SELECT checksum FROM data WHERE code_id = ?`, "d1"))
+	assert.Empty(t, readAlgoStamp(t, path), "a store without checksums must never stamp the algo version")
+}
+
+// TestWriteTimeChecksumFailureNeverFailsScan pins the failure contract: a
+// row whose hash errors is still written (the scan continues), the failure
+// is counted, and Finalize leaves the file unstamped so it is consumed
+// exactly like a pre-checksum file — fail-open, never a wrong skip.
+func TestWriteTimeChecksumFailureNeverFailsScan(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+
+	// Nesting deeper than llx/checksum's canon bound errors the hash while
+	// remaining perfectly writable as a blob.
+	deep := llx.StringPrimitive("leaf")
+	for i := 0; i < 70; i++ {
+		inner, err := deep.MarshalVT()
+		require.NoError(t, err)
+		deep = &llx.Primitive{Type: string(types.Dict), Value: inner}
+	}
+	poisoned := &llx.Result{CodeId: "poisoned", Data: deep}
+	fine := &llx.Result{CodeId: "fine", Data: llx.StringPrimitive("v")}
+
+	require.NoError(t, w.WriteData(ctx, []*llx.Result{poisoned, fine}),
+		"a hash failure must never fail the write")
+
+	cs := w.WriteChecksumStats()
+	assert.Equal(t, int64(1), cs.Errors)
+	assert.Equal(t, 1, cs.Counts.Data, "the healthy row still got its checksum")
+
+	w.StampChecksums() // refuses: a hash failed, the file must stay unstamped
+	_, err = w.Finalize()
+	require.NoError(t, err, "a hash failure must never fail Finalize")
+	require.NoError(t, w.Close())
+
+	// The poisoned row is stored (scan data intact), without a checksum.
+	assert.Zero(t, readChecksum(t, path, `SELECT checksum FROM data WHERE code_id = ?`, "poisoned"))
+	assert.NotZero(t, readChecksum(t, path, `SELECT checksum FROM data WHERE code_id = ?`, "fine"))
+
+	// And the file is NOT stamped: partially checksummed never masquerades
+	// as checksummed.
+	assert.Empty(t, readAlgoStamp(t, path))
+}
+
+// TestStampChecksumsWithoutFinalize pins the no-upload path: a kept scan
+// database whose scan never reaches Finalize (incognito / --output-scan-db
+// without an upstream) must still be stamped by an explicit StampChecksums
+// call — the regression that shipped 10 fully-checksummed but unstamped
+// files during verification.
+func TestStampChecksumsWithoutFinalize(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan.db")
+
+	w, err := NewSqliteScanDataStore(path, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	require.NoError(t, w.WriteScores(ctx, []*policy.Score{{QrId: "q1", Value: 100}}))
+
+	w.StampChecksums()
+	require.NoError(t, w.Close()) // no Finalize on this path
+
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, path),
+		"kept files must be stamped even when Finalize never runs")
+	assert.NotZero(t, readChecksum(t, path, `SELECT checksum FROM scores WHERE qr_id = ?`, "q1"))
+
+	// Idempotence with the Finalize path: stamping again through a fresh
+	// writer-style open must not error or change the value. (Also: a
+	// disabled store's StampChecksums is a no-op — covered by
+	// TestWriteTimeChecksumsDisabledByDefault via Finalize.)
+	w2, err := OpenForChecksums(path)
+	require.NoError(t, err)
+	_, err = w2.ComputeChecksums(ctx)
+	require.NoError(t, err)
+	require.NoError(t, w2.Close())
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, path))
+}

--- a/policy/scandb/manifest_diff_test.go
+++ b/policy/scandb/manifest_diff_test.go
@@ -1,0 +1,168 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scandb
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/checksum"
+	"go.mondoo.com/mql/v13/llx"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
+)
+
+// buildManifest extracts a manifest from a scan database — the projection
+// the server performs after processing an upload: each kind's key and
+// checksum, nothing else, plus the algo-version and asset metadata.
+func buildManifest(t *testing.T, scanPath, manifestPath, assetMrn string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", manifestPath)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	_, err = db.Exec(checksum.ManifestSchema)
+	require.NoError(t, err)
+	_, err = db.Exec(`ATTACH DATABASE ? AS scan`, scanPath)
+	require.NoError(t, err)
+	for _, q := range []string{
+		`INSERT INTO data SELECT code_id, checksum FROM scan.data`,
+		`INSERT INTO scores SELECT qr_id, checksum FROM scan.scores`,
+		`INSERT INTO scored_risk_factors SELECT mrn, checksum FROM scan.scored_risk_factors`,
+		`INSERT INTO resources SELECT name, id, checksum FROM scan.resources`,
+	} {
+		_, err = db.Exec(q)
+		require.NoError(t, err)
+	}
+	_, err = db.Exec(`INSERT INTO metadata SELECT key, value FROM scan.metadata WHERE key = ?`,
+		checksum.ManifestMetaAlgoVersion)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO metadata (key, value) VALUES (?, ?)`,
+		checksum.ManifestMetaAssetMrn, assetMrn)
+	require.NoError(t, err)
+	_, err = db.Exec(`DETACH DATABASE scan`)
+	require.NoError(t, err)
+}
+
+// manifestDiff is the minimal assertion: key-addressed SQL over a scan
+// database and a manifest, per kind — changed (both sides, different
+// checksum), added (scan only), removed (manifest only). Pure SQL over the
+// two files, so either side can run it.
+type manifestDiff struct {
+	changed, added, removed []string
+}
+
+func (d manifestDiff) unchanged() bool {
+	return len(d.changed) == 0 && len(d.added) == 0 && len(d.removed) == 0
+}
+
+func diffAgainstManifest(t *testing.T, scanPath, manifestPath string) manifestDiff {
+	t.Helper()
+	db, err := sql.Open("sqlite", scanPath)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+	_, err = db.Exec(`ATTACH DATABASE ? AS m`, manifestPath)
+	require.NoError(t, err)
+
+	collect := func(dst *[]string, query string) {
+		rows, err := db.Query(query)
+		require.NoError(t, err)
+		defer rows.Close() //nolint:errcheck
+		for rows.Next() {
+			var k string
+			require.NoError(t, rows.Scan(&k))
+			*dst = append(*dst, k)
+		}
+		require.NoError(t, rows.Err())
+	}
+
+	var d manifestDiff
+	for _, kind := range []struct{ prefix, table, key string }{
+		{"data:", "data", "code_id"},
+		{"score:", "scores", "qr_id"},
+		{"risk:", "scored_risk_factors", "mrn"},
+	} {
+		collect(&d.changed, `SELECT '`+kind.prefix+`' || s.`+kind.key+` FROM `+kind.table+` s JOIN m.`+kind.table+` mm USING(`+kind.key+`) WHERE s.checksum != mm.checksum`)
+		collect(&d.added, `SELECT '`+kind.prefix+`' || `+kind.key+` FROM (SELECT `+kind.key+` FROM `+kind.table+` EXCEPT SELECT `+kind.key+` FROM m.`+kind.table+`)`)
+		collect(&d.removed, `SELECT '`+kind.prefix+`' || `+kind.key+` FROM (SELECT `+kind.key+` FROM m.`+kind.table+` EXCEPT SELECT `+kind.key+` FROM `+kind.table+`)`)
+	}
+	collect(&d.changed, `SELECT 'res:' || s.name || '/' || s.id FROM resources s JOIN m.resources mm USING(name, id) WHERE s.checksum != mm.checksum`)
+	collect(&d.added, `SELECT 'res:' || name || '/' || id FROM (SELECT name, id FROM resources EXCEPT SELECT name, id FROM m.resources)`)
+	collect(&d.removed, `SELECT 'res:' || name || '/' || id FROM (SELECT name, id FROM m.resources EXCEPT SELECT name, id FROM resources)`)
+	return d
+}
+
+// TestManifestMinimalDiffAssertion proves the manifest schema carries
+// everything the unchanged-scan short-circuit needs, from either side:
+// a manifest extracted from one scan compares against another scan's rows
+// with nothing but key-addressed SQL — equal content reads as unchanged
+// (skip the upload), and a real change is attributed to exactly its rows.
+func TestManifestMinimalDiffAssertion(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Scan A: the baseline upload the server processed and staged a
+	// manifest for.
+	pathA := filepath.Join(dir, "a.db")
+	wa, err := NewSqliteScanDataStore(pathA, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	writeParityCorpus(t, ctx, wa)
+	wa.StampChecksums()
+	_, err = wa.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, wa.Close())
+
+	manifestPath := filepath.Join(dir, "a.manifest.db")
+	buildManifest(t, pathA, manifestPath, "//assets/a1")
+
+	// The reader's gate: the manifest announces the same algorithm the
+	// client runs; a version mismatch would mean "treat as absent".
+	assert.Equal(t, llxchecksum.AlgoVersion, readAlgoStamp(t, manifestPath))
+
+	// Scan B: identical content. The minimal assertion must read it as
+	// unchanged — the upload short-circuit case.
+	pathB := filepath.Join(dir, "b.db")
+	wb, err := NewSqliteScanDataStore(pathB, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	writeParityCorpus(t, ctx, wb)
+	wb.StampChecksums()
+	_, err = wb.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, wb.Close())
+
+	diff := diffAgainstManifest(t, pathB, manifestPath)
+	assert.True(t, diff.unchanged(),
+		"identical content must diff clean against the manifest, got changed=%v added=%v removed=%v",
+		diff.changed, diff.added, diff.removed)
+
+	// Scan C: one score's value flips, one data row appears, one risk row
+	// disappears. The diff must attribute exactly those keys — change
+	// attribution, not just a boolean.
+	pathC := filepath.Join(dir, "c.db")
+	wc, err := NewSqliteScanDataStore(pathC, "//assets/a1", WithWriteTimeChecksums())
+	require.NoError(t, err)
+	writeParityCorpus(t, ctx, wc)
+	require.NoError(t, wc.WriteScores(ctx, []*policy.Score{{QrId: "unicode", Value: 2, Message: "žluťoučký kůň 🐎 \x00 with NUL"}}))
+	require.NoError(t, wc.WriteData(ctx, []*llx.Result{{CodeId: "d-new", Data: llx.StringPrimitive("appeared")}}))
+	wc.StampChecksums()
+	_, err = wc.Finalize()
+	require.NoError(t, err)
+	require.NoError(t, wc.Close())
+	// The store has no delete API (scans only upsert); drop a row directly
+	// to exercise the removed leg of the diff.
+	db, err := sql.Open("sqlite", pathC)
+	require.NoError(t, err)
+	_, err = db.Exec(`DELETE FROM scored_risk_factors WHERE mrn = '//r/2'`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	diff = diffAgainstManifest(t, pathC, manifestPath)
+	assert.ElementsMatch(t, []string{"score:unicode"}, diff.changed)
+	assert.ElementsMatch(t, []string{"data:d-new"}, diff.added)
+	assert.ElementsMatch(t, []string{"risk://r/2"}, diff.removed)
+}

--- a/policy/scandb/query.sql
+++ b/policy/scandb/query.sql
@@ -14,8 +14,8 @@ SELECT value FROM metadata WHERE key = ?;
 -- Scores operations
 -- name: InsertScore :exec
 INSERT OR REPLACE INTO scores (
-    qr_id, risk_score, type, value, weight, message, risk_factors, sources
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+    qr_id, risk_score, type, value, weight, message, risk_factors, sources, checksum
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetScore :one
 SELECT qr_id, risk_score, type, value, weight, message, risk_factors, sources
@@ -27,7 +27,7 @@ FROM scores ORDER BY qr_id;
 
 -- Data operations
 -- name: InsertData :exec
-INSERT OR REPLACE INTO data (code_id, data) VALUES (?, ?);
+INSERT OR REPLACE INTO data (code_id, data, checksum) VALUES (?, ?, ?);
 
 -- name: GetData :one
 SELECT data FROM data WHERE code_id = ?;
@@ -37,8 +37,8 @@ SELECT code_id, data FROM data ORDER BY code_id;
 
 -- Risk factor operations
 -- name: InsertRiskFactor :exec
-INSERT OR REPLACE INTO scored_risk_factors (mrn, risk, is_toxic, is_detected)
-VALUES (?, ?, ?, ?);
+INSERT OR REPLACE INTO scored_risk_factors (mrn, risk, is_toxic, is_detected, checksum)
+VALUES (?, ?, ?, ?, ?);
 
 -- name: GetRiskFactor :one
 SELECT mrn, risk, is_toxic, is_detected
@@ -50,7 +50,7 @@ FROM scored_risk_factors ORDER BY mrn;
 
 -- Resource operations
 -- name: InsertResource :exec
-INSERT OR REPLACE INTO resources (name, id, data) VALUES (?, ?, ?);
+INSERT OR REPLACE INTO resources (name, id, data, checksum) VALUES (?, ?, ?, ?);
 
 -- name: GetResource :one
 SELECT data FROM resources WHERE name = ? AND id = ?;
@@ -58,14 +58,16 @@ SELECT data FROM resources WHERE name = ? AND id = ?;
 -- name: StreamResources :many
 SELECT name, id, data FROM resources ORDER BY name, id;
 
--- Asset operations (added in schema 1.1)
+-- Asset operations (optional table, announced by its presence;
+-- schema_version stays 1.0 - see SchemaVersion in scan_data_store.go)
 -- name: InsertAsset :exec
 INSERT OR REPLACE INTO asset (id, data) VALUES (0, ?);
 
 -- name: GetAsset :one
 SELECT data FROM asset WHERE id = 0;
 
--- Asset filter code_id operations (added in schema 1.1)
+-- Asset filter code_id operations (optional table, announced by its
+-- presence; schema_version stays 1.0 - see SchemaVersion)
 -- name: InsertAssetFilter :exec
 INSERT OR REPLACE INTO asset_filters (code_id) VALUES (?);
 

--- a/policy/scandb/scan_data_store.go
+++ b/policy/scandb/scan_data_store.go
@@ -11,13 +11,18 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnspec/v13"
 	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/checksum"
 	"go.mondoo.com/cnspec/v13/policy/scandb/sqlc"
 	"go.mondoo.com/mql/v13/llx"
+	llxchecksum "go.mondoo.com/mql/v13/llx/checksum"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"google.golang.org/protobuf/proto"
 )
@@ -64,7 +69,26 @@ type ScanDataStore interface {
 	ScanDataStoreWriter
 }
 
+// SchemaVersion is the scandb schema written by this client. The per-row
+// `checksum` columns and checksum metadata keys (see checksum.go) are
+// deliberately NOT a version bump: they are additive and invisible to older
+// readers (explicit-column queries everywhere), while today's server ingest
+// validates the version with an exact match — a bump would make every
+// upload from this client unprocessable by servers that haven't shipped
+// checksum support. Checksum presence is announced by the
+// checksum_algo_version metadata key instead.
 const SchemaVersion = "1.0"
+
+// readOnlyDSN builds a DSN that SQLite itself enforces as read-only. The
+// file: URI form is required: with a plain-path DSN the driver ignores the
+// query string entirely and opens READWRITE|CREATE — silently creating
+// missing files and letting raw SQL write through a handle the code
+// believes is read-only. The checksum ownership contract (checksums are
+// written by the scan owner, never a consumer) rests on this being real.
+// ToSlash keeps the URI valid on Windows paths.
+func readOnlyDSN(filePath string) string {
+	return "file:" + filepath.ToSlash(filePath) + "?mode=ro"
+}
 
 // SqliteScanDataStore implements ScanDataStore using SQLite with sqlc-generated queries
 type SqliteScanDataStore struct {
@@ -73,10 +97,119 @@ type SqliteScanDataStore struct {
 	assetMrn string
 	filePath string
 	readOnly bool
+
+	// computeChecksums makes every Write* hash its row inline (see
+	// WithWriteTimeChecksums). checksumStats tracks that activity.
+	computeChecksums bool
+	checksumStats    writeChecksumCounters
+}
+
+// writeChecksumCounters accumulates write-time checksum activity. Atomic:
+// writes may arrive from concurrent executor callbacks.
+type writeChecksumCounters struct {
+	data, scores, risks, resources atomic.Int64
+	errors                         atomic.Int64
+	nanos                          atomic.Int64
+}
+
+// WriteChecksumStats is a snapshot of a store's write-time checksum
+// activity. Counts are hash operations (an upserted row counts once per
+// write); Duration is pure accumulated hashing time.
+type WriteChecksumStats struct {
+	Counts   ChecksumCounts
+	Errors   int64
+	Duration time.Duration
+}
+
+// WriteChecksumStats snapshots the write-time checksum counters.
+func (s *SqliteScanDataStore) WriteChecksumStats() WriteChecksumStats {
+	return WriteChecksumStats{
+		Counts: ChecksumCounts{
+			Data:      int(s.checksumStats.data.Load()),
+			Scores:    int(s.checksumStats.scores.Load()),
+			Risks:     int(s.checksumStats.risks.Load()),
+			Resources: int(s.checksumStats.resources.Load()),
+		},
+		Errors:   s.checksumStats.errors.Load(),
+		Duration: time.Duration(s.checksumStats.nanos.Load()),
+	}
+}
+
+// StoreOption configures a SqliteScanDataStore at construction.
+type StoreOption func(*SqliteScanDataStore)
+
+// WithWriteTimeChecksums makes every Write* compute the row's content
+// checksum inline and store it with the row — no second pass over the
+// database. Correct under upserts by construction (INSERT OR REPLACE
+// rewrites the row's checksum with the row) and bit-identical to the
+// post-pass recompute (pinned by TestWriteTimeChecksumParity; the
+// nil-vs-empty normalizations in policy/checksum and mql's llx/checksum
+// are what make in-memory and round-tripped rows hash the same).
+//
+// Checksum work can never fail a scan: a hash error is counted and
+// logged, the row is stored with checksum 0, and Finalize then skips the
+// checksum_algo_version stamp so a partially checksummed file is never
+// announced as checksummed — consumers treat it exactly like a
+// pre-checksum file (full upload), fail-open.
+func WithWriteTimeChecksums() StoreOption {
+	return func(s *SqliteScanDataStore) { s.computeChecksums = true }
+}
+
+// rowChecksum runs one write-time hash, never failing the write: on error
+// it counts, logs, and returns 0 (the schema default, meaning "no
+// checksum"). Timing is accumulated so the true hashing cost is reported
+// per scan.
+func (s *SqliteScanDataStore) rowChecksum(kind, key string, counter *atomic.Int64, hash func() (uint64, error)) int64 {
+	if !s.computeChecksums {
+		return 0
+	}
+	start := time.Now()
+	sum, err := hash()
+	s.checksumStats.nanos.Add(time.Since(start).Nanoseconds())
+	if err != nil {
+		s.checksumStats.errors.Add(1)
+		log.Warn().Err(err).Str("kind", kind).Str("key", key).
+			Msg("failed to compute scan content checksum; row stored without one")
+		return 0
+	}
+	counter.Add(1)
+	// SQLite INTEGER is int64; store the uint64 bit pattern.
+	return int64(sum)
+}
+
+// StampChecksums announces the checksum algorithm version in the metadata
+// table — the marker consumers key on. The scan owner calls it exactly
+// once, when the scan's writes are complete: for cnspec that is the sqlite
+// datalake, right after the scan and before any Finalize/upload, which is
+// the one seam both paths share (an uploaded file and a kept
+// --output-scan-db file that never sees Finalize are stamped by the same
+// call). Finalize deliberately does NOT stamp — a store user who writes
+// checksums owns the stamp too.
+//
+// It refuses to stamp a file with any hash failure: partially checksummed
+// must never masquerade as checksummed — the unstamped file is consumed
+// exactly like a pre-checksum one (full upload, fail-open). Best-effort by
+// contract: checksum work never fails a scan, so problems are logged,
+// never returned.
+func (s *SqliteScanDataStore) StampChecksums() {
+	if !s.computeChecksums || s.readOnly {
+		return
+	}
+	if errs := s.checksumStats.errors.Load(); errs > 0 {
+		log.Warn().Int64("failures", errs).
+			Msg("scan content checksums incomplete; leaving file unstamped (uploads in full)")
+		return
+	}
+	if _, err := s.sqlDB.Exec(
+		`INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)`,
+		MetaChecksumAlgoVersion, llxchecksum.AlgoVersion); err != nil {
+		log.Warn().Err(err).
+			Msg("failed to stamp checksum algo version; leaving file unstamped (uploads in full)")
+	}
 }
 
 // NewSqliteScanDataStore creates a new SQLite-based scan data store for writing
-func NewSqliteScanDataStore(filePath string, assetMrn string) (*SqliteScanDataStore, error) {
+func NewSqliteScanDataStore(filePath string, assetMrn string, opts ...StoreOption) (*SqliteScanDataStore, error) {
 	sqlDB, err := sql.Open("sqlite", filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite file: %w", err)
@@ -95,6 +228,9 @@ func NewSqliteScanDataStore(filePath string, assetMrn string) (*SqliteScanDataSt
 		filePath: filePath,
 		readOnly: false,
 	}
+	for _, opt := range opts {
+		opt(store)
+	}
 
 	if err := store.initializeDatabase(); err != nil {
 		sqlDB.Close()
@@ -106,7 +242,7 @@ func NewSqliteScanDataStore(filePath string, assetMrn string) (*SqliteScanDataSt
 
 // NewSqliteScanDataStoreReader creates a new SQLite-based scan data store for reading
 func NewSqliteScanDataStoreReader(filePath string) (*SqliteScanDataStore, error) {
-	sqlDB, err := sql.Open("sqlite", filePath+"?mode=ro")
+	sqlDB, err := sql.Open("sqlite", readOnlyDSN(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite file: %w", err)
 	}
@@ -193,6 +329,9 @@ func (s *SqliteScanDataStore) WriteData(ctx context.Context, data []*llx.Result)
 		if err := s.queries.InsertData(ctx, sqlc.InsertDataParams{
 			CodeID: codeId,
 			Data:   resultData,
+			Checksum: s.rowChecksum("data", codeId, &s.checksumStats.data, func() (uint64, error) {
+				return llxchecksum.HashDataRow(codeId, result)
+			}),
 		}); err != nil {
 			return fmt.Errorf("failed to write data %s: %w", codeId, err)
 		}
@@ -215,6 +354,9 @@ func (s *SqliteScanDataStore) WriteResource(ctx context.Context, resource *llx.R
 		Name: resource.Resource,
 		ID:   resource.Id,
 		Data: resourceData,
+		Checksum: s.rowChecksum("resource", resource.Resource+"/"+resource.Id, &s.checksumStats.resources, func() (uint64, error) {
+			return llxchecksum.HashResourceRow(resource)
+		}),
 	}); err != nil {
 		return fmt.Errorf("failed to write resource %s/%s: %w", resource.Resource, resource.Id, err)
 	}
@@ -265,8 +407,10 @@ func isMissingAssetFiltersTable(err error) bool {
 }
 
 // WriteAsset persists the inventory.Asset proto for the scanned asset.
-// Schema 1.1+: enables consumers (e.g. cnspec loadtest) to replay scan databases
-// against SynchronizeAssets without out-of-band asset metadata.
+// The asset table is optional and announced by its own presence — the
+// stamped schema_version stays "1.0" (see SchemaVersion). It enables
+// consumers (e.g. cnspec loadtest) to replay scan databases against
+// SynchronizeAssets without out-of-band asset metadata.
 func (s *SqliteScanDataStore) WriteAsset(ctx context.Context, asset *inventory.Asset) error {
 	if s.readOnly {
 		return fmt.Errorf("cannot write asset in read-only mode")
@@ -295,6 +439,9 @@ func (s *SqliteScanDataStore) WriteRisk(ctx context.Context, risk *policy.Scored
 		Risk:       float64(risk.Risk),
 		IsToxic:    risk.IsToxic,
 		IsDetected: risk.IsDetected,
+		Checksum: s.rowChecksum("risk", risk.Mrn, &s.checksumStats.risks, func() (uint64, error) {
+			return checksum.HashRiskRow(risk)
+		}),
 	}); err != nil {
 		return fmt.Errorf("failed to write risk %s: %w", risk.Mrn, err)
 	}
@@ -335,6 +482,9 @@ func (s *SqliteScanDataStore) writeScore(ctx context.Context, score *policy.Scor
 		Message:     message,
 		RiskFactors: riskFactors,
 		Sources:     sources,
+		Checksum: s.rowChecksum("score", score.QrId, &s.checksumStats.scores, func() (uint64, error) {
+			return checksum.HashScoreRow(score)
+		}),
 	})
 }
 
@@ -415,7 +565,8 @@ func (s *SqliteScanDataStore) GetScore(ctx context.Context, qrId string) (*polic
 		return nil, fmt.Errorf("failed to get score: %w", err)
 	}
 
-	return s.convertScore(&scoreRow)
+	row := sqlc.StreamScoresRow(scoreRow)
+	return s.convertScore(&row)
 }
 
 // GetData retrieves a specific data result by code ID
@@ -545,8 +696,12 @@ func (s *SqliteScanDataStore) StreamResources(ctx context.Context, callback func
 	return nil
 }
 
-// convertScore converts a sqlc-generated Score to a policy.Score
-func (s *SqliteScanDataStore) convertScore(scoreRow *sqlc.Score) (*policy.Score, error) {
+// convertScore converts a sqlc-generated score row to a policy.Score. The
+// readers select every column except checksum (explicit-column queries are
+// what keep old files readable), so sqlc emits per-query row structs;
+// GetScoreRow is field-identical and converts to StreamScoresRow at its
+// call site.
+func (s *SqliteScanDataStore) convertScore(scoreRow *sqlc.StreamScoresRow) (*policy.Score, error) {
 	score := &policy.Score{
 		QrId:            scoreRow.QrID,
 		RiskScore:       uint32(scoreRow.RiskScore),
@@ -654,7 +809,7 @@ func (s *SqliteScanDataStore) Finalize() (string, error) {
 	}
 
 	// Reopen as read-only
-	sqlDB, err := sql.Open("sqlite", s.filePath+"?mode=ro")
+	sqlDB, err := sql.Open("sqlite", readOnlyDSN(s.filePath))
 	if err != nil {
 		return "", fmt.Errorf("failed to reopen database as read-only: %w", err)
 	}

--- a/policy/scandb/scan_db.sql
+++ b/policy/scandb/scan_db.sql
@@ -3,7 +3,11 @@
 
 -- SQLite schema for cnspec policy upload files
 -- Optimized for fast writes on client side
--- Version: 1.0
+-- Version: 1.0 - the checksum columns and the asset/asset_filters tables
+-- are additive (invisible to readers that don't query them), so the
+-- stamped schema_version stays 1.0; see SchemaVersion in
+-- scan_data_store.go. Checksum presence is announced by the
+-- checksum_algo_version metadata key instead.
 
 -- Metadata table for versioning and asset information
 CREATE TABLE metadata (
@@ -28,14 +32,16 @@ CREATE TABLE scores (
     weight INTEGER NOT NULL,          -- Score.weight  
     message TEXT,                     -- Score.message
     risk_factors BLOB,               -- protobuf encoded ScoredRiskFactors
-    sources BLOB                     -- protobuf encoded Sources
+    sources BLOB,                    -- protobuf encoded Sources
+    checksum INTEGER NOT NULL DEFAULT 0 -- 8-byte row content checksum (uint64 bit pattern)
 );
 
 -- Data table - stores LLX results with upsert capability
 -- code_id is the primary key for uniqueness and upsert operations
 CREATE TABLE data (
     code_id TEXT PRIMARY KEY,        -- llx.Result.CodeID (query checksum, unique identifier)
-    data BLOB NOT NULL               -- protobuf encoded llx.Result
+    data BLOB NOT NULL,              -- protobuf encoded llx.Result
+    checksum INTEGER NOT NULL DEFAULT 0 -- 8-byte row content checksum
 );
 
 -- ScoredRiskFactor table - stores individual risk factors for scores
@@ -44,19 +50,22 @@ CREATE TABLE scored_risk_factors (
     mrn TEXT PRIMARY KEY,            -- ScoredRiskFactor.mrn (unique identifier)
     risk REAL NOT NULL,              -- ScoredRiskFactor.risk (float32)
     is_toxic BOOLEAN NOT NULL,       -- ScoredRiskFactor.is_toxic
-    is_detected BOOLEAN NOT NULL     -- ScoredRiskFactor.is_detected
+    is_detected BOOLEAN NOT NULL,    -- ScoredRiskFactor.is_detected
+    checksum INTEGER NOT NULL DEFAULT 0 -- 8-byte row content checksum
 );
 
 CREATE TABLE resources (
     name TEXT NOT NULL,              -- The resource name
     id TEXT NOT NULL,                -- The resource ID
     data BLOB NOT NULL,              -- protobuf encoded llx.ResourceRecording
+    checksum INTEGER NOT NULL DEFAULT 0, -- 8-byte row content checksum
     PRIMARY KEY (name, id)           -- Composite primary key for uniqueness
 );
 
 -- Asset table - stores the inventory.Asset proto for the scanned asset.
--- Single-row table (id=0) added in schema 1.1 to make scan databases
--- self-contained for replay use cases (e.g. the cnspec loadtest tool).
+-- Optional single-row table (id=0), announced by its own presence (the
+-- stamped schema_version stays 1.0; see SchemaVersion), to make scan
+-- databases self-contained for replay use cases (e.g. cnspec loadtest).
 CREATE TABLE asset (
     id INTEGER PRIMARY KEY CHECK (id = 0),
     data BLOB NOT NULL               -- protobuf encoded inventory.Asset

--- a/policy/scandb/sqlc/models.go
+++ b/policy/scandb/sqlc/models.go
@@ -18,8 +18,9 @@ type AssetFilter struct {
 }
 
 type Datum struct {
-	CodeID string `json:"code_id"`
-	Data   []byte `json:"data"`
+	CodeID   string `json:"code_id"`
+	Data     []byte `json:"data"`
+	Checksum int64  `json:"checksum"`
 }
 
 type Metadata struct {
@@ -28,9 +29,10 @@ type Metadata struct {
 }
 
 type Resource struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-	Data []byte `json:"data"`
+	Name     string `json:"name"`
+	ID       string `json:"id"`
+	Data     []byte `json:"data"`
+	Checksum int64  `json:"checksum"`
 }
 
 type Score struct {
@@ -42,6 +44,7 @@ type Score struct {
 	Message     sql.NullString `json:"message"`
 	RiskFactors []byte         `json:"risk_factors"`
 	Sources     []byte         `json:"sources"`
+	Checksum    int64          `json:"checksum"`
 }
 
 type ScoredRiskFactor struct {
@@ -49,4 +52,5 @@ type ScoredRiskFactor struct {
 	Risk       float64 `json:"risk"`
 	IsToxic    bool    `json:"is_toxic"`
 	IsDetected bool    `json:"is_detected"`
+	Checksum   int64   `json:"checksum"`
 }

--- a/policy/scandb/sqlc/querier.go
+++ b/policy/scandb/sqlc/querier.go
@@ -14,11 +14,13 @@ type Querier interface {
 	GetMetadata(ctx context.Context) ([]Metadata, error)
 	GetMetadataByKey(ctx context.Context, key string) (string, error)
 	GetResource(ctx context.Context, arg GetResourceParams) ([]byte, error)
-	GetRiskFactor(ctx context.Context, mrn string) (ScoredRiskFactor, error)
-	GetScore(ctx context.Context, qrID string) (Score, error)
-	// Asset operations (added in schema 1.1)
+	GetRiskFactor(ctx context.Context, mrn string) (GetRiskFactorRow, error)
+	GetScore(ctx context.Context, qrID string) (GetScoreRow, error)
+	// Asset operations (optional table, announced by its presence;
+	// schema_version stays 1.0 - see SchemaVersion in scan_data_store.go)
 	InsertAsset(ctx context.Context, data []byte) error
-	// Asset filter code_id operations (added in schema 1.1)
+	// Asset filter code_id operations (optional table, announced by its
+	// presence; schema_version stays 1.0 - see SchemaVersion)
 	InsertAssetFilter(ctx context.Context, codeID string) error
 	// Data operations
 	InsertData(ctx context.Context, arg InsertDataParams) error
@@ -33,10 +35,10 @@ type Querier interface {
 	// Scores operations
 	InsertScore(ctx context.Context, arg InsertScoreParams) error
 	StreamAssetFilters(ctx context.Context) ([]string, error)
-	StreamData(ctx context.Context) ([]Datum, error)
-	StreamResources(ctx context.Context) ([]Resource, error)
-	StreamRiskFactors(ctx context.Context) ([]ScoredRiskFactor, error)
-	StreamScores(ctx context.Context) ([]Score, error)
+	StreamData(ctx context.Context) ([]StreamDataRow, error)
+	StreamResources(ctx context.Context) ([]StreamResourcesRow, error)
+	StreamRiskFactors(ctx context.Context) ([]StreamRiskFactorsRow, error)
+	StreamScores(ctx context.Context) ([]StreamScoresRow, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/policy/scandb/sqlc/query.sql.go
+++ b/policy/scandb/sqlc/query.sql.go
@@ -91,9 +91,16 @@ SELECT mrn, risk, is_toxic, is_detected
 FROM scored_risk_factors WHERE mrn = ?
 `
 
-func (q *Queries) GetRiskFactor(ctx context.Context, mrn string) (ScoredRiskFactor, error) {
+type GetRiskFactorRow struct {
+	Mrn        string  `json:"mrn"`
+	Risk       float64 `json:"risk"`
+	IsToxic    bool    `json:"is_toxic"`
+	IsDetected bool    `json:"is_detected"`
+}
+
+func (q *Queries) GetRiskFactor(ctx context.Context, mrn string) (GetRiskFactorRow, error) {
 	row := q.queryRow(ctx, q.getRiskFactorStmt, getRiskFactor, mrn)
-	var i ScoredRiskFactor
+	var i GetRiskFactorRow
 	err := row.Scan(
 		&i.Mrn,
 		&i.Risk,
@@ -108,9 +115,20 @@ SELECT qr_id, risk_score, type, value, weight, message, risk_factors, sources
 FROM scores WHERE qr_id = ?
 `
 
-func (q *Queries) GetScore(ctx context.Context, qrID string) (Score, error) {
+type GetScoreRow struct {
+	QrID        string         `json:"qr_id"`
+	RiskScore   int64          `json:"risk_score"`
+	Type        int64          `json:"type"`
+	Value       int64          `json:"value"`
+	Weight      int64          `json:"weight"`
+	Message     sql.NullString `json:"message"`
+	RiskFactors []byte         `json:"risk_factors"`
+	Sources     []byte         `json:"sources"`
+}
+
+func (q *Queries) GetScore(ctx context.Context, qrID string) (GetScoreRow, error) {
 	row := q.queryRow(ctx, q.getScoreStmt, getScore, qrID)
-	var i Score
+	var i GetScoreRow
 	err := row.Scan(
 		&i.QrID,
 		&i.RiskScore,
@@ -128,7 +146,8 @@ const insertAsset = `-- name: InsertAsset :exec
 INSERT OR REPLACE INTO asset (id, data) VALUES (0, ?)
 `
 
-// Asset operations (added in schema 1.1)
+// Asset operations (optional table, announced by its presence;
+// schema_version stays 1.0 - see SchemaVersion in scan_data_store.go)
 func (q *Queries) InsertAsset(ctx context.Context, data []byte) error {
 	_, err := q.exec(ctx, q.insertAssetStmt, insertAsset, data)
 	return err
@@ -138,24 +157,26 @@ const insertAssetFilter = `-- name: InsertAssetFilter :exec
 INSERT OR REPLACE INTO asset_filters (code_id) VALUES (?)
 `
 
-// Asset filter code_id operations (added in schema 1.1)
+// Asset filter code_id operations (optional table, announced by its
+// presence; schema_version stays 1.0 - see SchemaVersion)
 func (q *Queries) InsertAssetFilter(ctx context.Context, codeID string) error {
 	_, err := q.exec(ctx, q.insertAssetFilterStmt, insertAssetFilter, codeID)
 	return err
 }
 
 const insertData = `-- name: InsertData :exec
-INSERT OR REPLACE INTO data (code_id, data) VALUES (?, ?)
+INSERT OR REPLACE INTO data (code_id, data, checksum) VALUES (?, ?, ?)
 `
 
 type InsertDataParams struct {
-	CodeID string `json:"code_id"`
-	Data   []byte `json:"data"`
+	CodeID   string `json:"code_id"`
+	Data     []byte `json:"data"`
+	Checksum int64  `json:"checksum"`
 }
 
 // Data operations
 func (q *Queries) InsertData(ctx context.Context, arg InsertDataParams) error {
-	_, err := q.exec(ctx, q.insertDataStmt, insertData, arg.CodeID, arg.Data)
+	_, err := q.exec(ctx, q.insertDataStmt, insertData, arg.CodeID, arg.Data, arg.Checksum)
 	return err
 }
 
@@ -178,24 +199,30 @@ func (q *Queries) InsertMetadata(ctx context.Context, arg InsertMetadataParams) 
 }
 
 const insertResource = `-- name: InsertResource :exec
-INSERT OR REPLACE INTO resources (name, id, data) VALUES (?, ?, ?)
+INSERT OR REPLACE INTO resources (name, id, data, checksum) VALUES (?, ?, ?, ?)
 `
 
 type InsertResourceParams struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-	Data []byte `json:"data"`
+	Name     string `json:"name"`
+	ID       string `json:"id"`
+	Data     []byte `json:"data"`
+	Checksum int64  `json:"checksum"`
 }
 
 // Resource operations
 func (q *Queries) InsertResource(ctx context.Context, arg InsertResourceParams) error {
-	_, err := q.exec(ctx, q.insertResourceStmt, insertResource, arg.Name, arg.ID, arg.Data)
+	_, err := q.exec(ctx, q.insertResourceStmt, insertResource,
+		arg.Name,
+		arg.ID,
+		arg.Data,
+		arg.Checksum,
+	)
 	return err
 }
 
 const insertRiskFactor = `-- name: InsertRiskFactor :exec
-INSERT OR REPLACE INTO scored_risk_factors (mrn, risk, is_toxic, is_detected)
-VALUES (?, ?, ?, ?)
+INSERT OR REPLACE INTO scored_risk_factors (mrn, risk, is_toxic, is_detected, checksum)
+VALUES (?, ?, ?, ?, ?)
 `
 
 type InsertRiskFactorParams struct {
@@ -203,6 +230,7 @@ type InsertRiskFactorParams struct {
 	Risk       float64 `json:"risk"`
 	IsToxic    bool    `json:"is_toxic"`
 	IsDetected bool    `json:"is_detected"`
+	Checksum   int64   `json:"checksum"`
 }
 
 // Risk factor operations
@@ -212,14 +240,15 @@ func (q *Queries) InsertRiskFactor(ctx context.Context, arg InsertRiskFactorPara
 		arg.Risk,
 		arg.IsToxic,
 		arg.IsDetected,
+		arg.Checksum,
 	)
 	return err
 }
 
 const insertScore = `-- name: InsertScore :exec
 INSERT OR REPLACE INTO scores (
-    qr_id, risk_score, type, value, weight, message, risk_factors, sources
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    qr_id, risk_score, type, value, weight, message, risk_factors, sources, checksum
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertScoreParams struct {
@@ -231,6 +260,7 @@ type InsertScoreParams struct {
 	Message     sql.NullString `json:"message"`
 	RiskFactors []byte         `json:"risk_factors"`
 	Sources     []byte         `json:"sources"`
+	Checksum    int64          `json:"checksum"`
 }
 
 // Scores operations
@@ -244,6 +274,7 @@ func (q *Queries) InsertScore(ctx context.Context, arg InsertScoreParams) error 
 		arg.Message,
 		arg.RiskFactors,
 		arg.Sources,
+		arg.Checksum,
 	)
 	return err
 }
@@ -279,15 +310,20 @@ const streamData = `-- name: StreamData :many
 SELECT code_id, data FROM data ORDER BY code_id
 `
 
-func (q *Queries) StreamData(ctx context.Context) ([]Datum, error) {
+type StreamDataRow struct {
+	CodeID string `json:"code_id"`
+	Data   []byte `json:"data"`
+}
+
+func (q *Queries) StreamData(ctx context.Context) ([]StreamDataRow, error) {
 	rows, err := q.query(ctx, q.streamDataStmt, streamData)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Datum
+	var items []StreamDataRow
 	for rows.Next() {
-		var i Datum
+		var i StreamDataRow
 		if err := rows.Scan(&i.CodeID, &i.Data); err != nil {
 			return nil, err
 		}
@@ -306,15 +342,21 @@ const streamResources = `-- name: StreamResources :many
 SELECT name, id, data FROM resources ORDER BY name, id
 `
 
-func (q *Queries) StreamResources(ctx context.Context) ([]Resource, error) {
+type StreamResourcesRow struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	Data []byte `json:"data"`
+}
+
+func (q *Queries) StreamResources(ctx context.Context) ([]StreamResourcesRow, error) {
 	rows, err := q.query(ctx, q.streamResourcesStmt, streamResources)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Resource
+	var items []StreamResourcesRow
 	for rows.Next() {
-		var i Resource
+		var i StreamResourcesRow
 		if err := rows.Scan(&i.Name, &i.ID, &i.Data); err != nil {
 			return nil, err
 		}
@@ -334,15 +376,22 @@ SELECT mrn, risk, is_toxic, is_detected
 FROM scored_risk_factors ORDER BY mrn
 `
 
-func (q *Queries) StreamRiskFactors(ctx context.Context) ([]ScoredRiskFactor, error) {
+type StreamRiskFactorsRow struct {
+	Mrn        string  `json:"mrn"`
+	Risk       float64 `json:"risk"`
+	IsToxic    bool    `json:"is_toxic"`
+	IsDetected bool    `json:"is_detected"`
+}
+
+func (q *Queries) StreamRiskFactors(ctx context.Context) ([]StreamRiskFactorsRow, error) {
 	rows, err := q.query(ctx, q.streamRiskFactorsStmt, streamRiskFactors)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ScoredRiskFactor
+	var items []StreamRiskFactorsRow
 	for rows.Next() {
-		var i ScoredRiskFactor
+		var i StreamRiskFactorsRow
 		if err := rows.Scan(
 			&i.Mrn,
 			&i.Risk,
@@ -367,15 +416,26 @@ SELECT qr_id, risk_score, type, value, weight, message, risk_factors, sources
 FROM scores ORDER BY qr_id
 `
 
-func (q *Queries) StreamScores(ctx context.Context) ([]Score, error) {
+type StreamScoresRow struct {
+	QrID        string         `json:"qr_id"`
+	RiskScore   int64          `json:"risk_score"`
+	Type        int64          `json:"type"`
+	Value       int64          `json:"value"`
+	Weight      int64          `json:"weight"`
+	Message     sql.NullString `json:"message"`
+	RiskFactors []byte         `json:"risk_factors"`
+	Sources     []byte         `json:"sources"`
+}
+
+func (q *Queries) StreamScores(ctx context.Context) ([]StreamScoresRow, error) {
 	rows, err := q.query(ctx, q.streamScoresStmt, streamScores)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Score
+	var items []StreamScoresRow
 	for rows.Next() {
-		var i Score
+		var i StreamScoresRow
 		if err := rows.Scan(
 			&i.QrID,
 			&i.RiskScore,

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -61,6 +61,20 @@ const (
 	MetricCPUGCFraction       = "cnspec.scan.cpu.gc_fraction"       // gc / busy
 	MetricCPUUtilization      = "cnspec.scan.cpu.utilization"       // busy / available
 	MetricCPUGOMAXPROCS       = "cnspec.scan.cpu.gomaxprocs"        // unit: count
+
+	// Write-time scan-content checksums (feature-gated; see the sqlite
+	// datalake and scandb.WithWriteTimeChecksums). Shadow mode exists to
+	// measure the cost fleet-wide before comparison ships enabled, and
+	// duration is that measurement: pure accumulated hashing time across
+	// the scan's writes (there is no separate pass to time). Errors is the
+	// count of rows whose hash failed — checksum work never fails a scan
+	// (the row is stored without a checksum and the file stays unstamped,
+	// fail-open), so this uploaded count is the only way a silent hashing
+	// problem becomes visible fleet-wide. Per-kind row counts stay in the
+	// local log only — row volume is already visible upstream through the
+	// scan database itself.
+	MetricChecksumDuration = "cnspec.scan.checksum.duration" // unit: ms
+	MetricChecksumErrors   = "cnspec.scan.checksum.errors"   // unit: count
 )
 
 // Collector accumulates scan metrics. It is safe for concurrent use.


### PR DESCRIPTION
## What

The cnspec half of the unchanged-scan short-circuit, in one PR:

**Scan-content checksums (C0 emission, spiked and measured)**
- scandb gains per-row `checksum INTEGER` columns on `data`/`scores`/`scored_risk_factors`/`resources` and the `checksum_algo_version` metadata key. There is no kind- or asset-level fold anywhere — row equality (the manifest diff: server-side at every ingest, the client's manifest pull in `client_compare` later) is the only comparison currency.
- `ComputeChecksums` (via `OpenForChecksums`) runs one pass after `Finalize` (measured: **15.6 ms** on a real 2.1 MB / 312-row scan database; ~75% SQLite I/O, the multiset array canonicalization is ~1%), writing the checksum columns and announcing the algo version; it returns per-table row counts. Canonicalization lives in mql's `llx/checksum` for llx-typed rows (structural, never proto bytes; multiset arrays; `AlgoVersion = "1"`) and `policy/scandb/checksum` for score/risk rows, gated on the server-activated `ScanContentMode*` features via `Features.ScanContentChecksumsActive()` — zero checksum work for scopes that haven't opted in.
- `digestdiff` dev tool for diffing/benching two scan databases (can be dropped in review if unwanted).

**Wire surface (dormant until C1)**
- `ReportUploadCompletedReq.unchanged` — "no PUT happened: the scan is row-identical to the staged manifest"; statistics still ride `details` in both outcomes.
- New `GetDownloadURL` RPC — `GetUploadURL`'s mirror: a signed GET for a server-held artifact, kind-addressed (`DOWNLOAD_KIND_SCAN_MANIFEST`: the staged manifest — the trimmed-down scan database of keys + checksums the server already diffs at every ingest; the client diffs the same object). Response: `download_url` + `unavailable` — deliberately **no base-identity field**: the comparison policy is always-latest, and a delta that raced a concurrent upload fails the server's row-checksum verify and falls back to a full upload. `GetUploadURL` itself is **untouched** — no checksum travels in any RPC; checksums live in the file.
- cnspec's own `LocalServices.GetDownloadURL` answers `Unimplemented`, mirroring its upload-URL stance; the platform server implements it as a deliberate decline (`unavailable`, no URL) until `client_compare` ships.

Nothing calls the new surface yet — this lands the proto so the C1 compare-and-skip client can follow independently.

## Testing

`go generate ./policy` regenerated (pb/ranger/vtproto); `go build ./...` green. Checksum determinism was proven against real scans: score/risk rows bit-identical across five consecutive local scans on the released os provider (after cnspec#3179 + mql#9652 + mql#9713 fixed the ordering/parse bugs the checksums themselves surfaced). The server side additionally pins cross-repo parity in its test suite: this writer's columns vs the server's independent recompute over the same scandb, bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HHX819u6q9PngxJfpCaST

