### PR TITLE
✨ validation: validate audit: commands for the cloud CLI targets

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -314,7 +314,12 @@ python3 content/validation/validate_remediation_commands.py grafana
 python3 content/validation/validate_remediation_commands.py mongodbatlas
 ```
 
-The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli`/`vercel`/`kubectl`/`gh`/`glab`/`hcloud`/`databricks` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections. For the REST API and Cobra CLI targets, ```` ```bash ```` blocks in `audit:` sections are validated too (these products' verification paths use the same CLI/API surface, and the new validators have no backlog of unvalidated audit blocks). Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+The validator scans each `aws`/`az`/`oci`/`gcloud`/`doctl`/`ncli`/`vercel`/`kubectl`/`gh`/`glab`/`hcloud`/`databricks` CLI command — and `curl` calls against the registered vendor API hosts — in ```` ```bash ```` code blocks within `id: cli` remediation sections, **and in `audit:` sections**. A wrong audit command misleads an auditor exactly like a wrong remediation misleads an operator, so both are checked. Output shows `[PASS]` or `[FAIL]` with the check UID and the offending command.
+
+Two parsing details follow from validating audit blocks, which are read-only and shaped differently from remediation blocks:
+
+- A `$(...)` command substitution is pulled out and validated as a command in its own right, then removed from the text around it. Left inline, its flags read as flags of the outer command — `aws elasticbeanstalk describe-configuration-settings --application-name "$(aws elasticbeanstalk describe-environments --environment-names …)"` would otherwise report `--environment-names` as invalid on the outer command.
+- A subcommand held in a shell variable (`for cmd in list-a list-b; do aws sagemaker $cmd …`) has no literal name to check and is accepted rather than reported as unknown.
 
 The `vercel` target is the only one that runs a **CLI validator and a REST API validator together** (both keyed `vercel`): the Vercel policy fixes some settings with the `vercel` CLI (`- id: cli`) and others with `curl` against the Vercel REST API (`- id: api`). Both remediation ids and the `audit:` blocks are validated.
 

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.10.0
+    version: 12.10.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -61567,7 +61567,7 @@ queries:
         2. For each resource share ARN, list the associated principals:
 
         ```bash
-        aws ram get-principals \
+        aws ram list-principals \
           --resource-owner SELF \
           --resource-share-arns <resource-share-arn> \
           --query "principals[].id"

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.5.0
+    version: 2.5.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -3122,7 +3122,11 @@ queries:
         1. List the buckets and use `s3cmd` or the AWS CLI against the Spaces endpoint to inspect each bucket's ACL:
 
         ```bash
-        doctl spaces buckets list
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api list-buckets \
+            --endpoint-url https://<region>.digitaloceanspaces.com \
+            --query 'Buckets[].Name' --output text
+
         AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
           aws s3api get-bucket-acl --bucket <bucket> \
             --endpoint-url https://<region>.digitaloceanspaces.com
@@ -3654,7 +3658,11 @@ queries:
         1. Retrieve the bucket ACL with the S3-compatible API and look for an `AuthenticatedUsers` grantee:
 
         ```bash
-        doctl spaces buckets list
+        AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
+          aws s3api list-buckets \
+            --endpoint-url https://<region>.digitaloceanspaces.com \
+            --query 'Buckets[].Name' --output text
+
         AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
           aws s3api get-bucket-acl --bucket <bucket> \
             --endpoint-url https://<region>.digitaloceanspaces.com

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.9.0
+    version: 9.9.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -22460,12 +22460,14 @@ queries:
 
         ### Audit via CLI
 
-        1. List all Vertex AI datasets and their encryption specification:
+        1. List all Vertex AI datasets and their encryption specification. The
+           `gcloud ai` command group has no `datasets` surface, so query the
+           Vertex AI REST API directly:
 
         ```bash
-        gcloud ai datasets list \
-          --region=REGION \
-          --format="table(name,displayName,encryptionSpec.kmsKeyName)"
+        curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+          "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/REGION/datasets" \
+          | jq -r '.datasets[] | [.name, .displayName, .encryptionSpec.kmsKeyName // "none"] | @tsv'
         ```
 
         A passing dataset returns a KMS key name in the `KMS_KEY_NAME` column. A failing dataset returns an empty value in that column.
@@ -44159,12 +44161,14 @@ queries:
 
         ### Audit via CLI
 
-        1. List batch prediction jobs and their encryption specification:
+        1. List batch prediction jobs and their encryption specification. The
+           `gcloud ai` command group has no `batch-prediction-jobs` surface, so
+           query the Vertex AI REST API directly:
 
         ```bash
