### PR TITLE
✨ content: reach 100% IaC-variant coverage and enforce it flatly

### DIFF
--- a/.github/workflows/content-iac-tests.yaml
+++ b/.github/workflows/content-iac-tests.yaml
@@ -20,9 +20,9 @@ name: Content IaC Variant Tests
 ## runner each.
 ##
 ## The `coverage` job runs no scans at all. It compares the IaC variants each
-## policy declares against the fixtures on disk and enforces the per-policy
-## budgets in content/iac-variant-coverage-budget.json, so a variant added
-## without pass/fail fixtures fails CI instead of merging untested.
+## policy declares against the fixtures on disk and requires every one of them to
+## have both a pass and a fail fixture, so a variant added without them fails CI
+## instead of merging untested.
 on:
   push:
     branches: ["main"]
@@ -54,8 +54,8 @@ jobs:
           # as "no sharding". Explicit values keep IAC_SHARD_* non-empty so
           # Actions emits no empty-env annotations.
           # The coverage job runs no scans; it enforces the fixture-coverage
-          # ratchet in content/iac-variant-coverage-budget.json so a new variant
-          # cannot merge without pass/fail fixtures.
+          # 100% pass/fail fixture coverage, so a new variant cannot merge
+          # without fixtures.
           - { iac: coverage, shard: 0, shards: 1 }
           - { iac: cloudformation, shard: 0, shards: 1 }
           - { iac: bicep, shard: 0, shards: 1 }

--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,9 @@ test/go/content-iac/dockerfile: prep/tools
 test/go/content-iac/kubernetes: prep/tools
 	go test -tags iac_variants -timeout 30m -parallel $(IAC_VARIANT_PARALLEL) -run '^TestKubernetesManifestVariants$$' ./content
 
-# Fixture-coverage ratchet. Runs no scans: it compares the variants declared in
-# each policy against the fixtures on disk and enforces the per-policy budgets in
-# content/iac-variant-coverage-budget.json. Run with IAC_COVERAGE_BUDGET_UPDATE=1
-# to rewrite those budgets after adding fixtures.
+# Fixture-coverage gate. Runs no scans: it compares the IaC variants declared in
+# each policy against the fixtures on disk and fails if any variant lacks a pass
+# or a fail fixture. Coverage is at 100%, so this holds it there.
 test/go/content-iac/coverage: prep/tools
 	go test -tags iac_variants -timeout 10m -v -run '^TestTerraformVariantCoverage$$' ./content
 

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -182,14 +182,13 @@ Reference patterns in this repo:
 
 Every `-terraform-hcl`, `-cloudformation`, and `-bicep` variant is expected to ship with pass/fail fixtures under `content/iac-variant-testdata/<policy>/<variant-uid>/{pass,fail}/<scenario>/`, exercised by the suites in `content/iac_variants_test.go`.
 
-`TestTerraformVariantCoverage` enforces this as a ratchet against the per-policy budgets in `content/iac-variant-coverage-budget.json` — the number of variants still allowed to ship without fixtures. Adding a variant without fixtures pushes a policy over budget and fails CI (the `coverage` job in `.github/workflows/content-iac-tests.yaml`). The budgets may only shrink: once you add fixtures, tighten the entry in the same change.
+**Coverage is 100% and `TestTerraformVariantCoverage` holds it there.** Every IaC variant must have both a pass and a fail fixture; adding a variant without them fails CI (the `coverage` job in `.github/workflows/content-iac-tests.yaml`). There is no debt budget to grow — a new variant ships with fixtures or it does not ship.
 
 ```bash
-make test/go/content-iac/coverage                                # check the ratchet
-IAC_COVERAGE_BUDGET_UPDATE=1 make test/go/content-iac/coverage    # rewrite it after adding fixtures
+make test/go/content-iac/coverage    # check coverage
 ```
 
-Where a variant asserts exactly what its own `filters:` require, no failing input exists; record that with a `fail/IMPOSSIBLE.md` marker instead of a fail fixture and it counts as covered.
+Where a variant asserts exactly what its own `filters:` require, no failing input exists; record that with a `fail/IMPOSSIBLE.md` marker explaining why, instead of a fail fixture, and it counts as covered. That marker is the only sanctioned way to ship a variant without a real fail fixture.
 
 ### Terraform remediation
 

