### PR TITLE
ci: migrate workflow runners to arc-runners

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: "write"
 
     runs-on:
-      group: Default
+      group: arc-runners
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -191,6 +191,9 @@ jobs:
           TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
           TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.TSIGN_ACCESS_TOKEN }}
 
+      - name: Install rpm
+        # ARC runner image doesn't ship rpm; the check below needs it.
+        run: sudo apt-get update && sudo apt-get install -y rpm
       - name: Check RPMs
         run: |
           rpm -qpi dist/*.rpm

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -49,7 +49,7 @@ jobs:
       id-token: "write"
 
     runs-on:
-      group: Default
+      group: arc-runners
     environment: prod
     timeout-minutes: 120
     steps:

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -15,7 +15,7 @@ jobs:
   # Check if there is any dirty change for generated files
   generated-files:
     runs-on:
-      group: Default
+      group: arc-runners
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Migrates `cnspec` CI off the legacy **Default** runner group onto **ARC (`arc-runners`)**.

## Runner swap (`group: Default` → `group: arc-runners`)
- `.github/workflows/goreleaser-edge.yml`
- `.github/workflows/goreleaser.yml`
- `.github/workflows/pr-test-generated-files.yaml`

No private-module auth shim needed — this repo's `go.mod` pulls only **public** mondoohq modules (`mql`, `ranger-rpc`, `mondoo-go`). Existing release workflows already use the mergebot app token for their own purposes; unchanged here.

Draft so the ARC runs can be eyeballed before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)