### PR TITLE
✨ scan: report memory consumption upstream as scan statistics

### DIFF
--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -47,6 +47,13 @@ func outputDirFromCtx(ctx context.Context) string {
 	return ""
 }
 
+// recordMemStats folds the run's memory tracker into this asset's collector.
+// Extracted so the wiring is testable without standing up a scan. A nil
+// tracker (no tracker on ctx) is a no-op — MemTracker methods are nil-safe.
+func recordMemStats(ctx context.Context, stats *scanstats.Collector) {
+	scanstats.MemTrackerFromContext(ctx).Record(stats)
+}
+
 func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Asset, upstreamClient *upstream.UpstreamClient, f func(context.Context, *policy.LocalServices) error) error {
 	assetMrn := ""
 	if asset != nil {
@@ -90,6 +97,10 @@ func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Ass
 			return err
 		}
 		stats.AddDuration(scanstats.MetricScanDuration, time.Since(scanStart))
+
+		// Snapshot process memory as of this asset's completion. The values
+		// are process-wide, not this asset's cost — see ADR-0004.
+		recordMemStats(scanCtx, stats)
 
 		if upstream != nil {
 			scanDataPath, err := scanDataStore.Finalize()

--- a/internal/datalakes/sqlite/sqlite_memstats_test.go
+++ b/internal/datalakes/sqlite/sqlite_memstats_test.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy/scanstats"
+)
+
+func TestRecordMemStats_WritesTrackerIntoCollector(t *testing.T) {
+	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{RunID: "run-abc"})
+	ctx := scanstats.ContextWithMemTracker(context.Background(), tr)
+
+	c := scanstats.New()
+	recordMemStats(ctx, c)
+
+	stats := c.ToProto()
+	require.NotNil(t, stats)
+
+	names := map[string]bool{}
+	for _, m := range stats.Metrics {
+		names[m.Name] = true
+	}
+	require.True(t, names[scanstats.MetricRunID])
+	require.True(t, names[scanstats.MetricMemRuntimePeak])
+	require.True(t, names[scanstats.MetricConcurrencyParallelism])
+}
+
+func TestRecordMemStats_NoTrackerOnContextIsNoop(t *testing.T) {
+	// Scans that never installed a tracker must still upload cleanly.
+	c := scanstats.New()
+	require.NotPanics(t, func() { recordMemStats(context.Background(), c) })
+	require.Nil(t, c.ToProto())
+}

--- a/internal/datalakes/sqlite/sqlite_memstats_test.go
+++ b/internal/datalakes/sqlite/sqlite_memstats_test.go
@@ -5,6 +5,7 @@ package sqlite
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,12 @@ import (
 )
 
 func TestRecordMemStats_WritesTrackerIntoCollector(t *testing.T) {
-	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{RunID: "run-abc"})
+	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+		RunID: "run-abc",
+		// Avoid reading the real /sys/fs/cgroup default on a containerized
+		// CI runner.
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+	})
 	ctx := scanstats.ContextWithMemTracker(context.Background(), tr)
 
 	c := scanstats.New()

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -507,13 +507,19 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	// Memory is process-wide while scanstats Collectors are per-asset, so the
 	// tracker is created once per run and shared by every asset. run_id lets
 	// the resulting per-asset records be grouped back into one process.
+	//
+	// uuid.NewRandom (unlike uuid.New) can fail rather than panic if the
+	// entropy source is unavailable; telemetry must never fail a scan, so a
+	// failure here just leaves RunID empty, which Record already omits.
+	runID := ""
+	if u, err := uuid.NewRandom(); err == nil {
+		runID = u.String()
+	}
 	memTracker := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
-		RunID:          uuid.New().String(),
+		RunID:          runID,
 		Parallelism:    parallelism,
 		MaxConnections: maxConn,
 	})
-	memTracker.Start(memSampleInterval)
-	defer memTracker.Stop()
 	ctx = scanstats.ContextWithMemTracker(ctx, memTracker)
 
 	dispatcher := newScanDispatcher(
@@ -521,9 +527,13 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		reporter, multiprogress, services, spaceMrn, &scannedAssets,
 		memTracker,
 	)
-	// Registered after construction because the dispatcher owns the
-	// semaphore the tracker reads.
+	// Registered before Start so the sampler's immediate first sample —
+	// which can end up being the run's peak — already has an accessor to
+	// call, instead of recording an in-flight count of zero that would be
+	// indistinguishable from a legitimate zero.
 	memTracker.SetInFlightFunc(dispatcher.inFlight)
