### PR TITLE
🧹 aws: replace deprecated IAM inline-policy fields with inlinePolicyDetails

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -4013,7 +4013,7 @@ queries:
   - uid: mondoo-aws-security-iam-user-no-inline-policies-check-aws
     filters: asset.platform == "aws-iam-user"
     mql: |
-      aws.iam.user.policies == empty
+      aws.iam.user.inlinePolicyDetails == empty
       aws.iam.user.attachedPolicies == empty
   - uid: mondoo-aws-security-iam-user-no-inline-policies-check-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iam_user")
@@ -69797,7 +69797,7 @@ queries:
     mql: |
       aws.transfer.connectors.all(
         accessRole != null &&
-        accessRole.inlinePolicies.length == 0 &&
+        accessRole.inlinePolicyDetails.length == 0 &&
         accessRole.attachedPolicies.all(
           defaultVersion.document['Statement'].all(
             _['Effect'].upcase == "DENY" ||
@@ -71412,7 +71412,7 @@ queries:
       aws.batch.jobDefinition.status != "ACTIVE" ||
       aws.batch.jobDefinition.container == null ||
       aws.batch.jobDefinition.container.jobRole == null ||
-      aws.batch.jobDefinition.container.jobRole.inlinePolicies.length == 0 &&
+      aws.batch.jobDefinition.container.jobRole.inlinePolicyDetails.length == 0 &&
       aws.batch.jobDefinition.container.jobRole.attachedPolicies.all(
         defaultVersion.document['Statement'].all(
           _['Effect'].upcase == "DENY" ||
@@ -71601,7 +71601,7 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.stepfunctions.stateMachines.where(iamRole != null).all(
-        iamRole.inlinePolicies.length == 0 &&
+        iamRole.inlinePolicyDetails.length == 0 &&
         iamRole.attachedPolicies.all(
           defaultVersion.document['Statement'].all(
             _['Effect'].upcase == "DENY" ||
@@ -80221,7 +80221,7 @@ queries:
   - uid: mondoo-aws-security-iam-group-empty-no-policies-aws
     filters: asset.platform == "aws-iam-group"
     mql: |
-      aws.iam.group.usernames != empty || aws.iam.group.attachedPolicies == empty && aws.iam.group.inlinePolicies == empty
+      aws.iam.group.usernames != empty || aws.iam.group.attachedPolicies == empty && aws.iam.group.inlinePolicyDetails == empty
 
 # No Terraform variants: data protection policies are a separate aws_cloudwatch_log_data_protection_policy resource, so asserting every log group has one requires cross-resource correlation this check does not model.
 # No CloudFormation variant: AWS::Logs::LogGroup and the data protection policy are separate template resources, so the same cross-resource correlation would be required.
@@ -81668,7 +81668,7 @@ queries:
     filters: asset.platform == "aws-sagemaker-processingjob"
     mql: |
       aws.sagemaker.processingjob.iamRole == null ||
-      aws.sagemaker.processingjob.iamRole.inlinePolicies.length == 0 &&
+      aws.sagemaker.processingjob.iamRole.inlinePolicyDetails.length == 0 &&
       aws.sagemaker.processingjob.iamRole.attachedPolicies.all(
         defaultVersion.document['Statement'].all(
           _['Effect'].upcase == "DENY" ||


### PR DESCRIPTION
## What

Clears **six of the seven** `query-deprecated-symbol` warnings in `content/mondoo-aws-security.mql.yaml`. The seventh cannot be fixed in this repo — see below.

| Check | Deprecated | Replacement |
|---|---|---|
| `…-iam-user-no-inline-policies-check-aws` | `aws.iam.user.policies` | `inlinePolicyDetails` |
| `…-iam-group-empty-no-policies-aws` | `aws.iam.group.inlinePolicies` | `inlinePolicyDetails` |
| `…-transfer-connector-access-role-no-wildcards-aws` | `aws.iam.role.inlinePolicies` | `inlinePolicyDetails` |
| `…-batch-job-role-no-wildcards-aws` | `aws.iam.role.inlinePolicies` | `inlinePolicyDetails` |
| `…-sfn-role-no-wildcard-resource-aws` | `aws.iam.role.inlinePolicies` | `inlinePolicyDetails` |
| `…-sagemaker-processing-job-role-no-wildcards-aws` | `aws.iam.role.inlinePolicies` | `inlinePolicyDetails` |

The deprecated fields returned `[]string` of inline policy *names*; `inlinePolicyDetails` returns `[]aws.iam.inlinePolicy`, each carrying the policy document and its parsed statements. Every affected check only tested the list for emptiness (`== empty` or `.length == 0`), so **this swap is semantics-preserving** — no check changes verdict.

## The seventh warning is a provider issue, not a content issue

`mondoo-aws-security-ecs-service-not-internet-reachable` is reported as using `aws.ecs.service.clusterArn`, but its MQL never names that field:

```
aws.ecs.clusters.all(services.all(exposure == null || exposure.internetReachable == false))
```

The field enters through the resource's `@defaults("arn name clusterArn status")` in `providers/aws/resources/aws.lr`, and `mqlc.AnalyzeQuery` — which `lintDeprecatedSymbols` calls — counts default fields as usage.

I confirmed this with probe bundles rather than assuming. Every query that touches `aws.ecs.service` warns, regardless of shape:

| Probe query | Warns? |
|---|---|
| `aws.ecs.clusters.all(name != "")` (never touches the resource) | **no** |
| `aws.ecs.clusters.all(services.length >= 0)` (selects no fields) | yes |
| `aws.ecs.clusters.all(services.all(name != ""))` (explicit field) | yes |
| `…services.where(…).length == 0` (no per-entry defaults) | yes |

So no rewrite of the check clears it. The fix is to drop `clusterArn` from that `@defaults` list in the **mql** repo. I left this check untouched rather than contorting its MQL for no benefit.

## A follow-up worth considering (not done here)

Four of these checks gate on `inlinePolicies.length == 0` — "the role has no inline policy at all" — as a proxy for "no wildcard grants", which is what their UIDs and titles claim. `aws.iam.inlinePolicy` exposes `hasWildcardAllow()`, so they could instead assert `inlinePolicyDetails.all(hasWildcardAllow == false)` and stop failing roles that carry a properly scoped inline policy.

I deliberately did **not** make that change: it loosens the checks, which is out of scope for a deprecation cleanup and shouldn't ride along silently. Happy to do it as a separate PR.

## Verification

- `cnspec policy lint ./content/mondoo-aws-security.mql.yaml` → `valid policy bundle(s)`; deprecation warnings in this file **7 → 1** (the ECS `@defaults` one).
- `cnspec policy lint ./content` → `query-deprecated-symbol` **24 → 18**; only this file's count moved.
- `go test ./content/ -run TestBundles` — ok (5.7s).
- `go test -tags iac_variants -run 'TestTerraformVariants|TestCloudFormationVariants'` — **hit Go's default 10-minute timeout** at 601s (goroutines parked in `waitParallel`, zero `--- FAIL` assertion lines), so it did not complete. Re-running with `-timeout 40m`; result to follow in a comment. This suite exercises the Terraform/CloudFormation variants, none of which this PR touches — only `-aws` runtime variants changed.

No live AWS account was used; the changes are verified by compile plus the field contracts in `aws.lr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
