### PR TITLE
✨ content: cover the AWS terraform-hcl IaC-variant coverage gaps

### DIFF
--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -1,7 +1,6 @@
 {
   "mondoo-aws-security": {
-    "-cloudformation": 21,
-    "-terraform-hcl": 28
+    "-cloudformation": 21
   },
   "mondoo-azure-security": {
     "-bicep": 43,

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-terraform-hcl/fail/default-endpoint-live/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-terraform-hcl/fail/default-endpoint-live/main.tf
@@ -1,0 +1,10 @@
+# The execute-api endpoint stays reachable alongside the custom domain, so WAF
+# rules and domain-level controls attached to the custom domain can be bypassed.
+resource "aws_api_gateway_rest_api" "orders" {
+  name        = "orders-api"
+  description = "Order service, fronted by a custom domain"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-terraform-hcl/pass/disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-terraform-hcl/pass/disabled/main.tf
@@ -1,0 +1,9 @@
+resource "aws_api_gateway_rest_api" "orders" {
+  name                         = "orders-api"
+  description                  = "Order service, fronted by a custom domain"
+  disable_execute_api_endpoint = true
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-terraform-hcl/fail/default-endpoint-live/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-terraform-hcl/fail/default-endpoint-live/main.tf
@@ -1,0 +1,5 @@
+resource "aws_apigatewayv2_api" "events" {
+  name                         = "events-api"
+  protocol_type                = "HTTP"
+  disable_execute_api_endpoint = false
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-terraform-hcl/pass/disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-terraform-hcl/pass/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "aws_apigatewayv2_api" "events" {
+  name                         = "events-api"
+  protocol_type                = "HTTP"
+  disable_execute_api_endpoint = true
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
@@ -1,0 +1,29 @@
+# Without kms_arn the flow falls back to the AWS-managed AppFlow key, so the
+# data in transit through AppFlow is not under customer key control.
+resource "aws_appflow_flow" "salesforce_to_s3" {
+  name = "salesforce-to-s3"
+
+  source_flow_config {
+    connector_type = "Salesforce"
+
+    source_connector_properties {
+      salesforce {
+        object = "Account"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket.appflow.bucket
+      }
+    }
+  }
+
+  trigger_config {
+    trigger_type = "OnDemand"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,38 @@
+resource "aws_appflow_flow" "salesforce_to_s3" {
+  name    = "salesforce-to-s3"
+  kms_arn = aws_kms_key.appflow.arn
+
+  source_flow_config {
+    connector_type = "Salesforce"
+
+    source_connector_properties {
+      salesforce {
+        object = "Account"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket.appflow.bucket
+      }
+    }
+  }
+
+  task {
+    source_fields     = ["Id"]
+    task_type         = "Map"
+    destination_field = "Id"
+
+    connector_operator {
+      salesforce = "NO_OP"
+    }
+  }
+
+  trigger_config {
+    trigger_type = "OnDemand"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-terraform-hcl/fail/no-role/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-terraform-hcl/fail/no-role/main.tf
@@ -1,0 +1,12 @@
+# With no fleet role, streaming instances cannot be granted scoped AWS access,
+# so credentials end up baked into the image or the session instead.
+resource "aws_appstream_fleet" "designers" {
+  name          = "designers"
+  instance_type = "stream.standard.medium"
+  fleet_type    = "ON_DEMAND"
+  image_name    = "AppStream-WinServer2019-06-17-2024"
+
+  compute_capacity {
+    desired_instances = 2
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-terraform-hcl/pass/role-attached/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-terraform-hcl/pass/role-attached/main.tf
@@ -1,0 +1,11 @@
+resource "aws_appstream_fleet" "designers" {
+  name          = "designers"
+  instance_type = "stream.standard.medium"
+  fleet_type    = "ON_DEMAND"
+  image_name    = "AppStream-WinServer2019-06-17-2024"
+  iam_role_arn  = aws_iam_role.appstream_streaming.arn
+
+  compute_capacity {
+    desired_instances = 2
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-terraform-hcl/fail/imdsv1-allowed/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-terraform-hcl/fail/imdsv1-allowed/main.tf
@@ -1,0 +1,13 @@
+# IMDSv1 is unauthenticated and reachable from any process on the instance, so
+# an SSRF or a compromised browser session can read the fleet role credentials.
+resource "aws_appstream_fleet" "designers" {
+  name            = "designers"
+  instance_type   = "stream.standard.medium"
+  fleet_type      = "ON_DEMAND"
+  image_name      = "AppStream-WinServer2019-06-17-2024"
+  disable_imds_v1 = false
+
+  compute_capacity {
+    desired_instances = 2
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-terraform-hcl/pass/imdsv1-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-terraform-hcl/pass/imdsv1-disabled/main.tf
@@ -1,0 +1,11 @@
+resource "aws_appstream_fleet" "designers" {
+  name             = "designers"
+  instance_type    = "stream.standard.medium"
+  fleet_type       = "ON_DEMAND"
+  image_name       = "AppStream-WinServer2019-06-17-2024"
+  disable_imds_v1  = true
+
+  compute_capacity {
+    desired_instances = 2
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/fail/no-configuration-block/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/fail/no-configuration-block/main.tf
@@ -1,0 +1,4 @@
+# A workgroup with no configuration block enforces nothing at all.
+resource "aws_athena_workgroup" "analytics" {
+  name = "analytics"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/fail/not-enforced/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/fail/not-enforced/main.tf
@@ -1,0 +1,14 @@
+# Without minimum encryption enforcement a query author can override the
+# workgroup's encryption settings and write unencrypted results.
+resource "aws_athena_workgroup" "analytics" {
+  name = "analytics"
+
+  configuration {
+    enforce_workgroup_configuration         = true
+    enable_minimum_encryption_configuration = false
+
+    result_configuration {
+      output_location = "s3://example-athena-results/analytics/"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/pass/enforced/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-terraform-hcl/pass/enforced/main.tf
@@ -1,0 +1,17 @@
+resource "aws_athena_workgroup" "analytics" {
+  name = "analytics"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    enable_minimum_encryption_configuration = true
+
+    result_configuration {
+      output_location = "s3://example-athena-results/analytics/"
+
+      encryption_configuration {
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = aws_kms_key.athena.arn
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-agent-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-agent-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
@@ -1,0 +1,8 @@
+# Agent state, including session data and prompts, is encrypted with the
+# AWS-managed key rather than one the account controls.
+resource "aws_bedrockagent_agent" "support" {
+  agent_name              = "support-agent"
+  agent_resource_role_arn = aws_iam_role.bedrock_agent.arn
+  foundation_model        = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+  instruction             = "Answer customer questions using only the approved knowledge base."
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-agent-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-agent-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,7 @@
+resource "aws_bedrockagent_agent" "support" {
+  agent_name                  = "support-agent"
+  agent_resource_role_arn     = aws_iam_role.bedrock_agent.arn
+  foundation_model            = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+  customer_encryption_key_arn = aws_kms_key.bedrock.arn
+  instruction                 = "Answer customer questions using only the approved knowledge base."
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-flow-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-flow-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
@@ -1,0 +1,5 @@
+resource "aws_bedrockagent_flow" "enrichment" {
+  name               = "enrichment-flow"
+  execution_role_arn = aws_iam_role.bedrock_flow.arn
+  description        = "Enriches inbound tickets before routing"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-flow-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-flow-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,6 @@
+resource "aws_bedrockagent_flow" "enrichment" {
+  name                        = "enrichment-flow"
+  execution_role_arn          = aws_iam_role.bedrock_flow.arn
+  customer_encryption_key_arn = aws_kms_key.bedrock.arn
+  description                 = "Enriches inbound tickets before routing"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-guardrail-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-guardrail-cmk-encryption-terraform-hcl/fail/aws-managed-key/main.tf
@@ -1,0 +1,15 @@
+# Guardrail configuration encodes the organization's content policy; without a
+# customer key it is encrypted only with the AWS-managed one.
+resource "aws_bedrock_guardrail" "content_policy" {
+  name                      = "content-policy"
+  blocked_input_messaging   = "This request cannot be processed."
+  blocked_outputs_messaging = "This response cannot be returned."
+
+  content_policy_config {
+    filters_config {
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+      type            = "HATE"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-guardrail-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-bedrock-guardrail-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,14 @@
+resource "aws_bedrock_guardrail" "content_policy" {
+  name                      = "content-policy"
+  blocked_input_messaging   = "This request cannot be processed."
+  blocked_outputs_messaging = "This response cannot be returned."
+  kms_key_arn               = aws_kms_key.bedrock.arn
+
+  content_policy_config {
+    filters_config {
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
+      type            = "HATE"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-terraform-hcl/fail/encryption-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-terraform-hcl/fail/encryption-disabled/main.tf
@@ -1,0 +1,23 @@
+# Build artifacts frequently contain source, dependencies, and occasionally
+# credentials; writing them unencrypted removes the last control on the bucket.
+resource "aws_codebuild_project" "app" {
+  name         = "app-build"
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type                = "S3"
+    location            = aws_s3_bucket.artifacts.bucket
+    encryption_disabled = true
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/example/app.git"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-terraform-hcl/pass/encrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-terraform-hcl/pass/encrypted/main.tf
@@ -1,0 +1,21 @@
+resource "aws_codebuild_project" "app" {
+  name         = "app-build"
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type                = "S3"
+    location            = aws_s3_bucket.artifacts.bucket
+    encryption_disabled = false
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/example/app.git"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/fail/unencrypted-logs/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/fail/unencrypted-logs/main.tf
@@ -1,0 +1,29 @@
+# Build logs routinely echo environment variables and command output; storing
+# them unencrypted exposes whatever the build printed.
+resource "aws_codebuild_project" "app" {
+  name         = "app-build"
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/example/app.git"
+  }
+
+  logs_config {
+    s3_logs {
+      status              = "ENABLED"
+      location            = "${aws_s3_bucket.build_logs.id}/build-log"
+      encryption_disabled = true
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/pass/encrypted-logs/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/pass/encrypted-logs/main.tf
@@ -1,0 +1,27 @@
+resource "aws_codebuild_project" "app" {
+  name         = "app-build"
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/example/app.git"
+  }
+
+  logs_config {
+    s3_logs {
+      status              = "ENABLED"
+      location            = "${aws_s3_bucket.build_logs.id}/build-log"
+      encryption_disabled = false
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/pass/s3-logs-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-terraform-hcl/pass/s3-logs-disabled/main.tf
@@ -1,0 +1,32 @@
+# S3 logging turned off entirely, so there is no unencrypted log to worry about.
+# The check scopes itself to ENABLED s3_logs blocks.
+resource "aws_codebuild_project" "app" {
+  name         = "app-build"
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/example/app.git"
+  }
+
+  logs_config {
+    s3_logs {
+      status              = "DISABLED"
+      encryption_disabled = true
+    }
+
+    cloudwatch_logs {
+      status = "ENABLED"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/fail/aws-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/fail/aws-managed-key/main.tf
@@ -1,0 +1,8 @@
+# Encrypted with the default aws/ebs key, which the account cannot rotate on
+# its own schedule or deny access to independently.
+resource "aws_ebs_volume" "data" {
+  availability_zone = "us-east-1a"
+  size              = 500
+  type              = "gp3"
+  encrypted         = true
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/fail/unencrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/fail/unencrypted/main.tf
@@ -1,0 +1,6 @@
+resource "aws_ebs_volume" "data" {
+  availability_zone = "us-east-1a"
+  size              = 500
+  type              = "gp3"
+  encrypted         = false
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,11 @@
+resource "aws_ebs_volume" "data" {
+  availability_zone = "us-east-1a"
+  size              = 500
+  type              = "gp3"
+  encrypted         = true
+  kms_key_id        = aws_kms_key.ebs.arn
+
+  tags = {
+    Name = "app-data"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/fail/no-policy/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/fail/no-policy/main.tf
@@ -1,0 +1,6 @@
+# Encryption at rest is on, but nothing requires clients to mount over TLS, so
+# NFS traffic can cross the VPC in cleartext.
+resource "aws_efs_file_system" "shared" {
+  creation_token = "shared-app-data"
+  encrypted      = true
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/fail/policy-without-transport-condition/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/fail/policy-without-transport-condition/main.tf
@@ -1,0 +1,28 @@
+# A file system policy exists, but it only grants access; nothing denies
+# non-TLS mounts.
+resource "aws_efs_file_system" "shared" {
+  creation_token = "shared-app-data"
+  encrypted      = true
+}
+
+resource "aws_efs_file_system_policy" "shared" {
+  file_system_id = aws_efs_file_system.shared.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAppRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::123456789012:role/app"
+        }
+        Action = [
+          "elasticfilesystem:ClientMount",
+          "elasticfilesystem:ClientWrite",
+        ]
+        Resource = "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-0123456789abcdef0"
+      },
+    ]
+  })
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/pass/deny-insecure-transport/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl/pass/deny-insecure-transport/main.tf
@@ -1,0 +1,28 @@
+resource "aws_efs_file_system" "shared" {
+  creation_token = "shared-app-data"
+  encrypted      = true
+}
+
+resource "aws_efs_file_system_policy" "shared" {
+  file_system_id = aws_efs_file_system.shared.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyInsecureTransport"
+        Effect = "Deny"
+        Principal = {
+          AWS = "*"
+        }
+        Action   = "*"
+        Resource = "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-0123456789abcdef0"
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+    ]
+  })
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-iam-support-role-terraform-hcl/fail/IMPOSSIBLE.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-iam-support-role-terraform-hcl/fail/IMPOSSIBLE.md
@@ -1,0 +1,30 @@
+# No possible failing fixture: the filter asserts what the query asserts
+
+The variant's `filters:` already requires an `aws_iam_role_policy_attachment`
+whose `policy_arn` is `arn:aws:iam::aws:policy/AWSSupportAccess`:
+
+```
+asset.platform == "terraform-hcl" && terraform.resources.contains(
+  nameLabel == "aws_iam_role_policy_attachment" &&
+  arguments["policy_arn"] == "arn:aws:iam::aws:policy/AWSSupportAccess")
+```
+
+and the `mql:` then re-asserts the same condition:
+
+```
+terraform.resources.where(nameLabel == "aws_iam_role_policy_attachment").any(
+  arguments['policy_arn'] == "arn:aws:iam::aws:policy/AWSSupportAccess")
+```
+
+Any configuration that satisfies the filter necessarily satisfies the query, and
+any configuration that would fail the query is filtered out and never scored. The
+variant can only ever be "passed" or "not applicable" — never "failed" — so no
+failing input exists to write.
+
+This is a real design gap, not a fixture gap: a check that cannot fail provides no
+signal. It is tracked in issue #3118, which covers sweeping this class
+(filter == MQL assertion) across the policy. Fixing it means broadening the filter
+to the population that *should* have a support role (for example, any configuration
+declaring `aws_iam_role`) so a config lacking the attachment is scored and fails.
+
+When #3118 is addressed, delete this marker and add the real fail fixture.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/fail/period-too-long/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/fail/period-too-long/main.tf
@@ -1,0 +1,7 @@
+# Rotation is enabled but stretched well past a year, so a compromised key
+# stays in service far longer than the control allows.
+resource "aws_kms_key" "data" {
+  description             = "Application data key"
+  enable_key_rotation     = true
+  rotation_period_in_days = 2560
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/pass/annual-rotation/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/pass/annual-rotation/main.tf
@@ -1,0 +1,6 @@
+resource "aws_kms_key" "data" {
+  description             = "Application data key"
+  enable_key_rotation     = true
+  rotation_period_in_days = 365
+  deletion_window_in_days = 30
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/pass/default-period/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-terraform-hcl/pass/default-period/main.tf
@@ -1,0 +1,5 @@
+# Rotation on, period left at the AWS default of 365 days.
+resource "aws_kms_key" "data" {
+  description         = "Application data key"
+  enable_key_rotation = true
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/fail/nodejs16/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/fail/nodejs16/main.tf
@@ -1,0 +1,7 @@
+resource "aws_lambda_function" "webhook" {
+  function_name = "webhook-handler"
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "nodejs16.x"
+  filename      = "function.zip"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/fail/python38/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/fail/python38/main.tf
@@ -1,0 +1,8 @@
+# python3.8 is past end of support: no security patches reach the runtime.
+resource "aws_lambda_function" "processor" {
+  function_name = "event-processor"
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "python3.8"
+  filename      = "function.zip"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/pass/container-image/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/pass/container-image/main.tf
@@ -1,0 +1,8 @@
+# Image-based functions declare no runtime at all, which the check treats as
+# out of scope rather than as a deprecated runtime.
+resource "aws_lambda_function" "processor" {
+  function_name = "event-processor"
+  role          = aws_iam_role.lambda.arn
+  package_type  = "Image"
+  image_uri     = "123456789012.dkr.ecr.us-east-1.amazonaws.com/processor:1.4.2"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/pass/python313/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-terraform-hcl/pass/python313/main.tf
@@ -1,0 +1,7 @@
+resource "aws_lambda_function" "processor" {
+  function_name = "event-processor"
+  role          = aws_iam_role.lambda.arn
+  handler       = "index.handler"
+  runtime       = "python3.13"
+  filename      = "function.zip"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-terraform-hcl/fail/open-access/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-terraform-hcl/fail/open-access/main.tf
@@ -1,0 +1,9 @@
+# "open-access" is the built-in ACL that permits any user with any password to
+# run any command, which defeats MemoryDB's authentication entirely.
+resource "aws_memorydb_cluster" "sessions" {
+  name              = "sessions"
+  acl_name          = "open-access"
+  node_type         = "db.t4g.small"
+  num_shards        = 2
+  subnet_group_name = aws_memorydb_subnet_group.private.name
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-terraform-hcl/pass/scoped-acl/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-terraform-hcl/pass/scoped-acl/main.tf
@@ -1,0 +1,10 @@
+resource "aws_memorydb_cluster" "sessions" {
+  name                     = "sessions"
+  acl_name                 = aws_memorydb_acl.app.name
+  node_type                = "db.t4g.small"
+  num_shards               = 2
+  security_group_ids       = [aws_security_group.memorydb.id]
+  subnet_group_name        = aws_memorydb_subnet_group.private.name
+  tls_enabled              = true
+  kms_key_arn              = aws_kms_key.memorydb.arn
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-terraform-hcl/fail/auto-upgrade-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-terraform-hcl/fail/auto-upgrade-off/main.tf
@@ -1,0 +1,16 @@
+# Minor versions carry the broker's security patches; pinning them off means
+# known CVEs stay unpatched until someone upgrades by hand.
+resource "aws_mq_broker" "orders" {
+  broker_name                = "orders"
+  engine_type                = "ActiveMQ"
+  engine_version             = "5.18.4"
+  host_instance_type         = "mq.m5.large"
+  auto_minor_version_upgrade = false
+  publicly_accessible        = false
+  subnet_ids                 = [aws_subnet.private_a.id]
+
+  user {
+    username = "admin"
+    password = var.mq_password
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-terraform-hcl/pass/auto-upgrade-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-terraform-hcl/pass/auto-upgrade-on/main.tf
@@ -1,0 +1,14 @@
+resource "aws_mq_broker" "orders" {
+  broker_name                = "orders"
+  engine_type                = "ActiveMQ"
+  engine_version             = "5.18.4"
+  host_instance_type         = "mq.m5.large"
+  auto_minor_version_upgrade = true
+  publicly_accessible        = false
+  subnet_ids                 = [aws_subnet.private_a.id]
+
+  user {
+    username = "admin"
+    password = var.mq_password
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/fail/no-protections/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/fail/no-protections/main.tf
@@ -1,0 +1,10 @@
+# All three protections default to false when omitted.
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                = "perimeter"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id              = aws_vpc.prod.id
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/fail/policy-change-unprotected/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/fail/policy-change-unprotected/main.tf
@@ -1,0 +1,14 @@
+# Delete and subnet protection are on, but the policy itself can be swapped —
+# which is the change that silently stops the firewall from filtering.
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                              = "perimeter"
+  firewall_policy_arn               = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id                            = aws_vpc.prod.id
+  delete_protection                 = true
+  firewall_policy_change_protection = false
+  subnet_change_protection          = true
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/pass/all-protections/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-terraform-hcl/pass/all-protections/main.tf
@@ -1,0 +1,12 @@
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                              = "perimeter"
+  firewall_policy_arn               = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id                            = aws_vpc.prod.id
+  delete_protection                 = true
+  firewall_policy_change_protection = true
+  subnet_change_protection          = true
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/fail/aws-owned-kms/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/fail/aws-owned-kms/main.tf
@@ -1,0 +1,15 @@
+# AWS_OWNED_KMS_KEY is the default; the firewall's rule and flow state are then
+# encrypted with a key the account has no control over.
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                = "perimeter"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id              = aws_vpc.prod.id
+
+  encryption_configuration {
+    type = "AWS_OWNED_KMS_KEY"
+  }
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/fail/no-encryption-config/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/fail/no-encryption-config/main.tf
@@ -1,0 +1,9 @@
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                = "perimeter"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id              = aws_vpc.prod.id
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/pass/customer-kms/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-cmk-encryption-terraform-hcl/pass/customer-kms/main.tf
@@ -1,0 +1,14 @@
+resource "aws_networkfirewall_firewall" "perimeter" {
+  name                = "perimeter"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.perimeter.arn
+  vpc_id              = aws_vpc.prod.id
+
+  encryption_configuration {
+    type   = "CUSTOMER_KMS"
+    key_id = aws_kms_key.networkfirewall.arn
+  }
+
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall_a.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-terraform-hcl/fail/no-destinations/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-terraform-hcl/fail/no-destinations/main.tf
@@ -1,0 +1,8 @@
+# A logging configuration with no destinations records nothing, so alerts and
+# flow records from the firewall are lost.
+resource "aws_networkfirewall_logging_configuration" "perimeter" {
+  firewall_arn = aws_networkfirewall_firewall.perimeter.arn
+
+  logging_configuration {
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-terraform-hcl/pass/flow-and-alert-logs/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-terraform-hcl/pass/flow-and-alert-logs/main.tf
@@ -1,0 +1,24 @@
+resource "aws_networkfirewall_logging_configuration" "perimeter" {
+  firewall_arn = aws_networkfirewall_firewall.perimeter.arn
+
+  logging_configuration {
+    log_destination_config {
+      log_destination_type = "S3"
+      log_type             = "FLOW"
+
+      log_destination = {
+        bucketName = aws_s3_bucket.firewall_logs.bucket
+        prefix     = "flow/"
+      }
+    }
+
+    log_destination_config {
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "ALERT"
+
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.firewall_alerts.name
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl/fail/public-internet/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl/fail/public-internet/main.tf
@@ -1,0 +1,13 @@
+# PublicInternetOnly routes notebook traffic through an AWS-managed internet
+# gateway, bypassing the VPC's egress controls and inspection.
+resource "aws_sagemaker_domain" "research" {
+  domain_name             = "research"
+  auth_mode               = "IAM"
+  vpc_id                  = aws_vpc.prod.id
+  subnet_ids              = [aws_subnet.private_a.id]
+  app_network_access_type = "PublicInternetOnly"
+
+  default_user_settings {
+    execution_role = aws_iam_role.sagemaker.arn
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl/pass/vpc-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-domain-vpc-only-terraform-hcl/pass/vpc-only/main.tf
@@ -1,0 +1,11 @@
+resource "aws_sagemaker_domain" "research" {
+  domain_name             = "research"
+  auth_mode               = "IAM"
+  vpc_id                  = aws_vpc.prod.id
+  subnet_ids              = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+  app_network_access_type = "VpcOnly"
+
+  default_user_settings {
+    execution_role = aws_iam_role.sagemaker.arn
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/fail/capture-without-cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/fail/capture-without-cmk/main.tf
@@ -1,0 +1,22 @@
+# Captured inference data is the raw request and response payload, often the
+# most sensitive data the model touches, written here without a customer key.
+resource "aws_sagemaker_endpoint_configuration" "scoring" {
+  name = "scoring-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.scoring.name
+    initial_instance_count = 1
+    instance_type          = "ml.m5.large"
+  }
+
+  data_capture_config {
+    enable_capture              = true
+    initial_sampling_percentage = 100
+    destination_s3_uri          = "s3://example-model-capture/scoring/"
+
+    capture_options {
+      capture_mode = "InputAndOutput"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/pass/capture-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/pass/capture-disabled/main.tf
@@ -1,0 +1,22 @@
+# Capture turned off, so no inference payloads are written and there is nothing
+# to encrypt.
+resource "aws_sagemaker_endpoint_configuration" "scoring" {
+  name = "scoring-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.scoring.name
+    initial_instance_count = 1
+    instance_type          = "ml.m5.large"
+  }
+
+  data_capture_config {
+    enable_capture              = false
+    initial_sampling_percentage = 0
+    destination_s3_uri          = "s3://example-model-capture/scoring/"
+
+    capture_options {
+      capture_mode = "Input"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/pass/capture-with-cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-endpoint-data-capture-cmk-encryption-terraform-hcl/pass/capture-with-cmk/main.tf
@@ -1,0 +1,21 @@
+resource "aws_sagemaker_endpoint_configuration" "scoring" {
+  name = "scoring-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.scoring.name
+    initial_instance_count = 1
+    instance_type          = "ml.m5.large"
+  }
+
+  data_capture_config {
+    enable_capture              = true
+    initial_sampling_percentage = 20
+    destination_s3_uri          = "s3://example-model-capture/scoring/"
+    kms_key_id                  = aws_kms_key.sagemaker.arn
+
+    capture_options {
+      capture_mode = "Input"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-terraform-hcl/fail/no-subnet/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-terraform-hcl/fail/no-subnet/main.tf
@@ -1,0 +1,7 @@
+# With no subnet the notebook runs on the SageMaker-managed network, outside
+# the VPC's segmentation, flow logs, and egress filtering.
+resource "aws_sagemaker_notebook_instance" "research" {
+  name          = "research-notebook"
+  role_arn      = aws_iam_role.sagemaker.arn
+  instance_type = "ml.t3.medium"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-terraform-hcl/pass/in-vpc/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-terraform-hcl/pass/in-vpc/main.tf
@@ -1,0 +1,9 @@
+resource "aws_sagemaker_notebook_instance" "research" {
+  name                   = "research-notebook"
+  role_arn               = aws_iam_role.sagemaker.arn
+  instance_type          = "ml.t3.medium"
+  subnet_id              = aws_subnet.private_a.id
+  security_groups        = [aws_security_group.sagemaker.id]
+  direct_internet_access = "Disabled"
+  kms_key_id             = aws_kms_key.sagemaker.arn
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/fail/no-encryption-configuration/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/fail/no-encryption-configuration/main.tf
@@ -1,0 +1,7 @@
+resource "aws_securitylake_data_lake" "primary" {
+  meta_store_manager_role_arn = aws_iam_role.securitylake.arn
+
+  configuration {
+    region = "us-east-1"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/fail/s3-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/fail/s3-managed-key/main.tf
@@ -1,0 +1,14 @@
+# S3_MANAGED_KEY is the service default. The security data lake aggregates
+# findings and logs from the whole org, so it is exactly the store that should
+# be under a customer-controlled key.
+resource "aws_securitylake_data_lake" "primary" {
+  meta_store_manager_role_arn = aws_iam_role.securitylake.arn
+
+  configuration {
+    region = "us-east-1"
+
+    encryption_configuration {
+      kms_key_id = "S3_MANAGED_KEY"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/pass/customer-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-terraform-hcl/pass/customer-key/main.tf
@@ -1,0 +1,18 @@
+resource "aws_securitylake_data_lake" "primary" {
+  meta_store_manager_role_arn = aws_iam_role.securitylake.arn
+
+  configuration {
+    region = "us-east-1"
+
+    encryption_configuration {
+      kms_key_id = aws_kms_key.securitylake.id
+    }
+
+    lifecycle_configuration {
+      transition {
+        days          = 31
+        storage_class = "STANDARD_IA"
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/fail/no-delivery-options/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/fail/no-delivery-options/main.tf
@@ -1,0 +1,8 @@
+# With no delivery_options the set inherits the OPTIONAL default.
+resource "aws_sesv2_configuration_set" "transactional" {
+  configuration_set_name = "transactional"
+
+  reputation_options {
+    reputation_metrics_enabled = true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/fail/opportunistic-tls/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/fail/opportunistic-tls/main.tf
@@ -1,0 +1,9 @@
+# OPTIONAL means SES falls back to plaintext delivery whenever the receiving
+# MTA does not offer STARTTLS, silently downgrading mail in transit.
+resource "aws_sesv2_configuration_set" "transactional" {
+  configuration_set_name = "transactional"
+
+  delivery_options {
+    tls_policy = "OPTIONAL"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/pass/require-tls/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-terraform-hcl/pass/require-tls/main.tf
@@ -1,0 +1,11 @@
+resource "aws_sesv2_configuration_set" "transactional" {
+  configuration_set_name = "transactional"
+
+  delivery_options {
+    tls_policy = "REQUIRE"
+  }
+
+  reputation_options {
+    reputation_metrics_enabled = true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/fail/monitor-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/fail/monitor-only/main.tf
@@ -1,0 +1,10 @@
+# monitor mode reports unencrypted flows but does not block them, so traffic
+# still crosses the VPC in cleartext.
+resource "aws_vpc" "prod" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_encryption_control" "prod" {
+  vpc_id = aws_vpc.prod.id
+  mode   = "monitor"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/fail/no-encryption-control/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/fail/no-encryption-control/main.tf
@@ -1,0 +1,12 @@
+# A VPC with no encryption control declared at all: nothing enforces in-transit
+# encryption between instances.
+resource "aws_vpc" "prod" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.prod.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/pass/enforce/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-terraform-hcl/pass/enforce/main.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "prod" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_vpc_encryption_control" "prod" {
+  vpc_id = aws_vpc.prod.id
+  mode   = "enforce"
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-subnet-flow-logs-enabled-terraform-hcl/fail/subnet-without-flow-log/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-subnet-flow-logs-enabled-terraform-hcl/fail/subnet-without-flow-log/main.tf
@@ -1,0 +1,20 @@
+# One subnet has a flow log, the other does not. Traffic in private_b leaves no
+# network record.
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.prod.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.prod.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_flow_log" "private_a" {
+  subnet_id            = aws_subnet.private_a.id
+  traffic_type         = "ALL"
+  log_destination_type = "s3"
+  log_destination      = aws_s3_bucket.flow_logs.arn
+}

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-subnet-flow-logs-enabled-terraform-hcl/pass/flow-log-per-subnet/main.tf
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-subnet-flow-logs-enabled-terraform-hcl/pass/flow-log-per-subnet/main.tf
@@ -1,0 +1,12 @@
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.prod.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_flow_log" "private_a" {
+  subnet_id            = aws_subnet.private_a.id
+  traffic_type         = "ALL"
+  log_destination_type = "s3"
+  log_destination      = aws_s3_bucket.flow_logs.arn
+}


### PR DESCRIPTION
Round 4 of the push to 100% IaC-variant fixture coverage (rounds 1–3: #3271, #3273, #3275).

## Coverage

Fixtures for all **28** uncovered aws terraform-hcl variants:

| policy / suffix | before | after |
|---|---|---|
| mondoo-aws-security `-terraform-hcl` | 387/415 | **415/415** |

The aws terraform-hcl entry drops out of `iac-variant-coverage-budget.json`. Remaining: aws `-cloudformation` 21, azure 36 tf + 43 bicep.

## `iam-support-role`: a check that cannot fail

Its filter already requires the thing the query asserts:

```coffee
# filters
terraform.resources.contains(nameLabel == "aws_iam_role_policy_attachment" &&
  arguments["policy_arn"] == "arn:aws:iam::aws:policy/AWSSupportAccess")

# mql
terraform.resources.where(nameLabel == "aws_iam_role_policy_attachment").any(
  arguments['policy_arn'] == "arn:aws:iam::aws:policy/AWSSupportAccess")
```

Any config satisfying the filter satisfies the query; any config that would fail is filtered out and never scored. The variant can only be **passed** or **not applicable** — never failed.

That is a design gap, not a fixture gap, and it is the class already tracked in **issue #3118**. It gets a `fail/IMPOSSIBLE.md` marker recording the reasoning and what to do when #3118 lands (broaden the filter to the population that *should* have a support role, so a config lacking the attachment is scored and fails). Its pre-existing pass fixture is untouched.

## `efs-enforce-transit-encryption`: the harness's most intricate query

This one exercises two things that have historically been fragile together:

```coffee
goodPolicies = terraform.resources("aws_efs_file_system_policy").where(
  arguments["policy"].first["Statement"].where(_["Effect"] == "Deny").any(
    _["Condition"]["Bool"]["aws:SecureTransport"] != empty)
).map(arguments["file_system_id"]).join(",")
terraform.resources("aws_efs_file_system").all(goodPolicies.contains("." + labels[1] + "."))
```

— a `jsonencode`'d policy document indexed through `.first["Statement"]` (jsonencode of an object is list-wrapped), *and* a cross-resource match that joins `file_system_id` references and substring-matches the file system's own label. Both work.

One authoring constraint worth recording: the policy JSON is kept **fully static**, with literal ARNs rather than `aws_efs_file_system.shared.arn` references. A `jsonencode` containing an unresolved resource reference renders empty, which would make the pass fixture fail for a reason that has nothing to do with the control.

## No policy bugs this round

All 28 asserted correctly first time — same result as the alibaba round, and unlike rounds 1 and 2. These are largely newer AWS services (Bedrock, Security Lake, Network Firewall, VPC encryption control), which fits the pattern: recent checks were written against real provider shapes.

## Fixture notes

Scenarios split by failure mode rather than one pair per check:

- **lambda-no-deprecated-runtime** passes a container-image function that declares no `runtime` at all (out of scope, not a violation) and fails on two distinct EOL runtimes.
- **codebuild-s3-logs** passes when S3 logging is switched off entirely — that is what the check's `status == "ENABLED"` scoping intends, and the fixture pins it.
- **sagemaker data capture** passes with capture disabled, fails only when capture is on without a key.
- **networkfirewall change protection** fails both on all three flags omitted and on just `firewall_policy_change_protection = false`, since that single flag is the one that silently stops the firewall enforcing.

## Verification

```
aws terraform-hcl suite    294s at -parallel 8, 0 failures
TestTerraformVariantCoverage   ok  (budget regenerated and re-asserted)
```

No policy file changed — the diff is fixtures plus the budget entry removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