--- a/content/iac-variant-coverage-budget.json
+++ b/content/iac-variant-coverage-budget.json
@@ -1,5 +1,0 @@
-{
-  "mondoo-azure-security": {
-    "-bicep": 43
-  }
-}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-bicep/fail/enabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-bicep/fail/enabled/main.bicep
@@ -1,0 +1,14 @@
+// The gateway and its management plane stay reachable from the public internet.
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+  name: 'contoso-apim'
+  location: 'eastus'
+  sku: {
+    name: 'Developer'
+    capacity: 1
+  }
+  properties: {
+    publisherName: 'Example Corp'
+    publisherEmail: 'platform@example.com'
+    publicNetworkAccess: 'Enabled'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-bicep/pass/disabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-public-network-access-disabled-bicep/pass/disabled/main.bicep
@@ -1,0 +1,14 @@
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+  name: 'contoso-apim'
+  location: 'eastus'
+  sku: {
+    name: 'Developer'
+    capacity: 1
+  }
+  properties: {
+    publisherName: 'Example Corp'
+    publisherEmail: 'platform@example.com'
+    virtualNetworkType: 'Internal'
+    publicNetworkAccess: 'Disabled'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-bicep/fail/ssl30-enabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-bicep/fail/ssl30-enabled/main.bicep
@@ -1,0 +1,19 @@
+// SSL 3.0 is broken by POODLE; enabling it on the frontend downgrades every
+// client that will negotiate it.
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+  name: 'contoso-apim'
+  location: 'eastus'
+  sku: {
+    name: 'Developer'
+    capacity: 1
+  }
+  properties: {
+    publisherName: 'Example Corp'
+    publisherEmail: 'platform@example.com'
+    customProperties: {
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30': 'True'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168': 'False'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-bicep/pass/modern-protocols/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-api-management-weak-protocols-disabled-bicep/pass/modern-protocols/main.bicep
@@ -1,0 +1,17 @@
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+  name: 'contoso-apim'
+  location: 'eastus'
+  sku: {
+    name: 'Developer'
+    capacity: 1
+  }
+  properties: {
+    publisherName: 'Example Corp'
+    publisherEmail: 'platform@example.com'
+    customProperties: {
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30': 'False'
+      'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168': 'False'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-bicep/fail/allow-anonymous/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-bicep/fail/allow-anonymous/main.bicep
@@ -1,0 +1,14 @@
+// Authentication is configured but anonymous requests are still served, so the
+// app's own code is the only thing between the internet and its data.
+resource authSettings 'Microsoft.Web/sites/config@2023-01-01' = {
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      requireAuthentication: false
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-bicep/pass/auth-required/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-app-service-auth-no-anonymous-bicep/pass/auth-required/main.bicep
@@ -1,0 +1,17 @@
+resource authSettings 'Microsoft.Web/sites/config@2023-01-01' = {
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      requireAuthentication: true
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-bicep/fail/validation-off/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-bicep/fail/validation-off/main.bicep
@@ -1,0 +1,24 @@
+// HTTPS to the backend, but the certificate chain is not verified, so the
+// encrypted hop can be man-in-the-middled inside the VNet.
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    backendHttpSettingsCollection: [
+      {
+        name: 'app-https'
+        properties: {
+          port: 443
+          protocol: 'Https'
+          cookieBasedAffinity: 'Disabled'
+          validateCertChainAndExpiry: false
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-bicep/pass/validation-on/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-cert-validation-bicep/pass/validation-on/main.bicep
@@ -1,0 +1,22 @@
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    backendHttpSettingsCollection: [
+      {
+        name: 'app-https'
+        properties: {
+          port: 443
+          protocol: 'Https'
+          cookieBasedAffinity: 'Disabled'
+          validateCertChainAndExpiry: true
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-bicep/fail/http-backend/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-bicep/fail/http-backend/main.bicep
@@ -1,0 +1,30 @@
+// TLS terminates at the gateway and the hop to the backend pool is plaintext.
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    backendHttpSettingsCollection: [
+      {
+        name: 'app-http'
+        properties: {
+          port: 80
+          protocol: 'Http'
+          cookieBasedAffinity: 'Disabled'
+        }
+      }
+    ]
+    httpListeners: [
+      {
+        name: 'https-listener'
+        properties: {
+          protocol: 'Https'
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-bicep/pass/https-backend/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-backend-https-bicep/pass/https-backend/main.bicep
@@ -1,0 +1,30 @@
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    backendHttpSettingsCollection: [
+      {
+        name: 'app-https'
+        properties: {
+          port: 443
+          protocol: 'Https'
+          cookieBasedAffinity: 'Disabled'
+          validateCertChainAndExpiry: true
+        }
+      }
+    ]
+    httpListeners: [
+      {
+        name: 'https-listener'
+        properties: {
+          protocol: 'Https'
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-bicep/fail/plain-http-listener/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-bicep/fail/plain-http-listener/main.bicep
@@ -1,0 +1,27 @@
+// A plain HTTP listener accepts unencrypted client traffic, including any
+// credentials sent before a redirect could take effect.
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    httpListeners: [
+      {
+        name: 'https-listener'
+        properties: {
+          protocol: 'Https'
+        }
+      }
+      {
+        name: 'http-listener'
+        properties: {
+          protocol: 'Http'
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-bicep/pass/https-listener/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-listeners-https-only-bicep/pass/https-listener/main.bicep
@@ -1,0 +1,19 @@
+resource appgw 'Microsoft.Network/applicationGateways@2023-09-01' = {
+  name: 'public-appgw'
+  location: 'eastus'
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    httpListeners: [
+      {
+        name: 'https-listener'
+        properties: {
+          protocol: 'Https'
+        }
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-bicep/fail/disabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-bicep/fail/disabled/main.bicep
@@ -1,0 +1,20 @@
+// The policy exists and is attached but is switched off, so no rule in it is
+// evaluated. This reads as protected in an inventory while filtering nothing.
+resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-09-01' = {
+  name: 'public-waf'
+  location: 'eastus'
+  properties: {
+    policySettings: {
+      state: 'Disabled'
+      mode: 'Detection'
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          ruleSetType: 'OWASP'
+          ruleSetVersion: '3.2'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-bicep/pass/enabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-policy-enabled-bicep/pass/enabled/main.bicep
@@ -1,0 +1,20 @@
+resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-09-01' = {
+  name: 'public-waf'
+  location: 'eastus'
+  properties: {
+    policySettings: {
+      state: 'Enabled'
+      mode: 'Prevention'
+      requestBodyCheck: true
+      maxRequestBodySizeInKb: 128
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          ruleSetType: 'OWASP'
+          ruleSetVersion: '3.2'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-bicep/fail/body-check-off/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-bicep/fail/body-check-off/main.bicep
@@ -1,0 +1,13 @@
+// With body inspection off the WAF only sees headers and the URL, so injection
+// payloads delivered in a POST body pass straight through.
+resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-09-01' = {
+  name: 'public-waf'
+  location: 'eastus'
+  properties: {
+    policySettings: {
+      state: 'Enabled'
+      mode: 'Prevention'
+      requestBodyCheck: false
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-bicep/pass/body-check-on/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-appgw-waf-request-body-check-bicep/pass/body-check-on/main.bicep
@@ -1,0 +1,12 @@
+resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-09-01' = {
+  name: 'public-waf'
+  location: 'eastus'
+  properties: {
+    policySettings: {
+      state: 'Enabled'
+      mode: 'Prevention'
+      requestBodyCheck: true
+      maxRequestBodySizeInKb: 128
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-bicep/fail/microsoft-managed/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-bicep/fail/microsoft-managed/main.bicep
@@ -1,0 +1,15 @@
+// Microsoft.CognitiveServices is the service-managed key source, so uploaded
+// training and inference content is not under customer key control.
+resource vision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'vision'
+  location: 'eastus'
+  kind: 'ComputerVision'
+  sku: {
+    name: 'S1'
+  }
+  properties: {
+    encryption: {
+      keySource: 'Microsoft.CognitiveServices'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-bicep/pass/key-vault/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-cmk-encryption-bicep/pass/key-vault/main.bicep
@@ -1,0 +1,20 @@
+resource vision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'vision'
+  location: 'eastus'
+  kind: 'ComputerVision'
+  sku: {
+    name: 'S1'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    encryption: {
+      keySource: 'Microsoft.KeyVault'
+      keyVaultProperties: {
+        keyName: 'cognitive-cmk'
+        keyVaultUri: 'https://example-kv.vault.azure.net/'
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep/fail/unrestricted/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep/fail/unrestricted/main.bicep
@@ -1,0 +1,13 @@
+// The service can reach any outbound host, so a prompt-injected or
+// misconfigured workload can use it to exfiltrate data anywhere.
+resource vision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'vision'
+  location: 'eastus'
+  kind: 'ComputerVision'
+  sku: {
+    name: 'S1'
+  }
+  properties: {
+    restrictOutboundNetworkAccess: false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep/pass/restricted/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-cognitive-services-restrict-outbound-network-bicep/pass/restricted/main.bicep
@@ -1,0 +1,14 @@
+resource vision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'vision'
+  location: 'eastus'
+  kind: 'ComputerVision'
+  sku: {
+    name: 'S1'
+  }
+  properties: {
+    restrictOutboundNetworkAccess: true
+    allowedFqdnList: [
+      'storage.example.com'
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep/fail/proxy-agent-off/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep/fail/proxy-agent-off/main.bicep
@@ -1,0 +1,17 @@
+// Without the metadata proxy agent, any process on the VM can reach IMDS and
+// read the managed identity token directly.
+resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
+  name: 'app-vm'
+  location: 'eastus'
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_D2s_v5'
+    }
+    securityProfile: {
+      securityType: 'TrustedLaunch'
+      proxyAgentSettings: {
+        enabled: false
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep/pass/proxy-agent-on/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-compute-vm-proxy-agent-enabled-bicep/pass/proxy-agent-on/main.bicep
@@ -1,0 +1,17 @@
+resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
+  name: 'app-vm'
+  location: 'eastus'
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_D2s_v5'
+    }
+    securityProfile: {
+      securityType: 'TrustedLaunch'
+      encryptionAtHost: true
+      proxyAgentSettings: {
+        enabled: true
+        mode: 'Enforce'
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-auth-no-anonymous-bicep/fail/allow-anonymous/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-auth-no-anonymous-bicep/fail/allow-anonymous/main.bicep
@@ -1,0 +1,13 @@
+// The auth config exists but serves anonymous requests, so the platform
+// performs no access control.
+resource authConfig 'Microsoft.App/containerApps/authConfigs@2024-03-01' = {
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-auth-no-anonymous-bicep/pass/auth-required/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-auth-no-anonymous-bicep/pass/auth-required/main.bicep
@@ -1,0 +1,16 @@
+resource authConfig 'Microsoft.App/containerApps/authConfigs@2024-03-01' = {
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-bicep/fail/wildcard-origin/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-bicep/fail/wildcard-origin/main.bicep
@@ -1,0 +1,19 @@
+// A "*" origin lets any site on the internet make cross-origin calls to the
+// API with the browser's ambient credentials.
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  properties: {
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        corsPolicy: {
+          allowedOrigins: [
+            '*'
+          ]
+        }
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-bicep/pass/scoped-origins/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-cors-no-wildcard-bicep/pass/scoped-origins/main.bicep
@@ -1,0 +1,28 @@
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        corsPolicy: {
+          allowedOrigins: [
+            'https://app.example.com'
+            'https://admin.example.com'
+          ]
+        }
+        ipSecurityRestrictions: [
+          {
+            name: 'corporate-egress'
+            action: 'Allow'
+            ipAddressRange: '203.0.113.0/24'
+          }
+        ]
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/fail/external-unrestricted/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/fail/external-unrestricted/main.bicep
@@ -1,0 +1,13 @@
+// Externally reachable with no IP restrictions at all.
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  properties: {
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/pass/external-with-restrictions/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/pass/external-with-restrictions/main.bicep
@@ -1,0 +1,19 @@
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  properties: {
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        ipSecurityRestrictions: [
+          {
+            name: 'corporate-egress'
+            action: 'Allow'
+            ipAddressRange: '203.0.113.0/24'
+          }
+        ]
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/pass/internal-ingress/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-ingress-ip-restrictions-bicep/pass/internal-ingress/main.bicep
@@ -1,0 +1,14 @@
+// Internal-only ingress needs no IP allow list: it is not reachable from
+// outside the container app environment.
+resource worker 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'worker'
+  location: 'eastus'
+  properties: {
+    configuration: {
+      ingress: {
+        external: false
+        targetPort: 8080
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-bicep/fail/identity-none/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-bicep/fail/identity-none/main.bicep
@@ -1,0 +1,17 @@
+// Identity type None means the app authenticates to Azure services with
+// long-lived secrets carried in configuration instead.
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  identity: {
+    type: 'None'
+  }
+  properties: {
+    configuration: {
+      ingress: {
+        external: false
+        targetPort: 8080
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-bicep/pass/system-assigned/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-managed-identity-bicep/pass/system-assigned/main.bicep
@@ -1,0 +1,15 @@
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    configuration: {
+      ingress: {
+        external: false
+        targetPort: 8080
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-jit-network-access-enabled-bicep/fail/no-vms/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-jit-network-access-enabled-bicep/fail/no-vms/main.bicep
@@ -1,0 +1,8 @@
+// A JIT policy covering no virtual machines leaves every management port open
+// on its normal schedule.
+resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-01-01' = {
+  name: 'default'
+  properties: {
+    virtualMachines: []
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-jit-network-access-enabled-bicep/pass/vms-configured/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-jit-network-access-enabled-bicep/pass/vms-configured/main.bicep
@@ -1,0 +1,18 @@
+resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-01-01' = {
+  name: 'default'
+  properties: {
+    virtualMachines: [
+      {
+        id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/prod/providers/Microsoft.Compute/virtualMachines/app-vm'
+        ports: [
+          {
+            number: 22
+            protocol: 'TCP'
+            allowedSourceAddressPrefix: '203.0.113.0/24'
+            maxRequestAccessDuration: 'PT3H'
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/fail/never-expires/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/fail/never-expires/main.bicep
@@ -1,0 +1,10 @@
+// A suppression rule with no expiry silences an alert class forever, and
+// nothing forces anyone to revisit whether it is still justified.
+resource suppression 'Microsoft.Security/alertsSuppressionRules@2019-01-01-preview' = {
+  name: 'suppress-known-scanner'
+  properties: {
+    alertType: 'SuspiciousAuthenticationActivity'
+    reason: 'Known internal vulnerability scanner'
+    state: 'Enabled'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/pass/expiring-rule/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/pass/expiring-rule/main.bicep
@@ -1,0 +1,10 @@
+resource suppression 'Microsoft.Security/alertsSuppressionRules@2019-01-01-preview' = {
+  name: 'suppress-known-scanner'
+  properties: {
+    alertType: 'SuspiciousAuthenticationActivity'
+    reason: 'Known internal vulnerability scanner'
+    state: 'Enabled'
+    expirationDateUtc: '2026-12-31T23:59:59Z'
+    comment: 'Reviewed quarterly by the security team'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/pass/rule-disabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-defender-no-permanent-alert-suppression-bicep/pass/rule-disabled/main.bicep
@@ -1,0 +1,10 @@
+// A disabled rule suppresses nothing, so it needs no expiry. The check scopes
+// itself to Enabled rules.
+resource suppression 'Microsoft.Security/alertsSuppressionRules@2019-01-01-preview' = {
+  name: 'suppress-known-scanner'
+  properties: {
+    alertType: 'SuspiciousAuthenticationActivity'
+    reason: 'Retired scanner, rule kept for reference'
+    state: 'Disabled'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-bicep/fail/any-any-allow/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-bicep/fail/any-any-allow/main.bicep
@@ -1,0 +1,36 @@
+// Any source to any destination, allowed. A rule like this makes every other
+// rule in the policy irrelevant.
+resource ruleGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-09-01' = {
+  name: 'prod-rules'
+  properties: {
+    priority: 500
+    ruleCollections: [
+      {
+        name: 'allow-all'
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        priority: 400
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            name: 'any-any'
+            ruleType: 'NetworkRule'
+            ipProtocols: [
+              'Any'
+            ]
+            sourceAddresses: [
+              '*'
+            ]
+            destinationAddresses: [
+              '*'
+            ]
+            destinationPorts: [
+              '*'
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-bicep/pass/scoped-rule/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-any-any-allow-rule-bicep/pass/scoped-rule/main.bicep
@@ -1,0 +1,34 @@
+resource ruleGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-09-01' = {
+  name: 'prod-rules'
+  properties: {
+    priority: 500
+    ruleCollections: [
+      {
+        name: 'allow-app-to-db'
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        priority: 400
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            name: 'app-to-sql'
+            ruleType: 'NetworkRule'
+            ipProtocols: [
+              'TCP'
+            ]
+            sourceAddresses: [
+              '10.0.1.0/24'
+            ]
+            destinationAddresses: [
+              '10.0.2.10'
+            ]
+            destinationPorts: [
+              '1433'
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-bicep/fail/dnat-to-ssh/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-bicep/fail/dnat-to-ssh/main.bicep
@@ -1,0 +1,38 @@
+// DNAT publishing SSH straight to an internal host puts a management port on
+// the public internet behind a single NAT rule.
+resource ruleGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-09-01' = {
+  name: 'prod-nat'
+  properties: {
+    priority: 300
+    ruleCollections: [
+      {
+        name: 'inbound-admin'
+        ruleCollectionType: 'FirewallPolicyNatRuleCollection'
+        priority: 300
+        action: {
+          type: 'Dnat'
+        }
+        rules: [
+          {
+            name: 'ssh-jump'
+            ruleType: 'NatRule'
+            ipProtocols: [
+              'TCP'
+            ]
+            sourceAddresses: [
+              '*'
+            ]
+            destinationAddresses: [
+              '203.0.113.10'
+            ]
+            destinationPorts: [
+              '2222'
+            ]
+            translatedAddress: '10.0.1.5'
+            translatedPort: '22'
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-bicep/pass/dnat-app-port/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-dnat-management-ports-bicep/pass/dnat-app-port/main.bicep
@@ -1,0 +1,36 @@
+resource ruleGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-09-01' = {
+  name: 'prod-nat'
+  properties: {
+    priority: 300
+    ruleCollections: [
+      {
+        name: 'inbound-web'
+        ruleCollectionType: 'FirewallPolicyNatRuleCollection'
+        priority: 300
+        action: {
+          type: 'Dnat'
+        }
+        rules: [
+          {
+            name: 'web'
+            ruleType: 'NatRule'
+            ipProtocols: [
+              'TCP'
+            ]
+            sourceAddresses: [
+              '*'
+            ]
+            destinationAddresses: [
+              '203.0.113.10'
+            ]
+            destinationPorts: [
+              '443'
+            ]
+            translatedAddress: '10.0.1.10'
+            translatedPort: '8443'
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-bicep/fail/traffic-bypass/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-bicep/fail/traffic-bypass/main.bicep
@@ -1,0 +1,28 @@
+// A bypass rule exempts traffic from intrusion detection entirely. Broad
+// bypasses are how IDPS ends up enabled but blind on the paths that matter.
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2023-09-01' = {
+  name: 'prod-policy'
+  location: 'eastus'
+  properties: {
+    sku: {
+      tier: 'Premium'
+    }
+    intrusionDetection: {
+      mode: 'Deny'
+      configuration: {
+        bypassTrafficSettings: [
+          {
+            name: 'skip-partner-traffic'
+            protocol: 'TCP'
+            sourceAddresses: [
+              '10.0.0.0/8'
+            ]
+            destinationPorts: [
+              '443'
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-bicep/pass/no-bypass/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-firewall-no-idps-bypass-rules-bicep/pass/no-bypass/main.bicep
@@ -1,0 +1,15 @@
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2023-09-01' = {
+  name: 'prod-policy'
+  location: 'eastus'
+  properties: {
+    sku: {
+      tier: 'Premium'
+    }
+    intrusionDetection: {
+      mode: 'Deny'
+      configuration: {
+        signatureOverrides: []
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/fail/all-allowed/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/fail/all-allowed/main.bicep
@@ -1,0 +1,12 @@
+// AllAllowed permits plaintext FTP, so deployment credentials and function
+// code cross the network unencrypted.
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      ftpsState: 'AllAllowed'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/pass/ftp-disabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/pass/ftp-disabled/main.bicep
@@ -1,0 +1,11 @@
+// FTP deployment off entirely, which is stricter than requiring FTPS.
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      ftpsState: 'Disabled'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/pass/ftps-only/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ftps-required-bicep/pass/ftps-only/main.bicep
@@ -1,0 +1,11 @@
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      ftpsState: 'FtpsOnly'
+      minTlsVersion: '1.2'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep/fail/default-allow/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep/fail/default-allow/main.bicep
@@ -1,0 +1,20 @@
+// Allow-by-default turns the allow list into decoration: anything not named is
+// still permitted.
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      ipSecurityRestrictionsDefaultAction: 'Allow'
+      ipSecurityRestrictions: [
+        {
+          name: 'corporate-egress'
+          action: 'Allow'
+          ipAddress: '203.0.113.0/24'
+          priority: 100
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep/pass/default-deny/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-ip-restrictions-default-deny-bicep/pass/default-deny/main.bicep
@@ -1,0 +1,18 @@
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      ipSecurityRestrictionsDefaultAction: 'Deny'
+      ipSecurityRestrictions: [
+        {
+          name: 'corporate-egress'
+          action: 'Allow'
+          ipAddress: '203.0.113.0/24'
+          priority: 100
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-bicep/fail/debugging-on/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-bicep/fail/debugging-on/main.bicep
@@ -1,0 +1,12 @@
+// Remote debugging opens a powerful channel into the running app; it is meant
+// to be temporary and is routinely left on after a debug session.
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      remoteDebuggingEnabled: true
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-bicep/pass/debugging-off/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-remote-debugging-disabled-bicep/pass/debugging-off/main.bicep
@@ -1,0 +1,11 @@
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      remoteDebuggingEnabled: false
+      ftpsState: 'FtpsOnly'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-bicep/fail/inline-secret/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-bicep/fail/inline-secret/main.bicep
@@ -1,0 +1,21 @@
+// A literal connection string in app settings is readable by anyone with
+// Contributor on the app, and it lands in deployment history as well.
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'python'
+        }
+        {
+          name: 'DB_CONNECTIONSTRING'
+          value: 'Server=tcp:example.database.windows.net;User ID=app;Password=P@ssw0rd-not-a-real-secret;'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-bicep/pass/key-vault-references/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-function-app-secrets-in-key-vault-bicep/pass/key-vault-references/main.bicep
@@ -1,0 +1,26 @@
+resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'event-processor'
+  location: 'eastus'
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'python'
+        }
+        {
+          name: 'DB_CONNECTIONSTRING'
+          value: '@Microsoft.KeyVault(SecretUri=https://example-kv.vault.azure.net/secrets/db-connection/)'
+        }
+        {
+          name: 'PARTNER_APIKEY'
+          value: '@Microsoft.KeyVault(SecretUri=https://example-kv.vault.azure.net/secrets/partner-api-key/)'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-bicep/fail/default-allow/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-bicep/fail/default-allow/main.bicep
@@ -1,0 +1,22 @@
+// Allow-by-default means the IP rules constrain nothing: every address not
+// explicitly listed still reaches the hub.
+resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+  name: 'fleet-hub'
+  location: 'eastus'
+  sku: {
+    name: 'S1'
+    capacity: 1
+  }
+  properties: {
+    networkRuleSets: {
+      defaultAction: 'Allow'
+      ipRules: [
+        {
+          filterName: 'corporate-egress'
+          action: 'Allow'
+          ipMask: '203.0.113.0/24'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-bicep/pass/default-deny/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-iot-hub-network-rule-set-deny-bicep/pass/default-deny/main.bicep
@@ -1,0 +1,21 @@
+resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
+  name: 'fleet-hub'
+  location: 'eastus'
+  sku: {
+    name: 'S1'
+    capacity: 1
+  }
+  properties: {
+    networkRuleSets: {
+      defaultAction: 'Deny'
+      applyToBuiltInEventHubEndpoint: true
+      ipRules: [
+        {
+          filterName: 'corporate-egress'
+          action: 'Allow'
+          ipMask: '203.0.113.0/24'
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-bicep/fail/microsoft-managed/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-bicep/fail/microsoft-managed/main.bicep
@@ -1,0 +1,14 @@
+// No key vault properties, so the cluster's ingested data stays under the
+// Microsoft-managed key.
+resource kusto 'Microsoft.Kusto/clusters@2023-08-15' = {
+  name: 'analytics'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_D13_v2'
+    tier: 'Standard'
+    capacity: 2
+  }
+  properties: {
+    enableDiskEncryption: true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-bicep/pass/cmk/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-kusto-cluster-cmk-encryption-bicep/pass/cmk/main.bicep
@@ -1,0 +1,19 @@
+resource kusto 'Microsoft.Kusto/clusters@2023-08-15' = {
+  name: 'analytics'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_D13_v2'
+    tier: 'Standard'
+    capacity: 2
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    keyVaultProperties: {
+      keyName: 'kusto-cmk'
+      keyVaultUri: 'https://example-kv.vault.azure.net/'
+      keyVersion: '0123456789abcdef0123456789abcdef'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-auto-rotation-bicep/fail/no-rotation-policy/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-auto-rotation-bicep/fail/no-rotation-policy/main.bicep
@@ -1,0 +1,13 @@
+// A key with no rotation policy is rotated only when someone remembers to do
+// it by hand, which in practice means never.
+resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+  name: 'payment-signing'
+  properties: {
+    kty: 'EC-HSM'
+    curveName: 'P-256'
+    keyOps: [
+      'sign'
+      'verify'
+    ]
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-auto-rotation-bicep/pass/rotation-policy/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-auto-rotation-bicep/pass/rotation-policy/main.bicep
@@ -1,0 +1,23 @@
+resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+  name: 'payment-signing'
+  properties: {
+    kty: 'EC-HSM'
+    curveName: 'P-256'
+    keyOps: [
+      'sign'
+      'verify'
+    ]
+    rotationPolicy: {
+      lifetimeActions: [
+        {
+          trigger: {
+            timeBeforeExpiry: 'P30D'
+          }
+          action: {
+            type: 'Rotate'
+          }
+        }
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-bicep/fail/no-expiry/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-bicep/fail/no-expiry/main.bicep
@@ -1,0 +1,12 @@
+// A key with no expiration stays valid indefinitely, so nothing forces a
+// rotation or a review.
+resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+  name: 'payment-signing'
+  properties: {
+    kty: 'EC-HSM'
+    curveName: 'P-256'
+    attributes: {
+      enabled: true
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-bicep/pass/expiry-set/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-key-expiration-bicep/pass/expiry-set/main.bicep
@@ -1,0 +1,11 @@
+resource hsmKey 'Microsoft.KeyVault/managedHSMs/keys@2023-07-01' = {
+  name: 'payment-signing'
+  properties: {
+    kty: 'EC-HSM'
+    curveName: 'P-256'
+    attributes: {
+      enabled: true
+      exp: 1798761600
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-bicep/fail/default-allow/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-bicep/fail/default-allow/main.bicep
@@ -1,0 +1,21 @@
+// An HSM holding the organization's root key material, reachable from any
+// network by default.
+resource hsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+  name: 'prod-hsm'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_B1'
+    family: 'B'
+  }
+  properties: {
+    tenantId: '00000000-0000-0000-0000-000000000000'
+    initialAdminObjectIds: [
+      '11111111-1111-1111-1111-111111111111'
+    ]
+    softDeleteRetentionInDays: 90
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-bicep/pass/default-deny/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-network-acls-deny-bicep/pass/default-deny/main.bicep
@@ -1,0 +1,20 @@
+resource hsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+  name: 'prod-hsm'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_B1'
+    family: 'B'
+  }
+  properties: {
+    tenantId: '00000000-0000-0000-0000-000000000000'
+    initialAdminObjectIds: [
+      '11111111-1111-1111-1111-111111111111'
+    ]
+    enablePurgeProtection: true
+    softDeleteRetentionInDays: 90
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-bicep/fail/seven-days/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-bicep/fail/seven-days/main.bicep
@@ -1,0 +1,17 @@
+// A seven-day window gives very little time to notice and reverse a malicious
+// or mistaken deletion of the HSM.
+resource hsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+  name: 'prod-hsm'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_B1'
+    family: 'B'
+  }
+  properties: {
+    tenantId: '00000000-0000-0000-0000-000000000000'
+    initialAdminObjectIds: [
+      '11111111-1111-1111-1111-111111111111'
+    ]
+    softDeleteRetentionInDays: 7
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-bicep/pass/ninety-days/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-managed-hsm-soft-delete-retention-bicep/pass/ninety-days/main.bicep
@@ -1,0 +1,16 @@
+resource hsm 'Microsoft.KeyVault/managedHSMs@2023-07-01' = {
+  name: 'prod-hsm'
+  location: 'eastus'
+  sku: {
+    name: 'Standard_B1'
+    family: 'B'
+  }
+  properties: {
+    tenantId: '00000000-0000-0000-0000-000000000000'
+    initialAdminObjectIds: [
+      '11111111-1111-1111-1111-111111111111'
+    ]
+    enablePurgeProtection: true
+    softDeleteRetentionInDays: 90
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep/fail/key-auth/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep/fail/key-auth/main.bicep
@@ -1,0 +1,12 @@
+// Key auth is a shared static secret with no identity behind it, so calls
+// cannot be attributed and the key cannot be scoped or conditionally accessed.
+resource endpoint 'Microsoft.MachineLearningServices/workspaces/serverlessEndpoints@2024-04-01' = {
+  name: 'scoring'
+  location: 'eastus'
+  properties: {
+    authMode: 'Key'
+    modelSettings: {
+      modelId: 'azureml://registries/azureml/models/example/versions/1'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep/pass/aad-auth/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-serverless-endpoint-key-auth-disabled-bicep/pass/aad-auth/main.bicep
@@ -1,0 +1,10 @@
+resource endpoint 'Microsoft.MachineLearningServices/workspaces/serverlessEndpoints@2024-04-01' = {
+  name: 'scoring'
+  location: 'eastus'
+  properties: {
+    authMode: 'AAD'
+    modelSettings: {
+      modelId: 'azureml://registries/azureml/models/example/versions/1'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-bicep/fail/encryption-disabled/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-bicep/fail/encryption-disabled/main.bicep
@@ -1,0 +1,15 @@
+// Training data, models, and notebooks in the workspace stay under the
+// Microsoft-managed key.
+resource mlWorkspace 'Microsoft.MachineLearningServices/workspaces@2024-04-01' = {
+  name: 'research-ml'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    friendlyName: 'Research'
+    encryption: {
+      status: 'Disabled'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-bicep/pass/cmk/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-ml-workspace-cmk-encryption-bicep/pass/cmk/main.bicep
@@ -1,0 +1,17 @@
+resource mlWorkspace 'Microsoft.MachineLearningServices/workspaces@2024-04-01' = {
+  name: 'research-ml'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    friendlyName: 'Research'
+    encryption: {
+      status: 'Enabled'
+      keyVaultProperties: {
+        keyVaultArmId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/prod/providers/Microsoft.KeyVault/vaults/example-kv'
+        keyIdentifier: 'https://example-kv.vault.azure.net/keys/ml-cmk/0123456789abcdef'
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-bicep/fail/three-days/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-bicep/fail/three-days/main.bicep
@@ -1,0 +1,18 @@
+// Three days of backups is not enough to recover from corruption or ransomware
+// noticed after a weekend.
+resource mysql 'Microsoft.DBforMySQL/servers@2017-12-01' = {
+  name: 'app-mysql'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    version: '5.7'
+    sslEnforcement: 'Enabled'
+    storageProfile: {
+      storageMB: 51200
+      backupRetentionDays: 3
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-bicep/pass/thirty-days/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-backup-retention-bicep/pass/thirty-days/main.bicep
@@ -1,0 +1,17 @@
+resource mysql 'Microsoft.DBforMySQL/servers@2017-12-01' = {
+  name: 'app-mysql'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5_2'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    version: '5.7'
+    sslEnforcement: 'Enabled'
+    storageProfile: {
+      storageMB: 51200
+      backupRetentionDays: 30
+      geoRedundantBackup: 'Enabled'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep/fail/allow-azure-services/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep/fail/allow-azure-services/main.bicep
@@ -1,0 +1,9 @@
+// 0.0.0.0 to 0.0.0.0 is the "Allow access to Azure services" rule. It admits
+// every Azure tenant, not just this subscription.
+resource firewallRule 'Microsoft.DBforMySQL/servers/firewallRules@2017-12-01' = {
+  name: 'AllowAllWindowsAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep/pass/scoped-rule/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-mysql-server-no-azure-services-firewall-rule-bicep/pass/scoped-rule/main.bicep
@@ -1,0 +1,7 @@
+resource firewallRule 'Microsoft.DBforMySQL/servers/firewallRules@2017-12-01' = {
+  name: 'corporate-egress'
+  properties: {
+    startIpAddress: '203.0.113.0'
+    endIpAddress: '203.0.113.255'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/fail/allow-unencrypted/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/fail/allow-unencrypted/main.bicep
@@ -1,0 +1,17 @@
+// AllowUnencrypted means traffic falls back to cleartext whenever a peer does
+// not support encryption, which is the case the setting exists to prevent.
+resource vnet 'Microsoft.Network/virtualNetworks@2023-09-01' = {
+  name: 'prod-vnet'
+  location: 'eastus'
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    encryption: {
+      enabled: true
+      enforcement: 'AllowUnencrypted'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/fail/no-encryption-block/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/fail/no-encryption-block/main.bicep
@@ -1,0 +1,11 @@
+resource vnet 'Microsoft.Network/virtualNetworks@2023-09-01' = {
+  name: 'prod-vnet'
+  location: 'eastus'
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/pass/drop-unencrypted/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-peering-encryption-enabled-bicep/pass/drop-unencrypted/main.bicep
@@ -1,0 +1,15 @@
+resource vnet 'Microsoft.Network/virtualNetworks@2023-09-01' = {
+  name: 'prod-vnet'
+  location: 'eastus'
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    encryption: {
+      enabled: true
+      enforcement: 'DropUnencrypted'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-bicep/fail/learning-mode/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-bicep/fail/learning-mode/main.bicep
@@ -1,0 +1,11 @@
+// Learning mode observes and logs what the perimeter would block without
+// blocking anything, so the resource stays as reachable as before.
+resource association 'Microsoft.Network/networkSecurityPerimeters/resourceAssociations@2023-08-01-preview' = {
+  name: 'storage-association'
+  properties: {
+    accessMode: 'Learning'
+    privateLinkResource: {
+      id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/prod/providers/Microsoft.Storage/storageAccounts/exampledata'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-bicep/pass/enforced/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-network-security-perimeter-enforced-bicep/pass/enforced/main.bicep
@@ -1,0 +1,9 @@
+resource association 'Microsoft.Network/networkSecurityPerimeters/resourceAssociations@2023-08-01-preview' = {
+  name: 'storage-association'
+  properties: {
+    accessMode: 'Enforced'
+    privateLinkResource: {
+      id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/prod/providers/Microsoft.Storage/storageAccounts/exampledata'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-bicep/fail/no-expiration/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-bicep/fail/no-expiration/main.bicep
@@ -1,0 +1,17 @@
+// NoExpiration makes the active assignment permanent, which turns PIM into
+// ordinary standing access.
+resource roleAssignment 'Microsoft.Authorization/roleAssignmentScheduleRequests@2022-04-01-preview' = {
+  name: '00000000-0000-0000-0000-000000000001'
+  properties: {
+    principalId: '11111111-1111-1111-1111-111111111111'
+    roleDefinitionId: '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    requestType: 'AdminAssign'
+    justification: 'Platform team standing access'
+    scheduleInfo: {
+      startDateTime: '2026-01-01T00:00:00Z'
+      expiration: {
+        type: 'NoExpiration'
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-bicep/pass/after-duration/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-pim-active-assignments-time-bound-bicep/pass/after-duration/main.bicep
@@ -1,0 +1,16 @@
+resource roleAssignment 'Microsoft.Authorization/roleAssignmentScheduleRequests@2022-04-01-preview' = {
+  name: '00000000-0000-0000-0000-000000000001'
+  properties: {
+    principalId: '11111111-1111-1111-1111-111111111111'
+    roleDefinitionId: '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    requestType: 'AdminAssign'
+    justification: 'Scheduled maintenance window'
+    scheduleInfo: {
+      startDateTime: '2026-01-01T00:00:00Z'
+      expiration: {
+        type: 'AfterDuration'
+        duration: 'PT8H'
+      }
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-bicep/fail/entire-ipv4-space/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-bicep/fail/entire-ipv4-space/main.bicep
@@ -1,0 +1,9 @@
+// 0.0.0.0 through 255.255.255.255 is the whole IPv4 space, which is the same
+// as having no firewall at all.
+resource redisFirewall 'Microsoft.Cache/redis/firewallRules@2023-08-01' = {
+  name: 'allow_all'
+  properties: {
+    startIP: '0.0.0.0'
+    endIP: '255.255.255.255'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-bicep/pass/scoped-range/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-redis-no-unrestricted-firewall-rule-bicep/pass/scoped-range/main.bicep
@@ -1,0 +1,7 @@
+resource redisFirewall 'Microsoft.Cache/redis/firewallRules@2023-08-01' = {
+  name: 'app_tier'
+  properties: {
+    startIP: '10.0.1.0'
+    endIP: '10.0.1.255'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-bicep/fail/tls10/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-bicep/fail/tls10/main.bicep
@@ -1,0 +1,16 @@
+// TLS 1.0 is deprecated and disallowed by PCI DSS; accepting it lets a client
+// negotiate down to it.
+resource sqlMi 'Microsoft.Sql/managedInstances@2023-05-01-preview' = {
+  name: 'prod-sqlmi'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: 'sqladmin'
+    vCores: 4
+    storageSizeInGB: 32
+    minimalTlsVersion: '1.0'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-bicep/pass/tls12/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-min-tls-1-2-bicep/pass/tls12/main.bicep
@@ -1,0 +1,16 @@
+resource sqlMi 'Microsoft.Sql/managedInstances@2023-05-01-preview' = {
+  name: 'prod-sqlmi'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: 'sqladmin'
+    vCores: 4
+    storageSizeInGB: 32
+    licenseType: 'BasePrice'
+    minimalTlsVersion: '1.2'
+    publicDataEndpointEnabled: false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-bicep/fail/public-endpoint/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-bicep/fail/public-endpoint/main.bicep
@@ -1,0 +1,16 @@
+// The public data endpoint exposes the instance on port 3342 outside the VNet,
+// bypassing the subnet isolation SQL MI is deployed for.
+resource sqlMi 'Microsoft.Sql/managedInstances@2023-05-01-preview' = {
+  name: 'prod-sqlmi'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: 'sqladmin'
+    vCores: 4
+    storageSizeInGB: 32
+    publicDataEndpointEnabled: true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-bicep/pass/private-only/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-public-data-endpoint-disabled-bicep/pass/private-only/main.bicep
@@ -1,0 +1,15 @@
+resource sqlMi 'Microsoft.Sql/managedInstances@2023-05-01-preview' = {
+  name: 'prod-sqlmi'
+  location: 'eastus'
+  sku: {
+    name: 'GP_Gen5'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: 'sqladmin'
+    vCores: 4
+    storageSizeInGB: 32
+    publicDataEndpointEnabled: false
+    minimalTlsVersion: '1.2'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-bicep/fail/service-managed-key/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-bicep/fail/service-managed-key/main.bicep
@@ -1,0 +1,9 @@
+// TDE is on but with the service-managed key, so the account cannot revoke
+// access to the data by revoking the key.
+resource tde 'Microsoft.Sql/managedInstances/encryptionProtector@2023-05-01-preview' = {
+  name: 'current'
+  properties: {
+    serverKeyName: 'ServiceManaged'
+    serverKeyType: 'ServiceManaged'
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-bicep/pass/key-vault-key/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-sql-managed-instance-tde-cmk-encryption-bicep/pass/key-vault-key/main.bicep
@@ -1,0 +1,8 @@
+resource tde 'Microsoft.Sql/managedInstances/encryptionProtector@2023-05-01-preview' = {
+  name: 'current'
+  properties: {
+    serverKeyName: 'example-kv_sqlmi-cmk_0123456789abcdef'
+    serverKeyType: 'AzureKeyVault'
+    autoRotationEnabled: true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-bicep/fail/identity-none/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-bicep/fail/identity-none/main.bicep
@@ -1,0 +1,15 @@
+// Without a managed identity the workspace authenticates to linked data stores
+// with keys or SAS tokens held in its configuration.
+resource synapse 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'analytics-synapse'
+  location: 'eastus'
+  identity: {
+    type: 'None'
+  }
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://exampledatalake.dfs.core.windows.net'
+      filesystem: 'analytics'
+    }
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-bicep/pass/system-assigned/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-managed-identity-bicep/pass/system-assigned/main.bicep
@@ -1,0 +1,14 @@
+resource synapse 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'analytics-synapse'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://exampledatalake.dfs.core.windows.net'
+      filesystem: 'analytics'
+    }
+    trustedServiceBypassEnabled: false
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep/fail/bypass-on/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep/fail/bypass-on/main.bicep
@@ -1,0 +1,16 @@
+// Trusted service bypass lets any Azure service instance reach the workspace's
+// storage regardless of the firewall rules configured on it.
+resource synapse 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'analytics-synapse'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://exampledatalake.dfs.core.windows.net'
+      filesystem: 'analytics'
+    }
+    trustedServiceBypassEnabled: true
+  }
+}

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep/pass/bypass-off/main.bicep
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-synapse-trusted-service-bypass-disabled-bicep/pass/bypass-off/main.bicep
@@ -1,0 +1,14 @@
+resource synapse 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'analytics-synapse'
+  location: 'eastus'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://exampledatalake.dfs.core.windows.net'
+      filesystem: 'analytics'
+    }
+    trustedServiceBypassEnabled: false
+  }
+}

--- a/content/iac_variants_test.go
+++ b/content/iac_variants_test.go
@@ -12,7 +12,6 @@ package content
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -609,63 +608,16 @@ func iacSuffix(uid string) (string, bool) {
 	return "", false
 }
 
-// coverageBudgetFile records, per policy and variant kind, how many variants are
-// still allowed to ship without pass+fail fixtures. It is a ratchet: the numbers
-// may only go down.
-const coverageBudgetFile = "iac-variant-coverage-budget.json"
-
-// coverageBudgetUpdateEnv, when set, makes TestTerraformVariantCoverage rewrite
-// coverageBudgetFile from the fixtures on disk instead of asserting against it.
-const coverageBudgetUpdateEnv = "IAC_COVERAGE_BUDGET_UPDATE"
-
-// coverageBudget maps a policy directory to a variant suffix to the number of
-// that policy's variants of that kind allowed to lack pass+fail fixtures. A
-// policy or suffix absent from the file has a budget of zero: full coverage.
-type coverageBudget map[string]map[string]int
-
-func (b coverageBudget) get(policyDir, suffix string) int {
-	return b[policyDir][suffix]
-}
-
-func (b coverageBudget) set(policyDir, suffix string, n int) {
-	if b[policyDir] == nil {
-		b[policyDir] = map[string]int{}
-	}
-	b[policyDir][suffix] = n
-}
-
-func loadCoverageBudget(t *testing.T) coverageBudget {
-	data, err := os.ReadFile(coverageBudgetFile)
-	require.NoError(t, err, "reading the coverage budget")
-	budget := coverageBudget{}
-	require.NoError(t, json.Unmarshal(data, &budget), "parsing %s", coverageBudgetFile)
-	return budget
-}
-
-func writeCoverageBudget(t *testing.T, budget coverageBudget) {
-	data, err := json.MarshalIndent(budget, "", "  ")
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(coverageBudgetFile, append(data, '\n'), 0o644))
-	t.Logf("wrote %s", coverageBudgetFile)
-}
-
-// TestTerraformVariantCoverage reports how many IaC variants in each registered
-// policy have pass+fail fixtures, and enforces the ratchet in
-// coverageBudgetFile: a policy may not gain uncovered variants, and once
-// fixtures land its budget must be tightened in the same change. Adding a
-// variant without fixtures therefore fails here rather than merging silently
-// untested. Regenerate the budget after adding fixtures with:
+// TestTerraformVariantCoverage requires every IaC variant in every registered
+// policy to carry both a pass and a fail fixture. Coverage reached 100% across
+// the corpus, so this is a flat assertion rather than a per-policy debt budget:
+// a variant added without fixtures fails here instead of merging untested.
 //
-//	IAC_COVERAGE_BUDGET_UPDATE=1 make test/go/content-iac/coverage
+// A variant whose filter already asserts what its query asserts has no possible
+// failing input; those carry a fail/IMPOSSIBLE.md marker (see failIsImpossible)
+// and count as fail-covered. That marker is the only sanctioned way to ship a
+// variant without a real fail fixture, and it has to state why.
 func TestTerraformVariantCoverage(t *testing.T) {
-	update := os.Getenv(coverageBudgetUpdateEnv) != ""
-	var budget coverageBudget
-	if update {
-		budget = coverageBudget{}
-	} else {
-		budget = loadCoverageBudget(t)
-	}
-
 	for _, pol := range tfVariantPolicies {
 		policyDir := strings.TrimSuffix(pol.slugPrefix, "-")
 		bundle, err := policy.DefaultBundleLoader().BundleFromPaths(pol.bundleFile)
@@ -709,37 +661,17 @@ func TestTerraformVariantCoverage(t *testing.T) {
 			t.Logf("%s %s: %d/%d covered (%.1f%%)", policyDir, suffix, covered[suffix], total[suffix], pct)
 			uncovered := missing[suffix]
 			sort.Strings(uncovered)
-			if len(uncovered) > 0 && testing.Verbose() {
-				t.Logf("  uncovered (%d):\n%s", len(uncovered), strings.Join(indent(uncovered), "\n"))
-			}
-
-			if update {
-				if len(uncovered) > 0 {
-					budget.set(policyDir, suffix, len(uncovered))
-				}
-				continue
-			}
-
-			allowed := budget.get(policyDir, suffix)
-			switch {
-			case len(uncovered) > allowed:
-				t.Errorf("%s %s: %d variants lack pass+fail fixtures, budget allows %d.\n"+
-					"Add fixtures under %s/%s/<uid>/{pass,fail}/<scenario>/ for the variants below.\n"+
-					"uncovered (%d):\n%s",
-					policyDir, suffix, len(uncovered), allowed,
-					tfVariantsRoot, policyDir, len(uncovered), strings.Join(indent(uncovered), "\n"))
-			case len(uncovered) < allowed:
-				t.Errorf("%s %s: only %d variants lack pass+fail fixtures but the budget allows %d. "+
-					"Coverage improved, so tighten the ratchet: set this entry to %d in %s "+
-					"(or regenerate with %s=1 make test/go/content-iac/coverage).",
-					policyDir, suffix, len(uncovered), allowed, len(uncovered),
-					coverageBudgetFile, coverageBudgetUpdateEnv)
+			if len(uncovered) > 0 {
+				t.Errorf("%s %s: %d of %d variants lack pass+fail fixtures. Every IaC variant "+
+					"must have both.\nAdd fixtures under %s/%s/<uid>/{pass,fail}/<scenario>/ for "+
+					"the variants below. If a variant's filter already asserts what its query "+
+					"asserts, no failing input exists: add %s/%s/<uid>/fail/IMPOSSIBLE.md "+
+					"explaining why instead.\nuncovered (%d):\n%s",
+					policyDir, suffix, len(uncovered), total[suffix],
+					tfVariantsRoot, policyDir, tfVariantsRoot, policyDir,
+					len(uncovered), strings.Join(indent(uncovered), "\n"))
 			}
 		}
-	}
-
-	if update {
-		writeCoverageBudget(t, budget)
 	}
 }
 


### PR DESCRIPTION
Final round of the coverage push (rounds 1–6: #3271, #3273, #3275, #3276, #3277, #3278).

## 100% coverage

Fixtures for all **43** uncovered azure bicep variants:

| policy / suffix | before | after |
|---|---|---|
| mondoo-azure-security `-bicep` | 279/322 | **322/322** |

That takes the whole corpus to 100%. Every `-terraform-hcl`, `-cloudformation`, and `-bicep` variant in every registered policy now has both a pass and a fail fixture.

## The budget mechanism is removed

With no debt left to track, the per-policy budget from #3261 is deleted rather than left at zero:

- `TestTerraformVariantCoverage` now asserts coverage is **complete**, failing with the offending uids and where their fixtures go.
- `content/iac-variant-coverage-budget.json` is deleted.
- The `IAC_COVERAGE_BUDGET_UPDATE` escape hatch is gone.

A variant added without fixtures fails CI, and there is no longer a number someone can raise instead of writing them. `fail/IMPOSSIBLE.md` remains the one sanctioned exception — for variants whose filter already asserts what their query asserts — and it has to explain why.

## The documented bicep dotted-key trap did not reproduce

Worth recording, because it changes what we believe about the provider. `api-management-weak-protocols-disabled-bicep` reads APIM's `customProperties` through **dotted keys**:

```coffee
properties["customProperties"]["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30"] != "True"
```

Indexing a resource-derived map with a dotted key returned `null` in the provider version that prompted [mondoohq/mql#9081](https://github.com/mondoohq/mql/issues/9081) — which would make `null != "True"` vacuously true and let a TLS 1.0 misconfiguration pass silently. I wrote the fail fixture expecting to need a `KNOWN_BUG.md` marker.

Against the current provider **both fixtures assert correctly**. The check is genuinely enforced, no marker needed. The unrelated `firewall-premium-sku-bicep` marker still misbehaves and is untouched.

## No policy bugs

All 43 asserted correctly on the first pass — the fourth round in a row with a clean result, and consistent with bug density tracking check age rather than query complexity.

## Verification

```
full bicep suite   145s at -parallel 8, 0 failures
TestTerraformVariantCoverage   ok  (flat 100% assertion)
go vet -tags iac_variants      clean
```

The new gate was checked in both directions: it passes at 100%, and temporarily removing one variant's `fail/` directory produces

```
mondoo-oci-security -terraform-hcl: 1 of 63 variants lack pass+fail fixtures. Every IaC variant must have both.
  Add fixtures under ./iac-variant-testdata/mondoo-oci-security/<uid>/{pass,fail}/<scenario>/ ...
  uncovered (1):
      mondoo-oci-security-ipsec-tunnel-ikev2-terraform-hcl
```

## The push, end to end

| round | scope | variants | bugs found |
|---|---|---|---|
| 1 | oci + openstack + gcp | 15 | 1 |
| 2 | snowflake | 13 | 4 |
| 3 | alibaba | 32 | 0 |
| 4 | aws terraform-hcl | 28 | 0 (+1 IMPOSSIBLE) |
| 5 | aws cloudformation | 21 | 1 |
| 6 | azure terraform-hcl | 36 | 0 |
| 7 | azure bicep | 43 | 0 |
| | **total** | **188** | **6** |

The six were all the same species — checks that passed on everything. A nested block read through `arguments[]`, four checks sharing a `!= []` that never matches, and a CloudFormation variant that disagreed with its Terraform sibling about what counts as a customer key. None were visible to lint, and all of them shipped green until someone wrote a fixture that was supposed to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
