### PR TITLE
✨ validation: lint the remediation the existing validators were skipping

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -265,11 +265,15 @@ cnspec scan local -f content/your-policy.mql.yaml
 Remediation snippets that are *code* rather than CLI invocations get linted with the tool their ecosystem already uses. Each validator extracts the fenced blocks from one `- id:` and runs the linter on each snippet in isolation, so a snippet has to stand on its own.
 
 ```bash
-python3 content/validation/validate_bash_remediation.py     # `id: bash` via shellcheck
+python3 content/validation/validate_bash_remediation.py     # `id: bash`/`script`/`sh` via shellcheck
 python3 content/validation/validate_ansible_remediation.py  # `id: ansible` via ansible-lint
 python3 content/validation/validate_chef_remediation.py     # `id: chef` via cookstyle
 python3 content/validation/validate_terraform_remediation.py
 ```
+
+`bash`, `script` and `sh` are three names for the same method, so the shell validator reads all three. The **fence language** decides the dialect, which is what keeps a `script` entry holding PowerShell (the Windows convention above) out of shellcheck: only ```` ```bash ```` and ```` ```sh ```` fences are linted.
+
+**A validator only sees the policies in its `TARGETS`.** Adding a remediation method to a policy that is not listed there means it ships unlinted and CI stays green — so when a policy gains its first `terraform`/`ansible`/`bash` remediation, add it to that validator's `TARGETS` in the same change. For Terraform there is a second step: the resource prefix needs an entry in `PROVIDER_MAP` too. Without one the generated `required_providers` block comes out empty and the `terraform` preset's `terraform_required_providers` rule fails *every* resource in that policy, which looks like 20 content bugs rather than one missing line.
 
 Each takes an optional target (`linux`, `windows`, `macos`, `kubernetes`, `chef`, …) and `--github-actions`. They run per-PR from `.github/workflows/validate-remediation.yaml`.
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -225,12 +225,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable ASLR
-              ansible.posix.sysctl:
-                name: kern.elf64.aslr.enable
-                value: '1'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Enable ASLR
+                  ansible.posix.sysctl:
+                    name: kern.elf64.aslr.enable
+                    value: '1'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
             ```
         - id: chef
           desc: |
@@ -341,15 +347,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable savecore in rc.conf
-              community.general.sysrc:
-                name: savecore_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the savecore service
-              ansible.builtin.service:
-                name: savecore
-                state: stopped
+              tasks:
+                - name: Disable savecore in rc.conf
+                  community.general.sysrc:
+                    name: savecore_enable
+                    value: 'NO'
+
+                - name: Stop the savecore service
+                  ansible.builtin.service:
+                    name: savecore
+                    state: stopped
             ```
         - id: chef
           desc: |
@@ -431,10 +443,16 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable crash dump storage
-              community.general.sysrc:
-                name: dumpdev
-                value: 'NO'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable crash dump storage
+                  community.general.sysrc:
+                    name: dumpdev
+                    value: 'NO'
             ```
         - id: chef
           desc: |
@@ -539,15 +557,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable IPv4 and IPv6 forwarding
-              ansible.posix.sysctl:
-                name: "{{ item }}"
-                value: '0'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
-              loop:
-                - net.inet.ip.forwarding
-                - net.inet6.ip6.forwarding
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable IPv4 and IPv6 forwarding
+                  ansible.posix.sysctl:
+                    name: "{{ item }}"
+                    value: '0'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
+                  loop:
+                    - net.inet.ip.forwarding
+                    - net.inet6.ip6.forwarding
             ```
         - id: chef
           desc: |
@@ -676,15 +700,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable ICMP redirect sending
-              ansible.posix.sysctl:
-                name: "{{ item }}"
-                value: '0'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
-              loop:
-                - net.inet.ip.redirect
-                - net.inet6.ip6.redirect
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable ICMP redirect sending
+                  ansible.posix.sysctl:
+                    name: "{{ item }}"
+                    value: '0'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
+                  loop:
+                    - net.inet.ip.redirect
+                    - net.inet6.ip6.redirect
             ```
         - id: chef
           desc: |
@@ -813,15 +843,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Drop incoming ICMP redirects
-              ansible.posix.sysctl:
-                name: "{{ item.name }}"
-                value: "{{ item.value }}"
-                sysctl_file: /etc/sysctl.conf
-                reload: true
-              loop:
-                - { name: net.inet.icmp.drop_redirect, value: '1' }
-                - { name: net.inet6.icmp6.rediraccept, value: '0' }
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Drop incoming ICMP redirects
+                  ansible.posix.sysctl:
+                    name: "{{ item.name }}"
+                    value: "{{ item.value }}"
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
+                  loop:
+                    - { name: net.inet.icmp.drop_redirect, value: '1' }
+                    - { name: net.inet6.icmp6.rediraccept, value: '0' }
             ```
         - id: chef
           desc: |
@@ -942,12 +978,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable source routed packet acceptance
-              ansible.posix.sysctl:
-                name: net.inet.ip.accept_sourceroute
-                value: '0'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable source routed packet acceptance
+                  ansible.posix.sysctl:
+                    name: net.inet.ip.accept_sourceroute
+                    value: '0'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
             ```
         - id: chef
           desc: |
@@ -1068,12 +1110,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable TCP SYN cookies
-              ansible.posix.sysctl:
-                name: net.inet.tcp.syncookies
-                value: '1'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Enable TCP SYN cookies
+                  ansible.posix.sysctl:
+                    name: net.inet.tcp.syncookies
+                    value: '1'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
             ```
         - id: chef
           desc: |
@@ -1194,12 +1242,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable IPv6 router advertisement acceptance
-              ansible.posix.sysctl:
-                name: net.inet6.ip6.accept_rtadv
-                value: '0'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable IPv6 router advertisement acceptance
+                  ansible.posix.sysctl:
+                    name: net.inet6.ip6.accept_rtadv
+                    value: '0'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
             ```
         - id: chef
           desc: |
@@ -1320,12 +1374,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable broadcast ICMP echo responses
-              ansible.posix.sysctl:
-                name: net.inet.icmp.bmcastecho
-                value: '0'
-                sysctl_file: /etc/sysctl.conf
-                reload: true
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Disable broadcast ICMP echo responses
+                  ansible.posix.sysctl:
+                    name: net.inet.icmp.bmcastecho
+                    value: '0'
+                    sysctl_file: /etc/sysctl.conf
+                    reload: true
             ```
         - id: chef
           desc: |
