### PR TITLE
✨ freebsd/windows: add Chef Infra remediations

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -45,8 +45,10 @@ policies:
   - **AWS**: `console`, `cli`, `terraform`, `cloudformation`
   - **Azure**: `portal`, `cli`, `terraform`, `bicep` (Azure uses `portal` — the product name for the Azure web UI — instead of the generic `console` used by other clouds)
   - **GCP / OCI / DigitalOcean / Cloudflare / Hetzner / other clouds**: `console`, `cli`, `terraform`
-  - **Windows / macOS**: `gui`, `cli`, `ansible`, and `script` (PowerShell on Windows, bash on macOS)
-  - **Linux**: `cli`, `script` (bash), `ansible`. In `mondoo-linux-security` also `chef` — a Chef Infra recipe, matching the `chef` entries in the two Chef Infra policies.
+  - **Windows / macOS**: `gui`, `cli`, `ansible`, and `script` (PowerShell on Windows, bash on macOS). In `mondoo-windows-security` also `chef`.
+  - **Linux / FreeBSD**: `cli`, `script` (bash or sh), `ansible`. In `mondoo-linux-security` and `mondoo-freebsd-security` also `chef`.
+
+  A `chef` entry is a Chef Infra recipe, matching the `chef` entries in the two Chef Infra policies. Add one wherever Chef Infra Client runs on the asset and the fix is a change to state on that host. Prefer a purpose-built resource over a shell-out: `registry_key`, `windows_security_policy`, `windows_audit_policy`, and `windows_user_privilege` cover almost all of the Windows policy; `sysctl`, `kernel_module`, `systemd_unit`, `user_ulimit`, and `sudo` cover most of the Linux one. On FreeBSD the `sysctl` resource writes `/etc/sysctl.d`, which the base system does not read, so kernel parameters go into `/etc/sysctl.conf` instead; the `service` provider there edits `/etc/rc.conf` directly, making `action :disable` the `sysrc` equivalent.
   - **Kubernetes**: `kubectl`, `manifest` (YAML), and where applicable `helm`
   - **Microsoft 365** (`mondoo-m365-security`): `console`, `powershell`, and `terraform` where a real resource exists.
     - `console` — the relevant Microsoft admin center (Microsoft Entra, Microsoft 365, Microsoft Defender, Exchange, SharePoint, or Intune). Always applies.

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.0.4
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -222,6 +222,42 @@ queries:
                 sysctl_file: /etc/sysctl.conf
                 reload: true
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to enable address space layout randomization:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'kern.elf64.aslr.enable' => '1' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-core-dump-backtraces-are-disabled
     title: Ensure core dump backtraces are disabled
     impact: 75
@@ -305,6 +341,18 @@ queries:
                 name: savecore
                 state: stopped
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable `savecore`. The FreeBSD service provider derives the `savecore_enable` rc variable from the rc script and clears it in `/etc/rc.conf`:
+
+            ```ruby
+            service 'savecore' do
+              action :disable
+              only_if { ::File.exist?('/etc/rc.d/savecore') }
+            end
+            ```
   - uid: mondoo-freebsd-security-core-dump-storage-is-disabled
     title: Ensure core dump storage is disabled
     impact: 75
@@ -378,6 +426,18 @@ queries:
               community.general.sysrc:
                 name: dumpdev
                 value: 'NO'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop the kernel from writing a crash dump device:
+
+            ```ruby
+            execute 'set dumpdev in rc.conf' do
+              command 'sysrc dumpdev=NO'
+              not_if 'sysrc -n dumpdev | grep -qx NO'
+            end
             ```
   - uid: mondoo-freebsd-security-ip-forwarding-is-disabled
     title: Ensure IP forwarding is disabled
@@ -480,6 +540,42 @@ queries:
                 - net.inet.ip.forwarding
                 - net.inet6.ip6.forwarding
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable IP forwarding. Skip this on hosts that route traffic, such as gateways and jail hosts:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.ip.forwarding' => '0', 'net.inet6.ip6.forwarding' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-packet-redirect-sending-is-disabled
     title: Ensure packet redirect sending is disabled
     impact: 75
@@ -580,6 +676,42 @@ queries:
               loop:
                 - net.inet.ip.redirect
                 - net.inet6.ip6.redirect
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop the host from sending ICMP redirects:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.ip.redirect' => '0', 'net.inet6.ip6.redirect' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-icmp-redirects-are-not-accepted
     title: Ensure ICMP redirects are not accepted
@@ -682,6 +814,42 @@ queries:
                 - { name: net.inet.icmp.drop_redirect, value: '1' }
                 - { name: net.inet6.icmp6.rediraccept, value: '0' }
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to drop incoming ICMP redirects:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.icmp.drop_redirect' => '1', 'net.inet6.icmp6.rediraccept' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-source-routed-packets-are-not-accepted
     title: Ensure source routed packets are not accepted
     impact: 75
@@ -771,6 +939,42 @@ queries:
                 value: '0'
                 sysctl_file: /etc/sysctl.conf
                 reload: true
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to reject source routed packets:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.ip.accept_sourceroute' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-tcp-syn-cookies-is-enabled
     title: Ensure TCP SYN cookies are enabled
@@ -862,6 +1066,42 @@ queries:
                 sysctl_file: /etc/sysctl.conf
                 reload: true
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to enable TCP SYN cookies:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.tcp.syncookies' => '1' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ipv6-router-advertisements-are-not-accepted
     title: Ensure IPv6 router advertisements are not accepted
     impact: 75
@@ -952,6 +1192,42 @@ queries:
                 sysctl_file: /etc/sysctl.conf
                 reload: true
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to reject IPv6 router advertisements. Skip this on hosts that rely on SLAAC for their IPv6 address:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet6.ip6.accept_rtadv' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-broadcast-icmp-requests-are-ignored
     title: Ensure broadcast and multicast ICMP requests are ignored
     impact: 75
