### PR TITLE
🐛 cloudflare: bind the zone/account before reading sub-resource fields

### DIFF
--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -2468,7 +2468,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.ssl != "off"
+      cloudflare.zone { settings.ssl != "off" }
   - uid: mondoo-cloudflare-security-ssl-not-off-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2494,7 +2494,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.ssl == "strict"
+      cloudflare.zone { settings.ssl == "strict" }
   - uid: mondoo-cloudflare-security-ssl-strict-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2520,7 +2520,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.alwaysUseHttps == "on"
+      cloudflare.zone { settings.alwaysUseHttps == "on" }
   - uid: mondoo-cloudflare-security-always-use-https-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2546,7 +2546,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.minTlsVersion.in(["1.2", "1.3"])
+      cloudflare.zone { settings.minTlsVersion.in(["1.2", "1.3"]) }
   - uid: mondoo-cloudflare-security-min-tls-1-2-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2572,7 +2572,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.tls13 != "off"
+      cloudflare.zone { settings.tls13 != "off" }
   - uid: mondoo-cloudflare-security-tls-1-3-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2598,7 +2598,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.automaticHttpsRewrites == "on"
+      cloudflare.zone { settings.automaticHttpsRewrites == "on" }
   - uid: mondoo-cloudflare-security-automatic-https-rewrites-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2624,7 +2624,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.waf == "on"
+      cloudflare.zone { settings.waf == "on" }
   - uid: mondoo-cloudflare-security-waf-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2650,7 +2650,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.securityLevel != "essentially_off"
+      cloudflare.zone { settings.securityLevel != "essentially_off" }
   - uid: mondoo-cloudflare-security-security-level-not-off-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2676,7 +2676,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.browserCheck == "on"
+      cloudflare.zone { settings.browserCheck == "on" }
   - uid: mondoo-cloudflare-security-browser-check-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2702,7 +2702,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.emailObfuscation == "on"
+      cloudflare.zone { settings.emailObfuscation == "on" }
   - uid: mondoo-cloudflare-security-email-obfuscation-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2728,7 +2728,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.hotlinkProtection == "on"
+      cloudflare.zone { settings.hotlinkProtection == "on" }
   - uid: mondoo-cloudflare-security-hotlink-protection-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2754,7 +2754,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.opportunisticEncryption == "on"
+      cloudflare.zone { settings.opportunisticEncryption == "on" }
   - uid: mondoo-cloudflare-security-opportunistic-encryption-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2780,7 +2780,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.dnssec.status == "active"
+      cloudflare.zone { dnssec.status == "active" }
   - uid: mondoo-cloudflare-security-dnssec-active-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_dnssec')
@@ -2806,7 +2806,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-account"
     mql: |
-      cloudflare.account.settings.enforceTwoFactor == true
+      cloudflare.account { settings.enforceTwoFactor == true }
   - uid: mondoo-cloudflare-security-enforce-two-factor-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_account')
@@ -2832,7 +2832,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.hstsEnabled == true
+      cloudflare.zone { settings.hstsEnabled == true }
   - uid: mondoo-cloudflare-security-hsts-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2858,7 +2858,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.hstsEnabled != true || cloudflare.zone.settings.hstsMaxAge >= 31536000
+      cloudflare.zone { settings.hstsEnabled != true || settings.hstsMaxAge >= 31536000 }
   - uid: mondoo-cloudflare-security-hsts-max-age-one-year-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2884,7 +2884,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.hstsEnabled != true || cloudflare.zone.settings.hstsIncludeSubdomains == true
+      cloudflare.zone { settings.hstsEnabled != true || settings.hstsIncludeSubdomains == true }
   - uid: mondoo-cloudflare-security-hsts-include-subdomains-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')
@@ -2910,7 +2910,7 @@ queries:
     filters: |
       asset.platform == "cloudflare-zone"
     mql: |
-      cloudflare.zone.settings.hstsEnabled != true || cloudflare.zone.settings.hstsPreload == true
+      cloudflare.zone { settings.hstsEnabled != true || settings.hstsPreload == true }
   - uid: mondoo-cloudflare-security-hsts-preload-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'cloudflare_zone_setting')


### PR DESCRIPTION
## Problem

`cloudflare.zone.settings` and `cloudflare.account.settings` are dotted paths that are **also resource names**. The compiler extends the resource path greedily, so `cloudflare.zone.settings.ssl` builds a bare, id-less `cloudflare.zone.settings` resource — the zone's accessor never runs and every field reads `null`. This is the trap already documented in `CLAUDE.md`, which even names `cloudflare.zone.settings.*` as an example.

Confirmed against a live Cloudflare account, on the account resource where real data exists (the API reports `enforce_twofactor: false`):

```
cloudflare.account.settings.enforceTwoFactor       -> null    id= (empty)  [failed]
cloudflare.account { settings.enforceTwoFactor }   -> false
```

The empty `id=` in the provider diagnostic is the signature. It's the path *shape*, not a missing parent.

**18 runtime checks were affected**, and the breakage split by operator direction:

- **6 silently PASSED** — `null != "off"` is true, so `ssl-not-off`, `tls-1-3-enabled`, `security-level-not-off`, and the three `hsts-*` guard checks reported compliant without ever reading the setting. These are false negatives in a security policy.
- **12 could never pass** — `null == "on"` is false, so a correctly configured zone was still reported non-compliant.

## Fix

Bind the parent in a block so `settings` / `dnssec` resolve as field reads on the asset's zone or account:

```diff
-      cloudflare.zone.settings.ssl != "off"
+      cloudflare.zone { settings.ssl != "off" }
```

The checks are filtered to the per-resource `cloudflare-zone` / `cloudflare-account` platforms, so the singular resource bound to the asset is the right accessor here — not a `cloudflare.zones.all(...)` iteration, which would evaluate every zone against each zone asset.

Only the runtime `-cloudflare` variants changed. The Terraform variants already read their values correctly and are untouched.

## Verification

- `cnspec policy lint content/mondoo-cloudflare-security.mql.yaml` → valid.
- Live `cnspec scan cloudflare` before the fix: 1 `provider returned no data and no error for a field` diagnostic; after: **0**.
- `enforce-two-factor` still fails, but now on the real value `false` rather than on `null`.

The zone-side checks could not be exercised against live data — the test account has no zones — but the account check is the identical path shape and is verified end to end above.

## Follow-up (not in this PR)

Same-shaped paths exist in other providers per `CLAUDE.md` (Azure AKS, GCP GKE, AWS EMR, Cloudflare). A lint rule that flags an `mql:` path whose dotted prefix matches a resource name would catch this class at authoring time — worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)