@@ -1449,17 +1509,23 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Comment out FTP entries in inetd.conf
-              ansible.builtin.replace:
-                path: /etc/inetd.conf
-                regexp: '^ftp'
-                replace: '#ftp'
+              hosts: all
+              become: true
 
-            - name: Reload inetd to apply the change
-              ansible.builtin.service:
-                name: inetd
-                state: reloaded
-              failed_when: false
+              tasks:
+                - name: Comment out FTP entries in inetd.conf
+                  ansible.builtin.replace:
+                    path: /etc/inetd.conf
+                    regexp: '^ftp'
+                    replace: '#ftp'
+
+                - name: Reload inetd to apply the change
+                  ansible.builtin.service:
+                    name: inetd
+                    state: reloaded
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -1565,17 +1631,23 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Comment out telnet entries in inetd.conf
-              ansible.builtin.replace:
-                path: /etc/inetd.conf
-                regexp: '^telnet'
-                replace: '#telnet'
+              hosts: all
+              become: true
 
-            - name: Reload inetd to apply the change
-              ansible.builtin.service:
-                name: inetd
-                state: reloaded
-              failed_when: false
+              tasks:
+                - name: Comment out telnet entries in inetd.conf
+                  ansible.builtin.replace:
+                    path: /etc/inetd.conf
+                    regexp: '^telnet'
+                    replace: '#telnet'
+
+                - name: Reload inetd to apply the change
+                  ansible.builtin.service:
+                    name: inetd
+                    state: reloaded
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -1675,15 +1747,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable NIS server in rc.conf
-              community.general.sysrc:
-                name: nis_server_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the ypserv service
-              ansible.builtin.service:
-                name: ypserv
-                state: stopped
+              tasks:
+                - name: Disable NIS server in rc.conf
+                  community.general.sysrc:
+                    name: nis_server_enable
+                    value: 'NO'
+
+                - name: Stop the ypserv service
+                  ansible.builtin.service:
+                    name: ypserv
+                    state: stopped
             ```
         - id: chef
           desc: |
@@ -1769,15 +1847,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable rpcbind in rc.conf
-              community.general.sysrc:
-                name: rpcbind_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the rpcbind service
-              ansible.builtin.service:
-                name: rpcbind
-                state: stopped
+              tasks:
+                - name: Disable rpcbind in rc.conf
+                  community.general.sysrc:
+                    name: rpcbind_enable
+                    value: 'NO'
+
+                - name: Stop the rpcbind service
+                  ansible.builtin.service:
+                    name: rpcbind
+                    state: stopped
             ```
         - id: chef
           desc: |
@@ -1873,15 +1957,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable NFS server in rc.conf
-              community.general.sysrc:
-                name: nfs_server_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the nfsd service
-              ansible.builtin.service:
-                name: nfsd
-                state: stopped
+              tasks:
+                - name: Disable NFS server in rc.conf
+                  community.general.sysrc:
+                    name: nfs_server_enable
+                    value: 'NO'
+
+                - name: Stop the nfsd service
+                  ansible.builtin.service:
+                    name: nfsd
+                    state: stopped
             ```
         - id: chef
           desc: |
@@ -1974,16 +2064,22 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable snmpd in rc.conf
-              community.general.sysrc:
-                name: snmpd_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the snmpd service
-              ansible.builtin.service:
-                name: snmpd
-                state: stopped
-              failed_when: false
+              tasks:
+                - name: Disable snmpd in rc.conf
+                  community.general.sysrc:
+                    name: snmpd_enable
+                    value: 'NO'
+
+                - name: Stop the snmpd service
+                  ansible.builtin.service:
+                    name: snmpd
+                    state: stopped
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -2075,17 +2171,23 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Comment out TFTP entries in inetd.conf
-              ansible.builtin.replace:
-                path: /etc/inetd.conf
-                regexp: '^tftp'
-                replace: '#tftp'
+              hosts: all
+              become: true
 
-            - name: Reload inetd to apply the change
-              ansible.builtin.service:
-                name: inetd
-                state: reloaded
-              failed_when: false
+              tasks:
+                - name: Comment out TFTP entries in inetd.conf
+                  ansible.builtin.replace:
+                    path: /etc/inetd.conf
+                    regexp: '^tftp'
+                    replace: '#tftp'
+
+                - name: Reload inetd to apply the change
+                  ansible.builtin.service:
+                    name: inetd
+                    state: reloaded
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -2194,22 +2296,28 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable mail access services in rc.conf
-              community.general.sysrc:
-                name: "{{ item }}"
-                value: 'NO'
-              loop:
-                - dovecot_enable
-                - cyrus_imapd_enable
+              hosts: all
+              become: true
 
-            - name: Stop mail access services
-              ansible.builtin.service:
-                name: "{{ item }}"
-                state: stopped
-              loop:
-                - dovecot
-                - imapd
-              failed_when: false
+              tasks:
+                - name: Disable mail access services in rc.conf
+                  community.general.sysrc:
+                    name: "{{ item }}"
+                    value: 'NO'
+                  loop:
+                    - dovecot_enable
+                    - cyrus_imapd_enable
+
+                - name: Stop mail access services
+                  ansible.builtin.service:
+                    name: "{{ item }}"
+                    state: stopped
+                  loop:
+                    - dovecot
+                    - imapd
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -2304,16 +2412,22 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable squid in rc.conf
-              community.general.sysrc:
-                name: squid_enable
-                value: 'NO'
+              hosts: all
+              become: true
 
-            - name: Stop the squid service
-              ansible.builtin.service:
-                name: squid
-                state: stopped
-              failed_when: false
+              tasks:
+                - name: Disable squid in rc.conf
+                  community.general.sysrc:
+                    name: squid_enable
+                    value: 'NO'
+
+                - name: Stop the squid service
+                  ansible.builtin.service:
+                    name: squid
+                    state: stopped
+                  failed_when: false
             ```
         - id: chef
           desc: |
