### PR TITLE
✨ content: cover the Azure terraform-hcl IaC-variant coverage gaps

### DIFF
--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -1,6 +1,5 @@
 {
   "mondoo-azure-security": {
-    "-bicep": 43,
-    "-terraform-hcl": 36
+    "-bicep": 43
   }
 }

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-terraform-hcl/fail/public-access/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-terraform-hcl/fail/public-access/main.tf
@@ -1,0 +1,10 @@
+# The gateway and its management plane stay reachable from the public internet.
+resource "azurerm_api_management" "internal" {
+  name                          = "internal-apim"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  publisher_name                = "Example Corp"
+  publisher_email               = "platform@example.com"
+  sku_name                      = "Developer_1"
+  public_network_access_enabled = true
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-terraform-hcl/pass/private-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-terraform-hcl/pass/private-only/main.tf
@@ -1,0 +1,10 @@
+resource "azurerm_api_management" "internal" {
+  name                          = "internal-apim"
+  location                      = azurerm_resource_group.prod.location
+  resource_group_name           = azurerm_resource_group.prod.name
+  publisher_name                = "Example Corp"
+  publisher_email               = "platform@example.com"
+  sku_name                      = "Developer_1"
+  virtual_network_type          = "Internal"
+  public_network_access_enabled = false
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/fail/ssl30-enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/fail/ssl30-enabled/main.tf
@@ -1,0 +1,16 @@
+# SSL 3.0 is broken by POODLE and has been deprecated for a decade; enabling it
+# on the frontend downgrades every client that will negotiate it.
+resource "azurerm_api_management" "internal" {
+  name                = "internal-apim"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  publisher_name      = "Example Corp"
+  publisher_email     = "platform@example.com"
+  sku_name            = "Developer_1"
+
+  security {
+    frontend_ssl30_enabled     = true
+    backend_ssl30_enabled      = false
+    triple_des_ciphers_enabled = false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/fail/triple-des/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/fail/triple-des/main.tf
@@ -1,0 +1,15 @@
+# 3DES is a 64-bit block cipher vulnerable to Sweet32.
+resource "azurerm_api_management" "internal" {
+  name                = "internal-apim"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  publisher_name      = "Example Corp"
+  publisher_email     = "platform@example.com"
+  sku_name            = "Developer_1"
+
+  security {
+    frontend_ssl30_enabled     = false
+    backend_ssl30_enabled      = false
+    triple_des_ciphers_enabled = true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/pass/modern-protocols/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-terraform-hcl/pass/modern-protocols/main.tf
@@ -1,0 +1,16 @@
+resource "azurerm_api_management" "internal" {
+  name                = "internal-apim"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  publisher_name      = "Example Corp"
+  publisher_email     = "platform@example.com"
+  sku_name            = "Developer_1"
+
+  security {
+    frontend_ssl30_enabled     = false
+    backend_ssl30_enabled      = false
+    triple_des_ciphers_enabled = false
+    frontend_tls10_enabled     = false
+    backend_tls10_enabled      = false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/fail/allow-anonymous/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/fail/allow-anonymous/main.tf
@@ -1,0 +1,18 @@
+# Authentication is configured but anonymous requests are still served, so the
+# app's own code is the only thing standing between the internet and its data.
+resource "azurerm_linux_web_app" "portal" {
+  name                = "example-portal"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+
+  site_config {}
+
+  auth_settings_v2 {
+    auth_enabled           = true
+    require_authentication = false
+    unauthenticated_action = "AllowAnonymous"
+
+    login {}
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/fail/no-auth-block/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/fail/no-auth-block/main.tf
@@ -1,0 +1,9 @@
+# No auth_settings_v2 at all: the platform performs no authentication.
+resource "azurerm_windows_web_app" "portal" {
+  name                = "example-portal"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+
+  site_config {}
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/pass/auth-required/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-terraform-hcl/pass/auth-required/main.tf
@@ -1,0 +1,23 @@
+resource "azurerm_linux_web_app" "portal" {
+  name                = "example-portal"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+
+  site_config {}
+
+  auth_settings_v2 {
+    auth_enabled           = true
+    require_authentication = true
+    unauthenticated_action = "RedirectToLoginPage"
+    default_provider       = "azureactivedirectory"
+
+    active_directory_v2 {
+      client_id                  = var.aad_client_id
+      tenant_auth_endpoint       = "https://login.microsoftonline.com/${var.tenant_id}/v2.0"
+      client_secret_setting_name = "AAD_CLIENT_SECRET"
+    }
+
+    login {}
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl/fail/validation-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl/fail/validation-off/main.tf
@@ -1,0 +1,58 @@
+# The gateway speaks HTTPS to the backend but does not verify its certificate
+# chain, so the encrypted hop can be man-in-the-middled inside the VNet.
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "https"
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                                 = "app-https"
+    cookie_based_affinity                = "Disabled"
+    port                                 = 443
+    protocol                             = "Https"
+    request_timeout                      = 30
+    certificate_chain_validation_enabled = false
+  }
+
+  http_listener {
+    name                           = "https-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "https"
+    protocol                       = "Https"
+    ssl_certificate_name           = "app-cert"
+  }
+
+  request_routing_rule {
+    name                       = "https-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "https-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-https"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl/pass/validation-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-terraform-hcl/pass/validation-on/main.tf
@@ -1,0 +1,56 @@
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "https"
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                                 = "app-https"
+    cookie_based_affinity                = "Disabled"
+    port                                 = 443
+    protocol                             = "Https"
+    request_timeout                      = 30
+    certificate_chain_validation_enabled = true
+  }
+
+  http_listener {
+    name                           = "https-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "https"
+    protocol                       = "Https"
+    ssl_certificate_name           = "app-cert"
+  }
+
+  request_routing_rule {
+    name                       = "https-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "https-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-https"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-terraform-hcl/fail/http-backend/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-terraform-hcl/fail/http-backend/main.tf
@@ -1,0 +1,57 @@
+# TLS terminates at the gateway and the hop to the backend pool is plaintext,
+# so traffic crosses the VNet unencrypted.
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "https"
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                  = "app-http"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "https-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "https"
+    protocol                       = "Https"
+    ssl_certificate_name           = "app-cert"
+  }
+
+  request_routing_rule {
+    name                       = "https-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "https-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-http"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-terraform-hcl/pass/https-backend/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-terraform-hcl/pass/https-backend/main.tf
@@ -1,0 +1,56 @@
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "https"
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                                = "app-https"
+    cookie_based_affinity               = "Disabled"
+    port                                = 443
+    protocol                            = "Https"
+    request_timeout                     = 30
+    certificate_chain_validation_enabled = true
+  }
+
+  http_listener {
+    name                           = "https-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "https"
+    protocol                       = "Https"
+    ssl_certificate_name           = "app-cert"
+  }
+
+  request_routing_rule {
+    name                       = "https-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "https-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-https"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-terraform-hcl/fail/plain-http-listener/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-terraform-hcl/fail/plain-http-listener/main.tf
@@ -1,0 +1,56 @@
+# A plain HTTP listener accepts unencrypted client traffic, including any
+# credentials or session cookies sent before a redirect could take effect.
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "http"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                  = "app-https"
+    cookie_based_affinity = "Disabled"
+    port                  = 443
+    protocol              = "Https"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "http-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "http"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "http-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "http-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-https"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-terraform-hcl/pass/https-listener/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-terraform-hcl/pass/https-listener/main.tf
@@ -1,0 +1,55 @@
+resource "azurerm_application_gateway" "public" {
+  name                = "public-appgw"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_port {
+    name = "https"
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                 = "public-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  backend_address_pool {
+    name = "app-pool"
+  }
+
+  backend_http_settings {
+    name                  = "app-https"
+    cookie_based_affinity = "Disabled"
+    port                  = 443
+    protocol              = "Https"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "https-listener"
+    frontend_ip_configuration_name = "public-ip"
+    frontend_port_name             = "https"
+    protocol                       = "Https"
+    ssl_certificate_name           = "app-cert"
+  }
+
+  request_routing_rule {
+    name                       = "https-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "https-listener"
+    backend_address_pool_name  = "app-pool"
+    backend_http_settings_name = "app-https"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,19 @@
+# The policy exists and is attached, but is switched off, so no rule in it is
+# evaluated. This reads as protected in an inventory while filtering nothing.
+resource "azurerm_web_application_firewall_policy" "public" {
+  name                = "public-waf"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  policy_settings {
+    enabled = false
+    mode    = "Detection"
+  }
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/fail/no-policy-settings/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/fail/no-policy-settings/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_web_application_firewall_policy" "public" {
+  name                = "public-waf"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_web_application_firewall_policy" "public" {
+  name                = "public-waf"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  policy_settings {
+    enabled                     = true
+    mode                        = "Prevention"
+    request_body_check          = true
+    max_request_body_size_in_kb = 128
+  }
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl/fail/body-check-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl/fail/body-check-off/main.tf
@@ -1,0 +1,20 @@
+# With body inspection off the WAF only sees headers and the URL, so SQL
+# injection and similar payloads delivered in a POST body pass straight through.
+resource "azurerm_web_application_firewall_policy" "public" {
+  name                = "public-waf"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  policy_settings {
+    enabled            = true
+    mode               = "Prevention"
+    request_body_check = false
+  }
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl/pass/body-check-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-terraform-hcl/pass/body-check-on/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_web_application_firewall_policy" "public" {
+  name                = "public-waf"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  policy_settings {
+    enabled                     = true
+    mode                        = "Prevention"
+    request_body_check          = true
+    max_request_body_size_in_kb = 128
+  }
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl/fail/microsoft-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl/fail/microsoft-managed-key/main.tf
@@ -1,0 +1,9 @@
+# Without a customer_managed_key block the account's stored data, including
+# uploaded training and inference content, uses the Microsoft-managed key.
+resource "azurerm_cognitive_account" "vision" {
+  name                = "vision"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  kind                = "ComputerVision"
+  sku_name            = "S1"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,15 @@
+resource "azurerm_cognitive_account" "vision" {
+  name                = "vision"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  kind                = "ComputerVision"
+  sku_name            = "S1"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  customer_managed_key {
+    key_vault_key_id = azurerm_key_vault_key.cognitive.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl/fail/unrestricted/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl/fail/unrestricted/main.tf
@@ -1,0 +1,10 @@
+# The service can reach any outbound host, so a prompt-injected or misconfigured
+# workload can use it to exfiltrate data to an arbitrary endpoint.
+resource "azurerm_cognitive_account" "vision" {
+  name                               = "vision"
+  location                           = azurerm_resource_group.prod.location
+  resource_group_name                = azurerm_resource_group.prod.name
+  kind                               = "ComputerVision"
+  sku_name                           = "S1"
+  outbound_network_access_restricted = false
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl/pass/restricted/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-terraform-hcl/pass/restricted/main.tf
@@ -1,0 +1,9 @@
+resource "azurerm_cognitive_account" "vision" {
+  name                               = "vision"
+  location                           = azurerm_resource_group.prod.location
+  resource_group_name                = azurerm_resource_group.prod.name
+  kind                               = "ComputerVision"
+  sku_name                           = "S1"
+  outbound_network_access_restricted = true
+  fqdns                              = ["storage.example.com"]
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl/fail/wildcard-origin/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl/fail/wildcard-origin/main.tf
@@ -1,0 +1,31 @@
+# A "*" origin lets any site on the internet make cross-origin calls to the API
+# with the browser's ambient credentials.
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+
+    cors {
+      allowed_origins = ["*"]
+    }
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl/pass/scoped-origins/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-terraform-hcl/pass/scoped-origins/main.tf
@@ -1,0 +1,29 @@
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+
+    cors {
+      allowed_origins = ["https://app.example.com", "https://admin.example.com"]
+    }
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/fail/external-unrestricted/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/fail/external-unrestricted/main.tf
@@ -1,0 +1,26 @@
+# Externally reachable with no IP restrictions at all.
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/pass/external-with-restrictions/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/pass/external-with-restrictions/main.tf
@@ -1,0 +1,31 @@
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+
+    ip_security_restriction {
+      name             = "corporate-egress"
+      action           = "Allow"
+      ip_address_range = "203.0.113.0/24"
+    }
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/pass/internal-ingress/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-terraform-hcl/pass/internal-ingress/main.tf
@@ -1,0 +1,27 @@
+# Internal-only ingress needs no IP allow list: it is not reachable from
+# outside the container app environment.
+resource "azurerm_container_app" "worker" {
+  name                         = "worker"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = false
+    target_port      = 8080
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    container {
+      name   = "worker"
+      image  = "example.azurecr.io/worker:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-terraform-hcl/fail/no-identity/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-terraform-hcl/fail/no-identity/main.tf
@@ -1,0 +1,17 @@
+# With no managed identity the app authenticates to Azure services with
+# long-lived secrets carried in configuration instead.
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-terraform-hcl/pass/system-assigned/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-terraform-hcl/pass/system-assigned/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_container_app" "api" {
+  name                         = "api"
+  container_app_environment_id = azurerm_container_app_environment.prod.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  revision_mode                = "Single"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "example.azurecr.io/api:1.4.2"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl/fail/any-any-allow/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl/fail/any-any-allow/main.tf
@@ -1,0 +1,21 @@
+# Any source to any destination, allowed. A rule like this makes every other
+# rule in the policy irrelevant.
+resource "azurerm_firewall_policy_rule_collection_group" "prod" {
+  name               = "prod-rules"
+  firewall_policy_id = azurerm_firewall_policy.prod.id
+  priority           = 500
+
+  network_rule_collection {
+    name     = "allow-all"
+    priority = 400
+    action   = "Allow"
+
+    rule {
+      name                  = "any-any"
+      protocols             = ["Any"]
+      source_addresses      = ["*"]
+      destination_addresses = ["*"]
+      destination_ports     = ["*"]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl/pass/scoped-rule/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-terraform-hcl/pass/scoped-rule/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_firewall_policy_rule_collection_group" "prod" {
+  name               = "prod-rules"
+  firewall_policy_id = azurerm_firewall_policy.prod.id
+  priority           = 500
+
+  network_rule_collection {
+    name     = "allow-app-to-db"
+    priority = 400
+    action   = "Allow"
+
+    rule {
+      name                  = "app-to-sql"
+      protocols             = ["TCP"]
+      source_addresses      = ["10.0.1.0/24"]
+      destination_addresses = ["10.0.2.10"]
+      destination_ports     = ["1433"]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl/fail/dnat-to-ssh/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl/fail/dnat-to-ssh/main.tf
@@ -1,0 +1,23 @@
+# DNAT publishing SSH straight to an internal host, which puts a management
+# port on the public internet behind a single NAT rule.
+resource "azurerm_firewall_policy_rule_collection_group" "prod" {
+  name               = "prod-rules"
+  firewall_policy_id = azurerm_firewall_policy.prod.id
+  priority           = 500
+
+  nat_rule_collection {
+    name     = "inbound-admin"
+    priority = 300
+    action   = "Dnat"
+
+    rule {
+      name                = "ssh-jump"
+      protocols           = ["TCP"]
+      source_addresses    = ["*"]
+      destination_address = "203.0.113.10"
+      destination_ports   = ["2222"]
+      translated_address  = "10.0.1.5"
+      translated_port     = "22"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl/pass/dnat-app-port/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-terraform-hcl/pass/dnat-app-port/main.tf
@@ -1,0 +1,21 @@
+resource "azurerm_firewall_policy_rule_collection_group" "prod" {
+  name               = "prod-rules"
+  firewall_policy_id = azurerm_firewall_policy.prod.id
+  priority           = 500
+
+  nat_rule_collection {
+    name     = "inbound-web"
+    priority = 300
+    action   = "Dnat"
+
+    rule {
+      name                = "web"
+      protocols           = ["TCP"]
+      source_addresses    = ["*"]
+      destination_address = "203.0.113.10"
+      destination_ports   = ["443"]
+      translated_address  = "10.0.1.10"
+      translated_port     = "8443"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl/fail/traffic-bypass/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl/fail/traffic-bypass/main.tf
@@ -1,0 +1,19 @@
+# A bypass rule exempts traffic from intrusion detection entirely. Broad
+# bypasses are how IDPS ends up enabled but blind on the paths that matter.
+resource "azurerm_firewall_policy" "prod" {
+  name                = "prod-policy"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+  sku                 = "Premium"
+
+  intrusion_detection {
+    mode = "Deny"
+
+    traffic_bypass {
+      name              = "skip-partner-traffic"
+      protocol          = "TCP"
+      source_addresses  = ["10.0.0.0/8"]
+      destination_ports = ["443"]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl/pass/no-bypass/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-terraform-hcl/pass/no-bypass/main.tf
@@ -1,0 +1,10 @@
+resource "azurerm_firewall_policy" "prod" {
+  name                = "prod-policy"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+  sku                 = "Premium"
+
+  intrusion_detection {
+    mode = "Deny"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/fail/plain-ftp-allowed/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/fail/plain-ftp-allowed/main.tf
@@ -1,0 +1,14 @@
+# AllAllowed permits plaintext FTP, so deployment credentials and function code
+# cross the network unencrypted.
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    ftps_state = "AllAllowed"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/pass/ftp-disabled/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/pass/ftp-disabled/main.tf
@@ -1,0 +1,13 @@
+# FTP deployment turned off entirely, which is stricter than requiring FTPS.
+resource "azurerm_windows_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    ftps_state = "Disabled"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/pass/ftps-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-terraform-hcl/pass/ftps-only/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    ftps_state = "FtpsOnly"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl/fail/default-allow/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl/fail/default-allow/main.tf
@@ -1,0 +1,21 @@
+# Allow-by-default turns the allow list into decoration: anything not named is
+# still permitted.
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    ip_restriction_default_action = "Allow"
+
+    ip_restriction {
+      name       = "corporate-egress"
+      action     = "Allow"
+      ip_address = "203.0.113.0/24"
+      priority   = 100
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl/pass/default-deny/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-terraform-hcl/pass/default-deny/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    ip_restriction_default_action = "Deny"
+
+    ip_restriction {
+      name       = "corporate-egress"
+      action     = "Allow"
+      ip_address = "203.0.113.0/24"
+      priority   = 100
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl/fail/debugging-on/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl/fail/debugging-on/main.tf
@@ -1,0 +1,14 @@
+# Remote debugging opens an authenticated but powerful channel into the running
+# app; it is meant to be temporary and is routinely left on after a debug session.
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    remote_debugging_enabled = true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl/pass/debugging-off/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-terraform-hcl/pass/debugging-off/main.tf
@@ -1,0 +1,13 @@
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  site_config {
+    remote_debugging_enabled = false
+    ftps_state               = "FtpsOnly"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl/fail/inline-secret/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl/fail/inline-secret/main.tf
@@ -1,0 +1,17 @@
+# A literal connection string in app settings is readable by anyone with
+# Contributor on the app, and it lands in the Terraform state as well.
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  app_settings = {
+    "FUNCTIONS_WORKER_RUNTIME" = "python"
+    "DB_CONNECTIONSTRING"      = "Server=tcp:example.database.windows.net;User ID=app;Password=P@ssw0rd-not-a-real-secret;"
+  }
+
+  site_config {}
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl/pass/key-vault-references/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl/pass/key-vault-references/main.tf
@@ -1,0 +1,16 @@
+resource "azurerm_linux_function_app" "processor" {
+  name                = "event-processor"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  service_plan_id     = azurerm_service_plan.prod.id
+  storage_account_name       = azurerm_storage_account.functions.name
+  storage_account_access_key = azurerm_storage_account.functions.primary_access_key
+
+  app_settings = {
+    "FUNCTIONS_WORKER_RUNTIME" = "python"
+    "DB_CONNECTIONSTRING"      = "@Microsoft.KeyVault(SecretUri=https://example-kv.vault.azure.net/secrets/db-connection/)"
+    "PARTNER_APIKEY"           = "@Microsoft.KeyVault(SecretUri=https://example-kv.vault.azure.net/secrets/partner-api-key/)"
+  }
+
+  site_config {}
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/fail/default-allow/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/fail/default-allow/main.tf
@@ -1,0 +1,22 @@
+# Allow-by-default means the IP rules constrain nothing: every address that is
+# not explicitly listed still reaches the hub.
+resource "azurerm_iothub" "fleet" {
+  name                = "fleet-hub"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  sku {
+    name     = "S1"
+    capacity = 1
+  }
+
+  network_rule_set {
+    default_action = "Allow"
+
+    ip_rule {
+      name    = "corporate-egress"
+      ip_mask = "203.0.113.0/24"
+      action  = "Allow"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/fail/no-network-rule-set/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/fail/no-network-rule-set/main.tf
@@ -1,0 +1,12 @@
+# With no network_rule_set the hub accepts device and service connections from
+# any network.
+resource "azurerm_iothub" "fleet" {
+  name                = "fleet-hub"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  sku {
+    name     = "S1"
+    capacity = 1
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/pass/default-deny/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-terraform-hcl/pass/default-deny/main.tf
@@ -1,0 +1,21 @@
+resource "azurerm_iothub" "fleet" {
+  name                = "fleet-hub"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  sku {
+    name     = "S1"
+    capacity = 1
+  }
+
+  network_rule_set {
+    default_action                     = "Deny"
+    apply_to_builtin_eventhub_endpoint = true
+
+    ip_rule {
+      name    = "corporate-egress"
+      ip_mask = "203.0.113.0/24"
+      action  = "Allow"
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-terraform-hcl/fail/no-key-name/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-terraform-hcl/fail/no-key-name/main.tf
@@ -1,0 +1,7 @@
+# The CMK association is declared but names no key, so the cluster keeps
+# Microsoft-managed encryption.
+resource "azurerm_kusto_cluster_customer_managed_key" "analytics" {
+  cluster_id   = azurerm_kusto_cluster.analytics.id
+  key_vault_id = azurerm_key_vault.prod.id
+  key_name     = ""
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,6 @@
+resource "azurerm_kusto_cluster_customer_managed_key" "analytics" {
+  cluster_id   = azurerm_kusto_cluster.analytics.id
+  key_vault_id = azurerm_key_vault.prod.id
+  key_name     = azurerm_key_vault_key.kusto.name
+  key_version  = azurerm_key_vault_key.kusto.version
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl/fail/no-expiry/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl/fail/no-expiry/main.tf
@@ -1,0 +1,9 @@
+# A key with no expiration date stays valid indefinitely, so there is no
+# forcing function for rotation.
+resource "azurerm_key_vault_managed_hardware_security_module_key" "signing" {
+  name           = "payment-signing"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.prod.id
+  key_type       = "EC-HSM"
+  curve          = "P-256"
+  key_opts       = ["sign", "verify"]
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl/pass/expiry-set/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-terraform-hcl/pass/expiry-set/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_key_vault_managed_hardware_security_module_key" "signing" {
+  name           = "payment-signing"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.prod.id
+  key_type       = "EC-HSM"
+  curve          = "P-256"
+  key_opts       = ["sign", "verify"]
+  expiration_date = "2027-01-01T00:00:00Z"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl/fail/default-allow/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl/fail/default-allow/main.tf
@@ -1,0 +1,16 @@
+# An HSM holding the organization's root key material, reachable from any
+# network by default.
+resource "azurerm_key_vault_managed_hardware_security_module" "prod" {
+  name                       = "prod-hsm"
+  resource_group_name        = azurerm_resource_group.prod.name
+  location                   = azurerm_resource_group.prod.location
+  sku_name                   = "Standard_B1"
+  tenant_id                  = var.tenant_id
+  admin_object_ids           = [var.hsm_admin_object_id]
+  soft_delete_retention_days = 90
+
+  network_acls {
+    bypass         = "AzureServices"
+    default_action = "Allow"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl/pass/default-deny/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-terraform-hcl/pass/default-deny/main.tf
@@ -1,0 +1,15 @@
+resource "azurerm_key_vault_managed_hardware_security_module" "prod" {
+  name                       = "prod-hsm"
+  resource_group_name        = azurerm_resource_group.prod.name
+  location                   = azurerm_resource_group.prod.location
+  sku_name                   = "Standard_B1"
+  tenant_id                  = var.tenant_id
+  admin_object_ids           = [var.hsm_admin_object_id]
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 90
+
+  network_acls {
+    bypass         = "AzureServices"
+    default_action = "Deny"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl/fail/seven-days/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl/fail/seven-days/main.tf
@@ -1,0 +1,11 @@
+# A seven-day window gives very little time to notice and reverse a malicious
+# or mistaken deletion of the HSM.
+resource "azurerm_key_vault_managed_hardware_security_module" "prod" {
+  name                       = "prod-hsm"
+  resource_group_name        = azurerm_resource_group.prod.name
+  location                   = azurerm_resource_group.prod.location
+  sku_name                   = "Standard_B1"
+  tenant_id                  = var.tenant_id
+  admin_object_ids           = [var.hsm_admin_object_id]
+  soft_delete_retention_days = 7
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl/pass/ninety-days/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-terraform-hcl/pass/ninety-days/main.tf
@@ -1,0 +1,10 @@
+resource "azurerm_key_vault_managed_hardware_security_module" "prod" {
+  name                       = "prod-hsm"
+  resource_group_name        = azurerm_resource_group.prod.name
+  location                   = azurerm_resource_group.prod.location
+  sku_name                   = "Standard_B1"
+  tenant_id                  = var.tenant_id
+  admin_object_ids           = [var.hsm_admin_object_id]
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 90
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl/fail/microsoft-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl/fail/microsoft-managed-key/main.tf
@@ -1,0 +1,14 @@
+# Training data, models, and notebooks in the workspace stay under the
+# Microsoft-managed key.
+resource "azurerm_machine_learning_workspace" "research" {
+  name                    = "research-ml"
+  location                = azurerm_resource_group.prod.location
+  resource_group_name     = azurerm_resource_group.prod.name
+  application_insights_id = azurerm_application_insights.ml.id
+  key_vault_id            = azurerm_key_vault.prod.id
+  storage_account_id      = azurerm_storage_account.ml.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,17 @@
+resource "azurerm_machine_learning_workspace" "research" {
+  name                    = "research-ml"
+  location                = azurerm_resource_group.prod.location
+  resource_group_name     = azurerm_resource_group.prod.name
+  application_insights_id = azurerm_application_insights.ml.id
+  key_vault_id            = azurerm_key_vault.prod.id
+  storage_account_id      = azurerm_storage_account.ml.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  encryption {
+    key_vault_id = azurerm_key_vault.prod.id
+    key_id       = azurerm_key_vault_key.ml.id
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-terraform-hcl/fail/three-days/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-terraform-hcl/fail/three-days/main.tf
@@ -1,0 +1,16 @@
+# Three days of backups is not enough to recover from corruption or ransomware
+# that is noticed after a weekend.
+resource "azurerm_mysql_server" "app" {
+  name                = "app-mysql"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  sku_name            = "GP_Gen5_2"
+  version             = "5.7"
+  storage_mb          = 51200
+
+  administrator_login          = "mysqladmin"
+  administrator_login_password = var.mysql_password
+
+  backup_retention_days   = 3
+  ssl_enforcement_enabled = true
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-terraform-hcl/pass/thirty-days/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-terraform-hcl/pass/thirty-days/main.tf
@@ -1,0 +1,15 @@
+resource "azurerm_mysql_server" "app" {
+  name                = "app-mysql"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  sku_name            = "GP_Gen5_2"
+  version             = "5.7"
+  storage_mb          = 51200
+
+  administrator_login          = "mysqladmin"
+  administrator_login_password = var.mysql_password
+
+  backup_retention_days        = 30
+  geo_redundant_backup_enabled = true
+  ssl_enforcement_enabled      = true
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl/fail/allow-azure-services/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl/fail/allow-azure-services/main.tf
@@ -1,0 +1,9 @@
+# 0.0.0.0 to 0.0.0.0 is the "Allow access to Azure services" rule. It admits
+# every Azure tenant, not just this subscription.
+resource "azurerm_mysql_firewall_rule" "azure_services" {
+  name                = "AllowAllWindowsAzureIps"
+  resource_group_name = azurerm_resource_group.prod.name
+  server_name         = azurerm_mysql_server.app.name
+  start_ip_address    = "0.0.0.0"
+  end_ip_address      = "0.0.0.0"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl/pass/scoped-rule/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-terraform-hcl/pass/scoped-rule/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_mysql_firewall_rule" "corporate" {
+  name                = "corporate-egress"
+  resource_group_name = azurerm_resource_group.prod.name
+  server_name         = azurerm_mysql_server.app.name
+  start_ip_address    = "203.0.113.0"
+  end_ip_address      = "203.0.113.255"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/fail/allow-unencrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/fail/allow-unencrypted/main.tf
@@ -1,0 +1,12 @@
+# AllowUnencrypted means traffic falls back to cleartext whenever a peer does
+# not support encryption, which is the case the setting exists to prevent.
+resource "azurerm_virtual_network" "prod" {
+  name                = "prod-vnet"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  address_space       = ["10.0.0.0/16"]
+
+  encryption {
+    enforcement = "AllowUnencrypted"
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/fail/no-encryption-block/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/fail/no-encryption-block/main.tf
@@ -1,0 +1,6 @@
+resource "azurerm_virtual_network" "prod" {
+  name                = "prod-vnet"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  address_space       = ["10.0.0.0/16"]
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/pass/drop-unencrypted/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-terraform-hcl/pass/drop-unencrypted/main.tf
@@ -1,0 +1,15 @@
+resource "azurerm_virtual_network" "prod" {
+  name                = "prod-vnet"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  address_space       = ["10.0.0.0/16"]
+
+  encryption {
+    enforcement = "DropUnencrypted"
+  }
+
+  subnet {
+    name             = "app"
+    address_prefixes = ["10.0.1.0/24"]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-terraform-hcl/fail/learning-mode/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-terraform-hcl/fail/learning-mode/main.tf
@@ -1,0 +1,9 @@
+# Learning mode observes and logs what the perimeter would block without
+# blocking anything, so the resource remains reachable as before.
+resource "azurerm_network_security_perimeter_association" "storage" {
+  name                     = "storage-association"
+  perimeter_id             = azurerm_network_security_perimeter.prod.id
+  profile_id               = azurerm_network_security_perimeter_profile.prod.id
+  private_link_resource_id = azurerm_storage_account.data.id
+  access_mode              = "Learning"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-terraform-hcl/pass/enforced/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-terraform-hcl/pass/enforced/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_network_security_perimeter_association" "storage" {
+  name              = "storage-association"
+  perimeter_id      = azurerm_network_security_perimeter.prod.id
+  profile_id        = azurerm_network_security_perimeter_profile.prod.id
+  private_link_resource_id = azurerm_storage_account.data.id
+  access_mode       = "Enforced"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-terraform-hcl/fail/permanent/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-terraform-hcl/fail/permanent/main.tf
@@ -1,0 +1,8 @@
+# With no schedule block the active assignment is permanent, which turns PIM
+# into ordinary standing access.
+resource "azurerm_pim_active_role_assignment" "contributor" {
+  scope              = data.azurerm_subscription.prod.id
+  role_definition_id = "${data.azurerm_subscription.prod.id}${data.azurerm_role_definition.contributor.id}"
+  principal_id       = var.platform_group_object_id
+  justification      = "Platform team standing access"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-terraform-hcl/pass/scheduled/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-terraform-hcl/pass/scheduled/main.tf
@@ -1,0 +1,15 @@
+resource "azurerm_pim_active_role_assignment" "contributor" {
+  scope              = data.azurerm_subscription.prod.id
+  role_definition_id = "${data.azurerm_subscription.prod.id}${data.azurerm_role_definition.contributor.id}"
+  principal_id       = var.platform_group_object_id
+
+  schedule {
+    start_date_time = "2026-01-01T00:00:00Z"
+
+    expiration {
+      duration_hours = 8
+    }
+  }
+
+  justification = "Scheduled maintenance window"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-terraform-hcl/fail/entire-ipv4-space/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-terraform-hcl/fail/entire-ipv4-space/main.tf
@@ -1,0 +1,9 @@
+# 0.0.0.0 through 255.255.255.255 is the whole IPv4 space, which is the same as
+# having no firewall at all.
+resource "azurerm_redis_firewall_rule" "allow_all" {
+  name                = "allow_all"
+  redis_cache_name    = azurerm_redis_cache.prod.name
+  resource_group_name = azurerm_resource_group.prod.name
+  start_ip            = "0.0.0.0"
+  end_ip              = "255.255.255.255"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-terraform-hcl/pass/scoped-range/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-terraform-hcl/pass/scoped-range/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_redis_firewall_rule" "app_tier" {
+  name                = "app_tier"
+  redis_cache_name    = azurerm_redis_cache.prod.name
+  resource_group_name = azurerm_resource_group.prod.name
+  start_ip            = "10.0.1.0"
+  end_ip              = "10.0.1.255"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-terraform-hcl/fail/tls10/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-terraform-hcl/fail/tls10/main.tf
@@ -1,0 +1,17 @@
+# TLS 1.0 is deprecated and disallowed by PCI DSS; accepting it lets a client
+# negotiate down to it.
+resource "azurerm_mssql_managed_instance" "prod" {
+  name                = "prod-sqlmi"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  administrator_login          = "sqladmin"
+  administrator_login_password = var.sqlmi_password
+  license_type                 = "BasePrice"
+  subnet_id                    = azurerm_subnet.sqlmi.id
+  sku_name                     = "GP_Gen5"
+  vcores                       = 4
+  storage_size_in_gb           = 32
+
+  minimum_tls_version = "1.0"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-terraform-hcl/pass/tls12/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-terraform-hcl/pass/tls12/main.tf
@@ -1,0 +1,16 @@
+resource "azurerm_mssql_managed_instance" "prod" {
+  name                = "prod-sqlmi"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  administrator_login          = "sqladmin"
+  administrator_login_password = var.sqlmi_password
+  license_type                 = "BasePrice"
+  subnet_id                    = azurerm_subnet.sqlmi.id
+  sku_name                     = "GP_Gen5"
+  vcores                       = 4
+  storage_size_in_gb           = 32
+
+  minimum_tls_version           = "1.2"
+  public_data_endpoint_enabled  = false
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-terraform-hcl/fail/public-endpoint/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-terraform-hcl/fail/public-endpoint/main.tf
@@ -1,0 +1,17 @@
+# The public data endpoint exposes the instance on port 3342 outside the VNet,
+# bypassing the subnet isolation SQL MI is deployed for.
+resource "azurerm_mssql_managed_instance" "prod" {
+  name                = "prod-sqlmi"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  administrator_login          = "sqladmin"
+  administrator_login_password = var.sqlmi_password
+  license_type                 = "BasePrice"
+  subnet_id                    = azurerm_subnet.sqlmi.id
+  sku_name                     = "GP_Gen5"
+  vcores                       = 4
+  storage_size_in_gb           = 32
+
+  public_data_endpoint_enabled = true
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-terraform-hcl/pass/private-only/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-terraform-hcl/pass/private-only/main.tf
@@ -1,0 +1,16 @@
+resource "azurerm_mssql_managed_instance" "prod" {
+  name                = "prod-sqlmi"
+  resource_group_name = azurerm_resource_group.prod.name
+  location            = azurerm_resource_group.prod.location
+
+  administrator_login          = "sqladmin"
+  administrator_login_password = var.sqlmi_password
+  license_type                 = "BasePrice"
+  subnet_id                    = azurerm_subnet.sqlmi.id
+  sku_name                     = "GP_Gen5"
+  vcores                       = 4
+  storage_size_in_gb           = 32
+
+  public_data_endpoint_enabled = false
+  minimum_tls_version          = "1.2"
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-terraform-hcl/fail/service-managed-key/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-terraform-hcl/fail/service-managed-key/main.tf
@@ -1,0 +1,5 @@
+# TDE is on but with the service-managed key, so the account cannot revoke
+# access to the data by revoking the key.
+resource "azurerm_mssql_managed_instance_transparent_data_encryption" "prod" {
+  managed_instance_id = azurerm_mssql_managed_instance.prod.id
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-terraform-hcl/pass/cmk/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-terraform-hcl/pass/cmk/main.tf
@@ -1,0 +1,4 @@
+resource "azurerm_mssql_managed_instance_transparent_data_encryption" "prod" {
+  managed_instance_id = azurerm_mssql_managed_instance.prod.id
+  key_vault_key_id    = azurerm_key_vault_key.sqlmi.id
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-terraform-hcl/fail/no-identity/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-terraform-hcl/fail/no-identity/main.tf
@@ -1,0 +1,10 @@
+# Without a managed identity the workspace authenticates to linked data stores
+# with keys or SAS tokens held in its configuration.
+resource "azurerm_synapse_workspace" "analytics" {
+  name                                 = "analytics-synapse"
+  resource_group_name                  = azurerm_resource_group.prod.name
+  location                             = azurerm_resource_group.prod.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.analytics.id
+  sql_administrator_login              = "sqladmin"
+  sql_administrator_login_password     = var.synapse_password
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-terraform-hcl/pass/system-assigned/main.tf
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-terraform-hcl/pass/system-assigned/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_synapse_workspace" "analytics" {
+  name                                 = "analytics-synapse"
+  resource_group_name                  = azurerm_resource_group.prod.name
+  location                             = azurerm_resource_group.prod.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.analytics.id
+  sql_administrator_login              = "sqladmin"
+  sql_administrator_login_password     = var.synapse_password
+
+  identity {
+    type = "SystemAssigned"
+  }
+}


### PR DESCRIPTION
Round 6 of the push to 100% IaC-variant fixture coverage (rounds 1–5: #3271, #3273, #3275, #3276, #3277).

## Coverage

Fixtures for all **36** uncovered azure terraform-hcl variants:

| policy / suffix | before | after |
|---|---|---|
| mondoo-azure-security `-terraform-hcl` | 278/314 | **314/314** |

**Bicep is now the only remaining gap in the entire corpus.** The budget file is one line:

```json
{ "mondoo-azure-security": { "-bicep": 43 } }
```

## No policy bugs

All 36 asserted correctly first time — same as the alibaba (#3275) and aws (#3276) rounds. The pattern across six rounds holds: bug density tracks *when a check was written*, not how intricate its query is. The two rounds that found bugs were the ones covering the oldest checks.

## Fixture notes

**Application Gateway.** The five appgw/WAF checks share one resource, so each fixture carries a complete, deployable-looking gateway — sku, gateway IP configuration, frontend port and IP, backend pool, backend HTTP settings, listener, routing rule — with only the attribute under test varied. A minimal stub would not exercise the `blocks.where(type == "backend_http_settings")` traversal the way a real gateway does, and these checks are all block-traversal.

**Vacuous-when-absent is handled deliberately.** Several of these queries are vacuously true if their nested block is missing, so the fail fixtures *include* the block carrying the violating value rather than omitting it — appgw backend settings, WAF `request_body_check`, function app `site_config`, firewall rule collections. Where absence is itself the finding, it gets its own separate scenario: IoT Hub with no `network_rule_set`, WAF with no `policy_settings`, virtual network with no `encryption` block, web app with no `auth_settings_v2`.

**Pass fixtures include the legitimate-looking cases.** Internal-only container app ingress passes the IP-restriction check because it is not externally reachable at all; `ftps_state = "Disabled"` passes the FTPS check by being *stricter* than `FtpsOnly` rather than by matching it. Both are cases where a naive check would produce a false positive, so pinning them matters as much as the failures.

## Verification

```
azure terraform-hcl suite   137s at -parallel 8, 0 failures
TestTerraformVariantCoverage   ok  (budget regenerated and re-asserted)
```

No policy file changed — the diff is fixtures plus the budget entry removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
