### PR TITLE
🧹 content: label the code fences that carried no language

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-arista-eos-security
     name: Mondoo Arista EOS Security
-    version: 1.2.3
+    version: 1.2.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -174,20 +174,20 @@ queries:
 
             Enter global configuration mode and enable AAA accounting for all commands:
 
-            ```
+            ```text
             configure
             aaa accounting commands all default start-stop logging
             ```
 
             Configure a syslog server to receive accounting records:
 
-            ```
+            ```text
             logging host <syslog-server-ip>
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -243,14 +243,14 @@ queries:
 
             Enter global configuration mode and enable AAA accounting for exec sessions:
 
-            ```
+            ```text
             configure
             aaa accounting exec default start-stop logging
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -306,14 +306,14 @@ queries:
 
             Enter global configuration mode and enable AAA accounting for system events:
 
-            ```
+            ```text
             configure
             aaa accounting system default start-stop logging
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -372,7 +372,7 @@ queries:
 
             Enter global configuration mode and configure AAA authentication for console and remote access:
 
-            ```
+            ```text
             configure
             aaa authentication login default group <radius|tacacs+> local
             aaa authentication login console group <radius|tacacs+> local
@@ -382,7 +382,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -439,20 +439,20 @@ queries:
 
             Enter global configuration mode and enable authentication failure logging:
 
-            ```
+            ```text
             configure
             aaa authentication policy on-failure log
             ```
 
             Configure log monitoring and alerting for authentication failures:
 
-            ```
+            ```text
             logging host <siem-server-ip>
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -508,7 +508,7 @@ queries:
 
             Enter global configuration mode and enable AAA authorization for console access:
 
-            ```
+            ```text
             configure
             aaa authorization console
             aaa authorization commands all default local
@@ -516,7 +516,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -578,7 +578,7 @@ queries:
 
             Enter global configuration mode, then the `management defaults` sub-mode to set the hash, return to global configuration mode with `exit`, and create the admin account:
 
-            ```
+            ```text
             configure
             management defaults
             secret hash sha512
@@ -590,7 +590,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -645,7 +645,7 @@ queries:
 
             Configure an idle timeout for console sessions. EOS expresses the timeout in minutes under the `management console` block. Enter global configuration mode, then the `management console` sub-mode, and set the timeout:
 
-            ```
+            ```text
             configure
             management console
             idle-timeout 10
@@ -655,7 +655,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -712,7 +712,7 @@ queries:
 
             Enter global configuration mode and configure the DNS domain name:
 
-            ```
+            ```text
             configure
             dns domain <your-domain.com>
             ```
@@ -721,7 +721,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -777,7 +777,7 @@ queries:
 
             Configure an SSH idle timeout for remote management sessions. EOS expresses the timeout in minutes under the `management ssh` block. Enter global configuration mode, then the `management ssh` sub-mode, and set the timeout:
 
-            ```
+            ```text
             configure
             management ssh
             idle-timeout 10
@@ -787,7 +787,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -846,7 +846,7 @@ queries:
 
             Enter global configuration mode and configure a descriptive, unique hostname:
 
-            ```
+            ```text
             configure
             hostname <unique-descriptive-name>
             ```
@@ -855,7 +855,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -912,7 +912,7 @@ queries:
 
             Enable HTTPS for the management API first, then disable HTTP. Commands take effect immediately, so removing the HTTP listener before HTTPS is running can cut off any management session or automation that currently uses HTTP. Enter global configuration mode, then the `management api http-commands` sub-mode, and adjust the protocols:
 
-            ```
+            ```text
             configure
             management api http-commands
             protocol https
@@ -923,7 +923,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -980,7 +980,7 @@ queries:
 
             Enable HTTPS for the management API. Enter global configuration mode, then the `management api http-commands` sub-mode, and enable the protocol:
 
-            ```
+            ```text
             configure
             management api http-commands
             protocol https
@@ -988,7 +988,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1047,7 +1047,7 @@ queries:
 
             Configure descriptive names for all interfaces. Enter global configuration mode, then the interface sub-mode for each port, and set its description:
 
-            ```
+            ```text
             configure
             interface <interface-name>
             description <purpose and connection details>
@@ -1057,7 +1057,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1112,14 +1112,14 @@ queries:
 
             Enter global configuration mode and configure buffered logging with an appropriate size:
 
-            ```
+            ```text
             configure
             logging buffered 100000 informational
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1176,14 +1176,14 @@ queries:
 
             Enter global configuration mode and enable system logging:
 
-            ```
+            ```text
             configure
             logging on
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1240,7 +1240,7 @@ queries:
 
             Enter global configuration mode and configure one or more remote syslog servers:
 
-            ```
+            ```text
             configure
             logging host <syslog-server-ip>
             logging trap informational
@@ -1248,7 +1248,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1304,7 +1304,7 @@ queries:
 
             Enter global configuration mode and set logging levels for important subsystems, choosing informational or debugging as appropriate:
 
-            ```
+            ```text
             configure
             logging level all informational
             logging level security debugging
@@ -1312,7 +1312,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1368,7 +1368,7 @@ queries:
 
             Enter global configuration mode and configure a login banner with appropriate legal language. The `banner login` command starts a text-entry mode that ends when you type `EOF` on its own line:
 
-            ```
+            ```text
             configure
             banner login
             UNAUTHORIZED ACCESS TO THIS DEVICE IS PROHIBITED
@@ -1381,7 +1381,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1440,21 +1440,21 @@ queries:
 
             Enter global configuration mode and assign appropriate roles to users instead of granting blanket privilege 15:
 
-            ```
+            ```text
             configure
             username <username> privilege 1 role <appropriate-role>
             ```
 
             Create custom roles if needed. The `role` command enters a role sub-mode where you add privilege statements:
 
-            ```
+            ```text
             role <role-name>
                <privilege statements>
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1509,7 +1509,7 @@ queries:
 
             Enter global configuration mode and configure an MOTD banner. The `banner motd` command starts a text-entry mode that ends when you type `EOF` on its own line:
 
-            ```
+            ```text
             configure
             banner motd
             <your message here>
@@ -1518,7 +1518,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1576,7 +1576,7 @@ queries:
 
             Enter global configuration mode and direct console authentication to the AAA server group:
 
-            ```
+            ```text
             configure
             aaa authentication login console group radius local
             ```
@@ -1585,7 +1585,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1641,14 +1641,14 @@ queries:
 
             Enter global configuration mode and assign a password to every account configured with `nopassword`. Setting a secret replaces the `nopassword` attribute in the running-config:
 
-            ```
+            ```text
             configure
             username <username> secret 0 <strong-password>
             ```
 
             Remove accounts that are no longer needed:
 
-            ```
+            ```text
             no username <username>
             ```
 
@@ -1656,7 +1656,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1712,7 +1712,7 @@ queries:
 
             Enter global configuration mode and configure NTP servers for time synchronization:
 
-            ```
+            ```text
             configure
             ntp server <ntp-server-1>
             ntp server <ntp-server-2>
@@ -1722,7 +1722,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1778,7 +1778,7 @@ queries:
 
             Enter global configuration mode and configure at least two NTP servers for redundancy:
 
-            ```
+            ```text
             configure
             ntp server <primary-ntp-server>
             ntp server <secondary-ntp-server>
@@ -1788,7 +1788,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1845,7 +1845,7 @@ queries:
 
             Configure a minimum password length. A length of 15 characters is recommended for high security. Enter global configuration mode, then the `management security` sub-mode, and set the minimum length:
 
-            ```
+            ```text
             configure
             management security
             password minimum length 15
@@ -1855,7 +1855,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1911,7 +1911,7 @@ queries:
 
             EOS does not store local user passwords in cleartext when the `secret` keyword is used. To ensure all secrets are hashed with the strongest available algorithm, set SHA-512 as the default hashing algorithm. Enter global configuration mode, then the `management defaults` sub-mode, and set the hash:
 
-            ```
+            ```text
             configure
             management defaults
             secret hash sha512
@@ -1921,7 +1921,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -1979,7 +1979,7 @@ queries:
 
             Enter global configuration mode, remove default community strings, and configure secure, unique strings:
 
-            ```
+            ```text
             configure
             no snmp-server community public
             no snmp-server community private
@@ -1988,13 +1988,13 @@ queries:
 
             Consider using SNMPv3 with authentication and encryption instead of community strings:
 
-            ```
+            ```text
             snmp-server user <username> <group> v3 auth sha <password> priv aes <privpassword>
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2050,7 +2050,7 @@ queries:
 
             The real fix is to send traps using SNMPv3 with authentication and privacy, because SNMPv3 encrypts the notification and authenticates its source. SNMP v2c sends traps in cleartext even with a non-default community string, so anyone who can capture the traffic still reads the contents. Configure an SNMPv3 user and point the trap host at it. Enter global configuration mode first:
 
-            ```
+            ```text
             configure
             snmp-server user <username> <group> v3 auth sha <password> priv aes <privpassword>
             snmp-server host <server-ip> version 3 priv <username>
@@ -2058,7 +2058,7 @@ queries:
 
             If your monitoring system cannot yet accept SNMPv3, replacing the default community string with a strong, unique one is only a minimum stopgap that does not encrypt the traffic:
 
-            ```
+            ```text
             no snmp-server host <server-ip>
             snmp-server host <server-ip> version 2c <secure-community-string>
             ```
@@ -2067,7 +2067,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2125,7 +2125,7 @@ queries:
 
             Enter global configuration mode, then the `management ssh` sub-mode, and enable the service:
 
-            ```
+            ```text
             configure
             management ssh
             no shutdown
@@ -2133,13 +2133,13 @@ queries:
 
             Harden the SSH service while still in the `management ssh` sub-mode, for example by setting an idle timeout:
 
-            ```
+            ```text
             idle-timeout 10
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2195,7 +2195,7 @@ queries:
 
             Verify SSH access works before disabling Telnet. If your current session runs over Telnet, the `shutdown` command disconnects it immediately, so establish and test an SSH session first. Enter global configuration mode, then the `management ssh` sub-mode, and enable SSH:
 
-            ```
+            ```text
             configure
             management ssh
             no shutdown
@@ -2203,7 +2203,7 @@ queries:
 
             After confirming you can log in over SSH, enter the `management telnet` sub-mode and disable Telnet:
 
-            ```
+            ```text
             configure
             management telnet
             shutdown
@@ -2211,7 +2211,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2267,14 +2267,14 @@ queries:
 
             Enter global configuration mode and set the timezone to UTC or GMT:
 
-            ```
+            ```text
             configure
             clock timezone UTC
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2335,7 +2335,7 @@ queries:
 
             Disable unused interfaces. Enter global configuration mode, then the interface sub-mode for each unused port, and shut it down:
 
-            ```
+            ```text
             configure
             interface <interface-name>
             shutdown
@@ -2345,7 +2345,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2401,7 +2401,7 @@ queries:
 
             Move all access ports from VLAN 1 to appropriate user VLANs. Enter global configuration mode, then the interface sub-mode for each access port, and set its access VLAN:
 
-            ```
+            ```text
             configure
             interface <interface>
             switchport access vlan <appropriate-vlan>
@@ -2409,7 +2409,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2467,7 +2467,7 @@ queries:
 
             Enter global configuration mode, then the `management defaults` sub-mode to set the hash, return to global configuration mode with `exit`, and re-enter each user secret:
 
-            ```
+            ```text
             configure
             management defaults
             secret hash sha512
@@ -2479,7 +2479,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2536,7 +2536,7 @@ queries:
 
             Configure descriptive names for all VLANs. Enter global configuration mode, then the `vlan` sub-mode for each VLAN, and set its name:
 
-            ```
+            ```text
             configure
             vlan <vlan-id>
             name <descriptive-name>
@@ -2546,7 +2546,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2605,7 +2605,7 @@ queries:
 
             Configure a dedicated native VLAN other than VLAN 1 for trunk ports. Enter global configuration mode, then the interface sub-mode for each trunk port, and set its native VLAN:
 
-            ```
+            ```text
             configure
             interface <interface>
             switchport trunk native vlan <vlan-id>
@@ -2615,7 +2615,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2676,7 +2676,7 @@ queries:
 
             Create a route map and apply it inbound on each BGP peer. Enter global configuration mode, define the route map in its sub-mode, then enter the `router bgp` sub-mode to apply it to the neighbor:
 
-            ```
+            ```text
             configure
             route-map INBOUND-FILTER permit 10
             match ip address prefix-list ALLOWED-PREFIXES
@@ -2689,7 +2689,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2750,7 +2750,7 @@ queries:
 
             Create a route map and apply it outbound on each BGP peer. Enter global configuration mode, define the route map in its sub-mode, then enter the `router bgp` sub-mode to apply it to the neighbor:
 
-            ```
+            ```text
             configure
             route-map OUTBOUND-FILTER permit 10
             match ip address prefix-list ADVERTISED-PREFIXES
@@ -2763,7 +2763,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2822,7 +2822,7 @@ queries:
 
             Configure descriptions for all BGP peers. Enter global configuration mode, then the `router bgp` sub-mode, and set each neighbor description:
 
-            ```
+            ```text
             configure
             router bgp <asn>
             neighbor <peer-ip> description <peer-name and circuit details>
@@ -2832,7 +2832,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -2894,7 +2894,7 @@ queries:
 
             Investigate the state of non-established peers:
 
-            ```
+            ```text
             show ip bgp summary
             show ip bgp neighbors <peer-ip>
             ```
@@ -2964,7 +2964,7 @@ queries:
 
             Add an explicit deny entry at the end of each standard ACL. Use a sequence number higher than every existing entry so the deny stays last. Enter global configuration mode, then the `ip access-list standard` sub-mode, and add the entry:
 
-            ```
+            ```text
             configure
             ip access-list standard <acl-name>
             <high-sequence-number> deny any log
@@ -2974,7 +2974,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```
@@ -3034,13 +3034,13 @@ queries:
 
             List the current entries first to capture each sequence number and source:
 
-            ```
+            ```text
             show ip access-lists
             ```
 
             Re-enter each deny entry with its existing sequence number and append the `log` keyword. Standard ACL entries take only a source address. Enter global configuration mode, then the `ip access-list standard` sub-mode, and re-enter the deny entries:
 
-            ```
+            ```text
             configure
             ip access-list standard <acl-name>
             <sequence-number> deny <source> log
@@ -3048,7 +3048,7 @@ queries:
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:
 
-            ```
+            ```text
             end
             write memory
             ```

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-bigip-security
     name: Mondoo F5 BIG-IP Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -98,7 +98,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the installed certificates and their expiration dates:
 
-           ```
+           ```text
            tmsh list sys crypto cert
            ```
         3. Compare the `expiration` value reported for each certificate against the current date.
@@ -122,22 +122,22 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. List certificates and their expiration dates:
 
-               ```
+               ```text
                tmsh list sys crypto cert
                ```
             3. Install the renewed certificate over the existing object name so SSL profiles keep referencing it:
 
-               ```
+               ```text
                tmsh install sys crypto cert <name> from-local-file <path>
                ```
             4. If the renewal was issued for a new key pair, install the new key as well:
 
