### PR TITLE
🐛 aws: fix seven CloudFormation checks that could never pass

### DIFF
--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/fail/false/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/fail/false/template.yaml
@@ -6,4 +6,4 @@ Resources:
       RestApiId: !Ref MyApi
       DeploymentId: !Ref MyDeployment
       StageName: prod
-      XrayTracingEnabled: false
+      TracingEnabled: false

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/pass/bool-true/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/pass/bool-true/template.yaml
@@ -7,4 +7,3 @@ Resources:
       DeploymentId: !Ref MyDeployment
       StageName: prod
       TracingEnabled: true
-      XrayTracingEnabled: true

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/pass/string-true/template.yaml
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-api-gw-xray-enabled-cloudformation/pass/string-true/template.yaml
@@ -6,4 +6,4 @@ Resources:
       RestApiId: !Ref MyApi
       DeploymentId: !Ref MyDeployment
       StageName: prod
-      XrayTracingEnabled: "true"
+      TracingEnabled: "true"

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-cmks-in-kms-cloudformation/pass/kms/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-cmks-in-kms-cloudformation/pass/kms/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-eks-cluster-cmks-in-kms-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-restrict-public-access-cloudformation/pass/restricted/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-eks-cluster-restrict-public-access-cloudformation/pass/restricted/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-eks-cluster-restrict-public-access-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-encryption-at-rest-cloudformation/pass/at-rest-kms/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-encryption-at-rest-cloudformation/pass/at-rest-kms/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-emr-encryption-at-rest-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-encryption-in-transit-cloudformation/pass/in-transit/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-encryption-in-transit-cloudformation/pass/in-transit/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-emr-encryption-in-transit-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-local-disk-encryption-cloudformation/pass/local-disk/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-emr-local-disk-encryption-cloudformation/pass/local-disk/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-emr-local-disk-encryption-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kinesis-firehose-encrypted-cloudformation/pass/kms/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-kinesis-firehose-encrypted-cloudformation/pass/kms/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-kinesis-firehose-encrypted-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.10.1
+    version: 12.11.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1002,7 +1002,7 @@ queries:
       properties['EncryptionConfig'] != empty &&
       properties['EncryptionConfig'].all(
       _['Provider'] != empty &&
-      _['Provider'].all( _['KeyArn'] != empty )
+      _['Provider']['KeyArn'] != empty
       )
       )
   - uid: mondoo-aws-security-securitylake-data-lake-cmk-encryption
@@ -13370,7 +13370,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::ApiGateway::Stage")
     mql: |
       cloudformation.template.resources.where(type == "AWS::ApiGateway::Stage").all(
-      properties['XrayTracingEnabled'] == true
+      properties['TracingEnabled'] == true
       )
   - uid: mondoo-aws-security-ec2-user-data-no-secrets
     title: Ensure EC2 instance user data does not contain secrets
@@ -18168,10 +18168,8 @@ queries:
     mql: |
       cloudformation.template.resources.where(type == "AWS::EKS::Cluster").all(
       properties['ResourcesVpcConfig'] != empty &&
-      properties['ResourcesVpcConfig'].all(
-      _['PublicAccessCidrs'] != empty &&
-      _['PublicAccessCidrs'].none(_ == "0.0.0.0/0")
-      )
+      properties['ResourcesVpcConfig']['PublicAccessCidrs'] != empty &&
+      properties['ResourcesVpcConfig']['PublicAccessCidrs'].none(_ == "0.0.0.0/0")
       )
   - uid: mondoo-aws-security-eks-cluster-deletion-protection
     title: Ensure Amazon EKS clusters have deletion protection enabled
@@ -36069,7 +36067,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::KinesisFirehose::DeliveryStream")
     mql: |
       cloudformation.template.resources.where(type == "AWS::KinesisFirehose::DeliveryStream").all(
-      properties['DeliveryStreamEncryptionConfiguration'] != empty && properties['DeliveryStreamEncryptionConfiguration']['KeyType'] != empty
+      properties['DeliveryStreamEncryptionConfigurationInput'] != empty && properties['DeliveryStreamEncryptionConfigurationInput']['KeyType'] != empty
       )
   - uid: mondoo-aws-security-athena-workgroup-enforce-configuration
     title: Ensure Athena workgroups enforce workgroup configuration
