### PR TITLE
🧹 proxmox: replace deprecated fields in the Proxmox inventory querypack

### DIFF
--- a/content/querypacks/mondoo-proxmox-inventory.mql.yaml
+++ b/content/querypacks/mondoo-proxmox-inventory.mql.yaml
@@ -243,7 +243,7 @@ queries:
         enabled
         schedule
         mode
-        storage
+        targetStorage { id }
         compress
         mailto
         vmids
@@ -311,7 +311,7 @@ queries:
     mql: |
       proxmox.sdnVnets {
         vnet
-        zone
+        zoneRef { zone }
         type
         tag
         vlanAware
@@ -362,12 +362,12 @@ queries:
     filters: asset.platform == "proxmox"
     docs:
       desc: |
-        Lists the groups and their member user IDs.
+        Lists the groups and the user accounts that belong to each one.
     mql: |
       proxmox.groups {
         id
         comment
-        memberIds
+        members { id }
       }
 
   - uid: mondoo-asset-inventory-proxmox-roles
@@ -419,7 +419,7 @@ queries:
     mql: |
       proxmox.acl {
         path
-        roleId
+        role { id }
         type
         ugid
         propagate
@@ -435,8 +435,8 @@ queries:
       proxmox.replicationJobs {
         id
         type
-        source
-        target
+        sourceNode { name }
+        targetNode { name }
         schedule
         disabled
         rate


### PR DESCRIPTION
Clears the six `query-deprecated-symbol` lint warnings in `content/querypacks/mondoo-proxmox-inventory.mql.yaml`.

Every deprecated field here is a raw identifier string that the provider now also exposes as a typed resource reference, so each query selects the reference and reads its identity field back.

| Query | Deprecated | Replacement |
|---|---|---|
| `…-backup-jobs` | `proxmox.backup.job.storage` | `targetStorage { id }` |
| `…-sdn-vnets` | `proxmox.sdn.vnet.zone` | `zoneRef { zone }` |
| `…-groups` | `proxmox.group.memberIds` | `members { id }` |
| `…-acls` | `proxmox.acl.roleId` | `role { id }` |
| `…-replication-jobs` | `proxmox.replication.job.source` / `.target` | `sourceNode { name }` / `targetNode { name }` |

## Output equivalence

Four of the five resolvers build their resource straight from the stored string — `targetStorage()`, `zoneRef()`, `role()`, and `members()` all call `NewResource(…, {"id": <the deprecated string>})` without verifying existence. Reading the **init field** back is therefore exactly the value the deprecated field carried, and costs no extra API call.

`sourceNode`/`targetNode` are the one exception: `resolveNodeRef` calls `conn.LookupNode(name)` first and returns null when the node isn't in the cluster. A replication job pointing at a decommissioned node now reports null instead of a dangling hostname. That's the provider's intended semantics for the typed ref, and replication jobs referencing absent nodes are already broken jobs.

The groups query `desc` no longer says "member user IDs", since `members` emits user accounts rather than bare ID strings.

## Style

Nested-block selection (`targetStorage { id }`) matches the `vcn { id }` form used in the sibling OCI inventory querypack — see #3246, the same migration for OCI — and the majority of ref selections across `content/querypacks/`.

## Verification

```
$ cnspec policy lint content/querypacks/mondoo-proxmox-inventory.mql.yaml
→ lint policy bundle(s) files=["content/querypacks/mondoo-proxmox-inventory.mql.yaml"]
→ valid policy bundle(s)
```

Baseline on `main` reproduces all six warnings; the branch is clean. `content/mondoo-proxmox-security.mql.yaml` lints clean already and needed no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)