### PR TITLE
✨ content: assess running PostgreSQL, MySQL, and Grafana servers

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -204,6 +204,21 @@ The frameworks in the standard set appear on nearly every tagged check; the subj
 
 Read the control uid out of the framework YAML. Do not construct it from the framework name.
 
+### OWASP Top 10 mapping parity (enforced by test)
+
+The security policies are mapped to the OWASP Top 10:2025 (application) and, for AI/LLM assets, the OWASP Top 10:2025 for LLM Applications. The offline test in `content/validation/compliance/owasp_mapping_test.go` enforces a **parity invariant**: any check that carries a `compliance/pci-dss-4:` tag (the marker for a framework-mapped check) **must** also carry a `compliance/owasp-top-10-2025:` tag, and vice versa. A policy is either fully mapped or not mapped at all.
+
+**Practical consequence for contributors:** if you add a check to a policy whose sibling checks are framework-mapped, add its `compliance/owasp-top-10-2025:` tag **in the same PR**. Omitting it turns `main` red on the next run, because the new check inherits a `pci-dss-4` tag from the mapping convention but lacks its OWASP partner. Pick the category from the check's actual enforced behavior:
+
+- `a01` broken access control (anonymous/bypass, exposure, least privilege)
+- `a02` security misconfiguration (surface area, dangerous defaults)
+- `a04` cryptographic failures (encryption in transit and at rest, password storage)
+- `a07` authentication failures (login/identity, password policy, MFA)
+- `a08` software/data integrity
+- `a09` security logging and monitoring failures
+
+`a03` (supply chain) applies to build-time checks. **`a05` (injection), `a06` (insecure design), and `a10` (mishandling exceptional conditions) are the domain of source-level SAST tooling, not posture scanning — never map a cnspec posture check to them** (the test rejects these three). Tag `false` (unquoted) only where no framework control fits; the OWASP tag is not optional for a mapped check.
+
 ## Terraform variants and remediation for cloud policies
 
 When you add or modify a check in a cloud policy (`mondoo-aws-security`, `mondoo-azure-security`, `mondoo-gcp-security`, `mondoo-oci-security`, `mondoo-hetzner-security`, `mondoo-digitalocean-security`, etc.), **two things** must ship together:

--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -4,7 +4,7 @@ policies:
   - summary: Secure Grafana organizations across service accounts, user roles, datasources, and alerting
     uid: mondoo-grafana-security
     name: Mondoo Grafana Security
-    version: 1.0.3
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -51,6 +51,11 @@ policies:
         checks:
           - uid: mondoo-grafana-notification-policy-has-receiver
           - uid: mondoo-grafana-contact-points-resolve-enabled
+      - title: Authentication Security
+        filters: asset.platform == "grafana-org"
+        checks:
+          - uid: mondoo-grafana-users-mfa-enabled
+          - uid: mondoo-grafana-saml-enabled
     scoring_system: average
 queries:
   - uid: mondoo-grafana-no-admin-service-accounts
@@ -935,3 +940,132 @@ queries:
     refs:
       - url: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/contact-points/
         title: Grafana Contact Points
