### PR TITLE
👷 validation: fail when a validator stops seeing its blocks

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -11,6 +11,27 @@ permissions:
   contents: read
 
 jobs:
+  # Guards the other jobs rather than the content: it checks that each validator
+  # still *finds* the blocks it used to. Every extractor here is a regex over
+  # policy YAML, and one that stops matching reports success over an empty set —
+  # which looks exactly like a clean run. Needs no linters installed, so it is
+  # seconds rather than minutes.
+  validate-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Check that no validator stopped seeing its blocks
+        run: python3 content/validation/check_validation_coverage.py --check
+
   validate-cli:
     runs-on: ubuntu-latest
     steps:

--- a/content/validation/check_validation_coverage.py
+++ b/content/validation/check_validation_coverage.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Ratchet on how much remediation each validator actually sees.
+#
+# Every validator finds its work by regex over the policy YAML, and the failure
+# mode that costs us most is not a crash — it is a validator that quietly stops
+# matching and reports success over an empty set. That has happened more than
+# once in this directory's history: a `desc: |-` the pattern did not allow for,
+# a policy never added to a `TARGETS` list, an enrichment step scoped narrower
+# than the checking step. Every one of them looked like a green build.
+#
+# So this records how many blocks each validator extracts, per policy, and
+# fails when a number goes *down* without the checked-in counts being updated in
+# the same change. Growth needs no action; a drop has to be explained.
+#
+# It deliberately runs no linters and needs nothing installed — it calls each
+# validator's own extractor, so it is a fast CI job and it measures the same
+# code path the real run uses. Sharing the extractor is the point: a regex that
+# breaks breaks here too.
+#
+# Usage:
+#   python3 content/validation/check_validation_coverage.py            # report
+#   python3 content/validation/check_validation_coverage.py --check    # CI gate
+#   python3 content/validation/check_validation_coverage.py --update   # accept
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+CONTENT_DIR = SCRIPT_DIR.parent
+BUDGET_FILE = SCRIPT_DIR / "remediation-coverage.json"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from validators.common import extract_bash_blocks, split_commands  # noqa: E402
+
+
+def load_validator(module_name: str):
+    """Import a validate_*.py script as a module without running it."""
+    path = SCRIPT_DIR / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Code-block validators: each owns a TARGETS map and an extractor
+# ---------------------------------------------------------------------------
+
+BLOCK_VALIDATORS = [
+    ("bash", "validate_bash_remediation", "extract_bash_blocks"),
+    ("ansible", "validate_ansible_remediation", "extract_ansible_blocks"),
+    ("chef", "validate_chef_remediation", "extract_chef_blocks"),
+    ("cloudformation", "validate_cloudformation_remediation", "extract_cfn_blocks"),
+    ("bicep", "validate_bicep_remediation", "extract_bicep_blocks"),
+    ("terraform", "validate_terraform_remediation", "extract_hcl_blocks"),
+]
+
+
+def count_block_validators() -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {}
+    for name, module_name, extractor_name in BLOCK_VALIDATORS:
+        module = load_validator(module_name)
+        extractor = getattr(module, extractor_name)
+        per_policy: dict[str, int] = {}
+        for paths in module.TARGETS.values():
+            for path in paths:
+                path = Path(path)
+                if not path.exists():
+                    continue
+                blocks = extractor(path.read_text(), path)
+                if blocks:
+                    per_policy[path.name] = len(blocks)
+        counts[name] = dict(sorted(per_policy.items()))
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# CLI/API grammar validators
+#
+# Counting blocks would understate these: a block holds many commands and the
+# validator checks the ones that start with its own tool. The command count is
+# what actually moves when an extractor or a `TARGETS` entry breaks, so that is
+# what is recorded.
+# ---------------------------------------------------------------------------
+
+CLI_TARGETS = [
+    # (label, policy filename, command prefix, remediation ids)
+    ("aws", "mondoo-aws-security.mql.yaml", "aws", ("cli",)),
+    ("azure", "mondoo-azure-security.mql.yaml", "az", ("cli",)),
+    ("azure-m365", "mondoo-m365-security.mql.yaml", "az", ("cli",)),
+    ("gcp", "mondoo-gcp-security.mql.yaml", "gcloud", ("cli",)),
+    ("oci", "mondoo-oci-security.mql.yaml", "oci", ("cli",)),
+    ("digitalocean", "mondoo-digitalocean-security.mql.yaml", "doctl", ("cli",)),
+    ("nutanix", "mondoo-nutanix-security.mql.yaml", "ncli", ("cli",)),
+    ("alicloud", "mondoo-alibaba-security.mql.yaml", "aliyun", ("cli",)),
+    ("vercel", "mondoo-vercel-security.mql.yaml", "vercel", ("cli", "api")),
+    ("kubernetes", "mondoo-kubernetes-security.mql.yaml", "kubectl", ("cli",)),
+    ("kubernetes-bp", "mondoo-kubernetes-best-practices.mql.yaml", "kubectl", ("cli",)),
+    ("github", "mondoo-github-security.mql.yaml", "gh", ("cli",)),
+    ("github-bp", "mondoo-github-best-practices.mql.yaml", "gh", ("cli",)),
+    ("gitlab", "mondoo-gitlab-security.mql.yaml", "glab", ("cli",)),
+    ("hetzner", "mondoo-hetzner-security.mql.yaml", "hcloud", ("cli",)),
+    ("databricks", "mondoo-databricks-security.mql.yaml", "databricks", ("cli",)),
+    ("cloudflare", "mondoo-cloudflare-security.mql.yaml", "curl", ("cli",)),
+    ("tailscale", "mondoo-tailscale-security.mql.yaml", "curl", ("cli",)),
+    ("slack", "mondoo-slack-security.mql.yaml", "curl", ("cli",)),
+    ("atlassian", "mondoo-atlassian-security.mql.yaml", "curl", ("cli",)),
+    ("grafana", "mondoo-grafana-security.mql.yaml", "curl", ("cli",)),
+    ("mongodbatlas", "mondoo-mongodbatlas-security.mql.yaml", "curl", ("api",)),
+]
+
+
+def count_cli_validators() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for label, filename, prefix, ids in CLI_TARGETS:
+        path = CONTENT_DIR / filename
+        if not path.exists():
+            continue
+        total = 0
+        for block, line, _uid in extract_bash_blocks(
+            path.read_text(), include_audit=True, remediation_ids=ids
+        ):
+            total += len(split_commands(block, prefix, line))
+        counts[label] = total
+    return counts
+
+
+def collect() -> dict:
+    return {
+        "blocks": count_block_validators(),
+        "commands": dict(sorted(count_cli_validators().items())),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+def flatten(counts: dict) -> dict[str, int]:
+    """One flat name -> count map, so comparison is a single pass."""
+    flat: dict[str, int] = {}
+    for validator, per_policy in counts["blocks"].items():
+        for policy, n in per_policy.items():
+            flat[f"blocks/{validator}/{policy}"] = n
+    for label, n in counts["commands"].items():
+        flat[f"commands/{label}"] = n
+    return flat
+
+
+def compare(recorded: dict, current: dict) -> tuple[list[str], list[str]]:
+    """Returns (regressions, growth)."""
+    old, new = flatten(recorded), flatten(current)
+    regressions, growth = [], []
+    for key, was in sorted(old.items()):
+        now = new.get(key, 0)
+        if now < was:
+            regressions.append(
+                f"{key}: {was} -> {now}"
+                + (" (nothing extracted at all)" if now == 0 else "")
+            )
+        elif now > was:
+            growth.append(f"{key}: {was} -> {now}")
+    for key, now in sorted(new.items()):
+        if key not in old:
+            growth.append(f"{key}: new, {now}")
+    return regressions, growth
+
+
+def totals(counts: dict) -> tuple[int, int]:
+    blocks = sum(n for per in counts["blocks"].values() for n in per.values())
+    commands = sum(counts["commands"].values())
+    return blocks, commands
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ratchet on how much remediation each validator extracts"
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="fail if any count dropped")
+    group.add_argument("--update", action="store_true", help="record the current counts")
+    args = parser.parse_args()
+
+    current = collect()
+    blocks, commands = totals(current)
+
+    if args.update:
+        BUDGET_FILE.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        print(f"Recorded {blocks} blocks and {commands} commands to {BUDGET_FILE.name}")
+        return
+
+    if not BUDGET_FILE.exists():
+        print(
+            f"Error: {BUDGET_FILE} not found. Create it with --update.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    recorded = json.loads(BUDGET_FILE.read_text())
+    regressions, growth = compare(recorded, current)
+
+    if not args.check:
+        for validator, per_policy in current["blocks"].items():
+            print(f"{validator:<16} {sum(per_policy.values()):5d} blocks "
+                  f"across {len(per_policy)} policies")
+        for label, n in current["commands"].items():
+            print(f"{label:<16} {n:5d} commands")
+
+    print(f"\n{blocks} blocks, {commands} commands extracted", file=sys.stderr)
+
+    if growth:
+        print(f"\n{len(growth)} count(s) grew (fine, no action needed):", file=sys.stderr)
+        for line in growth:
+            print(f"  {line}", file=sys.stderr)
+
+    if regressions:
+        print(
+            f"\n{len(regressions)} validator count(s) DROPPED:\n  "
+            + "\n  ".join(regressions)
+            + "\n\nA validator extracting less than it used to is either content that "
+            "was removed\nor — the reason this check exists — an extractor that "
+            "silently stopped matching.\nIf the drop is intended, re-run with "
+            "--update in the same change so the new\nfloor is reviewable in the diff.",
+            file=sys.stderr,
+        )
+        if args.check:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/content/validation/check_validation_coverage.py
+++ b/content/validation/check_validation_coverage.py
@@ -70,8 +70,8 @@ def count_block_validators() -> dict[str, dict[str, int]]:
         extractor = getattr(module, extractor_name)
         per_policy: dict[str, int] = {}
         for paths in module.TARGETS.values():
-            for path in paths:
-                path = Path(path)
+            for entry in paths:
+                path = Path(entry)
                 if not path.exists():
                     continue
                 blocks = extractor(path.read_text(), path)

--- a/content/validation/remediation-coverage.json
+++ b/content/validation/remediation-coverage.json
@@ -16,16 +16,16 @@
       "mondoo-windows-workstation-security.mql.yaml": 3
     },
     "bash": {
-      "mondoo-edr-policy.mql.yaml": 2,
-      "mondoo-freebsd-security.mql.yaml": 56,
-      "mondoo-kubernetes-security.mql.yaml": 6,
-      "mondoo-linux-operational-policy.mql.yaml": 2,
-      "mondoo-linux-security.mql.yaml": 113,
-      "mondoo-linux-snmp-policy.mql.yaml": 3,
-      "mondoo-linux-workstation-security.mql.yaml": 2,
-      "mondoo-mariadb-security.mql.yaml": 37,
-      "mondoo-mysql-security.mql.yaml": 35,
-      "mondoo-proxmox-security.mql.yaml": 46
+      "mondoo-edr-policy.mql.yaml": 6,
+      "mondoo-freebsd-security.mql.yaml": 125,
+      "mondoo-kubernetes-security.mql.yaml": 22,
+      "mondoo-linux-operational-policy.mql.yaml": 7,
+      "mondoo-linux-security.mql.yaml": 354,
+      "mondoo-linux-snmp-policy.mql.yaml": 6,
+      "mondoo-linux-workstation-security.mql.yaml": 9,
+      "mondoo-mariadb-security.mql.yaml": 74,
+      "mondoo-mysql-security.mql.yaml": 70,
+      "mondoo-proxmox-security.mql.yaml": 99
     },
     "bicep": {
       "mondoo-azure-security.mql.yaml": 332

--- a/content/validation/remediation-coverage.json
+++ b/content/validation/remediation-coverage.json
@@ -1,0 +1,95 @@
+{
+  "blocks": {
+    "ansible": {
+      "mondoo-ai-security.mql.yaml": 38,
+      "mondoo-freebsd-security.mql.yaml": 56,
+      "mondoo-kubernetes-security.mql.yaml": 6,
+      "mondoo-linux-operational-policy.mql.yaml": 2,
+      "mondoo-linux-security.mql.yaml": 115,
+      "mondoo-linux-snmp-policy.mql.yaml": 3,
+      "mondoo-linux-workstation-security.mql.yaml": 2,
+      "mondoo-macos-security.mql.yaml": 35,
+      "mondoo-mariadb-security.mql.yaml": 37,
+      "mondoo-mysql-security.mql.yaml": 35,
+      "mondoo-proxmox-security.mql.yaml": 46,
+      "mondoo-windows-security.mql.yaml": 85,
+      "mondoo-windows-workstation-security.mql.yaml": 3
+    },
+    "bash": {
+      "mondoo-edr-policy.mql.yaml": 2,
+      "mondoo-freebsd-security.mql.yaml": 56,
+      "mondoo-kubernetes-security.mql.yaml": 6,
+      "mondoo-linux-operational-policy.mql.yaml": 2,
+      "mondoo-linux-security.mql.yaml": 113,
+      "mondoo-linux-snmp-policy.mql.yaml": 3,
+      "mondoo-linux-workstation-security.mql.yaml": 2,
+      "mondoo-mariadb-security.mql.yaml": 37,
+      "mondoo-mysql-security.mql.yaml": 35,
+      "mondoo-proxmox-security.mql.yaml": 46
+    },
+    "bicep": {
+      "mondoo-azure-security.mql.yaml": 332
+    },
+    "chef": {
+      "mondoo-chef-infra-client.mql.yaml": 13,
+      "mondoo-chef-infra-server.mql.yaml": 15,
+      "mondoo-freebsd-security.mql.yaml": 47,
+      "mondoo-linux-security.mql.yaml": 115,
+      "mondoo-windows-security.mql.yaml": 87
+    },
+    "cloudformation": {
+      "mondoo-aws-security.mql.yaml": 408
+    },
+    "terraform": {
+      "mondoo-alibaba-security.mql.yaml": 33,
+      "mondoo-aws-security.mql.yaml": 473,
+      "mondoo-azure-security.mql.yaml": 319,
+      "mondoo-cloudflare-security.mql.yaml": 21,
+      "mondoo-databricks-security.mql.yaml": 25,
+      "mondoo-digitalocean-security.mql.yaml": 18,
+      "mondoo-dns-security.mql.yaml": 8,
+      "mondoo-email-security.mql.yaml": 16,
+      "mondoo-gcp-security.mql.yaml": 277,
+      "mondoo-github-best-practices.mql.yaml": 6,
+      "mondoo-github-security.mql.yaml": 24,
+      "mondoo-gitlab-security.mql.yaml": 26,
+      "mondoo-hetzner-security.mql.yaml": 15,
+      "mondoo-m365-security.mql.yaml": 8,
+      "mondoo-oci-security.mql.yaml": 67,
+      "mondoo-okta-security.mql.yaml": 32,
+      "mondoo-openstack-security.mql.yaml": 29,
+      "mondoo-portainer-security.mql.yaml": 14,
+      "mondoo-snowflake-security.mql.yaml": 24,
+      "mondoo-stackit-security.mql.yaml": 25,
+      "mondoo-tailscale-security.mql.yaml": 11,
+      "mondoo-unifi-security.mql.yaml": 18,
+      "mondoo-vercel-security.mql.yaml": 11,
+      "mondoo-vmware-vsphere-esxi.mql.yaml": 5,
+      "mondoo-vmware-vsphere.mql.yaml": 36
+    }
+  },
+  "commands": {
+    "alicloud": 108,
+    "atlassian": 7,
+    "aws": 1819,
+    "azure": 757,
+    "azure-m365": 2,
+    "cloudflare": 53,
+    "databricks": 86,
+    "digitalocean": 120,
+    "gcp": 787,
+    "github": 66,
+    "github-bp": 21,
+    "gitlab": 55,
+    "grafana": 11,
+    "hetzner": 78,
+    "kubernetes": 76,
+    "kubernetes-bp": 12,
+    "mongodbatlas": 83,
+    "nutanix": 39,
+    "oci": 225,
+    "slack": 8,
+    "tailscale": 39,
+    "vercel": 15
+  }
+}


### PR DESCRIPTION
## What

A ratchet on how much remediation each validator actually extracts. New `check_validation_coverage.py` plus a checked-in `remediation-coverage.json` baseline, wired in as a fast `validate-coverage` job.

## Why

Every validator in `content/validation/` finds its work by regex over the policy YAML. The failure mode that costs us most is not a crash — it is a validator that quietly **stops matching and reports success over an empty set**.

That is not hypothetical; it has happened in this directory more than once:

- a `desc: |-` form the extraction pattern did not allow for
- a policy that was never added to a validator's `TARGETS`, so it shipped unlinted while CI stayed green
- an enrichment step scoped narrower than the checking step (the Azure phase-2 `--help` scope)

Every one of those looked like a passing build. `content/validation/` is ~7,500 lines of Python with no tests, and this is the specific regression it needs protection from.

## How

- Calls each validator's **own extractor** rather than reimplementing the matching, so a regex that breaks in the real run breaks here too.
- Records per-policy block counts for the six code-block validators, and command counts for the 22 CLI/API grammar targets — for those, blocks would understate the loss, since one block holds many commands.
- **Monotonic**: growth passes silently, a drop fails. If the drop is intended (content genuinely removed), re-run with `--update` in the same change so the new floor shows up in the diff.
- Runs **no linters and needs nothing installed** — seconds, not minutes, and it can gate the whole workflow rather than sitting behind a toolchain.

## Baseline

3,323 blocks and 4,467 commands:

```
bash               302 blocks across 10 policies
ansible            463 blocks across 13 policies
chef               277 blocks across  5 policies
cloudformation     408 blocks across  1 policy
bicep              332 blocks across  1 policy
terraform         1541 blocks across 25 policies
aws               1819 commands   gcp    787   azure  757   oci  225
digitalocean       120 commands   alicloud 108  databricks 86  mongodbatlas 83  …
```

## Verification

Both failure modes, confirmed:

```
# a count that drops
1 validator count(s) DROPPED:
  commands/aws: 1900 -> 1819

# an extractor broken outright (desc pattern sabotaged)
  blocks/bash/mondoo-linux-security.mql.yaml: 113 -> 0 (nothing extracted at all)
  blocks/bash/mondoo-freebsd-security.mql.yaml: 56 -> 0 (nothing extracted at all)
  …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)