@@ -2416,18 +2530,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Restrict Postfix to local interfaces
-              ansible.builtin.lineinfile:
-                path: /usr/local/etc/postfix/main.cf
-                regexp: '^inet_interfaces'
-                line: 'inet_interfaces = localhost'
-              notify: restart postfix
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart postfix
-                ansible.builtin.service:
-                  name: postfix
-                  state: restarted
+              tasks:
+                - name: Restrict Postfix to local interfaces
+                  ansible.builtin.lineinfile:
+                    path: /usr/local/etc/postfix/main.cf
+                    regexp: '^inet_interfaces'
+                    line: 'inet_interfaces = localhost'
+                  notify: Restart postfix
+
+              handlers:
+                - name: Restart postfix
+                  ansible.builtin.service:
+                    name: postfix
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -2538,12 +2658,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure sshd_config permissions
-              ansible.builtin.file:
-                path: /etc/ssh/sshd_config
-                owner: root
-                group: wheel
-                mode: '0600'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure sshd_config permissions
+                  ansible.builtin.file:
+                    path: /etc/ssh/sshd_config
+                    owner: root
+                    group: wheel
+                    mode: '0600'
             ```
         - id: chef
           desc: |
@@ -2639,20 +2765,26 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Find SSH private host key files
-              ansible.builtin.find:
-                paths: /etc/ssh
-                patterns: 'ssh_host_*key'
-                excludes: '*.pub'
-              register: ssh_private_keys
+              hosts: all
+              become: true
 
-            - name: Secure SSH private host key files
-              ansible.builtin.file:
-                path: "{{ item.path }}"
-                owner: root
-                group: wheel
-                mode: '0600'
-              loop: "{{ ssh_private_keys.files }}"
+              tasks:
+                - name: Find SSH private host key files
+                  ansible.builtin.find:
+                    paths: /etc/ssh
+                    patterns: 'ssh_host_*key'
+                    excludes: '*.pub'
+                  register: ssh_private_keys
+
+                - name: Secure SSH private host key files
+                  ansible.builtin.file:
+                    path: "{{ item.path }}"
+                    owner: root
+                    group: wheel
+                    mode: '0600'
+                  loop: "{{ ssh_private_keys.files }}"
             ```
         - id: chef
           desc: |
@@ -2747,19 +2879,25 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Find SSH public host key files
-              ansible.builtin.find:
-                paths: /etc/ssh
-                patterns: 'ssh_host_*key.pub'
-              register: ssh_public_keys
+              hosts: all
+              become: true
 
-            - name: Secure SSH public host key files
-              ansible.builtin.file:
-                path: "{{ item.path }}"
-                owner: root
-                group: wheel
-                mode: '0644'
-              loop: "{{ ssh_public_keys.files }}"
+              tasks:
+                - name: Find SSH public host key files
+                  ansible.builtin.find:
+                    paths: /etc/ssh
+                    patterns: 'ssh_host_*key.pub'
+                  register: ssh_public_keys
+
+                - name: Secure SSH public host key files
+                  ansible.builtin.file:
+                    path: "{{ item.path }}"
+                    owner: root
+                    group: wheel
+                    mode: '0644'
+                  loop: "{{ ssh_public_keys.files }}"
             ```
         - id: chef
           desc: |
@@ -2865,18 +3003,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Configure strong SSH ciphers
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?Ciphers'
-                line: 'Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Configure strong SSH ciphers
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?Ciphers'
+                    line: 'Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -2997,18 +3141,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Configure strong SSH MAC algorithms
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?MACs'
-                line: 'MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Configure strong SSH MAC algorithms
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?MACs'
+                    line: 'MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3129,18 +3279,32 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Configure strong SSH key exchange algorithms
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?KexAlgorithms'
-                line: 'KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              vars:
+                ssh_kex_algorithms:
+                  - sntrup761x25519-sha512@openssh.com
+                  - curve25519-sha256@libssh.org
+                  - curve25519-sha256
+                  - diffie-hellman-group18-sha512
+                  - diffie-hellman-group16-sha512
+
+              tasks:
+                - name: Configure strong SSH key exchange algorithms
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?KexAlgorithms'
+                    line: "KexAlgorithms {{ ssh_kex_algorithms | join(',') }}"
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3261,18 +3425,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable SSH root login
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?PermitRootLogin'
-                line: 'PermitRootLogin no'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Disable SSH root login
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?PermitRootLogin'
+                    line: 'PermitRootLogin no'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3393,18 +3563,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable SSH empty passwords
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?PermitEmptyPasswords'
-                line: 'PermitEmptyPasswords no'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Disable SSH empty passwords
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?PermitEmptyPasswords'
+                    line: 'PermitEmptyPasswords no'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3525,18 +3701,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable SSH host-based authentication
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?HostbasedAuthentication'
-                line: 'HostbasedAuthentication no'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Disable SSH host-based authentication
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?HostbasedAuthentication'
+                    line: 'HostbasedAuthentication no'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3657,18 +3839,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Disable SSH PermitUserEnvironment
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?PermitUserEnvironment'
-                line: 'PermitUserEnvironment no'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Disable SSH PermitUserEnvironment
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?PermitUserEnvironment'
+                    line: 'PermitUserEnvironment no'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3789,18 +3977,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable SSH IgnoreRhosts
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?IgnoreRhosts'
-                line: 'IgnoreRhosts yes'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Enable SSH IgnoreRhosts
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?IgnoreRhosts'
+                    line: 'IgnoreRhosts yes'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -3921,18 +4115,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Set SSH MaxAuthTries
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?MaxAuthTries'
-                line: 'MaxAuthTries 4'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Set SSH MaxAuthTries
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?MaxAuthTries'
+                    line: 'MaxAuthTries 4'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4054,18 +4254,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Set SSH LoginGraceTime
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?LoginGraceTime'
-                line: 'LoginGraceTime 60'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Set SSH LoginGraceTime
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?LoginGraceTime'
+                    line: 'LoginGraceTime 60'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4186,18 +4392,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Set SSH LogLevel
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?LogLevel'
-                line: 'LogLevel VERBOSE'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Set SSH LogLevel
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?LogLevel'
+                    line: 'LogLevel VERBOSE'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4332,21 +4544,27 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Configure SSH idle timeout
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: "{{ item.regexp }}"
-                line: "{{ item.line }}"
-              loop:
-                - { regexp: '^#?ClientAliveInterval', line: 'ClientAliveInterval 300' }
-                - { regexp: '^#?ClientAliveCountMax', line: 'ClientAliveCountMax 3' }
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Configure SSH idle timeout
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: "{{ item.regexp }}"
+                    line: "{{ item.line }}"
+                  loop:
+                    - { regexp: '^#?ClientAliveInterval', line: 'ClientAliveInterval 300' }
+                    - { regexp: '^#?ClientAliveCountMax', line: 'ClientAliveCountMax 3' }
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4467,18 +4685,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable SSH DisableForwarding
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?DisableForwarding'
-                line: 'DisableForwarding yes'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Enable SSH DisableForwarding
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?DisableForwarding'
+                    line: 'DisableForwarding yes'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4599,18 +4823,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable SSH UsePAM
-              ansible.builtin.lineinfile:
-                path: /etc/ssh/sshd_config
-                regexp: '^#?UsePAM'
-                line: 'UsePAM yes'
-              notify: restart sshd
+              hosts: all
+              become: true
 
-            handlers:
-              - name: restart sshd
-                ansible.builtin.service:
-                  name: sshd
-                  state: restarted
+              tasks:
+                - name: Enable SSH UsePAM
+                  ansible.builtin.lineinfile:
+                    path: /etc/ssh/sshd_config
+                    regexp: '^#?UsePAM'
+                    line: 'UsePAM yes'
+                  notify: Restart sshd
+
+              handlers:
+                - name: Restart sshd
+                  ansible.builtin.service:
+                    name: sshd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -4721,12 +4951,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure /etc/passwd permissions
-              ansible.builtin.file:
-                path: /etc/passwd
-                owner: root
-                group: wheel
-                mode: '0644'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure /etc/passwd permissions
+                  ansible.builtin.file:
+                    path: /etc/passwd
+                    owner: root
+                    group: wheel
+                    mode: '0644'
             ```
         - id: chef
           desc: |