+  - uid: mondoo-grafana-users-mfa-enabled
+    filters: asset.platform == "grafana-org"
+    title: Ensure active Grafana users have multi-factor authentication
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      grafana.users.where(isDisabled == false).all(mfaEnabled == true)
+    docs:
+      desc: |-
+        This check ensures that every active (non-disabled) Grafana user has multi-factor authentication enabled, so that a stolen password alone cannot sign in to the organization. Multi-factor enrollment is a Grafana Cloud and Grafana Enterprise capability.
+
+        **Why this matters**
+
+        - **Credential theft resistance:** A second factor blocks account takeover when a password is phished, reused, or leaked.
+        - **Elevated access:** Grafana users often hold access to data sources, alerting, and dashboards that expose sensitive operational data.
+        - **Consistent coverage:** Requiring MFA for every active user, not just administrators, removes weak links an attacker can pivot through.
+
+        **Risk mitigation**
+
+        - **Blocked reuse:** Passwords exposed in unrelated breaches cannot be replayed against Grafana.
+        - **Attributable access:** Strong per-user authentication keeps sessions tied to a verified identity.
+      audit: |-
+        ### Audit via the Grafana UI
+
+        1. Sign in to Grafana as an administrator.
+        2. Open **Administration > Users**.
+        3. Review each active (non-disabled) user and confirm that multi-factor authentication is enrolled.
+
+        If every active user has multi-factor authentication enabled, the check passes. If any active user is missing a second factor, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To require multi-factor authentication for active users in the Grafana UI:
+
+            1. Open **Administration > Users**.
+            2. For each active user, require and confirm that they enroll a second factor.
+            3. Disable or remove any account that cannot complete enrollment.
+        - id: config
+          desc: |-
+            To enable and require multi-factor authentication through the Grafana configuration where supported, edit the authentication settings in `grafana.ini` and restart Grafana:
+
+            ```ini
+            [auth]
+            # require multi-factor authentication for user logins where supported
+            ```
+
+            After updating the configuration, restart the Grafana service so the change takes effect, then confirm each active user completes enrollment.
+    refs:
+      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
+        title: Grafana Configure Authentication
+  - uid: mondoo-grafana-saml-enabled
+    filters: asset.platform == "grafana-org"
+    title: Ensure Grafana SAML single sign-on is enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      grafana.samlSettings.enabled == true
+    docs:
+      desc: |-
+        This check ensures that SAML single sign-on is enabled so that users authenticate through the organization's identity provider. Centralizing authentication puts account lifecycle, multi-factor, and conditional access under the identity provider rather than relying on local Grafana logins.
+
+        **Why this matters**
+
+        - **Centralized identity:** The identity provider governs who can sign in, so joiner and leaver events immediately propagate to Grafana access.
+        - **Inherited controls:** MFA, conditional access, and session policies enforced by the identity provider apply to Grafana automatically.
+        - **Fewer standing secrets:** Single sign-on reduces reliance on local passwords that can drift out of policy or be shared.
+
+        **Risk mitigation**
+
+        - **Prompt deprovisioning:** Disabling a user at the identity provider revokes their Grafana access without a separate cleanup step.
+        - **Consistent enforcement:** Authentication policy is applied uniformly instead of per-application.
+      audit: |-
+        ### Audit via the Grafana UI
+
+        1. Sign in to Grafana as an administrator.
+        2. Open **Administration > Authentication > SAML** and confirm that SAML is configured and enabled.
+        3. Alternatively, inspect the `[auth.saml]` section of `grafana.ini` and confirm `enabled = true`.
+
+        If SAML single sign-on is configured and enabled, the check passes. If it is not enabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enable SAML single sign-on in the Grafana UI:
+
+            1. Open **Administration > Authentication > SAML**.
+            2. Configure the identity provider metadata for your organization.
+            3. Enable SAML and save the configuration.
+        - id: config
+          desc: |-
+            To enable SAML single sign-on through the Grafana configuration, set the option under `[auth.saml]` in `grafana.ini` and provide the identity provider metadata, then restart Grafana:
+
+            ```ini
+            [auth.saml]
+            enabled = true
+            # provide the identity provider metadata (for example idp_metadata_url or idp_metadata_path)
+            ```
+
+            After updating the configuration, restart the Grafana service so the change takes effect.
+    refs:
+      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/
+        title: Grafana SAML Authentication

--- a/content/mondoo-mysql-security.mql.yaml
+++ b/content/mondoo-mysql-security.mql.yaml
@@ -3,22 +3,23 @@
 policies:
   - uid: mondoo-mysql-security
     name: Mondoo MySQL Security
-    version: 1.0.0
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,mysql
+      mondoo.com/platform: linux,mysqldb
     require:
       - provider: os
+      - provider: mysqldb
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
     summary: Harden MySQL server networking, authentication, privileges, and audit logging
     docs:
       desc: |
-        The Mondoo MySQL Security policy assesses the on-disk option files of a self-managed MySQL or Percona Server installation. It reads the option file chain, resolving the `!include` and `!includedir` directives so every fragment contributes, and normalizes option names so `-` and `_` are interchangeable exactly as the server treats them.
+        The Mondoo MySQL Security policy assesses a self-managed MySQL or Percona Server installation from two directions. On a Linux host it reads the on-disk option file chain, resolving the `!include` and `!includedir` directives so every fragment contributes, and normalizing option names so `-` and `_` are interchangeable exactly as the server treats them. Against a running server it connects over SQL and reads the effective global variables and the `mysql.user` account table.
 
-        This policy provides security checks across seven areas:
+        This policy provides security checks across eight areas:
 
         - Connection surface and network exposure
         - Transport encryption and certificate material
@@ -27,14 +28,17 @@ policies:
         - Error, general, and audit logging
         - Encryption at rest for tables and logs
         - Protection of option files and the credentials they hold
+        - The accounts and variables a running server is enforcing right now
 
         **Scope and limitations**
 