+	memTracker.Start(memSampleInterval)
+	defer memTracker.Stop()
 	batcher := newSyncBatcher(dispatcher, services, spaceMrn, s.recording, multiprogress)
 
 	scanCtx := &scanContext{

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
 	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog/log"
 	"github.com/segmentio/ksuid"
@@ -25,6 +26,7 @@ import (
 	"go.mondoo.com/cnspec/v13/internal/scandump"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/cnspec/v13/policy/executor"
+	"go.mondoo.com/cnspec/v13/policy/scanstats"
 	"go.mondoo.com/mql/v13"
 	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/cli/execruntime"
@@ -50,6 +52,11 @@ import (
 const (
 	defaultRefreshInterval = 3600
 )
+
+// memSampleInterval is how often the scan's memory footprint is sampled.
+// runtime/metrics reads are sub-microsecond and do not stop the world, so
+// one second costs nothing against scans that run for minutes.
+const memSampleInterval = time.Second
 
 type LocalScanner struct {
 	queue           *diskQueueClient
@@ -497,10 +504,26 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	connSem := make(chan struct{}, maxConn)
 	var scannedAssets atomic.Int64
 
+	// Memory is process-wide while scanstats Collectors are per-asset, so the
+	// tracker is created once per run and shared by every asset. run_id lets
+	// the resulting per-asset records be grouped back into one process.
+	memTracker := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+		RunID:          uuid.New().String(),
+		Parallelism:    parallelism,
+		MaxConnections: maxConn,
+	})
+	memTracker.Start(memSampleInterval)
+	defer memTracker.Stop()
+	ctx = scanstats.ContextWithMemTracker(ctx, memTracker)
+
 	dispatcher := newScanDispatcher(
 		parallelism, connSem, s, explorer, job, upstream,
 		reporter, multiprogress, services, spaceMrn, &scannedAssets,
+		memTracker,
 	)
+	// Registered after construction because the dispatcher owns the
+	// semaphore the tracker reads.
+	memTracker.SetInFlightFunc(dispatcher.inFlight)
 	batcher := newSyncBatcher(dispatcher, services, spaceMrn, s.recording, multiprogress)
 
 	scanCtx := &scanContext{

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -327,26 +327,20 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 
 // logMemoryStats emits memory diagnostics after an asset scan completes.
 // Only called when DEBUG_PROVIDER_MEMORY is set.
+//
+// Reads the run's MemTracker rather than sampling independently, so the
+// logged numbers and the numbers reported upstream cannot disagree.
 func (d *scanDispatcher) logMemoryStats(asset *inventory.Asset) {
-	var m goruntime.MemStats
-	goruntime.ReadMemStats(&m)
+	peakBytes, peakGoroutines, inFlightAtPeak := d.memTracker.Peaks()
 
-	ev := log.Info().
+	log.Info().
 		Str("asset", asset.Name).
 		Int64("scanned_assets", d.scannedAssets.Load()).
 		Int("goroutines", goruntime.NumGoroutine()).
-		Uint64("heap_alloc_mb", m.Alloc/1024/1024).
-		Uint64("heap_sys_mb", m.HeapSys/1024/1024).
-		Uint64("total_alloc_mb", m.TotalAlloc/1024/1024)
-
-	if cgroup, err := os.ReadFile("/sys/fs/cgroup/memory.current"); err == nil {
-		ev = ev.Str("cgroup_bytes", strings.TrimSpace(string(cgroup)))
-	}
-	if cgroupMax, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
-		ev = ev.Str("cgroup_max", strings.TrimSpace(string(cgroupMax)))
-	}
-
-	ev.Msg("memory after asset scan")
+		Uint64("runtime_peak_mb", peakBytes/1024/1024).
+		Int("goroutines_peak", peakGoroutines).
+		Int("in_flight_at_peak", inFlightAtPeak).
+		Msg("memory after asset scan")
 
 	if ar, ok := d.reporter.(*AggregateReporter); ok {
 		rptBytes, rpBytes, vrBytes, aBytes := ar.AccumulatedBytes()

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/cnspec/v13"
 	"go.mondoo.com/cnspec/v13/cli/progress"
 	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/cnspec/v13/policy/scanstats"
 	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/discovery"
 	"go.mondoo.com/mql/v13/llx"
@@ -149,6 +150,7 @@ type scanDispatcher struct {
 	services      *policy.Services
 	spaceMrn      string
 	scannedAssets *atomic.Int64
+	memTracker    *scanstats.MemTracker
 }
 
 func newScanDispatcher(
@@ -163,6 +165,7 @@ func newScanDispatcher(
 	services *policy.Services,
 	spaceMrn string,
 	scannedAssets *atomic.Int64,
+	memTracker *scanstats.MemTracker,
 ) *scanDispatcher {
 	return &scanDispatcher{
 		scanSem:       make(chan struct{}, parallelism),
@@ -176,6 +179,7 @@ func newScanDispatcher(
 		services:      services,
 		spaceMrn:      spaceMrn,
 		scannedAssets: scannedAssets,
+		memTracker:    memTracker,
 	}
 }
 
@@ -405,4 +409,12 @@ func (d *scanDispatcher) reportPanic(tracked *discovery.TrackedAsset) {
 		sendErrorToMondooPlatform(serviceAccount, event)
 		log.Info().Msg("reported panic to Mondoo Platform")
 	})
+}
+
+// inFlight reports how many assets are currently scanning. scanSem is a
+// buffered channel used as a semaphore, so its length is the number of
+// held slots. Read by the memory sampler to record the concurrency a peak
+// occurred at — a peak without its denominator cannot be compared.
+func (d *scanDispatcher) inFlight() int {
+	return len(d.scanSem)
 }

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -332,15 +332,30 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 // logged numbers and the numbers reported upstream cannot disagree.
 func (d *scanDispatcher) logMemoryStats(asset *inventory.Asset) {
 	peakBytes, peakGoroutines, inFlightAtPeak := d.memTracker.Peaks()
+	snap := d.memTracker.Snapshot()
 
-	log.Info().
+	ev := log.Info().
 		Str("asset", asset.Name).
 		Int64("scanned_assets", d.scannedAssets.Load()).
 		Int("goroutines", goruntime.NumGoroutine()).
 		Uint64("runtime_peak_mb", peakBytes/1024/1024).
 		Int("goroutines_peak", peakGoroutines).
-		Int("in_flight_at_peak", inFlightAtPeak).
-		Msg("memory after asset scan")
+		Int("in_flight_at_peak", inFlightAtPeak)
+
+	// Current footprint and cgroup readings, best-effort: absent rather
+	// than zero when they could not be measured, matching the upstream
+	// metrics this diagnostic is read alongside.
+	if snap.HasRuntime {
+		ev = ev.Uint64("runtime_mb", snap.RuntimeBytes/1024/1024)
+	}
+	if snap.HasCgroupCurrent {
+		ev = ev.Uint64("cgroup_current_mb", snap.CgroupCurrent/1024/1024)
+	}
+	if snap.HasCgroupMax {
+		ev = ev.Uint64("cgroup_max_mb", snap.CgroupMax/1024/1024)
+	}
+
+	ev.Msg("memory after asset scan")
 
 	if ar, ok := d.reporter.(*AggregateReporter); ok {
 		rptBytes, rpBytes, vrBytes, aBytes := ar.AccumulatedBytes()

--- a/policy/scan/scan_pipeline_memtracker_test.go
+++ b/policy/scan/scan_pipeline_memtracker_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanDispatcher_InFlightReflectsHeldScanSlots(t *testing.T) {
+	d := &scanDispatcher{scanSem: make(chan struct{}, 4)}
+	require.Equal(t, 0, d.inFlight())
+
+	d.scanSem <- struct{}{}
+	d.scanSem <- struct{}{}
+	require.Equal(t, 2, d.inFlight())
+
+	<-d.scanSem
+	require.Equal(t, 1, d.inFlight())
+}
+
+func TestScanDispatcher_InFlightZeroWhenNoSemaphore(t *testing.T) {
+	d := &scanDispatcher{}
+	require.Equal(t, 0, d.inFlight())
+}

--- a/policy/scan/scan_pipeline_memtracker_test.go
+++ b/policy/scan/scan_pipeline_memtracker_test.go
@@ -4,9 +4,12 @@
 package scan
 
 import (
+	"bytes"
 	"sync/atomic"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnspec/v13/policy/scanstats"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -41,16 +44,28 @@ func TestLogMemoryStats_NoTrackerDoesNotPanic(t *testing.T) {
 func TestLogMemoryStats_UsesTrackerPeak(t *testing.T) {
 	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
 		RunID:  "run-abc",
-		Sample: func() scanstats.Sample { return scanstats.Sample{RuntimeBytes: 4242, Goroutines: 9} },
+		Sample: func() scanstats.Sample { return scanstats.Sample{RuntimeBytes: 4242, Goroutines: 17} },
 	})
+	tr.SetInFlightFunc(func() int { return 5 })
 	tr.Observe()
 
 	d := &scanDispatcher{scannedAssets: &atomic.Int64{}, memTracker: tr}
-	require.NotPanics(t, func() {
-		d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
-	})
 
-	// The tracker, not a second independent reader, is the source of truth.
-	peak, _, _ := tr.Peaks()
-	require.Equal(t, uint64(4242), peak)
+	// logMemoryStats writes through the package-level zerolog logger, so
+	// capture that global for the duration of the test (not parallel-safe)
+	// and assert on the emitted line, proving the logged values came from
+	// the tracker rather than an independent reader.
+	buf := &bytes.Buffer{}
+	orig := log.Logger
+	log.Logger = zerolog.New(buf)
+	defer func() { log.Logger = orig }()
+
+	d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
+
+	out := buf.String()
+	// goroutines_peak and in_flight_at_peak come only from the tracker;
+	// runtime_peak_mb would be zero either way (4242 bytes truncates under
+	// MB division), so it can't discriminate a working implementation.
+	require.Contains(t, out, `"goroutines_peak":17`, out)
+	require.Contains(t, out, `"in_flight_at_peak":5`, out)
 }

--- a/policy/scan/scan_pipeline_memtracker_test.go
+++ b/policy/scan/scan_pipeline_memtracker_test.go
@@ -4,9 +4,12 @@
 package scan
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy/scanstats"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
 func TestScanDispatcher_InFlightReflectsHeldScanSlots(t *testing.T) {
@@ -24,4 +27,30 @@ func TestScanDispatcher_InFlightReflectsHeldScanSlots(t *testing.T) {
 func TestScanDispatcher_InFlightZeroWhenNoSemaphore(t *testing.T) {
 	d := &scanDispatcher{}
 	require.Equal(t, 0, d.inFlight())
+}
+
+func TestLogMemoryStats_NoTrackerDoesNotPanic(t *testing.T) {
+	// DEBUG_PROVIDER_MEMORY can be set on a scan whose dispatcher was built
+	// without a tracker (unit tests, embedded callers).
+	d := &scanDispatcher{scannedAssets: &atomic.Int64{}}
+	require.NotPanics(t, func() {
+		d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
+	})
+}
+
+func TestLogMemoryStats_UsesTrackerPeak(t *testing.T) {
+	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+		RunID:  "run-abc",
+		Sample: func() scanstats.Sample { return scanstats.Sample{RuntimeBytes: 4242, Goroutines: 9} },
+	})
+	tr.Observe()
+
+	d := &scanDispatcher{scannedAssets: &atomic.Int64{}, memTracker: tr}
+	require.NotPanics(t, func() {
+		d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
+	})
+
+	// The tracker, not a second independent reader, is the source of truth.
+	peak, _, _ := tr.Peaks()
+	require.Equal(t, uint64(4242), peak)
 }

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -38,12 +38,12 @@ const (
 	// only correct aggregation (max per run) is inexpressible.
 	MetricRunID = "cnspec.scan.run_id"
 
-	MetricMemRuntimePeak     = "cnspec.scan.mem.runtime_peak_bytes"     // unit: bytes
+	MetricMemRuntimePeak     = "cnspec.scan.mem.runtime_peak_bytes"      // unit: bytes
 	MetricMemRuntimeAtFinish = "cnspec.scan.mem.runtime_at_finish_bytes" // unit: bytes
-	MetricMemGoroutinesPeak  = "cnspec.scan.mem.goroutines_peak"        // unit: count
-	MetricMemCgroupCurrent   = "cnspec.scan.mem.cgroup_current_bytes"   // unit: bytes
-	MetricMemCgroupPeak      = "cnspec.scan.mem.cgroup_peak_bytes"      // unit: bytes
-	MetricMemCgroupMax       = "cnspec.scan.mem.cgroup_max_bytes"       // unit: bytes
+	MetricMemGoroutinesPeak  = "cnspec.scan.mem.goroutines_peak"         // unit: count
+	MetricMemCgroupCurrent   = "cnspec.scan.mem.cgroup_current_bytes"    // unit: bytes
+	MetricMemCgroupPeak      = "cnspec.scan.mem.cgroup_peak_bytes"       // unit: bytes
+	MetricMemCgroupMax       = "cnspec.scan.mem.cgroup_max_bytes"        // unit: bytes
 
 	MetricConcurrencyInFlightAtPeak = "cnspec.scan.concurrency.in_flight_at_peak" // unit: count
 	MetricConcurrencyParallelism    = "cnspec.scan.concurrency.parallelism"       // unit: count

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -30,6 +30,24 @@ const (
 	MetricFrameworks         = "cnspec.scan.frameworks"           // unit: count
 	MetricChecksErrored      = "cnspec.scan.checks_errored"       // unit: count
 	MetricDataQueriesErrored = "cnspec.scan.data_queries_errored" // unit: count
+
+	// MetricRunID identifies the scan process a record came from. The memory
+	// metrics below are process-wide but emitted once per asset, so a run
+	// scanning N assets produces N records carrying one process's rising
+	// high-water mark. Without this, those records cannot be grouped and the
+	// only correct aggregation (max per run) is inexpressible.
+	MetricRunID = "cnspec.scan.run_id"
+
+	MetricMemRuntimePeak     = "cnspec.scan.mem.runtime_peak_bytes"     // unit: bytes
+	MetricMemRuntimeAtFinish = "cnspec.scan.mem.runtime_at_finish_bytes" // unit: bytes
+	MetricMemGoroutinesPeak  = "cnspec.scan.mem.goroutines_peak"        // unit: count
+	MetricMemCgroupCurrent   = "cnspec.scan.mem.cgroup_current_bytes"   // unit: bytes
+	MetricMemCgroupPeak      = "cnspec.scan.mem.cgroup_peak_bytes"      // unit: bytes
+	MetricMemCgroupMax       = "cnspec.scan.mem.cgroup_max_bytes"       // unit: bytes
+
+	MetricConcurrencyInFlightAtPeak = "cnspec.scan.concurrency.in_flight_at_peak" // unit: count
+	MetricConcurrencyParallelism    = "cnspec.scan.concurrency.parallelism"       // unit: count
+	MetricConcurrencyMaxConnections = "cnspec.scan.concurrency.max_connections"   // unit: count
 )
 
 // Collector accumulates scan metrics. It is safe for concurrent use.
@@ -71,6 +89,11 @@ func (c *Collector) AddDouble(name, unit string, v float64) {
 // AddBool records a boolean flag metric.
 func (c *Collector) AddBool(name string, v bool) {
 	c.add(&policy.Metric{Name: name, Value: &policy.Metric_BoolValue{BoolValue: v}})
+}
+
+// AddString records a string metric (identifiers, labels). No unit applies.
+func (c *Collector) AddString(name, v string) {
+	c.add(&policy.Metric{Name: name, Value: &policy.Metric_StringValue{StringValue: v}})
 }
 
 // ToProto returns the collected metrics as a ScanStatistics, or nil when the

--- a/policy/scanstats/collector_test.go
+++ b/policy/scanstats/collector_test.go
@@ -60,3 +60,34 @@ func TestCollector_NilReceiverDoesNotPanic(t *testing.T) {
 	})
 	require.Nil(t, c.ToProto())
 }
+
+func TestCollector_AddString(t *testing.T) {
+	c := New()
+	c.AddString(MetricRunID, "1e8f7a0c-0000-4000-8000-000000000000")
+
+	stats := c.ToProto()
+	require.Len(t, stats.Metrics, 1)
+	require.Equal(t, MetricRunID, stats.Metrics[0].Name)
+	require.Equal(t, "1e8f7a0c-0000-4000-8000-000000000000", stats.Metrics[0].GetStringValue())
+}
+
+func TestCollector_AddStringNilReceiverIsSafe(t *testing.T) {
+	var c *Collector
+	require.NotPanics(t, func() { c.AddString(MetricRunID, "x") })
+	require.Nil(t, c.ToProto())
+}
+
+func TestMemMetricNamesMatchWireContract(t *testing.T) {
+	// These names are a wire contract (ADR-0004). They may be added to, but
+	// never renamed or repurposed — downstream queries key on them.
+	require.Equal(t, "cnspec.scan.run_id", MetricRunID)
+	require.Equal(t, "cnspec.scan.mem.runtime_peak_bytes", MetricMemRuntimePeak)
+	require.Equal(t, "cnspec.scan.mem.runtime_at_finish_bytes", MetricMemRuntimeAtFinish)
+	require.Equal(t, "cnspec.scan.mem.goroutines_peak", MetricMemGoroutinesPeak)
+	require.Equal(t, "cnspec.scan.mem.cgroup_current_bytes", MetricMemCgroupCurrent)
+	require.Equal(t, "cnspec.scan.mem.cgroup_peak_bytes", MetricMemCgroupPeak)
+	require.Equal(t, "cnspec.scan.mem.cgroup_max_bytes", MetricMemCgroupMax)
+	require.Equal(t, "cnspec.scan.concurrency.in_flight_at_peak", MetricConcurrencyInFlightAtPeak)
+	require.Equal(t, "cnspec.scan.concurrency.parallelism", MetricConcurrencyParallelism)
+	require.Equal(t, "cnspec.scan.concurrency.max_connections", MetricConcurrencyMaxConnections)
+}

--- a/policy/scanstats/context.go
+++ b/policy/scanstats/context.go
@@ -19,3 +19,19 @@ func CollectorFromContext(ctx context.Context) *Collector {
 	c, _ := ctx.Value(collectorCtxKey{}).(*Collector)
 	return c
 }
+
+type memTrackerCtxKey struct{}
+
+// ContextWithMemTracker returns a ctx carrying t so the datalake layer can
+// record process memory into a per-asset collector without threading the
+// tracker through every signature.
+func ContextWithMemTracker(ctx context.Context, t *MemTracker) context.Context {
+	return context.WithValue(ctx, memTrackerCtxKey{}, t)
+}
+
+// MemTrackerFromContext returns the MemTracker carried by ctx, or nil. Every
+// MemTracker method is nil-safe, so callers need not check.
+func MemTrackerFromContext(ctx context.Context) *MemTracker {
+	t, _ := ctx.Value(memTrackerCtxKey{}).(*MemTracker)
+	return t
+}

--- a/policy/scanstats/context_test.go
+++ b/policy/scanstats/context_test.go
@@ -57,3 +57,26 @@ func TestRecordKindCounts_NilCollector(t *testing.T) {
 	// Must not panic
 	RecordKindCounts(nil, KindCounts{Checks: 5})
 }
+
+func TestContextWithMemTracker_RoundTrip(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{RunID: "run-abc"})
+	ctx := ContextWithMemTracker(context.Background(), tr)
+	require.Same(t, tr, MemTrackerFromContext(ctx))
+}
+
+func TestMemTrackerFromContext_AbsentReturnsNil(t *testing.T) {
+	// Must return a usable nil rather than panicking: every MemTracker
+	// method is nil-safe, so callers need no branch.
+	tr := MemTrackerFromContext(context.Background())
+	require.Nil(t, tr)
+	require.NotPanics(t, func() { tr.Record(New()) })
+}
+
+func TestMemTrackerAndCollectorAreIndependentContextValues(t *testing.T) {
+	c := New()
+	tr := NewMemTracker(MemTrackerConfig{RunID: "run-abc"})
+	ctx := ContextWithMemTracker(ContextWithCollector(context.Background(), c), tr)
+
+	require.Same(t, c, CollectorFromContext(ctx))
+	require.Same(t, tr, MemTrackerFromContext(ctx))
+}

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import "sync"
+
+// Sample is one observation of this process's memory state.
+type Sample struct {
+	// RuntimeBytes is the Go runtime's memory footprint — the quantity the
+	// runtime accounts against GOMEMLIMIT, and the one the OOM killer acts
+	// on. Deliberately not MemStats.Alloc, which counts only live heap
+	// objects and so understates the real footprint.
+	RuntimeBytes uint64
+	Goroutines   int
+}
+
+// SampleFunc returns a current Sample. Injected so the high-water logic is
+// testable without a live runtime.
+type SampleFunc func() Sample
+
+// MemTrackerConfig configures a MemTracker. A zero Sample or CgroupRoot
+// falls back to the real process defaults.
+type MemTrackerConfig struct {
+	RunID          string
+	Parallelism    int
+	MaxConnections int
+	Sample         SampleFunc
+	CgroupRoot     string
+}
+
+// MemTracker holds process-wide memory high-water marks for one scan run.
+// Memory is per-process while scanstats Collectors are per-asset, so this is
+// shared across every asset scanned by a run and makes no per-asset claim.
+//
+// Every exported method is safe on a nil receiver: telemetry must never
+// panic a scan.
+type MemTracker struct {
+	mu             sync.Mutex
+	peakRuntime    uint64
+	peakGoroutines int
+	// inFlightAtPeak is sampled when the peak is set, not when the scan
+	// ends. A peak without the concurrency it occurred at cannot be
+	// compared against any other peak.
+	inFlightAtPeak int
+	lastRuntime    uint64
+
+	inFlight func() int
+
+	cfg MemTrackerConfig
+}
+
+// NewMemTracker returns a tracker. Sampling does not start until Start.
+func NewMemTracker(cfg MemTrackerConfig) *MemTracker {
+	if cfg.Sample == nil {
+		cfg.Sample = defaultSample
+	}
+	if cfg.CgroupRoot == "" {
+		cfg.CgroupRoot = defaultCgroupRoot
+	}
+	return &MemTracker{cfg: cfg}
+}
+
+// SetInFlightFunc registers an accessor for the number of assets currently
+// scanning. Registered after construction because the scan dispatcher that
+// owns the semaphore is built after the tracker.
+func (t *MemTracker) SetInFlightFunc(f func() int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.inFlight = f
+	t.mu.Unlock()
+}
+
+// Observe takes one sample and folds it into the high-water marks.
+func (t *MemTracker) Observe() {
+	if t == nil {
+		return
+	}
+	s := t.cfg.Sample()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.lastRuntime = s.RuntimeBytes
+	if s.RuntimeBytes > t.peakRuntime {
+		t.peakRuntime = s.RuntimeBytes
+		if t.inFlight != nil {
+			t.inFlightAtPeak = t.inFlight()
+		}
+	}
+	if s.Goroutines > t.peakGoroutines {
+		t.peakGoroutines = s.Goroutines
+	}
+}
+
+// Replaced in Task 2.
+const defaultCgroupRoot = "/sys/fs/cgroup"
+
+// Replaced in Task 3.
+func defaultSample() Sample { return Sample{} }

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -6,6 +6,8 @@ package scanstats
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/metrics"
 	"strconv"
 	"strings"
 	"sync"
@@ -143,5 +145,45 @@ func readCgroupValue(root, name string) (uint64, bool) {
 	return v, true
 }
 
-// Replaced in Task 3.
-func defaultSample() Sample { return Sample{} }
+// runtimeFootprintMetrics are the runtime/metrics names whose difference is
+// the Go runtime's memory footprint — the same quantity the runtime accounts
+// against GOMEMLIMIT.
+const (
+	metricTotalBytes        = "/memory/classes/total:bytes"
+	metricHeapReleasedBytes = "/memory/classes/heap/released:bytes"
+)
+
+// defaultSample reads the live process memory state.
+//
+// It uses runtime/metrics rather than runtime.ReadMemStats for two reasons:
+// ReadMemStats stops the world, which would perturb the very scan being
+// measured; and MemStats.Alloc counts only live heap objects, excluding
+// stacks and memory the runtime has retained but not returned to the OS, so
+// it systematically understates what the OOM killer acts on.
+func defaultSample() Sample {
+	// A fresh slice per call: metrics.Read writes into it, so a shared one
+	// would need its own lock and this is called once a second.
+	s := []metrics.Sample{
+		{Name: metricTotalBytes},
+		{Name: metricHeapReleasedBytes},
+	}
+	metrics.Read(s)
+
+	var total, released uint64
+	if s[0].Value.Kind() == metrics.KindUint64 {
+		total = s[0].Value.Uint64()
+	}
+	if s[1].Value.Kind() == metrics.KindUint64 {
+		released = s[1].Value.Uint64()
+	}
+
+	var footprint uint64
+	if total > released {
+		footprint = total - released
+	}
+
+	return Sample{
+		RuntimeBytes: footprint,
+		Goroutines:   runtime.NumGoroutine(),
+	}
+}

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -107,6 +107,18 @@ func (t *MemTracker) Observe() {
 	}
 }
 
+// Peaks returns the current high-water marks: runtime footprint bytes,
+// goroutine count, and the in-flight asset count at the moment the footprint
+// peak was set. Safe on a nil tracker, which reports zeroes.
+func (t *MemTracker) Peaks() (runtimeBytes uint64, goroutines int, inFlightAtPeak int) {
+	if t == nil {
+		return 0, 0, 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.peakRuntime, t.peakGoroutines, t.inFlightAtPeak
+}
+
 // defaultCgroupRoot is the cgroup v2 unified hierarchy mount point.
 const defaultCgroupRoot = "/sys/fs/cgroup"
 

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -4,6 +4,7 @@
 package scanstats
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -70,6 +71,11 @@ type MemTracker struct {
 
 	stopOnce sync.Once
 	stop     chan struct{}
+	// wg tracks the sampling goroutine so Stop can wait for it to exit.
+	// Without it Stop returns while a tick may still be in flight, which
+	// matters for a long-lived process (cnspec serve) that creates one
+	// tracker per job: samplers from consecutive jobs could otherwise overlap.
+	wg sync.WaitGroup
 }
 
 // NewMemTracker returns a tracker. Sampling does not start until Start.
@@ -266,7 +272,9 @@ func (t *MemTracker) Start(interval time.Duration) {
 	}
 	t.Observe()
 
+	t.wg.Add(1)
 	go func() {
+		defer t.wg.Done()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -280,12 +288,27 @@ func (t *MemTracker) Start(interval time.Duration) {
 	}()
 }
 
-// Stop ends sampling. Safe to call more than once, and on a nil tracker.
+// Stop ends sampling and waits for the sampling goroutine to exit, so that
+// once it returns no further observations can occur. Safe to call more than
+// once, and on a nil tracker.
 func (t *MemTracker) Stop() {
 	if t == nil {
 		return
 	}
 	t.stopOnce.Do(func() { close(t.stop) })
+	t.wg.Wait()
+}
+
+// addBytes records a byte-count metric, omitting it when the value cannot be
+// represented as an int64. A uint64 at or above 1<<63 would wrap negative in
+// the cast, and a negative byte count downstream is worse than an absent one —
+// the same rule the cgroup presence flags follow. Clamping was considered and
+// rejected: a fabricated ceiling reads as a real measurement.
+func addBytes(c *Collector, name string, v uint64) {
+	if v > math.MaxInt64 {
+		return
+	}
+	c.AddInt(name, "bytes", int64(v))
 }
 
 // Record writes the tracker's state into c. Called once per asset, so every
@@ -317,8 +340,8 @@ func (t *MemTracker) Record(c *Collector) {
 	// must omit these rather than report zero, which would be
 	// indistinguishable downstream from a real measurement.
 	if hasSample {
-		c.AddInt(MetricMemRuntimePeak, "bytes", int64(peak))
-		c.AddInt(MetricMemRuntimeAtFinish, "bytes", int64(last))
+		addBytes(c, MetricMemRuntimePeak, peak)
+		addBytes(c, MetricMemRuntimeAtFinish, last)
 		c.AddInt(MetricMemGoroutinesPeak, "count", int64(goroutines))
 	}
 
@@ -328,12 +351,12 @@ func (t *MemTracker) Record(c *Collector) {
 
 	cg := readCgroup(t.cfg.CgroupRoot)
 	if cg.hasCurrent {
-		c.AddInt(MetricMemCgroupCurrent, "bytes", int64(cg.current))
+		addBytes(c, MetricMemCgroupCurrent, cg.current)
 	}
 	if cg.hasPeak {
-		c.AddInt(MetricMemCgroupPeak, "bytes", int64(cg.peak))
+		addBytes(c, MetricMemCgroupPeak, cg.peak)
 	}
 	if cg.hasMax {
-		c.AddInt(MetricMemCgroupMax, "bytes", int64(cg.max))
+		addBytes(c, MetricMemCgroupMax, cg.max)
 	}
 }

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Sample is one observation of this process's memory state.
@@ -56,6 +57,9 @@ type MemTracker struct {
 	inFlight func() int
 
 	cfg MemTrackerConfig
+
+	stopOnce sync.Once
+	stop     chan struct{}
 }
 
 // NewMemTracker returns a tracker. Sampling does not start until Start.
@@ -66,7 +70,7 @@ func NewMemTracker(cfg MemTrackerConfig) *MemTracker {
 	if cfg.CgroupRoot == "" {
 		cfg.CgroupRoot = defaultCgroupRoot
 	}
-	return &MemTracker{cfg: cfg}
+	return &MemTracker{cfg: cfg, stop: make(chan struct{})}
 }
 
 // SetInFlightFunc registers an accessor for the number of assets currently
@@ -185,5 +189,74 @@ func defaultSample() Sample {
 	return Sample{
 		RuntimeBytes: footprint,
 		Goroutines:   runtime.NumGoroutine(),
+	}
+}
+
+// Start begins sampling every interval until Stop. It takes one sample
+// immediately so a scan shorter than a single tick still reports a value.
+func (t *MemTracker) Start(interval time.Duration) {
+	if t == nil {
+		return
+	}
+	t.Observe()
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-t.stop:
+				return
+			case <-ticker.C:
+				t.Observe()
+			}
+		}
+	}()
+}
+
+// Stop ends sampling. Safe to call more than once, and on a nil tracker.
+func (t *MemTracker) Stop() {
+	if t == nil {
+		return
+	}
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+// Record writes the tracker's state into c. Called once per asset, so every
+// asset's upload carries the process state as of that asset's completion.
+//
+// Values that could not be measured are omitted rather than recorded as
+// zero: a zero cannot be told apart from a real measurement downstream.
+func (t *MemTracker) Record(c *Collector) {
+	if t == nil || c == nil {
+		return
+	}
+
+	t.mu.Lock()
+	peak, last := t.peakRuntime, t.lastRuntime
+	goroutines, inFlight := t.peakGoroutines, t.inFlightAtPeak
+	t.mu.Unlock()
+
+	if t.cfg.RunID != "" {
+		c.AddString(MetricRunID, t.cfg.RunID)
+	}
+
+	c.AddInt(MetricMemRuntimePeak, "bytes", int64(peak))
+	c.AddInt(MetricMemRuntimeAtFinish, "bytes", int64(last))
+	c.AddInt(MetricMemGoroutinesPeak, "count", int64(goroutines))
+
+	c.AddInt(MetricConcurrencyInFlightAtPeak, "count", int64(inFlight))
+	c.AddInt(MetricConcurrencyParallelism, "count", int64(t.cfg.Parallelism))
+	c.AddInt(MetricConcurrencyMaxConnections, "count", int64(t.cfg.MaxConnections))
+
+	cg := readCgroup(t.cfg.CgroupRoot)
+	if cg.hasCurrent {
+		c.AddInt(MetricMemCgroupCurrent, "bytes", int64(cg.current))
+	}
+	if cg.hasPeak {
+		c.AddInt(MetricMemCgroupPeak, "bytes", int64(cg.peak))
+	}
+	if cg.hasMax {
+		c.AddInt(MetricMemCgroupMax, "bytes", int64(cg.max))
 	}
 }

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -38,9 +38,13 @@ type MemTrackerConfig struct {
 	CgroupRoot     string
 }
 
-// MemTracker holds process-wide memory high-water marks for one scan run.
-// Memory is per-process while scanstats Collectors are per-asset, so this is
-// shared across every asset scanned by a run and makes no per-asset claim.
+// MemTracker holds memory high-water marks for one scan run. A tracker is
+// created per scan run (per distributeJob call), not per process: for the
+// CLI these coincide, but a long-lived serve/queue process handling multiple
+// jobs gets a fresh tracker per job. Memory is process-wide while scanstats
+// Collectors are per-asset, so a single tracker is shared across every asset
+// scanned by its run; RunID is what lets the resulting per-asset records be
+// grouped back into the run they came from.
 //
 // Every exported method is safe on a nil receiver: telemetry must never
 // panic a scan.
@@ -53,6 +57,12 @@ type MemTracker struct {
 	// compared against any other peak.
 	inFlightAtPeak int
 	lastRuntime    uint64
+	// hasSample is true once at least one observation has measured a
+	// non-zero runtime footprint. Guards the runtime-derived metrics in
+	// Record: a tracker that never resolved a real sample must omit them
+	// rather than report zero, which would be indistinguishable downstream
+	// from a real measurement.
+	hasSample bool
 
 	inFlight func() int
 
@@ -76,6 +86,10 @@ func NewMemTracker(cfg MemTrackerConfig) *MemTracker {
 // SetInFlightFunc registers an accessor for the number of assets currently
 // scanning. Registered after construction because the scan dispatcher that
 // owns the semaphore is built after the tracker.
+//
+// f is invoked while the tracker's mutex is held, so it must not block, do
+// I/O, or call back into the tracker: the mutex is not reentrant, so a
+// callback into Peaks or Snapshot would self-deadlock.
 func (t *MemTracker) SetInFlightFunc(f func() int) {
 	if t == nil {
 		return
@@ -96,6 +110,9 @@ func (t *MemTracker) Observe() {
 	defer t.mu.Unlock()
 
 	t.lastRuntime = s.RuntimeBytes
+	if s.RuntimeBytes > 0 {
+		t.hasSample = true
+	}
 	if s.RuntimeBytes > t.peakRuntime {
 		t.peakRuntime = s.RuntimeBytes
 		if t.inFlight != nil {
@@ -117,6 +134,43 @@ func (t *MemTracker) Peaks() (runtimeBytes uint64, goroutines int, inFlightAtPea
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.peakRuntime, t.peakGoroutines, t.inFlightAtPeak
+}
+
+// MemSnapshot is a point-in-time view for diagnostics: the latest observed
+// runtime footprint plus best-effort cgroup readings. Presence flags follow
+// the same absent-never-zero rule as the recorded metrics.
+type MemSnapshot struct {
+	RuntimeBytes     uint64
+	HasRuntime       bool
+	CgroupCurrent    uint64
+	HasCgroupCurrent bool
+	CgroupMax        uint64
+	HasCgroupMax     bool
+}
+
+// Snapshot returns the current diagnostic view. Safe on a nil tracker, which
+// reports everything absent.
+func (t *MemTracker) Snapshot() MemSnapshot {
+	if t == nil {
+		return MemSnapshot{}
+	}
+
+	t.mu.Lock()
+	last, hasSample := t.lastRuntime, t.hasSample
+	t.mu.Unlock()
+
+	// File I/O outside the lock: reading cgroup files under the tracker
+	// mutex would block the sampler goroutine.
+	cg := readCgroup(t.cfg.CgroupRoot)
+
+	return MemSnapshot{
+		RuntimeBytes:     last,
+		HasRuntime:       hasSample,
+		CgroupCurrent:    cg.current,
+		HasCgroupCurrent: cg.hasCurrent,
+		CgroupMax:        cg.max,
+		HasCgroupMax:     cg.hasMax,
+	}
 }
 
 // defaultCgroupRoot is the cgroup v2 unified hierarchy mount point.
@@ -244,8 +298,14 @@ func (t *MemTracker) Record(c *Collector) {
 		return
 	}
 
+	// Refresh before reading: without this, a sample can be up to a full
+	// tick stale, and every asset that finishes inside one sampling window
+	// would report an identical "at finish" value. Observe takes the lock
+	// itself, so this must happen before the mutex block below.
+	t.Observe()
+
 	t.mu.Lock()
-	peak, last := t.peakRuntime, t.lastRuntime
+	peak, last, hasSample := t.peakRuntime, t.lastRuntime, t.hasSample
 	goroutines, inFlight := t.peakGoroutines, t.inFlightAtPeak
 	t.mu.Unlock()
 
@@ -253,9 +313,14 @@ func (t *MemTracker) Record(c *Collector) {
 		c.AddString(MetricRunID, t.cfg.RunID)
 	}
 
-	c.AddInt(MetricMemRuntimePeak, "bytes", int64(peak))
-	c.AddInt(MetricMemRuntimeAtFinish, "bytes", int64(last))
-	c.AddInt(MetricMemGoroutinesPeak, "count", int64(goroutines))
+	// Absent, not zero: a tracker that never resolved a real runtime sample
+	// must omit these rather than report zero, which would be
+	// indistinguishable downstream from a real measurement.
+	if hasSample {
+		c.AddInt(MetricMemRuntimePeak, "bytes", int64(peak))
+		c.AddInt(MetricMemRuntimeAtFinish, "bytes", int64(last))
+		c.AddInt(MetricMemGoroutinesPeak, "count", int64(goroutines))
+	}
 
 	c.AddInt(MetricConcurrencyInFlightAtPeak, "count", int64(inFlight))
 	c.AddInt(MetricConcurrencyParallelism, "count", int64(t.cfg.Parallelism))

--- a/policy/scanstats/mem.go
+++ b/policy/scanstats/mem.go
@@ -3,7 +3,13 @@
 
 package scanstats
 
-import "sync"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
 
 // Sample is one observation of this process's memory state.
 type Sample struct {
@@ -95,8 +101,47 @@ func (t *MemTracker) Observe() {
 	}
 }
 
-// Replaced in Task 2.
+// defaultCgroupRoot is the cgroup v2 unified hierarchy mount point.
 const defaultCgroupRoot = "/sys/fs/cgroup"
+
+// cgroupStats holds cgroup v2 memory readings. Each value carries a
+// presence flag: a value that could not be read is absent, never zero.
+// Reporting zero would be indistinguishable from a real measurement and
+// would corrupt any aggregate computed across a mixed fleet.
+type cgroupStats struct {
+	current, peak, max          uint64
+	hasCurrent, hasPeak, hasMax bool
+}
+
+// readCgroup reads cgroup v2 memory values from root, best-effort. Every
+// file is optional: non-Linux hosts have no cgroup at all, cgroup v1 has a
+// different layout, and memory.peak requires Linux 5.19 or later.
+func readCgroup(root string) cgroupStats {
+	var cg cgroupStats
+	cg.current, cg.hasCurrent = readCgroupValue(root, "memory.current")
+	cg.peak, cg.hasPeak = readCgroupValue(root, "memory.peak")
+	cg.max, cg.hasMax = readCgroupValue(root, "memory.max")
+	return cg
+}
+
+// readCgroupValue reads a single unsigned integer from a cgroup file. The
+// literal "max" means no limit and is reported as absent rather than as a
+// sentinel number.
+func readCgroupValue(root, name string) (uint64, bool) {
+	raw, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
 
 // Replaced in Task 3.
 func defaultSample() Sample { return Sample{} }

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -148,3 +148,12 @@ func TestReadCgroup_MalformedValueIsAbsent(t *testing.T) {
 	cg := readCgroup(dir)
 	require.False(t, cg.hasCurrent)
 }
+
+func TestDefaultSample_ReturnsLiveValues(t *testing.T) {
+	s := defaultSample()
+
+	// A running Go process always has a non-zero footprint and at least
+	// this test's own goroutine. The stub returned a zero Sample.
+	require.Greater(t, s.RuntimeBytes, uint64(0))
+	require.Greater(t, s.Goroutines, 0)
+}

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -276,6 +276,94 @@ func TestMemTracker_StartStopObservesAndIsIdempotent(t *testing.T) {
 	})
 }
 
+func TestMemTracker_RecordOmitsRuntimeMetricsWhenNoSampleEverResolved(t *testing.T) {
+	// A zero-byte sample simulates every runtime/metrics name failing to
+	// resolve: defaultSample falls back to 0 rather than a real footprint.
+	tr := NewMemTracker(MemTrackerConfig{
+		RunID:      "run-abc",
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 0, Goroutines: 0}),
+	})
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	// Absent, not zero: recording a zero here would be indistinguishable
+	// downstream from a real measurement and corrupt fleet-wide aggregates.
+	require.NotContains(t, m, MetricMemRuntimePeak)
+	require.NotContains(t, m, MetricMemRuntimeAtFinish)
+	require.NotContains(t, m, MetricMemGoroutinesPeak)
+	// Concurrency metrics and RunID are unconditional and must still be
+	// present even though no runtime sample was ever resolved.
+	require.Contains(t, m, MetricRunID)
+	require.Contains(t, m, MetricConcurrencyInFlightAtPeak)
+	require.Contains(t, m, MetricConcurrencyParallelism)
+	require.Contains(t, m, MetricConcurrencyMaxConnections)
+}
+
+func TestMemTracker_RecordRefreshesAtFinishRatherThanUsingStaleSample(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample: fakeSampler(
+			Sample{RuntimeBytes: 100, Goroutines: 1},
+			Sample{RuntimeBytes: 200, Goroutines: 2},
+		),
+	})
+	tr.Observe() // simulates the periodic sampler firing once, a tick ago
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	// Record must pull a fresh sample rather than reporting the value from
+	// the last periodic tick, or every asset finishing inside one sampling
+	// window would report an identical, stale value.
+	require.Equal(t, int64(200), m[MetricMemRuntimeAtFinish].GetIntValue())
+	// The peak also reflects the fresh sample since it is the larger value.
+	require.Equal(t, int64(200), m[MetricMemRuntimePeak].GetIntValue())
+}
+
+func TestMemTracker_SnapshotReportsPresentAndAbsentCgroupValues(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "1048576\n")
+	writeCgroupFile(t, dir, "memory.max", "2097152\n")
+
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: dir,
+		Sample:     fakeSampler(Sample{RuntimeBytes: 555, Goroutines: 5}),
+	})
+	tr.Observe()
+
+	snap := tr.Snapshot()
+	require.True(t, snap.HasRuntime)
+	require.Equal(t, uint64(555), snap.RuntimeBytes)
+	require.True(t, snap.HasCgroupCurrent)
+	require.Equal(t, uint64(1048576), snap.CgroupCurrent)
+	require.True(t, snap.HasCgroupMax)
+	require.Equal(t, uint64(2097152), snap.CgroupMax)
+}
+
+func TestMemTracker_SnapshotReportsAbsentWhenCgroupRootMissing(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 0, Goroutines: 0}),
+	})
+	tr.Observe()
+
+	snap := tr.Snapshot()
+	require.False(t, snap.HasRuntime)
+	require.False(t, snap.HasCgroupCurrent)
+	require.False(t, snap.HasCgroupMax)
+}
+
+func TestMemTracker_SnapshotNilReceiverIsSafe(t *testing.T) {
+	var tr *MemTracker
+	var snap MemSnapshot
+	require.NotPanics(t, func() { snap = tr.Snapshot() })
+	require.Equal(t, MemSnapshot{}, snap)
+}
+
 func TestMemTracker_StartTakesAnImmediateSample(t *testing.T) {
 	// A scan shorter than one tick must still report something.
 	tr := NewMemTracker(MemTrackerConfig{

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
 )
 
 // fakeSampler returns each sample in turn, repeating the last one forever.
@@ -156,4 +158,136 @@ func TestDefaultSample_ReturnsLiveValues(t *testing.T) {
 	// this test's own goroutine. The stub returned a zero Sample.
 	require.Greater(t, s.RuntimeBytes, uint64(0))
 	require.Greater(t, s.Goroutines, 0)
+}
+
+// metricByName indexes a ScanStatistics for assertion by metric name.
+func metricByName(t *testing.T, c *Collector) map[string]*policy.Metric {
+	t.Helper()
+	stats := c.ToProto()
+	require.NotNil(t, stats)
+	out := map[string]*policy.Metric{}
+	for _, m := range stats.Metrics {
+		out[m.Name] = m
+	}
+	return out
+}
+
+func TestMemTracker_RecordWritesPeaksAndRunConstants(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "3402137600\n")
+	writeCgroupFile(t, dir, "memory.peak", "3500000000\n")
+	writeCgroupFile(t, dir, "memory.max", "4294967296\n")
+
+	tr := NewMemTracker(MemTrackerConfig{
+		RunID:          "run-abc",
+		Parallelism:    16,
+		MaxConnections: 50,
+		CgroupRoot:     dir,
+		Sample: fakeSampler(
+			Sample{RuntimeBytes: 100, Goroutines: 10},
+			Sample{RuntimeBytes: 900, Goroutines: 90},
+			Sample{RuntimeBytes: 300, Goroutines: 30},
+		),
+	})
+	tr.SetInFlightFunc(func() int { return 7 })
+	tr.Observe()
+	tr.Observe()
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	require.Equal(t, "run-abc", m[MetricRunID].GetStringValue())
+	require.Equal(t, int64(900), m[MetricMemRuntimePeak].GetIntValue())
+	require.Equal(t, "bytes", m[MetricMemRuntimePeak].Unit)
+	require.Equal(t, int64(300), m[MetricMemRuntimeAtFinish].GetIntValue())
+	require.Equal(t, int64(90), m[MetricMemGoroutinesPeak].GetIntValue())
+	require.Equal(t, int64(7), m[MetricConcurrencyInFlightAtPeak].GetIntValue())
+	require.Equal(t, int64(16), m[MetricConcurrencyParallelism].GetIntValue())
+	require.Equal(t, int64(50), m[MetricConcurrencyMaxConnections].GetIntValue())
+	require.Equal(t, int64(3402137600), m[MetricMemCgroupCurrent].GetIntValue())
+	require.Equal(t, int64(3500000000), m[MetricMemCgroupPeak].GetIntValue())
+	require.Equal(t, int64(4294967296), m[MetricMemCgroupMax].GetIntValue())
+}
+
+func TestMemTracker_RecordOmitsCgroupMetricsWhenUnavailable(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		RunID:      "run-abc",
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 100, Goroutines: 10}),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	// Absent, not zero — a zero would be read downstream as a real limit.
+	require.NotContains(t, m, MetricMemCgroupCurrent)
+	require.NotContains(t, m, MetricMemCgroupPeak)
+	require.NotContains(t, m, MetricMemCgroupMax)
+	// Runtime metrics are unaffected by the cgroup being unavailable.
+	require.Contains(t, m, MetricMemRuntimePeak)
+}
+
+func TestMemTracker_RecordOmitsRunIDWhenUnset(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 100}),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	require.NotContains(t, metricByName(t, c), MetricRunID)
+}
+
+func TestMemTracker_RecordNilSafe(t *testing.T) {
+	var tr *MemTracker
+	c := New()
+	require.NotPanics(t, func() { tr.Record(c) })
+	require.Nil(t, c.ToProto())
+
+	real := NewMemTracker(MemTrackerConfig{Sample: fakeSampler(Sample{RuntimeBytes: 1})})
+	require.NotPanics(t, func() { real.Record(nil) })
+}
+
+func TestMemTracker_StartStopObservesAndIsIdempotent(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 500, Goroutines: 5}),
+	})
+
+	tr.Start(time.Millisecond)
+	require.Eventually(t, func() bool {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return tr.peakRuntime == 500
+	}, 2*time.Second, 5*time.Millisecond)
+
+	tr.Stop()
+	require.NotPanics(t, func() { tr.Stop() }) // double Stop must not panic
+
+	var nilTr *MemTracker
+	require.NotPanics(t, func() {
+		nilTr.Start(time.Millisecond)
+		nilTr.Stop()
+	})
+}
+
+func TestMemTracker_StartTakesAnImmediateSample(t *testing.T) {
+	// A scan shorter than one tick must still report something.
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 777, Goroutines: 7}),
+	})
+	tr.Start(time.Hour) // no tick will ever fire
+	defer tr.Stop()
+
+	require.Eventually(t, func() bool {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return tr.peakRuntime == 777
+	}, 2*time.Second, 5*time.Millisecond)
 }

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -4,9 +4,11 @@
 package scanstats
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -378,4 +380,66 @@ func TestMemTracker_StartTakesAnImmediateSample(t *testing.T) {
 		defer tr.mu.Unlock()
 		return tr.peakRuntime == 777
 	}, 2*time.Second, 5*time.Millisecond)
