### PR TITLE
🧹 gcp: migrate firewall checks off the deprecated `allowed` field

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -7637,10 +7637,8 @@ queries:
     filters: |
       asset.platform == 'gcp-compute-firewall'
       gcp.compute.firewall.direction == "INGRESS"
-      gcp.compute.firewall.allowed.any(ipProtocol == "tcp" && _['ports'] == empty || ipProtocol == "tcp" && _['ports'].contains("22"))
     mql: |
-      gcp.compute.firewall.sourceRanges.none(_ == "0.0.0.0/0")
-      gcp.compute.firewall.sourceRanges.none(_ == "::/0")
+      gcp.compute.firewall.allowsSshFromInternet == false
   - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -7807,10 +7805,8 @@ queries:
     filters: |
       asset.platform == 'gcp-compute-firewall'
       gcp.compute.firewall.direction == "INGRESS"
-      gcp.compute.firewall.allowed.any(ipProtocol == "tcp" && _['ports'] == empty || ipProtocol == "tcp" && _['ports'].contains("3389"))
     mql: |
-      gcp.compute.firewall.sourceRanges.none(_ == "0.0.0.0/0")
-      gcp.compute.firewall.sourceRanges.none(_ == "::/0")
+      gcp.compute.firewall.allowsRdpFromInternet == false
   - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -7975,10 +7971,8 @@ queries:
     filters: |
       asset.platform == 'gcp-compute-firewall'
       gcp.compute.firewall.direction == "INGRESS"
-      gcp.compute.firewall.allowed.any(ipProtocol == "all")
     mql: |
-      gcp.compute.firewall.sourceRanges.none(_ == "0.0.0.0/0")
-      gcp.compute.firewall.sourceRanges.none(_ == "::/0")
+      gcp.compute.firewall.openToInternet == false || gcp.compute.firewall.allowedProtocols.keys.none(_ == "all")
   - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -8141,10 +8135,9 @@ queries:
     filters: |
       asset.platform == 'gcp-compute-firewall'
       gcp.compute.firewall.direction == "INGRESS"
-      gcp.compute.firewall.allowed.any(ipProtocol == "tcp" && _['ports'] == empty || ipProtocol == "tcp" && _['ports'].contains("3306") || ipProtocol == "tcp" && _['ports'].contains("5432") || ipProtocol == "tcp" && _['ports'].contains("1433") || ipProtocol == "tcp" && _['ports'].contains("27017"))
     mql: |
-      gcp.compute.firewall.sourceRanges.none(_ == "0.0.0.0/0")
-      gcp.compute.firewall.sourceRanges.none(_ == "::/0")
+      gcp.compute.firewall.openToInternet == false || gcp.compute.firewall.allowedProtocols.where(key == "tcp").values.all(_.length > 0)
+      gcp.compute.firewall.openToInternet == false || gcp.compute.firewall.allowedProtocols.where(key == "tcp").values.flat.none(_.in(["3306", "5432", "1433", "27017"]))
   - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -8310,8 +8303,8 @@ queries:
       gcp.compute.firewall.direction == "INGRESS"
       gcp.compute.firewall.sourceRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(ipProtocol == "all")
-      gcp.compute.firewall.allowed.all(_['ports'] != empty && _['ports'].length > 0)
+      gcp.compute.firewall.allowedProtocols.keys.none(_ == "all")
+      gcp.compute.firewall.allowedProtocols.values.all(_.length > 0)
   - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -23173,10 +23166,8 @@ queries:
     filters: |
       asset.platform == 'gcp-compute-firewall'
       gcp.compute.firewall.direction == "EGRESS"
-      gcp.compute.firewall.allowed.any(ipProtocol == "all")
     mql: |
-      gcp.compute.firewall.destinationRanges.none(_ == "0.0.0.0/0")
-      gcp.compute.firewall.destinationRanges.none(_ == "::/0")
+      gcp.compute.firewall.disabled || gcp.compute.firewall.allowedProtocols.keys.none(_ == "all") || gcp.compute.firewall.destinationRanges.none(_ == "0.0.0.0/0" || _ == "::/0")
   - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -23343,8 +23334,8 @@ queries:
       gcp.compute.firewall.direction == "EGRESS"
       gcp.compute.firewall.destinationRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(ipProtocol == "all")
-      gcp.compute.firewall.allowed.where(ipProtocol != "icmp").all(_['ports'] != empty && _['ports'].length > 0)
+      gcp.compute.firewall.allowedProtocols.keys.none(_ == "all")
+      gcp.compute.firewall.allowedProtocols.where(key != "icmp").values.all(_.length > 0)
   - uid: mondoo-gcp-security-firewall-no-egress-all-ports-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