-               ```
+               ```text
                tmsh install sys crypto key <name> from-local-file <key-path>
                ```
             5. Save the configuration so the change persists across reboots and failovers:
 
-               ```
+               ```text
                tmsh save sys config
                ```
     refs:
@@ -194,7 +194,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the installed certificates with all of their properties:
 
-           ```
+           ```text
            tmsh list sys crypto cert all-properties
            ```
         3. Inspect the `key-size` and `key-type` values reported for each certificate.
@@ -219,23 +219,23 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Identify weak certificates:
 
-               ```
+               ```text
                tmsh list sys crypto cert all-properties
                ```
             3. Generate a new key and CSR with a 2048-bit key:
 
-               ```
+               ```text
                tmsh create sys crypto key <name> key-size 2048
                tmsh create sys crypto csr <name> key <name> common-name <cn>
                ```
             4. Submit the CSR to your certificate authority, then install the issued certificate:
 
-               ```
+               ```text
                tmsh install sys crypto cert <name> from-local-file <path>
                ```
             5. Update every SSL profile that references the old certificate, then save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
     refs:
@@ -291,7 +291,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the installed keys with all of their properties:
 
-           ```
+           ```text
            tmsh list sys crypto key all-properties
            ```
         3. Inspect the `key-size` and `key-type` values reported for each key.
@@ -314,18 +314,18 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. List existing keys to identify weak ones:
 
-               ```
+               ```text
                tmsh list sys crypto key
                ```
             3. Generate a new 2048-bit key and a CSR for it:
 
-               ```
+               ```text
                tmsh create sys crypto key <name> key-size 2048
                tmsh create sys crypto csr <name> key <name> common-name <cn>
                ```
             4. Re-issue the associated certificate with the new key, install it, update every SSL profile that references the old key, and save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
     refs:
@@ -384,7 +384,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the cipher string configured on each client SSL profile:
 
-           ```
+           ```text
            tmsh list ltm profile client-ssl ciphers
            ```
         3. Inspect each cipher string for `RC4`, `DES`, `3DES`, `NULL`, or `EXPORT` entries.
@@ -412,22 +412,22 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Create a cipher group that allows the `f5-secure` rule:
 
-               ```
+               ```text
                tmsh create ltm cipher group secure-gcm allow add { f5-secure }
                ```
             3. Attach the cipher group to the client SSL profile. The `ciphers none` argument clears any inline cipher string so the group takes effect:
 
-               ```
+               ```text
                tmsh modify ltm profile client-ssl <profile-name> cipher-group secure-gcm ciphers none
                ```
             4. Confirm the group resolves to AES-GCM suites only and that no weak suites remain:
 
-               ```
+               ```text
                tmsh show ltm cipher group secure-gcm
                ```
             5. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
 
@@ -487,7 +487,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the cipher string configured on each server SSL profile:
 
-           ```
+           ```text
            tmsh list ltm profile server-ssl ciphers
            ```
         3. Inspect each cipher string for `RC4`, `DES`, `3DES`, `NULL`, or `EXPORT` entries.
@@ -513,17 +513,17 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Update the cipher string on the server SSL profile:
 
-               ```
+               ```text
                tmsh modify ltm profile server-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
                ```
             3. From the advanced shell, list the cipher suites the string expands to and confirm no weak suites remain:
 
-               ```
+               ```text
                tmm --serverciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
                ```
             4. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
     refs:
@@ -584,7 +584,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the peer certificate mode and CA bundle configured on each server SSL profile:
 
-           ```
+           ```text
            tmsh list ltm profile server-ssl <name> peer-cert-mode ca-file
            ```
         3. Inspect the `peer-cert-mode` value reported for each profile.
@@ -610,17 +610,17 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Require backend certificate verification on the server SSL profile and point it at a trusted CA bundle:
 
-               ```
+               ```text
                tmsh modify ltm profile server-ssl <profile-name> peer-cert-mode require ca-file <ca-bundle-name>
                ```
             3. Verify the configuration:
 
-               ```
+               ```text
                tmsh list ltm profile server-ssl <profile-name> peer-cert-mode ca-file
                ```
             4. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
 
@@ -677,7 +677,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the source-checking setting configured on each VLAN:
 
-           ```
+           ```text
            tmsh list net vlan source-checking
            ```
         3. Inspect the `source-checking` value reported for each VLAN.
@@ -702,17 +702,17 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Enable source checking on the VLAN:
 
-               ```
+               ```text
                tmsh modify net vlan <vlan-name> source-checking enabled
                ```
             3. Verify the setting:
 
-               ```
+               ```text
                tmsh list net vlan <vlan-name> source-checking
                ```
             4. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
 
@@ -769,7 +769,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the strict setting configured on each route domain:
 
-           ```
+           ```text
            tmsh list net route-domain strict
            ```
         3. Inspect the `strict` value reported for each route domain.
@@ -793,17 +793,17 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Enable strict isolation on the route domain:
 
-               ```
+               ```text
                tmsh modify net route-domain <name> strict enabled
                ```
             3. Verify the configuration:
 
-               ```
+               ```text
                tmsh list net route-domain <name> strict
                ```
             4. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
 
@@ -860,7 +860,7 @@ queries:
         1. Open an SSH session to the BIG-IP and enter the tmsh shell.
         2. List the SNMP allowed addresses:
 
-           ```
+           ```text
            tmsh list sys snmp allowed-addresses
            ```
         3. Inspect the list for unrestricted entries such as `0.0.0.0/0`, `::/0`, or `ALL`.
@@ -882,17 +882,17 @@ queries:
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Restrict SNMP access to the loopback range and your specific management hosts:
 
-               ```
+               ```text
                tmsh modify sys snmp allowed-addresses replace-all-with { 127.0.0.0/8 10.0.1.100 10.0.1.101 }
                ```
             3. Verify the allowed addresses:
 
-               ```
+               ```text
                tmsh list sys snmp allowed-addresses
                ```
             4. Save the configuration:
 
-               ```
+               ```text
                tmsh save sys config
                ```
 

--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-iosxe-security
     name: Mondoo Cisco IOS-XE Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -147,7 +147,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the SSH server status:
 
-           ```
+           ```text
            show ip ssh
            ```
 
@@ -159,7 +159,7 @@ queries:
 
             SSH requires a hostname, a domain name, and an RSA key pair. Set the hostname and domain name only if they are not already configured, because changing them renames the device in logs and management systems:
 
-            ```
+            ```text
             configure terminal
             hostname <hostname>
             ip domain name <domain.com>
@@ -216,7 +216,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the SSH server status:
 
-           ```
+           ```text
            show ip ssh
            ```
 
@@ -228,7 +228,7 @@ queries:
 
             Configure SSH version 2:
 
-            ```
+            ```text
             configure terminal
             ip ssh version 2
             end
@@ -278,7 +278,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the SSH configuration:
 
-           ```
+           ```text
            show ip ssh
            ```
 
@@ -290,7 +290,7 @@ queries:
 
             Configure SSH timeout (60 seconds recommended):
 
-            ```
+            ```text
             configure terminal
             ip ssh time-out 60
             end
@@ -339,7 +339,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the device crypto keys:
 
-           ```
+           ```text
            show crypto key mypubkey rsa
            ```
 
@@ -351,7 +351,7 @@ queries:
 
             Generate a new RSA key pair with at least 2048 bits:
 
-            ```
+            ```text
             configure terminal
             crypto key generate rsa modulus 2048
             end
@@ -404,7 +404,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the AAA setting:
 
-           ```
+           ```text
            show running-config | include aaa new-model
            ```
 
@@ -416,7 +416,7 @@ queries:
 
             Enabling the AAA new model immediately changes authentication on every line, including the VTY lines you use for remote management. If no local user and no default login method list exist, you can lose access to the device. Create a local user and a default login method list in the same session, and keep that session open until you verify access:
 
-            ```
+            ```text
             configure terminal
             username <admin-user> privilege 15 algorithm-type scrypt secret <strong-password>
             aaa new-model
@@ -470,7 +470,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured AAA authentication login lists:
 
-           ```
+           ```text
            show running-config | include aaa authentication login
            ```
 
@@ -482,7 +482,7 @@ queries:
 
             Define the TACACS+ server, then configure the default login method list with a local fallback. The default list takes effect on all lines as soon as it is entered, so create a local user first and keep your current session open until you verify login from a second session:
 
-            ```
+            ```text
             configure terminal
             username <admin-user> privilege 15 algorithm-type scrypt secret <strong-password>
             aaa new-model
@@ -540,7 +540,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured AAA accounting entries:
 
-           ```
+           ```text
            show running-config | include aaa accounting
            ```
 
@@ -552,7 +552,7 @@ queries:
 
             AAA accounting requires the AAA new model and a configured TACACS+ server. With those prerequisites in place, enable accounting for EXEC sessions and privileged commands:
 
-            ```
+            ```text
             configure terminal
             aaa accounting exec default start-stop group tacacs+
             aaa accounting commands 15 default start-stop group tacacs+
@@ -607,7 +607,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured user accounts:
 
-           ```
+           ```text
            show running-config | include ^username
            ```
 
@@ -619,7 +619,7 @@ queries:
 
             Cisco IOS XE does not allow a user account to have both a password and a secret, so accounts configured with `password` must be removed and recreated with `secret`. Deleting the account removes its credentials until the next command recreates it. Before you begin, confirm that a second administrator account exists or that you have console access, so that a dropped session between the two commands cannot lock you out. If you are converting the account you are logged in with, keep your session open and verify the new credential from a second session before closing:
 
-            ```
+            ```text
             configure terminal
             no username <user>
             username <user> privilege <level> algorithm-type scrypt secret <password>
@@ -672,7 +672,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the enable credential:
 
-           ```
+           ```text
            show running-config | include enable
            ```
 
@@ -684,7 +684,7 @@ queries:
 
             Configure the enable secret with the strongest available hash first, then remove the legacy enable password so the device is never left without a privileged EXEC credential. Use `algorithm-type scrypt`, which stores the credential as a Type 9 hash that resists offline cracking far better than the older Type 5 MD5 hash:
 
-            ```
+            ```text
             configure terminal
             enable algorithm-type scrypt secret <strong-password>
             no enable password
@@ -737,7 +737,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the service setting:
 
-           ```
+           ```text
            show running-config | include service password-encryption
            ```
 
@@ -749,7 +749,7 @@ queries:
 
             Enable service password encryption:
 
-            ```
+            ```text
             configure terminal
             service password-encryption
             end
@@ -799,7 +799,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the HTTP server:
 
-           ```
+           ```text
            show running-config | include ip http server
            ```
 
@@ -811,7 +811,7 @@ queries:
 
             Disable the HTTP server:
 
-            ```
+            ```text
             configure terminal
             no ip http server
             end
@@ -860,7 +860,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the secure HTTP server:
 
-           ```
+           ```text
            show running-config | include ip http secure-server
            ```
 
@@ -872,7 +872,7 @@ queries:
 
             Enable the HTTPS server:
 
-            ```
+            ```text
             configure terminal
             ip http secure-server
             end
@@ -922,7 +922,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the global CDP status:
 
-           ```
+           ```text
            show cdp
            ```
 
@@ -934,7 +934,7 @@ queries:
 
             Disable CDP globally:
 
-            ```
+            ```text
             configure terminal
             no cdp run
             end
@@ -985,7 +985,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the BOOTP server:
 
-           ```
+           ```text
            show running-config all | include ip bootp server
            ```
 
@@ -997,7 +997,7 @@ queries:
 
             Disable BOOTP:
 
-            ```
+            ```text
             configure terminal
             no ip bootp server
             end
@@ -1047,7 +1047,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the source-route setting:
 
-           ```
+           ```text
            show running-config all | include ip source-route
            ```
 
@@ -1059,7 +1059,7 @@ queries:
 
             Disable IP source routing:
 
-            ```
+            ```text
             configure terminal
             no ip source-route
             end
@@ -1108,7 +1108,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the PAD service:
 
-           ```
+           ```text
            show running-config all | include service pad
            ```
 
@@ -1120,7 +1120,7 @@ queries:
 
             Disable PAD:
 
-            ```
+            ```text
             configure terminal
             no service pad
             end
@@ -1170,7 +1170,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for NTP authentication:
 
-           ```
+           ```text
            show running-config | include ntp authenticate
            ```
 
@@ -1182,7 +1182,7 @@ queries:
 
             Configure NTP authentication:
 
-            ```
+            ```text
             configure terminal
             ntp authenticate
             ntp authentication-key 1 md5 <key-value>
@@ -1237,7 +1237,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured NTP associations:
 
-           ```
+           ```text
            show ntp associations
            ```
 
@@ -1249,7 +1249,7 @@ queries:
 
             Configure NTP servers:
 
-            ```
+            ```text
             configure terminal
             ntp server <ntp-server-ip-1>
             ntp server <ntp-server-ip-2>
@@ -1300,7 +1300,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configuration archive logging status:
 
-           ```
+           ```text
            show archive log config all
            ```
 
@@ -1312,7 +1312,7 @@ queries:
 
             Enable configuration change logging:
 
-            ```
+            ```text
             configure terminal
             archive
             log config
@@ -1364,7 +1364,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the logging configuration:
 
-           ```
+           ```text
            show logging
            ```
 
@@ -1376,7 +1376,7 @@ queries:
 
             Configure remote logging hosts:
 
-            ```
+            ```text
             configure terminal
             logging host <syslog-server-ip>
             logging trap informational
@@ -1428,7 +1428,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for login logging:
 
-           ```
+           ```text
            show running-config | include login on-failure
            ```
 
@@ -1440,7 +1440,7 @@ queries:
 
             Enable failed login logging:
 
-            ```
+            ```text
             configure terminal
             login on-failure log
             end
@@ -1493,7 +1493,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show running-config | include snmp-server community
            ```
 
@@ -1507,7 +1507,7 @@ queries:
 
             Remove the default community strings, create an ACL that permits only your management stations, and configure a unique community string restricted by that ACL:
 
-            ```
+            ```text
             configure terminal
             no snmp-server community public
             no snmp-server community private
@@ -1563,7 +1563,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show running-config | include snmp-server community
            ```
 
@@ -1575,7 +1575,7 @@ queries:
 
             Create an ACL that permits only your management stations, then reapply each community string with the ACL. Re-entering a community string with the same name replaces the existing entry:
 
-            ```
+            ```text
             configure terminal
             access-list 10 permit <nms-ip-1>
             access-list 10 permit <nms-ip-2>
@@ -1632,7 +1632,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the VTY line configuration:
 
-           ```
+           ```text
            show running-config | section line vty
            ```
 
@@ -1644,7 +1644,7 @@ queries:
 
             Before restricting transport to SSH, verify that SSH login to the device works. Once applied, telnet connections are refused immediately, including the session you may be using. Display all VTY lines with `show line` and apply the setting to every VTY range, not just lines 0 to 15:
 
-            ```
+            ```text
             ! Before proceeding, open a new SSH session to this device and confirm login succeeds.
             ! Do not close your current session until SSH access is verified.
             configure terminal
@@ -1703,7 +1703,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the VTY line configuration:
 
-           ```
+           ```text
            show running-config | section line vty
            ```
 