-        This policy reads configuration as it is written to disk. It does not open a SQL connection to the server, so it cannot assess accounts, granted privileges, the `mysql.user` table, or the effective value of a dynamic variable. Checks describe the configuration the server would load on its next restart.
+        The host-based checks read configuration as it is written to disk. They describe the configuration the server would load on its next restart, and cannot assess accounts, granted privileges, the `mysql.user` table, or the effective value of a dynamic variable.
 
-        Options changed with `SET PERSIST` are written to `mysqld-auto.cnf` in the data directory rather than to an option file. The server applies that file after the option files, so it takes precedence over everything this policy reads. Remediation steps therefore edit the option file directly, which keeps the effective configuration and the audited configuration in agreement. Where an option has already been persisted that way, clear it with `RESET PERSIST <option>` so the option file value takes effect again.
+        Options changed with `SET PERSIST` are written to `mysqld-auto.cnf` in the data directory rather than to an option file. The server applies that file after the option files, so it takes precedence over everything the host-based checks read. Their remediation steps therefore edit the option file directly, which keeps the effective configuration and the audited configuration in agreement. Where an option has already been persisted that way, clear it with `RESET PERSIST <option>` so the option file value takes effect again.
 
-        MariaDB is covered by the Mondoo MariaDB Security policy instead. The underlying resource returns nothing on a host running MariaDB, so the checks here do not apply to those servers.
+        The running-server checks have the opposite trade-off: they see exactly what the server is enforcing, including anything set with `SET PERSIST`, but they only cover state the server exposes over SQL. Scan both an asset's host and its server to get the full picture.
+
+        MariaDB's on-disk configuration is covered by the Mondoo MariaDB Security policy instead. The underlying resource returns nothing on a host running MariaDB, so the host-based checks here do not apply to those servers. The running-server checks read state that MariaDB and Percona expose the same way MySQL does, so they apply to all three.
 
         Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
@@ -110,6 +114,13 @@ policies:
           - uid: mondoo-mysql-security-client-options-no-plaintext-password
           - uid: mondoo-mysql-security-option-files-restricted-permissions
           - uid: mondoo-mysql-security-user-option-files-protected
+      - title: Running Server Configuration
+        filters: asset.platform == "mysqldb"
+        checks:
+          - uid: mondoo-mysql-security-server-require-secure-transport
+          - uid: mondoo-mysql-security-server-accounts-have-passwords
+          - uid: mondoo-mysql-security-server-no-anonymous-accounts
+          - uid: mondoo-mysql-security-server-local-infile-disabled
 queries:
   - uid: mondoo-mysql-security-bind-address-restricted
     title: Ensure bind_address does not expose MySQL on every interface