@@ -4820,12 +5056,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure /etc/group permissions
-              ansible.builtin.file:
-                path: /etc/group
-                owner: root
-                group: wheel
-                mode: '0644'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure /etc/group permissions
+                  ansible.builtin.file:
+                    path: /etc/group
+                    owner: root
+                    group: wheel
+                    mode: '0644'
             ```
         - id: chef
           desc: |
@@ -4921,12 +5163,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure /etc/master.passwd permissions
-              ansible.builtin.file:
-                path: /etc/master.passwd
-                owner: root
-                group: wheel
-                mode: '0600'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure /etc/master.passwd permissions
+                  ansible.builtin.file:
+                    path: /etc/master.passwd
+                    owner: root
+                    group: wheel
+                    mode: '0600'
             ```
         - id: chef
           desc: |
@@ -5019,12 +5267,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure /etc/shells permissions
-              ansible.builtin.file:
-                path: /etc/shells
-                owner: root
-                group: wheel
-                mode: '0644'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure /etc/shells permissions
+                  ansible.builtin.file:
+                    path: /etc/shells
+                    owner: root
+                    group: wheel
+                    mode: '0644'
             ```
         - id: chef
           desc: |
@@ -5120,12 +5374,18 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Secure /boot/loader.conf permissions
-              ansible.builtin.file:
-                path: /boot/loader.conf
-                owner: root
-                group: wheel
-                mode: '0600'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Secure /boot/loader.conf permissions
+                  ansible.builtin.file:
+                    path: /boot/loader.conf
+                    owner: root
+                    group: wheel
+                    mode: '0600'
             ```
         - id: chef
           desc: |
@@ -5226,15 +5486,21 @@ queries:
             2. Run the playbook, then manually remove or re-number any reported account.
 
             ```yaml
+            ---
             - name: Find non-root accounts with UID 0
-              ansible.builtin.shell: "awk -F: '$3 == 0 && $1 != \"root\" { print $1 }' /etc/passwd"
-              register: uid0_accounts
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when a non-root UID 0 account exists
-              ansible.builtin.fail:
-                msg: "Non-root UID 0 accounts found: {{ uid0_accounts.stdout }}"
-              when: uid0_accounts.stdout | length > 0
+              tasks:
+                - name: Find non-root accounts with UID 0
+                  ansible.builtin.shell: "awk -F: '$3 == 0 && $1 != \"root\" { print $1 }' /etc/passwd"
+                  register: uid0_accounts
+                  changed_when: false
+
+                - name: Fail when a non-root UID 0 account exists
+                  ansible.builtin.fail:
+                    msg: "Non-root UID 0 accounts found: {{ uid0_accounts.stdout }}"
+                  when: uid0_accounts.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-uids-exist
@@ -5337,15 +5603,21 @@ queries:
             2. Run the playbook, then manually assign unique UIDs to any reported account.
 
             ```yaml
+            ---
             - name: Find duplicate UIDs
-              ansible.builtin.shell: "awk -F: '$3 != 0 { print $3 }' /etc/passwd | sort -n | uniq -d"
-              register: dup_uids
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when duplicate UIDs exist
-              ansible.builtin.fail:
-                msg: "Duplicate UIDs found: {{ dup_uids.stdout }}"
-              when: dup_uids.stdout | length > 0
+              tasks:
+                - name: Find duplicate UIDs
+                  ansible.builtin.shell: "awk -F: '$3 != 0 { print $3 }' /etc/passwd | sort -n | uniq -d"
+                  register: dup_uids
+                  changed_when: false
+
+                - name: Fail when duplicate UIDs exist
+                  ansible.builtin.fail:
+                    msg: "Duplicate UIDs found: {{ dup_uids.stdout }}"
+                  when: dup_uids.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-gids-exist
@@ -5448,15 +5720,21 @@ queries:
             2. Run the playbook, then manually assign unique GIDs to any reported group.
 
             ```yaml
+            ---
             - name: Find duplicate GIDs
-              ansible.builtin.shell: "awk -F: '{print $3}' /etc/group | sort -n | uniq -d"
-              register: dup_gids
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when duplicate GIDs exist
-              ansible.builtin.fail:
-                msg: "Duplicate GIDs found: {{ dup_gids.stdout }}"
-              when: dup_gids.stdout | length > 0
+              tasks:
+                - name: Find duplicate GIDs
+                  ansible.builtin.shell: "awk -F: '{print $3}' /etc/group | sort -n | uniq -d"
+                  register: dup_gids
+                  changed_when: false
+
+                - name: Fail when duplicate GIDs exist
+                  ansible.builtin.fail:
+                    msg: "Duplicate GIDs found: {{ dup_gids.stdout }}"
+                  when: dup_gids.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-user-names-exist
@@ -5535,15 +5813,21 @@ queries:
             2. Run the playbook, then manually resolve any reported duplicate.
 
             ```yaml
