### PR TITLE
🐛 Apply severity bands in BANDED policy scoring

### DIFF
--- a/policy/resolved_policy_builder.go
+++ b/policy/resolved_policy_builder.go
@@ -867,6 +867,19 @@ func (b *resolvedPolicyBuilder) addPolicy(policy *Policy) bool {
 						Scoring: ScoringSystem_IGNORE_SCORE,
 						Action:  Action_IGNORE,
 					}
+				} else if i := b.impactOverrides[c.Mrn]; i.GetValue() != nil {
+					// The check's severity has to reach the policy's score
+					// calculator: banded scoring buckets a check into its
+					// critical/high/medium/low band from the impact on this
+					// edge, and decayed scoring scales its weight by it.
+					// Without it every check is treated as critical.
+					//
+					// Only the value is carried. Scoring and weight stay on
+					// the variant/codeId -> check edge, which is where they
+					// are applied; re-applying them here would double up. The
+					// value itself is safe to repeat: it acts as a score floor
+					// (100-impact) that the check score already satisfies.
+					impact = &Impact{Value: &ImpactValue{Value: i.Value.Value}}
 				}
 				b.addEdge(c.Mrn, policy.Mrn, impact)
 			}

--- a/policy/resolver_v2_test.go
+++ b/policy/resolver_v2_test.go
@@ -5,6 +5,7 @@ package policy_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -461,12 +462,19 @@ queries:
 		rpTester.CodeIdReportingJobForMrn(queryMrn("check2")).Notifies(queryMrn("check2")).WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 70}})
 		rpTester.CodeIdReportingJobForMrn(queryMrn("check3")).Notifies(queryMrn("check3")).WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 80}})
 		rpTester.CodeIdReportingJobForMrn(queryMrn("query1")).Notifies(queryMrn("query1"))
-		rpTester.ReportingJobByMrn(queryMrn("check1")).Notifies(policyMrn("policy1"))
-		rpTester.ReportingJobByMrn(queryMrn("check2")).Notifies(policyMrn("policy1"))
-		rpTester.ReportingJobByMrn(queryMrn("check3")).Notifies(policyMrn("policy1"))
-		rpTester.ReportingJobByMrn(queryMrn("query1")).Notifies(policyMrn("policy1"))
-		rpTester.ReportingJobByMrn(queryMrn("check2")).Notifies(policyMrn("policy2"))
-		rpTester.ReportingJobByMrn(queryMrn("check3")).Notifies(policyMrn("policy2"))
+		// The same worst impact also lands on the check -> policy edges, so the
+		// policy's score calculator can tell a medium check from a critical one.
+		rpTester.ReportingJobByMrn(queryMrn("check1")).Notifies(policyMrn("policy1")).WithImpact(nil)
+		rpTester.ReportingJobByMrn(queryMrn("check2")).Notifies(policyMrn("policy1")).
+			WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 70}})
+		rpTester.ReportingJobByMrn(queryMrn("check3")).Notifies(policyMrn("policy1")).
+			WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 80}})
+		rpTester.ReportingJobByMrn(queryMrn("query1")).Notifies(policyMrn("policy1")).
+			WithImpact(&policy.Impact{Scoring: policy.ScoringSystem_IGNORE_SCORE, Action: policy.Action_IGNORE})
+		rpTester.ReportingJobByMrn(queryMrn("check2")).Notifies(policyMrn("policy2")).
+			WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 70}})
+		rpTester.ReportingJobByMrn(queryMrn("check3")).Notifies(policyMrn("policy2")).
+			WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 80}})
 
 		rpTester.doTest(t, rp)
 	})
@@ -1957,6 +1965,146 @@ policies:
 		}
 	}
 	require.True(t, foundEol, "scored risk factor %s not found in report", eolRiskMrn)