@@ -25141,7 +25132,7 @@ queries:
       gcp.compute.firewall.direction == "INGRESS"
       gcp.compute.firewall.sourceRanges.any(_ == "0.0.0.0/0" || _ == "::/0")
     mql: |
-      gcp.compute.firewall.allowed.none(_['ports'].any(_ == /^\d{1,4}-6553[0-5]$/))
+      gcp.compute.firewall.allowedProtocols.values.flat.none(_ == /^\d{1,4}-6553[0-5]$/)
 
   - uid: mondoo-gcp-security-firewall-no-large-port-range-terraform-hcl
     filters: |


### PR DESCRIPTION
Resolves the 5 `filter-deprecated-symbol` warnings on `mondoo-gcp-security.mql.yaml`, plus the 3 `query-deprecated-symbol` warnings for the same field in the same policy. The GCP policy now lints with zero warnings; content-wide deprecation warnings drop 16 → 8 (the rest are unrelated AWS/Azure fields).

## The deprecation

`gcp.project.computeService.firewall.allowed` is deprecated in favor of `allowedProtocols`. It's a shape change, not a rename: `allowed` was a `[]dict` of `{ipProtocol, ports}` entries, which buried `ports` a dict level below the rule; `allowedProtocols` is a `map[string][]string` keyed by protocol, where an **empty port list means every port** of that protocol.

## Filter sites (5)

All five kept predicate logic in `filters:`, which is asset selection only — a rule that didn't match the protocol clause was dropped from scoring entirely rather than scored as passing. Each moves its predicate into `mql:` and keeps `asset.platform` + `direction` in the filter.

| check | new `mql:` |
|---|---|
| `…-no-ingress-ssh-from-internet-gcp` | `allowsSshFromInternet == false` |
| `…-no-ingress-rdp-from-internet-gcp` | `allowsRdpFromInternet == false` |
| `…-no-unrestricted-ingress-all-protocols-gcp` | `openToInternet == false \|\| allowedProtocols.keys.none(_ == "all")` |
| `…-no-ingress-database-ports-from-internet-gcp` | `openToInternet == false \|\|` tcp ports non-empty / not a DB port |
| `…-no-unrestricted-egress-gcp` | `disabled \|\| allowedProtocols.keys.none(_ == "all") \|\| destinationRanges.none(…)` |

`allowsSshFromInternet`, `allowsRdpFromInternet`, and `openToInternet` are the provider's own derived predicates, added alongside `allowedProtocols` for exactly this pattern. Each folds in direction, `disabled`, and public-source-range handling.

## Query sites (3)

Direct translation onto the map, same verdicts:

- `allowed.none(ipProtocol == "all")` → `allowedProtocols.keys.none(_ == "all")`
- `allowed.all(_['ports'] != empty && _['ports'].length > 0)` → `allowedProtocols.values.all(_.length > 0)`
- `allowed.where(ipProtocol != "icmp").all(…)` → `allowedProtocols.where(key != "icmp").values.all(_.length > 0)`
- `allowed.none(_['ports'].any(_ == /…/))` → `allowedProtocols.values.flat.none(_ == /…/)`

## Behavior changes worth reviewing

These are deliberate, and all three reduce false results rather than weakening coverage:

1. **More assets get scored.** Firewall rules that don't touch the port in question now score as passing instead of being filtered out. Verdicts for previously-scored rules are unchanged.
2. **Broader detection on SSH/RDP.** The old filters only matched a literal `"22"` / `"3389"` in the port list. The provider predicates also match port *ranges* covering the port and the `all` protocol, so a rule opening `20-30` from `0.0.0.0/0` now fails instead of silently passing.
3. **Disabled rules are exempt.** A disabled rule enforces nothing. `openToInternet` and the SSH/RDP predicates skip them; `disabled ||` was added to the egress check for parity.

## Why not translate the filters in place

`allowedProtocols['tcp'] == empty` is true both when tcp is absent *and* when tcp permits every port, so an in-filter translation needs a `keys.contains("tcp")` presence guard the old form didn't. A subtly wrong filter drops assets from scoring silently instead of failing loudly, so the predicates moved to `mql:` — where `.where(key == "tcp")` on a map with no tcp key yields an empty map and passes vacuously, with no null access at all.

## Verification

- `cnspec policy lint content/mondoo-gcp-security.mql.yaml` → valid, **0 warnings**
- `cnspec policy lint ./content` → 8 deprecation warnings remain, none in the GCP policy
- Every replacement expression compile-checked in isolation first; map `keys` / `values` / `where(key == …)` runtime-verified against a live map-typed resource

No Terraform variants were touched — the deprecated field is runtime-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)