@@ -1715,7 +1715,7 @@ queries:
 
             Configure exec timeout on VTY lines (10 minutes recommended):
 
-            ```
+            ```text
             configure terminal
             line vty 0 15
             exec-timeout 10 0
@@ -1767,7 +1767,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the VTY line configuration:
 
-           ```
+           ```text
            show running-config | section line vty
            ```
 
@@ -1779,7 +1779,7 @@ queries:
 
             Create an ACL that permits your management hosts, then apply it inbound on every VTY line. The ACL takes effect immediately, so make sure it includes the address you are connecting from, keep your current session open, and verify that a new session still succeeds before closing:
 
-            ```
+            ```text
             configure terminal
             access-list 11 permit <management-subnet> <wildcard-mask>
             line vty 0 15
@@ -1835,7 +1835,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the auxiliary line configuration:
 
-           ```
+           ```text
            show running-config | section line aux
            ```
 
@@ -1847,7 +1847,7 @@ queries:
 
             Disable exec on the auxiliary line:
 
-            ```
+            ```text
             configure terminal
             line aux 0
             no exec
@@ -1897,7 +1897,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the console line configuration:
 
-           ```
+           ```text
            show running-config | section line con
            ```
 
@@ -1909,7 +1909,7 @@ queries:
 
             Configure console exec timeout (10 minutes recommended):
 
-            ```
+            ```text
             configure terminal
             line con 0
             exec-timeout 10 0
@@ -1960,7 +1960,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the login banner:
 
-           ```
+           ```text
            show running-config | include banner login
            ```
 
@@ -1972,7 +1972,7 @@ queries:
 
             Configure a login banner:
 
-            ```
+            ```text
             configure terminal
             banner login ^Authorized access only. All activity is monitored and logged.^
             end
@@ -2021,7 +2021,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the MOTD banner:
 
-           ```
+           ```text
            show running-config | include banner motd
            ```
 
@@ -2033,7 +2033,7 @@ queries:
 
             Configure a MOTD banner:
 
-            ```
+            ```text
             configure terminal
             banner motd ^Unauthorized access is prohibited. All activity is subject to monitoring.^
             end
@@ -2085,7 +2085,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured hostname:
 
-           ```
+           ```text
            show running-config | include ^hostname
            ```
 
@@ -2097,7 +2097,7 @@ queries:
 
             Configure a descriptive hostname:
 
-            ```
+            ```text
             configure terminal
             hostname <unique-descriptive-name>
             end
@@ -2147,7 +2147,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the domain name:
 
-           ```
+           ```text
            show running-config | include ip domain name
            ```
 
@@ -2159,7 +2159,7 @@ queries:
 
             Configure the domain name:
 
-            ```
+            ```text
             configure terminal
             ip domain name <your-domain.com>
             end
@@ -2208,7 +2208,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the service setting:
 
-           ```
+           ```text
            show running-config all | include service tcp-keepalives-in
            ```
 
@@ -2220,7 +2220,7 @@ queries:
 
             Enable TCP keepalives for inbound sessions:
 
-            ```
+            ```text
             configure terminal
             service tcp-keepalives-in
             end
@@ -2269,7 +2269,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the service setting:
 
-           ```
+           ```text
            show running-config all | include service tcp-keepalives-out
            ```
 
@@ -2281,7 +2281,7 @@ queries:
 
             Enable TCP keepalives for outbound sessions:
 
-            ```
+            ```text
             configure terminal
             service tcp-keepalives-out
             end
@@ -2332,7 +2332,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the BGP configuration:
 
-           ```
+           ```text
            show running-config | section router bgp
            ```
 
@@ -2344,7 +2344,7 @@ queries:
 
             Configure MD5 authentication for each BGP neighbor. The same password must be configured on both peers, and adding or changing the password resets the BGP session until the two sides match. Coordinate the change with the peer operator and schedule it during a maintenance window:
 
-            ```
+            ```text
             configure terminal
             router bgp <as-number>
             neighbor <neighbor-ip> password <password>
@@ -2401,7 +2401,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the OSPF configuration:
 
-           ```
+           ```text
            show running-config | section router ospf
            ```
 
@@ -2413,7 +2413,7 @@ queries:
 
             Configure a message digest key on every OSPF interface in the area, then enable message digest authentication for the area. Routers drop adjacencies with neighbors whose authentication does not match, so apply the same key on all routers in the area and schedule the change during a maintenance window:
 
-            ```
+            ```text
             configure terminal
             interface <interface>
             ip ospf message-digest-key 1 md5 <key>

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-iosxr-security
     name: Mondoo Cisco IOS-XR Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -135,7 +135,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the SSH server:
 
-           ```
+           ```text
            show running-config ssh server
            ```
 
@@ -147,7 +147,7 @@ queries:
 
             Configure SSH version 2:
 
-            ```
+            ```text
             configure terminal
             ssh server v2
             commit
@@ -195,7 +195,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the SSH timeout:
 
-           ```
+           ```text
            show running-config ssh timeout
            ```
 
@@ -207,7 +207,7 @@ queries:
 
             Configure the SSH timeout in seconds. This value limits how long an SSH connection may take to complete user authentication before the device drops it. Values up to 120 seconds are accepted and 60 is a reasonable value:
 
-            ```
+            ```text
             configure terminal
             ssh timeout 60
             commit
@@ -256,7 +256,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured crypto keys:
 
-           ```
+           ```text
            show crypto key mypubkey rsa
            ```
 
@@ -268,7 +268,7 @@ queries:
 
             Generate a new RSA key pair from EXEC mode. The command prompts for the modulus size; enter 2048 or larger:
 
-            ```
+            ```text
             crypto key generate rsa
             ```
 
@@ -318,7 +318,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for AAA authentication login:
 
-           ```
+           ```text
            show running-config aaa authentication login
            ```
 
@@ -330,7 +330,7 @@ queries:
 
             Changing the default login method list can lock you out if the AAA servers are unreachable or the configuration is wrong, so use IOS-XR's auto-rollback safety net: `commit confirmed <minutes>` reverts the change automatically unless you run a final `commit` within the timer.
 
-            ```
+            ```text
             configure terminal
             aaa authentication login default group tacacs+ local
             commit confirmed 5
@@ -338,7 +338,7 @@ queries:
 
             Open a new session and confirm you can authenticate, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
 
@@ -386,7 +386,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for AAA accounting:
 
-           ```
+           ```text
            show running-config aaa accounting
            ```
 
@@ -398,7 +398,7 @@ queries:
 
             Configure AAA accounting for exec sessions and commands:
 
-            ```
+            ```text
             configure terminal
             aaa accounting exec default start-stop group tacacs+
             aaa accounting commands default start-stop group tacacs+
@@ -447,7 +447,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for AAA authorization:
 
-           ```
+           ```text
            show running-config aaa authorization
            ```
 
@@ -459,7 +459,7 @@ queries:
 
             Configure AAA authorization:
 
-            ```
+            ```text
             configure terminal
             aaa authorization exec default group tacacs+ local
             aaa authorization commands default group tacacs+ local
@@ -507,7 +507,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the line settings:
 
-           ```
+           ```text
            show running-config line
            ```
 
@@ -519,7 +519,7 @@ queries:
 
             Configure line authentication:
 
-            ```
+            ```text
             configure terminal
             line console
             login authentication default
@@ -571,7 +571,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured user accounts:
 
-           ```
+           ```text
            show running-config username
            ```
 
@@ -583,7 +583,7 @@ queries:
 
             Replace clear-text passwords with hashed secrets. Enter the password in clear text with type 0 and the device stores only a hash:
 
-            ```
+            ```text
             configure terminal
             username <user> secret 0 <password>
             commit
@@ -591,7 +591,7 @@ queries:
 
             To supply a pre-computed SHA-512 crypt hash instead, use type 10:
 
-            ```
+            ```text
             configure terminal
             username <user> secret 10 <sha512-crypt-hash>
             commit
@@ -641,7 +641,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for password policies:
 
-           ```
+           ```text
            show running-config aaa password-policy
            ```
 
@@ -653,7 +653,7 @@ queries:
 
             Create a password policy:
 
-            ```
+            ```text
             configure terminal
             aaa password-policy <policy-name>
             min-length 15
@@ -666,7 +666,7 @@ queries:
 
             Assign the policy to each local user together with the user's password:
 
-            ```
+            ```text
             configure terminal
             username <user> password-policy <policy-name> password <password>
             commit
@@ -713,7 +713,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the Type 6 password encryption state:
 
-           ```
+           ```text
            show type6 server
            ```
 
@@ -725,7 +725,7 @@ queries:
 
             Enable the Type 6 AES password encryption feature in configuration mode:
 
-            ```
+            ```text
             configure terminal
             password6 encryption aes
             commit
@@ -734,7 +734,7 @@ queries:
 
             Then create the primary key from EXEC mode. The command prompts for the new key; enter a value of 6 to 64 characters:
 
-            ```
+            ```text
             key config-key password-encryption
             ```
 
@@ -782,7 +782,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for NTP authentication:
 
-           ```
+           ```text
            show running-config ntp authenticate
            ```
 
@@ -794,7 +794,7 @@ queries:
 
             Configure NTP authentication. MD5 is the minimum acceptable algorithm here: it authenticates the time source so the device rejects spoofed updates, but it is cryptographically weak, so use a stronger key digest if your IOS-XR release and NTP servers support one. The same key and key number must be configured on the NTP server, or the device will reject its updates.
 
-            ```
+            ```text
             configure terminal
             ntp authenticate
             ntp authentication-key 1 md5 <key-value>
@@ -844,7 +844,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured NTP associations:
 
-           ```
+           ```text
            show ntp associations
            ```
 
@@ -856,7 +856,7 @@ queries:
 
             Configure NTP servers:
 
-            ```
+            ```text
             configure terminal
             ntp server <ntp-server-ip-1>
             ntp server <ntp-server-ip-2>
@@ -907,7 +907,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the logging configuration and status:
 
-           ```
+           ```text
            show logging
            ```
 
@@ -919,7 +919,7 @@ queries:
 
             Enable logging:
 
-            ```
+            ```text
             configure terminal
             logging console informational
             logging monitor informational
@@ -970,7 +970,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for syslog hosts:
 
-           ```
+           ```text
            show running-config logging
            ```
 
@@ -982,7 +982,7 @@ queries:
 
             Configure remote syslog hosts:
 
-            ```
+            ```text
             configure terminal
             logging <syslog-server-ip>
             logging source-interface <interface>
@@ -1030,7 +1030,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for buffered logging:
 
-           ```
+           ```text
            show running-config logging buffered
            ```
 
@@ -1042,7 +1042,7 @@ queries:
 
             Configure buffer logging:
 
-            ```
+            ```text
             configure terminal
             logging buffered informational
             commit
@@ -1095,7 +1095,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show running-config snmp-server community
            ```
 
@@ -1107,7 +1107,7 @@ queries:
 
             First create an ACL that permits only your SNMP management stations, so the community string is reachable only from trusted hosts:
 
-            ```
+            ```text
             configure terminal
             ipv4 access-list <acl-name>
             10 permit ipv4 host <management-station-ip> any
@@ -1116,7 +1116,7 @@ queries:
 
             Then remove the default community strings and configure a unique community string restricted by that ACL. Confirm the exact keyword order for `RO`, `IPv4`, and the ACL name against the SNMP configuration guide for your IOS-XR release, because it has varied between releases:
 
-            ```
+            ```text
             configure terminal
             no snmp-server community public
             no snmp-server community private
@@ -1169,7 +1169,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP users:
 
-           ```
+           ```text
            show snmp user
            ```
 
@@ -1181,7 +1181,7 @@ queries:
 
             Configure SNMPv3 users with authentication and encryption:
 
-            ```
+            ```text
             configure terminal
             snmp-server group <group-name> v3 priv
             snmp-server user <username> <group-name> v3 auth sha clear <auth-password> priv aes 128 clear <priv-password>
@@ -1235,7 +1235,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show running-config snmp-server community
            ```
 
@@ -1247,7 +1247,7 @@ queries:
 
             Apply ACLs to SNMP community strings:
 
-            ```
+            ```text
             configure terminal
             snmp-server community <community-string> RO IPv4 <acl-name>
             commit
@@ -1298,7 +1298,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the login banner:
 
-           ```
+           ```text
            show running-config banner login
            ```
 
@@ -1310,7 +1310,7 @@ queries:
 
             Configure a login banner. On IOS-XR, `banner login` is followed by a delimiter character that marks the start and end of the message, not by double quotes. Pick a delimiter that does not appear anywhere in the banner text. The example below uses `#`:
 
-            ```
+            ```text
             configure terminal
             banner login # Authorized access only. All activity is monitored and logged. #
             commit
@@ -1358,7 +1358,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the console line:
 
-           ```
+           ```text
            show running-config line console
            ```
 
@@ -1370,7 +1370,7 @@ queries:
 
             Configure console exec timeout (10 minutes recommended):
 
-            ```
+            ```text
             configure terminal
             line console
             exec-timeout 10 0
@@ -1420,7 +1420,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured hostname:
 
-           ```
+           ```text
            show running-config hostname
            ```
 
@@ -1432,7 +1432,7 @@ queries:
 
             Configure a descriptive hostname:
 
-            ```
+            ```text
             configure terminal
             hostname <unique-descriptive-name>
             commit
@@ -1479,7 +1479,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for CDP:
 
-           ```
+           ```text
            show running-config cdp
            ```
 
@@ -1491,7 +1491,7 @@ queries:
 
             Disable CDP globally:
 
-            ```
+            ```text
             configure terminal
             no cdp
             commit
@@ -1540,7 +1540,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the small-server services:
 
-           ```
+           ```text
            show running-config | include small-servers
            ```
 
@@ -1552,7 +1552,7 @@ queries:
 
             Disable small servers:
 
-            ```
+            ```text
             configure terminal
             no service ipv4 tcp-small-servers
             no service ipv4 udp-small-servers
@@ -1606,7 +1606,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the line templates:
 
-           ```
+           ```text
            show running-config line template
            ```
 
@@ -1620,7 +1620,7 @@ queries:
 
             For the built-in default template:
 
-            ```
+            ```text
             configure terminal
             line default
             transport input ssh
@@ -1629,7 +1629,7 @@ queries:
 
             Open a new SSH session and verify you can still manage the device, then confirm the change:
 
-            ```
+            ```text
             commit
             ```
 
@@ -1678,7 +1678,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the line templates:
 
