### PR TITLE
🧹 aws: use the indented heredoc form in the EMR snippets

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.11.6
+    version: 12.11.7
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -50237,7 +50237,7 @@ queries:
             resource "aws_emr_security_configuration" "example" {
               name = "emr-encryption-config"
 
-              configuration = <<JSON
+              configuration = <<-JSON
               {
                 "EncryptionConfiguration": {
                   "EnableAtRestEncryption": true,
@@ -50460,7 +50460,7 @@ queries:
             resource "aws_emr_security_configuration" "example" {
               name = "emr-intransit-encryption-config"
 
-              configuration = <<JSON
+              configuration = <<-JSON
               {
                 "EncryptionConfiguration": {
                   "EnableInTransitEncryption": true,
@@ -51507,7 +51507,7 @@ queries:
             resource "aws_emr_security_configuration" "encryption" {
               name = "emr-local-disk-encryption"
 
-              configuration = <<JSON
+              configuration = <<-JSON
               {
                 "EncryptionConfiguration": {
                   "EnableAtRestEncryption": true,


### PR DESCRIPTION
Review follow-up to #3293 — the comment landed after that PR had already merged, so it comes as its own change.

`<<JSON` keeps the leading whitespace inside the string; `<<-JSON` strips the common indentation, which is the idiomatic form for a heredoc nested inside a resource block. JSON tolerates either, so this is about the example being worth copying rather than about correctness.

## Verification

- the three `emr-*-terraform-hcl` checks still pass against their own snippets (`go test -tags iac_variants -run '…mondoo-aws-security-emr-'` → `ok`)
- `validate_terraform_remediation.py aws` → 473 passed, 0 failed
- `cnspec policy lint` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)