### PR TITLE
🧹 oci: replace deprecated fields in the OCI inventory querypack

### DIFF
--- a/content/querypacks/mondoo-oci-inventory.mql.yaml
+++ b/content/querypacks/mondoo-oci-inventory.mql.yaml
@@ -294,7 +294,7 @@ queries:
     mql: |
       oci.objectStorage.buckets {
         name
-        id
+        ocid
         publicAccessType
         storageTier
         versioning
@@ -330,15 +330,31 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Lists the VCN security lists with their ingress and egress rules and parent VCN.
+        Lists the VCN security lists with their ingress and egress rules and parent VCN. Each rule reports its protocol, source or destination, port range, and whether it is stateless.
     mql: |
       oci.network.securityLists {
         id
         name
         state
         vcn { id }
-        ingressSecurityRules
-        egressSecurityRules
+        ingressRules {
+          protocol
+          source
+          sourceType
+          destinationPortMin
+          destinationPortMax
+          stateless
+          description
+        }
+        egressRules {
+          protocol
+          destination
+          destinationType
+          destinationPortMin
+          destinationPortMax
+          stateless
+          description
+        }
         created
       }
 
@@ -412,15 +428,31 @@ queries:
     filters: asset.platform == "oci"
     docs:
       desc: |
-        Lists the network security groups (NSGs) with their ingress and egress rules.
+        Lists the network security groups (NSGs) with their ingress and egress rules. Each rule reports its protocol, source or destination, port range, and whether it is stateless.
     mql: |
       oci.network.networkSecurityGroups {
         id
         name
         state
         hasStatelessRules
-        ingressSecurityRules
-        egressSecurityRules
+        ingressRules {
+          protocol
+          source
+          sourceType
+          destinationPortMin
+          destinationPortMax
+          stateless
+          description
+        }
+        egressRules {
+          protocol
+          destination
+          destinationType
+          destinationPortMin
+          destinationPortMax
+          stateless
+          description
+        }
         created
       }
 


### PR DESCRIPTION
## What

Clears the five `query-deprecated-symbol` lint warnings in `content/querypacks/mondoo-oci-inventory.mql.yaml`.

| Query | Deprecated | Replacement |
|---|---|---|
| `…-oci-object-storage-buckets` | `oci.objectStorage.bucket.id` | `ocid` |
| `…-oci-network-security-lists` | `securityList.{ingress,egress}SecurityRules` | `{ingress,egress}Rules` |
| `…-oci-network-security-groups` | `networkSecurityGroup.{ingress,egress}SecurityRules` | `{ingress,egress}Rules` |

## Why these aren't cosmetic renames

Per the deprecation notes in `providers/oci/resources/oci.lr` in the mql repo, each replacement changes what the query actually returns:

- **`bucket.id` → `ocid`** — `ListBuckets` returns no OCID, so the deprecated field is **null on the listing path** unless a detail-backed field happened to be resolved first in the same query. That made its presence depend on what else the query selected. `ocid()` resolves from the bucket detail call and reports the same value whichever way the bucket was reached.
- **`*SecurityRules` → `*Rules`** — the deprecated fields are opaque `[]dict` with the port ranges buried inside `tcpOptions.destinationPortRange.{min,max}`. The replacements are typed `oci.network.securityRule` resources that lift those into `destinationPortMin` / `destinationPortMax`, so rules can be selected by port without dict spelunking.

Because the replacements are typed resources rather than dicts, the two rule queries now name the fields they emit. They select protocol, source or destination plus its type, the destination port range, the stateless flag, and the description — richer output than the raw dicts it replaces. Both `desc:` fields were updated to say so.

## Verification

- `cnspec policy lint ./content/querypacks/mondoo-oci-inventory.mql.yaml` → `valid policy bundle(s)`, zero warnings.
- `cnspec policy lint ./content` → `query-deprecated-symbol` count drops **29 → 24**; all five removed are the OCI inventory ones, no other rule changed.
- All replacement fields confirmed present in the installed provider schema (`~/.config/mondoo/providers/oci/oci.resources.json`), which is what lint resolves against.
- `internal/bundle/lint.go:128` mirrors the scan path — it converts querypacks to policies and generates execution jobs — so a clean lint is a real compile of the new field paths, not just a YAML parse.

Not verified against a live OCI tenancy; no credentials for one here. The change is field-path only, and the compile check above covers path validity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)