### PR TITLE
🧹 arista: migrate BGP peer route-map checks off deprecated fields

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -2645,7 +2645,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       arista.eos.bgp.vrfs.all(
-        peers.all(inboundRouteMap != "")
+        peers.all(inboundPolicy != empty)
       )
     docs:
       desc: |
@@ -2668,8 +2668,9 @@ queries:
         1. Connect to the switch and enter privileged EXEC mode.
         2. Run `show running-config section router bgp` to display the BGP configuration.
         3. Confirm every `neighbor` has a `route-map ... in` statement applied.
+        4. Run `show route-map <name>` for each referenced route map to confirm it is defined on the device.
 
-        If every BGP peer has an inbound route map applied, the check passes. If any peer has no inbound route map, the check fails.
+        If every BGP peer applies an inbound route map that exists on the device, the check passes. If any peer has no inbound route map, or names one that is not defined, the check fails. A neighbor that references an undefined route map accepts everything the peer announces, so it is treated the same as having no filter at all.
       remediation:
         - id: cli
           desc: |
@@ -2718,7 +2719,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       arista.eos.bgp.vrfs.all(
-        peers.all(outboundRouteMap != "")
+        peers.all(outboundPolicy != empty)
       )
     docs:
       desc: |
@@ -2741,8 +2742,9 @@ queries:
         1. Connect to the switch and enter privileged EXEC mode.
         2. Run `show running-config section router bgp` to display the BGP configuration.
         3. Confirm every `neighbor` has a `route-map ... out` statement applied.
+        4. Run `show route-map <name>` for each referenced route map to confirm it is defined on the device.
 
-        If every BGP peer has an outbound route map applied, the check passes. If any peer has no outbound route map, the check fails.
+        If every BGP peer applies an outbound route map that exists on the device, the check passes. If any peer has no outbound route map, or names one that is not defined, the check fails. A neighbor that references an undefined route map advertises whatever the router would otherwise announce, so it is treated the same as having no filter at all.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
## What

`cnspec policy lint` reported two `query-deprecated-symbol` warnings in `mondoo-arista-eos-security.mql.yaml`:

```
2627  query 'mondoo-arista-eos-security-bgp-peers-inbound-route-map'  uses deprecated field 'arista.eos.bgp.peer.inboundRouteMap'
2700  query 'mondoo-arista-eos-security-bgp-peers-outbound-route-map' uses deprecated field 'arista.eos.bgp.peer.outboundRouteMap'
```

Both fields are deprecated upstream in favor of `inboundPolicy` / `outboundPolicy`, which resolve the configured name to the `arista.eos.routeMap` resource so its clauses can be inspected.

```diff
-peers.all(inboundRouteMap != "")
+peers.all(inboundPolicy != empty)

-peers.all(outboundRouteMap != "")
+peers.all(outboundPolicy != empty)
```

## Why this is more than a rename

The name-based form passed as long as a `route-map ... in` statement was present on the neighbor, regardless of whether that name matched a route map actually defined on the device. Per the upstream field docs, a name that resolves to nothing has the same effect as no policy at all: the peer's announcements are accepted unfiltered.

`inboundPolicy` / `outboundPolicy` are null in exactly that case, so `!= empty` now fails a neighbor pointing at an undefined route map. This closes a false pass rather than changing what the check is meant to assert.

Audit steps in both checks gained a step to confirm the referenced route map exists, and the pass/fail wording now spells out the undefined-route-map case.

## Verification

```
$ cnspec policy lint content/mondoo-arista-eos-security.mql.yaml
→ valid policy bundle(s)
```

No remaining deprecation warnings for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)