### PR TITLE
🧹 email: migrate PTR lookups off deprecated dns.reverse

### DIFF
--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -99,7 +99,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
+      dns.reverseRecords.any(rdata.any(_.contains(domainName.fqdn)))
     docs:
       desc: |
         A reverse DNS PTR record maps the sending mail server's IP address back to a fully qualified domain name within your domain. Reverse DNS queries for IPv4 addresses use the special domain `in-addr.arpa`, where the IPv4 address is represented in reverse octet order followed by the `.in-addr.arpa` suffix. When the PTR record resolves to a hostname whose forward A record points back to the original IP address, the domain is in a forward-confirmed reverse DNS state, which receiving mail servers treat as a reliable signal that the sender is legitimate.

--- a/content/querypacks/mondoo-email-inventory.mql.yaml
+++ b/content/querypacks/mondoo-email-inventory.mql.yaml
@@ -31,7 +31,7 @@ packs:
         docs:
           desc: Resolves the domain's IP address back to its PTR record via reverse DNS.
         mql: |
-          dns.reverse
+          dns.reverseRecords
       - uid: mondoo-email-inventory-spf-record
         title: Retrieve SPF record
         docs:


### PR DESCRIPTION
## What

`cnspec policy lint` reported two `query-deprecated-symbol` warnings on `dns.reverse`:

```
mondoo-email-inventory.mql.yaml  29  query 'mondoo-email-inventory-mail-records'
mondoo-email-security.mql.yaml   83  query 'mondoo-email-security-reverse-ip-ptr-record-set'
```

```diff
-dns.reverse
+dns.reverseRecords

-dns.reverse.any(rdata.any(_.contains(domainName.fqdn)))
+dns.reverseRecords.any(rdata.any(_.contains(domainName.fqdn)))
```

## Why the upstream field was deprecated

Both fields return the same PTR records. They differ in how they get the addresses:

- `reverse(params)` depends on `params`, which queries **every** DNS record type.
- `reverseRecords(fqdn)` depends on `fqdn`, so it issues two address queries instead of a full record-type sweep.

Per the upstream field docs, the `params` dependency is affordable once for the scanned asset but too expensive to instantiate per element of a list: resolvers rate-limit at that volume and PTR lookups then come back empty, which is **indistinguishable from a missing PTR record**. Both call sites here are single-asset lookups, so this is a straight swap onto the cheaper path.

## Verification

```
$ cnspec policy lint content/mondoo-email-security.mql.yaml content/querypacks/mondoo-email-inventory.mql.yaml
→ valid policy bundle(s)
```

Ran the check expression both ways against live domains to confirm the swap does not change the verdict, covering a failing and a passing case rather than only one:

| target | `dns.reverse…` | `dns.reverseRecords…` |
|---|---|---|
| `google.com` (PTRs resolve to `1e100.net`) | failed | failed |
| `one.one.one.one` (forward-confirmed) | ok | ok |

`dns.reverseRecords` on `google.com` returns the expected 10 `in-addr.arpa` / `ip6.arpa` PTR records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)