### PR TITLE
🧹  use users loggedIn resource on mac for query

### DIFF
--- a/content/querypacks/mondoo-macos-inventory.mql.yaml
+++ b/content/querypacks/mondoo-macos-inventory.mql.yaml
@@ -58,8 +58,8 @@ packs:
           - uid: mondoo-macos-logged-in-users
             title: Logged-in users
             docs:
-              desc: Lists currently logged-in users from the output of the w command.
-            mql: command('w -h').stdout
+              desc: Lists currently logged-in users 
+            mql: users.where(loggedIn).map(name)
       - uid: mondoo-macos-inventory-hardware-group
         title: Hardware & Firmware
         filters: asset.platform == "macos"


### PR DESCRIPTION
The query "mondoo-macos-logged-in-users" is currently using `command('w -h').stdout`. We have native resources for the users now and should use them for the query-pack.