### PR TITLE
👷 validation: stamp the Azure grammar and watch every pinned upstream

### DIFF
--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -1,0 +1,75 @@
+---
+name: Validator Upstream Drift
+
+## Reports which upstreams the remediation validators are pinned behind.
+##
+## The validators are only as good as what they check against — a linter
+## release, a vendor CLI grammar, an OpenAPI spec — and every one of those is
+## pinned somewhere in the repo. Dependabot covers gomod and github-actions, so
+## none of these pins are watched by anything.
+##
+## This is deliberately a *report*, not a gate. A bump is a judgement call: a
+## new cfn-lint can legitimately start failing snippets that were fine, and that
+## needs a person to decide whether the content or the pin is wrong. So the job
+## writes a table into one long-lived issue and never fails the build.
+on:
+  schedule:
+    # Mondays 06:00 UTC, an hour before the validators themselves run, so the
+    # "your pins are behind" table is already waiting if the run breaks.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-upstream-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Check pinned versions against upstream
+        run: |
+          {
+            echo "Each of these pins decides what the remediation validators accept."
+            echo "\`BEHIND\` is not automatically a bug — it is a prompt to look."
+            echo
+            python3 content/validation/check_upstream_versions.py --format markdown
+            echo
+            echo "Refresh instructions live in \`content/CLAUDE.md\`; the pins"
+            echo "themselves live in \`.github/workflows/validate-remediation.yaml\`,"
+            echo "\`content/validation/validators/openapi.py\`, and the \`dump_*.py\` scripts."
+          } > /tmp/drift.md
+          cat /tmp/drift.md
+
+      - name: Publish the report to a tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh label create validation-drift --force \
+            --color B7791F \
+            --description "Remediation validation broke without a content change"
+          title="Validator upstream pins: weekly drift report"
+          existing=$(gh issue list --state open --label validation-drift \
+            --search "$title in:title" --json number --jq '.[0].number // empty')
+          # One long-lived issue whose body is replaced each week: the table is a
+          # snapshot of right now, so appending weekly comments would bury the
+          # current state under stale ones.
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file /tmp/drift.md
+          else
+            gh issue create --title "$title" --body-file /tmp/drift.md --label validation-drift
+          fi

--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -40,6 +40,12 @@ jobs:
           python-version: "3.12"
 
       - name: Check pinned versions against upstream
+        env:
+          # 17 api.github.com calls per run. Unauthenticated that shares a
+          # 60/hour budget with the whole runner IP, and a throttled run would
+          # report "could not reach upstream" for most pins — a quiet false
+          # all-clear. With this token the limit is 5,000/hour.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           {
             echo "Each of these pins decides what the remediation validators accept."

