### PR TITLE
🧹 k8s testdata: shorten four over-length query titles

### DIFF
--- a/policy/scan/testdata/kubernetes-security.mql.yaml
+++ b/policy/scan/testdata/kubernetes-security.mql.yaml
@@ -327,7 +327,7 @@ queries:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
   - uid: mondoo-kubernetes-security-kubelet-authorization-mode
-    title: Ensure the kubelet is not configured with the AlwaysAllow authorization mode
+    title: Ensure the kubelet does not use AlwaysAllow authorization mode
     impact: 100
     mql: |
       kubelet.configuration['authorization']['mode'] != "AlwaysAllow"
@@ -464,7 +464,7 @@ queries:
         chmod 600 /etc/kubernetes/kubelet.conf
         ```
   - uid: mondoo-kubernetes-security-secure-kubelet-cert-authorities
-    title: Specify a kubelet certificate authorities file and ensure proper ownership and permissions
+    title: Ensure kubelet CA file is configured with proper ownership/perms
     impact: 100
     mql: |
       kubelet.configuration['authentication']['x509']['clientCAFile'] != null
@@ -533,9 +533,7 @@ queries:
         chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml
         ```
   - uid: mondoo-kubernetes-security-secure-etcd-data-dir
-    title: |
-      Set secure directory permissions on the etcd data directory.
-      Otherwise unprivileged users might get access to sensitive data stored in etcd, i.e., Kubernetes Secrets.
+    title: Set secure directory permissions on the etcd data directory
     impact: 60
     mql: |
       if (file("/var/lib/etcd").exists) {
@@ -569,7 +567,9 @@ queries:
         }
       }
     docs:
-      desc: Ensure that the etcd data directory has permissions of `700` and is owned by `etcd:etcd`.
+      desc: |
+        Ensure that the etcd data directory has permissions of `700` and is owned by `etcd:etcd`.
+        Otherwise unprivileged users might get access to sensitive data stored in etcd, i.e., Kubernetes Secrets.
       remediation: |-
         On the etcd server node, get the etcd data directory, passed as an argument `--data-dir`, from the below command:
 
@@ -731,16 +731,16 @@ queries:
       - url: https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security
         title: Controlling Access to the Kubernetes API - Transport security
   - uid: mondoo-kubernetes-security-api-server-no-anonymous-auth
-    title: |
-      Ensure the kube-apiserver does not allow anonymous authentication.
-      When allowed, request will have the privileges of the role `system:public-info-viewer`. This might expose data to an attacker.
+    title: Ensure the kube-apiserver does not allow anonymous authentication
     impact: 100
     mql: |
       processes.where(executable == /kube-apiserver/).list {
         flags["anonymous-auth"] == "false"
       }
     docs:
-      desc: Ensure the kube-apiserver does not allow anonymous authentication.
+      desc: |
+        Ensure the kube-apiserver does not allow anonymous authentication.
+        When allowed, request will have the privileges of the role `system:public-info-viewer`. This might expose data to an attacker.
       remediation: |-
         Find the kube-apiserver process and check the `--anonymous-auth` argument. If the argument is set to `false`, then the kube-apiserver does not allow anonymous authentication:
 


### PR DESCRIPTION
## What

Fixes the four `query-title-too-long` lint warnings in `policy/scan/testdata/kubernetes-security.mql.yaml`.

| Check | Before | After |
|---|---|---|
| `kubelet-authorization-mode` | 76 chars | 62 |
| `secure-kubelet-cert-authorities` | 90 chars | 64 |
| `secure-etcd-data-dir` | 167 chars (block scalar) | 59, tail → `docs.desc` |
| `api-server-no-anonymous-auth` | 194 chars (block scalar) | 65, tail → `docs.desc` |

## Why

Two of these were not long titles at all. They used YAML literal block scalars (`title: |`) containing a title sentence *plus* an explanatory paragraph, which YAML concatenates into one string — hence 167 and 194 characters. That is a schema misuse, not a style nit: the bundle parses fine and the UI would render a paragraph where a title belongs. Those trailing sentences move into `docs.desc`. No explanatory text is lost.

This file is a stale snapshot of the production Kubernetes policy. The equivalent titles in `content/mondoo-kubernetes-security.mql.yaml` were shortened previously and the fixture never followed along, so the new titles are taken verbatim from production to stop the drift.

## Deliberately not changed

`internal/bundle/testdata/fail-query-title-too-long.mql.yaml` also reports this warning, but it is the intentional fixture for the rule — `internal/bundle/lint_test.go` asserts the exact message `Global query 'ubuntu-hard-2-2' title is 83 characters long, exceeding the maximum of 75`. Shortening it would break the test that proves the rule fires.

## Verification

- `cnspec policy lint policy/scan/testdata/kubernetes-security.mql.yaml`: **4 → 0** `query-title-too-long` hits (baseline confirmed by linting the pre-change file from `HEAD`).
- `go test ./internal/bundle/... -run TestLint` — ok, rule fixture intact.
- `go test ./policy/scan/benchmark/ -bench . -benchtime 1x` — PASS. `policy/scan/benchmark/benchmark_test.go` is the only consumer of this fixture.

## Pre-existing issues left alone

The fixture still fails lint overall, unchanged from before this commit: 1 `bundle-global-props-deprecated`, 1 `policy-missing-require`, and 7 `cannot find field or resource 'image'` compile errors on `k8s.container`/`k8s.initContainer` where the snapshot predates a provider schema change. Out of scope here; worth a separate pass to make the fixture lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)