@@ -4709,3 +4720,268 @@ queries:
                   loop_control:
                     label: "{{ item.path }}"
             ```
+  - uid: mondoo-mysql-security-server-require-secure-transport
+    filters: asset.platform == "mysqldb"
+    title: Ensure the running server requires encrypted client connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      mysqldb.instance.requireSecureTransport == true
+    docs:
+      desc: |-
+        This check ensures that the `require_secure_transport` system variable is `ON`, so the server refuses any unencrypted client connection. When it is `OFF`, a client may negotiate a cleartext session and credentials and query data cross the network unprotected.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, query text, and result sets from network eavesdropping.
+        - **No opportunistic downgrade:** Requiring secure transport at the server prevents a client from falling back to an unencrypted session.
+        - **Compliance:** Many frameworks require encryption of sensitive database traffic in transit.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** Combined with a trusted server certificate, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via the mysql client
+
+        1. Connect with the `mysql` client and read the variable:
+
+           ```sql
+           SHOW GLOBAL VARIABLES LIKE 'require_secure_transport';
+           ```
+
+        If the value is `ON`, the check passes. If it is `OFF`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To require encrypted connections at runtime with the `mysql` client (the server must already have TLS configured with a certificate and key), set the variable persistently:
+
+            ```sql
+            SET PERSIST require_secure_transport = ON;
+            ```
+        - id: config
+          desc: |-
+            To require encrypted connections in the server configuration:
+
+            1. Configure server-side TLS (for example `ssl_cert`, `ssl_key`, and `ssl_ca`) so the server can offer encrypted connections.
+            2. In `my.cnf` under the `[mysqld]` section, set:
+
+               ```ini
+               require_secure_transport=ON
+               ```
+            3. Restart the MySQL server so the setting takes effect.
+    refs:
+      - url: https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html
+        title: MySQL Encrypted Connections
+  - uid: mondoo-mysql-security-server-accounts-have-passwords
+    filters: asset.platform == "mysqldb"
+    title: Ensure every account on the running server has a password or is locked
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      mysqldb.instance.users.all(hasPassword == true || accountLocked == true)
+    docs:
+      desc: |-
+        This check ensures that every account on the server either has a password set or is locked. An unlocked account with an empty authentication string lets anyone who matches its host connect without presenting any credential.
+
+        **Why this matters**
+
+        - **No credential-free logins:** An account with no password and no lock is an open door for any client that can reach the server on the account's host pattern.
+        - **Complete account coverage:** Service and legacy accounts are the ones most likely to be left without a password, and they often carry meaningful privileges.
+        - **Defense in depth:** Locking unused accounts keeps them from being an authentication path even if they are never removed.
+
+        **Risk mitigation**
+
+        - **Credential enforcement:** Every usable account must prove identity with a password.
+        - **Reduced exposure:** Locked accounts cannot be used to connect, shrinking the set of reachable logins.
+      audit: |-
+        ### Audit via the mysql client
+
+        1. Connect with the `mysql` client and list every account with its authentication string and lock state:
+
+           ```sql
+           SELECT user, host, authentication_string, account_locked FROM mysql.user;
+           ```
+
+        If no unlocked account (`account_locked = 'N'`) has an empty `authentication_string`, the check passes. If any unlocked account has an empty `authentication_string`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To fix an account with the `mysql` client, either set a strong password or lock it if it is unused:
+
+            ```sql
+            -- set a password
+            ALTER USER 'u'@'h' IDENTIFIED BY '<strong-password>';
+            -- or lock an account that should not be used
+            ALTER USER 'u'@'h' ACCOUNT LOCK;
+            ```
+        - id: config
+          desc: |-
+            To prevent password-free accounts through configuration and policy:
+
+            1. Document an account-provisioning standard that requires every account to be created with a password or in a locked state.
+            2. Enable the `validate_password` component so new and changed passwords must meet a minimum strength, and set `default_authentication_plugin` to a password-based plugin in `my.cnf`.
+            3. Review the account list on a schedule and lock or remove any account that no longer needs access.
+    refs:
+      - url: https://dev.mysql.com/doc/refman/8.0/en/user-account-management.html
+        title: MySQL User Account Management
+  - uid: mondoo-mysql-security-server-no-anonymous-accounts
+    filters: asset.platform == "mysqldb"
+    title: Ensure the running server has no anonymous accounts
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      mysqldb.instance.users.all(isAnonymous == false)
+    docs:
+      desc: |-
+        This check ensures that no anonymous account (one whose user name is the empty string) exists on the server. Anonymous accounts let unidentified clients connect and are a long-standing MySQL hardening finding, created by some default installations.
+
+        **Why this matters**
+
+        - **No unidentified access:** An anonymous account cannot be tied to a person or service, so any action taken through it is unattributable.
+        - **Precedence surprises:** MySQL account matching can select an anonymous row over a named one, silently granting a connection different privileges than intended.
+        - **Default-install residue:** These accounts are frequently left behind from initial setup and serve no ongoing purpose.
+
+        **Risk mitigation**
+
+        - **Attributable access:** Removing anonymous accounts forces every connection to a named identity.
+        - **Reduced surface:** Eliminating unused default accounts shrinks the set of ways to reach the server.
+      audit: |-
+        ### Audit via the mysql client
+
+        1. Connect with the `mysql` client and look for accounts with an empty user name:
+
+           ```sql
+           SELECT user, host FROM mysql.user WHERE user = '';
+           ```
+
+        If the query returns zero rows, the check passes. If it returns any rows, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To remove anonymous accounts with the `mysql` client, drop each one returned by the audit query (one per host), or run the guided hardening script:
+
+            ```sql
+            DROP USER ''@'localhost';
+            DROP USER ''@'<host>';
+            ```
+
+            Alternatively run `mysql_secure_installation`, which removes anonymous accounts as one of its steps.
+        - id: config
+          desc: |-
+            To keep anonymous accounts from being reintroduced:
+
+            1. Document a provisioning standard that forbids accounts with an empty user name.
+            2. Run `mysql_secure_installation` as part of every new server build so anonymous accounts are removed before the server is put into service.
+            3. Review the account list on a schedule and drop any anonymous account that reappears.
+    refs:
+      - url: https://dev.mysql.com/doc/refman/8.0/en/default-privileges.html
+        title: MySQL Securing the Initial Accounts
+  - uid: mondoo-mysql-security-server-local-infile-disabled
+    filters: asset.platform == "mysqldb"
+    title: Ensure the running server disables LOAD DATA LOCAL INFILE
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-protection
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      mysqldb.instance.localInfile == false
+    docs:
+      desc: |-
+        This check ensures that the `local_infile` system variable is `OFF`, disabling server-side support for `LOAD DATA LOCAL INFILE`. When it is `ON`, a malicious or compromised server (or a SQL injection flaw) can direct a connected client to read files from the client's own file system.
+
+        **Why this matters**
+
+        - **Client file disclosure:** With `LOAD DATA LOCAL` enabled, a rogue or hijacked server can request arbitrary readable files from the client host.
+        - **Injection amplification:** A SQL injection point can be turned into a client-side file read when the capability is available.
+        - **Rarely needed:** Most workloads do not use client-side local loading, so leaving it on keeps a powerful feature exposed for no benefit.
+
+        **Risk mitigation**
+
+        - **Closes a client-side read path:** Disabling the feature removes the mechanism a malicious server would use to exfiltrate client files.
+        - **Least functionality:** Turning off an unused capability shrinks the attack surface of the deployment.
+      audit: |-
+        ### Audit via the mysql client
+
+        1. Connect with the `mysql` client and read the variable:
+
+           ```sql
+           SHOW GLOBAL VARIABLES LIKE 'local_infile';
+           ```
+
+        If the value is `OFF`, the check passes. If it is `ON`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To disable the capability at runtime with the `mysql` client, set the variable persistently:
+
+            ```sql
+            SET PERSIST local_infile = OFF;
+            ```
+        - id: config
+          desc: |-
+            To disable the capability in the server configuration:
+
+            1. In `my.cnf` under the `[mysqld]` section, set:
+
+               ```ini
+               local_infile=OFF
+               ```
+            2. Restart the MySQL server so the setting takes effect.
+    refs:
+      - url: https://dev.mysql.com/doc/refman/8.0/en/load-data-local-security.html
+        title: MySQL LOAD DATA LOCAL Security

--- a/content/mondoo-postgresql-security.mql.yaml
+++ b/content/mondoo-postgresql-security.mql.yaml
@@ -3,33 +3,37 @@
 policies:
   - uid: mondoo-postgresql-security
     name: Mondoo PostgreSQL Security
-    version: 1.0.1
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
-      mondoo.com/platform: linux,postgresql
+      mondoo.com/platform: linux,postgresdb
     require:
       - provider: os
+      - provider: postgresdb
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
     summary: Harden PostgreSQL server transport, host-based authentication, and audit logging
     docs:
       desc: |
-        The Mondoo PostgreSQL Security policy assesses the on-disk configuration of a self-managed PostgreSQL server. It inspects `postgresql.conf` together with the fragments pulled in by its `include`, `include_if_exists`, and `include_dir` directives, plus the `pg_hba.conf` host-based authentication rules and the `pg_ident.conf` identity mappings.
+        The Mondoo PostgreSQL Security policy assesses a self-managed PostgreSQL server from two directions. On a Linux host it inspects the on-disk configuration: `postgresql.conf` together with the fragments pulled in by its `include`, `include_if_exists`, and `include_dir` directives, plus the `pg_hba.conf` host-based authentication rules and the `pg_ident.conf` identity mappings. Against a running server it connects over SQL and reads the effective runtime state from `pg_settings` and `pg_hba_file_rules`.
 
-        This policy provides security checks across four areas:
+        This policy provides security checks across five areas:
 
         - Connection surface and TLS transport settings
         - Host-based authentication rules and identity mapping
         - Audit logging coverage and log file protection
         - Ownership and permissions on the configuration files themselves
+        - The effective settings a running server is enforcing right now
 
         **Scope and limitations**
 
-        This policy reads configuration as it is written to disk. It does not open a SQL connection to the server, so it cannot assess roles, role attributes, object privileges, installed extensions, or the server version. Checks describe the configuration the server would load on its next start or reload.
+        The host-based checks read configuration as it is written to disk. They describe the configuration the server would load on its next start or reload, and cannot assess roles, role attributes, object privileges, installed extensions, or the server version.
 
-        Settings changed with `ALTER SYSTEM` are written to `postgresql.auto.conf` in the data directory rather than to `postgresql.conf`. PostgreSQL applies that file last, so it takes precedence over everything this policy reads. Remediation steps therefore edit `postgresql.conf` directly, which keeps the effective configuration and the audited configuration in agreement. Where a setting has already been overridden with `ALTER SYSTEM`, reset it with `ALTER SYSTEM RESET <parameter>` so the value in `postgresql.conf` takes effect again.
+        Settings changed with `ALTER SYSTEM` are written to `postgresql.auto.conf` in the data directory rather than to `postgresql.conf`. PostgreSQL applies that file last, so it takes precedence over everything the host-based checks read. Their remediation steps therefore edit `postgresql.conf` directly, which keeps the effective configuration and the audited configuration in agreement. Where a setting has already been overridden with `ALTER SYSTEM`, reset it with `ALTER SYSTEM RESET <parameter>` so the value in `postgresql.conf` takes effect again.
+
+        The running-server checks have the opposite trade-off: they see exactly what the server is enforcing, including anything set with `ALTER SYSTEM`, but they only cover settings the server exposes over SQL. Scan both an asset's host and its server to get the full picture.
 
         Learn more about scanning Linux in the [cnspec Linux documentation](https://mondoo.com/docs/cnspec/os/linux).
 
@@ -84,6 +88,13 @@ policies:
           - uid: mondoo-postgresql-security-conf-files-restricted-permissions
           - uid: mondoo-postgresql-security-hba-file-restricted-permissions
           - uid: mondoo-postgresql-security-local-preload-libraries-empty
+      - title: Running Server Configuration
+        filters: asset.platform == "postgresdb"
+        checks:
+          - uid: mondoo-postgresql-security-server-tls-enabled
+          - uid: mondoo-postgresql-security-server-password-encryption-scram
+          - uid: mondoo-postgresql-security-server-hba-no-trust-auth
+          - uid: mondoo-postgresql-security-server-connection-logging
 queries:
   - uid: mondoo-postgresql-security-listen-addresses-restricted
     title: Ensure listen_addresses does not bind PostgreSQL to every interface
@@ -3867,3 +3878,278 @@ queries:
                     name: postgresql
                     state: reloaded
             ```
