### PR TITLE
🐛 aws: point the Elasticsearch remediation at Elasticsearch resources

### DIFF
--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation/pass/enabled/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation/pass/enabled/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation/pass/json/KNOWN_BUG.md
+++ b/content/iac-variant-testdata/mondoo-aws-security/mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation/pass/json/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-elasticsearch-encrypted-at-rest-cloudformation` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.11.0
+    version: 12.11.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -10589,9 +10589,9 @@ queries:
               enable_key_rotation = true
             }
 
-            resource "aws_opensearch_domain" "secure_es" {
+            resource "aws_elasticsearch_domain" "secure_es" {
               domain_name    = "secure-es-domain"
-              engine_version = "OpenSearch_2.11"
+              elasticsearch_version = "7.10"
 
               encrypt_at_rest {
                 enabled    = true
@@ -10606,10 +10606,10 @@ queries:
             ```yaml
             Resources:
               SecureESDomain:
-                Type: "AWS::OpenSearchService::Domain"
+                Type: "AWS::Elasticsearch::Domain"
                 Properties:
                   DomainName: "secure-es-domain"
-                  EngineVersion: "OpenSearch_2.11"
+                  ElasticsearchVersion: "7.10"
                   EncryptionAtRestOptions:
                     Enabled: true
                     KmsKeyId: !Ref ESKMSKey
@@ -10653,8 +10653,8 @@ queries:
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Elasticsearch::Domain")
     mql: |
       cloudformation.template.resources.where(type == "AWS::Elasticsearch::Domain").all(
-      properties['EncryptAtRestOptions'] != empty &&
-      properties['EncryptAtRestOptions']['Enabled'] == true
+      properties['EncryptionAtRestOptions'] != empty &&
+      properties['EncryptionAtRestOptions']['Enabled'] == true
       )
   - uid: mondoo-aws-security-elasticsearch-node-to-node-encryption
     title: Ensure Amazon Elasticsearch Service domains use node-to-node encryption
@@ -10761,9 +10761,9 @@ queries:
             To ensure Amazon OpenSearch Service domains use node-to-node encryption in Terraform:
 
             ```hcl
-            resource "aws_opensearch_domain" "example" {
+            resource "aws_elasticsearch_domain" "example" {
               domain_name    = "example-domain"
-              engine_version = "OpenSearch_2.11"
+              elasticsearch_version = "7.10"
 
               node_to_node_encryption {
                 enabled = true
@@ -10777,10 +10777,10 @@ queries:
             ```yaml
             Resources:
               ElasticsearchDomain:
-                Type: "AWS::OpenSearchService::Domain"
+                Type: "AWS::Elasticsearch::Domain"
                 Properties:
                   DomainName: "example-domain"
-                  EngineVersion: "OpenSearch_2.11"
+                  ElasticsearchVersion: "7.10"
                   NodeToNodeEncryptionOptions:
                     Enabled: true
             ```
@@ -49702,9 +49702,9 @@ queries:
             To ensure OpenSearch domains enforce HTTPS in Terraform:
 
             ```hcl