@@ -1041,6 +1317,42 @@ queries:
                 value: '0'
                 sysctl_file: /etc/sysctl.conf
                 reload: true
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to ignore broadcast and multicast ICMP echo requests:
+
+            ```ruby
+            sysctl_conf = '/etc/sysctl.conf'
+
+            execute 'reload sysctl settings' do
+              command "sysctl -f #{sysctl_conf}"
+              action :nothing
+            end
+
+            { 'net.inet.icmp.bmcastecho' => '0' }.each do |key, value|
+              pattern = Regexp.escape(key)
+
+              ruby_block "set #{key} in sysctl.conf" do
+                block do
+                  body = ::File.exist?(sysctl_conf) ? ::File.read(sysctl_conf) : ''
+                  directive = "#{key}=#{value}"
+                  body = if body.match?(/^\s*#{pattern}\s*=/)
+                           body.gsub(/^\s*#{pattern}\s*=.*$/, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n".lstrip
+                         end
+                  ::File.write(sysctl_conf, body)
+                end
+                not_if do
+                  ::File.exist?(sysctl_conf) &&
+                    ::File.read(sysctl_conf).match?(/^#{pattern}\s*=\s*#{Regexp.escape(value)}\s*$/)
+                end
+                notifies :run, 'execute[reload sysctl settings]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ftp-server-is-not-enabled
     title: Ensure FTP server is not enabled
@@ -1140,6 +1452,31 @@ queries:
                 state: reloaded
               failed_when: false
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable the FTP service in inetd:
+
+            ```ruby
+            inetd_conf = '/etc/inetd.conf'
+
+            # inetd is often not running at all, in which case commenting the entry out is
+            # already enough and the reload has nothing to do.
+            service 'inetd' do
+              action :nothing
+              ignore_failure true
+            end
+
+            ruby_block 'comment out ftp entries in inetd.conf' do
+              block do
+                body = ::File.read(inetd_conf)
+                ::File.write(inetd_conf, body.gsub(/^ftp/, '#ftp'))
+              end
+              only_if { ::File.exist?(inetd_conf) && ::File.read(inetd_conf).match?(/^ftp/) }
+              notifies :restart, 'service[inetd]', :delayed
+            end
+            ```
   - uid: mondoo-freebsd-security-telnet-server-is-not-enabled
     title: Ensure telnet server is not enabled
     impact: 100
@@ -1231,6 +1568,31 @@ queries:
                 state: reloaded
               failed_when: false
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable the telnet service in inetd:
+
+            ```ruby
+            inetd_conf = '/etc/inetd.conf'
+
+            # inetd is often not running at all, in which case commenting the entry out is
+            # already enough and the reload has nothing to do.
+            service 'inetd' do
+              action :nothing
+              ignore_failure true
+            end
+
+            ruby_block 'comment out telnet entries in inetd.conf' do
+              block do
+                body = ::File.read(inetd_conf)
+                ::File.write(inetd_conf, body.gsub(/^telnet/, '#telnet'))
+              end
+              only_if { ::File.exist?(inetd_conf) && ::File.read(inetd_conf).match?(/^telnet/) }
+              notifies :restart, 'service[inetd]', :delayed
+            end
+            ```
   - uid: mondoo-freebsd-security-nis-server-is-not-enabled
     title: Ensure NIS server is not enabled
     impact: 100
@@ -1314,6 +1676,18 @@ queries:
                 name: ypserv
                 state: stopped
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable the NIS server:
+
+            ```ruby
+            service 'ypserv' do
+              action %i(stop disable)
+              only_if { ::File.exist?('/etc/rc.d/ypserv') }
+            end
+            ```
   - uid: mondoo-freebsd-security-rpcbind-is-not-enabled
     title: Ensure rpcbind is not enabled
     impact: 100
@@ -1396,6 +1770,18 @@ queries:
               ansible.builtin.service:
                 name: rpcbind
                 state: stopped
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable rpcbind:
+
+            ```ruby
+            service 'rpcbind' do
+              action %i(stop disable)
+              only_if { ::File.exist?('/etc/rc.d/rpcbind') }
+            end
             ```
   - uid: mondoo-freebsd-security-nfs-server-is-not-enabled
     title: Ensure NFS server is not enabled
@@ -1490,6 +1876,18 @@ queries:
                 name: nfsd
                 state: stopped
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable the NFS daemon:
+
+            ```ruby
+            service 'nfsd' do
+              action %i(stop disable)
+              only_if { ::File.exist?('/etc/rc.d/nfsd') }
+            end
+            ```
   - uid: mondoo-freebsd-security-snmp-server-is-not-enabled
     title: Ensure SNMP server is not enabled
     impact: 85
@@ -1581,6 +1979,18 @@ queries:
                 state: stopped
               failed_when: false
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable the SNMP daemon:
+
+            ```ruby
+            service 'snmpd' do
+              action %i(stop disable)
+              only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+            end
+            ```
   - uid: mondoo-freebsd-security-tftp-server-is-not-enabled
     title: Ensure TFTP server is not enabled
     impact: 100
@@ -1671,6 +2081,31 @@ queries:
                 name: inetd
                 state: reloaded
               failed_when: false
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable the TFTP service in inetd:
+
+            ```ruby
+            inetd_conf = '/etc/inetd.conf'
+
+            # inetd is often not running at all, in which case commenting the entry out is
+            # already enough and the reload has nothing to do.
+            service 'inetd' do
+              action :nothing
+              ignore_failure true
+            end
+
+            ruby_block 'comment out tftp entries in inetd.conf' do
+              block do
+                body = ::File.read(inetd_conf)
+                ::File.write(inetd_conf, body.gsub(/^tftp/, '#tftp'))
+              end
+              only_if { ::File.exist?(inetd_conf) && ::File.read(inetd_conf).match?(/^tftp/) }
+              notifies :restart, 'service[inetd]', :delayed
+            end
             ```
   - uid: mondoo-freebsd-security-imap-and-pop3-server-is-not-enabled
     title: Ensure IMAP and POP3 server is not enabled
@@ -1771,6 +2206,20 @@ queries:
                 - imapd
               failed_when: false
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable the IMAP and POP3 daemons:
+
+            ```ruby
+            { 'dovecot' => '/usr/local/etc/rc.d/dovecot', 'imapd' => '/usr/local/etc/rc.d/imapd' }.each do |name, rc_script|
+              service name do
+                action %i(stop disable)
+                only_if { ::File.exist?(rc_script) }
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-web-proxy-server-is-not-enabled
     title: Ensure web proxy server is not enabled
     impact: 100
@@ -1861,6 +2310,18 @@ queries:
                 name: squid
                 state: stopped
               failed_when: false
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop and disable the Squid web proxy:
+
+            ```ruby
+            service 'squid' do
+              action %i(stop disable)
+              only_if { ::File.exist?('/usr/local/etc/rc.d/squid') }
+            end
             ```
   - uid: mondoo-freebsd-security-mail-transfer-agent-is-configured-for-local-only-mode
     title: Ensure mail transfer agent is configured for local-only mode
@@ -1965,6 +2426,35 @@ queries:
                   name: postfix
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to bind Postfix to the loopback interface. On FreeBSD the Postfix configuration lives under `/usr/local/etc`:
+
+            ```ruby
+            main_cf = '/usr/local/etc/postfix/main.cf'
+
+            service 'postfix' do
+              action :nothing
+            end
+
+            ruby_block 'bind Postfix to the loopback interface' do
+              block do
+                body = ::File.read(main_cf)
+                directive = 'inet_interfaces = localhost'
+                body = if body.match?(/^\s*inet_interfaces\s*=/)
+                         body.gsub(/^\s*inet_interfaces\s*=.*$/, directive)
+                       else
+                         "#{body.chomp}\n#{directive}\n"
+                       end
+                ::File.write(main_cf, body)
+              end
+              only_if { ::File.exist?(main_cf) }
+              not_if { ::File.exist?(main_cf) && ::File.read(main_cf).match?(/^inet_interfaces\s*=\s*localhost\s*$/) }
+              notifies :restart, 'service[postfix]', :delayed
+            end
+            ```
   - uid: mondoo-freebsd-security-permissions-on-sshd-config-are-configured
     title: Ensure permissions on /etc/ssh/sshd_config are configured
     impact: 80
@@ -2051,6 +2541,19 @@ queries:
                 owner: root
                 group: wheel
                 mode: '0600'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict the SSH daemon configuration to root:
+
+            ```ruby
+            file '/etc/ssh/sshd_config' do
+              owner 'root'
+              group 'wheel'
+              mode '0600'
+            end
             ```
   - uid: mondoo-freebsd-security-permissions-on-ssh-private-host-key-files-are-configured
     title: Ensure permissions on SSH private host key files are configured
@@ -2148,6 +2651,21 @@ queries:
                 mode: '0600'
               loop: "{{ ssh_private_keys.files }}"
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict the SSH host private keys. The glob matches only the private keys, because the public keys end in `.pub`:
+
+            ```ruby
+            ::Dir.glob('/etc/ssh/ssh_host_*key').each do |private_key|
+              file private_key do
+                owner 'root'
+                group 'wheel'
+                mode '0600'
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-permissions-on-ssh-public-host-key-files-are-configured
     title: Ensure permissions on SSH public host key files are configured
     impact: 70
@@ -2239,6 +2757,21 @@ queries:
                 group: wheel
                 mode: '0644'
               loop: "{{ ssh_public_keys.files }}"
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the ownership and permissions on the SSH host public keys:
+
+            ```ruby
+            ::Dir.glob('/etc/ssh/ssh_host_*key.pub').each do |public_key|
+              file public_key do
+                owner 'root'
+                group 'wheel'
+                mode '0644'
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-only-strong-ciphers-are-used
     title: Ensure only strong ciphers are used
@@ -2342,6 +2875,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict SSH to strong ciphers:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'Ciphers' => 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-only-strong-mac-algorithms-are-used
     title: Ensure only strong MAC algorithms are used
     impact: 80