+  - uid: mondoo-postgresql-security-server-tls-enabled
+    filters: asset.platform == "postgresdb"
+    title: Ensure the running server has TLS enabled for client connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      postgresdb.instance.ssl == true
+    docs:
+      desc: |-
+        This check ensures that the PostgreSQL server has TLS enabled (the `ssl` setting is `on`) so that client connections can be encrypted in transit. Without TLS, credentials and query data cross the network in cleartext.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, query text, and result sets from network eavesdropping.
+        - **Integrity in transit:** It prevents tampering with statements and responses on the wire.
+        - **Compliance:** Many frameworks require encryption of sensitive data in transit for database traffic.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via psql
+
+        1. Connect to the server and read the `ssl` setting:
+
+           ```sql
+           SHOW ssl;
+           ```
+
+        If the value is `on`, the check passes. If it is `off`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To enable TLS using SQL (requires server certificate and key files to be present), then reload:
+
+            ```sql
+            ALTER SYSTEM SET ssl = 'on';
+            SELECT pg_reload_conf();
+            ```
+        - id: config
+          desc: |-
+            To enable TLS in the server configuration:
+
+            1. Provide a server certificate and key (for example `server.crt` and `server.key` in the data directory, readable only by the postgres user).
+            2. In `postgresql.conf`, set:
+
+               ```ini
+               ssl = on
+               ```
+            3. Reload the server (`pg_ctl reload`) or restart it.
+    refs:
+      - url: https://www.postgresql.org/docs/current/ssl-tcp.html
+        title: Secure TCP/IP Connections with TLS
+  - uid: mondoo-postgresql-security-server-password-encryption-scram
+    filters: asset.platform == "postgresdb"
+    title: Ensure the running server stores passwords with SCRAM-SHA-256
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      postgresdb.instance.passwordEncryption == "scram-sha-256"
+    docs:
+      desc: |-
+        This check ensures that the server's `password_encryption` setting is `scram-sha-256` so that role passwords are stored and verified with the SCRAM challenge-response mechanism rather than the legacy `md5` scheme.
+
+        **Why this matters**
+
+        - **Stronger stored secrets:** SCRAM-SHA-256 uses a salted, iterated hash that resists offline cracking far better than unsalted MD5.
+        - **Safer authentication exchange:** SCRAM never sends a reusable password-equivalent hash over the wire, unlike MD5 authentication.
+        - **Modern default:** SCRAM is the current PostgreSQL default; `md5` remains only for backward compatibility.
+
+        **Risk mitigation**
+
+        - **Credential-theft resistance:** A leaked `pg_authid` entry is much harder to reverse into a usable password.
+        - **Replay resistance:** The challenge-response flow prevents captured authentication data from being replayed.
+      audit: |-
+        ### Audit via psql
+
+        1. Read the `password_encryption` setting:
+
+           ```sql
+           SHOW password_encryption;
+           ```
+
+        If the value is `scram-sha-256`, the check passes. If it is `md5` (or another value), the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To switch to SCRAM, set the parameter and reload, then reset each role's password so it is re-hashed with SCRAM:
+
+            ```sql
+            ALTER SYSTEM SET password_encryption = 'scram-sha-256';
+            SELECT pg_reload_conf();
+            -- re-set each role's password so the new hash is stored
+            ALTER ROLE myrole WITH PASSWORD 'new-strong-password';
+            ```
+        - id: config
+          desc: |-
+            To require SCRAM in the server configuration:
+
+            1. In `postgresql.conf`, set:
+
+               ```ini
+               password_encryption = scram-sha-256
+               ```
+            2. Reload the server (`pg_ctl reload`).
+            3. Re-set existing role passwords so they are re-hashed with SCRAM, and update `pg_hba.conf` to use the `scram-sha-256` authentication method.
+    refs:
+      - url: https://www.postgresql.org/docs/current/auth-password.html
+        title: Password Authentication
+  - uid: mondoo-postgresql-security-server-hba-no-trust-auth
+    filters: asset.platform == "postgresdb"
+    title: Ensure the running server has no trust authentication rules
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      postgresdb.instance.hbaRules.all(authMethod != "trust")
+    docs:
+      desc: |-
+        This check ensures that no host-based authentication rule in `pg_hba.conf` uses the `trust` method. The `trust` method lets any client that can reach the server connect as the requested role without presenting a password.
+
+        **Why this matters**
+
+        - **No unauthenticated access:** A `trust` rule means possession of a network path is enough to authenticate, defeating password and certificate controls entirely.
+        - **Blast radius:** A `trust` rule that matches a superuser role hands full control of the cluster to anyone who can open a socket to it.
+        - **Least privilege of authentication:** Every connection should prove identity with a credential (SCRAM, certificate, or an external method).
+
+        **Risk mitigation**
+
+        - **Credential enforcement:** Removing `trust` forces every client to authenticate.
+        - **Reduced exposure:** Combined with tight address rules, this prevents anonymous connections from the network.
+      audit: |-
+        ### Audit via psql
+
+        1. List the active host-based authentication rules and their methods:
+
+           ```sql
+           SELECT type, database, user_name, address, auth_method FROM pg_hba_file_rules;
+           ```
+
+        If no rule uses `trust` as its `auth_method`, the check passes. If any rule uses `trust`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To remove trust authentication:
+
+            1. Edit `pg_hba.conf` and replace every `trust` in the METHOD column with a real authentication method, for example `scram-sha-256` for password logins or `cert` for certificate logins:
+
+               ```conf
+               # before
+               host    all    all    0.0.0.0/0    trust
+               # after
+               hostssl all    all    0.0.0.0/0    scram-sha-256
+               ```
+            2. Reload the server so the new rules take effect:
+
+               ```sql
+               SELECT pg_reload_conf();
+               ```
+    refs:
+      - url: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+        title: The pg_hba.conf File
+  - uid: mondoo-postgresql-security-server-connection-logging
+    filters: asset.platform == "postgresdb"
+    title: Ensure the running server logs connections and disconnections
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      postgresdb.instance.settings.where(name == "log_connections").all(setting == "on")
+      postgresdb.instance.settings.where(name == "log_disconnections").all(setting == "on")
+    docs:
+      desc: |-
+        This check ensures that the server records both successful connections (`log_connections`) and session terminations (`log_disconnections`). Together these produce an audit trail of who connected, when, and for how long.
+
+        **Why this matters**
+
+        - **Attributable access:** Connection records tie database sessions to source addresses and roles, which is essential for investigating misuse.
+        - **Session accounting:** Disconnection records capture session duration, helping detect anomalous long-lived or rapid repeated sessions.
+        - **Compliance evidence:** Audit frameworks require logging of access to systems that hold sensitive data.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** A record of connections narrows down the source and timeline of suspicious activity.
+        - **Deterrence and detection:** Logged access supports alerting on brute-force and off-hours connection attempts.
+      audit: |-
+        ### Audit via psql
+
+        1. Read both settings:
+
+           ```sql
+           SHOW log_connections;
+           SHOW log_disconnections;
+           ```
+
+        If both return `on`, the check passes. If either is `off`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To enable connection and disconnection logging, then reload:
+
+            ```sql
+            ALTER SYSTEM SET log_connections = 'on';
+            ALTER SYSTEM SET log_disconnections = 'on';
+            SELECT pg_reload_conf();
+            ```
+        - id: config
+          desc: |-
+            To enable connection logging in the server configuration:
+
+            1. In `postgresql.conf`, set:
+
+               ```ini
+               log_connections = on
+               log_disconnections = on
+               ```
+            2. Reload the server (`pg_ctl reload`).
+    refs:
+      - url: https://www.postgresql.org/docs/current/runtime-config-logging.html
+        title: Error Reporting and Logging

