### PR TITLE
🧹 lint: report every filter under filter-deprecated-symbol

### DIFF
--- a/internal/bundle/lint_results_sarif.go
+++ b/internal/bundle/lint_results_sarif.go
@@ -90,12 +90,12 @@ func sarifLinterRules() []Rule {
 	rules = append(rules, Rule{
 		ID:          QueryDeprecatedSymbolRuleID,
 		Name:        "Query uses deprecated MQL symbol",
-		Description: "Query references a resource or field annotated with @maturity('deprecated')",
+		Description: "A query's MQL references a resource or field annotated with @maturity('deprecated')",
 	})
 	rules = append(rules, Rule{
 		ID:          FilterDeprecatedSymbolRuleID,
 		Name:        "Filter uses deprecated MQL symbol",
-		Description: "A policy group, query pack or pack group filter references a resource or field annotated with @maturity('deprecated')",
+		Description: "A filter on a query, policy group, query pack or pack group references a resource or field annotated with @maturity('deprecated')",
 	})
 
 	return rules

--- a/internal/bundle/lint_rules_deprecated_symbols.go
+++ b/internal/bundle/lint_rules_deprecated_symbols.go
@@ -14,21 +14,27 @@ import (
 const (
 	QueryDeprecatedSymbolRuleID = "query-deprecated-symbol"
 
-	// FilterDeprecatedSymbolRuleID covers filters that belong to a container
-	// rather than to a query — policy groups, query packs and pack groups.
-	// A query's own filters stay under QueryDeprecatedSymbolRuleID, since those
-	// warnings are attributed to the query.
+	// FilterDeprecatedSymbolRuleID covers every filters block, whoever owns it —
+	// queries, policy groups, query packs and pack groups. The rule is split by
+	// site rather than by owner: QueryDeprecatedSymbolRuleID is what a query's
+	// mql uses, and a filter is a filter regardless of what it hangs off.
 	FilterDeprecatedSymbolRuleID = "filter-deprecated-symbol"
 )
 
-// lintDeprecatedSymbols compiles every query with non-empty MQL and reports
-// resources or fields whose effective maturity is "deprecated". Compile errors
-// are intentionally ignored here — bundle-compile-error already surfaces them.
+// lintDeprecatedSymbols compiles every query and filter in the bundle and
+// reports resources or fields whose effective maturity is "deprecated". Compile
+// errors are intentionally ignored here — bundle-compile-error already surfaces
+// them.
 //
-// Filters attached to a container rather than to a query — policy groups, query
-// packs and pack groups — are covered too. Their stakes are higher than a single
-// query's: when the symbol is removed the filter stops matching and the whole
-// group drops out of scoring rather than one check.
+// Reporting is split by site, not by owner. A query's mql reports under
+// QueryDeprecatedSymbolRuleID; every filters block reports under
+// FilterDeprecatedSymbolRuleID, whether it hangs off a query, a policy group, a
+// query pack or a pack group. Filters carry their own file context, so each
+// warning points at the filters block that has to change.
+//
+// Container filters raise the stakes over a query's: when the symbol is removed
+// the filter stops matching and the whole group drops out of scoring rather than
+// one check.
 //
 // ComputedFilters is deliberately skipped. It is derived at load time from the
 // group and query filters already walked here, so reporting it would duplicate
@@ -36,11 +42,15 @@ const (
 func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerConfig, filename string, b *Bundle) []*Entry {
 	var entries []*Entry
 
-	visit := func(q *Mquery) {
-		entries = append(entries, walkQueryForDeprecatedSymbols(schema, conf, filename, q)...)
-	}
 	visitFilters := func(subject string, filters *Filters) {
 		entries = append(entries, walkFiltersForDeprecatedSymbols(conf, filename, subject, filters)...)
+	}
+	visit := func(q *Mquery) {
+		if q == nil {
+			return
+		}
+		entries = append(entries, walkQueryForDeprecatedSymbols(schema, conf, filename, q)...)
+		visitFilters(fmt.Sprintf("query '%s'", queryDisplayID(q)), q.Filters)
 	}
 
 	for _, q := range b.Queries {
@@ -76,11 +86,11 @@ func lintDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerC
 }
 
 // walkFiltersForDeprecatedSymbols reports deprecated symbols used by a filters
-// block that belongs to a container rather than a query. Unlike a query's
-// filters, these carry their own file context, so warnings point straight at the
-// filters block instead of borrowing a parent's line.
+// block, whether it belongs to a query, a policy group, a query pack or a pack
+// group. A Filters records its own file context, so warnings point straight at
+// the block that has to change rather than at whatever owns it.
 func walkFiltersForDeprecatedSymbols(conf mqlc.CompilerConfig, filename string, subject string, filters *Filters) []*Entry {
-	symbols := deprecatedSymbolsInFilters(filters, conf, map[string]struct{}{})
+	symbols := deprecatedSymbolsInFilters(filters, conf)
 	if len(symbols) == 0 {
 		return nil
 	}
@@ -101,10 +111,10 @@ func walkFiltersForDeprecatedSymbols(conf mqlc.CompilerConfig, filename string, 
 }
 
 // deprecatedSymbolsInFilters returns the deprecated symbols used across every
-// item of a filters block, skipping any already recorded in seen and adding the
-// ones it reports. Filters are a map, so items are walked in sorted key order
+// item of a filters block, reporting each one once no matter how many items
+// mention it. Filters.Items is a map, so items are walked in sorted key order
 // for stable output across runs.
-func deprecatedSymbolsInFilters(filters *Filters, conf mqlc.CompilerConfig, seen map[string]struct{}) []string {
+func deprecatedSymbolsInFilters(filters *Filters, conf mqlc.CompilerConfig) []string {
 	if filters == nil || len(filters.Items) == 0 {
 		return nil
 	}
@@ -115,6 +125,7 @@ func deprecatedSymbolsInFilters(filters *Filters, conf mqlc.CompilerConfig, seen
 	}
 	sort.Strings(keys)
 
+	seen := map[string]struct{}{}
 	var symbols []string
 	for _, key := range keys {
 		filter := filters.Items[key]
@@ -160,50 +171,30 @@ func queryPackDisplayID(pack *QueryPack) string {
 	return pack.Mrn
 }
 
-// walkQueryForDeprecatedSymbols reports deprecated symbols used by a query,
-// looking at both its mql and its filters. Filters matter as much as mql here:
-// when a deprecated symbol is finally removed, a filter that references it stops
-// matching and the check silently stops scoring assets instead of failing loudly.
-//
-// A symbol used in both places is reported once. The mql site wins, because that
-// is where a reader will find it; the "in its filters" hint is only added for
-// symbols that appear nowhere else, since every warning points at the query's own
-// line and filter Mqueries carry no file context of their own.
+// walkQueryForDeprecatedSymbols reports deprecated symbols used by a query's
+// mql. Its filters are reported separately by walkFiltersForDeprecatedSymbols,
+// which points at the filters block rather than at the query.
 func walkQueryForDeprecatedSymbols(schema resources.ResourcesSchema, conf mqlc.CompilerConfig, filename string, q *Mquery) []*Entry {
 	if q == nil {
 		return nil
 	}
 
-	fromMql := deprecatedSymbolsIn(q.Mql, conf)
-
-	seen := make(map[string]struct{}, len(fromMql))
-	for _, symbol := range fromMql {
-		seen[symbol] = struct{}{}
-	}
-
-	fromFilters := deprecatedSymbolsInFilters(q.Filters, conf, seen)
-
-	if len(fromMql) == 0 && len(fromFilters) == 0 {
+	symbols := deprecatedSymbolsIn(q.Mql, conf)
+	if len(symbols) == 0 {
 		return nil
 	}
 
 	loc := []Location{{File: filename, Line: q.FileContext.Line, Column: q.FileContext.Column}}
 	display := queryDisplayID(q)
 
-	entries := make([]*Entry, 0, len(fromMql)+len(fromFilters))
-	newEntry := func(symbol, where string) *Entry {
-		return &Entry{
+	entries := make([]*Entry, 0, len(symbols))
+	for _, symbol := range symbols {
+		entries = append(entries, &Entry{
 			RuleID:   QueryDeprecatedSymbolRuleID,
 			Level:    LevelWarning,
-			Message:  fmt.Sprintf("query '%s' uses %s%s", display, symbol, where),
+			Message:  fmt.Sprintf("query '%s' uses %s", display, symbol),
 			Location: loc,
-		}
-	}
-	for _, symbol := range fromMql {
-		entries = append(entries, newEntry(symbol, ""))
-	}
-	for _, symbol := range fromFilters {
-		entries = append(entries, newEntry(symbol, " in its filters"))
+		})
 	}
 
 	return entries

--- a/internal/bundle/lint_rules_deprecated_symbols_test.go
+++ b/internal/bundle/lint_rules_deprecated_symbols_test.go
@@ -4,7 +4,6 @@
 package bundle
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,38 +138,31 @@ func TestDeprecatedSymbol_DedupesRepeatedReferences(t *testing.T) {
 	require.Len(t, entries, 1, "duplicate references to the same deprecated field should collapse to a single warning")
 }
 
-func TestDeprecatedSymbol_FiltersOnly(t *testing.T) {
-	overlay := &deprecateOverlay{
-		inner: schema,
-		deprecatedFields: map[string]map[string]struct{}{
-			"file": {"basename": {}},
-		},
-	}
+func TestDeprecatedSymbol_QueryFiltersOnly(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
 
 	// A variant parent carries filters but no mql of its own.
-	q := &Mquery{
-		Uid:         "test-filters-only",
-		FileContext: FileContext{Line: 11, Column: 3},
-		Filters: &Filters{
-			Items: map[string]*Mquery{
-				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
-			},
-		},
+	b := &Bundle{
+		Queries: []*Mquery{{
+			Uid:         "test-filters-only",
+			FileContext: FileContext{Line: 11, Column: 3},
+			Filters:     deprecatedFilters(12),
+		}},
 	}
 
-	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
 	require.Len(t, entries, 1)
-	assert.Equal(t, QueryDeprecatedSymbolRuleID, entries[0].RuleID)
+	assert.Equal(t, FilterDeprecatedSymbolRuleID, entries[0].RuleID,
+		"a filter is a filter regardless of who owns it")
 	assert.Equal(t, LevelWarning, entries[0].Level)
 	assert.Contains(t, entries[0].Message, "test-filters-only")
 	assert.Contains(t, entries[0].Message, "file.basename")
-	assert.Contains(t, entries[0].Message, "filters",
-		"a symbol found only in filters should say so, since the line points at the query")
-	assert.Equal(t, 11, entries[0].Location[0].Line,
-		"filter Mqueries carry no FileContext, so the parent query's line must be used")
+	assert.Contains(t, entries[0].Message, "filters")
+	assert.Equal(t, 12, entries[0].Location[0].Line,
+		"a query's filters block has its own file context too, so point at it rather than the query")
 }
 
-func TestDeprecatedSymbol_MqlAndFiltersReportSeparateSymbols(t *testing.T) {
+func TestDeprecatedSymbol_QueryMqlAndFiltersUseDistinctRules(t *testing.T) {
 	overlay := &deprecateOverlay{
 		inner:         schema,
 		deprecatedRes: map[string]struct{}{"processes": {}},
@@ -179,63 +171,55 @@ func TestDeprecatedSymbol_MqlAndFiltersReportSeparateSymbols(t *testing.T) {
 		},
 	}
 
-	q := &Mquery{
-		Uid: "test-both-sites",
-		Mql: "processes.length >= 0",
-		Filters: &Filters{
-			Items: map[string]*Mquery{
-				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
-			},
-		},
+	b := &Bundle{
+		Queries: []*Mquery{{
+			Uid:         "test-both-sites",
+			Mql:         "processes.length >= 0",
+			FileContext: FileContext{Line: 5},
+			Filters:     deprecatedFilters(6),
+		}},
 	}
 
-	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
 	require.Len(t, entries, 2)
 
-	messages := []string{entries[0].Message, entries[1].Message}
-	assert.Condition(t, func() bool {
-		for _, m := range messages {
-			if strings.Contains(m, "processes") {
-				return true
-			}
-		}
-		return false
-	}, "expected the deprecated resource from mql, got %v", messages)
-	assert.Condition(t, func() bool {
-		for _, m := range messages {
-			if strings.Contains(m, "file.basename") {
-				return true
-			}
-		}
-		return false
-	}, "expected the deprecated field from filters, got %v", messages)
+	byRule := map[string]*Entry{}
+	for _, e := range entries {
+		byRule[e.RuleID] = e
+	}
+	require.Contains(t, byRule, QueryDeprecatedSymbolRuleID)
+	require.Contains(t, byRule, FilterDeprecatedSymbolRuleID)
+	assert.Contains(t, byRule[QueryDeprecatedSymbolRuleID].Message, "processes")
+	assert.Equal(t, 5, byRule[QueryDeprecatedSymbolRuleID].Location[0].Line)
+	assert.Contains(t, byRule[FilterDeprecatedSymbolRuleID].Message, "file.basename")
+	assert.Equal(t, 6, byRule[FilterDeprecatedSymbolRuleID].Location[0].Line)
 }
 
-func TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedOnce(t *testing.T) {
-	overlay := &deprecateOverlay{
-		inner: schema,
-		deprecatedFields: map[string]map[string]struct{}{
-			"file": {"basename": {}},
-		},
+func TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedAtBothSites(t *testing.T) {
+	overlay := deprecatedFieldOverlay()
+
+	b := &Bundle{
+		Queries: []*Mquery{{
+			Uid:         "test-same-symbol-both-sites",
+			Mql:         "file('/etc/shadow').basename == 'shadow'",
+			FileContext: FileContext{Line: 5},
+			Filters:     deprecatedFilters(6),
+		}},
 	}
 
-	q := &Mquery{
-		Uid: "test-same-symbol-both-sites",
-		Mql: "file('/etc/shadow').basename == 'shadow'",
-		Filters: &Filters{
-			Items: map[string]*Mquery{
-				"": {Mql: "file('/etc/passwd').basename == 'passwd'"},
-			},
-		},
-	}
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
+	require.Len(t, entries, 2,
+		"the mql and the filters are two separate edits, and now two separate lines, so both are reported")
 
-	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
-	require.Len(t, entries, 1, "one symbol used in both mql and filters is still one migration to make")
-	assert.NotContains(t, entries[0].Message, "filters",
-		"the symbol is reachable from mql, so the filters hint would be misleading")
+	lines := map[int]string{}
+	for _, e := range entries {
+		lines[e.Location[0].Line] = e.RuleID
+	}
+	assert.Equal(t, QueryDeprecatedSymbolRuleID, lines[5])
+	assert.Equal(t, FilterDeprecatedSymbolRuleID, lines[6])
 }
 
-func TestDeprecatedSymbol_MultipleFilterItems(t *testing.T) {
+func TestDeprecatedSymbol_QueryMultipleFilterItems(t *testing.T) {
 	overlay := &deprecateOverlay{
 		inner:         schema,
 		deprecatedRes: map[string]struct{}{"processes": {}},
@@ -245,18 +229,24 @@ func TestDeprecatedSymbol_MultipleFilterItems(t *testing.T) {
 	}
 
 	// The list form of filters: yields one Mquery per entry, keyed by index.
-	q := &Mquery{
-		Uid: "test-multi-filter-items",
-		Filters: &Filters{
-			Items: map[string]*Mquery{
-				"0": {Mql: "file('/etc/passwd').basename == 'passwd'"},
-				"1": {Mql: "processes.length >= 0"},
+	b := &Bundle{
+		Queries: []*Mquery{{
+			Uid: "test-multi-filter-items",
+			Filters: &Filters{
+				FileContext: FileContext{Line: 8},
+				Items: map[string]*Mquery{
+					"0": {Mql: "file('/etc/passwd').basename == 'passwd'"},
+					"1": {Mql: "processes.length >= 0"},
+				},
 			},
-		},
+		}},
 	}
 
-	entries := walkQueryForDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", q)
+	entries := lintDeprecatedSymbols(overlay, newConf(overlay), "test.mql.yaml", b)
 	require.Len(t, entries, 2, "every filter item should be analyzed, not just the first")
+	for _, e := range entries {
+		assert.Equal(t, FilterDeprecatedSymbolRuleID, e.RuleID)
+	}
 }
 
 func TestDeprecatedSymbol_NoFiltersIsSafe(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3264 and #3266. Based on latest main (`3303e52b`), which has both merged.

## What

Those two PRs ended up splitting the deprecated-symbol rules **by who owns the filter**:

| site | before |
|---|---|
| query `mql:` | `query-deprecated-symbol` |
| query `filters:` | `query-deprecated-symbol` |
| policy group / pack / pack group `filters:` | `filter-deprecated-symbol` |

That's the wrong seam. A filter is a filter regardless of what it hangs off, and the thing that actually differs is the **site** — an `mql:` body versus a `filters:` block. So:

| site | after |
|---|---|
| query `mql:` | `query-deprecated-symbol` |
| **every** `filters:` block | `filter-deprecated-symbol` |

## Bonus: query filter warnings now point at the filter

#3264 reasoned that filter `Mquery` values "carry no `FileContext`, so the parent query's line must be used." That is true of the synthesized `Filters.Items[""]` entries — but the enclosing `Filters` struct records its own line, because `UnmarshalYAML` calls `addFileContext(node)` before decoding. Making the filters block the subject of its own warning surfaced that, so query filter warnings now land on the `filters:` line like container ones already did.

Across `content/`, the 5 GCP warnings each move down one line onto their filters block:

```
- query-deprecated-symbol  … 7636  query '…-no-ingress-ssh-from-internet-gcp' uses deprecated field '…allowed' in its filters
+ filter-deprecated-symbol … 7637  query '…-no-ingress-ssh-from-internet-gcp' uses deprecated field '…allowed' in its filters
```

## Effect on ./content

Totals unchanged — **16 warnings, 0 errors**, still exit 0. The split changes:

| | before | after |
|---|---|---|
| `query-deprecated-symbol` | 16 | 11 |
| `filter-deprecated-symbol` | 0 | 5 |

The 11 `mql:` warnings are byte-identical. The 5 that move are exactly the GCP firewall query filters from #3264.

## Behavior change worth reviewing

**A symbol used in both a query's `mql:` and its `filters:` is now reported twice**, where #3264 deliberately reported it once.

That dedup was right at the time: one rule, one line, so the second warning was pure noise. It isn't right anymore — the two warnings now carry different rule IDs and point at different lines, and they are two separate edits. Suppressing the filter half would let someone fix the `mql:`, see the warning clear, and leave the filter still referencing the dead symbol. `TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedAtBothSites` pins this, replacing the old `…ReportedOnce` test.

Nothing in `content/` hits this case today.

Also note `--strict-rule query-deprecated-symbol` no longer promotes filter findings; that now needs `filter-deprecated-symbol` too, or `all`. No CI in this repo passes `--strict-rule`.

## Cleanup

The merged-reporting bookkeeping is gone now that the two sites report separately:

- `walkQueryForDeprecatedSymbols` handles only `q.Mql` — no `seen` map, no conditional `" in its filters"` suffix
- `deprecatedSymbolsInFilters` no longer takes a caller-supplied `seen` map; it dedupes within the block, which is all either caller wanted
- SARIF rule descriptions updated to describe the sites rather than the owners

## Tests

Updated first and watched failing before the change (wrong rule ID, wrong line, 1 entry where 2 were expected):

| test | covers |
|---|---|
| `TestDeprecatedSymbol_QueryFiltersOnly` | variant parent's filters → filter rule, at the filters line |
| `TestDeprecatedSymbol_QueryMqlAndFiltersUseDistinctRules` | distinct symbols → distinct rules and distinct lines |
| `TestDeprecatedSymbol_SameSymbolInMqlAndFiltersReportedAtBothSites` | same symbol → both sites reported |
| `TestDeprecatedSymbol_QueryMultipleFilterItems` | list form of `filters:`, all under the filter rule |

The container-filter tests from #3266 are unchanged and still pass, which is the check that this didn't disturb them. `go test ./internal/bundle/...` passes; `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
