### PR TITLE
🐛 embed a VERSIONINFO resource in Windows builds

### DIFF
--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -6,6 +6,12 @@ version: 2
 project_name: cnspec
 env:
   - CGO_ENABLED=0
+# Generate the Windows version resource (VERSIONINFO) and application manifest.
+# Without it cnspec.exe reports no CompanyName/ProductName/FileDescription, which
+# contributes to heuristic AV/EDR misclassification of the binary.
+before:
+  hooks:
+    - go run github.com/tc-hib/go-winres@v0.3.3 make --in apps/cnspec/winres/winres.json --out apps/cnspec/rsrc --arch amd64,arm64 --file-version {{ .Version }} --product-version {{ .Version }}
 builds:
   - id: linux
     main: ./apps/cnspec/cnspec.go
@@ -49,7 +55,10 @@ builds:
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
   - id: windows
-    main: ./apps/cnspec/cnspec.go
+    # NOTE: this must stay a package path, not ./apps/cnspec/cnspec.go. Go only
+    # links rsrc_windows_*.syso when building a package directory; passing an
+    # explicit .go file silently drops the version resource and manifest.
+    main: ./apps/cnspec
     binary: cnspec
     goos:
       - windows

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ gha-creds-*.json
 # goreleaser build folder
 dist/
 
+# generated Windows version resource (see `make cnspec/winres`)
+apps/cnspec/rsrc_windows_*.syso
+
 # claude local config. .claude/settings.json is shared team config and is
 # tracked; everything else under .claude/ is personal. Note this must be
 # ".claude/*" and not ".claude/": git does not descend into an ignored

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,12 @@ version: 2
 project_name: cnspec
 env:
   - CGO_ENABLED=0
+# Generate the Windows version resource (VERSIONINFO) and application manifest.
+# Without it cnspec.exe reports no CompanyName/ProductName/FileDescription, which
+# contributes to heuristic AV/EDR misclassification of the binary.
+before:
+  hooks:
+    - go run github.com/tc-hib/go-winres@v0.3.3 make --in apps/cnspec/winres/winres.json --out apps/cnspec/rsrc --arch amd64,arm64 --file-version {{ .Version }} --product-version {{ .Version }}
 builds:
   - id: linux
     main: ./apps/cnspec/cnspec.go
@@ -51,7 +57,10 @@ builds:
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
   - id: windows
-    main: ./apps/cnspec/cnspec.go
+    # NOTE: this must stay a package path, not ./apps/cnspec/cnspec.go. Go only
+    # links rsrc_windows_*.syso when building a package directory; passing an
+    # explicit .go file silently drops the version resource and manifest.
+    main: ./apps/cnspec
     binary: cnspec
     goos:
       - windows

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ MAJOR_VERSION=v13
 LDFLAGS="-s -w -X go.mondoo.com/mql/${MAJOR_VERSION}.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnspec/${MAJOR_VERSION}.Version=${LATEST_VERSION_TAG} ${LDFLAGSEXTRA}"
 LDFLAGSDIST=-tags production -ldflags ${LDFLAGS}
 
+# Windows version resource generator. The PE version fields are numeric, so strip
+# the leading "v" from the tag (v13.32.1 -> 13.32.1) to match release builds,
+# which use goreleaser's already-stripped {{ .Version }}.
+GO_WINRES=github.com/tc-hib/go-winres@v0.3.3
+WINRES_VERSION=$(LATEST_VERSION_TAG:v%=%)
+
 .PHONY: info/ldflags
 info/ldflags:
 	$(info go run -ldflags ${LDFLAGS} apps/cnspec/cnspec.go)
@@ -90,9 +96,21 @@ cnspec/build/linux:
 cnspec/build/linux/arm:
 	GOOS=linux GOARCH=arm64 go build ${LDFLAGSDIST} apps/cnspec/cnspec.go
 
+# Generates the Windows version resource (VERSIONINFO) and application manifest
+# into apps/cnspec/rsrc_windows_<arch>.syso. Release builds run the equivalent
+# step from the `before` hook in .goreleaser.yml.
+.PHONY: cnspec/winres
+cnspec/winres:
+	go run ${GO_WINRES} make --in apps/cnspec/winres/winres.json --out apps/cnspec/rsrc \
+		--arch amd64,arm64 \
+		--file-version ${WINRES_VERSION} --product-version ${WINRES_VERSION}
+
+# NOTE: the build target must stay a package path, not apps/cnspec/cnspec.go. Go
+# only links rsrc_windows_*.syso when building a package directory; passing an
+# explicit .go file silently drops the version resource and manifest.
 .PHONY: cnspec/build/windows
-cnspec/build/windows:
-	GOOS=windows GOARCH=amd64 go build ${LDFLAGSDIST} apps/cnspec/cnspec.go
+cnspec/build/windows: cnspec/winres
+	GOOS=windows GOARCH=amd64 go build ${LDFLAGSDIST} ./apps/cnspec
 
 .PHONY: cnspec/install
 cnspec/install:

