### PR TITLE
✨ content: require an IaC remediation to satisfy the check that recommends it

### DIFF
--- a/.github/workflows/content-iac-tests.yaml
+++ b/.github/workflows/content-iac-tests.yaml
@@ -57,6 +57,12 @@ jobs:
           # 100% pass/fail fixture coverage, so a new variant cannot merge
           # without fixtures.
           - { iac: coverage, shard: 0, shards: 1 }
+          # The closed loop runs one scan per variant that has a same-language
+          # remediation snippet (~1,900), so it is sharded like terraform.
+          - { iac: remediation, shard: 0, shards: 4 }
+          - { iac: remediation, shard: 1, shards: 4 }
+          - { iac: remediation, shard: 2, shards: 4 }
+          - { iac: remediation, shard: 3, shards: 4 }
           - { iac: cloudformation, shard: 0, shards: 1 }
           - { iac: bicep, shard: 0, shards: 1 }
           - { iac: dockerfile, shard: 0, shards: 1 }
@@ -69,7 +75,7 @@ jobs:
           - { iac: terraform, shard: 5, shards: 8 }
           - { iac: terraform, shard: 6, shards: 8 }
           - { iac: terraform, shard: 7, shards: 8 }
-    name: ${{ matrix.iac == 'terraform' && format('terraform (shard {0}/{1})', matrix.shard, matrix.shards) || matrix.iac }}
+    name: ${{ (matrix.iac == 'terraform' || matrix.iac == 'remediation') && format('{0} (shard {1}/{2})', matrix.iac, matrix.shard, matrix.shards) || matrix.iac }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ test/go/plain-ci: prep/tools
 # that shard. Unset means run everything. See .github/workflows/content-iac-tests.yaml.
 IAC_VARIANT_PARALLEL ?= 4
 
-.PHONY: test/go/content-iac test/go/content-iac/terraform test/go/content-iac/cloudformation test/go/content-iac/bicep test/go/content-iac/dockerfile test/go/content-iac/kubernetes test/go/content-iac/coverage
+.PHONY: test/go/content-iac test/go/content-iac/terraform test/go/content-iac/cloudformation test/go/content-iac/bicep test/go/content-iac/dockerfile test/go/content-iac/kubernetes test/go/content-iac/coverage test/go/content-iac/remediation
 test/go/content-iac: prep/tools
 	go test -tags iac_variants -timeout 30m -parallel $(IAC_VARIANT_PARALLEL) -run 'TestTerraformVariants|TestCloudFormationVariants|TestBicepVariants|TestDockerfileVariants|TestKubernetesManifestVariants' ./content
 
@@ -157,6 +157,12 @@ test/go/content-iac/dockerfile: prep/tools
 
 test/go/content-iac/kubernetes: prep/tools
 	go test -tags iac_variants -timeout 30m -parallel $(IAC_VARIANT_PARALLEL) -run '^TestKubernetesManifestVariants$$' ./content
+
+# Closed loop: scans each IaC variant's own remediation snippet and requires the
+# check that recommends it to pass. Sharded like the terraform suite, since it
+# runs one provider-backed scan per variant.
+test/go/content-iac/remediation: prep/tools
+	go test -tags iac_variants -timeout 60m -parallel $(IAC_VARIANT_PARALLEL) -run '^TestRemediationSatisfiesCheck$$' ./content
 
 # Fixture-coverage gate. Runs no scans: it compares the IaC variants declared in
 # each policy against the fixtures on disk and fails if any variant lacks a pass

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -190,6 +190,41 @@ make test/go/content-iac/coverage    # check coverage
 
 Where a variant asserts exactly what its own `filters:` require, no failing input exists; record that with a `fail/IMPOSSIBLE.md` marker explaining why, instead of a fail fixture, and it counts as covered. That marker is the only sanctioned way to ship a variant without a real fail fixture.
 
+### The remediation has to satisfy the check
+
+`TestRemediationSatisfiesCheck` (in `content/remediation_closes_check_test.go`, behind the
+`iac_variants` tag) scans each IaC variant's **own remediation snippet** and requires the
+check that recommends it to pass:
+
+```bash
+make test/go/content-iac/remediation
+```
+
+This is the question the linters cannot answer. cfn-lint, tflint and `bicep build` prove a
+snippet is well-formed; they cannot prove it is right. A snippet can name every property
+correctly and still demonstrate the exact misconfiguration the check forbids, target a
+resource type the check does not match, or set a neighbouring property instead of the
+asserted one.
+
+The snippet is generated per run from the policy rather than checked in as a fixture — it
+is a copy of content that already lives in the bundle, and a checked-in copy would drift
+from it silently. Only what the snippet needs to be a scannable document is added: a
+`provider "x" {}` stub for HCL (so a filter reading `terraform.providers` does not skip the
+check), and the `AWSTemplateFormatVersion` preamble for a CloudFormation fragment.
+
+A variant whose remediation does not satisfy it yet is listed in
+`content/remediation-closes-check-budget.json` with a reason. The list may only shrink: an
+entry that starts passing fails the test, so the entry is removed together with the fix —
+the same contract as a `KNOWN_BUG.md` marker.
+
+Three distinct failures are reported differently, because they mean different things:
+
+- **the check did not run** — the snippet declares no resource the check's filter matches,
+  so applying it as shown leaves the check unevaluated
+- **the remediation does not satisfy the check** — a reader who applies the documented fix
+  still fails
+- **scanning failed** — the snippet is not a scannable document of its kind on its own
+
 ### Terraform remediation
 
 Every parent check that has Terraform variants must also document how to fix the issue in Terraform. Add an `- id: terraform` entry to the `remediation:` list alongside the existing `id: console`, `id: cli`, `id: cloudformation`, `id: bicep` entries. The block holds a short Markdown intro and a fenced ```hcl``` example that resolves the violation.

--- a/content/remediation-closes-check-budget.json
+++ b/content/remediation-closes-check-budget.json
@@ -1,0 +1,226 @@
+[
+  {
+    "uid": "mondoo-aws-security-apigatewayv2-websocket-tls-1-2-minimum-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-backup-vault-no-public-access-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-cloudtrail-config-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-cmk-disable-delete-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-config-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-console-auth-failure-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-iam-policy-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-nacl-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-network-gw-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-no-mfa-login-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-org-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-root-usage-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-route-table-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-s3-policy-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-security-group-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-unauthorized-api-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-cloudwatch-vpc-change-alarm-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-documentdb-instance-public-access-check-cloudformation",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-documentdb-instance-public-access-check-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-ebs-snapshot-public-restorable-check-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-ec2-ami-public-sharing-prohibited-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-ec2-snapshot-not-public-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-ecr-no-public-access-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-efs-enforce-transit-encryption-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-efs-filesystem-no-public-access-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-eventbridge-bus-policy-no-public-access-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-iam-users-only-one-access-key-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-rds-snapshot-encrypted-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-route53-dnssec-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-route53-query-logging-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-route53-resolver-query-logging-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-s3-bucket-encryption-uses-kms-cmk-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-s3-bucket-ownership-bucket-owner-enforced-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-s3-bucket-static-website-hosting-disabled-terraform-hcl",
+    "reason": "the snippet is not a scannable document of its kind on its own"
+  },
+  {
+    "uid": "mondoo-aws-security-s3-ownership-controls-enforced-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-secretsmanager-rotation-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-sns-topic-policy-secure-transport-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-sqs-queue-dead-letter-queue-cloudformation",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-sqs-queue-dead-letter-queue-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-vpc-endpoint-service-restrict-principals-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-aws-security-vpc-flow-logs-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-aws-security-vpc-subnet-flow-logs-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-azure-security-datafactory-public-access-disabled-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-azure-security-ensure-activity-log-alert-exists-for-create-update-delete-network-security-group-bicep",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-azure-security-ensure-that-notify-about-alerts-with-high-severity-is-on-bicep",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-azure-security-frontdoor-waf-policy-attached-bicep",
+    "reason": "the snippet is not a scannable document of its kind on its own"
+  },
+  {
+    "uid": "mondoo-azure-security-frontdoor-waf-policy-attached-terraform-hcl",
+    "reason": "the snippet is not a scannable document of its kind on its own"
+  },
+  {
+    "uid": "mondoo-azure-security-function-app-secrets-in-key-vault-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-azure-security-log-analytics-workspace-cmk-encryption-terraform-hcl",
+    "reason": "the snippet is not a scannable document of its kind on its own"
+  },
+  {
+    "uid": "mondoo-azure-security-recovery-vault-backup-policies-terraform-hcl",
+    "reason": "the snippet is not a scannable document of its kind on its own"
+  },
+  {
+    "uid": "mondoo-digitalocean-security-doks-supported-version-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-hcl",
+    "reason": "the documented fix does not make this check pass"
+  },
+  {
+    "uid": "mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  },
+  {
+    "uid": "mondoo-gcp-security-iam-project-no-service-account-impersonation-terraform-hcl",
+    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
+  }
+]

--- a/content/remediation_closes_check_test.go
+++ b/content/remediation_closes_check_test.go
@@ -1,0 +1,337 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build iac_variants
+
+package content
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// This suite asks the one question the linters cannot: does the fix we ship
+// actually make our own check pass?
+//
+// cfn-lint, tflint and `bicep build` prove a snippet is well-formed. They cannot
+// prove it is *right*. A snippet can name every property correctly and still
+// demonstrate the exact misconfiguration the check forbids, target a resource
+// type the check does not match, or set a neighbouring property instead of the
+// one asserted — and every one of those has been found in this corpus.
+//
+// The material to answer it was already here and simply never connected: each
+// IaC variant has a check, and its parent has a remediation snippet in the same
+// language. This writes that snippet into a scenario directory and scans it with
+// the same machinery the pass/fail fixtures use, requiring the check to pass.
+//
+// The snippet is generated per run rather than checked in. It is not a fixture
+// in its own right — it is a copy of content that already lives in the policy,
+// and a checked-in copy would drift from it silently.
+
+// remediationMethod maps an IaC variant suffix to the remediation `- id:` that
+// documents the fix for it, and to the fence language and filename that method
+// uses.
+var remediationMethod = map[string]struct {
+	id       string
+	fences   []string
+	filename string
+}{
+	"-terraform-hcl":  {"terraform", []string{"hcl", "terraform", "tf"}, "main.tf"},
+	"-cloudformation": {"cloudformation", []string{"yaml", "yml"}, "template.yaml"},
+	"-bicep":          {"bicep", []string{"bicep"}, "main.bicep"},
+}
+
+// knownUnsatisfiedFile records the variants whose remediation does not yet
+// satisfy them. Each entry needs a reason, and the list may only shrink: an
+// entry that starts passing fails the test so the entry is removed with the fix,
+// the same contract as the KNOWN_BUG.md markers.
+const knownUnsatisfiedFile = "./remediation-closes-check-budget.json"
+
+type unsatisfiedEntry struct {
+	Uid    string `json:"uid"`
+	Reason string `json:"reason"`
+}
+
+func loadKnownUnsatisfied(t *testing.T) map[string]string {
+	data, err := os.ReadFile(knownUnsatisfiedFile)
+	if os.IsNotExist(err) {
+		return map[string]string{}
+	}
+	require.NoError(t, err)
+
+	var entries []unsatisfiedEntry
+	require.NoError(t, json.Unmarshal(data, &entries), "%s is not valid JSON", knownUnsatisfiedFile)
+
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		require.NotEmpty(t, e.Reason, "%s: entry %q needs a reason", knownUnsatisfiedFile, e.Uid)
+		out[e.Uid] = e.Reason
+	}
+	return out
+}
+
+// fencePattern matches a fenced block and captures its language and body.
+var fencePattern = regexp.MustCompile("(?s)```([A-Za-z0-9_+-]*)[ \t]*\n(.*?)```")
+
+// snippetFor returns the remediation code a variant's parent documents for that
+// variant's language, already dedented out of the YAML block scalar.
+func snippetFor(parent *policy.Mquery, suffix string) (string, bool) {
+	method, ok := remediationMethod[suffix]
+	if !ok || parent == nil || parent.Docs == nil || parent.Docs.Remediation == nil {
+		return "", false
+	}
+	for _, item := range parent.Docs.Remediation.Items {
+		if item.Id != method.id {
+			continue
+		}
+		var bodies []string
+		for _, m := range fencePattern.FindAllStringSubmatch(item.Desc, -1) {
+			lang := strings.ToLower(m[1])
+			for _, want := range method.fences {
+				if lang == want {
+					bodies = append(bodies, dedent(m[2]))
+					break
+				}
+			}
+		}
+		if len(bodies) == 0 {
+			return "", false
+		}
+		// Several ```hcl fences in one entry form a single configuration, the
+		// way validate_terraform_remediation.py treats them. A second
+		// CloudFormation or Bicep fence is an alternative example, so only the
+		// first is used there.
+		if suffix == "-terraform-hcl" {
+			return strings.Join(bodies, "\n\n"), true
+		}
+		return bodies[0], true
+	}
+	return "", false
+}
+
+// dedent strips the common leading indentation the fence inherits from the
+// surrounding `desc: |` block scalar. Bicep is indentation-sensitive once a
+// nested object is involved, and YAML always is.
+func dedent(block string) string {
+	lines := strings.Split(block, "\n")
+	common := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		n := len(l) - len(strings.TrimLeft(l, " "))
+		if common == -1 || n < common {
+			common = n
+		}
+	}
+	if common <= 0 {
+		return block
+	}
+	for i, l := range lines {
+		if len(l) >= common {
+			lines[i] = l[common:]
+		} else {
+			lines[i] = strings.TrimLeft(l, " ")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+var hclResourcePrefix = regexp.MustCompile(`(?m)^\s*(?:resource|data)\s+"([a-z][a-z0-9]*)_`)
+
+// A documentation snippet elides the parts that are not the point, and marks a
+// placeholder the reader must replace. Neither is valid in the language, so both
+// are removed before scanning — the same substitutions
+// validate_terraform_remediation.py makes before handing a snippet to tflint.
+// Without this, `microsoft_defender { … }` inside a resource that also contains
+// a bare `...` line reads as a parse failure and looks like a content defect.
+var (
+	ellipsisLine      = regexp.MustCompile(`(?m)^\s*\.\.\.\s*$`)
+	quotedPlaceholder = regexp.MustCompile(`"<[^"<>\n]{1,60}>"`)
+	barePlaceholder   = regexp.MustCompile(`<[^<>\n]{1,60}>`)
+)
+
+func sanitizeSnippet(code string) string {
+	code = ellipsisLine.ReplaceAllString(code, "")
+	code = quotedPlaceholder.ReplaceAllString(code, `"placeholder"`)
+	return barePlaceholder.ReplaceAllString(code, `"placeholder"`)
+}
+
+// materialize writes a snippet into dir as the file its provider expects,
+// adding only what the snippet needs to be a scannable document of its kind.
+func materialize(dir, suffix, snippet string) (string, error) {
+	method := remediationMethod[suffix]
+	body := snippet
+	if suffix == "-terraform-hcl" {
+		// YAML and Bicep snippets are not sanitized: an ellipsis or an
+		// angle-bracket placeholder is a *string* there, so it parses, and
+		// rewriting it could change what the check reads.
+		body = sanitizeSnippet(body)
+		snippet = body
+	}
+
+	switch suffix {
+	case "-terraform-hcl":
+		// A snippet declares resources but no provider block. Most checks do not
+		// care, but a filter that reads terraform.providers would see an empty
+		// list and skip the check, which would look like a content failure.
+		seen := map[string]bool{}
+		var providers []string
+		for _, m := range hclResourcePrefix.FindAllStringSubmatch(snippet, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				providers = append(providers, m[1])
+			}
+		}
+		sort.Strings(providers)
+		var b strings.Builder
+		for _, p := range providers {
+			b.WriteString("provider \"" + p + "\" {}\n")
+		}
+		if b.Len() > 0 {
+			body = b.String() + "\n" + snippet
+		}
+	case "-cloudformation":
+		// A fragment starts at `Resources:`; the template needs its preamble.
+		if !strings.Contains(snippet, "AWSTemplateFormatVersion") {
+			body = "AWSTemplateFormatVersion: '2010-09-09'\n" + snippet
+		}
+	}
+
+	path := filepath.Join(dir, method.filename)
+	return path, os.WriteFile(path, []byte(body+"\n"), 0o644)
+}
+
+// scanSnippet runs the check against a materialised snippet, retrying a failed
+// scan before believing it.
+//
+// Each scan spawns a provider subprocess, and under the suite's concurrency one
+// occasionally dies mid-request: `rpc error: code = Unavailable desc = error
+// reading from server: EOF`. That is contention, not a property of the snippet —
+// it hit four checks in one run and two different ones in the next. Recorded as
+// a finding it would put a flaky entry in the budget, and then fail the *next*
+// run for "now satisfies it, remove the entry". A deterministic error, such as
+// `asset doesn't support any policies` for a snippet that yields no scannable
+// asset, reproduces on every attempt and is reported after the last one.
+func scanSnippet(bundleFile, policyMrn string, asset *inventory.Asset) ([]*policy.Report, error) {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		var reports []*policy.Report
+		reports, err = runBundleReports(bundleFile, policyMrn, asset)
+		if err == nil {
+			return reports, nil
+		}
+	}
+	return nil, err
+}
+
+// TestRemediationSatisfiesCheck scans each IaC variant's own remediation snippet
+// and requires the check that recommends it to pass.
+func TestRemediationSatisfiesCheck(t *testing.T) {
+	shardIndex, shardTotal := iacShard(t)
+	known := loadKnownUnsatisfied(t)
+	seen := map[string]bool{}
+
+	for _, pol := range tfVariantPolicies {
+		bundle, err := policy.DefaultBundleLoader().BundleFromPaths(pol.bundleFile)
+		require.NoError(t, err)
+
+		byUid := make(map[string]*policy.Mquery, len(bundle.Queries))
+		for _, q := range bundle.Queries {
+			byUid[q.Uid] = q
+		}
+
+		uids := make([]string, 0, len(bundle.Queries))
+		for _, q := range bundle.Queries {
+			uids = append(uids, q.Uid)
+		}
+		sort.Strings(uids)
+
+		for _, uid := range uids {
+			suffix, ok := iacSuffix(uid)
+			if !ok {
+				continue
+			}
+			parent := byUid[strings.TrimSuffix(uid, suffix)]
+			snippet, ok := snippetFor(parent, suffix)
+			if !ok {
+				// No same-language remediation to test. Whether one is required
+				// is TestTerraformVariantCoverage's and the content rules'
+				// business, not this suite's.
+				continue
+			}
+			// Recorded before the shard filter: every shard needs the full set to
+			// judge whether a budget entry is stale, otherwise that check could
+			// only run unsharded — which is never, since CI shards this suite.
+			seen[uid] = true
+			if !inShard(uid, shardIndex, shardTotal) {
+				continue
+			}
+
+			t.Run(uid, func(t *testing.T) {
+				t.Parallel()
+				dir := t.TempDir()
+				_, err := materialize(dir, suffix, snippet)
+				require.NoError(t, err)
+
+				reports, err := scanSnippet(pol.bundleFile, pol.policyMrn, tfAssetForVariant(uid, dir))
+				outcome := outcomeSkipped
+				if err == nil {
+					outcome, _ = checkResultAcross(reports, queryMrnPrefix+uid)
+				}
+
+				reason, isKnown := known[uid]
+				if isKnown {
+					if outcome == outcomePassed {
+						t.Fatalf("this variant's remediation now satisfies it, so remove its entry "+
+							"from %s\nreason on file: %s\ncheck: %s",
+							knownUnsatisfiedFile, reason, uid)
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("scanning the remediation snippet failed: %v\n"+
+						"the snippet is not a scannable %s document on its own\ncheck: %s",
+						err, strings.TrimPrefix(suffix, "-"), uid)
+				}
+				if outcome == outcomeSkipped {
+					t.Fatalf("the check did not run against its own remediation snippet\n"+
+						"the snippet does not declare a resource this check's filter matches, so "+
+						"applying it as shown leaves the check unevaluated\ncheck: %s", uid)
+				}
+				if outcome != outcomePassed {
+					t.Fatalf("the remediation for this check does not satisfy it\n"+
+						"a reader who applies the documented fix still fails the check\ncheck: %s", uid)
+				}
+			})
+		}
+	}
+
+	// An entry that no longer names a testable variant is stale: the variant or
+	// its remediation is gone, and the entry would silently excuse nothing.
+	// One shard reports it; every shard has the full set (see above).
+	if shardIndex == 0 {
+		var stale []string
+		for uid := range known {
+			if !seen[uid] {
+				stale = append(stale, uid)
+			}
+		}
+		sort.Strings(stale)
+		if len(stale) > 0 {
+			t.Errorf("%s lists %d variant(s) that no longer have a testable remediation "+
+				"snippet; remove them:\n%s",
+				knownUnsatisfiedFile, len(stale), strings.Join(indent(stale), "\n"))
+		}
+	}
+}


### PR DESCRIPTION
## The gap

`cfn-lint`, `tflint` and `bicep build` prove a remediation snippet is **well-formed**. None of them can prove it is **right**.

A snippet can name every property correctly and still demonstrate the exact misconfiguration the check forbids, target a resource type the check does not match, or set a neighbouring property instead of the asserted one. All three were found in this corpus over the last day — #3292 (seven checks that could never pass), #3293 (an egress example that allowed `0.0.0.0/0` under a heading saying not to), #3294 (Elasticsearch checks whose remediation had been modernised to OpenSearch resources the check does not look at). Every one of those passed its linter.

## What this adds

The material was already here and simply never connected: every IaC variant has a check, and its parent has a remediation snippet in the same language. `TestRemediationSatisfiesCheck` writes that snippet into a scenario directory and scans it with the machinery the pass/fail fixtures already use, requiring the check to pass.

The snippet is **generated per run from the bundle**, not checked in — it is a copy of content that already lives in the policy, and a checked-in copy would drift from it silently.

Three failures are reported differently, because they mean different things:

| Reported as | Meaning |
|---|---|
| the check did not run | the snippet declares no resource the check's filter matches, so applying it as shown leaves the check unevaluated |
| the fix does not satisfy the check | a reader who applies the documented fix still fails |
| scanning failed | the snippet is not a scannable document of its kind on its own |

## Today's numbers

**56 of ~1,900 eligible variants** fail: 35 check-never-ran, 16 fix-doesn't-satisfy, 5 not-scannable. AWS 43, Azure 11, GCP 3, DigitalOcean 1.

They are listed in `content/remediation-closes-check-budget.json`, each with a reason naming which of the three it is. **The list may only shrink**: an entry that starts passing fails the test, so it is removed together with the fix — the same contract as a `KNOWN_BUG.md` marker. A stale entry naming a variant that no longer has a testable snippet also fails.

## Two things the harness must do, or it invents findings

Both were found by running it, not by reasoning about it, and both are why the headline number is trustworthy:

**Sanitisation.** Snippets get the same `...`-ellipsis and `<placeholder>` substitution `validate_terraform_remediation.py` already applies before tflint. Without it a literal `...` line makes the resource unparseable, which reads as a content defect. That alone accounted for **18 checks** — 15 of them Azure AKS — in the first run.

**Retrying a failed scan.** Under this suite's concurrency a provider subprocess occasionally dies mid-request:

```
rpc error: code = Unavailable desc = error reading from server: EOF
```

That hit four checks in one run and two *different* ones in the next. Recorded as findings they produce a permanently flaky gate: the crash writes a budget entry, and the next run fails demanding its removal — which is exactly what happened when I first validated the budget. A deterministic error (`asset doesn't support any policies`, for a snippet that yields no scannable asset) reproduces across all three attempts and is still reported.

For the record, how the number moved and why:

| | |
|---:|---|
| 90 | first run — included 18 artifacts of the harness itself |
| 72 | after matching the Python validator's sanitisation |
| 58 | after #3292 / #3293 / #3294 merged |
| 56 | after retrying transient provider crashes |

## Verification

The budget was validated the way CI runs it — generate it from a run, then run again *with* it in place:

```
56 entries -> content/remediation-closes-check-budget.json
validation exit=0
```

`TestTerraformVariantCoverage` → `ok`. Runs as four sharded CI jobs alongside the existing IaC suites, and as `make test/go/content-iac/remediation`.

## Natural follow-up

The largest class is "the check did not run", and a chunk of it is snippets that are fragments *by design* — 16 CloudWatch alarm checks filter on the file also containing an `aws_cloudtrail`, which is a prerequisite rather than part of the fix. An optional per-check `context/` directory holding prerequisite resources would let those be tested against a realistic configuration, and would turn the prerequisite into documented information rather than a silent assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)