### PR TITLE
✨ content: cover the AWS CloudFormation IaC-variant coverage gaps

### DIFF
--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -1,7 +1,4 @@
 {
-  "mondoo-aws-security": {
-    "-cloudformation": 21
-  },
   "mondoo-azure-security": {
     "-bicep": 43,
     "-terraform-hcl": 36

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-cloudformation/fail/default-endpoint-live/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-cloudformation/fail/default-endpoint-live/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # The execute-api endpoint stays reachable alongside the custom domain, so
+  # controls attached to the custom domain can be bypassed.
+  OrdersApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: orders-api
+      EndpointConfiguration:
+        Types:
+          - REGIONAL

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-cloudformation/pass/disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-disable-default-endpoint-cloudformation/pass/disabled/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  OrdersApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: orders-api
+      Description: Order service, fronted by a custom domain
+      DisableExecuteApiEndpoint: true
+      EndpointConfiguration:
+        Types:
+          - REGIONAL

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-cloudformation/fail/default-endpoint-live/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-cloudformation/fail/default-endpoint-live/template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EventsApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: events-api
+      ProtocolType: HTTP
+      DisableExecuteApiEndpoint: false

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-cloudformation/pass/disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-disable-default-endpoint-cloudformation/pass/disabled/template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EventsApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: events-api
+      ProtocolType: HTTP
+      DisableExecuteApiEndpoint: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/fail/validation-disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/fail/validation-disabled/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # With schema validation off, malformed or hostile request bodies reach the
+  # backend integration unchecked.
+  EventsApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: events-api
+      ProtocolType: HTTP
+      DisableSchemaValidation: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/pass/validation-default/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/pass/validation-default/template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # DisableSchemaValidation omitted, which leaves validation on.
+  EventsApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: events-api
+      ProtocolType: HTTP

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/pass/validation-on/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigatewayv2-schema-validation-enabled-cloudformation/pass/validation-on/template.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EventsApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: events-api
+      ProtocolType: HTTP
+      DisableSchemaValidation: false
+      DisableExecuteApiEndpoint: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-cloudformation/fail/aws-managed-key/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-cloudformation/fail/aws-managed-key/template.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # No KMSArn, so the flow falls back to the AWS-managed AppFlow key.
+  SalesforceToS3:
+    Type: AWS::AppFlow::Flow
+    Properties:
+      FlowName: salesforce-to-s3
+      SourceFlowConfig:
+        ConnectorType: Salesforce
+        SourceConnectorProperties:
+          Salesforce:
+            Object: Account
+      DestinationFlowConfigList:
+        - ConnectorType: S3
+          DestinationConnectorProperties:
+            S3:
+              BucketName: example-appflow-landing
+      TriggerConfig:
+        TriggerType: OnDemand
+      Tasks: []

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-cloudformation/pass/cmk/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appflow-flow-cmk-encryption-cloudformation/pass/cmk/template.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  SalesforceToS3:
+    Type: AWS::AppFlow::Flow
+    Properties:
+      FlowName: salesforce-to-s3
+      KMSArn: arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      SourceFlowConfig:
+        ConnectorType: Salesforce
+        SourceConnectorProperties:
+          Salesforce:
+            Object: Account
+      DestinationFlowConfigList:
+        - ConnectorType: S3
+          DestinationConnectorProperties:
+            S3:
+              BucketName: example-appflow-landing
+      TriggerConfig:
+        TriggerType: OnDemand
+      Tasks: []

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-cloudformation/fail/no-role/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-cloudformation/fail/no-role/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Without a fleet role, streaming instances cannot be granted scoped AWS
+  # access, so credentials get baked into the image or the session instead.
+  DesignersFleet:
+    Type: AWS::AppStream::Fleet
+    Properties:
+      Name: designers
+      InstanceType: stream.standard.medium
+      FleetType: ON_DEMAND
+      ImageName: AppStream-WinServer2019-06-17-2024
+      ComputeCapacity:
+        DesiredInstances: 2

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-cloudformation/pass/role-attached/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-iam-role-attached-cloudformation/pass/role-attached/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  DesignersFleet:
+    Type: AWS::AppStream::Fleet
+    Properties:
+      Name: designers
+      InstanceType: stream.standard.medium
+      FleetType: ON_DEMAND
+      ImageName: AppStream-WinServer2019-06-17-2024
+      IamRoleArn: arn:aws:iam::123456789012:role/appstream-streaming
+      ComputeCapacity:
+        DesiredInstances: 2

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-cloudformation/fail/imdsv1-allowed/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-cloudformation/fail/imdsv1-allowed/template.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # IMDSv1 is unauthenticated, so an SSRF or a compromised browser session on
+  # the streaming instance can read the fleet role credentials.
+  DesignersFleet:
+    Type: AWS::AppStream::Fleet
+    Properties:
+      Name: designers
+      InstanceType: stream.standard.medium
+      FleetType: ON_DEMAND
+      ImageName: AppStream-WinServer2019-06-17-2024
+      DisableIMDSV1: false
+      ComputeCapacity:
+        DesiredInstances: 2

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-cloudformation/pass/imdsv1-disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-appstream-fleet-imdsv2-cloudformation/pass/imdsv1-disabled/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  DesignersFleet:
+    Type: AWS::AppStream::Fleet
+    Properties:
+      Name: designers
+      InstanceType: stream.standard.medium
+      FleetType: ON_DEMAND
+      ImageName: AppStream-WinServer2019-06-17-2024
+      DisableIMDSV1: true
+      ComputeCapacity:
+        DesiredInstances: 2

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/fail/no-workgroup-configuration/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/fail/no-workgroup-configuration/template.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AnalyticsWorkGroup:
+    Type: AWS::Athena::WorkGroup
+    Properties:
+      Name: analytics

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/fail/not-enforced/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/fail/not-enforced/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Without minimum encryption enforcement a query author can override the
+  # workgroup's settings and write unencrypted results.
+  AnalyticsWorkGroup:
+    Type: AWS::Athena::WorkGroup
+    Properties:
+      Name: analytics
+      WorkGroupConfiguration:
+        EnforceWorkGroupConfiguration: true
+        EnableMinimumEncryptionConfiguration: false
+        ResultConfiguration:
+          OutputLocation: s3://example-athena-results/analytics/

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/pass/enforced/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-cloudformation/pass/enforced/template.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AnalyticsWorkGroup:
+    Type: AWS::Athena::WorkGroup
+    Properties:
+      Name: analytics
+      WorkGroupConfiguration:
+        EnforceWorkGroupConfiguration: true
+        EnableMinimumEncryptionConfiguration: true
+        ResultConfiguration:
+          OutputLocation: s3://example-athena-results/analytics/
+          EncryptionConfiguration:
+            EncryptionOption: SSE_KMS
+            KmsKey: arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-cloudformation/fail/encryption-disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-cloudformation/fail/encryption-disabled/template.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Build artifacts routinely contain source and dependencies; writing them
+  # unencrypted removes the last control on the bucket.
+  AppBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: app-build
+      ServiceRole: arn:aws:iam::123456789012:role/codebuild
+      Artifacts:
+        Type: S3
+        Location: example-build-artifacts
+        EncryptionDisabled: true
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      Source:
+        Type: GITHUB
+        Location: https://github.com/example/app.git

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-cloudformation/pass/encrypted/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-artifacts-encryption-not-disabled-cloudformation/pass/encrypted/template.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AppBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: app-build
+      ServiceRole: arn:aws:iam::123456789012:role/codebuild
+      Artifacts:
+        Type: S3
+        Location: example-build-artifacts
+        EncryptionDisabled: false
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      Source:
+        Type: GITHUB
+        Location: https://github.com/example/app.git

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/fail/unencrypted-logs/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/fail/unencrypted-logs/template.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Build logs echo environment variables and command output; storing them
+  # unencrypted exposes whatever the build printed.
+  AppBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: app-build
+      ServiceRole: arn:aws:iam::123456789012:role/codebuild
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      Source:
+        Type: GITHUB
+        Location: https://github.com/example/app.git
+      LogsConfig:
+        S3Logs:
+          Status: ENABLED
+          Location: example-build-logs/build-log
+          EncryptionDisabled: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/pass/encrypted-logs/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/pass/encrypted-logs/template.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AppBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: app-build
+      ServiceRole: arn:aws:iam::123456789012:role/codebuild
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      Source:
+        Type: GITHUB
+        Location: https://github.com/example/app.git
+      LogsConfig:
+        S3Logs:
+          Status: ENABLED
+          Location: example-build-logs/build-log
+          EncryptionDisabled: false

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/pass/s3-logs-disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-s3-logs-encryption-not-disabled-cloudformation/pass/s3-logs-disabled/template.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # S3 logging off entirely, so there is no unencrypted log object. The check
+  # scopes itself to ENABLED S3Logs.
+  AppBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: app-build
+      ServiceRole: arn:aws:iam::123456789012:role/codebuild
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      Source:
+        Type: GITHUB
+        Location: https://github.com/example/app.git
+      LogsConfig:
+        S3Logs:
+          Status: DISABLED
+          EncryptionDisabled: true
+        CloudWatchLogs:
+          Status: ENABLED

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/fail/aws-managed-key/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/fail/aws-managed-key/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Encrypted with the default aws/ebs key, which the account cannot rotate on
+  # its own schedule or deny access to independently.
+  AppDataVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone: us-east-1a
+      Size: 500
+      VolumeType: gp3
+      Encrypted: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/fail/unencrypted/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/fail/unencrypted/template.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AppDataVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone: us-east-1a
+      Size: 500
+      VolumeType: gp3
+      Encrypted: false

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/pass/cmk/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ec2-ebs-volume-cmk-encrypted-cloudformation/pass/cmk/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AppDataVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone: us-east-1a
+      Size: 500
+      VolumeType: gp3
+      Encrypted: true
+      KmsKeyId: arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/fail/no-policy/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/fail/no-policy/template.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Encryption at rest is on, but nothing requires clients to mount over TLS.
+  SharedFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      Encrypted: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/fail/policy-without-transport-condition/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/fail/policy-without-transport-condition/template.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # A file system policy exists, but it only grants access; nothing denies
+  # non-TLS mounts.
+  SharedFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      Encrypted: true
+      FileSystemPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowAppRole
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:role/app
+            Action:
+              - elasticfilesystem:ClientMount
+              - elasticfilesystem:ClientWrite

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/pass/deny-insecure-transport/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-efs-enforce-transit-encryption-cloudformation/pass/deny-insecure-transport/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  SharedFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      Encrypted: true
+      FileSystemPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action: "*"
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/fail/period-too-long/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/fail/period-too-long/template.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Rotation is enabled but stretched past a year, so a compromised key stays
+  # in service far longer than the control allows.
+  AppDataKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Application data key
+      EnableKeyRotation: true
+      RotationPeriodInDays: 2560
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:root
+            Action: "kms:*"
+            Resource: "*"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/pass/annual-rotation/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/pass/annual-rotation/template.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AppDataKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Application data key
+      EnableKeyRotation: true
+      RotationPeriodInDays: 365
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:root
+            Action: "kms:*"
+            Resource: "*"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/pass/rotation-disabled/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kms-cmk-rotation-period-cloudformation/pass/rotation-disabled/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Rotation not enabled, so the period bound does not apply. A separate check
+  # covers whether rotation should be on at all.
+  ImportedKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Key with imported material, which cannot auto-rotate
+      EnableKeyRotation: false
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:root
+            Action: "kms:*"
+            Resource: "*"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/fail/python38/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/fail/python38/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # python3.8 is past end of support: no security patches reach the runtime.
+  EventProcessor:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: event-processor
+      Role: arn:aws:iam::123456789012:role/lambda
+      Handler: index.handler
+      Runtime: python3.8
+      Code:
+        S3Bucket: example-lambda-artifacts
+        S3Key: processor.zip

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/pass/container-image/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/pass/container-image/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Image-based functions declare no Runtime, which the check treats as out of
+  # scope rather than as a deprecated runtime.
+  EventProcessor:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: event-processor
+      Role: arn:aws:iam::123456789012:role/lambda
+      PackageType: Image
+      Code:
+        ImageUri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/processor:1.4.2

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/pass/python313/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-lambda-no-deprecated-runtime-cloudformation/pass/python313/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EventProcessor:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: event-processor
+      Role: arn:aws:iam::123456789012:role/lambda
+      Handler: index.handler
+      Runtime: python3.13
+      Code:
+        S3Bucket: example-lambda-artifacts
+        S3Key: processor.zip

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-cloudformation/fail/open-access/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-cloudformation/fail/open-access/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # "open-access" is the built-in ACL that permits any user with any password to
+  # run any command, defeating MemoryDB authentication entirely.
+  SessionsCluster:
+    Type: AWS::MemoryDB::Cluster
+    Properties:
+      ClusterName: sessions
+      ACLName: open-access
+      NodeType: db.t4g.small
+      NumShards: 2
+      SubnetGroupName: private

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-cloudformation/pass/scoped-acl/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-memorydb-cluster-no-open-access-acl-cloudformation/pass/scoped-acl/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  SessionsCluster:
+    Type: AWS::MemoryDB::Cluster
+    Properties:
+      ClusterName: sessions
+      ACLName: app-users
+      NodeType: db.t4g.small
+      NumShards: 2
+      TLSEnabled: true
+      SubnetGroupName: private

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-cloudformation/fail/auto-upgrade-off/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-cloudformation/fail/auto-upgrade-off/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Minor versions carry the broker's security patches; pinning them off leaves
+  # known CVEs unpatched until someone upgrades by hand.
+  OrdersBroker:
+    Type: AWS::AmazonMQ::Broker
+    Properties:
+      BrokerName: orders
+      EngineType: ACTIVEMQ
+      EngineVersion: 5.18.4
+      HostInstanceType: mq.m5.large
+      DeploymentMode: SINGLE_INSTANCE
+      AutoMinorVersionUpgrade: false
+      PubliclyAccessible: false
+      Users:
+        - Username: admin
+          Password: "{{resolve:secretsmanager:mq/admin:SecretString:password}}"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-cloudformation/pass/auto-upgrade-on/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-mq-broker-auto-minor-version-upgrade-cloudformation/pass/auto-upgrade-on/template.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  OrdersBroker:
+    Type: AWS::AmazonMQ::Broker
+    Properties:
+      BrokerName: orders
+      EngineType: ACTIVEMQ
+      EngineVersion: 5.18.4
+      HostInstanceType: mq.m5.large
+      DeploymentMode: SINGLE_INSTANCE
+      AutoMinorVersionUpgrade: true
+      PubliclyAccessible: false
+      Users:
+        - Username: admin
+          Password: "{{resolve:secretsmanager:mq/admin:SecretString:password}}"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/fail/no-protections/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/fail/no-protections/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # All three protections default to false when omitted.
+  PerimeterFirewall:
+    Type: AWS::NetworkFirewall::Firewall
+    Properties:
+      FirewallName: perimeter
+      FirewallPolicyArn: arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/perimeter
+      VpcId: vpc-0123456789abcdef0
+      SubnetMappings:
+        - SubnetId: subnet-0123456789abcdef0

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/fail/policy-change-unprotected/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/fail/policy-change-unprotected/template.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # Delete and subnet protection are on, but the policy can be swapped — the
+  # change that silently stops the firewall from filtering.
+  PerimeterFirewall:
+    Type: AWS::NetworkFirewall::Firewall
+    Properties:
+      FirewallName: perimeter
+      FirewallPolicyArn: arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/perimeter
+      VpcId: vpc-0123456789abcdef0
+      DeleteProtection: true
+      FirewallPolicyChangeProtection: false
+      SubnetChangeProtection: true
+      SubnetMappings:
+        - SubnetId: subnet-0123456789abcdef0

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/pass/all-protections/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-change-protection-enabled-cloudformation/pass/all-protections/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  PerimeterFirewall:
+    Type: AWS::NetworkFirewall::Firewall
+    Properties:
+      FirewallName: perimeter
+      FirewallPolicyArn: arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/perimeter
+      VpcId: vpc-0123456789abcdef0
+      DeleteProtection: true
+      FirewallPolicyChangeProtection: true
+      SubnetChangeProtection: true
+      SubnetMappings:
+        - SubnetId: subnet-0123456789abcdef0

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-cloudformation/fail/no-destinations/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-cloudformation/fail/no-destinations/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # A logging configuration with no destinations records nothing, so alerts and
+  # flow records from the firewall are lost.
+  PerimeterFirewallLogging:
+    Type: AWS::NetworkFirewall::LoggingConfiguration
+    Properties:
+      FirewallArn: arn:aws:network-firewall:us-east-1:123456789012:firewall/perimeter
+      LoggingConfiguration:
+        LogDestinationConfigs: []

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-cloudformation/pass/flow-and-alert-logs/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-networkfirewall-logging-enabled-cloudformation/pass/flow-and-alert-logs/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  PerimeterFirewallLogging:
+    Type: AWS::NetworkFirewall::LoggingConfiguration
+    Properties:
+      FirewallArn: arn:aws:network-firewall:us-east-1:123456789012:firewall/perimeter
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - LogType: FLOW
+            LogDestinationType: S3
+            LogDestination:
+              bucketName: example-firewall-logs
+              prefix: flow/
+          - LogType: ALERT
+            LogDestinationType: CloudWatchLogs
+            LogDestination:
+              logGroup: /aws/network-firewall/alerts

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-cloudformation/fail/no-subnet/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-cloudformation/fail/no-subnet/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # With no subnet the notebook runs on the SageMaker-managed network, outside
+  # the VPC's segmentation, flow logs, and egress filtering.
+  ResearchNotebook:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      NotebookInstanceName: research-notebook
+      RoleArn: arn:aws:iam::123456789012:role/sagemaker
+      InstanceType: ml.t3.medium

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-cloudformation/pass/in-vpc/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-sagemaker-notebook-in-vpc-cloudformation/pass/in-vpc/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ResearchNotebook:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      NotebookInstanceName: research-notebook
+      RoleArn: arn:aws:iam::123456789012:role/sagemaker
+      InstanceType: ml.t3.medium
+      SubnetId: subnet-0123456789abcdef0
+      SecurityGroupIds:
+        - sg-0123456789abcdef0
+      DirectInternetAccess: Disabled
+      KmsKeyId: arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/fail/no-encryption-configuration/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/fail/no-encryption-configuration/template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # The security data lake aggregates findings and logs from the whole org, so
+  # it is exactly the store that should sit under a customer-controlled key.
+  PrimaryDataLake:
+    Type: AWS::SecurityLake::DataLake
+    Properties:
+      MetaStoreManagerRoleArn: arn:aws:iam::123456789012:role/securitylake

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/fail/s3-managed-key/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/fail/s3-managed-key/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # S3_MANAGED_KEY is the literal Security Lake accepts to mean "no customer
+  # key". It reads as configured encryption while leaving the org's aggregated
+  # security logs outside customer key control.
+  PrimaryDataLake:
+    Type: AWS::SecurityLake::DataLake
+    Properties:
+      MetaStoreManagerRoleArn: arn:aws:iam::123456789012:role/securitylake
+      EncryptionConfiguration:
+        KmsKeyId: S3_MANAGED_KEY

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/pass/customer-key/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation/pass/customer-key/template.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  PrimaryDataLake:
+    Type: AWS::SecurityLake::DataLake
+    Properties:
+      MetaStoreManagerRoleArn: arn:aws:iam::123456789012:role/securitylake
+      EncryptionConfiguration:
+        KmsKeyId: arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/fail/no-delivery-options/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/fail/no-delivery-options/template.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # With no DeliveryOptions the set inherits the OPTIONAL default.
+  TransactionalSet:
+    Type: AWS::SES::ConfigurationSet
+    Properties:
+      Name: transactional
+      ReputationOptions:
+        ReputationMetricsEnabled: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/fail/opportunistic-tls/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/fail/opportunistic-tls/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  # OPTIONAL means SES falls back to plaintext whenever the receiving MTA does
+  # not offer STARTTLS, silently downgrading mail in transit.
+  TransactionalSet:
+    Type: AWS::SES::ConfigurationSet
+    Properties:
+      Name: transactional
+      DeliveryOptions:
+        TlsPolicy: OPTIONAL

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/pass/require-tls/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ses-configuration-set-require-tls-cloudformation/pass/require-tls/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  TransactionalSet:
+    Type: AWS::SES::ConfigurationSet
+    Properties:
+      Name: transactional
+      DeliveryOptions:
+        TlsPolicy: REQUIRE
+      ReputationOptions:
+        ReputationMetricsEnabled: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-cloudformation/fail/monitor-only/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-cloudformation/fail/monitor-only/template.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ProdVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+
+  # monitor mode reports unencrypted flows but does not block them, so traffic
+  # still crosses the VPC in cleartext.
+  ProdVpcEncryption:
+    Type: AWS::EC2::VPCEncryptionControl
+    Properties:
+      VpcId: !Ref ProdVpc
+      Mode: monitor

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-cloudformation/pass/enforce/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-vpc-encryption-in-transit-enforced-cloudformation/pass/enforce/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ProdVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsHostnames: true
+
+  ProdVpcEncryption:
+    Type: AWS::EC2::VPCEncryptionControl
+    Properties:
+      VpcId: !Ref ProdVpc
+      Mode: enforce

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -1167,10 +1167,14 @@ queries:
       )
   - uid: mondoo-aws-security-securitylake-data-lake-cmk-encryption-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::SecurityLake::DataLake")
+    # S3_MANAGED_KEY is the literal Security Lake accepts to mean "no customer
+    # key", so a present-but-S3_MANAGED_KEY value is exactly the state this
+    # check exists to flag. The terraform-hcl sibling already excludes it.
     mql: |
       cloudformation.template.resources.where(type == "AWS::SecurityLake::DataLake").all(
       properties['EncryptionConfiguration'] != empty &&
-      properties['EncryptionConfiguration']['KmsKeyId'] != empty
+      properties['EncryptionConfiguration']['KmsKeyId'] != empty &&
+      properties['EncryptionConfiguration']['KmsKeyId'] != "S3_MANAGED_KEY"
       )
   - uid: mondoo-aws-security-networkfirewall-logging-enabled
     title: Ensure Network Firewall firewalls have logging enabled


### PR DESCRIPTION
Round 5 of the push to 100% IaC-variant fixture coverage (rounds 1–4: #3271, #3273, #3275, #3276).

## Coverage

Fixtures for all **21** uncovered aws cloudformation variants:

| policy / suffix | before | after |
|---|---|---|
| mondoo-aws-security `-cloudformation` | 298/319 | **319/319** |

**`mondoo-aws-security` is now fully covered across both of its IaC suffixes.** The budget file is down to a single policy:

```json
{ "mondoo-azure-security": { "-bicep": 43, "-terraform-hcl": 36 } }
```

## A variant divergence the fixtures exposed

`securitylake-data-lake-cmk-encryption` asserted different things in its two IaC variants:

```coffee
# terraform-hcl
arguments.kms_key_id != empty && arguments.kms_key_id != "S3_MANAGED_KEY"

# cloudformation  (before)
properties['EncryptionConfiguration']['KmsKeyId'] != empty
```

`S3_MANAGED_KEY` is the literal Security Lake accepts to mean *no customer key*. So a template with:

```yaml
EncryptionConfiguration:
  KmsKeyId: S3_MANAGED_KEY
```

read as configured encryption and scored **compliant** under CloudFormation, while the identical intent expressed in Terraform correctly **failed**. Same check, same control, opposite verdicts depending on which IaC language you happened to write.

Added the missing clause to the cloudformation query and a `fail/s3-managed-key` fixture pinning it. This is the "variant siblings must reach the same determination" rule — and it was only visible because writing the fail fixture forced the question "what does a *failing* Security Lake template actually look like?"

## Otherwise clean

Everything else asserted correctly first time. Worth noting why CloudFormation is the easiest surface so far: templates parse to plain property dicts, so there is none of the nested-block-versus-attribute ambiguity that produced the openstack bug (#3271) and none of the list-comparison subtlety behind the snowflake bugs (#3273). The failure modes that bit HCL simply don't have an analogue here.

## Fixture notes

Scenarios preserve the distinctions the queries actually make:

- **codebuild-s3-logs** passes with S3 logging switched off entirely — the query scopes to `Status == "ENABLED"`, and the fixture pins that intent.
- **lambda-no-deprecated-runtime** passes a container-image function with no `Runtime` property at all.
- **apigatewayv2-schema-validation** passes both `DisableSchemaValidation: false` and the property omitted, since omitted means validation stays on.
- **networkfirewall change protection** fails both on all three flags omitted and on `FirewallPolicyChangeProtection` alone being false.

## Verification

```
full CloudFormation suite   190s at -parallel 8, 0 failures
cnspec policy lint mondoo-aws-security.mql.yaml   valid
TestTerraformVariantCoverage   ok  (budget regenerated and re-asserted)
```

The one pre-existing lint warning (`aws.iam.role.inlinePolicies` deprecated, on an unrelated sagemaker check) is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