+}
+
+// TestResolveV2_CheckImpactOnPolicyEdge asserts that the check -> policy edge
+// carries the check's severity. The banded score calculator derives a check's
+// critical/high/medium/low band from the impact on that edge, so leaving it
+// nil buckets every check as critical.
+func TestResolveV2_CheckImpactOnPolicyEdge(t *testing.T) {
+	ctx := context.Background()
+	b := parseBundle(t, `
+owner_mrn: //test.sth
+policies:
+- owner_mrn: //test.sth
+  mrn: //test.sth
+  groups:
+  - policies:
+    - uid: policy1
+- uid: policy1
+  groups:
+  - type: chapter
+    filters: "true"
+    checks:
+    - uid: check-no-impact
+    - uid: check-medium
+    - uid: check-group-impact
+      impact: 30
+queries:
+- uid: check-no-impact
+  mql: true == true
+- uid: check-medium
+  mql: true == false
+  impact: 60
+- uid: check-group-impact
+  mql: true == true
+  impact: 80
+`)
+
+	srv := initResolver(t, []*testAsset{
+		{asset: "asset1", policies: []string{policyMrn("policy1")}},
+	}, []*policy.Bundle{b})
+
+	rp, err := srv.Resolve(ctx, &policy.ResolveReq{
+		PolicyMrn:    "//test.sth",
+		AssetFilters: []*policy.Mquery{{Mql: "true"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rp)
+
+	rpTester := newResolvedPolicyTester(b, srv.NewCompilerConfig())
+	// A check without any impact stays unbanded on the edge.
+	rpTester.ReportingJobByMrn(queryMrn("check-no-impact")).Notifies(policyMrn("policy1")).WithImpact(nil)
+	// The severity declared on the query itself reaches the policy edge.
+	rpTester.ReportingJobByMrn(queryMrn("check-medium")).Notifies(policyMrn("policy1")).
+		WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 60}})
+	// The worst impact wins, same as on the code id -> check edge.
+	rpTester.ReportingJobByMrn(queryMrn("check-group-impact")).Notifies(policyMrn("policy1")).
+		WithImpact(&policy.Impact{Value: &policy.ImpactValue{Value: 80}})
+
+	rpTester.doTest(t, rp)
+}
+
+// TestResolveV2_BandedScoringUsesCheckImpact runs the full pipeline for a
+// policy scored with BANDED. Each failing check has to land in the band that
+// matches its own impact: a single failing MEDIUM check must not drag the
+// policy score into the critical band.
+func TestResolveV2_BandedScoringUsesCheckImpact(t *testing.T) {
+	tests := []struct {
+		name     string
+		impact   int
+		expected uint32
+	}{
+		// One failing check out of one, banded by its own severity:
+		// crit -> floor(50*0), high -> floor(50*0)+10, mid -> floor(50*0)+30,
+		// low -> floor(40*0)+60.
+		{name: "critical", impact: 100, expected: 0},
+		{name: "high", impact: 80, expected: 10},
+		{name: "medium", impact: 60, expected: 30},
+		{name: "low", impact: 20, expected: 60},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			runtime := testutils.LinuxMock()
+			_, srv, err := inmemory.NewServices(runtime)
+			require.NoError(t, err)
+
+			b := parseBundle(t, `
+owner_mrn: //test.sth
+policies:
+  - uid: banded-policy
+    scoring_system: banded
+    groups:
+    - filters: asset.name == "asset1"
+      checks:
+      - uid: failing-check
+        mql: 1 == 2
+        impact: `+strconv.Itoa(test.impact)+`
+`)
+
+			_, err = srv.SetBundle(ctx, b)
+			require.NoError(t, err)
+
+			_, err = srv.Assign(ctx, &policy.PolicyAssignment{
+				AssetMrn:   "asset1",
+				PolicyMrns: []string{policyMrn("banded-policy")},
+			})
+			require.NoError(t, err)
+
+			rp, err := srv.ResolveAndUpdateJobs(ctx, &policy.UpdateAssetJobsReq{
+				AssetMrn:     "asset1",
+				AssetFilters: []*policy.Mquery{{Mql: "asset.name == \"asset1\""}},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, rp)
+
+			err = executor.ExecuteResolvedPolicy(ctx, runtime, srv, "asset1", rp, mql.DefaultFeatures, nil)
+			require.NoError(t, err)
+
+			_, err = policy.WaitUntilDone(srv, "asset1", "asset1", 5*time.Second)
+			require.NoError(t, err)
+
+			report, err := srv.GetReport(ctx, &policy.EntityScoreReq{
+				EntityMrn: "asset1",
+				ScoreMrn:  "asset1",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, report)
+
+			// The check itself is always floored at 100-impact, independent of
+			// the policy's scoring system.
+			checkScore := report.Scores[queryMrn("failing-check")]
+			require.NotNil(t, checkScore, "check score not found in report")
+			assert.Equal(t, uint32(100-test.impact), checkScore.Value, "check score")
+
+			policyScore := report.Scores[policyMrn("banded-policy")]
+			require.NotNil(t, policyScore, "policy score not found in report")
+			assert.Equal(t, test.expected, policyScore.Value, "banded policy score")
+		})
+	}
 }
 
 func TestResolveV2_FrameworkExceptions(t *testing.T) {

--- a/policy/score_calculator.go
+++ b/policy/score_calculator.go
@@ -685,7 +685,9 @@ func (c *decayedScoreCalculator) Add(score *Score, impact *Impact) {
 			// with accelerator > 0, default = 1
 			v := float64(100-score.Value) / 100
 			c.x += v * float64(score.Weight)
-			if impact.Value == nil {
+			// GetValue, not .Value: edges without an impact hand us a nil
+			// *Impact, which a field access would panic on.
+			if impact.GetValue() == nil {
 				c.xmax += 1 * float64(score.Weight)
 			} else {
 				c.xmax += float64(impact.Value.Value) / 100 * float64(score.Weight)

--- a/policy/score_calculator_test.go
+++ b/policy/score_calculator_test.go
@@ -341,7 +341,53 @@ func TestDecayedScores(t *testing.T) {
 			},
 			out: &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 0, Type: ScoreType_Result},
 		},
+		{
+			// an edge without an impact must not panic; it counts as full weight,
+			// the same as an impact that carries no value
+			in: []*Score{
+				{Value: 0, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result},
+			},
+			out: &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result},
+		},
 	})
