### PR TITLE
🧹 lint: report deprecated symbols in group and pack filters

### DIFF
--- a/internal/bundle/lint_results_sarif.go
+++ b/internal/bundle/lint_results_sarif.go
@@ -92,6 +92,11 @@ func sarifLinterRules() []Rule {
 		Name:        "Query uses deprecated MQL symbol",
 		Description: "Query references a resource or field annotated with @maturity('deprecated')",
 	})
+	rules = append(rules, Rule{
+		ID:          FilterDeprecatedSymbolRuleID,
+		Name:        "Filter uses deprecated MQL symbol",
+		Description: "A policy group, query pack or pack group filter references a resource or field annotated with @maturity('deprecated')",
+	})
 
 	return rules
 }

--- a/internal/bundle/lint_rules_deprecated_symbols.go
+++ b/internal/bundle/lint_rules_deprecated_symbols.go
@@ -13,23 +13,43 @@ import (
 
 const (
 	QueryDeprecatedSymbolRuleID = "query-deprecated-symbol"
+
+	// FilterDeprecatedSymbolRuleID covers filters that belong to a container
+	// rather than to a query — policy groups, query packs and pack groups.
+	// A query's own filters stay under QueryDeprecatedSymbolRuleID, since those
+	// warnings are attributed to the query.
+	FilterDeprecatedSymbolRuleID = "filter-deprecated-symbol"
 )
 
 // lintDeprecatedSymbols compiles every query with non-empty MQL and reports
 // resources or fields whose effective maturity is "deprecated". Compile errors
 // are intentionally ignored here — bundle-compile-error already surfaces them.
+//
+// Filters attached to a container rather than to a query — policy groups, query
+// packs and pack groups — are covered too. Their stakes are higher than a single
+// query's: when the symbol is removed the filter stops matching and the whole
+// group drops out of scoring rather than one check.
+//
+// ComputedFilters is deliberately skipped. It is derived at load time from the
+// group and query filters already walked here, so reporting it would duplicate
+// warnings at a location the author never wrote.
 func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerConfig, filename string, b *Bundle) []*Entry {
 	var entries []*Entry
 
 	visit := func(q *Mquery) {
 		entries = append(entries, walkQueryForDeprecatedSymbols(schema, conf, filename, q)...)
 	}
+	visitFilters := func(subject string, filters *Filters) {
+		entries = append(entries, walkFiltersForDeprecatedSymbols(conf, filename, subject, filters)...)
+	}
 
 	for _, q := range b.Queries {
 		visit(q)
 	}
 	for _, p := range b.Policies {
-		for _, group := range p.Groups {
+		policy := fmt.Sprintf("policy '%s'", policyDisplayID(p))
+		for i, group := range p.Groups {
+			visitFilters(fmt.Sprintf("%s %s", policy, groupDisplay(group.Uid, group.Title, i)), group.Filters)
 			for _, q := range group.Checks {
 				visit(q)
 			}
@@ -39,10 +59,13 @@ func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerC
 		}
 	}
 	for _, pack := range b.Packs {
+		queryPack := fmt.Sprintf("query pack '%s'", queryPackDisplayID(pack))
+		visitFilters(queryPack, pack.Filters)
 		for _, q := range pack.Queries {
 			visit(q)
 		}
-		for _, group := range pack.Groups {
+		for i, group := range pack.Groups {
+			visitFilters(fmt.Sprintf("%s %s", queryPack, groupDisplay(group.Uid, group.Title, i)), group.Filters)
 			for _, q := range group.Queries {
 				visit(q)
 			}
@@ -50,6 +73,91 @@ func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerC
 	}
 
 	return entries
+}
+
+// walkFiltersForDeprecatedSymbols reports deprecated symbols used by a filters
+// block that belongs to a container rather than a query. Unlike a query's
+// filters, these carry their own file context, so warnings point straight at the
+// filters block instead of borrowing a parent's line.
+func walkFiltersForDeprecatedSymbols(conf mqlc.CompilerConfig, filename string, subject string, filters *Filters) []*Entry {
+	symbols := deprecatedSymbolsInFilters(filters, conf, map[string]struct{}{})
+	if len(symbols) == 0 {
+		return nil
+	}
+
+	loc := []Location{{File: filename, Line: filters.FileContext.Line, Column: filters.FileContext.Column}}
+
+	entries := make([]*Entry, 0, len(symbols))
+	for _, symbol := range symbols {
+		entries = append(entries, &Entry{
+			RuleID:   FilterDeprecatedSymbolRuleID,
+			Level:    LevelWarning,
+			Message:  fmt.Sprintf("%s uses %s in its filters", subject, symbol),
+			Location: loc,
+		})
+	}
+
+	return entries
+}
+
+// deprecatedSymbolsInFilters returns the deprecated symbols used across every
+// item of a filters block, skipping any already recorded in seen and adding the
+// ones it reports. Filters are a map, so items are walked in sorted key order
+// for stable output across runs.
+func deprecatedSymbolsInFilters(filters *Filters, conf mqlc.CompilerConfig, seen map[string]struct{}) []string {
+	if filters == nil || len(filters.Items) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(filters.Items))
+	for key := range filters.Items {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var symbols []string
+	for _, key := range keys {
+		filter := filters.Items[key]
+		if filter == nil {
+			continue
+		}
+		for _, symbol := range deprecatedSymbolsIn(filter.Mql, conf) {
+			if _, ok := seen[symbol]; ok {
+				continue
+			}
+			seen[symbol] = struct{}{}
+			symbols = append(symbols, symbol)
+		}
+	}
+
+	return symbols
+}
+
+// groupDisplay names a policy or query-pack group. Groups rarely carry a uid or
+// a title, so it falls back to the group's position, which is still enough to
+// find it alongside the reported line.
+func groupDisplay(uid, title string, index int) string {
+	if uid != "" {
+		return fmt.Sprintf("group '%s'", uid)
+	}
+	if title != "" {
+		return fmt.Sprintf("group '%s'", title)
+	}
+	return fmt.Sprintf("group %d", index+1)
+}
+
+func policyDisplayID(p *Policy) string {
+	if p.Uid != "" {
+		return p.Uid
+	}
+	return p.Mrn
+}
+
+func queryPackDisplayID(pack *QueryPack) string {
+	if pack.Uid != "" {
+		return pack.Uid
+	}
+	return pack.Mrn
 }
 
 // walkQueryForDeprecatedSymbols reports deprecated symbols used by a query,
@@ -73,29 +181,7 @@ func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.C
 		seen[symbol] = struct{}{}
 	}
 
-	var fromFilters []string
-	if q.Filters != nil {
-		// Sort for stable output across runs.
-		filterKeys := make([]string, 0, len(q.Filters.Items))
-		for key := range q.Filters.Items {
-			filterKeys = append(filterKeys, key)
-		}
-		sort.Strings(filterKeys)
-
-		for _, key := range filterKeys {
-			filter := q.Filters.Items[key]
-			if filter == nil {
-				continue
-			}
-			for _, symbol := range deprecatedSymbolsIn(filter.Mql, conf) {
-				if _, ok := seen[symbol]; ok {
-					continue
-				}
-				seen[symbol] = struct{}{}
-				fromFilters = append(fromFilters, symbol)
-			}
-		}
-	}
+	fromFilters := deprecatedSymbolsInFilters(q.Filters, conf, seen)
 
 	if len(fromMql) == 0 && len(fromFilters) == 0 {
 		return nil

--- a/internal/bundle/lint_rules_deprecated_symbols_test.go
+++ b/internal/bundle/lint_rules_deprecated_symbols_test.go
@@ -280,3 +280,191 @@ func TestDeprecatedSymbol_CompileFailureSilent(t *testing.T) {
 	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
 	assert.Empty(t, entries, "compile failures should be silently skipped — bundle-compile-error reports them")
 }
+
+// deprecatedFieldOverlay is the fixture shared by the container-filter tests:
+// file.basename is deprecated, and this filter references it.
+func deprecatedFieldOverlay() *deprecateOverlay {
+	return &deprecateOverlay{
+		inner: schema,
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+}
+
+func deprecatedFilters(line int) *Filters {
+	return &Filters{
+		FileContext: FileContext{Line: line, Column: 5},
+		Items: map[string]*Mquery{
+			"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+		},
+	}
+}
+
+func TestDeprecatedSymbol_PolicyGroupFilters(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Policies: []*Policy{{
+			Uid: "test-policy",
+			Groups: []*PolicyGroup{{
+				Title:   "Linux hosts",
+				Filters: deprecatedFilters(42),
+			}},
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 1)
+	assert.Equal(t, FilterDeprecatedSymbolRuleID, entries[0].RuleID,
+		"a policy group is not a query, so it must not report under the query rule")
+	assert.Equal(t, LevelWarning, entries[0].Level)
+	assert.Contains(t, entries[0].Message, "test-policy")
+	assert.Contains(t, entries[0].Message, "Linux hosts")
+	assert.Contains(t, entries[0].Message, "file.basename")
+	assert.Equal(t, 42, entries[0].Location[0].Line,
+		"a group's filters block has its own file context, so point at it directly")
+}
+
+func TestDeprecatedSymbol_PolicyGroupFiltersWithoutTitle(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Policies: []*Policy{{
+			Uid: "test-policy",
+			Groups: []*PolicyGroup{
+				{Title: "first group, no deprecation"},
+				{Filters: deprecatedFilters(77)},
+			},
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].Message, "group 2",
+		"an untitled group still needs to be identifiable, so fall back to its position")
+}
+
+func TestDeprecatedSymbol_QueryPackFilters(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Packs: []*QueryPack{{
+			Uid:     "test-pack",
+			Filters: deprecatedFilters(13),
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 1)
+	assert.Equal(t, FilterDeprecatedSymbolRuleID, entries[0].RuleID)
+	assert.Contains(t, entries[0].Message, "test-pack")
+	assert.Contains(t, entries[0].Message, "file.basename")
+	assert.Equal(t, 13, entries[0].Location[0].Line)
+}
+
+func TestDeprecatedSymbol_QueryPackGroupFilters(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Packs: []*QueryPack{{
+			Uid: "test-pack",
+			Groups: []*QueryGroup{{
+				Title:   "Inventory",
+				Filters: deprecatedFilters(21),
+			}},
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 1)
+	assert.Equal(t, FilterDeprecatedSymbolRuleID, entries[0].RuleID)
+	assert.Contains(t, entries[0].Message, "test-pack")
+	assert.Contains(t, entries[0].Message, "Inventory")
+	assert.Equal(t, 21, entries[0].Location[0].Line)
+}
+
+func TestDeprecatedSymbol_ComputedFiltersNotReported(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	// ComputedFilters is derived at load time from the group and query filters,
+	// so reporting it would double up on warnings the author cannot act on.
+	b := &Bundle{
+		Policies: []*Policy{{
+			Uid:             "test-policy",
+			ComputedFilters: deprecatedFilters(9),
+		}},
+		Packs: []*QueryPack{{
+			Uid:             "test-pack",
+			ComputedFilters: deprecatedFilters(11),
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	assert.Empty(t, entries)
+}
+
+func TestDeprecatedSymbol_GroupFilterAndCheckReportedIndependently(t *testing.T) {
+	overlay := &deprecateOverlay{
+		inner:         schema,
+		deprecatedRes: map[string]struct{}{"processes": {}},
+		deprecatedFields: map[string]map[string]struct{}{
+			"file": {"basename": {}},
+		},
+	}
+
+	b := &Bundle{
+		Policies: []*Policy{{
+			Uid: "test-policy",
+			Groups: []*PolicyGroup{{
+				Title:   "Linux hosts",
+				Filters: deprecatedFilters(42),
+				Checks: []*Mquery{{
+					Uid:         "test-check",
+					Mql:         "processes.length >= 0",
+					FileContext: FileContext{Line: 50},
+				}},
+			}},
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 2, "the group's filters and the check's mql are separate sites")
+
+	byRule := map[string]*Entry{}
+	for _, e := range entries {
+		byRule[e.RuleID] = e
+	}
+	require.Contains(t, byRule, FilterDeprecatedSymbolRuleID)
+	require.Contains(t, byRule, QueryDeprecatedSymbolRuleID)
+	assert.Contains(t, byRule[FilterDeprecatedSymbolRuleID].Message, "file.basename")
+	assert.Contains(t, byRule[QueryDeprecatedSymbolRuleID].Message, "processes")
+}
+
+func TestDeprecatedSymbol_ContainerFiltersDedupeAndSkipEmpties(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Policies: []*Policy{{
+			Uid: "test-policy",
+			Groups: []*PolicyGroup{
+				{Title: "no filters at all"},
+				{Title: "empty filters", Filters: &Filters{}},
+				{
+					Title: "repeated symbol",
+					Filters: &Filters{
+						FileContext: FileContext{Line: 31},
+						Items: map[string]*Mquery{
+							"0": {Mql: "file('/a').basename == 'a'"},
+							"1": {Mql: "file('/b').basename == 'b'"},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 1, "one deprecated symbol in one group's filters is one warning")
+	assert.Equal(t, 31, entries[0].Location[0].Line)
+}


### PR DESCRIPTION
Fixes #3265. Follow-up to #3264.

## What

#3264 made the deprecated-symbol lint inspect a **query's** `filters:`. Filters belonging to a *container* were still never analyzed. This covers the remaining three:

| type | field | before | after |
|---|---|---|---|
| `Mquery` | `Filters` | ✅ (#3264) | ✅ |
| `PolicyGroup` | `Filters` | ❌ | ✅ |
| `QueryPack` | `Filters` | ❌ | ✅ |
| `QueryGroup` (pack groups) | `Filters` | ❌ | ✅ |
| `Policy` / `QueryPack` | `ComputedFilters` | ❌ | ❌ — deliberate, see below |

A stale container filter is worse than a stale query filter: when the symbol is removed the filter stops matching and the **whole group** drops out of scoring, not one check.

## Decisions the issue left open

**New rule ID, not a reuse.** These report under `filter-deprecated-symbol` rather than `query-deprecated-symbol`. A policy group is not a query, and reusing the query rule would emit `policy 'X' group 'Y' uses ...` under a rule ID that claims otherwise — visible in SARIF output and in `--strict-rule` selections. Registered in `sarifLinterRules()` so it appears in the SARIF driver rule list. A query's own filters stay under `query-deprecated-symbol`, since those warnings are genuinely attributed to a query.

The tradeoff: anyone running `--strict-rule query-deprecated-symbol` will need to add the new ID to promote these to errors too. `--strict-rule all` covers both. Happy to collapse this into the single existing rule if you'd rather not fragment — it's a one-line change.

**Location is the filters block itself.** `Filters.UnmarshalYAML` calls `addFileContext` before decoding, so a container's filters block records its own line. These warnings point straight at it, rather than borrowing a parent's line the way query-filter warnings must (those filter `Mquery` values are synthesized with only `.Mql` set).

**Subject naming** is `policy 'X' group 'Y'` / `query pack 'X'` / `query pack 'X' group 'Y'`. Groups rarely carry a uid or title in practice, so `groupDisplay` falls back uid → title → position (`group 2`), which combined with the exact line is enough to find it.

**`ComputedFilters` is skipped.** It is derived at load time from the group and query filters already walked here, so reporting it would duplicate warnings at a location the author never wrote. There's a test pinning this.

## Effect on ./content: none today

All 452 container filter blocks (245 policy-group + 207 query-pack) are clean:

```
$ cnspec policy lint ./content
query-deprecated-symbol:  16   (unchanged)
filter-deprecated-symbol: 0
errors:                   0
```

So this is **preventative** — it closes the hole before a symbol the filters depend on gets deprecated. The issue flagged confirming this first, and that's what the count shows.

Because there's nothing in `content/` to catch, unit tests alone would be the only evidence the detection works. So it was also verified end to end against a bundle whose group filter uses a genuinely deprecated field (`gcp.compute.firewall.allowed`):

```
$ cnspec policy lint demo.mql.yaml     # this branch
 filter-deprecated-symbol  warning  demo.mql.yaml  7  policy 'demo-group-filter-policy' group 'GCP firewalls' uses deprecated field 'gcp.project.computeService.firewall.allowed' in its filters

$ cnspec policy lint demo.mql.yaml     # main
→ valid policy bundle(s)
```

Line 7 is the `filters:` block. Silent on main, caught here.

## Refactor

`walkQueryForDeprecatedSymbols` had its own copy of the filter walk from #3264. Both paths now share `deprecatedSymbolsInFilters(filters, conf, seen)`, which does the sorted-key iteration and dedup once. The `seen` map is what lets the query path suppress symbols already found in its `mql:` while the container path starts fresh.

## Tests

Written first; the six covering new detection were each watched failing before the fix (0 entries where 1 was expected, 1 where 2 were).

| test | covers |
|---|---|
| `TestDeprecatedSymbol_PolicyGroupFilters` | policy group filters, rule ID, and that the line is the filters block's own |
| `TestDeprecatedSymbol_PolicyGroupFiltersWithoutTitle` | positional fallback for an untitled group |
| `TestDeprecatedSymbol_QueryPackFilters` | pack-level filters |
| `TestDeprecatedSymbol_QueryPackGroupFilters` | pack group filters |
| `TestDeprecatedSymbol_ComputedFiltersNotReported` | derived filters stay silent |
| `TestDeprecatedSymbol_GroupFilterAndCheckReportedIndependently` | a group's filters and a check's mql are separate sites with separate rule IDs |
| `TestDeprecatedSymbol_ContainerFiltersDedupeAndSkipEmpties` | nil/empty filters, and one symbol across two filter items is one warning |

`go test ./internal/bundle/...` passes; `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
