### PR TITLE
🧹 ci: bump tflint rulesets used to validate Terraform remediation

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -49064,7 +49064,7 @@ queries:
               function_name = "example-function"
               role          = aws_iam_role.lambda.arn
               handler       = "index.handler"
-              runtime       = "nodejs20.x"
+              runtime       = "nodejs22.x"
               filename      = "function.zip"
 
               tracing_config {
@@ -49082,7 +49082,7 @@ queries:
                 Type: AWS::Lambda::Function
                 Properties:
                   FunctionName: example-function
-                  Runtime: nodejs20.x
+                  Runtime: nodejs22.x
                   Handler: index.handler
                   Role: !GetAtt LambdaRole.Arn
                   TracingConfig:

--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -56,9 +56,24 @@ PROVIDER_MAP = {
 
 # tflint provider plugins (only for providers that have rulesets)
 TFLINT_PLUGIN_MAP = {
-    "aws": ("github.com/terraform-linters/tflint-ruleset-aws", "0.38.0"),
-    "azurerm": ("github.com/terraform-linters/tflint-ruleset-azurerm", "0.28.0"),
-    "google": ("github.com/terraform-linters/tflint-ruleset-google", "0.32.0"),
+    "aws": ("github.com/terraform-linters/tflint-ruleset-aws", "0.48.0"),
+    "azurerm": ("github.com/terraform-linters/tflint-ruleset-azurerm", "0.32.0"),
+    "google": ("github.com/terraform-linters/tflint-ruleset-google", "0.39.0"),
+}
+
+# Ruleset rules that do not apply to documentation snippets, keyed by plugin.
+# A remediation example demonstrates the one setting its check is about and is
+# meant to be copied into a reader's own configuration, not applied as written,
+# so operational-completeness rules only produce noise here. prevent_destroy
+# would be worse than noise: following it hands the reader a resource they
+# cannot delete until they find and remove the lifecycle block. Neither rule
+# touches the security control being demonstrated. Both ship enabled-by-default
+# in tflint-ruleset-azurerm 0.29.0+.
+DISABLED_RULES = {
+    "azurerm": (
+        "azurerm_resources_missing_prevent_destroy",
+        "azurerm_app_service_missing_auto_heal_setting",
+    ),
 }
 
 # Providers that need extra config in their provider block
@@ -223,18 +238,15 @@ def write_tflint_config(tmp_dir: Path, providers: set[str]) -> None:
             lines.append(f'  enabled = true\n')
             lines.append(f'  version = "{version}"\n')
             lines.append(f'  source  = "{source}"\n')
-            # TEMPORARY (2026-07-17): pinned to PGP because the default "auto"
-            # verification crashes. GitHub removed the `bundle` field from
-            # attestation API responses, so `tflint --init` nil-derefs in
-            # sigstore-go while verifying the ruleset and never reaches the
-            # lint stage. Upstream fix: terraform-linters/tflint#2593
-            # (unreleased). "pgp" still verifies the plugin cryptographically
-            # via the legacy signing key -- it is NOT "none", which would skip
-            # verification entirely. Requires tflint >= 0.62; 0.61 and earlier
-            # silently ignore this attribute. REVERT (delete this line) once
-            # #2593 ships -- attestations verify provenance, PGP only signing.
-            lines.append('  signature = "pgp"\n')
             lines.append('}\n')
+            # Rule blocks only resolve for a plugin that is actually loaded --
+            # naming a rule from an absent ruleset fails the whole run with
+            # "Failed to check rule config; Rule not found". So each ruleset's
+            # opt-outs are emitted with the plugin, not unconditionally.
+            for rule in DISABLED_RULES.get(p, ()):
+                lines.append(f'\nrule "{rule}" {{\n')
+                lines.append('  enabled = false\n')
+                lines.append('}\n')
 
     (tmp_dir / ".tflint.hcl").write_text("".join(lines))
 


### PR DESCRIPTION
## Scope check first

The ask was "bump all the GitHub Actions + the CLI tools we use for IaC verification." I audited all of it; most of it was already current.

**GitHub Actions: no changes needed.** All **30** action pins across 20 workflows already resolve to their latest release SHAs — verified each against `releases/latest`. That's `.github/dependabot.yml` working: weekly `github-actions` updates with a 7-day cooldown, and a `codeql-action` group so `init`/`analyze` can't land on mismatched releases.

**IaC CLI tools: already current too.** tflint `v0.64.0`, doctl `1.166.0`, glab `1.113.0`, hcloud `1.67.0`, databricks `1.12.1` — all at latest.

**The drift was in the tflint ruleset plugins**, which is where this PR lands.

## The bump

`content/validation/validate_terraform_remediation.py` — these lint every `id: terraform` remediation snippet:

| ruleset | before | after | behind by |
|---|---|---|---|
| tflint-ruleset-aws | 0.38.0 | **0.48.0** | 10 minors |
| tflint-ruleset-google | 0.32.0 | **0.39.0** | 7 minors |
| tflint-ruleset-azurerm | 0.28.0 | **0.32.0** | 4 minors |

They drifted because Dependabot can't see them — a Python dict is not an ecosystem manifest. Same reason the CLI versions in `validate-remediation.yaml` are hand-managed `env:` values.

## What the bump caught

89 snippets started failing, across exactly three rules:

**`aws_lambda_function_deprecated_runtime` (1) — a real defect, fixed.** `mondoo-aws-security-lambda-xray-tracing` documented `runtime = "nodejs20.x"`, which has reached end of support. Now `nodejs22.x`, in both the Terraform and CloudFormation examples — only the former is linted, but a dead runtime in the adjacent snippet is the same bug.

**`azurerm_resources_missing_prevent_destroy` (74) and `azurerm_app_service_missing_auto_heal_setting` (16) — opted out.** Both are operational-completeness rules aimed at real infrastructure, not documentation. A remediation snippet shows the one setting its check is about and is copied into the reader's own config. `prevent_destroy` would be actively harmful advice here: follow it and you get a resource you cannot delete until you find and remove the lifecycle block. Neither rule touches the security control being demonstrated.

The opt-outs are emitted **with their plugin**, not globally. tflint rejects a rule block whose ruleset isn't loaded (`Failed to check rule config; Rule not found`), and each snippet loads only the providers it actually uses — so a global block breaks every AWS-only snippet. I found that the direct way: my first attempt turned 89 failures into 912.

## Bonus: retiring a workaround whose fix shipped

The `signature = "pgp"` plugin pin carried an explicit `REVERT (delete this line) once #2593 ships` note. [tflint#2593](https://github.com/terraform-linters/tflint/issues/2593) closed 2026-07-17, and CI pins v0.64.0, which contains it. Dropping it restores default attestation verification — provenance, not just the signing key.

This is genuinely exercised, not assumed: the validator creates a fresh `TemporaryDirectory` plugin cache per run, so all three rulesets are re-downloaded and re-verified from scratch every time. Local runs complete with no init or verification errors.

## Verification

Run with tflint **v0.64.0** — CI's version. Note that brew still ships 0.61.0, which silently ignores the `signature` attribute and false-fails; I used the upstream 0.64.0 binary so results match CI.

```
before (rulesets as on main):   1232 passed / 0 failed   exit 0
after  (this PR):               1232 passed / 0 failed   exit 0
```

Identical totals — the bump adds rule coverage without weakening or losing any snippet. `cnspec policy lint content/mondoo-aws-security.mql.yaml` → valid.

## Not in scope

- **Terraform provider constraints** in `PROVIDER_MAP` (aws `~> 5.0`, google `~> 6.0`, gitlab `~> 17.0`, …) are behind current majors. Bumping those changes which schema snippets validate against — a behavior change worth its own PR, not a tool bump.
- **Pinned OpenAPI spec SHAs** and the checked-in `cmd_data/` grammars are refreshed by their own dump scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)