-           ```
+           ```text
            show running-config line template
            ```
 
@@ -1690,7 +1690,7 @@ queries:
 
             Create an ACL that permits only your management stations. Confirm it includes the address you currently manage the device from before applying it, because an ACL that omits it cuts off your own remote access:
 
-            ```
+            ```text
             configure terminal
             ipv4 access-list <acl-name>
             10 permit ipv4 host <management-station-ip> any
@@ -1699,7 +1699,7 @@ queries:
 
             Apply the ACL to the built-in default template. Because a wrong or incomplete ACL can lock you out, use IOS-XR's auto-rollback safety net: `commit confirmed <minutes>` reverts the change automatically unless you run a final `commit` within the timer.
 
-            ```
+            ```text
             configure terminal
             line default
             access-class ingress <acl-name>
@@ -1708,7 +1708,7 @@ queries:
 
             Open a new SSH session and verify you can still reach the device, then confirm the change:
 
-            ```
+            ```text
             commit
             ```
 
@@ -1759,7 +1759,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the BGP configuration:
 
-           ```
+           ```text
            show running-config router bgp
            ```
 
@@ -1771,7 +1771,7 @@ queries:
 
             Configure a password on each BGP neighbor. This enables TCP MD5 session authentication, which protects the session from rogue peers and TCP reset attacks. MD5 is the floor: it is weak by modern standards, so prefer TCP-AO where both peers support it. Adding or changing a session password resets the BGP session and interrupts routing through that peer until both sides match, so apply this during a maintenance window and coordinate with the peer operator:
 
-            ```
+            ```text
             configure terminal
             router bgp <as-number>
             neighbor <neighbor-ip>
@@ -1826,7 +1826,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the OSPF configuration:
 
-           ```
+           ```text
            show running-config router ospf
            ```
 
@@ -1838,7 +1838,7 @@ queries:
 
             Create the key chain first. This authenticates OSPF adjacencies so an attacker cannot inject routes by joining the area. Choose a cryptographic algorithm supported by your software release: prefer HMAC-SHA-256 and treat MD5 as the floor, since MD5 is weak by modern standards. Replace `<start-date>` with the date the key takes effect, in `month day year` form:
 
-            ```
+            ```text
             configure terminal
             key chain <keychain-name>
             key 1
@@ -1851,7 +1851,7 @@ queries:
 
             Then apply the key chain to the OSPF area. Authentication must match on every router in the area, so stage this change on all area routers during a maintenance window to avoid dropping adjacencies:
 
-            ```
+            ```text
             configure terminal
             router ospf <process-id>
             area <area-id>

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-nxos-security
     name: Mondoo Cisco NX-OS Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -144,7 +144,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the SSH server key information:
 
-           ```
+           ```text
            show ssh key
            ```
 
@@ -158,7 +158,7 @@ queries:
 
             Generate an SSH key with a strong algorithm:
 
-            ```
+            ```text
             configure terminal
             no feature ssh
             ssh key rsa 2048 force
@@ -167,7 +167,7 @@ queries:
 
             Or for ECDSA:
 
-            ```
+            ```text
             configure terminal
             no feature ssh
             ssh key ecdsa 256 force
@@ -178,7 +178,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -224,7 +224,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the SSH server key information:
 
-           ```
+           ```text
            show ssh key
            ```
 
@@ -238,7 +238,7 @@ queries:
 
             Generate a 2048-bit RSA key:
 
-            ```
+            ```text
             configure terminal
             no feature ssh
             ssh key rsa 2048 force
@@ -249,7 +249,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -295,7 +295,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the effective SSH login attempts limit, including default values:
 
-           ```
+           ```text
            show running-config security all | include "ssh login-attempts"
            ```
 
@@ -307,14 +307,14 @@ queries:
 
             Configure SSH login attempts limit:
 
-            ```
+            ```text
             configure terminal
             ssh login-attempts 3
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -360,7 +360,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for AAA authentication login:
 
-           ```
+           ```text
            show running-config aaa | include authentication login
            ```
 
@@ -372,7 +372,7 @@ queries:
 
             Configure AAA authentication to use a TACACS+ or RADIUS server group with local fallback. The server group must already exist. For RADIUS, the predefined group named `radius` contains all globally configured RADIUS servers. For TACACS+, first enable `feature tacacs+` and create a named server group with `aaa group server tacacs+`. Keeping `local` as a fallback method and `local` on the console line prevents a lockout if the AAA servers become unreachable.
 
-            ```
+            ```text
             configure terminal
             aaa authentication login default group <server-group-name> local
             aaa authentication login console local
@@ -380,13 +380,13 @@ queries:
 
             Verify the configuration from a second session before closing your current one:
 
-            ```
+            ```text
             show running-config aaa | include "authentication login"
             ```
 
             NX-OS does not automatically persist running-config changes. Once you have confirmed access still works, save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -431,7 +431,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured AAA server groups:
 
-           ```
+           ```text
            show aaa groups
            ```
 
@@ -443,7 +443,7 @@ queries:
 
             Enable the TACACS+ feature, define the server, and create a server group. The `feature tacacs+` command must come first; NX-OS rejects all TACACS+ configuration while the feature is disabled.
 
-            ```
+            ```text
             configure terminal
             feature tacacs+
             tacacs-server host <server-ip> key <shared-secret>
@@ -457,7 +457,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -502,7 +502,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the password setting:
 
-           ```
+           ```text
            show running-config | include password strength-check
            ```
 
@@ -514,14 +514,14 @@ queries:
 
             Enable password strength checking:
 
-            ```
+            ```text
             configure terminal
             password strength-check
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -567,7 +567,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the password encryption status:
 
-           ```
+           ```text
            show encryption service stat
            ```
 
@@ -579,7 +579,7 @@ queries:
 
             Configure a master key and enable the AES password encryption feature. The `key config-key ascii` command prompts for the master key interactively; the key is not entered on the command line.
 
-            ```
+            ```text
             configure terminal
             key config-key ascii
             feature password encryption aes
@@ -587,13 +587,13 @@ queries:
 
             To convert existing Type 7 encrypted secrets in the configuration to Type 6 AES encryption:
 
-            ```
+            ```text
             encryption re-encrypt obfuscated
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -640,7 +640,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured user accounts:
 
-           ```
+           ```text
            show running-config | include ^username
            ```
 
@@ -652,20 +652,20 @@ queries:
 
             Reset the password for any user whose credential is stored in clear text. Enter the password in plain text; NX-OS hashes it before storing it in the configuration.
 
-            ```
+            ```text
             configure terminal
             username <user> password <strong-password> role <role>
             ```
 
             Verify that no credential is stored with encryption type 0:
 
-            ```
+            ```text
             show running-config | include ^username
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -710,7 +710,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the passphrase setting:
 
-           ```
+           ```text
            show running-config | include userpassphrase
            ```
 
@@ -722,14 +722,14 @@ queries:
 
             Configure minimum passphrase length:
 
-            ```
+            ```text
             configure terminal
             userpassphrase min-length 15 max-length 127
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -775,7 +775,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the login block setting:
 
-           ```
+           ```text
            show running-config | include system login block-for
            ```
 
@@ -787,14 +787,14 @@ queries:
 
             Configure login blocking:
 
-            ```
+            ```text
             configure terminal
             system login block-for 60 attempts 3 within 60
             ```
 
             This blocks logins for 60 seconds after 3 failed attempts within 60 seconds. During the block period the device denies all login attempts, which an attacker can abuse to lock out administrators. Permit trusted management hosts during the quiet period with an ACL:
 
-            ```
+            ```text
             ip access-list LOGIN-QUIET-MODE
               permit tcp <management-subnet> any eq 22
             exit
@@ -803,7 +803,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -848,7 +848,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured NTP peers:
 
-           ```
+           ```text
            show ntp peers
            ```
 
@@ -860,7 +860,7 @@ queries:
 
             Configure NTP servers:
 
-            ```
+            ```text
             configure terminal
             ntp server <ntp-server-ip-1> use-vrf management
             ntp server <ntp-server-ip-2> use-vrf management
@@ -868,7 +868,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -912,7 +912,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the clock timezone:
 
-           ```
+           ```text
            show running-config | include clock timezone
            ```
 
@@ -924,14 +924,14 @@ queries:
 
             Configure the timezone:
 
-            ```
+            ```text
             configure terminal
             clock timezone EST -5 0
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -977,7 +977,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured logging servers:
 
-           ```
+           ```text
            show logging server
            ```
 
@@ -989,7 +989,7 @@ queries:
 
             Configure remote logging:
 
-            ```
+            ```text
             configure terminal
             logging server <syslog-server-ip> 6 use-vrf management
             logging source-interface mgmt0
@@ -997,7 +997,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1042,7 +1042,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the logging timestamp setting:
 
-           ```
+           ```text
            show logging timestamp
            ```
 
@@ -1054,14 +1054,14 @@ queries:
 
             Configure millisecond timestamps:
 
-            ```
+            ```text
             configure terminal
             logging timestamp milliseconds
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1106,7 +1106,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the logging source interface:
 
-           ```
+           ```text
            show running-config | include logging source-interface
            ```
 
@@ -1118,14 +1118,14 @@ queries:
 
             Configure logging source interface:
 
-            ```
+            ```text
             configure terminal
             logging source-interface mgmt0
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1171,7 +1171,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show snmp community
            ```
 
@@ -1183,7 +1183,7 @@ queries:
 
             Remove default community strings:
 
-            ```
+            ```text
             configure terminal
             no snmp-server community public
             no snmp-server community private
@@ -1192,7 +1192,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1237,7 +1237,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the SNMP privacy setting:
 
-           ```
+           ```text
            show running-config | include snmp-server globalEnforcePriv
            ```
 
@@ -1251,7 +1251,7 @@ queries:
 
             Create an SNMPv3 user with SHA authentication and AES-128 privacy, then enforce global privacy:
 
-            ```
+            ```text
             configure terminal
             snmp-server user <username> network-operator auth sha <auth-password> priv aes-128 <priv-password>
             snmp-server globalEnforcePriv
@@ -1261,7 +1261,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1309,7 +1309,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured SNMP community strings:
 
-           ```
+           ```text
            show snmp community
            ```
 
@@ -1323,7 +1323,7 @@ queries:
 
             If you must keep v2c communities in the interim, create an ACL that permits only authorized management stations, then bind it to each SNMP community. The ACL must exist before it is referenced. Include every monitoring system in the ACL; any station not permitted loses SNMP access to the device as soon as the ACL is applied.
 
-            ```
+            ```text
             configure terminal
             ip access-list SNMP-MGMT
               permit ip <nms-ip>/32 any
@@ -1333,7 +1333,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1378,7 +1378,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the boot POAP setting:
 
-           ```
+           ```text
            show running-config | include boot poap
            ```
 
@@ -1390,14 +1390,14 @@ queries:
 
             Disable POAP:
 
-            ```
+            ```text
             configure terminal
             no boot poap enable
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1443,7 +1443,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the active CoPP profile:
 
-           ```
+           ```text
            show copp status
            ```
 
@@ -1455,14 +1455,14 @@ queries:
 
             Configure CoPP with a strict profile:
 
-            ```
+            ```text
             configure terminal
             copp profile strict
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1509,7 +1509,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the effective VTY line configuration, including default values:
 
-           ```
+           ```text
            show running-config all | section "line vty"
            ```
 
@@ -1521,7 +1521,7 @@ queries:
 
             Configure VTY exec timeout (10 minutes recommended):
 
-            ```
+            ```text
             configure terminal
             line vty
             exec-timeout 10
@@ -1529,7 +1529,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1575,7 +1575,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the effective console line configuration, including default values:
 
-           ```
+           ```text
            show running-config all | section "line console"
            ```
 
@@ -1587,7 +1587,7 @@ queries:
 
             Configure console exec timeout (10 minutes recommended):
 
-            ```
+            ```text
             configure terminal
             line console
             exec-timeout 10
@@ -1595,7 +1595,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1641,7 +1641,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the VTY line:
 
-           ```
+           ```text
            show running-config | section "line vty"
            ```
 
@@ -1653,7 +1653,7 @@ queries:
 
             Create the ACL before applying it to the VTY lines and make sure it permits the management hosts you connect from. Applying an inbound access class that does not match your management stations immediately cuts off remote SSH access, including the session you are working in. Keep a console session available until you have verified remote access still works.
 
-            ```
+            ```text
             configure terminal
             ip access-list VTY-MGMT
               permit tcp <management-subnet> any eq 22
@@ -1666,7 +1666,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Once you have confirmed remote access still works, save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1711,7 +1711,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the MOTD banner:
 
-           ```
+           ```text
            show running-config | include banner motd
            ```
 
@@ -1723,14 +1723,14 @@ queries:
 
             Configure a MOTD banner:
 
-            ```
+            ```text
             configure terminal
             banner motd @Authorized access only. All activity is monitored and logged.@
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1774,7 +1774,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the exec banner:
 
-           ```
+           ```text
            show running-config | include banner exec
            ```
 
@@ -1786,14 +1786,14 @@ queries:
 
             Configure an exec banner:
 
-            ```
+            ```text
             configure terminal
             banner exec @This system is for authorized use only. All activity is logged.@
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1840,7 +1840,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the configured hostname:
 
-           ```
+           ```text
            show running-config | include ^hostname
            ```
 
@@ -1852,14 +1852,14 @@ queries:
 
             Configure a descriptive hostname:
 
-            ```
+            ```text
             configure terminal
             hostname <unique-descriptive-name>
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1903,7 +1903,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the running configuration for the source-route setting:
 
-           ```
+           ```text
            show running-config all | include ip source-route
            ```
 
@@ -1915,14 +1915,14 @@ queries:
 
             Disable IP source routing:
 
-            ```
+            ```text
             configure terminal
             no ip source-route
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -1968,7 +1968,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the interface configuration:
 
-           ```
+           ```text
            show running-config interface
            ```
 
@@ -1982,7 +1982,7 @@ queries:
 
             Disable IP directed broadcast on interfaces:
 
-            ```
+            ```text
             configure terminal
             interface <interface>
             no ip directed-broadcast
@@ -1990,7 +1990,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -2038,7 +2038,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the BGP configuration:
 
-           ```
+           ```text
            show running-config bgp
            ```
 
@@ -2052,7 +2052,7 @@ queries:
 
             Configure BGP neighbor authentication:
 
-            ```
+            ```text
             configure terminal
             router bgp <as-number>
               neighbor <neighbor-ip>
@@ -2061,13 +2061,13 @@ queries:
 
             Enter the password in plain text; NX-OS stores it in encrypted form in the configuration. Verify the session returns to the established state:
 
-            ```
+            ```text
             show bgp sessions
             ```
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -2114,7 +2114,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the BGP configuration:
 
-           ```
+           ```text
            show running-config bgp
            ```
 
@@ -2126,7 +2126,7 @@ queries:
 
             Enable BGP neighbor change logging:
 
-            ```
+            ```text
             configure terminal
             router bgp <as-number>
             log-neighbor-changes
@@ -2134,7 +2134,7 @@ queries:
 
             NX-OS does not automatically persist running-config changes. Save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:
@@ -2185,7 +2185,7 @@ queries:
         1. Open an authenticated session to the device CLI.
         2. Display the OSPF configuration:
 
