### PR TITLE
✨ validation: lint Bicep remediation with the Bicep CLI

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -205,13 +205,25 @@ jobs:
           python-version: "3.12"
 
       - name: Install Bicep CLI
-        # `az bicep install` fetches the CLI into ~/.azure/bin. The Azure CLI
-        # ships on the runner image; the Bicep CLI does not. The installed
-        # version determines which resource types and apiVersions are known.
+        # Pinned release binary from https://github.com/Azure/bicep/releases.
+        # Bump BICEP_VERSION and BICEP_SHA256 in lockstep; the pinned version
+        # determines which resource types and apiVersions are known, so a bump
+        # can surface newly deprecated apiVersions in existing snippets.
+        #
+        # Installed directly rather than via `az bicep install`, which puts the
+        # binary under the Azure CLI's config directory (AZURE_CONFIG_DIR, not
+        # always ~/.azure on a runner) and gives nothing to checksum.
+        env:
+          BICEP_VERSION: "0.46.1"
+          BICEP_SHA256: "3e011d629ea4311b7a7dd8f0040ab2b1a072ea4ff5d02cb75e0e55a9a6703fb9"
         run: |
-          az bicep install
-          echo "$HOME/.azure/bin" >> "$GITHUB_PATH"
-          "$HOME/.azure/bin/bicep" --version
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://github.com/Azure/bicep/releases/download/v${BICEP_VERSION}/bicep-linux-x64" \
+            -o /tmp/bicep
+          echo "${BICEP_SHA256}  /tmp/bicep" | sha256sum -c -
+          chmod +x /tmp/bicep
+          sudo mv /tmp/bicep /usr/local/bin/bicep
+          bicep --version
 
       - name: Validate bicep remediation blocks
         run: python3 content/validation/validate_bicep_remediation.py --github-actions

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -191,6 +191,31 @@ jobs:
       - name: Validate cloudformation remediation blocks
         run: python3 content/validation/validate_cloudformation_remediation.py --github-actions
 
+  validate-bicep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Bicep CLI
+        # `az bicep install` fetches the CLI into ~/.azure/bin. The Azure CLI
+        # ships on the runner image; the Bicep CLI does not. The installed
+        # version determines which resource types and apiVersions are known.
+        run: |
+          az bicep install
+          echo "$HOME/.azure/bin" >> "$GITHUB_PATH"
+          "$HOME/.azure/bin/bicep" --version
+
+      - name: Validate bicep remediation blocks
+        run: python3 content/validation/validate_bicep_remediation.py --github-actions
+
   validate-ansible:
     runs-on: ubuntu-latest
     steps:

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -269,6 +269,7 @@ python3 content/validation/validate_bash_remediation.py     # `id: bash`/`script
 python3 content/validation/validate_ansible_remediation.py  # `id: ansible` via ansible-lint
 python3 content/validation/validate_chef_remediation.py     # `id: chef` via cookstyle
 python3 content/validation/validate_cloudformation_remediation.py  # `id: cloudformation` via cfn-lint
