### PR TITLE
🧹 gcp: migrate firewall checks off deprecated allowed dicts

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -8310,8 +8310,8 @@ queries:
       gcp.compute.firewall.direction == "INGRESS"
       gcp.compute.firewall.sourceRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(ipProtocol == "all")
-      gcp.compute.firewall.allowed.all(_['ports'] != empty && _['ports'].length > 0)
+      gcp.compute.firewall.allowedProtocols.keys.none(_ == "all")
+      gcp.compute.firewall.allowedProtocols.values.all(_ != empty)
   - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -23343,8 +23343,8 @@ queries:
       gcp.compute.firewall.direction == "EGRESS"
       gcp.compute.firewall.destinationRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(ipProtocol == "all")
-      gcp.compute.firewall.allowed.where(ipProtocol != "icmp").all(_['ports'] != empty && _['ports'].length > 0)
+      gcp.compute.firewall.allowedProtocols.keys.none(_ == "all")
+      gcp.compute.firewall.allowedProtocols.where(key != "icmp").values.all(_ != empty)
   - uid: mondoo-gcp-security-firewall-no-egress-all-ports-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -25141,7 +25141,7 @@ queries:
       gcp.compute.firewall.direction == "INGRESS"
       gcp.compute.firewall.sourceRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(_['ports'].any(_ == /^\d{1,4}-6553[0-5]$/))
+      gcp.compute.firewall.allowedProtocols.values.flat.none(_ == /^\d{1,4}-6553[0-5]$/)
 
   - uid: mondoo-gcp-security-firewall-no-large-port-range-terraform-hcl
     filters: |


### PR DESCRIPTION
## What

`cnspec policy lint` reported three `query-deprecated-symbol` warnings on `gcp.project.computeService.firewall.allowed`:

```
8307   mondoo-gcp-security-firewall-no-overly-permissive-ingress-gcp
23340  mondoo-gcp-security-firewall-no-egress-all-ports-gcp
25138  mondoo-gcp-security-firewall-no-large-port-range-gcp
```

`allowed` is a `[]dict` of `{ipProtocol, ports}` entries; the replacement `allowedProtocols` is a `map[string][]string` keyed by protocol. An empty port list means every port of that protocol, which is also the only form portless protocols such as icmp take.

| before | after |
|---|---|
| `allowed.none(ipProtocol == "all")` | `allowedProtocols.keys.none(_ == "all")` |
| `allowed.all(_['ports'] != empty && _['ports'].length > 0)` | `allowedProtocols.values.all(_ != empty)` |
| `allowed.where(ipProtocol != "icmp").all(…)` | `allowedProtocols.where(key != "icmp").values.all(_ != empty)` |
| `allowed.none(_['ports'].any(_ == /regex/))` | `allowedProtocols.values.flat.none(_ == /regex/)` |

The `_['ports'].length > 0` half of the port assertions is dropped: a map value is always a list, so `_ != empty` alone says "this protocol is not open on every port".

## Verification

Lint is clean:

```
$ cnspec policy lint content/mondoo-gcp-security.mql.yaml
→ valid policy bundle(s)
```

Because the shape change is more than a rename, each operation was also run against literal fixtures rather than trusting that it compiles:

| fixture | `keys.none('all')` | `values.all(!= empty)` | `where(key != 'icmp')…` | `values.flat.none(/range/)` |
|---|---|---|---|---|
| `{"tcp":[],"udp":["80","443"],"icmp":[]}` | ok | **failed** | **failed** | ok |
| `{"tcp":["22","8000-8080"],"udp":["53"]}` | ok | ok | ok | ok |
| `{"all":["22"]}` | **failed** | ok | ok | ok |
| `{"tcp":["1-65535"]}` | ok | ok | ok | **failed** |
| `{"icmp":[],"tcp":["22"]}` | ok | **failed** | ok | ok |
| `{}` | ok | ok | ok | ok |

The fifth row is the discriminating case for the icmp exclusion: a portless icmp entry fails the ingress form and passes the egress form, matching what the original `where(ipProtocol != "icmp")` did. The empty map passes everything vacuously, same as an empty `allowed` list did.

## Follow-up: 7 more usages the lint cannot see

`lintDeprecatedSymbols` only analyzes a query's `mql:` — `walkQueryForDeprecatedSymbols` returns early on `q.Mql == ""` and never inspects `filters:`. This file has 7 further uses of the deprecated `allowed` field inside `filters:` blocks (lines 7640, 7810, 7978, 8144, 23176), none of them reported.

They are deliberately **not** touched here. The map form needs a `keys.contains("tcp")` presence guard to stay correct, because `allowedProtocols['tcp'] == empty` is also true when tcp is absent, and a filter that is subtly wrong silently drops assets from scoring instead of failing loudly. That deserves its own PR with its own fixtures. Happy to take it next, and the lint gap is worth fixing separately so these surface on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)