--- a/content/validation/compliance/owasp_mapping_test.go
+++ b/content/validation/compliance/owasp_mapping_test.go
@@ -165,6 +165,26 @@ var llmAnchoredPolicies = []string{
 	"mondoo-mcp-security.mql.yaml",
 }
 
+// Coverage note (OWASP Top 10 for LLM Applications:2025): some categories have
+// no posture check because no connected provider's API exposes the underlying
+// configuration to assess:
+//   - LLM07 (System Prompt Leakage) and LLM09 (Misinformation) are properties
+//     of prompts and model behavior, not scannable infrastructure posture.
+//   - LLM10 (Unbounded Consumption) has no posture surface today: request
+//     rate-limiting and quotas live at an API gateway, not in the self-hosted
+//     inference servers we model. vLLM's consumption bounds (max-num-seqs,
+//     max-num-batched-tokens) are launch flags that its OpenAI-compatible API
+//     does not expose, so mql cannot read them. Revisit if a connected
+//     provider (e.g. an OpenAI/Anthropic admin API, or a modeled gateway)
+//     starts exposing rate-limit configuration.
+//   - LLM03 (Supply Chain) for Hugging Face is blocked on API surface: the
+//     huggingface.organization resource is token-scoped inventory, and HF
+//     Enterprise org security settings (SSO enforcement, token policy) must be
+//     confirmed to be API-readable before a check can be written.
+//
+// These are deliberate no-coverage cells, not gaps to paper over with a
+// vacuous check.
+
 // TestOwaspLlmTop10Mapping guards the OWASP Top 10 for LLM Applications:2025
 // mapping. Unlike the application Top 10, this framework is targeted: it is
 // applied only to AI/LLM/GenAI checks, so there is no per-policy parity rule.


