### PR TITLE
🧹 claude: stop writing session URLs into commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "sessionUrl": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,13 @@ gha-creds-*.json
 # goreleaser build folder
 dist/
 
-# claude local config
+# claude local config. .claude/settings.json is shared team config and is
+# tracked; everything else under .claude/ is personal. Note this must be
+# ".claude/*" and not ".claude/": git does not descend into an ignored
+# directory, so a trailing-slash rule cannot be un-ignored per file.
 settings.local.json
-.claude/
+.claude/*
+!.claude/settings.json
 
 # python
 __pycache__/


### PR DESCRIPTION
## What this does

Stops Claude Code from writing `claude.ai` session URLs into our git history and PR descriptions.

When Claude Code runs from a web or Remote Control session, it appends the originating session link in two places:

- a `Claude-Session: https://claude.ai/code/session_…` trailer on the commit
- a link in the pull request description

#3211 is a live example — the session ID landed in both the commit message and twice in the PR body. Those identifiers are permanent once merged, are meaningless to anyone reading the repo later, and are visible publicly.

## The fix

A shared project config at `.claude/settings.json`:

```json
{
  "$schema": "https://json.schemastore.org/claude-code-settings.json",
  "attribution": { "sessionUrl": false }
}
```

Normal attribution is untouched — the `🤖 Generated with Claude Code` line and the `Co-Authored-By:` trailer both still apply. Only the session link is suppressed.

## Why `.gitignore` also changed

`.claude/` was ignored wholesale, so a shared team config could never be checked in at all.

Git does not descend into an ignored directory, which means a trailing-slash rule cannot be un-ignored per file — `!.claude/settings.json` has no effect while `.claude/` is the rule. The pattern has to become `.claude/*` with an explicit negation:

```gitignore
settings.local.json
.claude/*
!.claude/settings.json
```

Everything else under `.claude/`, including `settings.local.json`, stays ignored exactly as before.

## Validation

```
$ git add -n .claude/
add '.claude/settings.json'          # and nothing else

$ git check-ignore .claude/settings.local.json
.claude/settings.local.json          # still ignored
```

The `attribution.sessionUrl` key is documented in the [Claude Code settings schema](https://json.schemastore.org/claude-code-settings.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