--- a/content/validation/check_upstream_versions.py
+++ b/content/validation/check_upstream_versions.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Reports which of the remediation validators' pinned upstreams have moved.
+#
+# The validators are only as current as the things they check against: a linter
+# release, a vendor CLI grammar, an OpenAPI spec. Every one of those is pinned —
+# in a `run:` step of validate-remediation.yaml, in a `_SHA` constant in
+# validators/openapi.py, or as a `_meta` version inside cmd_data/ — and none of
+# them are watched by Dependabot, which covers gomod and github-actions only.
+#
+# This script reads each pin from the file that declares it (never a second
+# copy, so it cannot itself go stale) and asks the upstream what the current
+# version is. It is a report, not a gate: a bump is a judgement call, and a
+# GitHub API blip must not fail a build.
+#
+# Usage:
+#   python3 content/validation/check_upstream_versions.py
+#   python3 content/validation/check_upstream_versions.py --format markdown
+#   python3 content/validation/check_upstream_versions.py --exit-code   # 1 if behind
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validate-remediation.yaml"
+OPENAPI_MODULE = SCRIPT_DIR / "validators" / "openapi.py"
+CMD_DATA = SCRIPT_DIR / "cmd_data"
+
+USER_AGENT = "cnspec-validation-drift-check"
+TIMEOUT = 30
+
+
+@dataclass
+class Result:
+    name: str
+    kind: str
+    pinned: str
+    latest: str
+    note: str = ""
+
+    # Set for a pin whose upstream publishes no machine-readable version, so an
+    # absent `latest` reads as "nothing to compare" rather than "network down".
+    manual: bool = False
+
+    @property
+    def state(self) -> str:
+        if self.manual:
+            return "manual"
+        if self.pinned == "unknown":
+            return "unstamped"
+        if self.latest == "unknown":
+            return "unchecked"
+        return "current" if self.pinned == self.latest else "behind"
+
+
+def fetch_json(url: str) -> dict | list | None:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        # Upstream metadata being unreachable is not a finding about our repo.
+        return None
+
+
+def latest_github_release(repo: str) -> str:
+    data = fetch_json(f"https://api.github.com/repos/{repo}/releases/latest")
+    if not isinstance(data, dict) or not data.get("tag_name"):
+        return "unknown"
+    return str(data["tag_name"]).lstrip("v")
+
+
+def latest_pypi(pkg: str) -> str:
+    data = fetch_json(f"https://pypi.org/pypi/{pkg}/json")
+    if not isinstance(data, dict):
+        return "unknown"
+    return str(data.get("info", {}).get("version", "unknown"))
+
+
+def latest_rubygem(gem: str) -> str:
+    data = fetch_json(f"https://rubygems.org/api/v1/gems/{gem}.json")
+    if not isinstance(data, dict):
+        return "unknown"
+    return str(data.get("version", "unknown"))
+
+
+def latest_gitlab_release(project: str) -> str:
+    """Latest release of a GitLab-hosted project. glab lives on gitlab.com and
+    the GitHub mirror publishes no releases, so `releases/latest` there 404s."""
+    data = fetch_json(f"https://gitlab.com/api/v4/projects/{project}/releases?per_page=1")
+    if not isinstance(data, list) or not data:
+        return "unknown"
+    return str(data[0].get("tag_name", "unknown")).lstrip("v")
+
+
+def latest_npm(pkg: str) -> str:
+    data = fetch_json(f"https://registry.npmjs.org/{pkg}/latest")
+    if not isinstance(data, dict):
+        return "unknown"
+    return str(data.get("version", "unknown"))
+
+
+def head_commit_for_path(repo: str, path: str) -> str:
+    data = fetch_json(f"https://api.github.com/repos/{repo}/commits?path={path}&per_page=1")
+    if not isinstance(data, list) or not data:
+        return "unknown"
+    return str(data[0].get("sha", "unknown"))
+
+
+# ---------------------------------------------------------------------------
+# Pins declared in the workflow's `run:` steps
+# ---------------------------------------------------------------------------
+
+# name -> (env var or literal pattern in validate-remediation.yaml, upstream lookup)
+WORKFLOW_TOOLS = [
+    # (display name, regex capturing the pinned version, resolver)
+    ("cfn-lint", r"pipx install cfn-lint==([0-9][^\s]*)", lambda: latest_pypi("cfn-lint")),
+    ("ansible-lint", r"pipx install ansible-lint==([0-9][^\s]*)", lambda: latest_pypi("ansible-lint")),
+    ("cookstyle", r"gem install cookstyle -v ([0-9][^\s]*)", lambda: latest_rubygem("cookstyle")),
+    ("tflint", r"tflint_version:\s*v?([0-9][^\s]*)", lambda: latest_github_release("terraform-linters/tflint")),
+    ("bicep", r"BICEP_VERSION:\s*\"?([0-9][^\"\s]*)", lambda: latest_github_release("Azure/bicep")),
+    ("doctl", r"DOCTL_VERSION:\s*\"?([0-9][^\"\s]*)", lambda: latest_github_release("digitalocean/doctl")),
+    ("glab", r"GLAB_VERSION:\s*\"?([0-9][^\"\s]*)", lambda: latest_gitlab_release("gitlab-org%2Fcli")),
+    ("hcloud", r"HCLOUD_VERSION:\s*\"?([0-9][^\"\s]*)", lambda: latest_github_release("hetznercloud/cli")),
+    ("databricks", r"DATABRICKS_VERSION:\s*\"?([0-9][^\"\s]*)", lambda: latest_github_release("databricks/cli")),
+]
+
+
+def check_workflow_tools() -> list[Result]:
+    if not WORKFLOW.exists():
+        return []
+    text = WORKFLOW.read_text()
+    out = []
+    for name, pattern, resolver in WORKFLOW_TOOLS:
+        m = re.search(pattern, text)
+        pinned = m.group(1) if m else "unknown"
+        note = "" if m else "no pin found in validate-remediation.yaml"
+        out.append(Result(name, "linter", pinned, resolver() if m else "unknown", note))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI specs pinned to a commit SHA in validators/openapi.py
+# ---------------------------------------------------------------------------
+
+SPEC_PINS = [
+    ("cloudflare spec", "CLOUDFLARE_OPENAPI_SHA", "cloudflare/api-schemas", "openapi.json"),
+    ("slack spec", "SLACK_OPENAPI_SHA", "slackapi/slack-api-specs", "web-api/slack_web_openapi_v2.json"),
+    ("grafana spec", "GRAFANA_OPENAPI_SHA", "grafana/grafana", "public/openapi3.json"),
+    ("mongodbatlas spec", "MONGODBATLAS_OPENAPI_SHA", "mongodb/openapi", "openapi/v2.json"),
+]
+
+
+def check_spec_pins() -> list[Result]:
+    if not OPENAPI_MODULE.exists():
+        return []
+    text = OPENAPI_MODULE.read_text()
+    out = []
+    for name, const, repo, path in SPEC_PINS:
+        m = re.search(rf'{const}\s*=\s*"([0-9a-f]{{7,40}})"', text)
+        if not m:
+            out.append(Result(name, "spec", "unknown", "unknown", f"{const} not found"))
+            continue
+        pinned = m.group(1)
+        head = head_commit_for_path(repo, path)
+        # A differing SHA is not by itself proof of drift: some of these specs
+        # live in repos whose default branch was rewritten, so the newest commit
+        # touching the path can predate the pin. Ask GitHub how many commits
+        # actually separate them and treat "none" as current.
+        if head != "unknown" and head != pinned:
+            cmp = fetch_json(f"https://api.github.com/repos/{repo}/compare/{pinned}...{head}")
+            if isinstance(cmp, dict) and cmp.get("total_commits") == 0:
+                head = pinned
+        out.append(Result(
+            name, "spec", pinned[:10],
+            head[:10] if head != "unknown" else "unknown",
+            f"{repo}/{path}",
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Checked-in grammars, versioned by their own `_meta`
+# ---------------------------------------------------------------------------
+
+def meta_of(filename: str) -> dict:
+    path = CMD_DATA / filename
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    meta = data.get("_meta") if isinstance(data, dict) else None
+    return meta if isinstance(meta, dict) else {}
+
+
+def check_grammars() -> list[Result]:
+    out = []
+
+    azure = meta_of("azure_commands.json").get("azure_cli_version", "unknown")
+    out.append(Result(
+        "azure CLI grammar", "grammar", azure, latest_pypi("azure-cli"),
+        "regenerate with dump_azure_commands.py",
+    ))
+
+    vercel = meta_of("vercel_commands.json").get("vercel_version", "unknown")
+    out.append(Result(
+        "vercel CLI grammar", "grammar", vercel, latest_npm("vercel"),
+        "regenerate with dump_vercel_commands.py",
+    ))
+
+    ncli = meta_of("ncli_commands.json").get("book", "unknown")
+    out.append(Result(
+        "nutanix ncli grammar", "grammar", ncli, "n/a",
+        "pinned to an AOS doc book; bump NCLI_BOOK in dump_ncli_commands.py",
+        manual=True,
+    ))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+STATE_MARK = {
+    "behind": "BEHIND",
+    "current": "ok",
+    "unstamped": "NO VERSION RECORDED",
+    "unchecked": "could not reach upstream",
+    "manual": "no machine-readable upstream, review by hand",
+}
+
+
+def render_text(results: list[Result]) -> str:
+    width = max(len(r.name) for r in results)
+    lines = []
+    for r in results:
+        lines.append(
+            f"{r.name:<{width}}  pinned={r.pinned:<12} upstream={r.latest:<12} "
+            f"{STATE_MARK[r.state]}"
+        )
+    return "\n".join(lines)
+
+
+def render_markdown(results: list[Result]) -> str:
+    lines = [
+        "| Pinned artifact | Kind | Pinned at | Upstream | State |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for r in results:
+        lines.append(
+            f"| {r.name} | {r.kind} | `{r.pinned}` | `{r.latest}` | {STATE_MARK[r.state]} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report which validator upstreams have moved past their pin"
+    )
+    parser.add_argument("--format", choices=["text", "markdown"], default="text")
+    parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help="exit 1 when any pin is behind (default: always exit 0, this is a report)",
+    )
+    args = parser.parse_args()
+
+    results = check_workflow_tools() + check_spec_pins() + check_grammars()
+
+    print(render_markdown(results) if args.format == "markdown" else render_text(results))
+
+    behind = [r for r in results if r.state == "behind"]
+    unstamped = [r for r in results if r.state == "unstamped"]
+    print(
+        f"\n{len(behind)} behind, {len(unstamped)} unstamped, {len(results)} checked",
+        file=sys.stderr,
+    )
+    if args.exit_code and behind:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/content/validation/check_upstream_versions.py
+++ b/content/validation/check_upstream_versions.py
@@ -22,6 +22,7 @@
 
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -37,6 +38,13 @@ CMD_DATA = SCRIPT_DIR / "cmd_data"
 
 USER_AGENT = "cnspec-validation-drift-check"
 TIMEOUT = 30
+
+# This makes up to 17 api.github.com calls per run. Unauthenticated that shares
+# a 60/hour budget with everything else on the runner's IP, so a rate-limited
+# run would report "could not reach upstream" for most pins and look like
+# everything is fine. With a token the limit is 5,000/hour. The workflow passes
+# the one Actions already provides.
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
 
 
 @dataclass
@@ -63,7 +71,10 @@ class Result:
 
 
 def fetch_json(url: str) -> dict | list | None:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    headers = {"User-Agent": USER_AGENT}
+    if GITHUB_TOKEN and "api.github.com" in url:
+        headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
             return json.load(resp)

--- a/content/validation/cmd_data/azure_commands.json
+++ b/content/validation/cmd_data/azure_commands.json
@@ -1,4 +1,8 @@
 {
+  "_meta": {
+    "azure_cli_version": "2.89.1",
+    "generated_by": "dump_azure_commands.py"
+  },
   "account accept-ownership-status": [
     "--debug",
     "--help",

--- a/content/validation/dump_azure_commands.py
+++ b/content/validation/dump_azure_commands.py
@@ -97,6 +97,23 @@ print(json.dumps(result))
 """
 
 
+def az_cli_version() -> str:
+    """Version of the Azure CLI this grammar was dumped from."""
+    result = subprocess.run(
+        ["az", "version", "--query", '"azure-cli"', "-o", "tsv"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        print(
+            f"Error: could not read the Azure CLI version:\n{result.stderr}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return result.stdout.strip()
+
+
 def find_az_site_packages() -> str:
     """Find the site-packages directory for the Azure CLI's bundled Python."""
     az_path = subprocess.run(
@@ -339,8 +356,24 @@ def main():
         if key not in policy_commands:
             commands[key] = sorted(set(commands[key] + GLOBAL_FLAGS))
 
+    # Record which Azure CLI produced this grammar, so its staleness is a fact
+    # rather than a guess (check_upstream_versions.py compares it against the
+    # current azure-cli release). Deliberately a version and not a timestamp:
+    # regenerating against an unchanged CLI then produces a byte-identical
+    # file, so a diff always means the grammar itself moved.
+    #
+    # Written here, after the loop above that appends GLOBAL_FLAGS to every
+    # value — `_meta` is a dict, not a flag list, and would break it.
+    # `sort_keys` puts `_meta` first (`_` sorts before every lowercase letter,
+    # and every command name is lowercase); lookups are by exact command path,
+    # so no consumer can collide with it.
+    commands["_meta"] = {
+        "azure_cli_version": az_cli_version(),
+        "generated_by": "dump_azure_commands.py",
+    }
+
     args.output.write_text(json.dumps(commands, indent=2, sort_keys=True) + "\n")
-    print(f"Wrote {len(commands)} commands to {args.output}", file=sys.stderr)
+    print(f"Wrote {len(commands) - 1} commands to {args.output}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/content/validation/dump_azure_commands.py
+++ b/content/validation/dump_azure_commands.py
@@ -99,8 +99,12 @@ print(json.dumps(result))
 
 def az_cli_version() -> str:
     """Version of the Azure CLI this grammar was dumped from."""
+    # `az version -o json` and a dict lookup, rather than a --query: the
+    # JMESPath for this key has to be written `"azure-cli"` because a bare
+    # azure-cli parses as subtraction, and quoting that through a shell or an
+    # argv list is a trap worth stepping around entirely.
     result = subprocess.run(
-        ["az", "version", "--query", '"azure-cli"', "-o", "tsv"],
+        ["az", "version", "--output", "json"],
         capture_output=True,
         text=True,
         timeout=60,
@@ -111,7 +115,12 @@ def az_cli_version() -> str:
             file=sys.stderr,
         )
         sys.exit(1)
-    return result.stdout.strip()
+    try:
+        version = json.loads(result.stdout)["azure-cli"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"Error: unexpected `az version` output: {e}", file=sys.stderr)
+        sys.exit(1)
+    return str(version)
 
 
 def find_az_site_packages() -> str:

--- a/content/validation/validators/azure.py
+++ b/content/validation/validators/azure.py
@@ -102,6 +102,11 @@ def validate_azure() -> tuple[int, int]:
         sys.exit(1)
 
     commands_db = json.loads(AZURE_COMMANDS_FILE.read_text())
+    # `_meta` records the Azure CLI version the grammar was dumped from. Drop it
+    # so the rest of this function sees command paths only; nothing here would
+    # match a key starting with `_`, but a stray dict among the flag lists is
+    # the kind of thing that surfaces later as an unexplained TypeError.
+    commands_db.pop("_meta", None)
 
     pass_count = 0
     fail_count = 0


### PR DESCRIPTION
## What

1. `dump_azure_commands.py` records the Azure CLI version it dumped from in a `_meta` key.
2. New `content/validation/check_upstream_versions.py` reports which pinned upstreams have moved.
3. New weekly `validation-upstream-drift.yaml` publishes that report into a tracking issue.

## Why

Every validator is only as current as the thing it validates against, and all of those are pinned:

- linter versions in `run:` steps of `validate-remediation.yaml` (cfn-lint, ansible-lint, cookstyle, tflint, bicep, doctl, glab, hcloud, databricks)
- spec commit SHAs in `validators/openapi.py` (cloudflare, slack, grafana, mongodbatlas)
- CLI grammars in `cmd_data/` (azure, vercel, ncli)

Dependabot covers `gomod` and `github-actions`. None of the above is in either ecosystem, so nothing watches any of them.

`azure_commands.json` was the worst case: it carried no version marker at all, while `vercel_commands.json` records `vercel_version` and `ncli_commands.json` records its AOS doc book. Its staleness was not just unwatched, it was unmeasurable.

## Output today

```
| Pinned artifact      | Kind    | Pinned at              | Upstream     | State  |
| cfn-lint             | linter  | 1.55.1                 | 1.55.1       | ok     |
| cookstyle            | linter  | 8.6.10                 | 8.7.6        | BEHIND |
| tflint               | linter  | 0.64.0                 | 0.64.0       | ok     |
| bicep                | linter  | 0.46.1                 | 0.46.1       | ok     |
| cloudflare spec      | spec    | a0e7cfa11b             | 2ac8369e9b   | BEHIND |
| slack spec           | spec    | bc08db4962             | bc08db4962   | ok     |
| grafana spec         | spec    | 8c7e01c44c             | 2003eb0385   | BEHIND |
| mongodbatlas spec    | spec    | 666c7156b8             | f6a978f003   | BEHIND |
| azure CLI grammar    | grammar | 2.89.1                 | 2.89.1       | ok     |
| vercel CLI grammar   | grammar | 56.4.1                 | 59.0.0       | BEHIND |
| nutanix ncli grammar | grammar | Command-Ref-AOS-v7_5   | n/a          | manual |
```

## Design notes

- **A version, not a timestamp.** A `generated_at` would make every regeneration produce a diff, which would defeat "re-run the dump and see whether anything actually changed". Verified: regenerating against az 2.89.1 produced exactly the four-line `_meta` addition and no other change to the 7,002 commands.
- **The checker reads each pin from the file that declares it**, so it cannot drift from the thing it is checking.
- **It reports, it does not gate.** A bump is a judgement call — a newer cfn-lint can legitimately start failing snippets that used to pass — and a GitHub API blip must not fail a build. Network failures degrade to `could not reach upstream`.
- **A differing spec SHA is not automatically drift.** Some of these repos rewrote their default branch, so the newest commit touching the path can predate the pin; the checker asks GitHub how many commits actually separate them and treats zero as current. That is what keeps slack from reporting a false BEHIND.
- `validators/azure.py` pops `_meta` after loading. Nothing there would match a key starting with `_`, but a stray dict among the flag lists is the kind of thing that surfaces later as an unexplained `TypeError`.

## Verification

```
python3 content/validation/validate_remediation_commands.py azure
759 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)