### PR TITLE
🧹 ci: update content validation dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -83,4 +83,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/policies_lint.yaml
+++ b/.github/workflows/policies_lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Display SARIF file content
         run: jq . results.sarif
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
       - name: Check SARIF for errors

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
+      - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -85,8 +85,8 @@ jobs:
         # registry. Bump GLAB_VERSION and GLAB_SHA256 in lockstep when
         # GitLab ships new commands or flags.
         env:
-          GLAB_VERSION: "1.112.0"
-          GLAB_SHA256: "f1c52907558b665f2032b615787d353cd06e54240b501a81f9489bfc8f6a8ebf"
+          GLAB_VERSION: "1.113.0"
+          GLAB_SHA256: "c265589fb2018f310b6a27df9356efee42991f858e7e3a5fa232228a13b47467"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/${GLAB_VERSION}/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
@@ -123,8 +123,8 @@ jobs:
         # `databricks_cli_<version>_SHA256SUMS` file. No auth needed for the
         # `__complete` / `--help` introspection the validator performs.
         env:
-          DATABRICKS_VERSION: "1.11.0"
-          DATABRICKS_SHA256: "bddad9e2d830dd7ea00292203c00088f3efe6f940f1ecdad59a3dc25bc28bca9"
+          DATABRICKS_VERSION: "1.12.1"
+          DATABRICKS_SHA256: "60833feee22caa98f575c4948ccbbc9473fda0dd80c9b79544dc7b079f6a9815"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/databricks/cli/releases/download/v${DATABRICKS_VERSION}/databricks_cli_${DATABRICKS_VERSION}_linux_amd64.zip" \
@@ -183,7 +183,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install ansible-lint
-        run: pipx install ansible-lint==26.6.0
+        run: pipx install ansible-lint==26.8.0
 
       - name: Validate ansible remediation blocks
         run: python3 content/validation/validate_ansible_remediation.py --github-actions

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -33,7 +33,7 @@ jobs:
           args: "--exclude **/iac-variant-testdata/**"
       - name: Upload SARIF results
         if: always()
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
           category: xgrep


### PR DESCRIPTION
Refreshes the pinned tooling used by the content validation workflows to the current upstream releases.

## Updated

| Dependency | Workflow | From | To |
|---|---|---|---|
| `github/codeql-action` | `policies_lint.yaml`, `xgrep.yaml`, `codeql.yml` | v4.37.4 | v4.37.7 |
| `crate-ci/typos` | `spell-check.yaml` | v1.48.0 | v1.49.0 |
| `glab` | `validate-remediation.yaml` | 1.112.0 | 1.113.0 |
| `databricks` CLI | `validate-remediation.yaml` | 1.11.0 | 1.12.1 |
| `ansible-lint` | `validate-remediation.yaml` | 26.6.0 | 26.8.0 |

`codeql.yml` isn't a content workflow, but it shares the same pinned SHA as the two SARIF uploads — bumping only some occurrences would leave the repo on two different codeql-action versions, so all four moved together.

## Already current, unchanged

`actions/checkout` v7.0.1, `actions/setup-python` v7.0.0, `actions/setup-go` v7.0.0, `actions/cache` v6.1.0, `mondoohq/actions` v13.3.0, `terraform-linters/setup-tflint` v6.3.0, `tflint` v0.64.0, `doctl` 1.166.0, `hcloud` 1.67.0. `oci-cli` is installed via `pip install --upgrade` and always resolves to the latest.

## Verification

- Every release-artifact SHA-256 was recomputed from the downloaded tarball/zip rather than trusted from a checksum file alone.
- Action pins resolve to commit SHAs, not annotated-tag object SHAs.
- The two bumps that can change validation outcomes were run against `content/` locally: `ansible-lint` 26.8.0 passes `validate_ansible_remediation.py` (exit 0) and `typos` 1.49.0 reports no findings.
- All workflow YAML re-parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)