### PR TITLE
🐛 freebsd: map the two new checks to OWASP Top 10:2025

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6401,6 +6401,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-10-6-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -6489,6 +6490,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-id-ra-09
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-14
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a08
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false


### PR DESCRIPTION
## Why

`main` is red. #2917 added `mondoo-freebsd-security-time-synchronization-is-enabled` and `mondoo-freebsd-security-pkg-signature-verification-is-enabled` without a `compliance/owasp-top-10-2025` tag, and `TestOwaspTop10Mapping` enforces parity — a policy that is OWASP-mapped must map *every* framework-mapped check, so partial coverage cannot silently under-report a policy:

```
FAIL: content/compliance TestOwaspTop10Mapping/mondoo-freebsd-security.mql.yaml
  check "mondoo-freebsd-security-pkg-signature-verification-is-enabled" is framework-mapped
  but missing a compliance/owasp-top-10-2025 tag (policy must be fully mapped)
  check "mondoo-freebsd-security-time-synchronization-is-enabled" ... (same)
```

This fails `go-test` on every open PR, not just the one where I hit it.

## Mapping rationale

Neither tag is copied from a topical neighbor. Each check already carries a full tag set, and in both cases `mondoo-linux-security` contains a check asserting the *same control* whose other framework mappings are identical — so the OWASP value is the one already established for that control objective.

**pkg signature verification → `a08` (Software or Data Integrity Failures)**

| | this check | linux `gpgcheck-is-globally-activated` | linux `apt-repositories-enforce-signature-verification` |
|---|---|---|---|
| iso-27001-2022 | `a-8-19` | `a-8-19` | `a-8-19` |
| nist-csf-2 | `id-ra-09` | `id-ra-09` | `id-ra-09` |
| 800-53-rev5 | `cm-14` | `cm-14` | `cm-14` |
| 800-171 | `3-4-8` | `3-4-8` | `3-4-8` |
| **owasp** | **`a08`** | `a08` | `a08` |

`mondoo-docker-security-no-gpg-skip-yum` is a third precedent at `a08`. Verifying package signatures before install is software-integrity verification of an update channel, which is what A08 covers.

**time synchronization → `a02` (Security Misconfiguration)**

| | this check | linux `chrony-time-source-is-configured` | linux `timesyncd-clock-is-synchronized` |
|---|---|---|---|
| iso-27001-2022 | `a-8-17` | `a-8-17` | `a-8-17` |
| pci-dss-4 | `10-6-1` | `10-6-1` | `10-6-1` |
| **owasp** | **`a02`** | `a02` | `a02` |

Worth flagging for the reviewer: the repo currently splits on this control. The OS policies map time sync to `a02` (an unconfigured time source is missing hardening); the network-appliance policies — arista, cisco iosxe/iosxr/nxos, fortios, mikrotik, nutanix, esxi — map it to `a09`, reading it as a logging-quality precondition. I followed the OS precedent since this is an OS policy whose tag set matches the Linux checks exactly. Happy to flip both this and the Linux pair to `a09` if the intended reading is the appliance one, but that is a broader re-mapping than this build fix.

## Verification

```
$ go test ./content/compliance
ok  	go.mondoo.com/cnspec/v13/content/compliance	5.683s

$ cnspec policy lint content/mondoo-freebsd-security.mql.yaml
→ valid policy bundle(s)
```

Diff is two lines, each inserted in the tags block's existing alphabetical position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)