@@ -50319,7 +50317,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EMR::SecurityConfiguration")
     mql: |
       cloudformation.template.resources.where(type == "AWS::EMR::SecurityConfiguration").all(
-      properties['SecurityConfiguration'].string.contains("AtRestEncryptionConfiguration")
+      properties['SecurityConfiguration']['EncryptionConfiguration']['AtRestEncryptionConfiguration'] != empty
       )
   - uid: mondoo-aws-security-emr-encryption-in-transit
     title: Ensure EMR clusters have in-transit encryption enabled
@@ -50540,7 +50538,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EMR::SecurityConfiguration")
     mql: |
       cloudformation.template.resources.where(type == "AWS::EMR::SecurityConfiguration").all(
-      properties['SecurityConfiguration'].string.contains("InTransitEncryptionConfiguration")
+      properties['SecurityConfiguration']['EncryptionConfiguration']['InTransitEncryptionConfiguration'] != empty
       )
   - uid: mondoo-aws-security-emr-logging-enabled
     title: Ensure EMR clusters have logging enabled
@@ -51586,7 +51584,7 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::EMR::SecurityConfiguration")
     mql: |
       cloudformation.template.resources.where(type == "AWS::EMR::SecurityConfiguration").all(
-      properties['SecurityConfiguration'].string.contains("LocalDiskEncryptionConfiguration")
+      properties['SecurityConfiguration']['EncryptionConfiguration']['AtRestEncryptionConfiguration']['LocalDiskEncryptionConfiguration'] != empty
       )
   - uid: mondoo-aws-security-cloudtrail-cloudwatch-integration
     title: Ensure CloudTrail trails deliver logs to CloudWatch


### PR DESCRIPTION
## What

Seven `-cloudformation` checks in `mondoo-aws-security` assert something **no valid CloudFormation template can satisfy**, so they fail every template they apply to — including the template our own remediation tells the user to write.

## How they were found

By feeding each check's `- id: cloudformation` remediation snippet back through the check that recommends it. If our own documented fix does not make the check pass, one of the two is wrong.

Six of the seven turn out to already have a `KNOWN_BUG.md` marker on their pass fixture, reading *"check does not yet assert this form"* — the realistic fixture was parked rather than the check fixed. Those markers are removed here.

## The defects

**Wrong property name** — the check names a property CloudFormation does not have:

| Check | Read | Actual property |
|---|---|---|
| `api-gw-xray-enabled` | `XrayTracingEnabled` | `TracingEnabled` (the read name is the *Terraform* attribute `xray_tracing_enabled` in CFN casing) |
| `kinesis-firehose-encrypted` | `DeliveryStreamEncryptionConfiguration` | `DeliveryStreamEncryptionConfigurationInput` (the short spelling exists only in describe output) |

**Reading a map as something it isn't:**

| Check | Problem |
|---|---|
| `emr-encryption-at-rest`, `-in-transit`, `-local-disk-encryption` | called `properties['SecurityConfiguration'].string` and substring-matched it. `SecurityConfiguration` is a JSON object in a template, and `.string` of a map is `null`, so there was never anything to match. Now reads the nested keys. |
| `eks-cluster-restrict-public-access` | `.all()` over `ResourcesVpcConfig`, which is a map, not a list |
| `eks-cluster-cmks-in-kms` | same over `Provider` inside each `EncryptionConfig` entry, so the inner read never reached `KeyArn` |

Confirmed against the provider rather than assumed, e.g.:

```
$ cnquery run cloudformation … -c '… properties["SecurityConfiguration"].string'
properties.SecurityConfiguration.string: null
```

## Fixture changes

The `api-gw-xray-enabled` fixtures were written against the invented property name — cfn-lint would reject `XrayTracingEnabled` on `AWS::ApiGateway::Stage` outright — and `pass/bool-true` hedged by setting *both* spellings. They now use `TracingEnabled`. (The provider coerces `"true"` to `true`, so the `string-true` scenario keeps its intent.)

## Verification

- All seven pass their existing pass fixtures and still fail their fail fixtures:
  `go test -tags iac_variants -run '^TestCloudFormationVariants$/…' ./content` → `ok`
- All seven now pass their own remediation snippet; the CloudFormation closed-loop failure count drops from **16 to 9** (the remaining 9 are a different root cause — remediation-side bugs and the Elasticsearch→OpenSearch resource-type gap — and are handled separately).
- `TestTerraformVariantCoverage` → `ok`
- `cnspec policy lint` → valid

Version 12.10.1 → 12.11.0 (check semantics change, not just prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)