+            ---
             - name: Find duplicate user names
-              ansible.builtin.shell: "awk -F: '{print $1}' /etc/passwd | sort | uniq -d"
-              register: dup_users
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when duplicate user names exist
-              ansible.builtin.fail:
-                msg: "Duplicate user names found: {{ dup_users.stdout }}"
-              when: dup_users.stdout | length > 0
+              tasks:
+                - name: Find duplicate user names
+                  ansible.builtin.shell: "awk -F: '{print $1}' /etc/passwd | sort | uniq -d"
+                  register: dup_users
+                  changed_when: false
+
+                - name: Fail when duplicate user names exist
+                  ansible.builtin.fail:
+                    msg: "Duplicate user names found: {{ dup_users.stdout }}"
+                  when: dup_users.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-no-duplicate-group-names-exist
@@ -5622,15 +5906,21 @@ queries:
             2. Run the playbook, then manually resolve any reported duplicate.
 
             ```yaml
+            ---
             - name: Find duplicate group names
-              ansible.builtin.shell: "awk -F: '{print $1}' /etc/group | sort | uniq -d"
-              register: dup_groups
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when duplicate group names exist
-              ansible.builtin.fail:
-                msg: "Duplicate group names found: {{ dup_groups.stdout }}"
-              when: dup_groups.stdout | length > 0
+              tasks:
+                - name: Find duplicate group names
+                  ansible.builtin.shell: "awk -F: '{print $1}' /etc/group | sort | uniq -d"
+                  register: dup_groups
+                  changed_when: false
+
+                - name: Fail when duplicate group names exist
+                  ansible.builtin.fail:
+                    msg: "Duplicate group names found: {{ dup_groups.stdout }}"
+                  when: dup_groups.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-all-groups-in-passwd-exist-in-group
@@ -5718,15 +6008,21 @@ queries:
             2. Run the playbook, then create the missing groups or reassign the reported users.
 
             ```yaml
+            ---
             - name: Find users whose primary group is missing
-              ansible.builtin.shell: "awk -F: 'NR==FNR { gids[$3]; next } !($4 in gids) { print $1 }' /etc/group /etc/passwd"
-              register: missing_groups
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when a primary group is missing
-              ansible.builtin.fail:
-                msg: "Users with missing primary groups: {{ missing_groups.stdout }}"
-              when: missing_groups.stdout | length > 0
+              tasks:
+                - name: Find users whose primary group is missing
+                  ansible.builtin.shell: "awk -F: 'NR==FNR { gids[$3]; next } !($4 in gids) { print $1 }' /etc/group /etc/passwd"
+                  register: missing_groups
+                  changed_when: false
+
+                - name: Fail when a primary group is missing
+                  ansible.builtin.fail:
+                    msg: "Users with missing primary groups: {{ missing_groups.stdout }}"
+                  when: missing_groups.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-syslogd-is-enabled-and-running
@@ -5802,15 +6098,21 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable syslogd in rc.conf
-              community.general.sysrc:
-                name: syslogd_enable
-                value: 'YES'
+              hosts: all
+              become: true
 
-            - name: Start the syslogd service
-              ansible.builtin.service:
-                name: syslogd
-                state: started
+              tasks:
+                - name: Enable syslogd in rc.conf
+                  community.general.sysrc:
+                    name: syslogd_enable
+                    value: 'YES'
+
+                - name: Start the syslogd service
+                  ansible.builtin.service:
+                    name: syslogd
+                    state: started
             ```
         - id: chef
           desc: |
@@ -5900,16 +6202,22 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Set syslogd secure-mode flag
-              community.general.sysrc:
-                name: syslogd_flags
-                value: '-s'
-                state: value_present
+              hosts: all
+              become: true
 
-            - name: Restart the syslogd service
-              ansible.builtin.service:
-                name: syslogd
-                state: restarted
+              tasks:
+                - name: Set syslogd secure-mode flag
+                  community.general.sysrc:
+                    name: syslogd_flags
+                    value: '-s'
+                    state: value_present
+
+                - name: Restart the syslogd service
+                  ansible.builtin.service:
+                    name: syslogd
+                    state: restarted
             ```
         - id: chef
           desc: |
@@ -6005,10 +6313,16 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Install sudo
-              community.general.pkgng:
-                name: sudo
-                state: present
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Install sudo
+                  community.general.pkgng:
+                    name: sudo
+                    state: present
             ```
         - id: chef
           desc: |
@@ -6112,14 +6426,20 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Require a pseudo terminal for sudo
-              ansible.builtin.copy:
-                dest: /usr/local/etc/sudoers.d/99-use-pty
-                content: "Defaults use_pty\n"
-                owner: root
-                group: wheel
-                mode: '0440'
-                validate: 'visudo -cf %s'
+              hosts: all
+              become: true
+
+              tasks:
+                - name: Require a pseudo terminal for sudo
+                  ansible.builtin.copy:
+                    dest: /usr/local/etc/sudoers.d/99-use-pty
+                    content: "Defaults use_pty\n"
+                    owner: root
+                    group: wheel
+                    mode: '0440'
+                    validate: 'visudo -cf %s'
             ```
         - id: chef
           desc: |
