### PR TITLE
🧹 azure: migrate Front Door WAF check off deprecated wafPolicyId

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -44905,7 +44905,7 @@ queries:
     filters: |
       asset.platform == "azure"
     mql: |
-      azure.subscription.frontDoor.profiles.all(securityPolicies.where(policyType == "WebApplicationFirewall" && wafPolicyId != "").length > 0)
+      azure.subscription.frontDoor.profiles.all(securityPolicies.where(policyType == "WebApplicationFirewall" && wafPolicy != empty).length > 0)
   - uid: mondoo-azure-security-frontdoor-waf-policy-attached-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_cdn_frontdoor_profile")
     mql: |


### PR DESCRIPTION
## What

`cnspec policy lint` reported:

```
44904  query 'mondoo-azure-security-frontdoor-waf-policy-attached-azure'
       uses deprecated field 'azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId'
```

```diff
-azure.subscription.frontDoor.profiles.all(securityPolicies.where(policyType == "WebApplicationFirewall" && wafPolicyId != "").length > 0)
+azure.subscription.frontDoor.profiles.all(securityPolicies.where(policyType == "WebApplicationFirewall" && wafPolicy != empty).length > 0)
```

`wafPolicy` resolves the same association to the `azure.subscription.frontDoorService.wafPolicy` resource, which additionally exposes the policy's mode, managed rule sets, and custom rules.

Beyond the rename, this tightens the check: `wafPolicyId != ""` passed on any non-empty ARM resource ID, including one referencing a policy that no longer exists. `wafPolicy` is null in that case, so `!= empty` now fails it.

## Needs mondoohq/mql#9831 to fully clear the warning

The content change alone does **not** silence the lint. The resource declares:

```
private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id name policyType wafPolicyId") {
```

`@defaults` fields are compiled into every query that materializes the resource, so the deprecated field is fetched regardless of what the query references. Verified with a query that never mentions it:

```yaml
mql: azure.subscription.frontDoor.profiles.all(securityPolicies.length > 0)
```

still reports `uses deprecated field '...securityPolicy.wafPolicyId'`.

mondoohq/mql#9831 removes it from `@defaults`. Both changes are required, and each was confirmed insufficient alone:

| content | provider | lint |
|---|---|---|
| old | old | warning |
| new | old | warning |
| old | new | warning |
| new | new | clean |

## Verification

With mondoohq/mql#9831 built and installed locally:

```
$ cnspec policy lint content/mondoo-azure-security.mql.yaml
→ valid policy bundle(s)
```

Until that provider change ships, this branch's lint still reports the warning; merging it is what makes the warning fixable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)