+python3 content/validation/validate_bicep_remediation.py    # `id: bicep` via the Bicep CLI
 python3 content/validation/validate_terraform_remediation.py
 ```
 
@@ -281,6 +282,14 @@ cfn-lint checks resource types and property names against the AWS resource speci
 Deprecation warnings are split by what the fix is. A deprecated Lambda runtime or RDS engine version (`W2531`, `W3690`) **fails** — the fix is to bump a version string. A whole service being retired (`W3696`, `W3697`) prints as `[INFO]` and does not fail, because the fix is to migrate the check to a different service, which is a content decision rather than a typo.
 
 Each takes an optional target (`linux`, `windows`, `macos`, `kubernetes`, `chef`, …) and `--github-actions`. They run per-PR from `.github/workflows/validate-remediation.yaml`.
+
+`bicep build` resolves each resource type and apiVersion against the ARM type index, so it rejects a property the type does not define and a resource declared at the wrong deployment scope — the Bicep equivalent of what tflint's provider rulesets give us on Terraform. Snippets are dedented out of the `desc: |` block scalar first, because Bicep, unlike HCL, is indentation-sensitive at the token level once a nested object is involved.
+
+`BCP057` ("the name X does not exist in the current context") is ignored. A remediation example wires itself to a key vault or subnet it does not declare, and there is no type-safe stand-in: declaring the name as `param x object` merely trades `BCP057` for `BCP036`/`BCP240`, because Bicep requires a genuine resource reference in the positions those names occupy. This mirrors the CloudFormation validator ignoring `E1010` for `!GetAtt` targets.
+
+Two diagnostics print as `[INFO]` rather than failing: `BCP081` (no types available for that resource type or apiVersion) and the `no-hardcoded-env-urls` linter rule, since a remediation example names a specific cloud on purpose.
+
+The job takes several minutes: the Bicep CLI reloads the ARM type index on every invocation, so ~330 snippets cost roughly a second and a half each.
 
 cookstyle is Chef's RuboCop distribution, so `validate_chef_remediation.py` catches Ruby syntax errors *and* Chef-specific problems: `Chef/Modernize/ExecuteSysctl` pushes sysctl settings onto the `sysctl` resource instead of a template plus `execute`, `Chef/Style/FileMode` rejects integer file modes, and `Chef/Style/UsePlatformHelpers` requires `platform_family?` over raw node attribute comparisons. Snippets are linted inside a temporary `recipes/` directory with `--force-default-config`, which is what makes cookstyle apply the recipe-scoped cops.
 

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -289,6 +289,8 @@ Each takes an optional target (`linux`, `windows`, `macos`, `kubernetes`, `chef`
 
 Two diagnostics print as `[INFO]` rather than failing: `BCP081` (no types available for that resource type or apiVersion) and the `no-hardcoded-env-urls` linter rule, since a remediation example names a specific cloud on purpose.
 
+CI installs a pinned `bicep-linux-x64` release binary rather than running `az bicep install`, which places the binary under the Azure CLI's config directory (`AZURE_CONFIG_DIR`, not reliably `~/.azure` on a runner) and offers nothing to checksum. The pinned version decides which resource types and apiVersions are known, so bumping it can surface newly deprecated apiVersions in snippets that used to pass.
+
 The job takes several minutes: the Bicep CLI reloads the ARM type index on every invocation, so ~330 snippets cost roughly a second and a half each.
 
 cookstyle is Chef's RuboCop distribution, so `validate_chef_remediation.py` catches Ruby syntax errors *and* Chef-specific problems: `Chef/Modernize/ExecuteSysctl` pushes sysctl settings onto the `sysctl` resource instead of a template plus `execute`, `Chef/Style/FileMode` rejects integer file modes, and `Chef/Style/UsePlatformHelpers` requires `platform_family?` over raw node attribute comparisons. Snippets are linted inside a temporary `recipes/` directory with `--force-default-config`, which is what makes cookstyle apply the recipe-scoped cops.

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -2817,6 +2817,11 @@ queries:
               name: 'example-keyvault'
               location: resourceGroup().location
               properties: {
+                sku: {
+                  family: 'A'
+                  name: 'standard'
+                }
+                tenantId: subscription().tenantId
                 enableSoftDelete: true
                 softDeleteRetentionInDays: 90
                 enablePurgeProtection: true
@@ -3849,6 +3854,8 @@ queries:
             To ensure that "Notify about alerts with high severity" is enabled in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource securityContact 'Microsoft.Security/securityContacts@2023-12-01-preview' = {
               name: 'default'
               properties: {
@@ -3860,10 +3867,12 @@ queries:
                     'ServiceAdmin'
                   ]
                 }
-                alertNotifications: {
-                  state: 'On'
-                  minimalSeverity: 'High'
-                }
+                notificationsSources: [
+                  {
+                    sourceType: 'Alert'
+                    minimalSeverity: 'High'
+                  }
+                ]
               }
             }
             ```