-            resource "aws_opensearch_domain" "example" {
+            resource "aws_elasticsearch_domain" "example" {
               domain_name    = "example-domain"
-              engine_version = "OpenSearch_2.11"
+              elasticsearch_version = "7.10"
 
               domain_endpoint_options {
                 enforce_https = true
@@ -49718,10 +49718,10 @@ queries:
             ```yaml
             Resources:
               ElasticsearchDomain:
-                Type: AWS::OpenSearchService::Domain
+                Type: AWS::Elasticsearch::Domain
                 Properties:
                   DomainName: example-domain
-                  EngineVersion: "OpenSearch_2.11"
+                  ElasticsearchVersion: "7.10"
                   DomainEndpointOptions:
                     EnforceHTTPS: true
             ```
@@ -49867,9 +49867,9 @@ queries:
             To ensure OpenSearch domains use TLS 1.2 or higher in Terraform:
 
             ```hcl
-            resource "aws_opensearch_domain" "example" {
+            resource "aws_elasticsearch_domain" "example" {
               domain_name    = "example-domain"
-              engine_version = "OpenSearch_2.11"
+              elasticsearch_version = "7.10"
 
               domain_endpoint_options {
                 enforce_https       = true
@@ -49884,10 +49884,10 @@ queries:
             ```yaml
             Resources:
               ElasticsearchDomain:
-                Type: AWS::OpenSearchService::Domain
+                Type: AWS::Elasticsearch::Domain
                 Properties:
                   DomainName: example-domain
-                  EngineVersion: "OpenSearch_2.11"
+                  ElasticsearchVersion: "7.10"
                   DomainEndpointOptions:
                     EnforceHTTPS: true
                     TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
@@ -50036,9 +50036,9 @@ queries:
             To ensure OpenSearch domains have audit logging enabled in Terraform. Audit logging requires fine-grained access control to be enabled on the domain, otherwise the apply fails at the API:
 
             ```hcl
-            resource "aws_opensearch_domain" "example" {
+            resource "aws_elasticsearch_domain" "example" {
               domain_name    = "example-domain"
-              engine_version = "OpenSearch_2.11"
+              elasticsearch_version = "7.10"
 
               log_publishing_options {
                 log_type                 = "AUDIT_LOGS"
@@ -50053,10 +50053,10 @@ queries:
             ```yaml
             Resources:
               ElasticsearchDomain:
-                Type: AWS::OpenSearchService::Domain
+                Type: AWS::Elasticsearch::Domain
                 Properties:
                   DomainName: example-domain
-                  EngineVersion: "OpenSearch_2.11"
+                  ElasticsearchVersion: "7.10"
                   LogPublishingOptions:
                     AUDIT_LOGS:
                       CloudWatchLogsLogGroupArn: !GetAtt AuditLogGroup.Arn
@@ -83939,7 +83939,7 @@ queries:
             To deploy an OpenSearch domain inside a VPC in Terraform, set `vpc_options` (this removes the public endpoint):
 
             ```hcl
-            resource "aws_opensearch_domain" "example" {
+            resource "aws_elasticsearch_domain" "example" {
               domain_name = "my-domain"
 
               vpc_options {
@@ -83955,7 +83955,7 @@ queries:
             ```yaml
             Resources:
               OpenSearchDomain:
-                Type: AWS::OpenSearchService::Domain
+                Type: AWS::Elasticsearch::Domain
                 Properties:
                   DomainName: my-domain
                   VPCOptions:


### PR DESCRIPTION
Third in the closed-loop series (#3292 fixed checks, #3293 fixed snippets). Same method: run each check's own remediation snippet through the check that recommends it.

## What

The six `elasticsearch-*` checks match `AWS::Elasticsearch::Domain` / `aws_elasticsearch_domain`. Every one of their Terraform and CloudFormation snippets had been modernised to `aws_opensearch_domain` / `AWS::OpenSearchService::Domain`.

So a reader who applied the documented fix ended up with a resource the check does not look at. The finding stayed open, and the closed-loop run reported the check as *never evaluating at all* — the snippet contains nothing it matches:

```
check did not run against …/elasticsearch-enforce-https-cloudformation/pass/zzremediation
the fixture likely does not contain a resource matched by the check's filter
```

## Why point them back at Elasticsearch

These checks only fire on a domain that is **still on Elasticsearch**. That is precisely the reader who needs the fix, and the fix has to be expressed in the resource they have.

OpenSearch is not left uncovered — eleven `opensearch-*` checks already exist in this policy, with direct equivalents for all five overlapping objectives:

| Elasticsearch check | OpenSearch equivalent |
|---|---|
| `elasticsearch-audit-logging` | `opensearch-audit-logging` |
| `elasticsearch-encrypted-at-rest` | `opensearch-encrypted-at-rest` |
| `elasticsearch-enforce-https` | `opensearch-enforce-https` |
| `elasticsearch-node-to-node-encryption` | `opensearch-node-to-node-encryption` |
| `elasticsearch-tls-policy` | `opensearch-tls-policy` |

`engine_version` / `EngineVersion` revert to `elasticsearch_version` / `ElasticsearchVersion` with a `7.10` value, which is what the Elasticsearch resource accepts.

## One more never-passing check

While verifying, `elasticsearch-encrypted-at-rest-cloudformation` turned out to read **`EncryptAtRestOptions`**. The property is `EncryptionAtRestOptions` — as the remediation, all four of its own fixtures, and the OpenSearch twin fifty lines away all spell it. Two of its pass fixtures carried a `KNOWN_BUG.md` for exactly this; both are removed.

## Verification

```
go test -tags iac_variants -run '…mondoo-aws-security-(elasticsearch|opensearch)' ./content   # CFN
ok
go test -tags iac_variants -run '…mondoo-aws-security-elasticsearch' ./content                # Terraform
ok
python3 content/validation/validate_terraform_remediation.py aws
473 passed, 0 failed
cnspec policy lint content/mondoo-aws-security.mql.yaml
→ valid policy bundle(s)
```

Version 12.11.0 → 12.11.3 (12.11.1 and .2 are claimed by #3293 and #3290).

🤖 Generated with [Claude Code](https://claude.com/claude-code)