### PR TITLE
✨ content: cover the Alibaba Cloud IaC-variant coverage gaps

### DIFF
--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -1,7 +1,4 @@
 {
-  "mondoo-alibaba-security": {
-    "-terraform-hcl": 32
-  },
   "mondoo-aws-security": {
     "-cloudformation": 21,
     "-terraform-hcl": 28

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-actiontrail-trail-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-actiontrail-trail-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,9 @@
+# A disabled trail exists in the console but records nothing, which is worse
+# than no trail because it looks like coverage.
+resource "alicloud_actiontrail_trail" "org_audit" {
+  trail_name      = "org-audit"
+  oss_bucket_name = alicloud_oss_bucket.audit.bucket
+  event_rw        = "All"
+  trail_region    = "All"
+  status          = "Disable"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-actiontrail-trail-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-actiontrail-trail-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_actiontrail_trail" "org_audit" {
+  trail_name      = "org-audit"
+  oss_bucket_name = alicloud_oss_bucket.audit.bucket
+  oss_key_prefix  = "actiontrail/"
+  event_rw        = "All"
+  trail_region    = "All"
+  status          = "Enable"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/fail/dedicated-cluster-public/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/fail/dedicated-cluster-public/main.tf
@@ -1,0 +1,8 @@
+# The dedicated (non-managed) cluster type is covered by the same control.
+resource "alicloud_cs_kubernetes" "legacy" {
+  name                 = "legacy-ack"
+  master_vswitch_ids   = [alicloud_vswitch.k8s.id, alicloud_vswitch.k8s_b.id, alicloud_vswitch.k8s_c.id]
+  worker_vswitch_ids   = [alicloud_vswitch.k8s.id]
+  master_instance_types = ["ecs.n4.large", "ecs.n4.large", "ecs.n4.large"]
+  slb_internet_enabled = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/fail/public-apiserver/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/fail/public-apiserver/main.tf
@@ -1,0 +1,9 @@
+# A public SLB in front of the API server exposes the cluster control plane to
+# the internet.
+resource "alicloud_cs_managed_kubernetes" "prod" {
+  name                 = "prod-ack"
+  worker_vswitch_ids   = [alicloud_vswitch.k8s.id]
+  pod_cidr             = "172.20.0.0/16"
+  service_cidr         = "172.21.0.0/20"
+  slb_internet_enabled = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/pass/private-apiserver/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-no-public-apiserver-terraform-hcl/pass/private-apiserver/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_cs_managed_kubernetes" "prod" {
+  name                 = "prod-ack"
+  worker_vswitch_ids   = [alicloud_vswitch.k8s.id]
+  pod_cidr             = "172.20.0.0/16"
+  service_cidr         = "172.21.0.0/20"
+  slb_internet_enabled = false
+  enable_rrsa          = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-rrsa-enabled-terraform-hcl/fail/rrsa-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-rrsa-enabled-terraform-hcl/fail/rrsa-disabled/main.tf
@@ -1,0 +1,10 @@
+# Without RRSA, workloads fall back to the node's RAM role, so every pod on a
+# node inherits the same permissions.
+resource "alicloud_cs_managed_kubernetes" "prod" {
+  name                 = "prod-ack"
+  worker_vswitch_ids   = [alicloud_vswitch.k8s.id]
+  pod_cidr             = "172.20.0.0/16"
+  service_cidr         = "172.21.0.0/20"
+  slb_internet_enabled = false
+  enable_rrsa          = false
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-rrsa-enabled-terraform-hcl/pass/rrsa-enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-cs-cluster-rrsa-enabled-terraform-hcl/pass/rrsa-enabled/main.tf
@@ -1,0 +1,10 @@
+resource "alicloud_cs_managed_kubernetes" "prod" {
+  name                 = "prod-ack"
+  worker_vswitch_ids   = [alicloud_vswitch.k8s.id]
+  pod_cidr             = "172.20.0.0/16"
+  service_cidr         = "172.21.0.0/20"
+  slb_internet_enabled = false
+
+  # RRSA lets pods assume RAM roles via OIDC instead of sharing node credentials.
+  enable_rrsa = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-encryption-enabled-terraform-hcl/fail/unencrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-encryption-enabled-terraform-hcl/fail/unencrypted/main.tf
@@ -1,0 +1,9 @@
+# Disks are unencrypted unless the flag is set, so snapshots and the underlying
+# storage hold plaintext.
+resource "alicloud_ecs_disk" "data" {
+  disk_name = "prod-data"
+  zone_id   = "cn-hangzhou-b"
+  category  = "cloud_essd"
+  size      = 500
+  encrypted = false
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-encryption-enabled-terraform-hcl/pass/encrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-encryption-enabled-terraform-hcl/pass/encrypted/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_ecs_disk" "data" {
+  disk_name   = "prod-data"
+  zone_id     = "cn-hangzhou-b"
+  category    = "cloud_essd"
+  size        = 500
+  encrypted   = true
+  kms_key_id  = alicloud_kms_key.disk.id
+  description = "Application data volume"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-kms-encryption-terraform-hcl/fail/service-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-kms-encryption-terraform-hcl/fail/service-managed-key/main.tf
@@ -1,0 +1,9 @@
+# Encrypted, but with the service-managed key: the customer cannot rotate or
+# revoke it, and cannot audit its use.
+resource "alicloud_ecs_disk" "data" {
+  disk_name = "prod-data"
+  zone_id   = "cn-hangzhou-b"
+  category  = "cloud_essd"
+  size      = 500
+  encrypted = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-kms-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-disk-kms-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_ecs_disk" "data" {
+  disk_name  = "prod-data"
+  zone_id    = "cn-hangzhou-b"
+  category   = "cloud_essd"
+  size       = 500
+  encrypted  = true
+  kms_key_id = alicloud_kms_key.disk.id
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-all-ports-terraform-hcl/fail/all-protocols-world/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-all-ports-terraform-hcl/fail/all-protocols-world/main.tf
@@ -1,0 +1,10 @@
+# Every protocol and every port, open to the internet.
+resource "alicloud_security_group_rule" "all_world" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "all"
+  port_range        = "-1/-1"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-all-ports-terraform-hcl/pass/scoped-ports/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-all-ports-terraform-hcl/pass/scoped-ports/main.tf
@@ -1,0 +1,19 @@
+resource "alicloud_security_group_rule" "https_public" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "443/443"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}
+
+resource "alicloud_security_group_rule" "internal_all" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "all"
+  port_range        = "-1/-1"
+  cidr_ip           = "10.0.0.0/8"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-terraform-hcl/fail/world-open-ipv6-ssh/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-terraform-hcl/fail/world-open-ipv6-ssh/main.tf
@@ -1,0 +1,11 @@
+# The IPv6 equivalent of 0.0.0.0/0. Groups are often hardened on IPv4 only,
+# leaving this path open.
+resource "alicloud_security_group_rule" "ssh_world_v6" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "22/22"
+  ipv6_cidr_ip      = "::/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-terraform-hcl/pass/restricted-ipv6/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ipv6-admin-terraform-hcl/pass/restricted-ipv6/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_security_group_rule" "ssh_from_office_v6" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "22/22"
+  ipv6_cidr_ip      = "2001:db8:1::/48"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-rdp-terraform-hcl/fail/world-open-rdp/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-rdp-terraform-hcl/fail/world-open-rdp/main.tf
@@ -1,0 +1,10 @@
+# RDP open to the internet is among the most commonly brute-forced exposures.
+resource "alicloud_security_group_rule" "rdp_world" {
+  security_group_id = alicloud_security_group.windows.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "3389/3389"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-rdp-terraform-hcl/pass/restricted-source/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-rdp-terraform-hcl/pass/restricted-source/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_security_group_rule" "rdp_from_bastion" {
+  security_group_id = alicloud_security_group.windows.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "3389/3389"
+  cidr_ip           = "10.0.100.0/24"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/fail/world-open-full-range/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/fail/world-open-full-range/main.tf
@@ -1,0 +1,11 @@
+# A 1/65535 range from anywhere includes 22, so SSH is world-reachable even
+# though the rule never names the port.
+resource "alicloud_security_group_rule" "all_tcp_world" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "1/65535"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/fail/world-open-ssh/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/fail/world-open-ssh/main.tf
@@ -1,0 +1,10 @@
+# SSH open to the entire internet.
+resource "alicloud_security_group_rule" "ssh_world" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "22/22"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/pass/restricted-source/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ecs-security-group-no-public-ssh-terraform-hcl/pass/restricted-source/main.tf
@@ -1,0 +1,21 @@
+# SSH is reachable only from the corporate egress range.
+resource "alicloud_security_group_rule" "ssh_from_office" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "22/22"
+  cidr_ip           = "203.0.113.0/24"
+  policy            = "accept"
+  priority          = 1
+}
+
+# A world-open rule is fine here: 443 is the service's intended public port.
+resource "alicloud_security_group_rule" "https_public" {
+  security_group_id = alicloud_security_group.app.id
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  port_range        = "443/443"
+  cidr_ip           = "0.0.0.0/0"
+  policy            = "accept"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/fail/rotation-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/fail/rotation-disabled/main.tf
@@ -1,0 +1,7 @@
+# A long-lived encryption key that never rotates widens the blast radius of a
+# key compromise indefinitely.
+resource "alicloud_kms_key" "data" {
+  description        = "Application data encryption key"
+  key_usage          = "ENCRYPT/DECRYPT"
+  automatic_rotation = "Disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/pass/rotation-enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/pass/rotation-enabled/main.tf
@@ -1,0 +1,7 @@
+resource "alicloud_kms_key" "data" {
+  description            = "Application data encryption key"
+  key_usage              = "ENCRYPT/DECRYPT"
+  automatic_rotation     = "Enabled"
+  rotation_interval      = "31536000s"
+  pending_window_in_days = 30
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/pass/signing-key-excluded/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-kms-key-rotation-enabled-terraform-hcl/pass/signing-key-excluded/main.tf
@@ -1,0 +1,8 @@
+# Automatic rotation does not apply to asymmetric signing keys, so the check
+# scopes itself to ENCRYPT/DECRYPT keys and this one is out of scope.
+resource "alicloud_kms_key" "signing" {
+  description        = "Artifact signing key"
+  key_usage          = "SIGN/VERIFY"
+  key_spec           = "RSA_2048"
+  automatic_rotation = "Disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-restrict-security-ip-list-terraform-hcl/fail/world-open/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-restrict-security-ip-list-terraform-hcl/fail/world-open/main.tf
@@ -1,0 +1,10 @@
+# Internet-wide access to a document store, which is how unsecured MongoDB
+# deployments end up in breach reports.
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  security_ip_list    = ["0.0.0.0/0"]
+  name                = "prod-mongo"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-restrict-security-ip-list-terraform-hcl/pass/vpc-range/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-restrict-security-ip-list-terraform-hcl/pass/vpc-range/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  security_ip_list    = ["10.0.0.0/16"]
+  name                = "prod-mongo"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-ssl-and-audit-terraform-hcl/fail/ssl-closed/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-ssl-and-audit-terraform-hcl/fail/ssl-closed/main.tf
@@ -1,0 +1,9 @@
+# Client connections, including credentials and query payloads, are unencrypted
+# in transit.
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  ssl_action          = "Close"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-ssl-and-audit-terraform-hcl/pass/ssl-open/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-ssl-and-audit-terraform-hcl/pass/ssl-open/main.tf
@@ -1,0 +1,7 @@
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  ssl_action          = "Open"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
@@ -1,0 +1,9 @@
+# MongoDB's tde_status uses lowercase values, unlike RDS and Redis; "disabled"
+# leaves the collections unencrypted at rest.
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  tde_status          = "disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-mongodb-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
@@ -1,0 +1,7 @@
+resource "alicloud_mongodb_instance" "prod" {
+  engine_version      = "6.0"
+  db_instance_class   = "dds.mongo.mid"
+  db_instance_storage = 100
+  vswitch_id          = alicloud_vswitch.db.id
+  tde_status          = "enabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/fail/rdwr-world/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/fail/rdwr-world/main.tf
@@ -1,0 +1,9 @@
+# Read-write NFS export reachable from anywhere: anyone who can route to the
+# mount target can overwrite the share.
+resource "alicloud_nas_access_rule" "open_rw" {
+  access_group_name = alicloud_nas_access_group.shared.access_group_name
+  source_cidr_ip    = "0.0.0.0/0"
+  rw_access_type    = "RDWR"
+  user_access_type  = "no_squash"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/pass/rdwr-restricted/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/pass/rdwr-restricted/main.tf
@@ -1,0 +1,8 @@
+# Read-write, but only from the VPC range that hosts the application tier.
+resource "alicloud_nas_access_rule" "app_tier" {
+  access_group_name = alicloud_nas_access_group.shared.access_group_name
+  source_cidr_ip    = "10.0.0.0/16"
+  rw_access_type    = "RDWR"
+  user_access_type  = "root_squash"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/pass/read-only-world/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-nas-access-rule-restrict-source-terraform-hcl/pass/read-only-world/main.tf
@@ -1,0 +1,8 @@
+# World-reachable but read-only, which the control permits.
+resource "alicloud_nas_access_rule" "public_read" {
+  access_group_name = alicloud_nas_access_group.shared.access_group_name
+  source_cidr_ip    = "0.0.0.0/0"
+  rw_access_type    = "RDONLY"
+  user_access_type  = "no_squash"
+  priority          = 1
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-block-public-access-terraform-hcl/fail/not-blocked/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-block-public-access-terraform-hcl/fail/not-blocked/main.tf
@@ -1,0 +1,6 @@
+# Declaring the resource with the block turned off is worse than not declaring
+# it: it reads as a deliberate decision to permit public access grants.
+resource "alicloud_oss_bucket_public_access_block" "data" {
+  bucket              = alicloud_oss_bucket.data.bucket
+  block_public_access = false
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-block-public-access-terraform-hcl/pass/blocked/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-block-public-access-terraform-hcl/pass/blocked/main.tf
@@ -1,0 +1,4 @@
+resource "alicloud_oss_bucket_public_access_block" "data" {
+  bucket              = alicloud_oss_bucket.data.bucket
+  block_public_access = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/fail/no-encryption-rule/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/fail/no-encryption-rule/main.tf
@@ -1,0 +1,5 @@
+# No server_side_encryption_rule, so objects land unencrypted at rest.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/pass/aes256/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/pass/aes256/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  server_side_encryption_rule {
+    sse_algorithm = "AES256"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/pass/kms/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-encryption-enabled-terraform-hcl/pass/kms/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  server_side_encryption_rule {
+    sse_algorithm     = "KMS"
+    kms_master_key_id = alicloud_kms_key.oss.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/fail/aes256/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/fail/aes256/main.tf
@@ -1,0 +1,10 @@
+# AES256 is service-managed encryption: the keys are not customer-controlled,
+# so key rotation and revocation stay with the provider.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  server_side_encryption_rule {
+    sse_algorithm = "AES256"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/fail/no-encryption-rule/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/fail/no-encryption-rule/main.tf
@@ -1,0 +1,5 @@
+# No encryption rule at all, so there is no customer-managed key either.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/pass/kms/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-kms-encryption-terraform-hcl/pass/kms/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  server_side_encryption_rule {
+    sse_algorithm     = "KMS"
+    kms_master_key_id = alicloud_kms_key.oss.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-logging-enabled-terraform-hcl/fail/no-logging/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-logging-enabled-terraform-hcl/fail/no-logging/main.tf
@@ -1,0 +1,9 @@
+# Without a logging block there is no record of who read or wrote objects.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  server_side_encryption_rule {
+    sse_algorithm = "KMS"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-logging-enabled-terraform-hcl/pass/logging-configured/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-logging-enabled-terraform-hcl/pass/logging-configured/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  logging {
+    target_bucket = alicloud_oss_bucket.access_logs.id
+    target_prefix = "oss-access/prod-data/"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/fail/public-read-write/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/fail/public-read-write/main.tf
@@ -1,0 +1,6 @@
+# public-read-write additionally lets anonymous callers upload and overwrite,
+# which is how buckets get used to host malware.
+resource "alicloud_oss_bucket" "uploads" {
+  bucket = "example-prod-uploads"
+  acl    = "public-read-write"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/fail/public-read/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/fail/public-read/main.tf
@@ -1,0 +1,5 @@
+# public-read exposes every object in the bucket to anonymous callers.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "public-read"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/pass/private/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-no-public-acl-terraform-hcl/pass/private/main.tf
@@ -1,0 +1,4 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/fail/no-versioning-block/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/fail/no-versioning-block/main.tf
@@ -1,0 +1,5 @@
+# Versioning is off by default when the block is omitted.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/fail/suspended/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/fail/suspended/main.tf
@@ -1,0 +1,10 @@
+# Suspended versioning stops retaining prior object versions, so an overwrite
+# or delete is unrecoverable.
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  versioning {
+    status = "Suspended"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-oss-bucket-versioning-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_oss_bucket" "data" {
+  bucket = "example-prod-data"
+  acl    = "private"
+
+  versioning {
+    status = "Enabled"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-restrict-access-whitelist-terraform-hcl/fail/world-open/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-restrict-access-whitelist-terraform-hcl/fail/world-open/main.tf
@@ -1,0 +1,13 @@
+# A /0 entry in the cluster whitelist accepts connections from any address.
+resource "alicloud_polardb_cluster" "prod" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  db_node_class = "polar.mysql.x4.large"
+  pay_type      = "PostPaid"
+  vswitch_id    = alicloud_vswitch.db.id
+
+  db_cluster_ip_array {
+    db_cluster_ip_array_name = "default"
+    security_ips             = ["10.0.0.0/16", "0.0.0.0/0"]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-restrict-access-whitelist-terraform-hcl/pass/vpc-range/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-restrict-access-whitelist-terraform-hcl/pass/vpc-range/main.tf
@@ -1,0 +1,12 @@
+resource "alicloud_polardb_cluster" "prod" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  db_node_class = "polar.mysql.x4.large"
+  pay_type      = "PostPaid"
+  vswitch_id    = alicloud_vswitch.db.id
+
+  db_cluster_ip_array {
+    db_cluster_ip_array_name = "default"
+    security_ips             = ["10.0.0.0/16"]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-tde-enabled-terraform-hcl/fail/tde-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-tde-enabled-terraform-hcl/fail/tde-off/main.tf
@@ -1,0 +1,10 @@
+# TDE cannot be turned on after the cluster is created, so shipping it disabled
+# means a migration later.
+resource "alicloud_polardb_cluster" "prod" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  db_node_class = "polar.mysql.x4.large"
+  pay_type      = "PostPaid"
+  vswitch_id    = alicloud_vswitch.db.id
+  tde_status    = "Disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-tde-enabled-terraform-hcl/pass/tde-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-polardb-cluster-tde-enabled-terraform-hcl/pass/tde-on/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_polardb_cluster" "prod" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  db_node_class = "polar.mysql.x4.large"
+  pay_type      = "PostPaid"
+  vswitch_id    = alicloud_vswitch.db.id
+  description   = "prod-polardb"
+  tde_status    = "Enabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-complexity-terraform-hcl/fail/no-symbols/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-complexity-terraform-hcl/fail/no-symbols/main.tf
@@ -1,0 +1,9 @@
+# Dropping one character class shrinks the keyspace an attacker has to search.
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length      = 14
+  require_lowercase_characters = true
+  require_uppercase_characters = true
+  require_numbers              = true
+  require_symbols              = false
+  max_login_attempts           = 5
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-complexity-terraform-hcl/pass/all-classes/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-complexity-terraform-hcl/pass/all-classes/main.tf
@@ -1,0 +1,10 @@
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length      = 14
+  require_lowercase_characters = true
+  require_uppercase_characters = true
+  require_numbers              = true
+  require_symbols              = true
+  max_login_attempts           = 5
+  password_reuse_prevention    = 5
+  max_password_age             = 90
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/fail/too-many-attempts/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/fail/too-many-attempts/main.tf
@@ -1,0 +1,5 @@
+# Fifty attempts before lockout leaves ample room for online password guessing.
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length = 14
+  max_login_attempts      = 50
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/fail/unlimited/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/fail/unlimited/main.tf
@@ -1,0 +1,5 @@
+# 0 means no lockout at all, so guessing is unbounded.
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length = 14
+  max_login_attempts      = 0
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/pass/five-attempts/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-max-login-attempts-terraform-hcl/pass/five-attempts/main.tf
@@ -1,0 +1,4 @@
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length = 14
+  max_login_attempts      = 5
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-min-length-terraform-hcl/fail/eight/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-min-length-terraform-hcl/fail/eight/main.tf
@@ -1,0 +1,5 @@
+# The Alibaba Cloud default of 8 is well inside offline cracking range for a
+# modern GPU rig.
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length = 8
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-min-length-terraform-hcl/pass/fourteen/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-ram-password-policy-min-length-terraform-hcl/pass/fourteen/main.tf
@@ -1,0 +1,7 @@
+resource "alicloud_ram_account_password_policy" "default" {
+  minimum_password_length      = 14
+  require_lowercase_characters = true
+  require_uppercase_characters = true
+  require_numbers              = true
+  require_symbols              = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-deletion-protection-terraform-hcl/fail/unprotected/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-deletion-protection-terraform-hcl/fail/unprotected/main.tf
@@ -1,0 +1,10 @@
+# A production database one API call away from deletion.
+resource "alicloud_db_instance" "prod" {
+  engine              = "MySQL"
+  engine_version      = "8.0"
+  instance_type       = "mysql.n2.medium.1"
+  instance_storage    = 100
+  instance_name       = "prod-mysql"
+  vswitch_id          = alicloud_vswitch.db.id
+  deletion_protection = false
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-deletion-protection-terraform-hcl/pass/protected/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-deletion-protection-terraform-hcl/pass/protected/main.tf
@@ -1,0 +1,10 @@
+resource "alicloud_db_instance" "prod" {
+  engine              = "MySQL"
+  engine_version      = "8.0"
+  instance_type       = "mysql.n2.medium.1"
+  instance_storage    = 100
+  instance_name       = "prod-mysql"
+  vswitch_id          = alicloud_vswitch.db.id
+  security_ips        = ["10.0.0.0/16"]
+  deletion_protection = true
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-restrict-security-ip-list-terraform-hcl/fail/world-open/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-restrict-security-ip-list-terraform-hcl/fail/world-open/main.tf
@@ -1,0 +1,10 @@
+# 0.0.0.0/0 in the whitelist makes the database reachable from any address that
+# can route to it.
+resource "alicloud_db_instance" "prod" {
+  engine           = "MySQL"
+  engine_version   = "8.0"
+  instance_type    = "mysql.n2.medium.1"
+  instance_storage = 100
+  vswitch_id       = alicloud_vswitch.db.id
+  security_ips     = ["10.0.0.0/16", "0.0.0.0/0"]
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-restrict-security-ip-list-terraform-hcl/pass/vpc-range/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-restrict-security-ip-list-terraform-hcl/pass/vpc-range/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_db_instance" "prod" {
+  engine           = "MySQL"
+  engine_version   = "8.0"
+  instance_type    = "mysql.n2.medium.1"
+  instance_storage = 100
+  vswitch_id       = alicloud_vswitch.db.id
+  security_ips     = ["10.0.0.0/16", "10.1.0.0/16"]
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
@@ -1,0 +1,9 @@
+# Without TDE the data files and backups sit unencrypted at rest.
+resource "alicloud_db_instance" "prod" {
+  engine           = "MySQL"
+  engine_version   = "8.0"
+  instance_type    = "mysql.n2.medium.1"
+  instance_storage = 100
+  vswitch_id       = alicloud_vswitch.db.id
+  tde_status       = "Disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-rds-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_db_instance" "prod" {
+  engine           = "MySQL"
+  engine_version   = "8.0"
+  instance_type    = "mysql.n2.medium.1"
+  instance_storage = 100
+  vswitch_id       = alicloud_vswitch.db.id
+  tde_status       = "Enabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-auth-enabled-terraform-hcl/fail/vpc-auth-closed/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-auth-enabled-terraform-hcl/fail/vpc-auth-closed/main.tf
@@ -1,0 +1,10 @@
+# "Close" disables password authentication for VPC clients, so anything that
+# can reach the instance can read and write every key.
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  vpc_auth_mode    = "Close"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-auth-enabled-terraform-hcl/pass/vpc-auth-open/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-auth-enabled-terraform-hcl/pass/vpc-auth-open/main.tf
@@ -1,0 +1,10 @@
+# vpc_auth_mode "Open" means password authentication is required inside the VPC.
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  vpc_auth_mode    = "Open"
+  password         = var.redis_password
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-ssl-and-private-terraform-hcl/fail/ssl-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-ssl-and-private-terraform-hcl/fail/ssl-disabled/main.tf
@@ -1,0 +1,9 @@
+# Redis traffic, including the AUTH password, crosses the network in cleartext.
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  ssl_enable       = "Disable"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-ssl-and-private-terraform-hcl/pass/ssl-enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-ssl-and-private-terraform-hcl/pass/ssl-enabled/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  ssl_enable       = "Enable"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-tde-enabled-terraform-hcl/fail/tde-off/main.tf
@@ -1,0 +1,10 @@
+# Cached data, which often mirrors the primary database, sits unencrypted at
+# rest.
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  tde_status       = "Disabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-redis-instance-tde-enabled-terraform-hcl/pass/tde-on/main.tf
@@ -1,0 +1,8 @@
+resource "alicloud_kvstore_instance" "cache" {
+  db_instance_name = "prod-redis"
+  instance_class   = "redis.master.small.default"
+  instance_type    = "Redis"
+  engine_version   = "7.0"
+  vswitch_id       = alicloud_vswitch.cache.id
+  tde_status       = "Enabled"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-vpc-flow-logs-enabled-terraform-hcl/fail/inactive/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-vpc-flow-logs-enabled-terraform-hcl/fail/inactive/main.tf
@@ -1,0 +1,11 @@
+# An inactive flow log captures no traffic, leaving no network record for
+# incident investigation.
+resource "alicloud_vpc_flow_log" "prod" {
+  flow_log_name  = "prod-vpc-flow"
+  resource_id    = alicloud_vpc.prod.id
+  resource_type  = "VPC"
+  traffic_type   = "All"
+  project_name   = "vpc-flow-logs"
+  log_store_name = "prod-vpc"
+  status         = "Inactive"
+}

--- a/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-vpc-flow-logs-enabled-terraform-hcl/pass/active/main.tf
+++ b/content/iac-variant-testdata/mondoo-alibaba-security/mondoo-alibaba-security-vpc-flow-logs-enabled-terraform-hcl/pass/active/main.tf
@@ -1,0 +1,9 @@
+resource "alicloud_vpc_flow_log" "prod" {
+  flow_log_name  = "prod-vpc-flow"
+  resource_id    = alicloud_vpc.prod.id
+  resource_type  = "VPC"
+  traffic_type   = "All"
+  project_name   = "vpc-flow-logs"
+  log_store_name = "prod-vpc"
+  status         = "Active"
+}


### PR DESCRIPTION
Round 3 of the push to 100% IaC-variant fixture coverage (rounds 1–2: #3271, #3273).

## Coverage

The alibaba policy shipped in #3098 with 32 terraform-hcl variants and **no fixtures at all**. This adds 73 scenarios covering every one:

| policy | before | after |
|---|---|---|
| mondoo-alibaba-security | 0/32 | **32/32** |

Alibaba drops out of `iac-variant-coverage-budget.json`. Remaining: aws 28 tf + 21 cfn, azure 36 tf + 43 bicep.

## First real exercise of the alicloud provider

#3261 registered `mondoo-alibaba-security` in `tfVariantPolicies` and added `alicloud` to `extraProviders`, so its gap would at least be *visible*. But with zero fixtures, nothing had ever scanned an alicloud asset through the harness — the registration was untested plumbing. It works: all 32 checks assert correctly on the first pass, no provider surprises.

## No policy bugs this round

Worth stating plainly after round 1 found the openstack nested-block bug and round 2 found four checks sharing a broken `!= []` idiom: **this policy is clean.** It is recent, and it was evidently written against the provider's actual value shapes rather than assumed ones. The tell is in details a from-memory author gets wrong — MongoDB's `tde_status` takes lowercase `enabled`/`disabled` where RDS and Redis take capitalized `Enabled`/`Disabled`, and the policy has that right.

## Fixture notes

Scenarios split by meaningful distinction, not one pair per check:

- **Security-group rules** are driven through their whole `.where().where().where().none()` chain: world-open SSH; a `1/65535` range that contains port 22 without naming it; the IPv6 `::/0` path that IPv4-only hardening misses; and — in the pass fixture — a legitimately world-open `443/443` rule that must *not* trip the check. That last one is the important one: it proves the check discriminates rather than flagging any public rule.
- **KMS rotation** includes a `SIGN/VERIFY` key with rotation disabled, which passes because the check deliberately scopes itself to `ENCRYPT/DECRYPT`. The fixture documents that exclusion so a future edit that drops the scoping fails here.
- **NAS access rule** covers both halves of `rw_access_type != "RDWR" || source != 0.0.0.0/0 && ipv6 != ::/0` — world-readable-but-read-only passes, read-write-from-anywhere fails.
- **OSS** distinguishes "no encryption rule" from "AES256 instead of KMS", which are different findings for the two encryption checks that share the resource.

## Verification

```
alibaba suite   73 scenarios, 0 failures
TestTerraformVariantCoverage   ok  (budget regenerated, alibaba at 100%)
```

No policy file changed, so there is nothing for lint to re-check; the diff is fixtures plus the budget entry removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