@@ -6239,15 +6559,21 @@ queries:
             2. Run the playbook, then edit the reported files with `visudo` to remove the `NOPASSWD` tag.
 
             ```yaml
+            ---
             - name: Search for NOPASSWD entries
-              ansible.builtin.shell: "grep -rilE '^[^#]*NOPASSWD' /usr/local/etc/sudoers /usr/local/etc/sudoers.d/ || true"
-              register: nopasswd_files
-              changed_when: false
+              hosts: all
+              become: true
 
-            - name: Fail when NOPASSWD is configured
-              ansible.builtin.fail:
-                msg: "NOPASSWD found in: {{ nopasswd_files.stdout }}"
-              when: nopasswd_files.stdout | length > 0
+              tasks:
+                - name: Search for NOPASSWD entries
+                  ansible.builtin.shell: "grep -rilE '^[^#]*NOPASSWD' /usr/local/etc/sudoers /usr/local/etc/sudoers.d/ || true"
+                  register: nopasswd_files
+                  changed_when: false
+
+                - name: Fail when NOPASSWD is configured
+                  ansible.builtin.fail:
+                    msg: "NOPASSWD found in: {{ nopasswd_files.stdout }}"
+                  when: nopasswd_files.stdout | length > 0
             ```
         # No Chef Infra remediation: resolving this means deciding which account or sudoers entry to change, which is a human decision rather than a converge step.
   - uid: mondoo-freebsd-security-firewall-is-enabled
@@ -6348,20 +6674,26 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable ipfw in rc.conf
-              community.general.sysrc:
-                name: "{{ item.name }}"
-                value: "{{ item.value }}"
-              loop:
-                - { name: firewall_enable, value: 'YES' }
-                - { name: firewall_type, value: 'workstation' }
-                - { name: firewall_myservices, value: '22/tcp' }
-                - { name: firewall_allowservices, value: 'any' }
+              hosts: all
+              become: true
 
-            - name: Start the ipfw service
-              ansible.builtin.service:
-                name: ipfw
-                state: started
+              tasks:
+                - name: Enable ipfw in rc.conf
+                  community.general.sysrc:
+                    name: "{{ item.name }}"
+                    value: "{{ item.value }}"
+                  loop:
+                    - { name: firewall_enable, value: 'YES' }
+                    - { name: firewall_type, value: 'workstation' }
+                    - { name: firewall_myservices, value: '22/tcp' }
+                    - { name: firewall_allowservices, value: 'any' }
+
+                - name: Start the ipfw service
+                  ansible.builtin.service:
+                    name: ipfw
+                    state: started
             ```
         - id: chef
           desc: |
@@ -6463,18 +6795,24 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enable ntpd in rc.conf
-              community.general.sysrc:
-                name: "{{ item.name }}"
-                value: "{{ item.value }}"
-              loop:
-                - { name: ntpd_enable, value: 'YES' }
-                - { name: ntpd_sync_on_start, value: 'YES' }
+              hosts: all
+              become: true
 
-            - name: Start the ntpd service
-              ansible.builtin.service:
-                name: ntpd
-                state: started
+              tasks:
+                - name: Enable ntpd in rc.conf
+                  community.general.sysrc:
+                    name: "{{ item.name }}"
+                    value: "{{ item.value }}"
+                  loop:
+                    - { name: ntpd_enable, value: 'YES' }
+                    - { name: ntpd_sync_on_start, value: 'YES' }
+
+                - name: Start the ntpd service
+                  ansible.builtin.service:
+                    name: ntpd
+                    state: started
             ```
   - uid: mondoo-freebsd-security-pkg-signature-verification-is-enabled
     title: Ensure pkg repository signature verification is enabled
@@ -6580,25 +6918,31 @@ queries:
             2. Run the playbook.
 
             ```yaml
+            ---
             - name: Enforce fingerprint signature verification for the base repository
-              ansible.builtin.lineinfile:
-                path: /etc/pkg/FreeBSD.conf
-                regexp: '^\s*signature_type:'
-                line: '  signature_type: "fingerprints",'
+              hosts: all
+              become: true
 
-            - name: Ensure the fingerprints path is configured
-              ansible.builtin.lineinfile:
-                path: /etc/pkg/FreeBSD.conf
-                regexp: '^\s*fingerprints:'
-                line: '  fingerprints: "/usr/share/keys/pkg"'
+              tasks:
+                - name: Enforce fingerprint signature verification for the base repository
+                  ansible.builtin.lineinfile:
+                    path: /etc/pkg/FreeBSD.conf
+                    regexp: '^\s*signature_type:'
+                    line: '  signature_type: "fingerprints",'
 
-            - name: Confirm the trusted fingerprint keys are present
-              ansible.builtin.stat:
-                path: /usr/share/keys/pkg/trusted
-              register: pkg_keys
+                - name: Ensure the fingerprints path is configured
+                  ansible.builtin.lineinfile:
+                    path: /etc/pkg/FreeBSD.conf
+                    regexp: '^\s*fingerprints:'
+                    line: '  fingerprints: "/usr/share/keys/pkg"'
 
-            - name: Fail when the fingerprint keys are missing
-              ansible.builtin.fail:
-                msg: "/usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update."
-              when: not pkg_keys.stat.exists
+                - name: Confirm the trusted fingerprint keys are present
+                  ansible.builtin.stat:
+                    path: /usr/share/keys/pkg/trusted
+                  register: pkg_keys
+
+                - name: Fail when the fingerprint keys are missing
+                  ansible.builtin.fail:
+                    msg: "/usr/share/keys/pkg/trusted is missing; restore the fingerprint keys before running pkg update."
+                  when: not pkg_keys.stat.exists
             ```

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-proxmox-security
     name: Mondoo Proxmox VE Security
-    version: 1.1.3
+    version: 1.1.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -5476,9 +5476,10 @@ queries:
               printf 'PASS_MAX_DAYS\t%s\n' "$max_days" >> "$file"
             fi
 
-            for user in $(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd); do
-              chage --maxdays "$max_days" "$user"
-            done
+            awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd |
+              while read -r user; do
+                chage --maxdays "$max_days" "$user"
+              done
             ```
         - id: ansible
           desc: |
@@ -5588,9 +5589,10 @@ queries:
               printf 'PASS_MIN_DAYS\t%s\n' "$min_days" >> "$file"
             fi
 
-            for user in $(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd); do
-              chage --mindays "$min_days" "$user"
-            done
+            awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd |
+              while read -r user; do
+                chage --mindays "$min_days" "$user"
+              done
             ```
         - id: ansible
           desc: |