### PR DESCRIPTION
## What this does

Three existing policies gain checks that read **live server state** through a connected provider, alongside the on-disk configuration they already assess.

### `mondoo-postgresql-security` — addresses @tas50's review

#3150 landed the OS-side PostgreSQL checks. Rather than ship a competing `mondoo-postgres-security` policy, the live-server checks are now a **Running Server Configuration** group in that policy, behind the `postgresdb` provider:

| Check | Reads | Category |
|---|---|---|
| TLS enabled for client connections | `pg_settings` | A04 |
| Passwords stored with SCRAM-SHA-256 | `pg_settings` | A04 |
| No `trust` rule in host-based auth | `pg_hba_file_rules` | A07 |
| Connections and disconnections logged | `pg_settings` | A09 |

The two halves are complementary, and the policy docs now say so: the host-based checks see the configuration the server *would* load on its next reload; the running-server checks see what it *is* enforcing, including anything set with `ALTER SYSTEM` (which lands in `postgresql.auto.conf` and is invisible to the on-disk checks).

### `mondoo-mysql-security`

Same treatment behind `mysqldb`: require secure transport (A04), accounts have a password or are locked (A07), no anonymous accounts (A07), `LOAD DATA LOCAL INFILE` disabled (A02). MariaDB's on-disk configuration stays with the MariaDB policy, but these read state MariaDB and Percona expose the same way MySQL does, so they apply to all three.

### `mondoo-grafana-security`

New **Authentication Security** group: per-user multi-factor enrollment (A07) and SAML single sign-on (A07). The existing policy covered service accounts, datasources, and alerting but had no user-authentication checks.

### Docs

Documents the OWASP Top 10 mapping parity invariant in `content/CLAUDE.md`, and records the deliberate LLM03/07/09/10 no-coverage cells next to the test that guards the mapping.

## Scope

This PR was split out of a larger branch. The 15 new policies that were on it now ship separately:

- 3337 — self-hosted databases (Cassandra, ClickHouse, Elasticsearch, OpenSearch, Redis, MongoDB, SQL Server)
- 3338 — SaaS and cloud platforms (ClickHouse Cloud, Neon, Netlify, Equinix Metal, HCP)
- 3339 — Active Directory, Jamf, Weaviate

Each branches off `main` independently — no stacking.

## Validation

- `cnspec policy lint ./content` — no new findings against a pristine-`main` baseline.
- `go test ./content/validation/...` — passes, including the OWASP parity test.