@@ -2443,6 +3006,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict SSH to strong MAC algorithms:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'MACs' => 'umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-only-strong-kex-algorithms-are-used
     title: Ensure only strong key exchange algorithms are used
@@ -2546,6 +3139,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict SSH to strong key exchange algorithms:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'KexAlgorithms' => 'sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-root-login-is-disabled
     title: Ensure SSH root login is disabled
     impact: 100
@@ -2647,6 +3270,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop root from logging in over SSH. Confirm that an account in the `wheel` group can log in and reach root before you apply it, or you will lock yourself out:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'PermitRootLogin' => 'no' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ssh-permitemptypasswords-is-disabled
     title: Ensure SSH PermitEmptyPasswords is disabled
@@ -2750,6 +3403,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to reject accounts with an empty password:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'PermitEmptyPasswords' => 'no' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-hostbasedauthentication-is-disabled
     title: Ensure SSH HostbasedAuthentication is disabled
     impact: 70
@@ -2851,6 +3534,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disable host-based authentication:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'HostbasedAuthentication' => 'no' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ssh-permituserenvironment-is-disabled
     title: Ensure SSH PermitUserEnvironment is disabled
@@ -2954,6 +3667,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to stop sshd from reading user-supplied environment options:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'PermitUserEnvironment' => 'no' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-ignorerhosts-is-enabled
     title: Ensure SSH IgnoreRhosts is enabled
     impact: 60
@@ -3056,6 +3799,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to make sshd ignore `.rhosts` and `.shosts` files:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'IgnoreRhosts' => 'yes' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-maxauthtries-is-set-to-4-or-less
     title: Ensure SSH MaxAuthTries is set to 4 or less
     impact: 75
@@ -3157,6 +3930,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to cap the number of authentication attempts per connection:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'MaxAuthTries' => '4' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ssh-logingracetime-is-configured
     title: Ensure SSH LoginGraceTime is configured
@@ -3261,6 +4064,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to close connections that do not authenticate within one minute:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'LoginGraceTime' => '60' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-loglevel-is-appropriate
     title: Ensure SSH LogLevel is appropriate
     impact: 60
@@ -3362,6 +4195,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to raise the SSH log level so that failed logins and key fingerprints are recorded:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'LogLevel' => 'VERBOSE' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ssh-idle-timeout-interval-is-configured
     title: Ensure SSH idle timeout interval is configured
@@ -3482,6 +4345,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to disconnect idle SSH sessions:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'ClientAliveInterval' => '300', 'ClientAliveCountMax' => '3' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-ssh-disableforwarding-is-enabled
     title: Ensure SSH DisableForwarding is enabled
     impact: 75