--- a/apps/cnspec/winres/winres.json
+++ b/apps/cnspec/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Cloud-Native Security and Policy Framework",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "unaware",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": true,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "https://mondoo.com/docs/cnspec",
+            "CompanyName": "Mondoo, Inc.",
+            "FileDescription": "Cloud-Native Security and Policy Framework",
+            "FileVersion": "",
+            "InternalName": "cnspec",
+            "LegalCopyright": "Copyright Mondoo, Inc. All rights reserved.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "cnspec.exe",
+            "PrivateBuild": "",
+            "ProductName": "cnspec",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/cnspec/winres/winres.json
+++ b/apps/cnspec/winres/winres.json
@@ -2,25 +2,11 @@
   "RT_MANIFEST": {
     "#1": {
       "0409": {
-        "identity": {
-          "name": "",
-          "version": ""
-        },
         "description": "Cloud-Native Security and Policy Framework",
         "minimum-os": "win7",
         "execution-level": "as invoker",
-        "ui-access": false,
-        "auto-elevate": false,
         "dpi-awareness": "unaware",
-        "disable-theming": false,
-        "disable-window-filtering": false,
-        "high-resolution-scrolling-aware": false,
-        "ultra-high-resolution-scrolling-aware": false,
-        "long-path-aware": true,
-        "printer-driver-isolation": false,
-        "gdi-scaling": false,
-        "segment-heap": false,
-        "use-common-controls-v6": false
+        "long-path-aware": true
       }
     }
   },
@@ -36,15 +22,10 @@
             "Comments": "https://mondoo.com/docs/cnspec",
             "CompanyName": "Mondoo, Inc.",
             "FileDescription": "Cloud-Native Security and Policy Framework",
-            "FileVersion": "",
             "InternalName": "cnspec",
             "LegalCopyright": "Copyright Mondoo, Inc. All rights reserved.",
-            "LegalTrademarks": "",
             "OriginalFilename": "cnspec.exe",
-            "PrivateBuild": "",
-            "ProductName": "cnspec",
-            "ProductVersion": "",
-            "SpecialBuild": ""
+            "ProductName": "cnspec"
           }
         }
       }


### PR DESCRIPTION
Closes #3228.

`cnspec.exe` shipped with no PE file metadata — empty `CompanyName`, `ProductName`, `FileDescription`, `FileVersion` and `OriginalFilename`. Go does not emit a version resource on its own; it has to be linked in as a `.syso`, and nothing in the build supplied one.

## Changes

- **`apps/cnspec/winres/winres.json`** — new [go-winres](https://github.com/tc-hib/go-winres) config holding the version resource and application manifest. No icon is included; there is no icon asset in the repo and that can follow separately.
- **`.goreleaser.yml`, `.github/.goreleaser-unstable.yml`** — a global `before` hook generates `apps/cnspec/rsrc_windows_{amd64,arm64}.syso`, with the version fed from `{{ .Version }}`. Pinned to `go-winres@v0.3.3` and invoked via `go run`, so no new entry in `go.mod` and no extra CI install step. `.github/.goreleaser-edge.yml` is Linux-only and needs no change.
- **`Makefile`** — new `cnspec/winres` target, made a prerequisite of `cnspec/build/windows`. The tag is stripped of its leading `v` for the numeric PE fields.
- **`.gitignore`** — ignores the generated `.syso` files.

## The one non-obvious bit

The windows build target had to move from `./apps/cnspec/cnspec.go` to `./apps/cnspec`. Go only links `rsrc_windows_*.syso` when building a **package directory** — passing an explicit `.go` file makes it ignore the resource with no warning. I hit exactly this while testing: the first binary I built had the `.syso` sitting right next to it and still came out with no resource directory at all.

Both goreleaser configs and the Makefile carry a comment on this so it does not get "tidied" back.

The `linux` and `macos` builds still use the file path. They are unaffected either way, and I kept the diff narrow rather than churn all three.

## Verification

Built `windows/amd64` and read the resource back out of the linked binary with `go-winres extract`:

```
"file_version":     "13.32.1.0"
"product_version":  "13.32.1.0"
"CompanyName":      "Mondoo, Inc."
"ProductName":      "cnspec"
"FileDescription":  "Cloud-Native Security and Policy Framework"
"FileVersion":      "13.32.1"
"OriginalFilename": "cnspec.exe"
"LegalCopyright":   "Copyright Mondoo, Inc. All rights reserved."
```

Extracted manifest confirms the execution level is unchanged:

```xml
<requestedExecutionLevel level="asInvoker" uiAccess="false"/>
```

Also confirmed:

- `make cnspec/build/windows` produces the metadata end to end.
- `darwin/arm64` and `linux/amd64` builds are unaffected with the `.syso` files present — the `_windows_<arch>` filename suffix keeps the Go toolchain from linking them.
- `go.mod` / `go.sum` are untouched by the `go run` invocation.
- Both goreleaser configs parse; `goreleaser check` runs on them in CI via the existing GoReleaser Check workflow.

Signing is unaffected. It remains a post-build hook and still runs last, so the Authenticode signature covers the new resource.

## Why bother

A stripped (`-s -w`), statically linked, `CGO_ENABLED=0` Go binary with no file metadata is a well-documented contributor to heuristic and ML-based AV/EDR misclassification — endpoint products weight PE metadata completeness as a feature. `cnspec serve` compounds it by legitimately doing several things those classifiers score on: running as a SYSTEM service under `services.exe`, fetching and executing provider plugin binaries at runtime, and shelling out to PowerShell for host inventory checks. Every release also lands as a previously unseen hash with no cloud prevalence.

This does not make the problem go away on its own, but it is the cheapest available mitigation and removes an easy strike against the binary.