+}
+
+func TestRecord_OmitsByteValuesThatCannotBeRepresented(t *testing.T) {
+	// A uint64 at or above 1<<63 would wrap negative in the int64 cast used by
+	// the metric API. Omitting is deliberate: clamping would emit a fabricated
+	// ceiling that reads downstream as a real measurement.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "1024\n")
+	writeCgroupFile(t, dir, "memory.max", "18446744073709551615\n") // 2^64-1
+
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: dir,
+		Sample:     fakeSampler(Sample{RuntimeBytes: 1 << 63, Goroutines: 3}),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	require.NotContains(t, m, MetricMemCgroupMax)
+	require.NotContains(t, m, MetricMemRuntimePeak)
+	// Representable values alongside them are unaffected.
+	require.Equal(t, int64(1024), m[MetricMemCgroupCurrent].GetIntValue())
+	require.Equal(t, int64(3), m[MetricMemGoroutinesPeak].GetIntValue())
+}
+
+func TestRecord_KeepsLargestRepresentableByteValue(t *testing.T) {
+	// The boundary itself must still be reported — the guard rejects only what
+	// genuinely cannot round-trip.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "9223372036854775807\n") // 2^63-1
+
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: dir,
+		Sample:     fakeSampler(Sample{RuntimeBytes: 100, Goroutines: 1}),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	require.Equal(t, int64(math.MaxInt64), metricByName(t, c)[MetricMemCgroupCurrent].GetIntValue())
+}
+
+func TestMemTracker_StopWaitsForSamplerToExit(t *testing.T) {
+	var samples atomic.Int64
+	tr := NewMemTracker(MemTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample: func() Sample {
+			samples.Add(1)
+			return Sample{RuntimeBytes: 100, Goroutines: 1}
+		},
+	})
+
+	tr.Start(time.Millisecond)
+	require.Eventually(t, func() bool { return samples.Load() > 1 }, 2*time.Second, 5*time.Millisecond)
+
+	tr.Stop()
+	// Stop returned, so the sampler has exited: the count must not move again.
+	after := samples.Load()
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, after, samples.Load())
 }

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSampler returns each sample in turn, repeating the last one forever.
+// Mutex-guarded because Start calls the sampler from its own goroutine while
+// the test reads from the main one — an unguarded counter here fails -race.
+func fakeSampler(samples ...Sample) SampleFunc {
+	var mu sync.Mutex
+	i := 0
+	return func() Sample {
+		mu.Lock()
+		defer mu.Unlock()
+		s := samples[i]
+		if i < len(samples)-1 {
+			i++
+		}
+		return s
+	}
+}
+
+func TestMemTracker_TracksHighWaterNotLatest(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		Sample: fakeSampler(
+			Sample{RuntimeBytes: 100, Goroutines: 10},
+			Sample{RuntimeBytes: 900, Goroutines: 90},
+			Sample{RuntimeBytes: 300, Goroutines: 30},
+		),
+	})
+
+	tr.Observe()
+	tr.Observe()
+	tr.Observe()
+
+	// Peak is the maximum ever seen, not the most recent value.
+	require.Equal(t, uint64(900), tr.peakRuntime)
+	require.Equal(t, 90, tr.peakGoroutines)
+	// The latest value is tracked separately.
+	require.Equal(t, uint64(300), tr.lastRuntime)
+}
+
+func TestMemTracker_InFlightCapturedAtPeakNotAtLastSample(t *testing.T) {
+	inFlight := 0
+	tr := NewMemTracker(MemTrackerConfig{
+		Sample: fakeSampler(
+			Sample{RuntimeBytes: 100},
+			Sample{RuntimeBytes: 900}, // peak happens here
+			Sample{RuntimeBytes: 300},
+		),
+	})
+	tr.SetInFlightFunc(func() int { return inFlight })
+
+	inFlight = 2
+	tr.Observe()
+	inFlight = 48 // busy when the peak is set
+	tr.Observe()
+	inFlight = 1 // quiet again by the last sample
+	tr.Observe()
+
+	// The denominator must describe the moment of the peak, not the moment
+	// of the final sample — otherwise the peak is uninterpretable.
+	require.Equal(t, 48, tr.inFlightAtPeak)
+}
+
+func TestMemTracker_NilReceiverIsSafe(t *testing.T) {
+	var tr *MemTracker
+	require.NotPanics(t, func() {
+		tr.Observe()
+		tr.SetInFlightFunc(func() int { return 1 })
+	})
+}
+
+func TestMemTracker_NoInFlightFuncDoesNotPanic(t *testing.T) {
+	tr := NewMemTracker(MemTrackerConfig{
+		Sample: fakeSampler(Sample{RuntimeBytes: 100}),
+	})
+	require.NotPanics(t, func() { tr.Observe() })
+	require.Equal(t, 0, tr.inFlightAtPeak)
+}