-           ```
+           ```text
            show running-config ospf
            ```
 
@@ -2199,7 +2199,7 @@ queries:
 
             Configure OSPF interface authentication with message digest keys:
 
-            ```
+            ```text
             configure terminal
             interface <interface>
               ip ospf authentication message-digest
@@ -2208,7 +2208,7 @@ queries:
 
             Or create a key chain and reference it on the interface:
 
-            ```
+            ```text
             configure terminal
             key chain <keychain-name>
               key 1
@@ -2220,13 +2220,13 @@ queries:
 
             Verify the adjacency reforms:
 
-            ```
+            ```text
             show ip ospf neighbors
             ```
 
             NX-OS does not automatically persist running-config changes. Once the adjacency has reformed, save the configuration so the change survives a reload:
 
-            ```
+            ```text
             copy running-config startup-config
             ```
     refs:

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-fortios-security
     name: Mondoo Fortinet FortiOS Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -140,7 +140,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system status
            ```
 
@@ -165,19 +165,19 @@ queries:
 
             Check the current firmware version:
 
-            ```
+            ```text
             get system status
             ```
 
             Back up the configuration before upgrading. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if the upgrade has to be rolled back:
 
-            ```
+            ```text
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
             Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If your current version is several releases behind the GA target, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time rather than jumping directly. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
-            ```
+            ```text
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
@@ -232,7 +232,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system status
            ```
 
@@ -257,19 +257,19 @@ queries:
 
             Check the current firmware status:
 
-            ```
+            ```text
             get system status
             ```
 
             Back up the configuration before upgrading. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if the upgrade has to be rolled back:
 
-            ```
+            ```text
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
             Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If the target Mature release is several versions ahead, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
-            ```
+            ```text
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
@@ -327,7 +327,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system status
            ```
 
@@ -353,19 +353,19 @@ queries:
 
             Check the current firmware version:
 
-            ```
+            ```text
             get system status
             ```
 
             Back up the configuration. `execute backup full-config` captures both user-specified and default settings, which gives you a complete restore point if an upgrade hop has to be rolled back:
 
-            ```
+            ```text
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
             Follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade through each required intermediate version. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** Run the command once per hop in the supported sequence rather than jumping straight to the target version, because skipping intermediate releases can corrupt the configuration migration. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
-            ```
+            ```text
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
@@ -420,7 +420,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system global | grep admintimeout
            ```
 
@@ -439,7 +439,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config system global
                 set admintimeout 5
             end
@@ -494,7 +494,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system global | grep admin-sport
            ```
 
@@ -517,7 +517,7 @@ queries:
 
             Pick a port that does not overlap the SSL-VPN listening `port`, which commonly uses 443 or 8443. If `admin-sport` collides with the SSL-VPN port, one of the two services fails to bind and either administrators or VPN users lose access.
 
-            ```
+            ```text
             config system global
                 set admin-sport 8443
             end
@@ -570,7 +570,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system global | grep admin-ssh-port
            ```
 
@@ -589,7 +589,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config system global
                 set admin-ssh-port 2222
             end
@@ -644,7 +644,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system global | grep admin-scp
            ```
 
@@ -663,7 +663,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config system global
                 set admin-scp disable
             end
@@ -718,7 +718,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system ha | grep mode
            ```
 
@@ -740,7 +740,7 @@ queries:
 
             **Important**: HA configuration requires a second FortiGate unit with matching hardware, firmware, and licenses. Forming a cluster renegotiates interfaces and can briefly interrupt traffic, so apply this change during a maintenance window from the console or a dedicated management interface. Set a cluster password so only authorized units can join.
 
-            ```
+            ```text
             config system ha
                 set mode a-p
                 set group-name "fg-cluster"
@@ -800,7 +800,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system ha | grep session-pickup
            ```
 
@@ -817,7 +817,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            ```
+            ```text
             config system ha
                 set session-pickup enable
             end
@@ -871,7 +871,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system dns
            ```
 
@@ -894,7 +894,7 @@ queries:
 
             FortiOS 7.0 and later select the DNS transport with the `protocol` option:
 
-            ```
+            ```text
             config system dns
                 set protocol dot
                 set ssl-certificate "Fortinet_Factory"
@@ -903,7 +903,7 @@ queries:
 
             FortiOS 6.4 and earlier use the `dns-over-tls` option:
 
-            ```
+            ```text
             config system dns
                 set dns-over-tls enable
             end
@@ -958,7 +958,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get system ntp | grep ntpsync
            ```
 
@@ -978,7 +978,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config system ntp
                 set ntpsync enable
                 set type custom
@@ -1037,7 +1037,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show system ntp
            ```
 
@@ -1057,7 +1057,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config system ntp
                 set ntpsync enable
                 set type custom
@@ -1120,7 +1120,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log setting | grep fwpolicy-implicit-log
            ```
 
@@ -1140,7 +1140,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config log setting
                 set fwpolicy-implicit-log enable
             end
@@ -1194,7 +1194,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log setting | grep local-in-deny-unicast
            ```
 
@@ -1214,7 +1214,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config log setting
                 set local-in-deny-unicast enable
             end
@@ -1264,7 +1264,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log setting | grep extended-log
            ```
 
@@ -1279,7 +1279,7 @@ queries:
 
             The global extended log format option is available only in the CLI:
 
-            ```
+            ```text
             config log setting
                 set extended-log enable
             end
@@ -1329,7 +1329,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log setting | grep user-anonymize
            ```
 
@@ -1344,7 +1344,7 @@ queries:
 
             The user anonymization option is available only in the CLI:
 
-            ```
+            ```text
             config log setting
                 set user-anonymize disable
             end
@@ -1399,7 +1399,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log syslogd setting | grep status
            ```
 
@@ -1420,7 +1420,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config log syslogd setting
                 set status enable
                 set server "10.0.0.100"
@@ -1481,7 +1481,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following commands:
 
-           ```
+           ```text
            get log syslogd setting | grep status
            get log fortianalyzer setting | grep status
            ```
@@ -1509,7 +1509,7 @@ queries:
 
             **Option 1: Syslog**
 
-            ```
+            ```text
             config log syslogd setting
                 set status enable
                 set server "10.0.0.100"
@@ -1518,7 +1518,7 @@ queries:
 
             **Option 2: FortiAnalyzer**
 
-            ```
+            ```text
             config log fortianalyzer setting
                 set status enable
                 set server "10.0.0.200"
@@ -1574,7 +1574,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log fortianalyzer setting | grep -e status -e enc-algorithm
            ```
 
@@ -1593,7 +1593,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config log fortianalyzer setting
                 set enc-algorithm high
             end
@@ -1648,7 +1648,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get log fortianalyzer setting | grep -e status -e reliable
            ```
 
@@ -1667,7 +1667,7 @@ queries:
 
             On a multi-VDOM device, first run `config global`.
 
-            ```
+            ```text
             config log fortianalyzer setting
                 set reliable enable
             end
@@ -1723,7 +1723,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show firewall policy
            ```
 
@@ -1745,13 +1745,13 @@ queries:
 
             List all policies and their status:
 
-            ```
+            ```text
             show firewall policy
             ```
 
             Delete an unused policy:
 
-            ```
+            ```text
             config firewall policy
                 delete <policy-id>
             end
@@ -1814,7 +1814,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show firewall policy
            ```
 
@@ -1835,13 +1835,13 @@ queries:
 
             Review all policies:
 
-            ```
+            ```text
             show firewall policy
             ```
 
             Modify the overly permissive policy to restrict scope:
 
-            ```
+            ```text
             config firewall policy
                 edit <policy-id>
                     set srcaddr "specific-source-group"
@@ -1901,7 +1901,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show firewall policy
            ```
 
@@ -1919,7 +1919,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            ```
+            ```text
             config firewall policy
                 edit <policy-id>
                     set logtraffic all
@@ -1979,7 +1979,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show firewall policy
            ```
 
@@ -2003,7 +2003,7 @@ queries:
 
             Setting `utm-status enable` without an `ssl-ssh-profile` leaves the policy with no SSL/SSH inspection, so the antivirus, IPS, and web filter profiles never see inside encrypted sessions and the UTM stack is effectively bypassed for HTTPS and other TLS traffic. Always pair the UTM profiles with an inspection profile:
 
-            ```
+            ```text
             config firewall policy
                 edit <policy-id>
                     set utm-status enable
@@ -2070,7 +2070,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show firewall policy
            ```
 
@@ -2090,7 +2090,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            ```
+            ```text
             config firewall policy
                 edit <policy-id>
                     set ssl-ssh-profile "certificate-inspection"
@@ -2151,7 +2151,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show system interface
            ```
 
@@ -2178,7 +2178,7 @@ queries:
 
             Repeat for every WAN interface:
 
-            ```
+            ```text
             config system interface
                 edit "wan1"
                     set allowaccess ping
@@ -2237,7 +2237,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            show system interface
            ```
 
@@ -2258,13 +2258,13 @@ queries:
 
             List the interfaces that currently allow telnet:
 
-            ```
+            ```text
             show system interface
             ```
 
             Remove only the telnet option from each affected interface. The `unselect` keyword removes a single option from a multi-option field without touching the others:
 
-            ```
+            ```text
             config system interface
                 edit "mgmt"
                     unselect allowaccess telnet
@@ -2274,7 +2274,7 @@ queries:
 
             Alternatively, set the complete list of allowed protocols without telnet:
 
-            ```
+            ```text
             config system interface
                 edit "mgmt"
                     set allowaccess ping https ssh
@@ -2332,7 +2332,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get router bgp | grep log-neighbour-changes
            ```
 
@@ -2349,7 +2349,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            ```
+            ```text
             config router bgp
                 set log-neighbour-changes enable
             end
@@ -2405,7 +2405,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get router bgp | grep graceful-restart
            ```
 
@@ -2427,7 +2427,7 @@ queries:
 
             **Important**: Enabling graceful restart resets established BGP sessions while the new capability is negotiated. Apply this change during a maintenance window.
 
-            ```
+            ```text
             config router bgp
                 set graceful-restart enable
                 set graceful-restart-time 120
@@ -2483,7 +2483,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            get router ospf | grep log-neighbour-changes
            ```
 
@@ -2500,7 +2500,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            ```
+            ```text
             config router ospf
                 set log-neighbour-changes enable
             end
@@ -2554,7 +2554,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            diagnose autoupdate versions
            ```
 
@@ -2574,14 +2574,14 @@ queries:
 
             Check the current FortiGuard license status:
 
-            ```
+            ```text
             get system fortiguard
             diagnose autoupdate status
             ```
 
             Once a valid contract is registered, refresh the FortiGuard packages:
 
-            ```
+            ```text
             execute update-now
             ```
 
@@ -2637,7 +2637,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            diagnose autoupdate versions
            ```
 
@@ -2657,14 +2657,14 @@ queries:
 
             Check the current FortiGuard license status:
 
-            ```
+            ```text
             get system fortiguard
             diagnose autoupdate status
             ```
 
             Once a valid contract is registered, refresh the FortiGuard packages:
 
-            ```
+            ```text
             execute update-now
             ```
 
@@ -2720,7 +2720,7 @@ queries:
         1. Open an SSH or console session to the FortiGate.
         2. Run the following command:
 
-           ```
+           ```text
            diagnose autoupdate versions
            ```
 
@@ -2740,14 +2740,14 @@ queries:
 
             Check the current FortiGuard license status:
 
-            ```
+            ```text
             get system fortiguard
             diagnose autoupdate status
             ```
 
             Once a valid contract is registered, refresh the FortiGuard packages:
 
-            ```
+            ```text
             execute update-now
             ```
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -2960,7 +2960,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
             ```
 
@@ -3098,7 +3098,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             MACs umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512
             ```
 
@@ -3236,7 +3236,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512
             ```
 
@@ -3381,7 +3381,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             PermitRootLogin no
             ```
 
@@ -3519,7 +3519,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             PermitEmptyPasswords no
             ```
 
@@ -3657,7 +3657,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             HostbasedAuthentication no
             ```
 
@@ -3795,7 +3795,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             PermitUserEnvironment no
             ```
 
@@ -3933,7 +3933,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             IgnoreRhosts yes
             ```
 
@@ -4071,7 +4071,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             MaxAuthTries 4
             ```
 
@@ -4210,7 +4210,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             LoginGraceTime 60
             ```
 
@@ -4348,7 +4348,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             LogLevel VERBOSE
             ```
 
@@ -4488,7 +4488,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             ClientAliveInterval 300
             ClientAliveCountMax 3
             ```
@@ -4641,7 +4641,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             DisableForwarding yes
             ```
 
@@ -4779,7 +4779,7 @@ queries:
 
             Edit `/etc/ssh/sshd_config` and set:
 
-            ```
+            ```text
             UsePAM yes
             ```
 
@@ -6382,7 +6382,7 @@ queries:
 
             Edit the sudoers file using `visudo` and add:
 
-            ```
+            ```text
             Defaults use_pty
             ```
         - id: sh
@@ -6505,13 +6505,13 @@ queries:
 
             Remove the `NOPASSWD` tag from any rule so that sudo prompts for a password. For example, change a line like:
 
-            ```
+            ```text
             alice ALL=(ALL) NOPASSWD: ALL
             ```
 
             to:
 
-            ```
+            ```text
             alice ALL=(ALL) PASSWD: ALL
             ```
 

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-junos-security
     name: Mondoo Juniper Junos Security
-    version: 1.1.2
+    version: 1.1.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -138,7 +138,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -154,7 +154,7 @@ queries:
 
             Enter configuration mode, disable root login via SSH, and commit with automatic rollback in case access is lost:
 
-            ```
+            ```text
             configure
             set system services ssh root-login deny
             commit confirmed 5
@@ -162,7 +162,7 @@ queries:
 
             Or allow key-based root login only:
 
-            ```
+            ```text
             configure
             set system services ssh root-login deny-password
             commit confirmed 5
@@ -170,7 +170,7 @@ queries:
 
             Open a new SSH session as a named user to confirm access still works, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -217,7 +217,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -231,7 +231,7 @@ queries:
 
             Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing cipher list, so first remove the current list including any weak entries, then configure only strong ciphers. Commit with automatic rollback so a cipher mismatch with your SSH client cannot lock you out:
 
-            ```
+            ```text
             configure exclusive
             delete system services ssh ciphers
             set system services ssh ciphers aes256-gcm@openssh.com
@@ -244,7 +244,7 @@ queries:
 
             Open a new SSH session to confirm connectivity, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -291,7 +291,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -305,7 +305,7 @@ queries:
 
             Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing MAC list, so first remove the current list including any weak entries, then configure only strong MACs. Commit with automatic rollback so a MAC mismatch with your SSH client cannot lock you out:
 
-            ```
+            ```text
             configure exclusive
             delete system services ssh macs
             set system services ssh macs hmac-sha2-256
@@ -317,7 +317,7 @@ queries:
 
             Open a new SSH session to confirm connectivity, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -364,7 +364,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -378,7 +378,7 @@ queries:
 
             Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. The `group-exchange-sha2` keyword selects the SHA-256 variant of Diffie-Hellman group exchange, which replaces the weak SHA-1 `group-exchange-sha1` that this check flags. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
 
-            ```
+            ```text
             configure exclusive
             delete system services ssh key-exchange
             set system services ssh key-exchange curve25519-sha256
@@ -391,7 +391,7 @@ queries:
 
             Open a new SSH session to confirm connectivity, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -437,7 +437,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -451,7 +451,7 @@ queries:
 
             Disabling TCP forwarding can break active tunnels and management workflows that rely on it. Enter configuration mode and disable SSH TCP forwarding, committing with automatic rollback:
 
-            ```
+            ```text
             configure
             set system services ssh no-tcp-forwarding
             commit confirmed 5
@@ -459,7 +459,7 @@ queries:
 
             `commit confirmed 5` automatically rolls back the change after 5 minutes unless it is confirmed. Verify that management access and any required workflows still work, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -505,7 +505,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -519,7 +519,7 @@ queries:
 
             Enter configuration mode and configure an SSH connection limit:
 
-            ```
+            ```text
             configure
             set system services ssh connection-limit 5
             commit
@@ -567,7 +567,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SSH service configuration:
 
-           ```
+           ```text
            show configuration system services ssh
            ```
 
