### PR TITLE
📃 content: re-verify the provider KNOWN_BUG markers, all 34 still broken

### DIFF
--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-apigateway-cors-not-wildcard-with-credentials-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-cloudtrail-insights-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-cloudtrail-insights-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-cloudwatch-log-destination-restrict-access-terraform-hcl/fail/jsonencode-wildcard/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-cloudwatch-log-destination-restrict-access-terraform-hcl/fail/jsonencode-wildcard/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider returns an empty value for `jsonencode([list])`, so a check reading the encoded structure cannot evaluate this fixture correctly. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9079 is closed as *completed*, but the fix does not cover this case: all
+2 jsonencode-list scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-dynamodb-table-encrypted-kms-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl/pass/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-image-scan-on-push-terraform-hcl/pass/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-hcl/fail/jsonencode/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-no-overly-permissive-policy-terraform-hcl/fail/jsonencode/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider returns an empty value for `jsonencode([list])`, so a check reading the encoded structure cannot evaluate this fixture correctly. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9079 is closed as *completed*, but the fix does not cover this case: all
+2 jsonencode-list scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-repository-cmk-encryption-terraform-hcl/pass/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecr-repository-cmk-encryption-terraform-hcl/pass/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecs-cluster-container-insights-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecs-cluster-container-insights-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecs-cluster-container-insights-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-ecs-cluster-container-insights-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-cmks-in-kms-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-private-controlplane-terraform-hcl/pass/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-private-controlplane-terraform-hcl/pass/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticbeanstalk-enhanced-health-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticbeanstalk-enhanced-health-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticbeanstalk-environment-https-listener-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-audit-logging-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-audit-logging-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-hcl/pass/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-terraform-hcl/pass/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-tls-policy-terraform-hcl/pass/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-tls-policy-terraform-hcl/pass/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-secgroup-restricted-ssh-terraform-hcl/fail/dynamic-ssh/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-secgroup-restricted-ssh-terraform-hcl/fail/dynamic-ssh/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-image-digest-pinned-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-app-image-digest-pinned-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-instance-private-registry-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-azure-security/mondoo-azure-security-container-instance-private-registry-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-gcp-security/mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-terraform-hcl/pass/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-protocols-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-all-tcp-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ipv6-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ipv6-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-rdp-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl/fail/ternary/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-ssh-ingress-terraform-hcl/fail/ternary/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider leaves `cond ? a : b` expressions unresolved during static analysis, so a scalar-equality assertion sees the unresolved value rather than the compliant literal. Tracked as a provider limitation.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9078 is closed as *completed*, but the fix does not cover this case: all
+11 conditional/ternary scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.

--- a/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-udp-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-oci-security/mondoo-oci-security-vcn-no-unrestricted-udp-ingress-terraform-hcl/fail/dynamic/KNOWN_BUG.md
@@ -3,3 +3,15 @@
 The mql terraform provider parses a `dynamic "x" { content {...} }` block as type `dynamic` with the real content nested under `content`, so `blocks.where(type == "x")` does not see it. Checks that iterate nested blocks this way cannot evaluate the dynamic form correctly until the provider normalizes `dynamic "x"` into a type-`x` block. Tracked as a provider fix.
 
 Remove this marker when the underlying fix lands and this scenario asserts correctly.
+
+## Re-verified 2026-08-14 — still broken, upstream issue closed
+
+Re-run against terraform provider **v13.3.13**, downloaded into a clean
+providers directory the way CI does, so this is not a stale-local-install
+result. This scenario still asserts incorrectly.
+
+mondoohq/mql#9077 is closed as *completed*, but the fix does not cover this case: all
+21 dynamic-block scenarios in this corpus still fail against v13.3.13, and none
+of them flipped. **Do not delete this marker on the strength of the issue being
+closed** — the marker is load-bearing and the harness will tell you if the
+scenario ever starts asserting correctly.


### PR DESCRIPTION
Follow-up to the coverage push: re-verifying the `KNOWN_BUG.md` markers, because "100% fixture coverage" and "100% of checks work" are different claims and the markers are the gap between them.

## Why this needed checking

34 markers are attributed to terraform provider bugs, and **every issue they cite is now closed as completed**:

| issue | closed | markers |
|---|---|---|
| [mondoohq/mql#9077](https://github.com/mondoohq/mql/issues/9077) dynamic blocks | 2026-07-21 | 21 |
| [mondoohq/mql#9078](https://github.com/mondoohq/mql/issues/9078) unresolved conditionals | 2026-07-16 | 11 |
| [mondoohq/mql#9079](https://github.com/mondoohq/mql/issues/9079) `jsonencode([...])` → empty | 2026-07-21 | 2 |

A closed issue reads like a stale marker, and a stale marker is supposed to fail the build. The obvious conclusion was that these were ready to delete. **They are not**, and this PR records why so nobody reaches that conclusion again.

## The experiment

Deleted all 34 markers, then re-ran the four affected policies against terraform provider **v13.3.13**, downloaded into a clean `PROVIDERS_PATH` the way CI does — deliberately not judged against whatever my machine had cached, since that would make the result meaningless.

```
FAIL subtests:   34
PASS subtests: 3450
```

And the failing set is **exactly** the deleted set:

```
deleted markers                 : 34
still broken (marker justified) : 34
FIXED (marker can be dropped)   : 0
newly broken (unrelated)        : 0
```

Zero flipped. No unrelated scenario regressed on the newer provider either, which is its own useful signal given CI always pulls latest.

## What still fails

Both directions still reproduce for the first two categories — the same signature the original reports described:

| category | false positives | false negatives |
|---|---|---|
| dynamic blocks | 11 `pass/dynamic` — a **compliant** config written with `dynamic` blocks is wrongly flagged | 10 `fail/dynamic` — a **violating** one is wrongly passed |
| conditionals | 5 `pass/ternary` | 6 `fail/ternary` |
| jsonencode | — | 2 `fail/jsonencode*` — violating policy documents wrongly pass |

The false-negative half is the one that matters for security posture: a real misconfiguration expressed in the idiomatic `dynamic` form scores compliant today.

## What changed here

All 34 markers restored, each annotated with the re-verification: the provider version, the date, and an explicit instruction not to delete it on the strength of the issue being closed. No fixture or policy content changed — this is marker prose only.

## Suggested follow-up

The three issues look like they need reopening with this evidence. That is a conversation with the mql side rather than something to land here, so this PR just makes the evidence citable. Happy to open the reopen requests if that is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
