### PR TITLE
🧹 validation: drop the "had never been linted" TARGETS comments

### DIFF
--- a/content/validation/validate_ansible_remediation.py
+++ b/content/validation/validate_ansible_remediation.py
@@ -38,7 +38,6 @@ TARGETS = {
     ],
     "macos": [SCRIPT_DIR / ".." / "mondoo-macos-security.mql.yaml"],
     "kubernetes": [SCRIPT_DIR / ".." / "mondoo-kubernetes-security.mql.yaml"],
-    # Policies whose ansible remediation had never been linted.
     "ai": [SCRIPT_DIR / ".." / "mondoo-ai-security.mql.yaml"],
     "edr": [SCRIPT_DIR / ".." / "mondoo-edr-policy.mql.yaml"],
     "freebsd": [SCRIPT_DIR / ".." / "mondoo-freebsd-security.mql.yaml"],

--- a/content/validation/validate_bash_remediation.py
+++ b/content/validation/validate_bash_remediation.py
@@ -34,7 +34,6 @@ TARGETS = {
         SCRIPT_DIR / ".." / "mondoo-linux-workstation-security.mql.yaml",
     ],
     "kubernetes": [SCRIPT_DIR / ".." / "mondoo-kubernetes-security.mql.yaml"],
-    # Policies whose shell remediation had never been linted.
     "edr": [SCRIPT_DIR / ".." / "mondoo-edr-policy.mql.yaml"],
     "freebsd": [SCRIPT_DIR / ".." / "mondoo-freebsd-security.mql.yaml"],
     "mariadb": [SCRIPT_DIR / ".." / "mondoo-mariadb-security.mql.yaml"],

--- a/content/validation/validate_terraform_remediation.py
+++ b/content/validation/validate_terraform_remediation.py
@@ -37,9 +37,8 @@ TARGETS = {
     "gitlab": [SCRIPT_DIR / ".." / "mondoo-gitlab-security.mql.yaml"],
     "okta": [SCRIPT_DIR / ".." / "mondoo-okta-security.mql.yaml"],
     "m365": [SCRIPT_DIR / ".." / "mondoo-m365-security.mql.yaml"],
-    # Policies whose terraform remediation had never been linted. Each uses a
-    # single provider; those without a tflint ruleset still get the terraform
-    # preset's syntax and declaration checks.
+    # Only aws/azurerm/google have tflint rulesets; the rest are checked by
+    # the terraform preset's syntax and declaration rules alone.
     "alibaba": [SCRIPT_DIR / ".." / "mondoo-alibaba-security.mql.yaml"],
     "cloudflare": [SCRIPT_DIR / ".." / "mondoo-cloudflare-security.mql.yaml"],
     "databricks": [SCRIPT_DIR / ".." / "mondoo-databricks-security.mql.yaml"],


### PR DESCRIPTION
Follow-up to #3283, now that it has merged.

Those three comments describe the moment the targets were added, not the code:

```python
# Policies whose terraform remediation had never been linted. …
# Policies whose ansible remediation had never been linted.
# Policies whose shell remediation had never been linted.
```

The policies are linted like every other entry now, so the notes only date the file and invite a reader to wonder whether that half of the dict is somehow different. Removed.

The terraform comment carried one fact worth keeping — only `aws`/`azurerm`/`google` have tflint rulesets, so the rest are covered by the terraform preset's syntax and declaration rules alone — so that is stated directly instead of as a historical aside.

No behaviour change: all three validators parse, and `validate_ansible_remediation.py freebsd` still reports 56 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)