### PR TITLE
🐛 content: restore OWASP Top 10:2025 mapping parity, fixing red main

### DIFF
--- a/content/mondoo-alibaba-security.mql.yaml
+++ b/content/mondoo-alibaba-security.mql.yaml
@@ -2285,6 +2285,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-171: false
       compliance/nist-sp-800-53-rev5: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -7608,6 +7608,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: false
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -30716,6 +30717,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-20
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a08
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -30850,6 +30852,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-17
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -30991,6 +30994,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-8
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-5-4-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -56942,6 +56946,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-1-4-2
       compliance/soc2-2017: soc2-control-cc6-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -58986,6 +58991,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -79115,6 +79121,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
@@ -79266,6 +79273,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
@@ -85453,6 +85461,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-2-1
@@ -85595,6 +85604,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
@@ -85757,6 +85767,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
@@ -85892,6 +85903,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -31765,6 +31765,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -49775,6 +49776,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -14247,6 +14247,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -25201,6 +25202,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -1797,6 +1797,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a03
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -1861,6 +1862,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -1923,6 +1925,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -1475,6 +1475,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -1555,6 +1556,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -1632,6 +1634,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: false
       compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false


### PR DESCRIPTION
## The failure is on `main`, not on any one PR

`TestOwaspTop10Mapping` has failed on `main` since **`9210f7d2` (#3242)** — the commit that introduced both the OWASP mapping and the test that guards it. `Code Test` runs on main:

| commit | result |
|---|---|
| `0a94e306` #3246 | failure |
| `9210f7d2` #3242 | failure |
| `7afaf309` #3241 | success |

Every open PR inherits this red build, which is why it shows up on unrelated deprecation-cleanup PRs.

## Cause

The test enforces **parity**: a policy that participates in OWASP mapping must map *every* framework-mapped check in that policy, where "framework-mapped" means the check carries a `compliance/pci-dss-4:` key (regardless of its value). 23 checks across six policies were merged without a `compliance/owasp-top-10-2025:` tag — mostly checks added around the same time as #3242.

This PR adds the missing tag to those 23 checks. **No check logic changes; tags only.**

## How the categories were chosen

Per `content/CLAUDE.md`, compliance tags must never be copied from an adjacent check — a neighbor is mapped for a different control objective. Instead I derived each assignment from **in-repo precedent for structurally identical checks**, by building a UID→category index over all 2,785 existing mappings:

| Category | n | Basis |
|---|---|---|
| `a01` | 10 | imdsv2 (6/6 existing), `*-not-internet-reachable` (4/4), wildcard grants (16/17), role-not-admin (8/8), `*-not-public` (40/40), unrestricted ingress (6/6), Vercel authorization checks |
| `a02` | 3 | privileged/rootless containers (15/19); Route 53 DMARC + CAA, matching the DNS-record hardening family (`mondoo-email-security-dmarc` → a02) |
| `a03` | 1 | SKE support window, matching the supported-version / end-of-support family (6/6) |
| `a04` | 3 | CMK encryption (7/7), KMS key rotation; Vercel plaintext env vars, matching its same-file sibling `project-no-plaintext-env-vars` |
| `a07` | 4 | managed identity (6/6), federated identity; Vercel deployment-protection bypass |
| `a08` | 1 | Route 53 DNSSEC key signing keys, matching same-file `route53-dnssec-enabled` |
| `false` | 1 | `rds-instance-no-active-security-recommendation` |

Two calls worth flagging for review:

- **`mondoo-aws-security-rds-instance-no-active-security-recommendation` → `false`.** It rolls up heterogeneous AWS advisories that don't share one category, and *every other framework tag on that check is already `false`*. The test's value regex accepts `false`, and `content/CLAUDE.md` is explicit that an honest gap beats a wrong compliance claim.
- **`mondoo-vercel-security-project-aliases-no-protection-bypass` → `a07`, not `a01`.** Genuinely close to the a01/a07 line. Its own `desc` settles it: a bypass secret means a request "skips authentication entirely", and the same file maps the gate itself (`project-password-protection-enabled`) to a07.

The three application-only categories (`a05` Injection, `a06` Insecure Design, `a10` Mishandling of Exceptional Conditions) are rejected by the test and are not used.

## Verification

- `go test ./content/compliance/` — **ok** (was 7 failing subtests / 23 assertions).
- `go test ./content/...` — ok.
- `cnspec policy lint ./content` → `valid policy bundle(s)`; no new lint warnings.

`go test ./...` locally also shows `TestNextAvailableFilename` (timestamp collision on a fast machine) and `TestScanFlags/github_scan_WITHOUT_flags` (needs GitHub credentials) failing. Both are local-environment artifacts, unrelated to this change — neither appears in CI's failure list, which was 7 `TestOwaspTop10Mapping` subtests and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