+}
+
+// TestBandedScores_UsesImpactValueForBand pins the property the banded
+// calculator exists for: a single failing check has to land in the band its
+// impact declares. Passing no impact at all leaves it critical.
+func TestBandedScores_UsesImpactValueForBand(t *testing.T) {
+	failingCheck := func(impact int32) scoreTest {
+		return scoreTest{
+			in: []*Score{
+				{Value: uint32(100 - impact), ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result},
+			},
+			impacts: []*Impact{{Value: &ImpactValue{Value: impact}}},
+		}
+	}
+
+	crit := failingCheck(100)
+	crit.out = &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, Weight: 1, Type: ScoreType_Result}
+
+	high := failingCheck(80)
+	high.out = &Score{Value: 10, ScoreCompletion: 100, DataCompletion: 100, Weight: 1, Type: ScoreType_Result}
+
+	mid := failingCheck(60)
+	mid.out = &Score{Value: 30, ScoreCompletion: 100, DataCompletion: 100, Weight: 1, Type: ScoreType_Result}
+
+	low := failingCheck(20)
+	low.out = &Score{Value: 60, ScoreCompletion: 100, DataCompletion: 100, Weight: 1, Type: ScoreType_Result}
+
+	// No impact on the edge: nothing to band with, so it stays critical.
+	noImpact := scoreTest{
+		in:  []*Score{{Value: 40, ScoreCompletion: 100, DataCompletion: 100, DataTotal: 1, Weight: 1, Type: ScoreType_Result}},
+		out: &Score{Value: 0, ScoreCompletion: 100, DataCompletion: 100, Weight: 1, Type: ScoreType_Result},
+	}
+
+	testScoring(t, func() ScoreCalculator {
+		res := bandedScoreCalculator{}
+		res.Init()
+		return &res
+	}, []scoreTest{crit, high, mid, low, noImpact})
 }
 
 func TestDataOnly(t *testing.T) {


### PR DESCRIPTION
## What

`bandedScoreCalculator` buckets a policy's checks into critical / high / medium / low bands and weights the policy score accordingly. It never did — every check landed in the **critical** band regardless of its declared `impact`, so a policy scored with `BANDED` reported `floor(50 × passRatio)` as soon as anything failed. One failing MEDIUM check produced a CRITICAL policy score.

`bandedScoreCalculator.Add` derives the band from the impact on the edge being added:

```go
category := uint32(0)
if impact != nil && impact.Value != nil {
    category = 100 - uint32(impact.Value.Value)
}
if category <= 10 { /* critical */ }
```

That edge is check → policy, and `addPolicy` left it `nil` for every check that wasn't snoozed. Impact only lived one level down, on the variant/codeId → check edge (which is why the *check* score was always correct and only the aggregation was wrong). So `category` stayed `0`, `0 <= 10`, everything critical.

## How

`addPolicy` now carries the check's severity — already resolved into `b.impactOverrides[c.Mrn]` as the worst impact across the bundle — onto the check → policy edge.

Only the **value** is copied. `Scoring` and `Weight` stay on the edge below, which is where they are applied; re-applying them here would double up (check weights are currently not honoured at all, and starting to honour them silently is a separate change). Repeating the value is safe because it acts as a score floor of `100-impact` that the forwarded check score already satisfies — so `worst`, `weighted` and `average` see no change. `decayed` also reads this impact to scale a check's weight, and gets more accurate as a result.

### Drive-by: nil-impact panic in the decayed calculator

While checking the other calculators for fallout, `decayedScoreCalculator.Add` turned out to do a bare `impact.Value` field access on a `*Impact` that is `nil` for any edge without an impact — a nil-pointer panic for any policy using `scoring_system: decayed` with a check that declares no impact. Reproduced with a one-liner, fixed with `impact.GetValue()`, regression test added. Same `nil` → "full weight" semantics as the existing branch.

## Before / after

The reported scenario — a Terraform HCL directory with exactly one failing MEDIUM check under a `banded` policy:

```
===== BEFORE =====
✕ MEDIUM (60):    EBS volumes must be encrypted
Terraform HCL
  CRITICAL (100):  Terraform HCL directory tfdemo

===== AFTER =====
✕ MEDIUM (60):    EBS volumes must be encrypted
Terraform HCL
  HIGH (70):    Terraform HCL directory tfdemo
```

## Tests

- `TestResolveV2_BandedScoringUsesCheckImpact` — full pipeline (resolve → execute → report) for a single failing check at each severity. Asserts the banded policy score is 0 / 10 / 30 / 60 for critical / high / medium / low. Fails on `main` with 0 across the board.
- `TestResolveV2_CheckImpactOnPolicyEdge` — the check → policy edge carries the severity, including worst-impact-wins across group and query declarations.
- `TestResolveV2_PolicyWithImpacts` — strengthened; it asserted the check → policy edges existed but never asserted their impact, so it passed either way.
- `TestBandedScores_UsesImpactValueForBand` — pins the calculator-level property, plus the no-impact-stays-critical case.
- `TestDecayedScores` — added the nil-impact case that panicked before.

`go test ./...` is clean apart from `test/providers`, which fails identically on the base commit (needs platform credentials and a local package manager).

## Notes for review

Two things I deliberately did **not** change, both pre-existing and both arguably worth their own issue:

1. Under the `ErrorsAsFailures` feature flag, an errored check reaches `bandedScoreCalculator.Add`'s error branch, which writes `c.value` — a field `Calculate()` never reads for this calculator. Errored checks are therefore invisible to every band, i.e. effectively treated as passing.
2. The same flag means an errored check's value now gets floored by its impact at the policy edge (0 → `100-impact`), consistent with how the identical impact is applied to that check when it fails normally, and with how policy → policy edges with an impact already behave.

The compliance-control variant of this problem is tracked separately; `addControl` is untouched here.