@@ -581,7 +581,7 @@ queries:
 
             Enter configuration mode and configure an SSH rate limit:
 
-            ```
+            ```text
             configure
             set system services ssh rate-limit 4
             commit
@@ -632,7 +632,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the login configuration:
 
-           ```
+           ```text
            show configuration system login
            ```
 
@@ -646,7 +646,7 @@ queries:
 
             Enter configuration mode, then set a password interactively. Junos prompts for the password and stores only the hash:
 
-            ```
+            ```text
             configure
             set system login user <username> authentication plain-text-password
             commit
@@ -654,7 +654,7 @@ queries:
 
             Or supply a pre-computed password hash directly:
 
-            ```
+            ```text
             configure
             set system login user <username> authentication encrypted-password "<hash>"
             commit
@@ -662,7 +662,7 @@ queries:
 
             Or configure SSH key authentication:
 
-            ```
+            ```text
             configure
             set system login user <username> authentication ssh-ed25519 "<public-key>"
             commit
@@ -670,7 +670,7 @@ queries:
 
             If the account is no longer needed, remove it instead of adding credentials:
 
-            ```
+            ```text
             configure
             delete system login user <username>
             commit
@@ -718,7 +718,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the login configuration:
 
-           ```
+           ```text
            show configuration system login
            ```
 
@@ -734,7 +734,7 @@ queries:
 
             Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session, then reassign users who do not need full access to a more restrictive login class, committing with automatic rollback:
 
-            ```
+            ```text
             configure exclusive
             set system login user <username> class operator
             commit confirmed 5
@@ -742,7 +742,7 @@ queries:
 
             Or create a custom login class with targeted permissions:
 
-            ```
+            ```text
             configure exclusive
             set system login class limited-admin permissions configure
             set system login class limited-admin permissions view
@@ -752,7 +752,7 @@ queries:
 
             Confirm that affected users retain the access they need and that a super-user session still works, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -801,7 +801,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the configured system services:
 
-           ```
+           ```text
            show configuration system services
            ```
 
@@ -817,7 +817,7 @@ queries:
 
             Enter configuration mode and enable SSH if it is not already configured:
 
-            ```
+            ```text
             configure
             set system services ssh
             commit
@@ -825,7 +825,7 @@ queries:
 
             Open an SSH session to confirm access, then enter configuration mode and remove Telnet with automatic rollback:
 
-            ```
+            ```text
             configure
             delete system services telnet
             commit confirmed 5
@@ -833,7 +833,7 @@ queries:
 
             Confirm that your SSH session still works, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -879,7 +879,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the configured system services:
 
-           ```
+           ```text
            show configuration system services
            ```
 
@@ -893,13 +893,13 @@ queries:
 
             SCP is automatically available when SSH is enabled. First, from operational mode, verify SSH is configured so you retain a secure file-transfer path after FTP is removed:
 
-            ```
+            ```text
             show configuration system services ssh
             ```
 
             Then enter configuration mode, disable FTP, and commit with automatic rollback in case the SSH path is not actually available:
 
-            ```
+            ```text
             configure
             delete system services ftp
             commit confirmed 5
@@ -907,13 +907,13 @@ queries:
 
             `commit confirmed 5` automatically rolls back the change after 5 minutes unless it is confirmed. Confirm that SSH and SCP file transfer still work, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
 
             To transfer files using SCP from an external host:
 
-            ```
+            ```text
             scp <file> <user>@<junos-device>:/var/tmp/
             ```
     refs:
@@ -959,7 +959,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the configured system services:
 
-           ```
+           ```text
            show configuration system services
            ```
 
@@ -973,7 +973,7 @@ queries:
 
             Enter configuration mode and disable the finger service:
 
-            ```
+            ```text
             configure
             delete system services finger
             commit
@@ -1024,7 +1024,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SNMP configuration:
 
-           ```
+           ```text
            show configuration snmp
            ```
 
@@ -1038,7 +1038,7 @@ queries:
 
             Enter configuration mode, remove default communities, and configure unique strings:
 
-            ```
+            ```text
             configure
             delete snmp community public
             delete snmp community private
@@ -1089,7 +1089,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SNMP configuration:
 
-           ```
+           ```text
            show configuration snmp
            ```
 
@@ -1103,7 +1103,7 @@ queries:
 
             Removing read-write access stops any management system that relies on SNMP SET operations from making changes through this community, so confirm no orchestration or monitoring tooling depends on write access first. Enter configuration mode, change the community to read-only, and commit with automatic rollback so a loss of expected management access can be recovered:
 
-            ```
+            ```text
             configure
             set snmp community <community-name> authorization read-only
             commit confirmed 5
@@ -1111,7 +1111,7 @@ queries:
 
             Confirm that monitoring still works as expected, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -1157,7 +1157,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the SNMP configuration:
 
-           ```
+           ```text
            show configuration snmp
            ```
 
@@ -1171,7 +1171,7 @@ queries:
 
             A client list blocks every source address that is not explicitly permitted, so include all of your existing SNMP pollers or they will stop receiving data. Enter configuration mode, restrict the community to specific client addresses, and commit with automatic rollback so a missed poller can be recovered:
 
-            ```
+            ```text
             configure
             set snmp community <community-name> clients <management-host>/32
             set snmp community <community-name> clients <management-network>/24
@@ -1180,7 +1180,7 @@ queries:
 
             Confirm that all expected pollers still reach the device, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -1230,7 +1230,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the syslog configuration:
 
-           ```
+           ```text
            show configuration system syslog
            ```
 
@@ -1244,7 +1244,7 @@ queries:
 
             Enter configuration mode and configure a remote syslog host:
 
-            ```
+            ```text
             configure
             set system syslog host <syslog-server> any notice
             set system syslog host <syslog-server> authorization info
@@ -1295,7 +1295,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the syslog configuration:
 
-           ```
+           ```text
            show configuration system syslog
            ```
 
@@ -1311,7 +1311,7 @@ queries:
 
             Enter configuration mode and configure TLS transport for encrypted and reliable log delivery. The collector must accept syslog over TLS, which conventionally uses port 6514. Commit with automatic rollback so a transport mismatch can be recovered:
 
-            ```
+            ```text
             configure
             set system syslog host <syslog-server> transport tls
             set system syslog host <syslog-server> port 6514
@@ -1320,7 +1320,7 @@ queries:
 
             If the collector does not support TLS, configure TCP transport instead. TCP provides reliable delivery but does not encrypt log data in transit:
 
-            ```
+            ```text
             configure
             set system syslog host <syslog-server> transport tcp
             commit confirmed 5
@@ -1328,7 +1328,7 @@ queries:
 
             Confirm the collector is receiving logs over the new transport, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -1378,7 +1378,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the security policy configuration:
 
-           ```
+           ```text
            show configuration security policies
            ```
 
@@ -1392,7 +1392,7 @@ queries:
 
             Enter configuration mode and enable logging on security policies:
 
-            ```
+            ```text
             configure
             set security policies from-zone <src> to-zone <dst> policy <name> then log session-init
             set security policies from-zone <src> to-zone <dst> policy <name> then log session-close
@@ -1442,7 +1442,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the security zone configuration:
 
-           ```
+           ```text
            show configuration security zones
            ```
 
@@ -1456,7 +1456,7 @@ queries:
 
             Enter configuration mode, then create and apply a screen profile to the untrust zone:
 
-            ```
+            ```text
             configure
             set security screen ids-option untrust-screen icmp ping-death
             set security screen ids-option untrust-screen ip source-route-option
@@ -1511,7 +1511,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the security zone configuration:
 
-           ```
+           ```text
            show configuration security zones
            ```
 
@@ -1527,7 +1527,7 @@ queries:
 
             Remove the `all` keyword and the insecure host-inbound services, re-add only the secure services you still need such as SSH or IKE, and commit the whole change atomically with automatic rollback:
 
-            ```
+            ```text
             configure exclusive
             delete security zones security-zone untrust host-inbound-traffic system-services all
             delete security zones security-zone untrust host-inbound-traffic system-services telnet
@@ -1541,7 +1541,7 @@ queries:
 
             Verify management access still works, then make the change permanent:
 
-            ```
+            ```text
             commit
             ```
     refs:
@@ -1591,7 +1591,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1605,7 +1605,7 @@ queries:
 
             Enter configuration mode and enable SYN flood protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> tcp syn-flood alarm-threshold 1024
             set security screen ids-option <screen-name> tcp syn-flood attack-threshold 200
@@ -1655,7 +1655,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1669,7 +1669,7 @@ queries:
 
             Enter configuration mode and enable ping-of-death protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> icmp ping-death
             commit
@@ -1718,7 +1718,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1732,7 +1732,7 @@ queries:
 
             Enter configuration mode and enable source route option protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> ip source-route-option
             commit
@@ -1780,7 +1780,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1794,7 +1794,7 @@ queries:
 
             Enter configuration mode and enable land attack protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> tcp land
             commit
@@ -1842,7 +1842,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1856,7 +1856,7 @@ queries:
 
             Enter configuration mode and enable teardrop protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> ip tear-drop
             commit
@@ -1904,7 +1904,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the screen configuration:
 
-           ```
+           ```text
            show configuration security screen
            ```
 
@@ -1918,7 +1918,7 @@ queries:
 
             Enter configuration mode and enable WinNuke protection:
 
-            ```
+            ```text
             configure
             set security screen ids-option <screen-name> tcp winnuke
             commit
@@ -1969,7 +1969,7 @@ queries:
         1. Open an SSH session to the device and enter operational mode.
         2. Display the installed licenses and their state:
 
-           ```
+           ```text
            show system license
            ```
 
@@ -1985,25 +1985,25 @@ queries:
 
             Check license status and identify expired entries:
 
-            ```
+            ```text
             show system license
             ```
 
             Obtain renewed license keys from the Juniper Agile Licensing portal, then install them by pasting at the terminal:
 
-            ```
+            ```text
             request system license add terminal
             ```
 
             Paste the license key text and press Ctrl+D to finish. Alternatively, install from a file or URL:
 
-            ```
+            ```text
             request system license add <filename-or-url>
             ```
 
             Verify the new license state:
 
-            ```
+            ```text
             show system license
             ```
     refs:

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.8.0
+    version: 2.8.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1711,7 +1711,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/atm.conf` and add the following lines to disable loading and installation of the ATM module:
 
-            ```
+            ```text
             blacklist atm
             install atm /bin/false
             ```
@@ -1826,7 +1826,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/can.conf` and add the following lines to disable loading and installation of the CAN module:
 
-            ```
+            ```text
             blacklist can
             install can /bin/false
             ```
@@ -1940,7 +1940,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/dccp.conf` and add the following lines to disable loading and installation of the DCCP module:
 
-            ```
+            ```text
             blacklist dccp
             install dccp /bin/false
             ```
@@ -2054,7 +2054,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/rds.conf` and add the following lines to disable loading and installation of the RDS module:
 
-            ```
+            ```text
             blacklist rds
             install rds /bin/false
             ```
@@ -2168,7 +2168,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/sctp.conf` and add the following lines to disable loading and installation of the SCTP module:
 
-            ```
+            ```text
             blacklist sctp
             install sctp /bin/false
             ```
@@ -2282,7 +2282,7 @@ queries:
 
             Create or edit the file `/etc/modprobe.d/tipc.conf` and add the following lines to disable loading and installation of the TIPC module:
 
-            ```
+            ```text
             blacklist tipc
             install tipc /bin/false
             ```
@@ -7820,7 +7820,7 @@ queries:
 
             Add the following lines:
 
-            ```
+            ```text
             -w /etc/sudoers -p wa -k scope
             -w /etc/sudoers.d -p wa -k scope
             ```
@@ -8001,20 +8001,20 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -w /var/log/lastlog -p wa -k logins
                 -w /var/log/tallylog -p wa -k logins
                 ```
 
             3. Add the following additional line for Debian/Ubuntu based systems:
 
-                ```
+                ```text
                 -w /var/log/faillog -p wa -k logins
                 ```
 
             4. Add the following additional line for Red Hat/Fedora/Amazon Linux based systems:
 
-                ```
+                ```text
                 -w /var/run/faillock -p wa -k logins
                 ```
 
@@ -8243,7 +8243,7 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -w /var/run/utmp -p wa -k session
                 -w /var/log/wtmp -p wa -k logins
                 -w /var/log/btmp -p wa -k logins
@@ -8432,7 +8432,7 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
                 -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
                 -a always,exit -F arch=b32 -S clock_settime -k time-change
@@ -8622,14 +8622,14 @@ queries:
 
         The check passes when the persistent rules define a complete Mandatory Access Control set with `wa` permissions and any non-empty audit key — either both AppArmor paths:
 
-        ```
+        ```text
         -w /etc/apparmor -p wa -k MAC-policy
         -w /etc/apparmor.d -p wa -k MAC-policy
         ```
 
         or both SELinux paths:
 
-        ```
+        ```text
         -w /etc/selinux -p wa -k MAC-policy
         -w /usr/share/selinux -p wa -k MAC-policy
         ```
@@ -8652,14 +8652,14 @@ queries:
 
             2. Add the following lines, for SELinux:
 
-                ```
+                ```text
                 -w /etc/selinux -p wa -k MAC-policy
                 -w /usr/share/selinux -p wa -k MAC-policy
                 ```
 
             3. Add the following lines, for AppArmor:
 
-                ```
+                ```text
                 -w /etc/apparmor -p wa -k MAC-policy
                 -w /etc/apparmor.d -p wa -k MAC-policy
                 ```
@@ -8836,7 +8836,7 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
                 -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
 
@@ -8847,13 +8847,13 @@ queries:
 
             3. Add the following line for Red Hat based systems:
 
-                ```
+                ```text
                 -w /etc/sysconfig/network -p wa -k system-locale
                 ```
 
             4. Add the following line for Debian/Ubuntu based systems:
 