@@ -4512,6 +4521,11 @@ queries:
               name: 'example-keyvault'
               location: resourceGroup().location
               properties: {
+                sku: {
+                  family: 'A'
+                  name: 'standard'
+                }
+                tenantId: subscription().tenantId
                 publicNetworkAccess: 'Disabled'
                 networkAcls: {
                   defaultAction: 'Deny'
@@ -6730,6 +6744,11 @@ queries:
               name: 'example-keyvault'
               location: resourceGroup().location
               properties: {
+                sku: {
+                  family: 'A'
+                  name: 'standard'
+                }
+                tenantId: subscription().tenantId
                 enableRbacAuthorization: true
                 // ...
               }
@@ -8422,6 +8441,8 @@ queries:
             To ensure auto-provisioning of the monitoring agent is enabled in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource autoProvisioning 'Microsoft.Security/autoProvisioningSettings@2017-08-01-preview' = {
               name: 'default'
               properties: {
@@ -9550,11 +9571,11 @@ queries:
                 enableNonSslPort: false
                 minimumTlsVersion: '1.2'
                 // ...
-              }
-              sku: {
-                name: 'Standard'
-                family: 'C'
-                capacity: 1
+                sku: {
+                  name: 'Standard'
+                  family: 'C'
+                  capacity: 1
+                }
               }
             }
             ```
@@ -9672,11 +9693,11 @@ queries:
               properties: {
                 publicNetworkAccess: 'Disabled'
                 // ...
-              }
-              sku: {
-                name: 'Premium'
-                family: 'P'
-                capacity: 1
+                sku: {
+                  name: 'Premium'
+                  family: 'P'
+                  capacity: 1
+                }
               }
             }
             ```
@@ -12762,11 +12783,11 @@ queries:
               properties: {
                 minimumTlsVersion: '1.2'
                 // ...
-              }
-              sku: {
-                name: 'Standard'
-                family: 'C'
-                capacity: 1
+                sku: {
+                  name: 'Standard'
+                  family: 'C'
+                  capacity: 1
+                }
               }
             }
             ```
@@ -12898,11 +12919,11 @@ queries:
               properties: {
                 redisVersion: '6'
                 // ...
-              }
-              sku: {
-                name: 'Standard'
-                family: 'C'
-                capacity: 1
+                sku: {
+                  name: 'Standard'
+                  family: 'C'
+                  capacity: 1
+                }
               }
             }
             ```
@@ -13023,11 +13044,11 @@ queries:
               properties: {
                 redisConfiguration: {}
                 // ...
-              }
-              sku: {
-                name: 'Standard'
-                family: 'C'
-                capacity: 1
+                sku: {
+                  name: 'Standard'
+                  family: 'C'
+                  capacity: 1
+                }
               }
             }
             ```
@@ -15396,6 +15417,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 publicNetworkAccess: 'Disabled'
                 // ...
               }
@@ -15547,6 +15574,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 disableLocalAuth: true
                 // ...
               }
@@ -15710,6 +15743,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 isVirtualNetworkFilterEnabled: true
                 virtualNetworkRules: [
                   {
@@ -15874,6 +15913,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 disableKeyBasedMetadataWriteAccess: true
                 // ...
               }
@@ -16041,6 +16086,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 enableAutomaticFailover: true
                 // ...
               }
@@ -16199,6 +16250,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 minimalTlsVersion: 'Tls12'
                 // ...
               }
@@ -16356,6 +16413,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 networkAclBypass: 'None'
                 // ...
               }
@@ -16510,6 +16573,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 keyVaultKeyUri: 'https://example-kv.vault.azure.net/keys/example-key'
                 // ...
               }
@@ -16654,6 +16723,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 ipRules: [
                   {
                     ipAddressOrRange: '203.0.113.0/24'
@@ -16926,6 +17001,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 cors: [
                   {
                     allowedOrigins: 'https://example.com'
@@ -17085,6 +17166,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 backupPolicy: {
                   type: 'Continuous'
                 }
@@ -17236,6 +17323,7 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
                 enableMultipleWriteLocations: true
                 locations: [
                   {
@@ -17389,6 +17477,12 @@ queries:
               name: 'example-cosmosdb'
               location: resourceGroup().location
               properties: {
+                databaseAccountOfferType: 'Standard'
+                locations: [
+                  {
+                    locationName: resourceGroup().location
+                  }
+                ]
                 consistencyPolicy: {
                   defaultConsistencyLevel: 'BoundedStaleness'
                   maxIntervalInSeconds: 300
@@ -19609,10 +19703,16 @@ queries:
             To ensure PostgreSQL servers enforce minimum TLS version 1.2 in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
               name: 'example-postgresql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 minimalTlsVersion: 'TLS1_2'
                 sslEnforcement: 'Enabled'
                 // ...
@@ -19720,10 +19820,16 @@ queries:
             To ensure PostgreSQL servers enforce SSL connections in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
               name: 'example-postgresql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 sslEnforcement: 'Enabled'
                 // ...
               }
@@ -19831,10 +19937,16 @@ queries:
             To ensure PostgreSQL servers disable public network access in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
               name: 'example-postgresql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 publicNetworkAccess: 'Disabled'
                 // ...
               }
@@ -19940,10 +20052,16 @@ queries:
             To ensure PostgreSQL servers enable infrastructure double encryption in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource postgresServer 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
               name: 'example-postgresql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 infrastructureEncryption: 'Enabled'
                 // ...
               }
@@ -20844,10 +20962,16 @@ queries:
             To ensure MySQL servers enforce minimum TLS version 1.2 in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
               name: 'example-mysql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 minimalTlsVersion: 'TLS1_2'
                 sslEnforcement: 'Enabled'
                 // ...
@@ -20955,10 +21079,16 @@ queries:
             To ensure MySQL servers enforce SSL connections in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
               name: 'example-mysql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 sslEnforcement: 'Enabled'
                 // ...
               }
@@ -21066,10 +21196,16 @@ queries:
             To ensure MySQL servers disable public network access in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
               name: 'example-mysql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 publicNetworkAccess: 'Disabled'
                 // ...
               }
@@ -21175,10 +21311,16 @@ queries:
             To ensure MySQL servers enable infrastructure double encryption in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
               name: 'example-mysql'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 infrastructureEncryption: 'Enabled'
                 // ...
               }
@@ -22020,6 +22162,7 @@ queries:
               name: 'example-databricks'
               location: resourceGroup().location
               properties: {
+                managedResourceGroupId: subscription().id
                 publicNetworkAccess: 'Disabled'
                 requiredNsgRules: 'NoAzureDatabricksRules'
                 // ...
@@ -22161,6 +22304,8 @@ queries:
             To ensure Microsoft Defender for Endpoint integration is enabled in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource defenderForEndpoint 'Microsoft.Security/settings@2022-05-01' = {
               name: 'WDATP'
               kind: 'DataExportSettings'
@@ -28809,13 +28954,15 @@ queries:
             To ensure password authentication is disabled on Linux VMs in Bicep:
 
             ```bicep
