### PR TITLE
🐛 oci: migrate VCN security list checks to typed rules, fixing a vacuous check

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -1307,8 +1307,8 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.none(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "all"
+      oci.network.securityList.ingressRules.none(
+        source == "0.0.0.0/0" && protocol == "all"
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -1467,9 +1467,9 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['protocol'] == "6"
-      ).none(_['tcpOptions'] == empty)
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && protocol == "6"
+      ).none(destinationPortMin == null)
   - uid: mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -1618,8 +1618,8 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.egressSecurityRules.none(
-        _['destination'] == "0.0.0.0/0" && _['protocol'] == "all"
+      oci.network.securityList.egressRules.none(
+        destination == "0.0.0.0/0" && protocol == "all"
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-protocols-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -2743,9 +2743,9 @@ queries:
   - uid: mondoo-oci-security-vcn-no-stateless-ingress-from-internet-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0"
-      ).none(_['isStateless'] == true)
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0"
+      ).none(stateless == true)
   - uid: mondoo-oci-security-vcn-no-stateless-ingress-from-internet-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -2892,9 +2892,9 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-tcp-ports-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.egressSecurityRules.where(
-        _['destination'] == "0.0.0.0/0" && _['protocol'] == "6"
-      ).none(_['tcpOptions'] == empty)
+      oci.network.securityList.egressRules.where(
+        destination == "0.0.0.0/0" && protocol == "6"
+      ).none(destinationPortMin == null)
   - uid: mondoo-oci-security-vcn-no-unrestricted-egress-all-tcp-ports-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
     mql: |
@@ -7339,10 +7339,10 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-icmp-ingress-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(
-        _['source'] == "0.0.0.0/0" && _['icmpOptions'] == empty
+      oci.network.securityList.ingressRules.where(
+        source == "0.0.0.0/0" && icmpType == null
       ).none(
-        _['protocol'].in(["1", "58", "all"])
+        protocol.in(["1", "58", "all"])
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-icmp-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")
@@ -7505,12 +7505,12 @@ queries:
   - uid: mondoo-oci-security-vcn-no-unrestricted-ipv6-ingress-oci
     filters: asset.platform == "oci-network-securitylist"
     mql: |
-      oci.network.securityList.ingressSecurityRules.where(_['source'] == "::/0").none(
-        _['protocol'] == "all" ||
-        _['protocol'] == "6" && _['tcpOptions'] == empty ||
-        _['protocol'] == "6" && _['tcpOptions']['destinationPortRange']['min'] <= 22 && _['tcpOptions']['destinationPortRange']['max'] >= 22 ||
-        _['protocol'] == "6" && _['tcpOptions']['destinationPortRange']['min'] <= 3389 && _['tcpOptions']['destinationPortRange']['max'] >= 3389 ||
-        _['protocol'] == "17" && _['udpOptions'] == empty
+      oci.network.securityList.ingressRules.where(source == "::/0").none(
+        protocol == "all" ||
+        protocol == "6" && destinationPortMin == null ||
+        protocol == "6" && destinationPortMin <= 22 && destinationPortMax >= 22 ||
+        protocol == "6" && destinationPortMin <= 3389 && destinationPortMax >= 3389 ||
+        protocol == "17" && destinationPortMin == null
       )
   - uid: mondoo-oci-security-vcn-no-unrestricted-ipv6-ingress-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "oci_core_security_list")


### PR DESCRIPTION
## What

Clears the seven `query-deprecated-symbol` warnings on `oci.network.securityList.{ingress,egress}SecurityRules` in `content/mondoo-oci-security.mql.yaml`, by moving the seven `-oci` runtime variants to the typed `{ingress,egress}Rules` replacements. The Terraform HCL/plan/state variants are untouched.

| Check (`-oci` variant) | Change |
|---|---|
| `…-ingress-all-protocols` | field access only |
| `…-egress-all-protocols` | field access only |
| `…-icmp-ingress` | `_['icmpOptions'] == empty` → `icmpType == null` |
| `…-ingress-all-tcp-ports` | `_['tcpOptions'] == empty` → `destinationPortMin == null` ⚠️ |
| `…-egress-all-tcp-ports` | `_['tcpOptions'] == empty` → `destinationPortMin == null` ⚠️ |
| `…-ipv6-ingress` | nested `tcpOptions.destinationPortRange.{min,max}` → `destinationPort{Min,Max}` ⚠️ |
| `…-no-stateless-ingress-from-internet` | `_['isStateless']` → `stateless` ⚠️ **fixes a check that could never fail** |

## ⚠️ This is not a pure rename

Two behavioral changes ride along. Both make checks stricter; neither was optional if the deprecated fields are to go away.

### 1. One check has never been able to fail

`mondoo-oci-security-vcn-no-stateless-ingress-from-internet-oci` read `_['isStateless']`. But the security list ingress dict serializes that key as **`stateless`** — see the struct tag at `providers/oci/resources/network.go:298` in the mql repo. `isStateless` is the *network security group* dict's key (`network.go:844`).

So the field read `null` on every rule, `null == true` is false, and `.none(false)` is unconditionally true. The check passed vacuously on every asset it ever ran against. The typed resource's field is named `stateless`, so the migration fixes this as a side effect, and the check now enforces what its title has always claimed: "Ensure VCN security lists have no stateless rules from internet."

### 2. Port-range tests moved from "block absent" to "range absent"

The old checks asked *is the `tcpOptions`/`udpOptions` block absent?* The new ones ask *is the destination port range absent?* These differ for a rule that has an options block carrying only a `sourcePortRange`: the old form read it as restricted, when it in fact admits every destination port.

`oci.lr` documents the intended handling of the typed field explicitly:

> A null therefore admits more traffic than any explicit range, so treat it as matching when selecting rules by port.

**Consequence:** four of the seven checks can now fail on configurations that previously passed. That is the correct direction — they were under-reporting — but it will surface new findings on unchanged infrastructure. Worth knowing before this lands in a release.

## Verification

- `cnspec policy lint ./content/mondoo-oci-security.mql.yaml` → `valid policy bundle(s)`; deprecation warnings in this file **7 → 0** (baseline measured by linting the `HEAD` copy of the file).
- `cnspec policy lint ./content` → `query-deprecated-symbol` **24 → 17**; the seven removed are exactly this file's, no other file's count moved.
- `go test ./content/ -run TestBundles` — ok (18s).
- `go test -tags iac_variants ./content/ -run TestTerraformVariants` — ok (536s). This suite is behind the `iac_variants` build tag; without `-tags` it silently reports "no tests to run".

**Not verified against a live OCI tenancy** — no credentials for one here, and `content/iac-variant-testdata/mondoo-oci-security/` has fixtures only for the `-terraform-hcl` variants, which this PR does not touch. There is no fixture for the `-oci` runtime variants. The rewrites are verified by compile and by reading the provider's Go source, not by execution. Given change (2) above, a scan against a real tenancy before release would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)