### PR TITLE
🧹 aws: migrate IAM incident-response query off deprecated user.policies

### DIFF
--- a/content/querypacks/mondoo-aws-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-aws-incident-response.mql.yaml
@@ -154,7 +154,7 @@ queries:
       aws.iam.user {
         arn
         name
-        policies
+        inlinePolicyDetails
         id
         tags
         attachedPolicies


### PR DESCRIPTION
## What

Clears the `query-deprecated-symbol` lint warning in `content/querypacks/mondoo-aws-incident-response.mql.yaml`:

```
 RULE ID                  LEVEL    FILE                                   LINE  MESSAGE
 query-deprecated-symbol  warning  mondoo-aws-incident-response.mql.yaml  142   query 'mondoo-incident-response-aws-iam-administrator-access-user' uses deprecated field 'aws.iam.user.policies'
```

`aws.iam.user.policies` is marked `@maturity("deprecated")` in the AWS provider (`providers/aws/resources/aws.lr`) in favor of `inlinePolicyDetails`, which resolves each inline policy to an `aws.iam.inlinePolicy` carrying the policy document and its parsed statements.

## Change

One field swap in `mondoo-incident-response-aws-iam-administrator-access-user`:

```diff
       aws.iam.user {
         arn
         name
-        policies
+        inlinePolicyDetails
         id
```

This is a data-collection querypack, so nothing is scored and no verdicts change. `aws.iam.inlinePolicy` declares `@defaults("name entityType entityName")`, so the inline policy names the old `[]string` field returned are still collected, now alongside the owning entity and a reachable policy document.

It was the only use of the deprecated field in the file; `aws.iam.policies` at line 193 is the non-deprecated account-level collection and is untouched.

## Verification

Before, on `main`:

```
$ cnspec policy lint content/querypacks/mondoo-aws-incident-response.mql.yaml
 RULE ID                  LEVEL    FILE                                   LINE  MESSAGE
 query-deprecated-symbol  warning  mondoo-aws-incident-response.mql.yaml  142   query '...-user' uses deprecated field 'aws.iam.user.policies'
→ valid policy bundle(s)
```

After, on this branch:

```
$ cnspec policy lint content/querypacks/mondoo-aws-incident-response.mql.yaml
→ lint policy bundle(s) files=["content/querypacks/mondoo-aws-incident-response.mql.yaml"]
→ valid policy bundle(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)