### PR TITLE
🧹 lint: report deprecated symbols used in query filters

### DIFF
--- a/internal/bundle/lint_rules_deprecated_symbols.go
+++ b/internal/bundle/lint_rules_deprecated_symbols.go
@@ -52,18 +52,90 @@ func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerC
 	return entries
 }
 
+// walkQueryForDeprecatedSymbols reports deprecated symbols used by a query,
+// looking at both its mql and its filters. Filters matter as much as mql here:
+// when a deprecated symbol is finally removed, a filter that references it stops
+// matching and the check silently stops scoring assets instead of failing loudly.
+//
+// A symbol used in both places is reported once. The mql site wins, because that
+// is where a reader will find it; the "in its filters" hint is only added for
+// symbols that appear nowhere else, since every warning points at the query's own
+// line and filter Mqueries carry no file context of their own.
 func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerConfig, filename string, q *Mquery) []*Entry {
-	if q == nil || q.Mql == "" {
+	if q == nil {
 		return nil
 	}
 
-	usage, _, err := mqlc.AnalyzeQuery(q.Mql, mqlc.EmptyPropsHandler, conf)
-	if err != nil || usage == nil {
+	fromMql := deprecatedSymbolsIn(q.Mql, conf)
+
+	seen := make(map[string]struct{}, len(fromMql))
+	for _, symbol := range fromMql {
+		seen[symbol] = struct{}{}
+	}
+
+	var fromFilters []string
+	if q.Filters != nil {
+		// Sort for stable output across runs.
+		filterKeys := make([]string, 0, len(q.Filters.Items))
+		for key := range q.Filters.Items {
+			filterKeys = append(filterKeys, key)
+		}
+		sort.Strings(filterKeys)
+
+		for _, key := range filterKeys {
+			filter := q.Filters.Items[key]
+			if filter == nil {
+				continue
+			}
+			for _, symbol := range deprecatedSymbolsIn(filter.Mql, conf) {
+				if _, ok := seen[symbol]; ok {
+					continue
+				}
+				seen[symbol] = struct{}{}
+				fromFilters = append(fromFilters, symbol)
+			}
+		}
+	}
+
+	if len(fromMql) == 0 && len(fromFilters) == 0 {
 		return nil
 	}
 
 	loc := []Location{{File: filename, Line: q.FileContext.Line, Column: q.FileContext.Column}}
 	display := queryDisplayID(q)
+
+	entries := make([]*Entry, 0, len(fromMql)+len(fromFilters))
+	newEntry := func(symbol, where string) *Entry {
+		return &Entry{
+			RuleID:   QueryDeprecatedSymbolRuleID,
+			Level:    LevelWarning,
+			Message:  fmt.Sprintf("query '%s' uses %s%s", display, symbol, where),
+			Location: loc,
+		}
+	}
+	for _, symbol := range fromMql {
+		entries = append(entries, newEntry(symbol, ""))
+	}
+	for _, symbol := range fromFilters {
+		entries = append(entries, newEntry(symbol, " in its filters"))
+	}
+
+	return entries
+}
+
+// deprecatedSymbolsIn compiles a single MQL snippet and returns the deprecated
+// symbols it uses, as stable-sorted descriptions such as "deprecated resource
+// 'processes'" or "deprecated field 'file.basename'". Compile errors are
+// intentionally ignored — bundle-compile-error already surfaces them.
+func deprecatedSymbolsIn(query string, conf mqlc.CompilerConfig) []string {
+	if query == "" {
+		return nil
+	}
+
+	usage, _, err := mqlc.AnalyzeQuery(query, mqlc.EmptyPropsHandler, conf)
+	if err != nil || usage == nil {
+		return nil
+	}
 
 	// Sort for stable output across runs.
 	providerIDs := make([]string, 0, len(usage.Providers))
@@ -72,7 +144,7 @@ func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.C
 	}
 	sort.Strings(providerIDs)
 
-	var entries []*Entry
+	var symbols []string
 	for _, pid := range providerIDs {
 		pu := usage.Providers[pid]
 		resourceNames := make([]string, 0, len(pu.Resources))
@@ -84,12 +156,7 @@ func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.C
 		for _, rname := range resourceNames {
 			ru := pu.Resources[rname]
 			if ru.Maturity == resources.MaturityDeprecated {
-				entries = append(entries, &Entry{
-					RuleID:   QueryDeprecatedSymbolRuleID,
-					Level:    LevelWarning,
-					Message:  fmt.Sprintf("query '%s' uses deprecated resource '%s'", display, rname),
-					Location: loc,
-				})
+				symbols = append(symbols, fmt.Sprintf("deprecated resource '%s'", rname))
 				// Skip field warnings on a deprecated resource — every field
 				// inherits the deprecated effective maturity, which would
 				// drown the resource-level warning in noise.
@@ -106,17 +173,12 @@ func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.C
 				if ru.Fields[fname].EffectiveMaturity != resources.MaturityDeprecated {
 					continue
 				}
-				entries = append(entries, &Entry{
-					RuleID:   QueryDeprecatedSymbolRuleID,
-					Level:    LevelWarning,
-					Message:  fmt.Sprintf("query '%s' uses deprecated field '%s.%s'", display, rname, fname),
-					Location: loc,
-				})
+				symbols = append(symbols, fmt.Sprintf("deprecated field '%s.%s'", rname, fname))
 			}
 		}
 	}
 
-	return entries
+	return symbols
 }
 
 func queryDisplayID(q *Mquery) string {

--- a/internal/bundle/lint_rules_deprecated_symbols_test.go
+++ b/internal/bundle/lint_rules_deprecated_symbols_test.go
@@ -4,6 +4,7 @@
 package bundle
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +137,136 @@ func TestDeprecatedSymbol_DedupesRepeatedReferences(t *testing.T) {
 
 	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
 	require.Len(t, entries, 1, "duplicate references to the same deprecated field should collapse to a single warning")
+}
+
+func TestDeprecatedSymbol_FiltersOnly(t *testing.T) {
+	overlay := &deprecateOverlay{
+		inner: schema,
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+
+	// A variant parent carries filters but no mql of its own.
+	q := &Mquery{
+		Uid:         "test-filters-only",
+		FileContext: FileContext{Line: 11, Column: 3},
+		Filters: &Filters{
+			Items: map[string]*Mquery{
+				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+			},
+		},
+	}
+
+	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	require.Len(t, entries, 1)
+	assert.Equal(t, QueryDeprecatedSymbolRuleID, entries[0].RuleID)
+	assert.Equal(t, LevelWarning, entries[0].Level)
+	assert.Contains(t, entries[0].Message, "test-filters-only")
+	assert.Contains(t, entries[0].Message, "file.basename")
+	assert.Contains(t, entries[0].Message, "filters",
+		"a symbol found only in filters should say so, since the line points at the query")
+	assert.Equal(t, 11, entries[0].Location[0].Line,
+		"filter Mqueries carry no FileContext, so the parent query's line must be used")
+}
+
+func TestDeprecatedSymbol_MqlAndFiltersReportSeparateSymbols(t *testing.T) {
+	overlay := &deprecateOverlay{
+		inner:         schema,
+		deprecatedRes: map[string]struct{}{"processes": {}},
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+
+	q := &Mquery{
+		Uid: "test-both-sites",
+		Mql: "processes.length >= 0",
+		Filters: &Filters{
+			Items: map[string]*Mquery{
+				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+			},
+		},
+	}
+
+	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	require.Len(t, entries, 2)
+
+	messages := []string{entries[0].Message, entries[1].Message}
+	assert.Condition(t, func() bool {
+		for _, m := range messages {
+			if strings.Contains(m, "processes") {
+				return true
+			}
+		}
+		return false
+	}, "expected the deprecated resource from mql, got %v", messages)
+	assert.Condition(t, func() bool {
+		for _, m := range messages {
+			if strings.Contains(m, "file.basename") {
+				return true
+			}
+		}
+		return false
+	}, "expected the deprecated field from filters, got %v", messages)
+}
+
+func TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedOnce(t *testing.T) {
+	overlay := &deprecateOverlay{
+		inner: schema,
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+
+	q := &Mquery{
+		Uid: "test-same-symbol-both-sites",
+		Mql: "file('/etc/shadow').basename == 'shadow'",
+		Filters: &Filters{
+			Items: map[string]*Mquery{
+				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+			},
+		},
+	}
+
+	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	require.Len(t, entries, 1, "one symbol used in both mql and filters is still one migration to make")
+	assert.NotContains(t, entries[0].Message, "filters",
+		"the symbol is reachable from mql, so the filters hint would be misleading")
+}
+
+func TestDeprecatedSymbol_MultipleFilterItems(t *testing.T) {
+	overlay := &deprecateOverlay{
+		inner:         schema,
+		deprecatedRes: map[string]struct{}{"processes": {}},
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+
+	// The list form of filters: yields one Mquery per entry, keyed by index.
+	q := &Mquery{
+		Uid: "test-multi-filter-items",
+		Filters: &Filters{
+			Items: map[string]*Mquery{
+				"0": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+				"1": {Mql: "processes.length >= 0"},
+			},
+		},
+	}
+
+	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	require.Len(t, entries, 2, "every filter item should be analyzed, not just the first")
+}
+
+func TestDeprecatedSymbol_NoFiltersIsSafe(t *testing.T) {
+	overlay := &deprecateOverlay{inner: schema}
+
+	q := &Mquery{Uid: "test-nil-filters", Mql: "file('/etc/passwd').basename == 'passwd'"}
+	assert.Empty(t, walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q))
+
+	empty := &Mquery{Uid: "test-empty-everything"}
+	assert.Empty(t, walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", empty))
 }
 
 func TestDeprecatedSymbol_CompileFailureSilent(t *testing.T) {


### PR DESCRIPTION
Fixes #3262.

## What

`query-deprecated-symbol` only ever analyzed a query's `mql:`. Deprecated resources and fields used in `filters:` were silently unreported, so the warning count was a floor rather than a total and a policy could lint clean while still depending on symbols that are on their way out.

`walkQueryForDeprecatedSymbols` now analyzes `q.Filters.Items` alongside `q.Mql`. The `q.Mql == ""` early return no longer short-circuits the whole function — that return was separately dropping **variant parent queries**, which carry `filters:` but no `mql:` of their own, so those were never inspected at all.

The per-snippet analysis moved to a small `deprecatedSymbolsIn` helper. Symbol descriptions are built as strings and the entry construction is shared, so the existing warning text is byte-for-byte unchanged.

## Why filters matter as much as mql

`filters:` is asset selection. When a deprecated symbol is finally removed, a filter that references it stops matching and the check **silently stops scoring assets** rather than failing loudly. Deprecation warnings exist to give us a migration window before that happens, and until now that window was invisible for every filter in the repo.

## Reporting decisions

Two judgement calls worth flagging for review:

- **A symbol used in both `mql:` and `filters:` is reported once**, not twice. It is one migration to make, and both warnings would point at the same line.
- **The `in its filters` hint is added only for symbols that appear nowhere else.** Filter `Mquery` values built by `Filters.UnmarshalYAML` carry no `Uid` and no `FileContext`, so warnings necessarily borrow the parent query's line. Without the hint, a reader given a query's start line would search its `mql:` and find nothing. Where the symbol *is* reachable from `mql:`, the hint would be misleading, so it is omitted.

## Effect on ./content

`cnspec policy lint ./content` goes from 11 to 16 `query-deprecated-symbol` warnings. All 5 new ones are the deprecated `gcp.project.computeService.firewall.allowed` field used in filters, and **every pre-existing warning line is byte-identical**:

```
 query-deprecated-symbol  warning  mondoo-gcp-security.mql.yaml  7636   query 'mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-gcp' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters
 query-deprecated-symbol  warning  mondoo-gcp-security.mql.yaml  7806   query 'mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-gcp' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters
 query-deprecated-symbol  warning  mondoo-gcp-security.mql.yaml  7974   query 'mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-gcp' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters
 query-deprecated-symbol  warning  mondoo-gcp-security.mql.yaml  8140   query 'mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-gcp' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters
 query-deprecated-symbol  warning  mondoo-gcp-security.mql.yaml  23172  query 'mondoo-gcp-security-firewall-no-unrestricted-egress-gcp' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters
```

**No content changes are needed to land this.** These are warnings, `make test/lint/content` passes no `--strict-rule`, and `policies_lint.yaml` only fails the build on SARIF `level == "error"`. Verified: `cnspec policy lint ./content` still exits 0 with 0 errors.

Migrating those 5 GCP filters is deliberately left out of this PR. The replacement `allowedProtocols` is a `map[string][]string`, and the naive translation is unsafe in a filter — `allowedProtocols['tcp'] == empty` is true both when tcp allows every port **and** when tcp is absent entirely. They need a `keys.contains("tcp")` presence guard and their own fixtures, and a subtly wrong filter drops assets from scoring silently. That belongs in its own PR now that the warnings are visible.

## Tests

Written first, and each was watched failing for the right reason before the fix (the three that exercise new detection reported 0 or 1 entries where 1 or 2 were expected):

| test | covers |
|---|---|
| `TestDeprecatedSymbol_FiltersOnly` | variant parent — filters, no mql; also asserts the parent's line is used |
| `TestDeprecatedSymbol_MqlAndFiltersReportSeparateSymbols` | distinct symbols in each site both reported |
| `TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedOnce` | dedup, and no misleading `in its filters` hint |
| `TestDeprecatedSymbol_MultipleFilterItems` | list form of `filters:` — every item analyzed, not just the first |
| `TestDeprecatedSymbol_NoFiltersIsSafe` | nil `Filters`, and a query with neither mql nor filters |

`go test ./internal/bundle/...` passes; `gofmt` and `go vet` clean.

## Known remaining gap

Policy- and group-level `filters:` are still not inspected — only query filters are. Those are not `Mquery` values owned by a query, so they need a different message shape and display ID than `query 'X' uses ...`. Worth a follow-up issue rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