--- a/content/validation/validate_ansible_remediation.py
+++ b/content/validation/validate_ansible_remediation.py
@@ -38,6 +38,13 @@ TARGETS = {
     ],
     "macos": [SCRIPT_DIR / ".." / "mondoo-macos-security.mql.yaml"],
     "kubernetes": [SCRIPT_DIR / ".." / "mondoo-kubernetes-security.mql.yaml"],
+    # Policies whose ansible remediation had never been linted.
+    "ai": [SCRIPT_DIR / ".." / "mondoo-ai-security.mql.yaml"],
+    "edr": [SCRIPT_DIR / ".." / "mondoo-edr-policy.mql.yaml"],
+    "freebsd": [SCRIPT_DIR / ".." / "mondoo-freebsd-security.mql.yaml"],
+    "mariadb": [SCRIPT_DIR / ".." / "mondoo-mariadb-security.mql.yaml"],
+    "mysql": [SCRIPT_DIR / ".." / "mondoo-mysql-security.mql.yaml"],
+    "proxmox": [SCRIPT_DIR / ".." / "mondoo-proxmox-security.mql.yaml"],
 }
 
 # ansible-lint rules to skip — these are too noisy for remediation snippets

--- a/content/validation/validate_bash_remediation.py
+++ b/content/validation/validate_bash_remediation.py
@@ -29,10 +29,17 @@ SCRIPT_DIR = Path(__file__).parent
 TARGETS = {
     "linux": [
         SCRIPT_DIR / ".." / "mondoo-linux-security.mql.yaml",
+        SCRIPT_DIR / ".." / "mondoo-linux-operational-policy.mql.yaml",
         SCRIPT_DIR / ".." / "mondoo-linux-snmp-policy.mql.yaml",
         SCRIPT_DIR / ".." / "mondoo-linux-workstation-security.mql.yaml",
     ],
     "kubernetes": [SCRIPT_DIR / ".." / "mondoo-kubernetes-security.mql.yaml"],
+    # Policies whose shell remediation had never been linted.
+    "edr": [SCRIPT_DIR / ".." / "mondoo-edr-policy.mql.yaml"],
+    "freebsd": [SCRIPT_DIR / ".." / "mondoo-freebsd-security.mql.yaml"],
+    "mariadb": [SCRIPT_DIR / ".." / "mondoo-mariadb-security.mql.yaml"],
+    "mysql": [SCRIPT_DIR / ".." / "mondoo-mysql-security.mql.yaml"],
+    "proxmox": [SCRIPT_DIR / ".." / "mondoo-proxmox-security.mql.yaml"],
 }
 
 # shellcheck codes to exclude:
@@ -65,10 +72,19 @@ class ShellcheckResult:
 # Extraction
 # ---------------------------------------------------------------------------
 
