### PR TITLE
✨ content: cover the OCI, OpenStack, and GCP IaC-variant coverage gaps

### DIFF
--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -10,15 +10,6 @@
     "-bicep": 43,
     "-terraform-hcl": 36
   },
-  "mondoo-gcp-security": {
-    "-terraform-hcl": 8
-  },
-  "mondoo-oci-security": {
-    "-terraform-hcl": 2
-  },
-  "mondoo-openstack-security": {
-    "-terraform-hcl": 5
-  },
   "mondoo-snowflake-security": {
     "-terraform-hcl": 13
   }

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/fail/no-management-settings/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/fail/no-management-settings/main.tf
@@ -1,0 +1,11 @@
+# Omitting management_settings entirely leaves the lock state unmanaged.
+resource "google_clouddomains_registration" "corp" {
+  project     = var.project_id
+  location    = "global"
+  domain_name = "example-corp.com"
+
+  yearly_price {
+    currency_code = "USD"
+    units         = 12
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/fail/unlocked/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/fail/unlocked/main.tf
@@ -1,0 +1,16 @@
+# An unlocked registration can be transferred away without the extra
+# confirmation step, which is how domain hijacks usually start.
+resource "google_clouddomains_registration" "corp" {
+  project     = var.project_id
+  location    = "global"
+  domain_name = "example-corp.com"
+
+  yearly_price {
+    currency_code = "USD"
+    units         = 12
+  }
+
+  management_settings {
+    transfer_lock_state = "UNLOCKED"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/pass/locked/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-terraform-hcl/pass/locked/main.tf
@@ -1,0 +1,37 @@
+resource "google_clouddomains_registration" "corp" {
+  project     = var.project_id
+  location    = "global"
+  domain_name = "example-corp.com"
+
+  yearly_price {
+    currency_code = "USD"
+    units         = 12
+  }
+
+  management_settings {
+    transfer_lock_state = "LOCKED"
+  }
+
+  dns_settings {
+    custom_dns {
+      name_servers = ["ns-cloud-a1.googledomains.com", "ns-cloud-a2.googledomains.com"]
+    }
+  }
+
+  contact_settings {
+    privacy = "PRIVATE_CONTACT_DATA"
+
+    registrant_contact {
+      email = "domains@example-corp.com"
+      phone_number = "+1.5555550100"
+
+      postal_address {
+        region_code  = "US"
+        postal_code  = "94105"
+        address_lines = ["1 Example Way"]
+        locality      = "San Francisco"
+        recipients    = ["Example Corp"]
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/fail/act-as/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/fail/act-as/main.tf
@@ -1,0 +1,14 @@
+# actAs lets a holder of this role run workloads as any service account it can
+# name, inheriting that account's privileges.
+resource "google_project_iam_custom_role" "deployer" {
+  project     = var.project_id
+  role_id     = "pipelineDeployer"
+  title       = "Pipeline Deployer"
+  description = "Used by the deployment pipeline"
+  stage       = "GA"
+
+  permissions = [
+    "compute.instances.create",
+    "iam.serviceAccounts.actAs",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/fail/sign-jwt/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/fail/sign-jwt/main.tf
@@ -1,0 +1,14 @@
+# signJwt mints assertions a service account can exchange for access tokens,
+# which is impersonation by another name.
+resource "google_project_iam_custom_role" "token_minter" {
+  project     = var.project_id
+  role_id     = "tokenMinter"
+  title       = "Token Minter"
+  description = "Used by the workload identity broker"
+  stage       = "GA"
+
+  permissions = [
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.signJwt",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/pass/read-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-terraform-hcl/pass/read-only/main.tf
@@ -1,0 +1,14 @@
+resource "google_project_iam_custom_role" "inventory_reader" {
+  project     = var.project_id
+  role_id     = "inventoryReader"
+  title       = "Inventory Reader"
+  description = "Read-only access used by the asset inventory job"
+  stage       = "GA"
+
+  permissions = [
+    "compute.instances.list",
+    "compute.disks.list",
+    "storage.objects.get",
+    "storage.buckets.list",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/fail/all-authenticated-binding/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/fail/all-authenticated-binding/main.tf
@@ -1,0 +1,11 @@
+# allAuthenticatedUsers is every Google account in existence, not just this
+# organization's.
+resource "google_project_iam_binding" "storage_readers" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+
+  members = [
+    "group:data-analysts@example.com",
+    "allAuthenticatedUsers",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/fail/all-users-member/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/fail/all-users-member/main.tf
@@ -1,0 +1,6 @@
+# allUsers grants the role to the entire internet, unauthenticated.
+resource "google_project_iam_member" "public_viewer" {
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = "allUsers"
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/pass/named-principals/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-public-members-terraform-hcl/pass/named-principals/main.tf
@@ -1,0 +1,15 @@
+resource "google_project_iam_member" "log_viewer" {
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = "serviceAccount:log-reader@example-prod.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_binding" "storage_readers" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+
+  members = [
+    "group:data-analysts@example.com",
+    "serviceAccount:etl@example-prod.iam.gserviceaccount.com",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/fail/sa-user-binding/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/fail/sa-user-binding/main.tf
@@ -1,0 +1,10 @@
+# serviceAccountUser at project scope allows attaching any service account to
+# a new workload, inheriting its privileges.
+resource "google_project_iam_binding" "sa_users" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+
+  members = [
+    "group:developers@example.com",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/fail/token-creator-member/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/fail/token-creator-member/main.tf
@@ -1,0 +1,7 @@
+# Granted project-wide, serviceAccountTokenCreator lets the principal mint
+# tokens for every service account in the project.
+resource "google_project_iam_member" "token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "group:developers@example.com"
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/pass/non-impersonation-roles/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl/pass/non-impersonation-roles/main.tf
@@ -1,0 +1,14 @@
+resource "google_project_iam_member" "log_viewer" {
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = "group:sre@example.com"
+}
+
+resource "google_project_iam_binding" "storage_readers" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+
+  members = [
+    "group:data-analysts@example.com",
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl/fail/no-encryption-spec/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl/fail/no-encryption-spec/main.tf
@@ -1,0 +1,16 @@
+# Without encryption_spec the runtime's disks fall back to Google-managed keys.
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+
+  network_spec {
+    enable_internet_access = false
+    network                = "projects/example-prod/global/networks/research-vpc"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl/pass/cmek/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-terraform-hcl/pass/cmek/main.tf
@@ -1,0 +1,20 @@
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+
+  network_spec {
+    enable_internet_access = false
+    network                = "projects/example-prod/global/networks/research-vpc"
+    subnetwork             = "projects/example-prod/regions/us-central1/subnetworks/research"
+  }
+
+  encryption_spec {
+    kms_key_name = "projects/example-prod/locations/us-central1/keyRings/notebooks/cryptoKeys/colab"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl/fail/no-network-spec/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl/fail/no-network-spec/main.tf
@@ -1,0 +1,12 @@
+# With no network_spec the runtime lands on the default Google-managed network
+# instead of a VPC the organization controls.
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl/pass/vpc-attached/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-terraform-hcl/pass/vpc-attached/main.tf
@@ -1,0 +1,16 @@
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+
+  network_spec {
+    enable_internet_access = false
+    network                = "projects/example-prod/global/networks/research-vpc"
+    subnetwork             = "projects/example-prod/regions/us-central1/subnetworks/research"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/fail/no-shielded-config/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/fail/no-shielded-config/main.tf
@@ -1,0 +1,11 @@
+# shielded_vm_config omitted, so secure boot is off by default.
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/fail/secure-boot-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/fail/secure-boot-disabled/main.tf
@@ -1,0 +1,16 @@
+# Secure boot explicitly disabled: the runtime will boot unsigned kernels and
+# bootloaders, so a rootkit survives reboots undetected.
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+
+  shielded_vm_config {
+    enable_secure_boot = false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/pass/secure-boot/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-terraform-hcl/pass/secure-boot/main.tf
@@ -1,0 +1,14 @@
+resource "google_colab_runtime_template" "research" {
+  provider     = google-beta
+  name         = "research-template"
+  display_name = "Research notebooks"
+  location     = "us-central1"
+
+  machine_spec {
+    machine_type = "n1-standard-4"
+  }
+
+  shielded_vm_config {
+    enable_secure_boot = true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/default-compute-sa/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/default-compute-sa/main.tf
@@ -1,0 +1,15 @@
+# The default Compute Engine service account holds project-wide Editor by
+# default, so every notebook on it can rewrite the project.
+resource "google_notebooks_instance" "research" {
+  project      = var.project_id
+  name         = "research-workbench"
+  location     = "us-central1-a"
+  machine_type = "n1-standard-4"
+
+  service_account = "123456789012-compute@developer.gserviceaccount.com"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/no-service-account/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/no-service-account/main.tf
@@ -1,0 +1,13 @@
+# With service_account omitted the instance silently falls back to the default
+# Compute Engine account.
+resource "google_notebooks_instance" "research" {
+  project      = var.project_id
+  name         = "research-workbench"
+  location     = "us-central1-a"
+  machine_type = "n1-standard-4"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/pass/dedicated-sa/main.tf
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/pass/dedicated-sa/main.tf
@@ -1,0 +1,17 @@
+resource "google_notebooks_instance" "research" {
+  project      = var.project_id
+  name         = "research-workbench"
+  location     = "us-central1-a"
+  machine_type = "n1-standard-4"
+
+  # Purpose-built account scoped to just what the notebook needs.
+  service_account = "workbench-research@example-prod.iam.gserviceaccount.com"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  no_public_ip    = true
+  no_proxy_access = true
+}

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-ipsec-tunnel-ikev2-terraform-hcl/fail/ikev1/main.tf
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-ipsec-tunnel-ikev2-terraform-hcl/fail/ikev1/main.tf
@@ -1,0 +1,17 @@
+resource "oci_core_ipsec" "vpn" {
+  compartment_id = var.compartment_ocid
+  cpe_id         = oci_core_cpe.on_prem.id
+  drg_id         = oci_core_drg.main.id
+  display_name   = "legacy-vpn"
+
+  static_routes = ["10.10.0.0/16"]
+}
+
+# IKEv1 is deprecated and offers weaker key exchange than IKEv2.
+resource "oci_core_ipsec_connection_tunnel_management" "tunnel_1" {
+  ipsec_id     = oci_core_ipsec.vpn.id
+  tunnel_id    = data.oci_core_ipsec_connection_tunnels.vpn.ip_sec_connection_tunnels[0].id
+  display_name = "tunnel-1"
+  routing      = "STATIC"
+  ike_version  = "V1"
+}

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-ipsec-tunnel-ikev2-terraform-hcl/pass/ikev2/main.tf
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-ipsec-tunnel-ikev2-terraform-hcl/pass/ikev2/main.tf
@@ -1,0 +1,22 @@
+resource "oci_core_ipsec" "vpn" {
+  compartment_id = var.compartment_ocid
+  cpe_id         = oci_core_cpe.on_prem.id
+  drg_id         = oci_core_drg.main.id
+  display_name   = "prod-vpn"
+
+  static_routes = ["10.10.0.0/16"]
+}
+
+resource "oci_core_ipsec_connection_tunnel_management" "tunnel_1" {
+  ipsec_id     = oci_core_ipsec.vpn.id
+  tunnel_id    = data.oci_core_ipsec_connection_tunnels.vpn.ip_sec_connection_tunnels[0].id
+  display_name = "tunnel-1"
+  routing      = "BGP"
+  ike_version  = "V2"
+
+  bgp_session_info {
+    customer_bgp_asn      = "64512"
+    customer_interface_ip = "10.0.0.16/31"
+    oracle_interface_ip   = "10.0.0.17/31"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-oke-secrets-customer-managed-encryption-terraform-hcl/fail/no-kms-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-oke-secrets-customer-managed-encryption-terraform-hcl/fail/no-kms-key/main.tf
@@ -1,0 +1,16 @@
+# No kms_key_id, so etcd secrets fall back to Oracle-managed encryption.
+resource "oci_containerengine_cluster" "prod" {
+  compartment_id     = var.compartment_ocid
+  kubernetes_version = "v1.31.1"
+  name               = "prod-oke"
+  vcn_id             = oci_core_vcn.oke.id
+
+  options {
+    service_lb_subnet_ids = [oci_core_subnet.lb.id]
+
+    kubernetes_network_config {
+      pods_cidr     = "10.244.0.0/16"
+      services_cidr = "10.96.0.0/16"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-oke-secrets-customer-managed-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-oke-secrets-customer-managed-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,18 @@
+resource "oci_containerengine_cluster" "prod" {
+  compartment_id     = var.compartment_ocid
+  kubernetes_version = "v1.31.1"
+  name               = "prod-oke"
+  vcn_id             = oci_core_vcn.oke.id
+
+  # Envelope-encrypt Kubernetes secrets with a customer-managed Vault key.
+  kms_key_id = "ocid1.key.oc1.iad.bbqxxxxxxxxxx.abuwcljrxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+  options {
+    service_lb_subnet_ids = [oci_core_subnet.lb.id]
+
+    kubernetes_network_config {
+      pods_cidr     = "10.244.0.0/16"
+      services_cidr = "10.96.0.0/16"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/fail/admin-role/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/fail/admin-role/main.tf
@@ -1,0 +1,8 @@
+# Granting admin to an application credential hands full project control to
+# whatever holds the secret.
+resource "openstack_identity_application_credential_v3" "ci_deploy" {
+  name        = "ci-deploy"
+  description = "Credential used by the deployment pipeline"
+  roles       = ["admin", "member"]
+  expires_at  = "2027-01-01T00:00:00Z"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/pass/roles-omitted/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/pass/roles-omitted/main.tf
@@ -1,0 +1,7 @@
+# With roles omitted the credential inherits the creating user's roles minus
+# any that are explicitly restricted, which is the common least-privilege form.
+resource "openstack_identity_application_credential_v3" "backup_agent" {
+  name        = "backup-agent"
+  description = "Credential used by the nightly backup agent"
+  expires_at  = "2027-01-01T00:00:00Z"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/pass/scoped-roles/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-app-credential-no-admin-terraform-hcl/pass/scoped-roles/main.tf
@@ -1,0 +1,7 @@
+resource "openstack_identity_application_credential_v3" "ci_deploy" {
+  name         = "ci-deploy"
+  description  = "Credential used by the deployment pipeline"
+  roles        = ["member", "reader"]
+  expires_at   = "2027-01-01T00:00:00Z"
+  unrestricted = false
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-container-no-wildcard-write-terraform-hcl/fail/wildcard-write/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-container-no-wildcard-write-terraform-hcl/fail/wildcard-write/main.tf
@@ -1,0 +1,7 @@
+# A "*" write ACL lets any authenticated tenant upload into the container.
+resource "openstack_objectstorage_container_v1" "backups" {
+  name            = "prod-backups"
+  region          = "RegionOne"
+  container_read  = ".r:*,.rlistings"
+  container_write = "*:*"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-container-no-wildcard-write-terraform-hcl/pass/scoped-write/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-container-no-wildcard-write-terraform-hcl/pass/scoped-write/main.tf
@@ -1,0 +1,10 @@
+resource "openstack_objectstorage_container_v1" "backups" {
+  name          = "prod-backups"
+  region        = "RegionOne"
+  container_read  = "project:backup-reader"
+  container_write = "project:backup-writer"
+
+  metadata = {
+    environment = "production"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-ipsec-policy-encrypts-terraform-hcl/fail/ah/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-ipsec-policy-encrypts-terraform-hcl/fail/ah/main.tf
@@ -1,0 +1,8 @@
+# AH authenticates the payload but does not encrypt it, so traffic crosses the
+# tunnel in cleartext.
+resource "openstack_vpnaas_ipsec_policy_v2" "site_to_site" {
+  name               = "site-to-site"
+  transform_protocol = "ah"
+  auth_algorithm     = "sha256"
+  pfs                = "group14"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-ipsec-policy-encrypts-terraform-hcl/pass/esp/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-ipsec-policy-encrypts-terraform-hcl/pass/esp/main.tf
@@ -1,0 +1,7 @@
+resource "openstack_vpnaas_ipsec_policy_v2" "site_to_site" {
+  name                 = "site-to-site"
+  transform_protocol   = "esp"
+  encryption_algorithm = "aes-256"
+  auth_algorithm       = "sha256"
+  pfs                  = "group14"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/fail/attribute-form-wide/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/fail/attribute-form-wide/main.tf
@@ -1,0 +1,12 @@
+# Attribute-list form carrying an IPv6 catch-all pair.
+resource "openstack_networking_port_v2" "vip" {
+  name           = "keepalived-vip"
+  network_id     = openstack_networking_network_v2.internal.id
+  admin_state_up = true
+
+  allowed_address_pairs = [
+    {
+      ip_address = "::/0"
+    },
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/fail/wide-cidr/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/fail/wide-cidr/main.tf
@@ -1,0 +1,11 @@
+# A /0 allowed address pair lets the port spoof any source address, defeating
+# anti-spoofing enforcement entirely.
+resource "openstack_networking_port_v2" "vip" {
+  name           = "keepalived-vip"
+  network_id     = openstack_networking_network_v2.internal.id
+  admin_state_up = true
+
+  allowed_address_pairs {
+    ip_address = "0.0.0.0/0"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/pass/attribute-form/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/pass/attribute-form/main.tf
@@ -1,0 +1,15 @@
+# Same setting written as an attribute list rather than repeated blocks.
+resource "openstack_networking_port_v2" "vip" {
+  name           = "keepalived-vip"
+  network_id     = openstack_networking_network_v2.internal.id
+  admin_state_up = true
+
+  allowed_address_pairs = [
+    {
+      ip_address = "10.0.10.42"
+    },
+    {
+      ip_address = "10.0.10.43"
+    },
+  ]
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/pass/specific-address/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl/pass/specific-address/main.tf
@@ -1,0 +1,10 @@
+resource "openstack_networking_port_v2" "vip" {
+  name           = "keepalived-vip"
+  network_id     = openstack_networking_network_v2.internal.id
+  admin_state_up = true
+
+  # Only the single VIP the node is allowed to answer for.
+  allowed_address_pairs {
+    ip_address = "10.0.10.42"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/fail/3des-ike/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/fail/3des-ike/main.tf
@@ -1,0 +1,8 @@
+# 3DES is a 64-bit block cipher deprecated by NIST; the IKE policy negotiates
+# the tunnel keys, so a weak cipher here undermines the whole VPN.
+resource "openstack_vpnaas_ike_policy_v2" "site_to_site" {
+  name                 = "site-to-site-ike"
+  encryption_algorithm = "3des"
+  auth_algorithm       = "sha1"
+  pfs                  = "group5"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/fail/des-ipsec/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/fail/des-ipsec/main.tf
@@ -1,0 +1,9 @@
+# Single DES has a 56-bit key and is brute-forceable; the IPsec policy governs
+# the data channel, so payload traffic is effectively unprotected.
+resource "openstack_vpnaas_ipsec_policy_v2" "site_to_site" {
+  name                 = "site-to-site-ipsec"
+  transform_protocol   = "esp"
+  encryption_algorithm = "des"
+  auth_algorithm       = "sha1"
+  pfs                  = "group5"
+}

--- a/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/pass/aes256/main.tf
+++ b/content/iac-variant-testdata/mondoo-openstack-security/mondoo-openstack-security-vpn-no-weak-encryption-terraform-hcl/pass/aes256/main.tf
@@ -1,0 +1,15 @@
+resource "openstack_vpnaas_ike_policy_v2" "site_to_site" {
+  name                 = "site-to-site-ike"
+  encryption_algorithm = "aes-256"
+  auth_algorithm       = "sha256"
+  pfs                  = "group14"
+  ike_version          = "v2"
+}
+
+resource "openstack_vpnaas_ipsec_policy_v2" "site_to_site" {
+  name                 = "site-to-site-ipsec"
+  transform_protocol   = "esp"
+  encryption_algorithm = "aes-256"
+  auth_algorithm       = "sha256"
+  pfs                  = "group14"
+}

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -4381,9 +4381,17 @@ queries:
       openstack.ports.all(allowedAddressPairs == empty || allowedAddressPairs.all(_['ip_address'].contains("/0") == false))
   - uid: mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "openstack_networking_port_v2")
+    # allowed_address_pairs accepts both HCL forms. Written as an attribute list
+    # it lands in arguments; written as repeated nested blocks (the form the
+    # provider documents) arguments['allowed_address_pairs'] is null, so the
+    # first statement alone passes a spoofing-enabled port vacuously. Both forms
+    # are asserted; each is vacuously true when the config uses the other.
     mql: |
       terraform.resources("openstack_networking_port_v2").all(
         arguments['allowed_address_pairs'] == empty || arguments['allowed_address_pairs'].all(_['ip_address'].contains("/0") == false)
+      )
+      terraform.resources("openstack_networking_port_v2").all(
+        blocks.where(type == "allowed_address_pairs").all(arguments['ip_address'].contains("/0") == false)
       )
   - uid: mondoo-openstack-security-port-no-wide-address-pairs-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "openstack_networking_port_v2")


### PR DESCRIPTION
First round of the push to 100% IaC-variant fixture coverage, following the ratchet added in #3261.

## Coverage

Fixtures for all **15** uncovered variants in the three smallest-debt policies. Each reaches 100% and drops out of `iac-variant-coverage-budget.json` entirely:

| policy | before | after |
|---|---|---|
| mondoo-oci-security | 61/63 | **63/63** |
| mondoo-openstack-security | 24/29 | **29/29** |
| mondoo-gcp-security | 248/256 | **256/256** |

Remaining budget after this PR: alibaba 32, aws 28 tf + 21 cfn, azure 36 tf + 43 bicep, snowflake 13.

## A broken check the fixtures found

`mondoo-openstack-security-port-no-wide-address-pairs-terraform-hcl` could not fail on the form its own provider documents.

```coffee
terraform.resources("openstack_networking_port_v2").all(
  arguments['allowed_address_pairs'] == empty || arguments['allowed_address_pairs'].all(...)
)
```

`allowed_address_pairs` accepts two HCL forms. As an attribute list it lands in `arguments`; as repeated nested blocks — the idiomatic form, and the one in the provider docs — `arguments['allowed_address_pairs']` is **null**, so `== empty` short-circuits the whole assertion.

The practical effect: a port carrying an `0.0.0.0/0` allowed address pair, which switches off Neutron anti-spoofing for every address, **scored as compliant**. The check only ever worked against the attribute-list form.

Fixed by asserting both forms as separate statements (newline-AND), each vacuously true when the config uses the other:

```coffee
terraform.resources("openstack_networking_port_v2").all(
  arguments['allowed_address_pairs'] == empty || arguments['allowed_address_pairs'].all(_['ip_address'].contains("/0") == false)
)
terraform.resources("openstack_networking_port_v2").all(
  blocks.where(type == "allowed_address_pairs").all(arguments['ip_address'].contains("/0") == false)
)
```

Fixtures cover **both** forms in both directions (block + attribute list, IPv4 `0.0.0.0/0` + IPv6 `::/0`), so neither branch can regress silently.

The `-terraform-plan` and `-terraform-state` siblings are **not** affected and are deliberately unchanged: both serialize nested blocks as arrays, so their existing queries already see the block form.

## Fixture notes

Fixtures are realistic idiomatic HCL, not minimal stubs — a compliant OKE cluster carries its `options`/`kubernetes_network_config`, a Cloud Domains registration carries `yearly_price` and `contact_settings`. Where a check's failure mode has genuinely different shapes, each gets its own scenario: the Workbench service-account check fails both on the default `-compute@developer.gserviceaccount.com` account and on the attribute being omitted (which silently falls back to that same account); the Colab shielded-VM check fails both on `enable_secure_boot = false` and on the whole block being absent.

## Verification

Per-policy scoped runs, all green:

```
oci        2 new scenarios
openstack  97 subtests, 0 failures
gcp        full policy run 97s, 0 failures
TestTerraformVariantCoverage   ok  (budget regenerated and re-asserted)
cnspec policy lint mondoo-openstack-security.mql.yaml   valid
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)