-        gcloud ai batch-prediction-jobs list \
-          --region=REGION \
-          --format="table(name,displayName,encryptionSpec.kmsKeyName)"
+        curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+          "https://REGION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/REGION/batchPredictionJobs" \
+          | jq -r '.batchPredictionJobs[] | [.name, .displayName, .encryptionSpec.kmsKeyName // "none"] | @tsv'
         ```
 
         A passing job returns a KMS key name. A failing job returns an empty value.

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-nutanix-security
     name: Mondoo Nutanix Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1417,10 +1417,12 @@ queries:
         Run on a Controller VM:
 
         ```bash
-        ncli protection-domain list-vms
+        ncli protection-domain list
         ```
 
-        A passing result shows the VMs assigned to protection domains.
+        A passing result lists each protection domain with the VMs it protects
+        under **VM Names**. A failing result shows a business-critical VM that
+        appears under no protection domain.
       remediation:
         - id: console
           desc: |

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.4.0
+    version: 4.4.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -9360,7 +9360,7 @@ queries:
         1. List OCI Cache clusters, then check the subnet of each to confirm public IPs are prohibited:
 
         ```bash
-        oci redis redis-cluster redis-cluster list \
+        oci redis redis-cluster redis-cluster-summary list-redis-clusters \
           --compartment-id <compartment-ocid> \
           --query 'data.items[*].{name:"display-name", subnetId:"subnet-id"}' \
           --output table
@@ -9490,7 +9490,7 @@ queries:
         1. List OCI Cache clusters and check the `nsg-ids` field for each:
 
         ```bash
-        oci redis redis-cluster redis-cluster list \
+        oci redis redis-cluster redis-cluster-summary list-redis-clusters \
           --compartment-id <compartment-ocid> \
           --query 'data.items[*].{name:"display-name", nsgIds:"nsg-ids"}' \
           --output table
@@ -9628,7 +9628,7 @@ queries:
         1. List OCI Cache clusters and retrieve the software version for each:
 
         ```bash
-        oci redis redis-cluster redis-cluster list \
+        oci redis redis-cluster redis-cluster-summary list-redis-clusters \
           --compartment-id <compartment-ocid> \
           --query 'data.items[*].{name:"display-name", softwareVersion:"software-version"}' \
           --output table
@@ -9750,7 +9750,7 @@ queries:
         1. List all security zones in the tenancy root compartment:
 
         ```bash
-        oci cloud-guard security-zone list \
+        oci cloud-guard security-zone-collection list-security-zones \
           --compartment-id <tenancy-ocid> \
           --lifecycle-state ACTIVE \
           --query 'data.items[*].{name:"display-name", id:id}' \
@@ -9855,7 +9855,7 @@ queries:
         1. List security zones and check the `is-inheritance-after-delete-enabled` flag for each:
 
         ```bash
-        oci cloud-guard security-zone list \
+        oci cloud-guard security-zone-collection list-security-zones \
           --compartment-id <compartment-ocid> \
           --query 'data.items[*].{name:"display-name", inheritAfterDelete:"is-inheritance-after-delete-enabled"}' \
           --output table

--- a/content/validation/validators/aws.py
+++ b/content/validation/validators/aws.py
@@ -57,15 +57,24 @@ AWS_GLOBAL_FLAGS = [
     "--version",
 ]
 
-_XFORM_RE1 = re.compile(r"([a-z0-9])([A-Z])")
-_XFORM_RE2 = re.compile(r"([A-Z])([A-Z][a-z])")
+_XFORM_FIRST_CAP = re.compile(r"(.)([A-Z][a-z]+)")
+_XFORM_END_CAP = re.compile(r"([a-z0-9])([A-Z])")
+# A trailing all-caps plural is one word, not an acronym followed by a stray
+# "s": ListWebACLs is `list-web-acls`, never `list-web-ac-ls`. botocore special
+# cases this before the general splits, and the CLI's command names follow.
+_XFORM_SPECIAL_CASE = re.compile(r"[A-Z]{2,}s$")
 
 
-def _xform_name(name: str) -> str:
+def _xform_name(name: str, sep: str = "_") -> str:
     """CamelCase → snake_case (mirrors botocore.xform_name)."""