-                ```
+                ```text
                 -w /etc/network -p wa -k system-locale
                 ```
 
@@ -9159,7 +9159,7 @@ queries:
 
                 **On non-ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
                 -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
                 -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
@@ -9170,7 +9170,7 @@ queries:
 
                 **On ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
                 -a always,exit -F arch=b32 -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
                 -a always,exit -F arch=b64 -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
@@ -9454,7 +9454,7 @@ queries:
 
                 **On non-ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
                 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
                 -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
@@ -9463,7 +9463,7 @@ queries:
 
                 **On ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
                 -a always,exit -F arch=b32 -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
                 -a always,exit -F arch=b64 -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
@@ -9675,7 +9675,7 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -w /etc/group -p wa -k identity
                 -w /etc/passwd -p wa -k identity
                 -w /etc/gshadow -p wa -k identity
@@ -9866,7 +9866,7 @@ queries:
 
             2. Add the following lines to the configuration file:
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
                 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
                 ```
@@ -10068,14 +10068,14 @@ queries:
 
                 ** On non-ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
                 -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
                 ```
 
                 ** On ARM architectures:**
 
-                ```
+                ```text
                 -a always,exit -F arch=b64 -S unlinkat -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
                 -a always,exit -F arch=b32 -S unlinkat -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
                 ```
@@ -10284,7 +10284,7 @@ queries:
 
             2. Add the following lines to the configuration file. The `b32` syscall rule audits 32-bit module operations, `finit_module` covers the file-descriptor based loader that modern `modprobe` uses, and the `/sbin` watch paths are required by this check. On distributions where the module tools live under `/usr/sbin`, `/sbin` is normally a symlink to `/usr/sbin`, so the `/sbin` paths still match. Add equivalent `/usr/sbin` watch lines as well if your host does not provide that symlink:
 
-                ```
+                ```text
                 -w /sbin/insmod -p x -k modules
                 -w /sbin/rmmod -p x -k modules
                 -w /sbin/modprobe -p x -k modules
@@ -10462,7 +10462,7 @@ queries:
 
             Add the following line:
 
-            ```
+            ```text
             -w /var/log/sudo.log -p wa -k actions
             ```
 
@@ -10622,7 +10622,7 @@ queries:
 
             2. Add the following line to the file:
 
-                ```
+                ```text
                 -e 2
                 ```
 
@@ -14249,22 +14249,22 @@ queries:
             Then, based on the version, set the appropriate `KexAlgorithms` value:
 
             - **OpenSSH 6.x**:
-              ```
+              ```text
               KexAlgorithms curve25519-sha256@libssh.org
               ```
 
             - **OpenSSH 7.x**:
-              ```
+              ```text
               KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
               ```
 
             - **OpenSSH 8.0 to 8.5**:
-              ```
+              ```text
               KexAlgorithms sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
               ```
 
             - **OpenSSH 8.6 or later**:
-              ```
+              ```text
               KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512
               ```
 
@@ -16775,7 +16775,7 @@ queries:
 
             This setting affects only accounts created after the change. It does not renumber existing accounts, so any current UID overlaps must be corrected separately. Edit the `/etc/login.defs` file and set UID_MIN:
 
-            ```
+            ```text
             UID_MIN                  1000
             ```
         - id: bash
@@ -17472,7 +17472,7 @@ queries:
 
             2. To make the change persistent, edit `/etc/selinux/config` and set:
 
-                ```
+                ```ini
                 SELINUX=enforcing
                 ```
 
@@ -17568,7 +17568,7 @@ queries:
           desc: |
             Edit `/etc/selinux/config` and ensure the following line is set:
 
-            ```
+            ```ini
             SELINUX=enforcing
             ```
 

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-mikrotik-security
     name: Mondoo MikroTik RouterOS Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -119,7 +119,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the management services:
 
-           ```
+           ```text
            /ip service print
            ```
 
@@ -133,7 +133,7 @@ queries:
 
             Confirm SSH access works before disabling Telnet so you do not lose remote management. Then disable the service:
 
-            ```
+            ```text
             /ip service disable telnet
             ```
     refs:
@@ -180,7 +180,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the management services:
 
-           ```
+           ```text
            /ip service print
            ```
 
@@ -192,7 +192,7 @@ queries:
           desc: |
             To disable the FTP service using the RouterOS CLI:
 
-            ```
+            ```text
             /ip service disable ftp
             ```
     refs:
@@ -239,7 +239,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the management services:
 
-           ```
+           ```text
            /ip service print
            ```
 
@@ -253,7 +253,7 @@ queries:
 
             Ensure the TLS-protected `www-ssl` service is configured with a certificate before disabling `www`, then disable the cleartext listener:
 
-            ```
+            ```text
             /ip service disable www
             ```
     refs:
@@ -300,7 +300,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the management services:
 
-           ```
+           ```text
            /ip service print
            ```
 
@@ -314,7 +314,7 @@ queries:
 
             Configure `api-ssl` with a certificate for any automation that needs API access, then disable the cleartext listener:
 
-            ```
+            ```text
             /ip service disable api
             ```
     refs:
@@ -364,7 +364,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the services with their allowed address ranges:
 
-           ```
+           ```text
            /ip service print detail
            ```
 
@@ -378,7 +378,7 @@ queries:
 
             Set the `address` field on each enabled service to your administrative network(s). For example, to limit SSH and WinBox to a management subnet:
 
-            ```
+            ```text
             /ip service set ssh address=192.168.88.0/24
             /ip service set winbox address=192.168.88.0/24
             ```
@@ -426,7 +426,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the services in detail:
 
-           ```
+           ```text
            /ip service print detail
            ```
 
@@ -438,7 +438,7 @@ queries:
           desc: |
             To enforce a modern minimum TLS version using the RouterOS CLI:
 
-            ```
+            ```text
             /ip service set www-ssl tls-version=only-1.2
             /ip service set api-ssl tls-version=only-1.2
             ```
@@ -489,7 +489,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the local user accounts:
 
-           ```
+           ```text
            /user print
            ```
 
@@ -503,13 +503,13 @@ queries:
 
             First create a replacement administrator account and confirm you can log in with it:
 
-            ```
+            ```text
             /user add name=netadmin group=full password=<strong-password>
             ```
 
             Then disable (or remove) the default account:
 
-            ```
+            ```text
             /user disable admin
             ```
     refs:
@@ -556,7 +556,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the user accounts in detail:
 
-           ```
+           ```text
            /user print detail
            ```
 
@@ -568,7 +568,7 @@ queries:
           desc: |
             To restrict a user account to trusted source addresses using the RouterOS CLI:
 
-            ```
+            ```text
             /user set netadmin address=192.168.88.0/24
             ```
     refs:
@@ -618,7 +618,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the SNMP configuration:
 
-           ```
+           ```text
            /snmp print
            ```
 
@@ -630,7 +630,7 @@ queries:
           desc: |
             To set a non-default SNMP trap community using the RouterOS CLI:
 
-            ```
+            ```text
             /snmp set trap-community=<unique-community-string>
             ```
 
@@ -682,7 +682,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the NTP client configuration:
 
-           ```
+           ```text
            /system ntp client print
            ```
 
@@ -694,7 +694,7 @@ queries:
           desc: |
             To enable and configure the NTP client using the RouterOS CLI:
 
-            ```
+            ```text
             /system ntp client set enabled=yes servers=time.cloudflare.com,pool.ntp.org
             ```
     refs:
@@ -744,7 +744,7 @@ queries:
         1. Open an SSH session to the device.
         2. Display the DNS settings:
 
-           ```
+           ```text
            /ip dns print
            ```
 
@@ -758,7 +758,7 @@ queries:
 
             Ensure the appropriate root CA certificates are imported, then enable verification:
 
-            ```
+            ```text
             /ip dns set verify-doh-cert=yes
             ```
     refs:
@@ -808,7 +808,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the firewall filter rules for the input chain:
 
-           ```
+           ```text
            /ip firewall filter print where chain=input
            ```
 
@@ -822,7 +822,7 @@ queries:
 
             Add accept rules for the traffic the router must handle (for example established/related connections and management access from trusted sources) **before** adding the final drop, then append the drop:
 
-            ```
+            ```text
             /ip firewall filter add chain=input connection-state=established,related action=accept
             /ip firewall filter add chain=input src-address=192.168.88.0/24 action=accept
             /ip firewall filter add chain=input action=drop
@@ -871,7 +871,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the firewall filter rules:
 
-           ```
+           ```text
            /ip firewall filter print
            ```
 
@@ -883,7 +883,7 @@ queries:
           desc: |
             To drop invalid connection-state packets using the RouterOS CLI:
 
-            ```
+            ```text
             /ip firewall filter add chain=input connection-state=invalid action=drop
             /ip firewall filter add chain=forward connection-state=invalid action=drop
             ```
@@ -934,7 +934,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the WiFi interfaces and their security settings:
 
-           ```
+           ```text
            /interface/wifi/print detail
            ```
 
@@ -948,7 +948,7 @@ queries:
 
             Configure a passphrase and authentication types on the interface (or its security profile):
 
-            ```
+            ```text
             /interface/wifi/set [find name=wifi1] security.authentication-types=wpa2-psk,wpa3-psk security.passphrase=<strong-passphrase>
             ```
     refs:
@@ -995,7 +995,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the WiFi interfaces and their security settings:
 
-           ```
+           ```text
            /interface/wifi/print detail
            ```
 
@@ -1009,7 +1009,7 @@ queries:
 
             Add a WPA3 authentication type (mixed WPA2/WPA3 mode shown for client compatibility):
 
-            ```
+            ```text
             /interface/wifi/set [find name=wifi1] security.authentication-types=wpa2-psk,wpa3-psk
             ```
     refs:
@@ -1059,7 +1059,7 @@ queries:
         1. Open an SSH session to the device.
         2. List the bridges and their protocol modes:
 
-           ```
+           ```text
            /interface bridge print
            ```
 
@@ -1071,7 +1071,7 @@ queries:
           desc: |
             To enable a spanning-tree protocol on a bridge using the RouterOS CLI:
 
-            ```
+            ```text
             /interface bridge set [find name=bridge1] protocol-mode=rstp
             ```
     refs:

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.4.1
+    version: 4.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -415,7 +415,7 @@ queries:
             2. Identify policies containing `manage all-resources in tenancy`.
             3. Replace with scoped policies that grant access to specific resource types in specific compartments:
 
-            ```
+            ```text
             # Instead of:
             Allow group Admins to manage all-resources in tenancy
 
@@ -1804,7 +1804,7 @@ queries:
             2. Identify policies containing `manage all-resources in compartment`.
             3. Replace with scoped policies that grant access to specific resource types:
 
-            ```
+            ```text
             # Instead of:
             Allow group DevOps to manage all-resources in compartment Production
 

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 2.0.2
+    version: 2.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -145,7 +145,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show system info | match av-version
            ```
 
@@ -171,7 +171,7 @@ queries:
 
             Download and install the latest antivirus content:
 
-            ```
+            ```text
             request anti-virus upgrade download latest
             request anti-virus upgrade install version latest
             ```
@@ -228,7 +228,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show system info | match app-version
            ```
 
@@ -255,7 +255,7 @@ queries:
 
             Download and install the latest application and threat content:
 
-            ```
+            ```text
             request content upgrade download latest
             request content upgrade install version latest
             ```
@@ -316,7 +316,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            request license info
            ```
 
@@ -339,7 +339,7 @@ queries:
 
             Retrieve the license key after purchase and verify activation:
 
-            ```
+            ```text
             request license fetch
             request license info
             ```
@@ -395,7 +395,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            request license info
            ```
 
@@ -420,7 +420,7 @@ queries:
 
             Fetch renewed license keys and verify their status:
 
-            ```
+            ```text
             request license fetch
             request license info
             ```
@@ -467,7 +467,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show system info | match oper
            ```
 
@@ -497,13 +497,13 @@ queries:
 
             Check the current operational mode:
 
-            ```
+            ```text
             show system info | match oper
             ```
 
             If the mode is not normal, investigate the system logs and the maintenance mode console before taking action. A restart is usually required to return to normal mode, but it reboots the entire device and interrupts all traffic, so run it only during an approved maintenance window:
 
-            ```
+            ```text
             request restart system
             ```
 
@@ -557,7 +557,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show system info | match threat-version
            ```
 
@@ -586,7 +586,7 @@ queries:
 
             Download and install the latest threat content:
 
-            ```
+            ```text
             request content upgrade download latest
             request content upgrade install version latest
             ```
@@ -647,7 +647,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            request license info
            ```
 
@@ -672,7 +672,7 @@ queries:
 
             Retrieve the license key after purchase, download the latest content, and verify:
 
-            ```
+            ```text
             request license fetch
             request license info
             request content upgrade download latest
@@ -734,7 +734,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            request license info
            ```
 
@@ -759,7 +759,7 @@ queries:
 
             Retrieve the license key after purchase and verify activation:
 
-            ```
+            ```text
             request license fetch
             request license info
             ```
@@ -814,7 +814,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show system info | match wildfire-version
            ```
 
@@ -843,7 +843,7 @@ queries:
 
             Download and install the latest WildFire content:
 
-            ```
+            ```text
             request wildfire upgrade download latest
             request wildfire upgrade install version latest
             ```
@@ -904,7 +904,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            request license info
            ```
 
@@ -930,7 +930,7 @@ queries:
 
             Retrieve the license key after purchase, configure WildFire updates, and verify:
 
-            ```
+            ```text
             request license fetch
             request license info
             request wildfire upgrade download latest
@@ -991,7 +991,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/zone
            ```
 
@@ -1016,7 +1016,7 @@ queries:
 
             Create a zone protection profile with flood and reconnaissance protection, then apply it to a zone. Reconnaissance protection entries are keyed by threat ID: 8001 is TCP port scan, 8002 is host sweep, and 8003 is UDP port scan. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network profiles zone-protection-profile <profile-name> flood tcp-syn enable yes
             set network profiles zone-protection-profile <profile-name> flood udp enable yes
@@ -1079,7 +1079,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/zone
            ```
 
@@ -1106,7 +1106,7 @@ queries:
 
             Enable packet buffer protection on a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set zone <zone-name> network enable-packet-buffer-protection yes
             commit
@@ -1165,7 +1165,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/zone
            ```
 
@@ -1185,7 +1185,7 @@ queries:
 
             Configure log forwarding on a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set zone <zone-name> network log-setting <log-forwarding-profile>
             commit
@@ -1254,7 +1254,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show running security-policy
            ```
 
@@ -1279,13 +1279,13 @@ queries:
 
             Review the rulebase from the operational prompt:
 
-            ```
+            ```text
             show running security-policy
             ```
 
             Then enter configuration mode and replace each wildcard member list with specific values. The `set` command appends members to an existing list, so delete each list first to remove the `any` entry. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             delete rulebase security rules <rule-name> application
             set rulebase security rules <rule-name> application [ <app1> <app2> ]
@@ -1353,7 +1353,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show running security-policy
            ```
 