+            param adminUsername string
+
             resource linuxVM 'Microsoft.Compute/virtualMachines@2023-07-01' = {
               name: 'example-vm'
               location: resourceGroup().location
               properties: {
                 osProfile: {
                   computerName: 'example-vm'
-                  adminUsername: 'azureuser'
+                  adminUsername: adminUsername
                   linuxConfiguration: {
                     disablePasswordAuthentication: true
                     ssh: {
@@ -29941,6 +30088,8 @@ queries:
             To ensure activity log retention is at least 365 days in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
               name: 'default'
               location: ''
@@ -30125,6 +30274,8 @@ queries:
             To ensure activity logs capture events from all locations in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
               name: 'default'
               location: ''
@@ -30307,6 +30458,8 @@ queries:
             To ensure log profile captures all activity categories in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource logProfile 'Microsoft.Insights/logprofiles@2016-03-01' = {
               name: 'default'
               location: ''
@@ -30500,6 +30653,8 @@ queries:
             To ensure security contact notification emails are configured in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource securityContact 'Microsoft.Security/securityContacts@2020-01-01-preview' = {
               name: 'default'
               properties: {
@@ -30658,6 +30813,8 @@ queries:
             To ensure security contacts are enabled and active in Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource securityContact 'Microsoft.Security/securityContacts@2020-01-01-preview' = {
               name: 'default'
               properties: {
@@ -39487,7 +39644,7 @@ queries:
               name: 'example-app'
               location: resourceGroup().location
               properties: {
-                managedEnvironmentId: environment.id
+                managedEnvironmentId: managedEnvironment.id
                 configuration: {
                   ingress: {
                     external: true
@@ -39685,7 +39842,7 @@ queries:
                 type: 'SystemAssigned'
               }
               properties: {
-                managedEnvironmentId: environment.id
+                managedEnvironmentId: managedEnvironment.id
                 configuration: {
                   registries: [
                     {
@@ -39884,7 +40041,7 @@ queries:
               name: 'example-app'
               location: resourceGroup().location
               properties: {
-                managedEnvironmentId: environment.id
+                managedEnvironmentId: managedEnvironment.id
                 template: {
                   containers: [
                     {
@@ -47737,7 +47894,7 @@ queries:
 
             ```bicep
             resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-01-01' = {
-              name: 'default'
+              name: 'eastus/default'
               properties: {
                 virtualMachines: [
                   {
@@ -47855,6 +48012,8 @@ queries:
             To define a time-bound alert suppression rule using Bicep:
 
             ```bicep
+            targetScope = 'subscription'
+
             resource suppression 'Microsoft.Security/alertsSuppressionRules@2019-01-01-preview' = {
               name: '<rule-name>'
               properties: {
@@ -47991,6 +48150,8 @@ queries:
             To create a time-bound active role assignment using Bicep, set `scheduleInfo.expiration.type` to a value other than `NoExpiration`:
 
             ```bicep
+            param assignmentStart string = utcNow()
+
             resource activeAssignment 'Microsoft.Authorization/roleAssignmentScheduleRequests@2020-10-01' = {
               name: guid(subscription().id, principalId, roleDefinitionId)
               properties: {
@@ -47998,7 +48159,7 @@ queries:
                 roleDefinitionId: roleDefinitionId
                 requestType: 'AdminAssign'
                 scheduleInfo: {
-                  startDateTime: utcNow()
+                  startDateTime: assignmentStart
                   expiration: {
                     type: 'AfterDuration'
                     duration: 'PT8H'
@@ -52704,10 +52865,16 @@ queries:
             To extend the backup retention period in Bicep:
 
             ```bicep
+            @secure()
+            param administratorLoginPassword string
+
             resource mysqlServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
               name: 'example-mysql-server'
               location: resourceGroup().location
               properties: {
+                createMode: 'Default'
+                administratorLogin: 'dbadmin'
+                administratorLoginPassword: administratorLoginPassword
                 storageProfile: {
                   backupRetentionDays: 7
                 }

--- a/content/validation/validate_bicep_remediation.py
+++ b/content/validation/validate_bicep_remediation.py
@@ -54,6 +54,11 @@ INFORMATIONAL = {
     "no-hardcoded-env-urls",
 }
 
+# Collected failures, for the GitHub annotations emitted at the end of a run.
+# Appended to only by validate_policy_file, on the main thread, after its worker
+# pool has been drained — validate_block returns its findings rather than
+# writing here. Keep it that way: this list is not synchronized, so appending
+# from inside the pool would race.
 FAILURES: list[dict] = []
 
 DIAGNOSTIC = re.compile(
@@ -72,7 +77,10 @@ class BicepBlock:
 
 @dataclass
 class LintResult:
-    issues: list[str] = field(default_factory=list)
+    # (line, message) — line is the diagnostic's position in the policy file,
+    # already offset from the block's start, so annotations point at the snippet
+    # rather than at the temp file the linter saw.
+    issues: list[tuple[int, str]] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
 
 

--- a/content/validation/validate_bicep_remediation.py
+++ b/content/validation/validate_bicep_remediation.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Validates the Bicep snippets in `- id: bicep` remediation blocks with the
+# Bicep CLI, which resolves resource types and apiVersions against the ARM type
+# index and rejects properties a type does not define.
+#
+# Mirrors validate_cloudformation_remediation.py: extract the fenced blocks
+# from one `- id:`, make each snippet stand on its own, run the ecosystem's own
+# compiler over it.
+#
+# Usage: python3 validate_bicep_remediation.py [azure|m365] [--github-actions]
+
+import argparse
+import concurrent.futures
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+
+TARGETS = {
+    "azure": [SCRIPT_DIR / ".." / "mondoo-azure-security.mql.yaml"],
+    "m365": [SCRIPT_DIR / ".." / "mondoo-m365-security.mql.yaml"],
+}
+
+# `bicep build` needs a resolvable module/type cache. Snippets never use
+# registry modules, so --no-restore keeps the run offline and fast.
+BICEP_ARGS = ("build", "--stdout", "--no-restore")
+
+# Diagnostics that only fire because a documentation snippet is a fragment.
+#
+# BCP057 ("the name X does not exist in the current context") is the Bicep
+# equivalent of CloudFormation's unresolved-!Ref: a remediation example wires
+# itself to a key vault or subnet it does not declare. There is no type-safe
+# stand-in — declaring the name as `param x object` merely trades BCP057 for
+# BCP036/BCP240, because Bicep requires a genuine resource reference in the
+# positions these names occupy. So the rule is ignored, exactly as the
+# CloudFormation validator ignores E1010 for `!GetAtt` targets.
+IGNORED_DIAGNOSTICS = {"BCP057"}
+
+# Informational: reported, but not a build failure. The fix is a migration or
+# a deliberate documentation choice rather than a typo.
+INFORMATIONAL = {
+    "BCP081",  # no types available for this resource type/apiVersion
+    # A remediation example names a specific cloud on purpose; telling readers
+    # to write environment().resourceManager in a two-line snippet is noise.
+    "no-hardcoded-env-urls",
+}
+
+FAILURES: list[dict] = []
+
+DIAGNOSTIC = re.compile(
+    r"^(?P<path>.+?)\((?P<line>\d+),(?P<col>\d+)\)\s*:\s*"
+    r"(?P<sev>Error|Warning)\s+(?P<code>[A-Za-z0-9-]+):\s*(?P<msg>.*)$"
+)
+
+
+@dataclass
+class BicepBlock:
+    code: str
+    line: int
+    uid: str
+    file: Path
+
+
+@dataclass
+class LintResult:
+    issues: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+def dedent_block(block: str) -> str:
+    """Strip the YAML block-scalar indentation the fence sits inside."""
+    lines = block.split("\n")
+    indents = [len(l) - len(l.lstrip(" ")) for l in lines if l.strip()]
+    if not indents:
+        return block
+    common = min(indents)
+    return "\n".join(l[common:] if l.strip() else "" for l in lines)
+
+
+def extract_bicep_blocks(content: str, filepath: Path) -> list[BicepBlock]:
+    """Extract Bicep code blocks from `- id: bicep` remediation sections."""
+    lines = content.split("\n")
+    uid_positions: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        m = re.match(r"^  - uid:\s+(\S+)", line)
+        if m:
+            uid_positions.append((i + 1, m.group(1)))
+
+    def find_uid_for_line(line_num: int) -> str:
+        result = ""
+        for pos, uid in uid_positions:
+            if pos <= line_num:
+                result = uid
+            else:
+                break
+        return result
+
+    pattern = re.compile(
+        r"- id: bicep\s*\n\s+desc: \|-?\s*\n"
+        r"(.*?)(?=\n\s+- id: |\n\s+refs:|\n  - uid: |\Z)",
+        re.DOTALL,
+    )
+
+    blocks = []
+    for match in pattern.finditer(content):
+        desc_block = match.group(1)
+        desc_start = match.start(1)
+        bicep_line = content[: match.start()].count("\n") + 1
+        uid = find_uid_for_line(bicep_line)
+
+        fences, first_line = [], None
+        for fence in re.finditer(r"```bicep\s*\n(.*?)```", desc_block, re.DOTALL):
+            block = fence.group(1).rstrip()
+            if not block.strip():
+                continue
+            if first_line is None:
+                code_offset = desc_start + fence.start(1)
+                first_line = content[:code_offset].count("\n") + 1
+            fences.append(dedent_block(block))
+
+        if fences:
+            blocks.append(
+                BicepBlock(code="\n\n".join(fences), line=first_line, uid=uid, file=filepath)
+            )
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# bicep execution
+# ---------------------------------------------------------------------------
+
+def run_bicep(path: Path) -> list[tuple[int, str, str, str]]:
+    """Compile one file. Returns [(line, severity, code, message), ...]."""
+    result = subprocess.run(
+        ["bicep", *BICEP_ARGS, str(path)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = []
+    for line in (result.stdout + result.stderr).splitlines():
+        m = DIAGNOSTIC.match(line.strip())
+        if m:
+            out.append(
+                (int(m.group("line")), m.group("sev"), m.group("code"), m.group("msg").strip())
+            )
+    return out
+
+
+def validate_block(block: BicepBlock) -> tuple[BicepBlock, LintResult]:
+    """Compile one snippet and classify its diagnostics."""
+    with tempfile.TemporaryDirectory(prefix="bicep_") as tmp:
+        path = Path(tmp) / "main.bicep"
+        path.write_text(block.code + "\n")
+
+        result = LintResult()
+        for line, _sev, code, msg in run_bicep(path):
+            if code in IGNORED_DIAGNOSTICS:
+                continue
+            if code in INFORMATIONAL:
+                result.notes.append(f"{code}: {msg}")
+                continue
+            result.issues.append((block.line + max(line, 1) - 1, f"{code}: {msg}"))
+        return block, result
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def truncate_snippet(code: str, max_len: int = 100) -> str:
+    m = re.search(r"resource\s+\S+\s+'([^']+)'", code)
+    if m:
+        return m.group(1)
+    first_line = code.split("\n")[0].strip()
+    return first_line[: max_len - 3] + "..." if len(first_line) > max_len else first_line
+
+
+def validate_policy_file(filepath: Path, workers: int) -> tuple[int, int]:
+    if not filepath.exists():
+        print(f"Warning: Policy file not found: {filepath}", file=sys.stderr)
+        return 0, 0
+
+    content = filepath.read_text()
+    blocks = extract_bicep_blocks(content, filepath)
+    if not blocks:
+        return 0, 0
+
+    relpath = str(filepath.resolve().relative_to(REPO_ROOT))
+    pass_count = fail_count = 0
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(lambda b: validate_block(b), blocks))
+    results.sort(key=lambda r: r[0].line)
+
+    for block, result in results:
+        snippet = truncate_snippet(block.code)
+        for note in result.notes:
+            print(f"[INFO] {block.uid}")
+            print(f"       {note}")
+        if not result.issues:
+            print(f"[PASS] {block.uid}")
+            print(f"       {snippet}")
+            pass_count += 1
+            continue
+        print(f"[FAIL] {block.uid}")
+        print(f"       {snippet}")
+        for _line, text in result.issues:
+            print(f"       {text}")
+        fail_count += 1
+        FAILURES.append({
+            "file": relpath,
+            "line": result.issues[0][0],
+            "uid": block.uid,
+            "snippet": snippet,
+            "errors": [t for _l, t in result.issues],
+        })
+
+    return pass_count, fail_count
+
+
+def emit_github_annotations() -> None:
+    for r in FAILURES:
+        msg = "; ".join(r["errors"]) + f" — {r['snippet']}"
+        title = f"Bicep validation ({r['uid']})"
+        msg = msg.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        title = (
+            title.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+            .replace(",", "%2C").replace("::", "%3A%3A")
+        )
+        print(f"::error file={r['file']},line={r['line']},title={title}::{msg}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate Bicep remediation snippets with the Bicep CLI"
+    )
+    parser.add_argument("target", nargs="?", default="all", choices=["all", *TARGETS])
+    parser.add_argument("--github-actions", action="store_true")
+    parser.add_argument("--workers", type=int, default=8)
+    args = parser.parse_args()
+
+    if not shutil.which("bicep"):
+        print(
+            "Error: bicep not found in PATH.\n"
+            "Install with: az bicep install && "
+            'export PATH="$HOME/.azure/bin:$PATH"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total_pass = total_fail = 0
+    for t in (TARGETS if args.target == "all" else [args.target]):
+        for filepath in TARGETS[t]:
+            p, f = validate_policy_file(filepath, args.workers)
+            total_pass += p
+            total_fail += f
+
+    if args.github_actions:
+        emit_github_annotations()
+
+    print(f"\n{total_pass} passed, {total_fail} failed", file=sys.stderr)
+    sys.exit(1 if total_fail > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

**334 Bicep snippets in `mondoo-azure-security` had never been checked.** `bicep build` resolves each resource type and apiVersion against the ARM type index, so it rejects a property the type does not define and a resource declared at the wrong deployment scope — the Bicep equivalent of what tflint's provider rulesets give us on Terraform.

## Design

Follows `validate_cloudformation_remediation.py` (#3284), including the dedent out of the `desc: |` block scalar. **One deliberate difference: Bicep fragment references cannot be stubbed.**

CloudFormation lets an undeclared `!Ref` target become a stub `Parameters:` entry. The Bicep equivalent does not work — I tried it:

| Approach | Result |
|---|---|
| `param <name> object` for each undeclared name | 233 `BCP057` removed, but **77 `BCP036`** (type mismatch) and **64 `BCP240`** ("only permits direct references to resources") appeared. 137 failing snippets. |
| Ignore `BCP057` | 45 failing snippets, all real |

An object param satisfies property access (`keyVault.properties.vaultUri` compiles) but not the positions where Bicep demands a genuine resource reference. So `BCP057` is ignored outright, exactly as the CloudFormation validator ignores `E1010` for `!GetAtt` targets. Dropping the stub pass also halves the runtime.

`BCP081` (no types available for that resource type/apiVersion) and the `no-hardcoded-env-urls` linter rule print as `[INFO]` and do not fail — 14 snippets report one today.

## What it found

45 snippets failed, in four families that each spanned many checks. These were written by copying a working neighbour, so a single wrong pattern propagated silently:

| Family | Count | Defect |
|---|---|---|
| Cosmos DB | 13 | missing `databaseAccountOfferType`, then `locations` behind it |
| MySQL / PostgreSQL single servers | 9 | missing the `createMode` discriminator, then `administratorLogin`/`administratorLoginPassword` behind it |
| Defender, security contacts, Insights log profiles | 8 | declared at `resourceGroup` scope when ARM permits only `subscription` (`BCP135` — a hard error, cannot deploy). Each now opens with `targetScope = 'subscription'` |
| Redis | 5 | `sku` at the resource root; `Microsoft.Cache/redis` puts it inside `properties` |

Plus singles: Key Vault missing `sku`/`tenantId`; `environment` used as a symbol name when it is a Bicep **built-in function**; `jitNetworkAccessPolicies` named without its location segment; `utcNow()` outside a parameter default; `alertNotifications` on `securityContacts@2023-12-01-preview` (that api-version replaced it with `notificationsSources` — the 2020 preview still takes the object, and those two snippets are unchanged); a literal VM `adminUsername`; Databricks missing `managedResourceGroupId`.

**Worth knowing for estimating this kind of cleanup:** `bicep build` reports required properties *one layer at a time*, unlike cfn-lint which lists them all at once. Adding `databaseAccountOfferType` revealed `locations`; adding `createMode` revealed the administrator credentials. This took three fix rounds to reach green.

## Verification

```console
$ python3 content/validation/validate_bicep_remediation.py
332 passed, 0 failed

$ cnspec policy lint content/mondoo-azure-security.mql.yaml
→ valid policy bundle(s)
```

New `validate-bicep` job; the CLI comes from `az bicep install` (the Azure CLI ships on the runner image, the Bicep CLI does not). The job takes several minutes — Bicep reloads the ARM type index on every invocation, ~1.5s per snippet. `mondoo-azure-security` → 9.9.1.

## Note for reviewers

Touches `mondoo-azure-security.mql.yaml` and the same `content/CLAUDE.md` section as #3281 and #3284; expect a small merge on whichever lands later. The edits here are confined to `- id: bicep` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)