### PR TITLE
🐛 ci: bump codeql-action init and analyze together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      # codeql-action/init and codeql-action/analyze run as a pair within a single
+      # workflow and must resolve to the same release. Ungrouped, Dependabot opens a
+      # separate PR per sub-action, so each PR bumps only one half and CodeQL fails
+      # with "Loaded a configuration file for version X, but running version Y".
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -83,4 +83,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
## Problem

Dependabot split the `github/codeql-action` 4.37.3 → 4.37.4 bump into two PRs, one per sub-action:

- #3198 — `codeql-action/analyze`
- #3199 — `codeql-action/init`

Both edit the same workflow (`.github/workflows/codeql.yml`), which uses `init` and `analyze` as a pair. Each PR bumps only one half, so the run has `init@4.37.3` + `analyze@4.37.4` (or the reverse) and CodeQL aborts:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.4'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.3', but running version '4.37.4'
```

Neither PR can go green on its own — the `Analyze (actions)` check is red on both.

## Fix

- Bump both `init` and `analyze` to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4) in one commit. This is the same SHA `upload-sarif` already pins in `xgrep.yaml` and `policies_lint.yaml`.
- Add a `codeql-action` group to the `github-actions` ecosystem in `.github/dependabot.yml` so future bumps of these sub-actions arrive as a single PR instead of recurring as a red pair.

Once this merges, #3198 and #3199 become no-ops and Dependabot should close them automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)