@@ -1375,7 +1375,7 @@ queries:
 
             Replace the application list with specific App-IDs. The `set` command appends members to an existing list, so delete the list first to remove the `any` entry. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             delete rulebase security rules <rule-name> application
             set rulebase security rules <rule-name> application [ <app1> <app2> ]
@@ -1443,7 +1443,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/security
            ```
 
@@ -1468,7 +1468,7 @@ queries:
 
             Attach a security profile group to a rule. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase security rules <rule-name> profile-setting group <profile-group-name>
             commit
@@ -1476,7 +1476,7 @@ queries:
 
             Or attach individual profiles:
 
-            ```
+            ```text
             configure
             set rulebase security rules <rule-name> profile-setting profiles virus <av-profile>
             set rulebase security rules <rule-name> profile-setting profiles spyware <as-profile>
@@ -1539,7 +1539,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/security
            ```
 
@@ -1562,7 +1562,7 @@ queries:
 
             Attach a URL filtering profile to a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase security rules <rule-name> profile-setting profiles url-filtering <url-profile>
             commit
@@ -1623,7 +1623,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/security
            ```
 
@@ -1644,7 +1644,7 @@ queries:
 
             Enable session-end logging on a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase security rules <rule-name> log-end yes
             commit
@@ -1701,7 +1701,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/security
            ```
 
@@ -1723,13 +1723,13 @@ queries:
 
             Review the rulebase from the operational prompt:
 
-            ```
+            ```text
             show running security-policy
             ```
 
             Then enter configuration mode and remove each disabled rule. The `delete` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             delete rulebase security rules <disabled-rule-name>
             commit
@@ -1789,7 +1789,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/security
            ```
 
@@ -1812,7 +1812,7 @@ queries:
 
             Attach a WildFire Analysis profile to a rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase security rules <rule-name> profile-setting profiles wildfire-analysis <wf-profile>
             commit
@@ -1875,7 +1875,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/interface/ethernet
            ```
 
@@ -1902,7 +1902,7 @@ queries:
 
             Before you commit, confirm that you are not removing your own management path. A deny-all profile or an incorrect `permitted-ip` on the interface you administer the firewall through will sever your access. The commit is atomic and applies immediately, so verify that a trusted interface with the correct services and permitted IP addresses still reaches the management plane.
 
-            ```
+            ```text
             configure
             set network profiles interface-management-profile deny-all ping no
             set network interface ethernet <untrusted-interface> layer3 interface-management-profile deny-all
@@ -1970,7 +1970,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/interface/ethernet
            ```
 
@@ -1992,7 +1992,7 @@ queries:
 
             Replace DHCP with a static address. Perform this change during a maintenance window: the address change interrupts traffic on the interface, and any static routes, NAT rules, or IKE gateways that reference the old address must be updated in the same commit. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network interface ethernet <interface> layer3 ip <address/mask>
             delete network interface ethernet <interface> layer3 dhcp-client
@@ -2053,7 +2053,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show interface all
            ```
 
@@ -2075,7 +2075,7 @@ queries:
 
             Assign an interface to a zone. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set zone <zone-name> network layer3 <interface-name>
             commit
@@ -2139,7 +2139,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/ike/gateway
            ```
 
@@ -2162,7 +2162,7 @@ queries:
 
             Update an IKE gateway to use IKEv2. Setting the version to IKEv2 only drops the tunnel until the remote peer also negotiates IKEv2, so coordinate the change or use `ikev2-preferred` during migration. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network ike gateway <gateway-name> protocol version ikev2
             commit
@@ -2223,7 +2223,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/ike/gateway
            ```
 
@@ -2248,7 +2248,7 @@ queries:
 
             Switch the gateway from pre-shared key to certificate authentication. The tunnel stays down until the remote peer is also reconfigured for certificate authentication, so coordinate the change. The `set` and `delete` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             delete network ike gateway <gateway-name> authentication pre-shared-key
             set network ike gateway <gateway-name> authentication certificate local-certificate name <cert-name>
@@ -2314,7 +2314,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/ike/gateway
            ```
 
@@ -2335,7 +2335,7 @@ queries:
 
             Enable dead peer detection for IKEv1 gateways and the liveness check for IKEv2 gateways. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network ike gateway <gateway-name> protocol ikev1 dpd enable yes interval 5 retry 5
             set network ike gateway <gateway-name> protocol ikev2 dpd enable yes interval 5
@@ -2398,7 +2398,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/ike/gateway
            ```
 
@@ -2421,7 +2421,7 @@ queries:
 
             Change the IKEv1 exchange mode. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network ike gateway <gateway-name> protocol ikev1 exchange-mode main
             commit
@@ -2481,7 +2481,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/tunnel/ipsec
            ```
 
@@ -2503,7 +2503,7 @@ queries:
 
             Enable anti-replay on an IPsec tunnel. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network tunnel ipsec <tunnel-name> anti-replay yes
             commit
@@ -2563,7 +2563,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/tunnel/ipsec
            ```
 
@@ -2587,7 +2587,7 @@ queries:
 
             Assign an IP address to the tunnel interface if it does not already have one, then enable tunnel monitoring. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network interface tunnel units <tunnel-interface> ip <local-address/mask>
             set network tunnel ipsec <tunnel-name> tunnel-monitor enable yes destination-ip <remote-ip>
@@ -2652,7 +2652,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/decryption
            ```
 
@@ -2676,7 +2676,7 @@ queries:
 
             Attach a decryption profile to a decryption rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase decryption rules <rule-name> profile <decryption-profile>
             commit
@@ -2737,7 +2737,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/vsys/entry/rulebase/decryption
            ```
 
@@ -2758,7 +2758,7 @@ queries:
 
             Enable TLS failure logging on a decryption rule. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set rulebase decryption rules <rule-name> log-fail yes
             commit
@@ -2820,7 +2820,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show routing route
            ```
 
@@ -2845,7 +2845,7 @@ queries:
 
             Add a default route to a virtual router. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network virtual-router <vr-name> routing-table ip static-route default-route destination 0.0.0.0/0 nexthop ip-address <gateway-ip> interface <egress-interface>
             commit
@@ -2906,7 +2906,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/virtual-router
            ```
 
@@ -2931,7 +2931,7 @@ queries:
 
             Create an MD5 authentication profile and reference it from the OSPF interface. Adjacencies drop until neighbors are configured with the same key. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
             set network virtual-router <vr-name> protocol ospf area <area-id> interface <interface-name> authentication <profile-name>
@@ -2993,7 +2993,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/virtual-router
            ```
 
@@ -3018,7 +3018,7 @@ queries:
 
             Create an MD5 authentication profile and reference it from the OSPF virtual link. The virtual link drops until the remote end is configured with the same key. The `set` commands edit the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network virtual-router <vr-name> protocol ospf auth-profile <profile-name> md5 <key-id> key <key-value>
             set network virtual-router <vr-name> protocol ospf area <transit-area-id> virtual-link <link-name> authentication <profile-name>
@@ -3080,7 +3080,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/virtual-router
            ```
 
@@ -3101,7 +3101,7 @@ queries:
 
             Disable RFC 1583 compatibility on OSPF. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network virtual-router <vr-name> protocol ospf rfc1583 no
             commit
@@ -3162,7 +3162,7 @@ queries:
         1. Open an SSH session to the firewall.
         2. Run the following command:
 
-           ```
+           ```text
            show config running xpath devices/entry/network/virtual-router
            ```
 
@@ -3183,7 +3183,7 @@ queries:
 
             Configure OSPF to reject default routes. The `set` command edits the candidate configuration; `commit` activates the change on the running configuration.
 
-            ```
+            ```text
             configure
             set network virtual-router <vr-name> protocol ospf reject-default-route yes
             commit

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: phoenix-plcnext
     name: Phoenix PLCnext Security Policy
-    version: 1.1.2
+    version: 1.1.3
     license: BUSL-1.1
     tags:
       benchmark: Mondoo Phoenix PLCnext
@@ -173,7 +173,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `KexAlgorithms` parameter so that it contains a comma-separated list of the site approved key exchange algorithms:
 
-        ```
+        ```text
         KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
         ```
 
@@ -200,7 +200,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `MACs` parameter so that it contains a comma-separated list of the site approved MACs:
 
-        ```
+        ```text
         MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
         ```
 
@@ -227,7 +227,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `Ciphers` parameter so that it contains a comma-separated list of the site approved ciphers:
 
-        ```
+        ```text
         Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
         ```
 
@@ -333,7 +333,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `Protocol` parameter as follows:
 
-        ```
+        ```text
         Protocol 2
         ```
 
@@ -355,13 +355,13 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `LogLevel` parameter as follows:
 
-        ```
+        ```text
         LogLevel VERBOSE
         ```
 
         or
 
-        ```
+        ```text
         LogLevel INFO
         ```
 
@@ -380,7 +380,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `X11Forwarding` parameter as follows:
 
-        ```
+        ```text
         X11Forwarding no
         ```
 
@@ -399,7 +399,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `MaxAuthTries` parameter as follows:
 
-        ```
+        ```text
         MaxAuthTries 4
         ```
 
@@ -420,7 +420,7 @@ queries:
 
         Edit the `/etc/ssh/sshd_config` file to set the `IgnoreRhosts` parameter as follows:
 
-        ```
+        ```text
         IgnoreRhosts yes
         ```
 
@@ -441,7 +441,7 @@ queries:
 
         Edit the `/etc/ssh/sshd_config` file to set the `HostbasedAuthentication` parameter as follows:
 
-        ```
+        ```text
         HostbasedAuthentication no
         ```
 
@@ -465,13 +465,13 @@ queries:
         1. Create or confirm a non-root administrative account, and verify from a separate session that you can log in with it and elevate privileges.
         2. Edit the `/etc/ssh/sshd_config` file to set the `PermitRootLogin` parameter as follows:
 
-           ```
+           ```text
            PermitRootLogin no
            ```
 
            or
 
-           ```
+           ```text
            PermitRootLogin prohibit-password
            ```
 
@@ -492,7 +492,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `PermitEmptyPasswords` parameter as follows:
 
-        ```
+        ```text
         PermitEmptyPasswords no
         ```
 
@@ -511,7 +511,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `PermitUserEnvironment` parameter as follows:
 
-        ```
+        ```text
         PermitUserEnvironment no
         ```
 
@@ -534,7 +534,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `ClientAliveInterval` and `ClientAliveCountMax` parameters according to site policy:
 
-        ```
+        ```text
         ClientAliveInterval 300
         ClientAliveCountMax 3
         ```
@@ -557,7 +557,7 @@ queries:
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `LoginGraceTime` parameter as follows:
 
-        ```
+        ```text
         LoginGraceTime 60
         ```
 

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Mondoo Microsoft Windows Security
-    version: 2.5.0
+    version: 2.5.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -197,7 +197,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -997,7 +997,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9217-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1113,7 +1113,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9239-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1225,7 +1225,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE922F-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1339,7 +1339,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9230-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1447,7 +1447,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9231-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1555,7 +1555,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE923F-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1659,7 +1659,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9244-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1765,7 +1765,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9224-69AE-11D9-BED3-505054503030}
            ```
 
@@ -1987,7 +1987,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9249-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2102,7 +2102,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9213-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2207,7 +2207,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9216-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2315,7 +2315,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9215-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2434,7 +2434,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9232-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2548,7 +2548,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE921C-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2665,7 +2665,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9227-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2777,7 +2777,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9234-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2894,7 +2894,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9214-69AE-11D9-BED3-505054503030}
            ```
 
@@ -2999,7 +2999,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9248-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3107,7 +3107,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE922B-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3213,7 +3213,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9245-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3332,7 +3332,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9237-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3439,7 +3439,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9210-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3547,7 +3547,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9211-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3670,7 +3670,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9228-69AE-11D9-BED3-505054503030}
            ```
 
@@ -3888,7 +3888,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE921B-69AE-11D9-BED3-505054503030}
            ```
 
@@ -4002,7 +4002,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9212-69AE-11D9-BED3-505054503030}
            ```
 
@@ -4122,7 +4122,7 @@ queries:
         1. Open an elevated command prompt.
         2. Display the effective setting for the subcategory:
 
-           ```
+           ```cmd
            auditpol /get /subcategory:{0CCE9235-69AE-11D9-BED3-505054503030}
            ```
 
@@ -5316,7 +5316,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -5437,7 +5437,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -5554,7 +5554,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -5679,7 +5679,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -5925,7 +5925,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -8248,7 +8248,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 
@@ -9796,7 +9796,7 @@ queries:
         1. Open an elevated command prompt.
         2. Export the effective security policy:
 
-           ```
+           ```cmd
            secedit /export /cfg %TEMP%\secpol.cfg
            ```
 


### PR DESCRIPTION
## What

Labels 744 bare ` ``` ` fences across 14 policies, choosing the label from what each block actually holds.

## Why

Every validator selects its work by **fence language**. A fence with no language is therefore invisible to all of them — these blocks cannot be counted, attributed to a validator, or picked up by any future one. That is worse than "unvalidated": it is unenumerable, and it shows up in no coverage measurement as a gap.

It also leaves the dialect undeclared, so a later edit can relabel one ` ```bash ` by accident and silently change which linter owns it — which now matters more, since #3290 makes shellcheck read every ` ```bash ` fence in `content/`.

## Labels applied

| Label | Count | What it covers |
|---|---:|---|
| `cmd` | 35 | Windows: `auditpol /get /subcategory:{…}`, `secedit /export /cfg %TEMP%\secpol.cfg` — cmd.exe commands |
| `ini` | 2 | linux: `SELINUX=enforcing` in `/etc/selinux/config`, matching the existing `sysctl.conf` blocks in the FreeBSD policy |
| `text` | 707 | network-device CLI sessions, auditd rules, modprobe blacklists, sshd_config directives, OCI IAM policy statements |

`text` is not a default here — it is the accurate label for the remainder. No linter in this repo knows Junos, EOS or NX-OS syntax, and no common highlighter does either, so a ` ```junos ` fence would render exactly like ` ```text ` while inventing a dialect tag. If a network-CLI validator is ever built, it selects on policy + `id: cli` + ` ```text `, which is now possible and was not before.

## Where they were

| Policy | Fences |
|---|---:|
| cisco-nxos | 101 |
| arista-eos | 94 |
| fortios | 81 |
| junos | 78 |
| panos | 76 |
| cisco-iosxe / iosxr | 135 |
| bigip | 39 |
| linux | 37 |
| windows | 35 |
| mikrotik | 33 |
| freebsd / phoenix | 33 |
| oci | 2 |

## Verification

The change is mechanical and was asserted to be exactly that:

```
labels applied by this branch: {'text': 707, 'ini': 2, 'cmd': 35}
non-fence, non-version deletions: 0
all bundles parse
remaining bare fences: 0

cnspec policy lint ./content
→ valid policy bundle(s)
```

Patch versions bumped on all 14 policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)