@@ -3583,6 +4476,36 @@ queries:
                 ansible.builtin.service:
                   name: sshd
                   state: restarted
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to turn off all SSH forwarding: Apply it only where no one relies on port, agent, or X11 forwarding through this host.
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'DisableForwarding' => 'yes' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
             ```
   - uid: mondoo-freebsd-security-ssh-usepam-is-enabled
     title: Ensure SSH UsePAM is enabled
@@ -3686,6 +4609,36 @@ queries:
                   name: sshd
                   state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to have sshd authenticate through PAM:
+
+            ```ruby
+            sshd_config = '/etc/ssh/sshd_config'
+
+            service 'sshd' do
+              action :nothing
+            end
+
+            { 'UsePAM' => 'yes' }.each do |keyword, value|
+              ruby_block "set #{keyword} in sshd_config" do
+                block do
+                  body = ::File.read(sshd_config)
+                  directive = "#{keyword} #{value}"
+                  body = if body.match?(/^\s*#?\s*#{keyword}\b/i)
+                           body.gsub(/^\s*#?\s*#{keyword}\b.*$/i, directive)
+                         else
+                           "#{body.chomp}\n#{directive}\n"
+                         end
+                  ::File.write(sshd_config, body)
+                end
+                not_if { ::File.read(sshd_config).match?(/^#{keyword}\s+#{Regexp.escape(value)}\s*$/i) }
+                notifies :restart, 'service[sshd]', :delayed
+              end
+            end
+            ```
   - uid: mondoo-freebsd-security-permissions-on-etc-passwd-are-configured
     title: Ensure permissions on /etc/passwd are configured
     impact: 100
@@ -3772,6 +4725,19 @@ queries:
                 group: wheel
                 mode: '0644'
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the ownership and permissions on `/etc/passwd`:
+
+            ```ruby
+            file '/etc/passwd' do
+              owner 'root'
+              group 'wheel'
+              mode '0644'
+            end
+            ```
   - uid: mondoo-freebsd-security-permissions-on-etc-group-are-configured
     title: Ensure permissions on /etc/group are configured
     impact: 100
@@ -3857,6 +4823,19 @@ queries:
                 owner: root
                 group: wheel
                 mode: '0644'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the ownership and permissions on `/etc/group`:
+
+            ```ruby
+            file '/etc/group' do
+              owner 'root'
+              group 'wheel'
+              mode '0644'
+            end
             ```
   - uid: mondoo-freebsd-security-permissions-on-etc-master-passwd-are-configured
     title: Ensure permissions on /etc/master.passwd are configured
@@ -3946,6 +4925,19 @@ queries:
                 group: wheel
                 mode: '0600'
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict `/etc/master.passwd`, which holds the password hashes:
+
+            ```ruby
+            file '/etc/master.passwd' do
+              owner 'root'
+              group 'wheel'
+              mode '0600'
+            end
+            ```
   - uid: mondoo-freebsd-security-permissions-on-etc-shells-are-configured
     title: Ensure permissions on /etc/shells are configured
     impact: 75
@@ -4030,6 +5022,19 @@ queries:
                 owner: root
                 group: wheel
                 mode: '0644'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the ownership and permissions on `/etc/shells`:
+
+            ```ruby
+            file '/etc/shells' do
+              owner 'root'
+              group 'wheel'
+              mode '0644'
+            end
             ```
   - uid: mondoo-freebsd-security-permissions-on-bootloader-config-are-configured
     title: Ensure permissions on bootloader config are configured
@@ -4118,6 +5123,19 @@ queries:
                 owner: root
                 group: wheel
                 mode: '0600'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to restrict the bootloader configuration to root:
+
+            ```ruby
+            file '/boot/loader.conf' do
+              owner 'root'
+              group 'wheel'
+              mode '0600'
+            end
             ```
   - uid: mondoo-freebsd-security-root-is-the-only-uid-0-account
     title: Ensure root is the only UID 0 account
@@ -4215,6 +5233,7 @@ queries:
                 msg: "Non-root UID 0 accounts found: {{ uid0_accounts.stdout }}"
               when: uid0_accounts.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-uids-exist
     title: Ensure no duplicate UIDs exist
     impact: 80
@@ -4325,6 +5344,7 @@ queries:
                 msg: "Duplicate UIDs found: {{ dup_uids.stdout }}"
               when: dup_uids.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-gids-exist
     title: Ensure no duplicate GIDs exist
     impact: 80
@@ -4435,6 +5455,7 @@ queries:
                 msg: "Duplicate GIDs found: {{ dup_gids.stdout }}"
               when: dup_gids.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-user-names-exist
     title: Ensure no duplicate user names exist
     impact: 80
@@ -4521,6 +5542,7 @@ queries:
                 msg: "Duplicate user names found: {{ dup_users.stdout }}"
               when: dup_users.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-group-names-exist
     title: Ensure no duplicate group names exist
     impact: 80
@@ -4607,6 +5629,7 @@ queries:
                 msg: "Duplicate group names found: {{ dup_groups.stdout }}"
               when: dup_groups.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-all-groups-in-passwd-exist-in-group
     title: Ensure all groups in /etc/passwd exist in /etc/group
     impact: 70
@@ -4702,6 +5725,7 @@ queries:
                 msg: "Users with missing primary groups: {{ missing_groups.stdout }}"
               when: missing_groups.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-syslogd-is-enabled-and-running
     title: Ensure syslogd is enabled and running
     impact: 50
@@ -4784,6 +5808,17 @@ queries:
               ansible.builtin.service:
                 name: syslogd
                 state: started
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to enable syslogd in `/etc/rc.conf` and start it:
+
+            ```ruby
+            service 'syslogd' do
+              action %i(enable start)
+            end
             ```
   - uid: mondoo-freebsd-security-syslogd-is-not-accepting-remote-messages
     title: Ensure syslogd is not accepting remote messages
@@ -4873,6 +5908,23 @@ queries:
                 name: syslogd
                 state: restarted
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to put syslogd in secure mode so it stops listening for remote log messages:
+
+            ```ruby
+            service 'syslogd' do
+              action :nothing
+            end
+
+            execute 'set syslogd_flags in rc.conf' do
+              command 'sysrc syslogd_flags="-s"'
+              not_if 'sysrc -n syslogd_flags | grep -q -- -s'
+              notifies :restart, 'service[syslogd]', :delayed
+            end
+            ```
   - uid: mondoo-freebsd-security-sudo-is-installed
     title: Ensure sudo is installed
     impact: 75
@@ -4954,6 +6006,17 @@ queries:
               community.general.pkgng:
                 name: sudo
                 state: present
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to install sudo. On FreeBSD the `package` resource resolves to `freebsd_package`, which uses pkg:
+
+            ```ruby
+            package 'sudo' do
+              action :install
+            end
             ```
   - uid: mondoo-freebsd-security-sudo-commands-use-pty
     title: Ensure sudo commands use a pseudo terminal
@@ -5054,6 +6117,17 @@ queries:
                 group: wheel
                 mode: '0440'
                 validate: 'visudo -cf %s'
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to require a pseudo terminal for sudo. The `sudo` resource knows FreeBSD keeps its sudoers configuration under `/usr/local/etc`, and validates the generated file with `visudo` before installing it:
+
+            ```ruby
+            sudo '99-use-pty' do
+              defaults ['use_pty']
+            end
             ```
   - uid: mondoo-freebsd-security-sudo-nopasswd-is-not-configured
     title: Ensure NOPASSWD is not configured in sudoers
@@ -5172,6 +6246,7 @@ queries:
                 msg: "NOPASSWD found in: {{ nopasswd_files.stdout }}"
               when: nopasswd_files.stdout | length > 0
             ```
+        # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-firewall-is-enabled
     title: Ensure a firewall is enabled
     impact: 60
@@ -5284,4 +6359,28 @@ queries:
               ansible.builtin.service:
                 name: ipfw
                 state: started
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            **Warning: confirm the rule set allows your management access before you apply this.** The `workstation` firewall type denies inbound traffic that is not listed in `firewall_myservices`, so add every port you rely on to that list first. Use this Chef Infra recipe code to enable ipfw:
+
+            ```ruby
+            service 'ipfw' do
+              action :nothing
+            end
+
+            {
+              'firewall_enable' => 'YES',
+              'firewall_type' => 'workstation',
+              'firewall_myservices' => '22/tcp',
+              'firewall_allowservices' => 'any',
+            }.each do |key, value|
+              execute "set #{key} in rc.conf" do
+                command "sysrc #{key}=#{value}"
+                not_if "sysrc -n #{key} | grep -qx #{value}"
+                notifies :start, 'service[ipfw]', :delayed
+              end
+            end
             ```

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Mondoo Microsoft Windows Security
-    version: 2.4.2
+    version: 2.5.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -275,6 +275,18 @@ queries:
                     - C:\Windows\Temp\secpol-import.cfg
                     - C:\Windows\Temp\secpol-db.sdb
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to remove every account from the Debug programs user right. The `:clear` action strips all accounts currently holding the privilege:
+
+            ```ruby
+            windows_user_privilege 'Debug programs' do
+              privilege 'SeDebugPrivilege'
+              action :clear
+            end
+            ```
   - uid: mondoo-windows-security-additional-LSA-protection
     title: Ensure additional LSA protection is enabled
     impact: 100
@@ -390,6 +402,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `RunAsPPL` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'RunAsPPL',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-always-prompt-for-password-upon-connection-is-set-to-enabled
     title: Ensure 'Always prompt for password upon connection' is set to 'Enabled'
     impact: 80
@@ -503,6 +532,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fPromptForPassword` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fPromptForPassword',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-application-control-event-log-behavior-when-the-log-file-reaches-its-maximum
     title: "Ensure 'Application: Control Event Log max size behavior' is disabled"
     impact: 30
@@ -615,6 +661,23 @@ queries:
                     name: Retention
                     data: "0"
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `Retention` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Application' do
+              values [{
+                name: 'Retention',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-application-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure Application log file size is set to 32,768 KB or greater"
@@ -733,6 +796,23 @@ queries:
                     data: 32768
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxSize` registry value that backs this policy to `32768`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Application' do
+              values [{
+                name: 'MaxSize',
+                type: :dword,
+                data: 32768,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-apply-uac-restrictions-to-local-accounts-on-network-logons-is-set-to-enabled
     title: Ensure UAC restrictions apply to local accounts on network logons
     impact: 80
@@ -844,6 +924,23 @@ queries:
                     data: 0
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `LocalAccountTokenFilterPolicy` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' do
+              values [{
+                name: 'LocalAccountTokenFilterPolicy',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-audit-account-lockout-is-set-to-include-failure
     title: Ensure 'Audit Account Lockout' is set to include 'Failure'
     impact: 30
@@ -943,6 +1040,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9217-69AE-11D9-BED3-505054503030}"
                       /success:disable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit failure events for the `Account Lockout` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Account Lockout' do
+              subcategory 'Account Lockout'
+              success false
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-application-group-management-is-set-to-success-and-failure
     title: Ensure 'Audit Application Group Management' is set to 'Success and Failure'
@@ -1046,6 +1157,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9239-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Application Group Management` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Application Group Management' do
+              subcategory 'Application Group Management'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-audit-policy-change-is-set-to-include-success
     title: Ensure 'Audit Audit Policy Change' is set to include 'Success'
     impact: 30
@@ -1143,6 +1268,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE922F-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Audit Policy Change` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Audit Policy Change' do
+              subcategory 'Audit Policy Change'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-authentication-policy-change-is-set-to-include-success
     title: Ensure 'Audit Authentication Policy Change' is set to include 'Success'
@@ -1244,6 +1383,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9230-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Authentication Policy Change` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Authentication Policy Change' do
+              subcategory 'Authentication Policy Change'
+              success true
+              failure false
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-authorization-policy-change-is-set-to-include-success
     title: Ensure 'Audit Authorization Policy Change' is set to include 'Success'
     impact: 30
@@ -1337,6 +1490,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9231-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Authorization Policy Change` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Authorization Policy Change' do
+              subcategory 'Authorization Policy Change'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-credential-validation-is-set-to-success-and-failure
     title: Ensure 'Audit Credential Validation' is set to 'Success and Failure'
@@ -1432,6 +1599,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE923F-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Credential Validation` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Credential Validation' do
+              subcategory 'Credential Validation'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-detailed-file-share-is-set-to-include-failure
     title: Ensure 'Audit Detailed File Share' is set to include 'Failure'
     impact: 30
@@ -1521,6 +1702,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9244-69AE-11D9-BED3-505054503030}"
                       /success:disable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit failure events for the `Detailed File Share` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Detailed File Share' do
+              subcategory 'Detailed File Share'
+              success false
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-file-share-is-set-to-success-and-failure
     title: Ensure 'Audit File Share' is set to 'Success and Failure'
@@ -1613,6 +1808,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9224-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `File Share` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit File Share' do
+              subcategory 'File Share'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-force-audit-policy-subcategory-settings-windows-vista-or-later-to-override
     title: "Ensure audit policy subcategory settings override category settings"
@@ -1714,6 +1923,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `SCENoApplyLegacyAuditPolicy` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'SCENoApplyLegacyAuditPolicy',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-audit-group-membership-is-set-to-include-success
     title: Ensure 'Audit Group Membership' is set to include 'Success'
     impact: 30
@@ -1804,6 +2030,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9249-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Group Membership` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Group Membership' do
+              subcategory 'Group Membership'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-ipsec-driver-is-set-to-success-and-failure
     title: Ensure 'Audit IPsec Driver' is set to 'Success and Failure'
@@ -1906,6 +2146,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9213-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `IPsec Driver` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit IPsec Driver' do
+              subcategory 'IPsec Driver'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-logoff-is-set-to-include-success
     title: Ensure 'Audit Logoff' is set to include 'Success'
     impact: 30
@@ -1996,6 +2250,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9216-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Logoff` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Logoff' do
+              subcategory 'Logoff'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-logon-is-set-to-success-and-failure
     title: Ensure 'Audit Logon' is set to 'Success and Failure'
@@ -2090,6 +2358,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9215-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Logon` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Logon' do
+              subcategory 'Logon'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-mpssvc-rule-level-policy-change-is-set-to-success-and-failure
     title: "Ensure 'Audit MPSSVC Rule-Level Policy Change' is Success/Failure"
@@ -2196,6 +2478,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9232-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `MPSSVC Rule-Level Policy Change` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit MPSSVC Rule-Level Policy Change' do
+              subcategory 'MPSSVC Rule-Level Policy Change'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-other-logonlogoff-events-is-set-to-success-and-failure
     title: Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'
     impact: 30
@@ -2295,6 +2591,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE921C-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Other Logon/Logoff Events` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Other Logon/Logoff Events' do
+              subcategory 'Other Logon/Logoff Events'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-other-object-access-events-is-set-to-success-and-failure
     title: Ensure 'Audit Other Object Access Events' is set to 'Success and Failure'
@@ -2399,6 +2709,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9227-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Other Object Access Events` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Other Object Access Events' do
+              subcategory 'Other Object Access Events'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-other-policy-change-events-is-set-to-include-failure
     title: Ensure 'Audit Other Policy Change Events' is set to include 'Failure'
     impact: 30
@@ -2496,6 +2820,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9234-69AE-11D9-BED3-505054503030}"
                       /success:disable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit failure events for the `Other Policy Change Events` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Other Policy Change Events' do
+              subcategory 'Other Policy Change Events'
+              success false
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-other-system-events-is-set-to-success-and-failure
     title: Ensure 'Audit Other System Events' is set to 'Success and Failure'
@@ -2600,6 +2938,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9214-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Other System Events` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Other System Events' do
+              subcategory 'Other System Events'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-pnp-activity-is-set-to-include-success
     title: Ensure 'Audit PNP Activity' is set to include 'Success'
     impact: 30
@@ -2690,6 +3042,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9248-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Plug and Play Events` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Plug and Play Events' do
+              subcategory 'Plug and Play Events'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-process-creation-is-set-to-include-success
     title: Ensure 'Audit Process Creation' is set to include 'Success'
@@ -2785,6 +3151,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE922B-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Process Creation` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Process Creation' do
+              subcategory 'Process Creation'
+              success true
+              failure false
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-removable-storage-is-set-to-success-and-failure
     title: Ensure 'Audit Removable Storage' is set to 'Success and Failure'
     impact: 30
@@ -2876,6 +3256,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9245-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Removable Storage` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Removable Storage' do
+              subcategory 'Removable Storage'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-security-group-management-is-set-to-include-success
     title: Ensure 'Audit Security Group Management' is set to include 'Success'
@@ -2982,6 +3376,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9237-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Security Group Management` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Security Group Management' do
+              subcategory 'Security Group Management'
+              success true
+              failure false
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-security-state-change-is-set-to-include-success
     title: Ensure 'Audit Security State Change' is set to include 'Success'
     impact: 30
@@ -3074,6 +3482,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9210-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Security State Change` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Security State Change' do
+              subcategory 'Security State Change'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-security-system-extension-is-set-to-include-success
     title: Ensure 'Audit Security System Extension' is set to include 'Success'
@@ -3168,6 +3590,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9211-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Security System Extension` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Security System Extension' do
+              subcategory 'Security System Extension'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-sensitive-privilege-use-is-set-to-success-and-failure
     title: Ensure 'Audit Sensitive Privilege Use' is set to 'Success and Failure'
@@ -3278,6 +3714,20 @@ queries:
                       Auditpol /set /subcategory:"{0CCE9228-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `Sensitive Privilege Use` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Sensitive Privilege Use' do
+              subcategory 'Sensitive Privilege Use'
+              success true
+              failure true
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-audit-shut-down-system-immediately-if-unable-to-log-security-audits
     title: "Ensure 'Audit: Shut down if unable to log audits' is disabled"
     impact: 30
@@ -3375,6 +3825,23 @@ queries:
                     data: 0
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `CrashOnAuditFail` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\LSA' do
+              values [{
+                name: 'CrashOnAuditFail',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-audit-special-logon-is-set-to-include-success
     title: Ensure 'Audit Special Logon' is set to include 'Success'
     impact: 30
@@ -3464,6 +3931,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE921B-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:disable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success events for the `Special Logon` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit Special Logon' do
+              subcategory 'Special Logon'
+              success true
+              failure false
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-system-integrity-is-set-to-success-and-failure
     title: Ensure 'Audit System Integrity' is set to 'Success and Failure'
@@ -3564,6 +4045,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9212-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `System Integrity` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit System Integrity' do
+              subcategory 'System Integrity'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-audit-user-account-management-is-set-to-success-and-failure
     title: Ensure 'Audit User Account Management' is set to 'Success and Failure'
@@ -3670,6 +4165,20 @@ queries:
                     cmd: >-
                       Auditpol /set /subcategory:"{0CCE9235-69AE-11D9-BED3-505054503030}"
                       /success:enable /failure:enable
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to audit success and failure events for the `User Account Management` subcategory:
+
+            ```ruby
+            windows_audit_policy 'Audit User Account Management' do
+              subcategory 'User Account Management'
+              success true
+              failure true
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-configure-smb-v1-client-driver-is-set-to-enabled-disable-driver-recommended
     title: "Ensure SMB v1 client driver is disabled"
@@ -3790,6 +4299,23 @@ queries:
                     data: 4
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `Start` registry value that backs this policy to `4`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\mrxsmb10' do
+              values [{
+                name: 'Start',
+                type: :dword,
+                data: 4,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-configure-smb-v1-server-is-set-to-disabled
     title: Ensure 'Configure SMB v1 server' is set to 'Disabled'
     impact: 100
@@ -3905,6 +4431,23 @@ queries:
                     name: SMB1Protocol
                     state: absent
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `SMB1` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters' do
+              values [{
+                name: 'SMB1',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-do-not-allow-com-port-redirection-is-set-to-enabled
     title: Ensure 'Do not allow COM port redirection' is set to 'Enabled'
     impact: 60
@@ -4002,6 +4545,23 @@ queries:
                     name: fDisableCcm
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fDisableCcm` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fDisableCcm',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-do-not-allow-drive-redirection-is-set-to-enabled
     title: Ensure 'Do not allow drive redirection' is set to 'Enabled'
@@ -4105,6 +4665,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fDisableCdm` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fDisableCdm',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-do-not-allow-lpt-port-redirection-is-set-to-enabled
     title: Ensure 'Do not allow LPT port redirection' is set to 'Enabled'
     impact: 60
@@ -4202,6 +4779,23 @@ queries:
                     name: fDisableLPT
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fDisableLPT` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fDisableLPT',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-do-not-allow-passwords-to-be-saved-is-set-to-enabled
     title: Ensure 'Do not allow passwords to be saved' is set to 'Enabled'
@@ -4304,6 +4898,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `DisablePasswordSaving` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'DisablePasswordSaving',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-do-not-allow-supported-plug-and-play-device-redirection-is-set-to-enabled
     title: Ensure Plug and Play device redirection is disabled for RDS
     impact: 60
@@ -4401,6 +5012,23 @@ queries:
                     name: fDisablePNPRedir
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fDisablePNPRedir` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fDisablePNPRedir',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-do-not-delete-temp-folders-upon-exit-is-set-to-disabled
     title: Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'
@@ -4503,6 +5131,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `DeleteTempDirsOnExit` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'DeleteTempDirsOnExit',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-enable-structured-exception-handling-overwrite-protection-sehop-is-set-to-enabled
     title: Ensure SEHOP is enabled
     impact: 80
@@ -4602,6 +5247,23 @@ queries:
                     name: DisableExceptionChainValidation
                     data: 0
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `DisableExceptionChainValidation` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel' do
+              values [{
+                name: 'DisableExceptionChainValidation',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-enforce-password-history-is-set-to-24-or-more-passwords
     title: Ensure 'Enforce password history' is set to '24 or more password(s)'
@@ -4709,6 +5371,18 @@ queries:
                     section: System Access
                     key: PasswordHistorySize
                     value: 24
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. Use this Chef Infra recipe code to remember the last 24 passwords so they cannot be reused:
+
+            ```ruby
+            windows_security_policy 'PasswordHistorySize' do
+              secvalue '24'
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-maximum-password-age-is-set-to-365-or-fewer-days-but-not-0
     title: Ensure 'Maximum password age' is set to '365 or fewer days, but not 0'
@@ -4819,6 +5493,18 @@ queries:
                     key: MaximumPasswordAge
                     value: 365
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. A value of `0` means the password never expires, which fails this check. Use this Chef Infra recipe code to expire passwords after 365 days:
+
+            ```ruby
+            windows_security_policy 'MaximumPasswordAge' do
+              secvalue '365'
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-minimum-password-age-is-set-to-1-or-more-days
     title: Ensure 'Minimum password age' is set to '1 or more day(s)'
     impact: 60
@@ -4923,6 +5609,18 @@ queries:
                     section: System Access
                     key: MinimumPasswordAge
                     value: 1
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. Use this Chef Infra recipe code to stop a password from being changed again within a day, which is what makes the history requirement effective:
+
+            ```ruby
+            windows_security_policy 'MinimumPasswordAge' do
+              secvalue '1'
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-minimum-password-length-is-set-to-14-or-more-characters
     title: Ensure 'Minimum password length' is set to '14 or more character(s)'
@@ -5041,6 +5739,18 @@ queries:
             ```
 
             Note: The `win_security_policy` module requires the `ansible.windows` collection. Alternatively, use the win_shell module with secedit commands.
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. This check compares against the `mondooWindowsSecurityMinimumPasswordLength` property, which defaults to 14, so raise the value below to match if you raise that property. Use this Chef Infra recipe code to require passwords of at least 14 characters:
+
+            ```ruby
+            windows_security_policy 'MinimumPasswordLength' do
+              secvalue '14'
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-netbt-nodetype-configuration-is-set-to-enabled-p-node-recommended
     title: "Ensure NetBT NodeType is set to P-node"
     impact: 60
@@ -5156,6 +5866,23 @@ queries:
                     data: 2
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `NodeType` registry value that backs this policy to `2`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' do
+              values [{
+                name: 'NodeType',
+                type: :dword,
+                data: 2,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-allow-anonymous-sidname-translation-is-set-to-disabled
     title: "Ensure anonymous SID/Name translation is disabled"
     impact: 80
@@ -5253,6 +5980,18 @@ queries:
                     section: System Access
                     key: LSAAnonymousNameLookup
                     value: 0
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. Use this Chef Infra recipe code to stop anonymous callers translating SIDs into account names:
+
+            ```ruby
+            windows_security_policy 'LSAAnonymousNameLookup' do
+              secvalue '0'
+              action :set
+            end
             ```
   - uid: mondoo-windows-security-network-access-do-not-allow-anonymous-enumeration-of-sam-accounts
     title: "Ensure anonymous enumeration of SAM accounts is not allowed"
@@ -5352,6 +6091,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `RestrictAnonymousSAM` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'RestrictAnonymousSAM',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-do-not-allow-anonymous-enumeration-of-sam-accounts-and-shares
     title: "Ensure anonymous enumeration of SAM accounts and shares is blocked"
     impact: 80
@@ -5449,6 +6205,23 @@ queries:
                     name: RestrictAnonymous
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `RestrictAnonymous` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'RestrictAnonymous',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-access-do-not-allow-storage-of-passwords-and-credentials-for-network-auth
     title: "Ensure network credential and password storage is disabled"
@@ -5548,6 +6321,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `DisableDomainCreds` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'DisableDomainCreds',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-let-everyone-permissions-apply-to-anonymous-users-is-set-to-disabled
     title: "Ensure Everyone permissions do not apply to anonymous users"
     impact: 70
@@ -5642,6 +6432,23 @@ queries:
                     name: EveryoneIncludesAnonymous
                     data: 0
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `EveryoneIncludesAnonymous` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'EveryoneIncludesAnonymous',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none
     title: "Ensure no Named Pipes can be accessed anonymously"
@@ -5778,6 +6585,29 @@ queries:
                     type: multistring
                   when: is_domain_controller
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            **Warning: do not clear this list on a domain controller.** Domain controllers require the `LSARPC`, `NETLOGON`, and `SAMR` pipes for legacy authentication. Use this Chef Infra recipe code, which selects the correct value from the raw `ProductType` that Ohai collects, where `2` identifies a domain controller:
+
+            ```ruby
+            null_session_pipes = if node['kernel']['os_info']['product_type'] == 2
+                                   %w(LSARPC NETLOGON SAMR)
+                                 else
+                                   []
+                                 end
+
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters' do
+              values [{
+                name: 'NullSessionPipes',
+                type: :multi_string,
+                data: null_session_pipes,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-restrict-anonymous-access-to-named-pipes-and-shares
     title: "Ensure anonymous access to Named Pipes and Shares is restricted"
     impact: 80
@@ -5892,6 +6722,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `RestrictNullSessAccess` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters' do
+              values [{
+                name: 'RestrictNullSessAccess',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-restrict-clients-allowed-to-make-remote-calls-to-sam
     title: "Ensure remote SAM access is restricted to Administrators only"
     impact: 80
@@ -6001,6 +6848,23 @@ queries:
                     data: "O:BAG:BAD:(A;;RC;;;BA)"
                     type: string
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `restrictremotesam` registry value that backs this policy to `O:BAG:BAD:(A;;RC;;;BA)`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'restrictremotesam',
+                type: :string,
+                data: 'O:BAG:BAD:(A;;RC;;;BA)',
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-shares-that-can-be-accessed-anonymously-is-set-to-none
     title: "Ensure no shares can be accessed anonymously"
     impact: 80
@@ -6095,6 +6959,23 @@ queries:
                     name: NullSessionShares
                     data: []
                     type: multistring
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to clear the list of shares that can be reached without authentication:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters' do
+              values [{
+                name: 'NullSessionShares',
+                type: :multi_string,
+                data: [],
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-access-sharing-and-security-model-for-local-accounts-is-set-to-classic
     title: "Ensure local accounts use Classic sharing and security model"
@@ -6194,6 +7075,23 @@ queries:
                     data: 0
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `ForceGuest` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'ForceGuest',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-security-allow-local-system-to-use-computer-identity-for-ntlm
     title: "Ensure Local System uses computer identity for NTLM"
     impact: 60
@@ -6289,6 +7187,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `UseMachineId` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'UseMachineId',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-security-allow-localsystem-null-session-fallback-is-set-to-disabled
     title: "Ensure LocalSystem NULL session fallback is disabled"
     impact: 80
@@ -6383,6 +7298,23 @@ queries:
                     name: AllowNullSessionFallback
                     data: 0
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `AllowNullSessionFallback` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0' do
+              values [{
+                name: 'AllowNullSessionFallback',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-security-allow-pku2u-authentication-requests-is-set-to-disabled
     title: "Ensure PKU2U online identity authentication requests are disabled"
@@ -6485,6 +7417,23 @@ queries:
                     name: AllowOnlineID
                     data: 0
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `AllowOnlineID` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa\pku2u' do
+              values [{
+                name: 'AllowOnlineID',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-security-configure-encryption-types-allowed-for-kerberos-is-set-to-aes12
     title: "Ensure Kerberos encryption types are limited to AES and newer"
@@ -6608,6 +7557,23 @@ queries:
                     data: 2147483640
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `SupportedEncryptionTypes` registry value that backs this policy to `2147483640`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters' do
+              values [{
+                name: 'SupportedEncryptionTypes',
+                type: :dword,
+                data: 2147483640,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-security-do-not-store-lan-manager-hash-value-on-next-password-change
     title: "Ensure LAN Manager hash value is not stored on password change"
     impact: 90
@@ -6705,6 +7671,23 @@ queries:
                     name: NoLMHash
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `NoLMHash` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'NoLMHash',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-security-lan-manager-authentication-level-is-set-to-send-ntlmv2-response
     title: "Ensure LAN Manager auth is set to NTLMv2 only, refuse LM/NTLM"
@@ -6817,6 +7800,23 @@ queries:
                     data: 5
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `LmCompatibilityLevel` registry value that backs this policy to `5`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa' do
+              values [{
+                name: 'LmCompatibilityLevel',
+                type: :dword,
+                data: 5,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-security-ldap-client-signing-requirements-is-set-to-negotiate-signing
     title: "Ensure LDAP client signing is set to 'Negotiate signing' or higher"
     impact: 40
@@ -6918,6 +7918,23 @@ queries:
                     name: LDAPClientIntegrity
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `LDAPClientIntegrity` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Services\LDAP' do
+              values [{
+                name: 'LDAPClientIntegrity',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-network-security-minimum-session-security-for-ntlm-ssp-based-servers-is-set-to-ntlmv2
     title: "Ensure NTLM SSP server requires NTLMv2 and 128-bit encryption"
@@ -7027,6 +8044,23 @@ queries:
                     data: 537395200
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `NTLMMinServerSec` registry value that backs this policy to `537395200`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0' do
+              values [{
+                name: 'NTLMMinServerSec',
+                type: :dword,
+                data: 537395200,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-security-minimum-session-security-for-ntlm-ssp-clients-is-set-to-ntlmv2
     title: "Ensure NTLM SSP client requires NTLMv2 and 128-bit encryption"
     impact: 80
@@ -7134,6 +8168,23 @@ queries:
                     name: NTLMMinClientSec
                     data: 537395200
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `NTLMMinClientSec` registry value that backs this policy to `537395200`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\Lsa\MSV1_0' do
+              values [{
+                name: 'NTLMMinClientSec',
+                type: :dword,
+                data: 537395200,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-password-must-meet-complexity-requirements-is-set-to-enabled
     title: Ensure 'Password must meet complexity requirements' is set to 'Enabled'
@@ -7277,6 +8328,18 @@ queries:
                     - C:\Windows\Temp\secpol-import.cfg
                     - C:\Windows\Temp\secpol-db.sdb
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. Use this Chef Infra recipe code to require passwords that meet the complexity requirements:
+
+            ```ruby
+            windows_security_policy 'PasswordComplexity' do
+              secvalue '1'
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-relax-minimum-password-length-limits-is-set-to-enabled
     title: Ensure 'Relax minimum password length limits' is set to 'Enabled'
     impact: 60
@@ -7382,6 +8445,23 @@ queries:
                     name: RelaxMinimumPasswordLengthLimits
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `RelaxMinimumPasswordLengthLimits` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\System\CurrentControlSet\Control\SAM' do
+              values [{
+                name: 'RelaxMinimumPasswordLengthLimits',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-require-secure-rpc-communication-is-set-to-enabled
     title: Ensure 'Require secure RPC communication' is set to 'Enabled'
@@ -7490,6 +8570,23 @@ queries:
                     name: fEncryptRPCTraffic
                     data: 1
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `fEncryptRPCTraffic` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'fEncryptRPCTraffic',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-require-use-of-specific-security-layer-for-remote-rdp-connections-is-set-to
     title: "Ensure RDP connections use SSL security layer"
@@ -7605,6 +8702,23 @@ queries:
                     name: SecurityLayer
                     data: 2
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `SecurityLayer` registry value that backs this policy to `2`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'SecurityLayer',
+                type: :dword,
+                data: 2,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-require-user-authentication-for-remote-connections-by-using-network-level-a
     title: Ensure Network Level Authentication is required for RDP
@@ -7730,6 +8844,23 @@ queries:
                     data: 1
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `UserAuthentication` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'UserAuthentication',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-security-control-event-log-behavior-when-the-log-file-reaches-its-maximum-size
     title: "Ensure 'Security: Control Event Log max size behavior' is disabled"
     impact: 30
@@ -7835,6 +8966,23 @@ queries:
                     data: "0"
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `Retention` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Security' do
+              values [{
+                name: 'Retention',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-security-specify-the-maximum-log-file-size-kb-is-set-to-enabled-196608
     title: "Ensure Security log file size is set to 196,608 KB or greater"
     impact: 50
@@ -7939,6 +9087,23 @@ queries:
                     name: MaxSize
                     data: 196608
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxSize` registry value that backs this policy to `196608`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Security' do
+              values [{
+                name: 'MaxSize',
+                type: :dword,
+                data: 196608,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-set-client-connection-encryption-level-is-set-to-enabled-high-level
     title: "Ensure RDP client connection encryption is set to High Level"
@@ -8057,6 +9222,23 @@ queries:
                     name: MinEncryptionLevel
                     data: 3
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MinEncryptionLevel` registry value that backs this policy to `3`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'MinEncryptionLevel',
+                type: :dword,
+                data: 3,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-set-time-limit-for-active-but-idle-remote-desktop-services-sessions-is-set
     title: "Ensure idle RDS sessions time out in 15 minutes or less"
@@ -8178,6 +9360,23 @@ queries:
                     data: 900000
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxIdleTime` registry value that backs this policy to `900000`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'MaxIdleTime',
+                type: :dword,
+                data: 900000,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-set-time-limit-for-disconnected-sessions-is-set-to-enabled-1-minute
     title: "Ensure disconnected RDS sessions time out in 1 minute"
     impact: 50
@@ -8288,6 +9487,23 @@ queries:
                     data: 60000
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxDisconnectionTime` registry value that backs this policy to `60000`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services' do
+              values [{
+                name: 'MaxDisconnectionTime',
+                type: :dword,
+                data: 60000,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-setup-control-event-log-behavior-when-the-log-file-reaches-its-maximum-size
     title: "Ensure 'Setup: Control Event Log max size behavior' is disabled"
     impact: 30
@@ -8393,6 +9609,23 @@ queries:
                     data: "0"
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `Retention` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Setup' do
+              values [{
+                name: 'Retention',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-setup-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure Setup log file size is set to 32,768 KB or greater"
     impact: 30
@@ -8497,6 +9730,23 @@ queries:
                     name: MaxSize
                     data: 32768
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxSize` registry value that backs this policy to `32768`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\Setup' do
+              values [{
+                name: 'MaxSize',
+                type: :dword,
+                data: 32768,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-store-passwords-using-reversible-encryption-is-set-to-disabled
     title: Ensure 'Store passwords using reversible encryption' is set to 'Disabled'
@@ -8622,6 +9872,18 @@ queries:
                     - C:\Windows\Temp\secpol-import.cfg
                     - C:\Windows\Temp\secpol-db.sdb
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            On a domain member, apply this through the Default Domain Policy GPO instead, because a local change is overwritten when Group Policy refreshes. Use this Chef Infra recipe code to stop passwords being stored with reversible encryption, which is equivalent to storing them in plaintext:
+
+            ```ruby
+            windows_security_policy 'ClearTextPassword' do
+              secvalue '0'
+              action :set
+            end
+            ```
   - uid: mondoo-windows-security-system-control-event-log-behavior-when-the-log-file-reaches-its-maximum-size
     title: "Ensure 'System: Control Event Log max size behavior' is disabled"
     impact: 30
@@ -8725,6 +9987,23 @@ queries:
                     name: Retention
                     data: "0"
                     type: dword
+            ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `Retention` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\System' do
+              values [{
+                name: 'Retention',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
             ```
   - uid: mondoo-windows-security-system-specify-the-maximum-log-file-size-kb-is-set-to-enabled-32768
     title: "Ensure System log file size is set to 32,768 KB or greater"
@@ -8843,6 +10122,23 @@ queries:
                     data: 32768
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `MaxSize` registry value that backs this policy to `32768`:
+
+            ```ruby
+            registry_key 'HKLM\Software\Policies\Microsoft\Windows\EventLog\System' do
+              values [{
+                name: 'MaxSize',
+                type: :dword,
+                data: 32768,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-turn-off-multicast-name-resolution-is-set-to-enabled
     title: Ensure 'Turn off multicast name resolution' is set to 'Enabled'
     impact: 80
@@ -8954,6 +10250,23 @@ queries:
                     data: 0
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `EnableMulticast` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient' do
+              values [{
+                name: 'EnableMulticast',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-wdigest-authentication-is-set-to-disabled
     title: Ensure 'WDigest Authentication' is set to 'Disabled'
     impact: 80
@@ -9059,6 +10372,23 @@ queries:
                     data: 0
                     type: dword
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            Use this Chef Infra recipe code to set the `UseLogonCredential` registry value that backs this policy to `0`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest' do
+              values [{
+                name: 'UseLogonCredential',
+                type: :dword,
+                data: 0,
+              }]
+              recursive true
+              action :create
+            end
+            ```
   - uid: mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none-dc
     filters: |
       windows.computerInfo.OsProductType == 2
@@ -9152,6 +10482,23 @@ queries:
                 type: dword
               notify: reboot
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `Enabled` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity' do
+              values [{
+                name: 'Enabled',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/windows/security/hardware-security/enable-virtualization-based-protection-of-code-integrity
         title: Enable memory integrity
@@ -9237,6 +10584,23 @@ queries:
                 type: dword
               notify: reboot
             ```
+        - id: chef
+          desc: |
+            **Using Chef Infra**
+
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `LsaCfgFlags` registry value that backs this policy to `1`:
+
+            ```ruby
+            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\LSA' do
+              values [{
+                name: 'LsaCfgFlags',
+                type: :dword,
+                data: 1,
+              }]
+              recursive true
+              action :create
+            end
+            ```
     refs:
       - url: https://learn.microsoft.com/en-us/windows/security/identity-protection/credential-guard/configure
         title: Configure Credential Guard
@@ -9297,6 +10661,7 @@ queries:
             3. Ensure the system is in **UEFI** boot mode (not Legacy/CSM), then set **Secure Boot** to **Enabled**.
             4. Save changes and exit. For a virtual machine, enable Secure Boot in the hypervisor's firmware/boot settings instead.
         # No Group Policy / PowerShell / Ansible remediation: Secure Boot is enabled in UEFI firmware and cannot be turned on from the running operating system.
+        # No Chef Infra remediation: Secure Boot is a UEFI firmware setting changed before the operating system loads, so no converge step can reach it.
     refs:
       - url: https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-secure-boot
         title: Secure Boot

--- a/content/validation/validate_chef_remediation.py
+++ b/content/validation/validate_chef_remediation.py
@@ -38,6 +38,11 @@ TARGETS = {
         SCRIPT_DIR / ".." / "mondoo-linux-snmp-policy.mql.yaml",
         SCRIPT_DIR / ".." / "mondoo-linux-workstation-security.mql.yaml",
     ],
+    "freebsd": [SCRIPT_DIR / ".." / "mondoo-freebsd-security.mql.yaml"],
+    "windows": [
+        SCRIPT_DIR / ".." / "mondoo-windows-security.mql.yaml",
+        SCRIPT_DIR / ".." / "mondoo-windows-workstation-security.mql.yaml",
+    ],
     "chef": [
         SCRIPT_DIR / ".." / "mondoo-chef-infra-client.mql.yaml",
         SCRIPT_DIR / ".." / "mondoo-chef-infra-server.mql.yaml",


### PR DESCRIPTION
Follow-on to #3257, which added `validate_chef_remediation.py`. This extends it with `freebsd` and `windows` targets and adds the recipes.

## mondoo-windows-security — 87 checks

Almost everything maps onto a purpose-built core resource rather than a shell-out:

| Resource | Checks |
|---|---|
| `registry_key` | 52 |
| `windows_audit_policy` | 27 |
| `windows_security_policy` | 7 |
| `windows_user_privilege` | 1 |

Every value is derived from what the policy already ships, not invented:

- **Registry** paths, names, values, and types come from the existing `powershell` remediation.
- **Audit subcategory names** come from each check's own **MQL** (`windows.auditPolicy.subcategory(name: "…")`) — that is what the check actually reads. This matters: the Group Policy UI path says *PNP Activity* where the check reads *Plug and Play Events*.
- **success/failure** pairs match the `auditpol` call the PowerShell remediation makes, and each was confirmed against what the check asserts.

**Domain controller branch.** The named-pipes check must keep `LSARPC`, `NETLOGON`, and `SAMR` on a DC and clear the list everywhere else, exactly as its PowerShell remediation does. The recipe branches on `node['kernel']['os_info']['product_type'] == 2`. Worth flagging for review: the more obvious `node['kernel']['product_type']` collapses to `Workstation`/`Server` and **cannot** identify a domain controller — I checked Ohai's `product_type_decode` rather than assuming.

**Account policies** carry the same caveat the PowerShell remediation does: `windows_security_policy` drives `secedit`, so on a domain member a local change is overwritten at the next Group Policy refresh.

## mondoo-freebsd-security — 47 checks

Two platform differences drive these, both verified against the Chef source rather than assumed:

- **The `sysctl` resource is not usable here.** It writes `/etc/sysctl.d`, which FreeBSD base does not read, so the setting would never persist. Kernel parameters go into `/etc/sysctl.conf` and reload with `sysctl -f`. Cookstyle's `Chef/Modernize/ExecuteSysctl` only matches `sysctl -p`, so this does not trip it.
- **`service` is the `sysrc` equivalent.** Chef's FreeBSD service provider derives the rcvar from the rc script and edits `/etc/rc.conf` itself, so `action :disable` does what `sysrc foo_enable=NO` does. Guards on the rc script path keep the converge from failing where a daemon was never installed.

The `sudo` resource already knows FreeBSD keeps sudoers under `/usr/local/etc`, so `sudo '99-use-pty'` needs no override.

## Eight checks get a comment instead of a recipe

- **Secure Boot** — a UEFI firmware setting changed before the OS loads. The policy ships only a `gui` remediation for the same reason.
- **Seven FreeBSD account-hygiene checks** (duplicate UIDs/GIDs/names, missing primary groups, `NOPASSWD` in sudoers) — these need a human to decide which account to renumber or which sudoers line to edit. Their existing Ansible "remediations" only report, too.

## Verification

- `validate_chef_remediation.py`: **277 passed, 0 failed** across the repo (114 Linux + 87 Windows + 47 FreeBSD + 29 pre-existing)
- `cnspec policy lint ./content`: valid
- `go test -count=1 ./content/...`: passing
- Windows registry paths checked in Ruby to confirm single-quoted backslashes resolve literally (`'HKLM\SYSTEM\…'` → one backslash per segment)

Versions bumped: freebsd 1.0.4 → 1.1.0, windows 2.4.2 → 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)