### PR TITLE
🐛 Retry the scan-data upload instead of discarding the scan

### DIFF
--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -167,19 +167,14 @@ func fileSizeBytes(path string) int64 {
 	return info.Size()
 }
 
-// uploadFailureReportKind is the value sent on the "reportKind" tag to mark a
-// report as an upload failure. The platform dispatches on it to record the
-// failure with its structured fields, so the literal is part of the wire
-// contract and must stay in sync with the server side.
-const uploadFailureReportKind = "upload_failure"
-
-// uploadFailureTags builds the tag set for an upload-failure report. Numeric
-// values are rendered as strings because health.SendError tags are
-// map[string]string; httpStatus and uploadSessionId are omitted rather than
-// sent as zero/empty so the server can tell "absent" from "actually zero".
+// uploadFailureTags builds the tags shared by every upload report. It does not
+// set reportKind — uploadOutcomeTags owns that, since the same fields describe
+// both a failure and a recovery. Numeric values are rendered as strings because
+// health.SendError tags are map[string]string; httpStatus and uploadSessionId
+// are omitted rather than sent as zero/empty so the server can tell "absent"
+// from "actually zero".
 func uploadFailureTags(sessionID, assetMrn string, kind upload.FailureKind, httpStatus int, res upload.Result, bytesTotal int64) map[string]string {
 	tags := map[string]string{
-		"reportKind":  uploadFailureReportKind,
 		"failureKind": string(kind),
 		"bytesSent":   strconv.FormatInt(res.BytesSent, 10),
 		"bytesTotal":  strconv.FormatInt(bytesTotal, 10),

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -5,10 +5,7 @@ package sqlite
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -24,7 +21,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream/health"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // outputDirCtxKey is the unexported key used to thread the
@@ -201,93 +197,39 @@ func uploadFailureTags(sessionID, assetMrn string, kind upload.FailureKind, http
 	return tags
 }
 
-// reportUploadFailure sends one upload-failure report. Best-effort by
-// construction: health.ReportError swallows its own errors and returns
-// nothing, so a reporting problem can never fail the scan.
-func reportUploadFailure(msg string, tags map[string]string) {
+// sendUploadReport sends one client upload report — a failure or a recovery,
+// discriminated by the reportKind tag. Best-effort by construction:
+// health.ReportError swallows its own errors and returns nothing, so a
+// reporting problem can never fail the scan.
+func sendUploadReport(msg string, tags map[string]string) {
 	health.ReportError("cnspec", cnspec.Version, cnspec.Build, msg, health.WithTags(tags))
 }
 
 func uploadScanDataStore(ctx context.Context, services *policy.Services, assetMrn string, scanDataPath string, stats *scanstats.Collector) error {
-	bytesTotal := fileSizeBytes(scanDataPath)
-
-	urlResp, err := services.GetUploadURL(ctx, &policy.GetUploadURLReq{
-		Kind:     policy.UploadURLKind_UPLOAD_URL_KIND_SCAN_DATABASE_V0,
-		ScopeMrn: assetMrn,
-	})
+	out, err := doScanUpload(ctx, services, scanDataPath, assetMrn, stats)
 	if err != nil {
-		// No upload session exists yet, so the platform has nothing to
-		// correlate this with — but a client that cannot even obtain a URL is
-		// still worth surfacing.
-		reportUploadFailure("upload failed: could not get upload URL: "+upload.RedactError(err),
-			uploadFailureTags("", assetMrn, upload.FailureURLRequest, 0, upload.Result{}, bytesTotal))
+		// Every attempt is spent; this scan is lost. One report, carrying how
+		// many attempts it took to get here, so an upload-failure report keeps
+		// meaning "a scan was lost" rather than "an attempt failed".
+		sendUploadReport(out.lastErrMsg, uploadOutcomeTags(uploadReportKindFailure, out, assetMrn))
 		return err
 	}
 
-	uploadUrl := urlResp.UploadUrl
-	if uploadUrl == nil {
-		reportUploadFailure("upload failed: no upload URL for scan data store",
-			uploadFailureTags(urlResp.UploadSessionId, assetMrn, upload.FailureURLRequest, 0, upload.Result{}, bytesTotal))
-		return errors.New("no upload URL for scan data store")
-	}
-
-	headers := uploadUrl.Headers
-	url := uploadUrl.Url
-
-	res, err := upload.UploadFile(ctx, url, headers, scanDataPath, "application/octet-stream")
-	if err != nil {
-		// Previously a bare return with no telemetry at all, which made a
-		// client that fails here invisible: the platform sees only an upload
-		// session that never completed, with no reason attached.
-		kind := upload.ClassifyFailure(err)
-		reportUploadFailure("upload failed: "+upload.RedactError(err),
-			uploadFailureTags(urlResp.UploadSessionId, assetMrn, kind, 0, res, bytesTotal))
-		return err
-	}
-	defer res.Response.Body.Close()
-
-	if res.Response.StatusCode != http.StatusOK && res.Response.StatusCode != http.StatusCreated {
-		// Read a limited amount of the response body for diagnostics.
-		// Truncate to 512 bytes to avoid leaking sensitive details in Sentry tags.
-		body, _ := io.ReadAll(io.LimitReader(res.Response.Body, 512))
-		tags := uploadFailureTags(urlResp.UploadSessionId, assetMrn,
-			upload.FailureHTTPStatus, res.Response.StatusCode, res, bytesTotal)
-		tags["responseBody"] = string(body)
-		reportUploadFailure(fmt.Sprintf("upload failed with status %d", res.Response.StatusCode), tags)
-		return fmt.Errorf("upload failed with status %d", res.Response.StatusCode)
-	}
-
-	// Success-path baseline: without these, a slow failing upload cannot be
-	// compared against the normal distribution.
-	stats.AddDuration(scanstats.MetricUploadDuration, res.Duration)
-	if secs := res.Duration.Seconds(); secs > 0 {
-		stats.AddDouble(scanstats.MetricUploadThroughput, "bps", float64(res.BytesSent*8)/secs)
-	}
-
-	// Confirm the upload, attaching scan statistics as the completion payload.
-	req := &policy.ReportUploadCompletedReq{
-		UploadSessionId: urlResp.UploadSessionId,
-		ScopeMrn:        assetMrn,
-	}
-	if s := stats.ToProto(); s != nil {
-		if details, aerr := anypb.New(s); aerr != nil {
-			log.Warn().Err(aerr).Msg("failed to encode scan statistics; sending upload confirmation without them")
-		} else {
-			req.Details = details
-		}
-	}
-	if _, err = services.ReportUploadCompleted(ctx, req); err != nil {
-		// The PUT succeeded, so the object IS in the bucket: this upload is
-		// recoverable, unlike a failed PUT. Worth distinguishing.
-		reportUploadFailure("upload failed: could not report completion: "+upload.RedactError(err),
-			uploadFailureTags(urlResp.UploadSessionId, assetMrn, upload.FailureReportRPC, 0, res, bytesTotal))
-		return err
+	// Succeeded, but not on the first try: this is a scan that would have been
+	// discarded before the retry existed. Reported separately so it does not
+	// inflate the failure counts.
+	if out.recovered() {
+		sendUploadReport(
+			fmt.Sprintf("upload recovered after %d attempts: %s", out.attempts, out.lastErrMsg),
+			uploadOutcomeTags(uploadReportKindRecovered, out, assetMrn))
 	}
 
 	log.Info().
-		Str("session", urlResp.UploadSessionId).
-		Int64("bytes", res.BytesSent).
-		Dur("duration", res.Duration).
-		Msg("successfully uploaded scan data store")
+		Str("session", out.sessionID).
+		Int64("bytes", out.okRes.BytesSent).
+		Dur("duration", out.okRes.Duration).
+		Int("attempts", out.attempts).
+		Msg("uploaded scan data store")
+
 	return nil
 }

--- a/internal/datalakes/sqlite/upload_report_test.go
+++ b/internal/datalakes/sqlite/upload_report_test.go
@@ -50,3 +50,37 @@ func TestUploadFailureTags_EmptySessionOmitted(t *testing.T) {
 	assert.False(t, ok, "no session id exists yet for url_request_failed")
 	assert.Equal(t, "url_request_failed", tags["failureKind"])
 }
+
+func TestUploadOutcomeTags_FailureCarriesAttempts(t *testing.T) {
+	out := scanUploadOutcome{
+		sessionID:  "sess-9",
+		attempts:   5,
+		lastKind:   upload.FailureConnectionReset,
+		lastRes:    upload.Result{BytesSent: 229376, Duration: 19403 * time.Millisecond},
+		bytesTotal: 1855488,
+	}
+
+	tags := uploadOutcomeTags(uploadReportKindFailure, out, "//assets/a1")
+
+	assert.Equal(t, "upload_failure", tags["reportKind"])
+	assert.Equal(t, "5", tags["attempts"])
+	assert.Equal(t, "connection_reset", tags["failureKind"])
+	assert.Equal(t, "229376", tags["bytesSent"])
+}
+
+func TestUploadOutcomeTags_RecoveryUsesItsOwnReportKind(t *testing.T) {
+	out := scanUploadOutcome{
+		sessionID:  "sess-9",
+		attempts:   3,
+		lastKind:   upload.FailureConnectionReset,
+		bytesTotal: 1855488,
+	}
+
+	tags := uploadOutcomeTags(uploadReportKindRecovered, out, "//assets/a1")
+
+	assert.Equal(t, "upload_recovered", tags["reportKind"],
+		"a recovery must not be reported as upload_failure — that means a lost scan")
+	assert.Equal(t, "3", tags["attempts"])
+	assert.Equal(t, "connection_reset", tags["failureKind"],
+		"the recovery still says what it was fighting")
+}

--- a/internal/datalakes/sqlite/upload_report_test.go
+++ b/internal/datalakes/sqlite/upload_report_test.go
@@ -22,7 +22,9 @@ func TestUploadFailureTags_TransportError(t *testing.T) {
 		3_621_572,
 	)
 
-	assert.Equal(t, "upload_failure", tags["reportKind"])
+	// reportKind is set by uploadOutcomeTags, not here — see
+	// TestUploadOutcomeTags_*.
+	assert.NotContains(t, tags, "reportKind")
 	assert.Equal(t, "sess-1", tags["uploadSessionId"])
 	assert.Equal(t, "timeout", tags["failureKind"])
 	assert.Equal(t, "1441792", tags["bytesSent"])

--- a/internal/datalakes/sqlite/upload_retry.go
+++ b/internal/datalakes/sqlite/upload_retry.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sqlite

--- a/internal/datalakes/sqlite/upload_retry.go
+++ b/internal/datalakes/sqlite/upload_retry.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/scanstats"
+	"go.mondoo.com/cnspec/v13/upload"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// uploadResolver is the slice of the upstream policy service the scan-database
+// upload needs. *policy.Services satisfies it; a fake stands in for tests.
+//
+// upload/findings.go declares an equivalent interface, but it is unexported and
+// in a different package, so this is a deliberate duplicate rather than a shared
+// type.
+type uploadResolver interface {
+	GetUploadURL(ctx context.Context, in *policy.GetUploadURLReq) (*policy.GetUploadURLResp, error)
+	ReportUploadCompleted(ctx context.Context, in *policy.ReportUploadCompletedReq) (*policy.Empty, error)
+}
+
+// scanUploadOutcome is what doScanUpload observed, so the caller can decide what
+// to report without doScanUpload touching the health package. Keeping telemetry
+// at the edge is what makes the retry logic testable without a global.
+type scanUploadOutcome struct {
+	sessionID string
+	// attempts is the number of attempts actually made, not the budget. 1 on a
+	// permanent error that failed fast; DefaultRetryAttempts when the budget was
+	// spent.
+	attempts int
+	// last* describe the most recent FAILED attempt, and stay set even when a
+	// later attempt succeeds — that is what a recovery report describes.
+	lastKind   upload.FailureKind
+	lastStatus int
+	lastRes    upload.Result
+	lastBody   string
+	lastErrMsg string
+	// okRes is the successful attempt, used for the upload stats.
+	okRes      upload.Result
+	bytesTotal int64
+}
+
+// recovered reports whether the upload succeeded only after failing at least
+// once. Callers use it to pick between the failure and recovery reports.
+func (o scanUploadOutcome) recovered() bool { return o.attempts > 1 }
+
+// doScanUpload runs the signed-URL upload handshake with bounded retries:
+// request a URL, PUT the scan database, then report completion.
+//
+// GetUploadURL and the PUT share one retry block because signed URLs expire
+// quickly (X-Goog-Expires=299) — reusing a URL across a backoff window would PUT
+// against an expired URL and 403. A fresh URL per attempt avoids that, and the
+// PUT is idempotent (same object key, same content) so repeating it is safe.
+// This mirrors upload/findings.go doUpload.
+func doScanUpload(ctx context.Context, resolver uploadResolver, scanDataPath, assetMrn string, stats *scanstats.Collector) (scanUploadOutcome, error) {
+	out := scanUploadOutcome{bytesTotal: fileSizeBytes(scanDataPath)}
+
+	if err := upstream.WithRetry(ctx, "upload scan data", func() (bool, time.Duration, error) {
+		out.attempts++
+
+		urlResp, err := resolver.GetUploadURL(ctx, &policy.GetUploadURLReq{
+			Kind:     policy.UploadURLKind_UPLOAD_URL_KIND_SCAN_DATABASE_V0,
+			ScopeMrn: assetMrn,
+		})
+		if err != nil {
+			out.lastKind = upload.FailureURLRequest
+			out.lastErrMsg = "upload failed: could not get upload URL: " + upload.RedactError(err)
+			// Unauthenticated and PermissionDenied are permanent: fail fast
+			// rather than spending the budget re-asking the same question.
+			return upstream.RetryableRPCError(err), 0, err
+		}
+		out.sessionID = urlResp.UploadSessionId
+
+		uploadURL := urlResp.UploadUrl
+		if uploadURL == nil {
+			out.lastKind = upload.FailureURLRequest
+			out.lastErrMsg = "upload failed: no upload URL for scan data store"
+			// A server that returns no URL is broken, not busy.
+			return false, 0, errors.New("no upload URL for scan data store")
+		}
+
+		res, err := upload.UploadFile(ctx, uploadURL.Url, uploadURL.Headers, scanDataPath, "application/octet-stream")
+		if err != nil {
+			out.lastKind = upload.ClassifyFailure(err)
+			out.lastStatus = 0
+			out.lastRes = res
+			out.lastErrMsg = "upload failed: " + upload.RedactError(err)
+			// Transport failure — the connection_reset/wsasend/dial-timeout
+			// class. Always worth another attempt.
+			return true, 0, err
+		}
+		defer res.Response.Body.Close()
+
+		if res.Response.StatusCode != http.StatusOK && res.Response.StatusCode != http.StatusCreated {
+			// Truncate to 512 bytes to avoid leaking sensitive details.
+			body, _ := io.ReadAll(io.LimitReader(res.Response.Body, 512))
+			out.lastKind = upload.FailureHTTPStatus
+			out.lastStatus = res.Response.StatusCode
+			out.lastRes = res
+			out.lastBody = string(body)
+			out.lastErrMsg = fmt.Sprintf("upload failed with status %d", res.Response.StatusCode)
+			return upstream.RetryableHTTPStatus(res.Response.StatusCode),
+				upstream.RetryAfter(res.Response.Header),
+				fmt.Errorf("upload failed with status %d", res.Response.StatusCode)
+		}
+
+		out.okRes = res
+		return false, 0, nil
+	}); err != nil {
+		return out, err
+	}
+
+	// Success-path baseline: without these, a slow failing upload cannot be
+	// compared against the normal distribution. Records the successful attempt,
+	// not the sum across retries.
+	if stats != nil {
+		stats.AddDuration(scanstats.MetricUploadDuration, out.okRes.Duration)
+		if secs := out.okRes.Duration.Seconds(); secs > 0 {
+			stats.AddDouble(scanstats.MetricUploadThroughput, "bps", float64(out.okRes.BytesSent*8)/secs)
+		}
+	}
+
+	req := &policy.ReportUploadCompletedReq{
+		UploadSessionId: out.sessionID,
+		ScopeMrn:        assetMrn,
+	}
+	if stats != nil {
+		if s := stats.ToProto(); s != nil {
+			if details, aerr := anypb.New(s); aerr != nil {
+				log.Warn().Err(aerr).Msg("failed to encode scan statistics; sending upload confirmation without them")
+			} else {
+				req.Details = details
+			}
+		}
+	}
+
+	// The PUT already succeeded, so the object IS in the bucket. Losing the
+	// completion call means the platform never learns the data arrived and
+	// discards it anyway, so this is worth retrying.
+	if err := upstream.RetryRPC(ctx, "report upload completed", func() error {
+		_, err := resolver.ReportUploadCompleted(ctx, req)
+		return err
+	}); err != nil {
+		out.lastKind = upload.FailureReportRPC
+		out.lastErrMsg = "upload failed: could not report completion: " + upload.RedactError(err)
+		return out, err
+	}
+
+	return out, nil
+}
+
+// uploadReportKind selects which client report an outcome becomes. The values
+// are read by the platform's error-report handler to pick the record type, so
+// they are part of the wire contract — do not change them casually.
+type uploadReportKind string
+
+const (
+	uploadReportKindFailure   uploadReportKind = "upload_failure"
+	uploadReportKindRecovered uploadReportKind = "upload_recovered"
+)
+
+// uploadOutcomeTags builds the health.SendError tags for an upload outcome.
+// Both report kinds carry the same fields — a recovery describes the last
+// failure before success, so "what was it fighting" survives either way.
+func uploadOutcomeTags(kind uploadReportKind, out scanUploadOutcome, assetMrn string) map[string]string {
+	tags := uploadFailureTags(out.sessionID, assetMrn, out.lastKind, out.lastStatus, out.lastRes, out.bytesTotal)
+	tags["reportKind"] = string(kind)
+	tags["attempts"] = strconv.Itoa(out.attempts)
+	if out.lastBody != "" {
+		tags["responseBody"] = out.lastBody
+	}
+	return tags
+}

--- a/internal/datalakes/sqlite/upload_retry.go
+++ b/internal/datalakes/sqlite/upload_retry.go
@@ -101,10 +101,18 @@ func doScanUpload(ctx context.Context, resolver uploadResolver, scanDataPath, as
 			// class. Always worth another attempt.
 			return true, 0, err
 		}
-		defer res.Response.Body.Close()
+		// Drain before Close on every path: the transport can only recycle a
+		// connection whose body was read to EOF, and with no api_proxy set
+		// UploadFile runs on http.DefaultTransport's process-wide pool. An
+		// undrained body would cost a pooled connection per scan.
+		defer func() {
+			_, _ = io.Copy(io.Discard, res.Response.Body)
+			res.Response.Body.Close()
+		}()
 
 		if res.Response.StatusCode != http.StatusOK && res.Response.StatusCode != http.StatusCreated {
-			// Truncate to 512 bytes to avoid leaking sensitive details.
+			// Truncate to 512 bytes to avoid leaking sensitive details. The
+			// deferred drain consumes whatever is left.
 			body, _ := io.ReadAll(io.LimitReader(res.Response.Body, 512))
 			out.lastKind = upload.FailureHTTPStatus
 			out.lastStatus = res.Response.StatusCode

--- a/internal/datalakes/sqlite/upload_retry_test.go
+++ b/internal/datalakes/sqlite/upload_retry_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package sqlite

--- a/internal/datalakes/sqlite/upload_retry_test.go
+++ b/internal/datalakes/sqlite/upload_retry_test.go
@@ -1,0 +1,186 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sqlite
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
+)
+
+// fakeResolver stands in for *policy.Services so the upload handshake can be
+// driven without credentials. urlErrs is consumed one entry per call, so a test
+// can make the first N GetUploadURL calls fail and the rest succeed.
+type fakeResolver struct {
+	uploadURL string
+
+	urlCalls int
+	urlErr   error
+
+	completedCalls int
+	completedErrs  []error
+}
+
+func (f *fakeResolver) GetUploadURL(ctx context.Context, in *policy.GetUploadURLReq) (*policy.GetUploadURLResp, error) {
+	f.urlCalls++
+	if f.urlErr != nil {
+		return nil, f.urlErr
+	}
+	return &policy.GetUploadURLResp{
+		UploadSessionId: "sess-1",
+		UploadUrl:       &policy.UploadURL{Url: f.uploadURL},
+	}, nil
+}
+
+func (f *fakeResolver) ReportUploadCompleted(ctx context.Context, in *policy.ReportUploadCompletedReq) (*policy.Empty, error) {
+	f.completedCalls++
+	if f.completedCalls <= len(f.completedErrs) {
+		if err := f.completedErrs[f.completedCalls-1]; err != nil {
+			return nil, err
+		}
+	}
+	return &policy.Empty{}, nil
+}
+
+func testScanDataFile(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "scan.db")
+	require.NoError(t, os.WriteFile(p, []byte("scan-database-contents"), 0o600))
+	return p
+}
+
+// flakyPUT returns a server whose first failCount PUTs fail with status, then
+// succeed. status 0 means "hijack the connection and drop it" — a transport
+// failure rather than an HTTP error.
+func flakyPUT(t *testing.T, failCount int, status int) *httptest.Server {
+	t.Helper()
+	var n int
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n <= failCount {
+			if status == 0 {
+				hj, ok := w.(http.Hijacker)
+				require.True(t, ok)
+				conn, _, err := hj.Hijack()
+				require.NoError(t, err)
+				conn.Close()
+				return
+			}
+			w.WriteHeader(status)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestDoScanUpload_RetriesTransportErrorThenSucceeds(t *testing.T) {
+	srv := flakyPUT(t, 1, 0)
+	defer srv.Close()
+	f := &fakeResolver{uploadURL: srv.URL}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, out.attempts, "one failed attempt then success")
+	assert.NotEmpty(t, out.lastKind, "the failure that was recovered from must be recorded")
+}
+
+func TestDoScanUpload_RetriesRetryableHTTPStatus(t *testing.T) {
+	srv := flakyPUT(t, 1, http.StatusServiceUnavailable)
+	defer srv.Close()
+	f := &fakeResolver{uploadURL: srv.URL}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, out.attempts)
+	assert.Equal(t, http.StatusServiceUnavailable, out.lastStatus)
+}
+
+func TestDoScanUpload_FetchesFreshURLPerAttempt(t *testing.T) {
+	// Signed URLs carry X-Goog-Expires=299, so a URL reused across a backoff
+	// window would PUT against an expired URL and 403.
+	srv := flakyPUT(t, 2, 0)
+	defer srv.Close()
+	f := &fakeResolver{uploadURL: srv.URL}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, out.attempts)
+	assert.Equal(t, 3, f.urlCalls, "GetUploadURL must be called once per attempt, not once total")
+}
+
+func TestDoScanUpload_ExhaustsBudgetAndFails(t *testing.T) {
+	srv := flakyPUT(t, 99, 0)
+	defer srv.Close()
+	f := &fakeResolver{uploadURL: srv.URL}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.Error(t, err)
+	assert.Equal(t, 5, out.attempts, "the full retry budget is spent before giving up")
+	// The exact kind is platform-dependent (upload.ClassifyFailure differs on
+	// Windows), so assert only that one was classified.
+	assert.NotEmpty(t, out.lastKind)
+}
+
+func TestDoScanUpload_PermanentRPCErrorFailsFast(t *testing.T) {
+	srv := flakyPUT(t, 0, 0)
+	defer srv.Close()
+	// Ranger status, not grpc status: upstream.RetryableRPCError classifies with
+	// go.mondoo.com/ranger-rpc/status, and a grpc error read through it comes
+	// back as Unknown — which IS retryable. Production errors arrive from a
+	// ranger client, so this is the shape that matters.
+	f := &fakeResolver{
+		uploadURL: srv.URL,
+		urlErr:    status.Error(codes.Unauthenticated, "request permission unauthenticated"),
+	}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, out.attempts, "a permanent error must not burn the retry budget")
+	assert.Equal(t, 1, f.urlCalls)
+}
+
+func TestDoScanUpload_RetriesReportUploadCompleted(t *testing.T) {
+	srv := flakyPUT(t, 0, 0)
+	defer srv.Close()
+	f := &fakeResolver{
+		uploadURL:     srv.URL,
+		completedErrs: []error{status.Error(codes.Unavailable, "backend hiccup")},
+	}
+
+	out, err := doScanUpload(context.Background(), f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, f.completedCalls, "a transient completion RPC failure is retried")
+	assert.Equal(t, 1, out.attempts, "the PUT itself never failed")
+}
+
+func TestDoScanUpload_CancelledContextReturnsPromptly(t *testing.T) {
+	srv := flakyPUT(t, 99, 0)
+	defer srv.Close()
+	f := &fakeResolver{uploadURL: srv.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := doScanUpload(ctx, f, testScanDataFile(t), "//assets/a1", nil)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second, "must abort rather than sleep out the budget")
+}

--- a/internal/datalakes/sqlite/upload_retry_test.go
+++ b/internal/datalakes/sqlite/upload_retry_test.go
@@ -5,10 +5,13 @@ package sqlite
 
 import (
 	"context"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -183,4 +186,37 @@ func TestDoScanUpload_CancelledContextReturnsPromptly(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, time.Since(start), 5*time.Second, "must abort rather than sleep out the budget")
+}
+
+func TestDoScanUpload_ReusesConnectionAcrossUploads(t *testing.T) {
+	// The success-path response body must be drained before Close, or the
+	// transport cannot recycle the connection. With no api_proxy configured
+	// UploadFile uses http.DefaultTransport, a process-wide pool, so an
+	// undrained body costs a pooled connection on every scan.
+	var conns int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		// GCS answers a signed-URL PUT with a body; an empty one would make
+		// this test pass whether or not we drain.
+		_, _ = w.Write([]byte("<?xml version='1.0' encoding='UTF-8'?><PostResponse/>"))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			atomic.AddInt64(&conns, 1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	f := &fakeResolver{uploadURL: srv.URL}
+	path := testScanDataFile(t)
+
+	for i := 0; i < 3; i++ {
+		_, err := doScanUpload(context.Background(), f, path, "//assets/a1", nil)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&conns),
+		"three sequential uploads should share one pooled connection")
 }


### PR DESCRIPTION
## The problem

`uploadScanDataStore` was terminal at every failure point — each failure was reported and the error
returned, nothing retried. A transient network blip meant the scan was discarded and the asset's
findings silently went stale.

## What changed

Ports the retry structure from `upload/findings.go` `doUpload` into the scan-database path.

**`GetUploadURL` and the PUT share one retry block.** Signed URLs expire quickly, so a URL reused
across a backoff window would PUT against an expired URL and 403. A fresh URL per attempt avoids
that. The PUT is idempotent — same object key, same content — so repeating it is safe. This is the
same reasoning `findings.go:150` already documents.

**`ReportUploadCompleted` gets `upstream.RetryRPC`.** The PUT has already succeeded at that point, so
the object *is* in the bucket; losing the completion call means an upload that did arrive gets
discarded anyway.

**Classification reuses the existing helpers** rather than inventing a policy:

| failure | retryable |
|---|---|
| `GetUploadURL` RPC error | `upstream.RetryableRPCError` — Unauthenticated / PermissionDenied fail fast |
| nil upload URL | no — a broken server, not a busy one |
| PUT transport error | yes — the connection-reset / dial-timeout class |
| PUT non-2xx | `upstream.RetryableHTTPStatus` (429 or ≥500), honouring `Retry-After` |
| `ReportUploadCompleted` | `upstream.RetryableRPCError` |

Budget is `upstream.DefaultRetryAttempts` (5), exponential backoff from 500 ms with full jitter,
capped at 30 s, aborting promptly on context cancellation.

## Telemetry

An upload-failure report keeps meaning **a scan was lost** — one report once the budget is spent, now
carrying `attempts`. Folding retried-but-recovered attempts into it would silently change what every
existing query on that event measures.

An upload that succeeds only after failing reports `upload_recovered` instead — scans that would
previously have been discarded, which is the number that says whether this is working. The platform
side of that mapping ships separately and should land first; until it does, the new tags are
recorded but not queryable.

`attempts` is the *actual* count, not the budget, so `1` means permanent and `5` means flaky.

## Testability

`uploadScanDataStore` had **no test** — it took a concrete `*policy.Services` and reported through
the global `health.ReportError`. Extracted `doScanUpload` behind a small resolver interface with
telemetry pushed out to the caller, so the retry is testable against a fake resolver and `httptest`
without touching a global.

`internal/datalakes/sqlite/upload_retry_test.go`:

- transport error then 200 → 2 attempts, recovery path
- 503 then 200 → retried, `lastStatus` 503
- `GetUploadURL` called **once per attempt**, not once total
- 5× failure → budget spent, error returned
- `Unauthenticated` → 1 attempt, budget untouched
- transient `ReportUploadCompleted` → retried, PUT attempts unaffected
- cancelled context → returns promptly instead of sleeping out the budget

One note for reviewers: `upstream.RetryableRPCError` classifies with `go.mondoo.com/ranger-rpc/status`,
not gRPC's. A gRPC error read through it comes back as `Unknown`, which *is* retryable — the first
version of the fail-fast test used a gRPC error and retried 5 times. The test now uses ranger status,
which is what production errors actually are.

`go build ./...`, `go vet`, and `go test ./internal/datalakes/... ./upload/...` all clean.

## Scope

Deliberately **not** included: a fallback to v1 `StoreResults`. v1 and v2 are two datalakes chosen
before the scan runs (`policy/scan/local_scanner.go:1478`), and the v2 path disables v1 outright via
`policy.NoStoreResults`. Results live in a SQLite file, not the in-memory structures
`StoreResultsReq` expects, so a fallback needs a converter or a re-scan. Separate work.

This targets intermittent failures, where a host succeeds sometimes and fails others. A host that
can never reach the upload destination at all has nothing to retry and is unaffected.
