### PR TITLE
🐛 freebsd: drop redundant rc.d guards from Chef service remediations

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -350,7 +350,6 @@ queries:
             ```ruby
             service 'savecore' do
               action :disable
-              only_if { ::File.exist?('/etc/rc.d/savecore') }
             end
             ```
   - uid: mondoo-freebsd-security-core-dump-storage-is-disabled
@@ -1685,7 +1684,6 @@ queries:
             ```ruby
             service 'ypserv' do
               action %i(stop disable)
-              only_if { ::File.exist?('/etc/rc.d/ypserv') }
             end
             ```
   - uid: mondoo-freebsd-security-rpcbind-is-not-enabled
@@ -1780,7 +1778,6 @@ queries:
             ```ruby
             service 'rpcbind' do
               action %i(stop disable)
-              only_if { ::File.exist?('/etc/rc.d/rpcbind') }
             end
             ```
   - uid: mondoo-freebsd-security-nfs-server-is-not-enabled
@@ -1885,7 +1882,6 @@ queries:
             ```ruby
             service 'nfsd' do
               action %i(stop disable)
-              only_if { ::File.exist?('/etc/rc.d/nfsd') }
             end
             ```
   - uid: mondoo-freebsd-security-snmp-server-is-not-enabled
@@ -1988,7 +1984,6 @@ queries:
             ```ruby
             service 'snmpd' do
               action %i(stop disable)
-              only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
             end
             ```
   - uid: mondoo-freebsd-security-tftp-server-is-not-enabled
@@ -2213,10 +2208,9 @@ queries:
             Use this Chef Infra recipe code to stop and disable the IMAP and POP3 daemons:
 
             ```ruby
-            { 'dovecot' => '/usr/local/etc/rc.d/dovecot', 'imapd' => '/usr/local/etc/rc.d/imapd' }.each do |name, rc_script|
-              service name do
+            %w(dovecot imapd).each do |svc|
+              service svc do
                 action %i(stop disable)
-                only_if { ::File.exist?(rc_script) }
               end
             end
             ```
@@ -2320,7 +2314,6 @@ queries:
             ```ruby
             service 'squid' do
               action %i(stop disable)
-              only_if { ::File.exist?('/usr/local/etc/rc.d/squid') }
             end
             ```
   - uid: mondoo-freebsd-security-mail-transfer-agent-is-configured-for-local-only-mode


### PR DESCRIPTION
Follow-up to #3258. The Chef remediations I added there guarded every `service` resource with `only_if { ::File.exist?('/etc/rc.d/<name>') }`. That guard is unnecessary, and in two cases actively wrong.

## It is unnecessary

Chef's FreeBSD service provider excludes `:stop` and `:disable` from the assertion that requires an rc.d script — only `:start`, `:enable`, `:reload`, and `:restart` are listed:

```ruby
# chef/provider/service/freebsd.rb
requirements.assert(:start, :enable, :reload, :restart) do |a|
  a.assertion { init_command }
  a.failure_message Chef::Exceptions::Service, "#{new_resource}: unable to locate the rc.d script"
end
```

And the base provider's actions only do work when the current state says there is work to do:

```ruby
# chef/provider/service.rb
action :disable do
  if current_resource.enabled
    converge_by("disable service #{new_resource}") { disable_service }
  else
    logger.debug("#{new_resource} already disabled - nothing to do")
  end
end
```

When the rc script is missing, `load_current_resource` returns early without reading `running` or `enabled`, so both are nil and both actions log "nothing to do". **Disabling a service that was never installed is already a no-op, not a failure.** The same holds for the systemd provider, where `systemctl show` reports `UnitFileState=` for an unknown unit and `is_enabled?` returns false.

## It is wrong

The path was hardcoded per service, but the provider itself looks in **both** `/etc/rc.d` and `/usr/local/etc/rc.d`:

```ruby
if ::TargetIO::File.exist?("/etc/rc.d/#{new_resource.service_name}")
  @init_command = "/etc/rc.d/#{new_resource.service_name}"
elsif ::TargetIO::File.exist?("/usr/local/etc/rc.d/#{new_resource.service_name}")
  @init_command = "/usr/local/etc/rc.d/#{new_resource.service_name}"
end
```

So the guard could skip a service that genuinely needed disabling:

- **snmpd** was guarded on `/usr/local/etc/rc.d/snmpd` only — a host running base `bsnmpd` out of `/etc/rc.d` would have been silently skipped.
- **dovecot / imapd** had the same gap in the other direction.

That is the worse failure mode: the recipe converges green while leaving the daemon enabled.

## Change

Removes the guards from all seven affected checks, which also lets the two-service case collapse from a path map back to a plain list:

```ruby
%w(dovecot imapd).each do |svc|
  service svc do
    action %i(stop disable)
  end
end
```

Note this does **not** apply to the `systemd_unit` guards in `mondoo-linux-security`. That is a different resource which shells out unconditionally, so `systemctl disable` on a missing unit does fail and the guard there is required.

Verified: `validate_chef_remediation.py freebsd` 47 passed / 0 failed, `cnspec policy lint` valid, `go test -count=1 ./content/...` passing. Version 1.1.0 → 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)