-def extract_bash_blocks(content: str, filepath: Path) -> list[BashBlock]:
-    """Extract bash code blocks from bash remediation sections.
+# Remediation ids that hold a shell script. `bash`, `script` and `sh` are the
+# same method under three names; all three are linted, and the fence language
+# decides the dialect so a `script` entry holding PowerShell (the Windows
+# convention in content/CLAUDE.md) is skipped rather than linted as shell.
+SHELL_REMEDIATION_IDS = ("bash", "script", "sh")
+SHELL_FENCE_LANGUAGES = ("bash", "sh")
 
-    Only extracts from `- id: bash` sections, NOT `- id: cli`.
+
+def extract_bash_blocks(content: str, filepath: Path) -> list[BashBlock]:
+    """Extract shell code blocks from shell remediation sections.
+
+    Reads `- id: bash`, `- id: script` and `- id: sh`, never `- id: cli`
+    (which validate_remediation_commands.py owns).
     """
     lines = content.split("\n")
     uid_positions: list[tuple[int, str]] = []
@@ -86,8 +102,10 @@ def extract_bash_blocks(content: str, filepath: Path) -> list[BashBlock]:
                 break
         return result
 
+    id_alt = "|".join(SHELL_REMEDIATION_IDS)
     pattern = re.compile(
-        r"- id: bash\s*\n\s+desc: \|\s*\n(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
+        rf"- id: (?:{id_alt})\s*\n\s+desc: \|-?\s*\n"
+        r"(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
         re.DOTALL,
     )
     blocks = []
@@ -97,7 +115,8 @@ def extract_bash_blocks(content: str, filepath: Path) -> list[BashBlock]:
         bash_line = content[: match.start()].count("\n") + 1
         uid = find_uid_for_line(bash_line)
 
-        for fence in re.finditer(r"```bash\s*\n(.*?)```", desc_block, re.DOTALL):
+        lang_alt = "|".join(SHELL_FENCE_LANGUAGES)
+        for fence in re.finditer(rf"```(?:{lang_alt})\s*\n(.*?)```", desc_block, re.DOTALL):
             block = fence.group(1).rstrip()
             if block.strip():
                 code_offset = desc_start + fence.start(1)

--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -37,6 +37,27 @@ TARGETS = {
     "gitlab": [SCRIPT_DIR / ".." / "mondoo-gitlab-security.mql.yaml"],
     "okta": [SCRIPT_DIR / ".." / "mondoo-okta-security.mql.yaml"],
     "m365": [SCRIPT_DIR / ".." / "mondoo-m365-security.mql.yaml"],
+    # Policies whose terraform remediation had never been linted. Each uses a
+    # single provider; those without a tflint ruleset still get the terraform
+    # preset's syntax and declaration checks.
+    "alibaba": [SCRIPT_DIR / ".." / "mondoo-alibaba-security.mql.yaml"],
+    "cloudflare": [SCRIPT_DIR / ".." / "mondoo-cloudflare-security.mql.yaml"],
+    "databricks": [SCRIPT_DIR / ".." / "mondoo-databricks-security.mql.yaml"],
+    "digitalocean": [SCRIPT_DIR / ".." / "mondoo-digitalocean-security.mql.yaml"],
+    "dns": [SCRIPT_DIR / ".." / "mondoo-dns-security.mql.yaml"],
+    "email": [SCRIPT_DIR / ".." / "mondoo-email-security.mql.yaml"],
+    "hetzner": [SCRIPT_DIR / ".." / "mondoo-hetzner-security.mql.yaml"],
+    "openstack": [SCRIPT_DIR / ".." / "mondoo-openstack-security.mql.yaml"],
+    "portainer": [SCRIPT_DIR / ".." / "mondoo-portainer-security.mql.yaml"],
+    "snowflake": [SCRIPT_DIR / ".." / "mondoo-snowflake-security.mql.yaml"],
+    "stackit": [SCRIPT_DIR / ".." / "mondoo-stackit-security.mql.yaml"],
+    "tailscale": [SCRIPT_DIR / ".." / "mondoo-tailscale-security.mql.yaml"],
+    "unifi": [SCRIPT_DIR / ".." / "mondoo-unifi-security.mql.yaml"],
+    "vercel": [SCRIPT_DIR / ".." / "mondoo-vercel-security.mql.yaml"],
+    "vsphere": [
+        SCRIPT_DIR / ".." / "mondoo-vmware-vsphere.mql.yaml",
+        SCRIPT_DIR / ".." / "mondoo-vmware-vsphere-esxi.mql.yaml",
+    ],
 }
 
 # Map resource prefix -> (provider source, version constraint)
@@ -52,6 +73,23 @@ PROVIDER_MAP = {
     "okta": ("okta/okta", "~> 4.0"),
     "null": ("hashicorp/null", "~> 3.0"),
     "time": ("hashicorp/time", "~> 0.12"),
+    # Providers for the policies added to TARGETS above. A prefix missing
+    # from this map produces an empty `required_providers` block, which the
+    # terraform preset's terraform_required_providers rule fails on every
+    # resource — so a new target needs an entry here to be checkable at all.
+    "alicloud": ("aliyun/alicloud", "~> 1.0"),
+    "cloudflare": ("cloudflare/cloudflare", "~> 5.0"),
+    "databricks": ("databricks/databricks", "~> 1.0"),
+    "digitalocean": ("digitalocean/digitalocean", "~> 2.0"),
+    "hcloud": ("hetznercloud/hcloud", "~> 1.0"),
+    "openstack": ("terraform-provider-openstack/openstack", "~> 3.0"),
+    "portainer": ("portainer/portainer", "~> 1.0"),
+    "snowflake": ("snowflakedb/snowflake", "~> 2.0"),
+    "stackit": ("stackitcloud/stackit", "~> 0.111"),
+    "tailscale": ("tailscale/tailscale", "~> 0.29"),
+    "unifi": ("paultyng/unifi", "~> 0.41"),
+    "vercel": ("vercel/vercel", "~> 5.0"),
+    "vsphere": ("hashicorp/vsphere", "~> 2.0"),
 }
 
 # tflint provider plugins (only for providers that have rulesets)


### PR DESCRIPTION
## The gap

A validator only sees the policies listed in its `TARGETS`. A policy that gains a `terraform` / `ansible` / `bash` remediation without being added there ships **unlinted, with CI green** — the failure mode is silence. Three validators had drifted that way.

This adds the missing entries. No new tooling, no workflow changes (each job already runs all targets).

| Validator | Blocks before | Blocks after | Policies added |
|---|---|---|---|
| terraform | 1,439 | **1,748** | 14 |
| ansible | 253 | **463** | 6 |
| shellcheck | 124 | **302** | 5 (+ two new ids) |

## Terraform

14 policies whose HCL remediation had never been linted: alibaba, cloudflare, databricks, digitalocean, dns, hetzner, openstack, portainer, snowflake, stackit, tailscale, unifi, vercel, vmware-vsphere (+esxi).

Each also needs a `PROVIDER_MAP` entry. Without one the generated `required_providers` block comes out empty and the terraform preset's `terraform_required_providers` rule fails **every resource in the policy** — which reads as ~20 content bugs rather than one missing line. Sources and versions verified against the Terraform registry.

Only `aws`/`azurerm`/`google` have tflint rulesets, so the new targets get the terraform preset's syntax and declaration checks rather than provider schema validation. Still worth having, and honest about what it proves. **All 309 blocks pass as written.**

## Shell

`bash`, `script` and `sh` are three names for the same method, but only `- id: bash` was read — leaving 132 shell snippets unlinted. All three ids are now extracted, and the **fence language** decides the dialect, so a `script` entry holding PowerShell (the Windows convention in `content/CLAUDE.md`) is skipped rather than linted as shell.

The `desc: |-` chomping form is accepted too. The edr policy uses it, so its blocks were invisible to the extractor even once the policy was listed.

## Content fixes the new coverage surfaced

**freebsd** — all 56 ansible snippets were bare task lists rather than plays, so none of them run with `ansible-playbook` as written:

```yaml
# before                          # after
- name: Enable ASLR               ---
  ansible.posix.sysctl:           - name: Enable ASLR
    name: kern.elf64.aslr.enable    hosts: all
    ...                             become: true

                                    tasks:
                                      - name: Enable ASLR
                                        ...
```

Every other policy already used complete plays. `handlers:` sections were promoted to a play-level key rather than nested under `tasks:` (which is what made them invalid YAML), handler names capitalized for `name[casing]`, and the over-long `KexAlgorithms` line moved to a `vars:` list joined with `| join(',')` — a folded scalar would have inserted spaces into the cipher list and broken the config.

**proxmox** — two scripts iterated `for user in $(awk ...)` (SC2013); both now pipe into `while read -r`.

## Verification

```console
$ python3 content/validation/validate_terraform_remediation.py
1748 passed, 0 failed
$ python3 content/validation/validate_ansible_remediation.py
463 passed, 0 failed
$ python3 content/validation/validate_bash_remediation.py
302 passed, 0 failed
```

`mondoo-freebsd-security` → 1.2.1, `mondoo-proxmox-security` → 1.1.4; both lint clean.

`content/CLAUDE.md` now states the rule that would have prevented this: a policy's first `terraform`/`ansible`/`bash` remediation adds it to that validator's `TARGETS` in the same change, and Terraform needs the `PROVIDER_MAP` entry alongside.

## Note for reviewers

The freebsd diff is large but almost entirely mechanical re-indentation from the play wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)