-    s = _XFORM_RE1.sub(r"\1_\2", name)
-    s = _XFORM_RE2.sub(r"\1_\2", s)
-    return s.lower()
+    if sep in name:
+        return name
+    special = _XFORM_SPECIAL_CASE.search(name)
+    if special is not None:
+        matched = special.group()
+        name = name[: -len(matched)] + sep + matched.lower()
+    s = _XFORM_FIRST_CAP.sub(r"\1" + sep + r"\2", name)
+    return _XFORM_END_CAP.sub(r"\1" + sep + r"\2", s).lower()
 
 
 def _load_aws_service_ops(service_dir: Path) -> tuple[list[str], dict[str, list[str]]]:
@@ -271,6 +280,9 @@ AWS_CLI_CUSTOM_FLAGS = {
         "--assign-ipv6-address-on-creation",
         "--no-assign-ipv6-address-on-creation",
     ],
+    # ListClusters takes ClusterStates; the CLI adds --active/--terminated/
+    # --failed as shorthand for the common state groupings.
+    "emr list-clusters": ["--active", "--terminated", "--failed"],
 }
 
 
@@ -290,6 +302,13 @@ def validate_aws_command(
     if not subcommand:
         errors.append(f"missing subcommand for '{service}'")
         return False, errors
+
+    # Audit blocks sometimes loop over a set of related operations with the
+    # subcommand held in a shell variable (`for cmd in list-x list-y; do aws
+    # sagemaker $cmd ...`). There is no literal name to check, so accept it
+    # rather than report the variable as an unknown subcommand.
+    if subcommand.startswith("$"):
+        return True, []
 
     if subcommand in AWS_CLI_CUSTOM_SUBCOMMANDS:
         return True, []
@@ -329,7 +348,7 @@ def validate_aws() -> tuple[int, int]:
         return 0, 0
 
     content = AWS_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
+    blocks = extract_bash_blocks(content, include_audit=True)
 
     pass_count = 0
     fail_count = 0

--- a/content/validation/validators/aws.py
+++ b/content/validation/validators/aws.py
@@ -62,6 +62,15 @@ _XFORM_END_CAP = re.compile(r"([a-z0-9])([A-Z])")
 # A trailing all-caps plural is one word, not an acronym followed by a stray
 # "s": ListWebACLs is `list-web-acls`, never `list-web-ac-ls`. botocore special
 # cases this before the general splits, and the CLI's command names follow.
+#
+# The three regexes and the order they are applied in mirror
+# `xform_name` in awscli/botocore/__init__.py (`_first_cap_regex`,
+# `_end_cap_regex`, `_special_case_transform`). Matching botocore exactly is
+# the point, including where the rule is broader than the ACLs example: any
+# name ending in two-or-more capitals plus "s" takes it, so a hypothetical
+# `ListAPs` becomes `list-aps`. Verify a change here against the bundled
+# botocore rather than against intuition — `aws <service> help` lists the
+# command names the CLI actually accepts.
 _XFORM_SPECIAL_CASE = re.compile(r"[A-Z]{2,}s$")
 
 

--- a/content/validation/validators/common.py
+++ b/content/validation/validators/common.py
@@ -17,10 +17,30 @@ REPO_ROOT = SCRIPT_DIR.parent.parent
 # file, line, uid, command, errors, cloud
 FAILURES: list[dict] = []
 
-# `$(...)` command substitution, non-greedy so adjacent substitutions on one
-# line stay separate. Nested substitutions are rare enough in audit blocks that
-# the simple form is enough.
+# `$(...)` command substitution. The character class excludes parens, so a
+# single match is always the innermost substitution; extract_substitutions()
+# loops to unwrap nested ones.
 COMMAND_SUBSTITUTION = re.compile(r"\$\(([^()]*)\)")
+
+
+def extract_substitutions(text: str) -> tuple[list[str], str]:
+    """Pull every `$(...)` command out of `text`.
+
+    Returns (inner commands, text with the substitutions blanked out).
+
+    Replacing in one pass would mishandle nesting: substituting the inner
+    `$(cmd2)` of `$(cmd1 $(cmd2))` leaves `$(cmd1 )` behind, and re.sub
+    resumes *after* the match rather than rescanning, so the outer command
+    would stay inline and its flags would read as flags of whatever command
+    surrounds it. Looping until no match remains unwraps both.
+    """
+    commands = []
+    while True:
+        m = COMMAND_SUBSTITUTION.search(text)
+        if not m:
+            return commands, text
+        commands.append(m.group(1).strip())
+        text = text[: m.start()] + " " + text[m.end() :]
 
 
 def policy_relpath(policy_file: Path) -> str:
@@ -173,11 +193,10 @@ def split_commands(block: str, prefix: str, block_start_line: int) -> list[tuple
             # audit blocks use them to feed one query into the next. Pull each
             # one out as a separate command and drop it from the text around
             # it — left inline, its flags read as flags of the outer command.
-            for inner in COMMAND_SUBSTITUTION.findall(rejoined):
-                inner = inner.strip()
+            inner_commands, rejoined = extract_substitutions(rejoined)
+            for inner in inner_commands:
                 if inner.startswith(f"{prefix} "):
                     commands.append((inner, raw_line_num))
-            rejoined = COMMAND_SUBSTITUTION.sub(" ", rejoined)
 
             # Split on pipe/semicolon boundaries
             for segment in re.split(r"\s*[|;]\s*", rejoined):

--- a/content/validation/validators/common.py
+++ b/content/validation/validators/common.py
@@ -17,6 +17,11 @@ REPO_ROOT = SCRIPT_DIR.parent.parent
 # file, line, uid, command, errors, cloud
 FAILURES: list[dict] = []
 
+# `$(...)` command substitution, non-greedy so adjacent substitutions on one
+# line stay separate. Nested substitutions are rare enough in audit blocks that
+# the simple form is enough.
+COMMAND_SUBSTITUTION = re.compile(r"\$\(([^()]*)\)")
+
 
 def policy_relpath(policy_file: Path) -> str:
     """Repo-root-relative path for a policy file, as GitHub annotations
@@ -49,12 +54,13 @@ def extract_bash_blocks(
 
     With include_audit=True, bash blocks in `audit: |` sections are
     extracted as well. A wrong audit command misleads users exactly like a
-    wrong remediation, so the REST API and Cobra validators have always
-    enabled it. `azure` can enable it too now that dump_azure_commands.py
-    records CLI option strings rather than argparse destination names: with
-    the old grammar, commands used only in audit blocks kept names like
-    `--resource-group-name`, and turning this on reported ~170 failures that
-    were the grammar's fault rather than the content's.
+    wrong remediation, so every validator that can enable this does: the
+    REST API and Cobra validators from the start, and the cloud CLI
+    validators as of this change. `azure` included, now that
+    dump_azure_commands.py records CLI option strings rather than argparse
+    destination names — with the old grammar, commands used only in audit
+    blocks kept names like `--resource-group-name`, and turning this on
+    reported ~170 failures that were the grammar's fault, not the content's.
     """
     # Pre-compute a list of (line_number, uid) from all `- uid:` lines so we
     # can look up the enclosing check for any position in the file.
@@ -163,6 +169,16 @@ def split_commands(block: str, prefix: str, block_start_line: int) -> list[tuple
                         break
                     cont_lines += 1
                     stripped = stripped + "\n" + lines[i + cont_lines]
+            # A `$(...)` substitution holds a command in its own right, and
+            # audit blocks use them to feed one query into the next. Pull each
+            # one out as a separate command and drop it from the text around
+            # it — left inline, its flags read as flags of the outer command.
+            for inner in COMMAND_SUBSTITUTION.findall(rejoined):
+                inner = inner.strip()
+                if inner.startswith(f"{prefix} "):
+                    commands.append((inner, raw_line_num))
+            rejoined = COMMAND_SUBSTITUTION.sub(" ", rejoined)
+
             # Split on pipe/semicolon boundaries
             for segment in re.split(r"\s*[|;]\s*", rejoined):
                 segment = segment.strip()

--- a/content/validation/validators/digitalocean.py
+++ b/content/validation/validators/digitalocean.py
@@ -265,7 +265,7 @@ def validate_digitalocean() -> tuple[int, int]:
         return 0, 0
 
     content = DO_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
+    blocks = extract_bash_blocks(content, include_audit=True)
 
     pass_count = 0
     fail_count = 0

--- a/content/validation/validators/gcloud.py
+++ b/content/validation/validators/gcloud.py
@@ -11,7 +11,15 @@ import sys
 from collections.abc import Iterator
 from pathlib import Path
 
-from .common import FAILURES, SCRIPT_DIR, extract_bash_blocks, policy_relpath, split_commands, truncate_cmd
+from .common import (
+    COMMAND_SUBSTITUTION,
+    FAILURES,
+    SCRIPT_DIR,
+    extract_bash_blocks,
+    policy_relpath,
+    split_commands,
+    truncate_cmd,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -38,8 +46,18 @@ def detect_gcloud_services_from_policy() -> list[str]:
         joined = re.sub(r"\\\s*\n\s*", " ", block)
         for line in joined.split("\n"):
             line = line.strip()
-            if line.startswith("gcloud "):
-                parts = line.split()
+            # A gcloud call is not always at the start of the line: audit
+            # blocks reach APIs with no gcloud surface via
+            # `curl -H "Authorization: Bearer $(gcloud auth print-access-token)"`.
+            # Miss those and the service never gets walked, so every command
+            # under it reports as unknown.
+            candidates = [line] + [
+                inner.strip() for inner in COMMAND_SUBSTITUTION.findall(line)
+            ]
+            for candidate in candidates:
+                if not candidate.startswith("gcloud "):
+                    continue
+                parts = candidate.split()
                 if len(parts) >= 2 and not parts[1].startswith("-"):
                     services.add(parts[1])
     return sorted(services)
@@ -159,8 +177,15 @@ _GCLOUD_SUBCOMMAND_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 
 
 def _iter_gcloud_policy_invocations() -> Iterator[list[str]]:
-    """Yield the post-``gcloud`` token list for every gcloud invocation in an
-    ``id: cli`` remediation in the GCP policy.
+    """Yield the post-``gcloud`` token list for every gcloud invocation the
+    validator will check in the GCP policy.
+
+    That means `audit:` blocks as well as `id: cli` remediations. The scope
+    here decides which commands get their flags enriched from `gcloud --help`,
+    so it has to match what validate_gcloud() actually reads: a command left
+    out lands in the DB with only the static completion tree's flags — which
+    for many leaf commands is an empty list — and then rejects every flag it
+    is given, `--format` included.
 
     Centralises the YAML + fenced-block + line-continuation parsing so the
     per-token filtering logic stays in the callers.
@@ -169,20 +194,17 @@ def _iter_gcloud_policy_invocations() -> Iterator[list[str]]:
         return
 
     content = GCLOUD_POLICY_FILE.read_text()
-    for match in re.finditer(
-        r"- id: cli\s*\n\s+desc: \|\s*\n(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
-        content,
-        re.DOTALL,
-    ):
-        for fence in re.finditer(
-            r"```bash\s*\n(.*?)```", match.group(1), re.DOTALL
-        ):
-            joined = re.sub(r"\\\s*\n\s*", " ", fence.group(1))
-            for line in joined.split("\n"):
-                line = line.strip()
-                if not line.startswith("gcloud "):
+    for block, _line, _uid in extract_bash_blocks(content, include_audit=True):
+        joined = re.sub(r"\\\s*\n\s*", " ", block)
+        for line in joined.split("\n"):
+            line = line.strip()
+            candidates = [line] + [
+                inner.strip() for inner in COMMAND_SUBSTITUTION.findall(line)
+            ]
+            for candidate in candidates:
+                if not candidate.startswith("gcloud "):
                     continue
-                yield line.split()[1:]
+                yield candidate.split()[1:]
 
 
 def detect_gcloud_policy_command_paths() -> set[str]:
@@ -215,9 +237,18 @@ def detect_gcloud_policy_commands(commands_db: dict[str, list[str]]) -> set[str]
             if p.startswith("-"):
                 break
             cmd_parts.append(p)
-        candidate = " ".join(cmd_parts)
-        if candidate in commands_db:
-            policy_commands.add(candidate)
+        # Trailing tokens are usually positional arguments, not subcommands
+        # (`gcloud sql instances describe INSTANCE_NAME`). Walk back to the
+        # longest prefix that names a real command so the argument does not
+        # hide it — otherwise the command is never enriched from `--help` and
+        # keeps the completion tree's flags, which for many leaves is nothing
+        # at all.
+        while cmd_parts:
+            candidate = " ".join(cmd_parts)
+            if candidate in commands_db:
+                policy_commands.add(candidate)
+                break
+            cmd_parts.pop()
     return policy_commands
 
 
@@ -395,7 +426,7 @@ def validate_gcloud() -> tuple[int, int]:
         return 0, 0
 
     content = GCLOUD_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
+    blocks = extract_bash_blocks(content, include_audit=True)
 
     pass_count = 0
     fail_count = 0

--- a/content/validation/validators/nutanix.py
+++ b/content/validation/validators/nutanix.py
@@ -133,7 +133,7 @@ def validate_nutanix() -> tuple[int, int]:
         sys.exit(1)
 
     content = NUTANIX_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
+    blocks = extract_bash_blocks(content, include_audit=True)
     relpath = policy_relpath(NUTANIX_POLICY_FILE)
 
     pass_count = 0

--- a/content/validation/validators/oci.py
+++ b/content/validation/validators/oci.py
@@ -316,7 +316,7 @@ def validate_oci() -> tuple[int, int]:
         return 0, 0
 
     content = OCI_POLICY_FILE.read_text()
-    blocks = extract_bash_blocks(content)
+    blocks = extract_bash_blocks(content, include_audit=True)
 
     pass_count = 0
     fail_count = 0


### PR DESCRIPTION
## Why

`extract_bash_blocks` has always taken `include_audit`, and the REST API and Cobra validators pass it. The cloud CLI validators did not, on the assumption recorded in the docstring:

> The CLI validators don't enable it yet: that adds ~1,900 so-far-unvalidated blocks repo-wide, which need to be cleaned up cloud by cloud first.

I measured it. **The backlog is 43 commands, not ~1,900.** A wrong `audit:` command misleads an auditor exactly like a wrong `remediation:` command misleads an operator, so `aws` / `gcp` / `oci` / `digitalocean` / `nutanix` now validate both.

**Coverage goes from 1,655 to 2,990 checked commands.**

## What the 43 turned out to be

Most were validator gaps, not content bugs — which is worth knowing, because "turn the flag on" would otherwise have meant rewriting correct documentation to satisfy a broken checker.

### Validator fixes

| Fix | Effect |
|---|---|
| `_xform_name` split a trailing all-caps plural mid-word — `ListWebACLs` → `list-web-ac-ls` | every acronym-plural operation reported unknown. botocore special-cases these before the general splits; mirrored. |
| `emr list-clusters --active` is a CLI customization with no botocore flag | added to `AWS_CLI_CUSTOM_FLAGS` alongside `--terminated`/`--failed` |
| `aws sagemaker $cmd` — subcommand in a shell variable | no literal name to check; accepted rather than reported unknown |
| `$(...)` command substitution | now extracted and validated as its own command, then removed from the surrounding text. Left inline, its flags read as flags of the *outer* command — which is why `--environment-names` looked invalid on `describe-configuration-settings` |
| gcloud flag enrichment was scoped to `- id: cli` **and** stopped at the first positional | `sql instances describe INSTANCE_NAME` never matched a known command, so it kept the completion tree's *empty* flag list and rejected `--format` on 25 audit commands. Scope now follows what the validator reads; lookup walks back to the longest known prefix. |
| gcloud service detection only saw commands at the start of a line | missed `$(gcloud auth print-access-token)` inside curl calls, so the `auth` service was never walked |

### Genuine content defects

- **aws** — `ram get-principals` → `list-principals` (no such operation; verified against the CLI)
- **gcp** — `gcloud ai datasets list` and `gcloud ai batch-prediction-jobs list` do not exist. `gcloud ai` has no `datasets` or `batch-prediction-jobs` group, so both audits now query the Vertex AI REST API with `gcloud auth print-access-token`
- **oci** — `redis redis-cluster redis-cluster list` → `redis-cluster-summary list-redis-clusters`; `cloud-guard security-zone list` → `security-zone-collection list-security-zones`
- **digitalocean** — `doctl spaces buckets list` (no such subcommand; `doctl spaces` only has `keys`) → the S3-compatible `aws s3api list-buckets` the rest of the block already uses
- **nutanix** — `ncli protection-domain list-vms` → `list`

## Not included: azure

`azure` stays remediation-only here. Its checked-in grammar records argparse destination names rather than CLI option strings, so enabling audit validation today reports ~170 failures that are the grammar's fault rather than the content's. #3281 fixes the dump and enables it there.

## Verification

```console
aws            1819 passed, 0 failed
gcp             787 passed, 0 failed
oci             225 passed, 0 failed
digitalocean    120 passed, 0 failed
nutanix          39 passed, 0 failed
```

All five policies lint clean; patch versions bumped.

## Note for reviewers

This touches the same `extract_bash_blocks` docstring as #3281; whichever lands second may need a one-line merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)