--- a/policy/scanstats/mem_test.go
+++ b/policy/scanstats/mem_test.go
@@ -4,6 +4,8 @@
 package scanstats
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -84,4 +86,65 @@ func TestMemTracker_NoInFlightFuncDoesNotPanic(t *testing.T) {
 	})
 	require.NotPanics(t, func() { tr.Observe() })
 	require.Equal(t, 0, tr.inFlightAtPeak)
+}
+
+func writeCgroupFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
+}
+
+func TestReadCgroup_AllPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "3402137600\n")
+	writeCgroupFile(t, dir, "memory.peak", "3500000000\n")
+	writeCgroupFile(t, dir, "memory.max", "4294967296\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.Equal(t, uint64(3402137600), cg.current)
+	require.True(t, cg.hasPeak)
+	require.Equal(t, uint64(3500000000), cg.peak)
+	require.True(t, cg.hasMax)
+	require.Equal(t, uint64(4294967296), cg.max)
+}
+
+func TestReadCgroup_AbsentDirectoryReportsNothing(t *testing.T) {
+	// Non-Linux hosts and cgroup v1 systems: every value must be absent,
+	// never zero. A zero would be read downstream as a real measurement.
+	cg := readCgroup(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.False(t, cg.hasCurrent)
+	require.False(t, cg.hasPeak)
+	require.False(t, cg.hasMax)
+}
+
+func TestReadCgroup_UnlimitedMaxIsAbsent(t *testing.T) {
+	// "max" means no limit. Reporting it as a number would invent a ceiling
+	// that does not exist and make headroom ratios meaningless.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "1024\n")
+	writeCgroupFile(t, dir, "memory.max", "max\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.False(t, cg.hasMax)
+}
+
+func TestReadCgroup_MissingPeakOnOlderKernel(t *testing.T) {
+	// memory.peak requires Linux 5.19+; the others must still be reported.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "2048\n")
+	writeCgroupFile(t, dir, "memory.max", "8192\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.False(t, cg.hasPeak)
+	require.True(t, cg.hasMax)
+}
+
+func TestReadCgroup_MalformedValueIsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "not-a-number\n")
+
+	cg := readCgroup(dir)
+	require.False(t, cg.hasCurrent)
 }


### PR DESCRIPTION
Implements **ADR-0004** (#3270 — please read that first; it carries the design rationale and the rejected alternatives).

cnspec runs in memory-constrained environments — operator pods, CI runners, containers with a hard cgroup limit. When a scan exhausts that limit the process is killed and the operator is left with an exit code. Memory *was* already sampled in the scan pipeline, but only behind `DEBUG_PROVIDER_MEMORY` and only into a local log line — available exclusively to someone who already reproduced the problem on a machine they control, which is never the scan that actually died.

Meanwhile a namespaced `policy.Metric` / `ScanStatistics` channel already ships upstream on `ReportUploadCompleted` (#3103, #3148, #3234) and was built so new measurements need no proto change. The two had simply never been connected.

## What this does

A `scanstats.MemTracker` samples the process's Go runtime footprint once per second, keeps high-water marks, reads cgroup v2 values best-effort, and records them into the per-asset collector that already serializes into `ReportUploadCompletedReq.details`.

**No proto change and no new dependency.** `policy.Metric` is deliberately namespace-based, so additional measurements need no schema change.

New metrics under the existing namespaces: `cnspec.scan.run_id`, `cnspec.scan.mem.{runtime_peak_bytes, runtime_at_finish_bytes, goroutines_peak, cgroup_current_bytes, cgroup_peak_bytes, cgroup_max_bytes}`, `cnspec.scan.concurrency.{in_flight_at_peak, parallelism, max_connections}`.

## Three design points worth reviewer attention

**We sample the runtime footprint, not `MemStats.Alloc`.** `/memory/classes/total:bytes` minus `/memory/classes/heap/released:bytes` is what the runtime accounts against `GOMEMLIMIT` and what the OOM killer effectively acts on; `Alloc` counts only live heap objects and understates it. `runtime/metrics.Read` also doesn't stop the world, so a 1s tick is free where the same tick on `ReadMemStats` would perturb the thing being measured.

**Absent, never zero.** A cgroup value that can't be read is *omitted*, not recorded as `0` — downstream a zero is indistinguishable from a real measurement, and a fleet average over zeros reports a memory limit that doesn't exist. This is enforced with presence flags for cgroup values and a `hasSample` gate for the runtime values.

**Peaks are process-wide but records are per-asset.** A run scanning N assets emits N records carrying one process's rising high-water mark. They are repeated observations of one process, not N measurements — hence `run_id`, and hence the in-flight concurrency count is captured *at the moment the peak is set*, not at asset finish. **Aggregate these with `max` grouped by `run_id`; averaging them is weighted by asset count and understates every peak.**

## Scope and known gaps

- **Bounded to the `UploadResultsV2` path**, the only path with a metrics transport. Scans on the in-memory path emit nothing.
- **The kill itself is never reported** — the upload channel can't report its own process's death. This captures the ramp toward a limit; the death is inferred from the gap that follows.
- **Provider subprocess memory is covered via the cgroup total**, not measured directly (providers fork into the same cgroup). On hosts without cgroups you get Go footprint only, which undercounts providers.
- `DEBUG_PROVIDER_MEMORY` keeps its existing meaning and now reads the same tracker, so the log and the upstream numbers can't disagree.

## Testing

TDD throughout; 12 commits, each independently reviewed.

- `make test/lint`: 0 issues. All touched packages pass under `-race`.
- Real smoke test: `DEBUG_PROVIDER_MEMORY=1 cnspec scan local` → `memory after asset scan goroutines=40 goroutines_peak=84 in_flight_at_peak=1 runtime_peak_mb=233`.
- Pre-existing, unrelated: `test/providers` `TestScanFlags/github_scan_WITHOUT_flags` fails in this environment. Verified it fails identically on the base commit `7cdc4570`.

## Follow-ups (deliberately not in this PR)

- **Cgroup path resolution.** We read `/sys/fs/cgroup` directly, which only resolves in a private cgroup namespace. Reading the relative path from `/proc/self/cgroup` would extend coverage to bare-metal Linux and `--cgroupns=host` containers — the single change that most increases the fraction of the fleet reporting cgroup data.
- **CPU metrics.** `runtime/metrics` exposes `/cpu/classes/*` in the same `Read` call, and cgroup `cpu.stat` carries throttling — the CPU counterpart to OOM headroom. Deliberately deferred: CPU values are cumulative counters needing a start baseline and a delta, not a high-water mark, so they deserve their own design pass.
- A comment at `local_scanner.go:507-509` still says "process-wide"; the tracker is per scan run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
