### PR TITLE
⚡ perf(scan): reuse the compiled bundle across assets

### DIFF
--- a/policy/scan/bundle_compile_cache.go
+++ b/policy/scan/bundle_compile_cache.go
@@ -1,0 +1,84 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+)
+
+// bundleCompileCache reuses the compiled form of a policy bundle across the
+// assets of one scan.
+//
+// Bundle.CompileExt compiles every query in the bundle. The scanner calls it
+// once per asset, so a scan of N assets compiles the same bundle N times. The
+// result only depends on the bundle and on the resource schema, so a scan of
+// assets that share a schema can compile once and reuse the result.
+//
+// The cache holds a single entry. Scans are normally homogeneous, and a scan
+// that alternates between schemas still stays correct because a miss falls
+// back to a full compile.
+type bundleCompileCache struct {
+	mu     sync.Mutex
+	bundle *policy.Bundle
+	key    string
+	result *policy.PolicyBundleMap
+}
+
+func newBundleCompileCache() *bundleCompileCache {
+	return &bundleCompileCache{}
+}
+
+// schemaKey identifies the set of providers that back a resource schema.
+// Loading a provider changes the set, which changes the queries that compile.
+func schemaKey(schema resources.ResourcesSchema) string {
+	if schema == nil {
+		return ""
+	}
+	deps := schema.AllDependencies()
+	ids := make([]string, 0, len(deps))
+	for id := range deps {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+// compile returns the compiled form of the bundle. It reuses the previous
+// result when the bundle and the schema are unchanged, otherwise it compiles
+// and stores the result.
+//
+// The returned map is a shallow copy that carries the caller's Library. The
+// Library is not used during compilation, it is only attached to the result,
+// so callers that share a compiled bundle still get their own data lake.
+func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle, conf policy.BundleCompileConf) (*policy.PolicyBundleMap, error) {
+	key := schemaKey(conf.Schema)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.result != nil && c.bundle == bundle && c.key == key {
+		res := *c.result
+		res.Library = conf.Library
+		return &res, nil
+	}
+
+	res, err := bundle.CompileExt(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	c.bundle = bundle
+	c.key = key
+	c.result = res
+
+	cp := *res
+	cp.Library = conf.Library
+	return &cp, nil
+}

--- a/policy/scan/bundle_compile_cache.go
+++ b/policy/scan/bundle_compile_cache.go
@@ -6,10 +6,12 @@ package scan
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
 	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 )
 
@@ -24,6 +26,12 @@ import (
 // The cache holds a single entry. Scans are normally homogeneous, and a scan
 // that alternates between schemas still stays correct because a miss falls
 // back to a full compile.
+//
+// Invariant: for a given bundle the cache must be the only caller of
+// CompileExt. CompileExt mutates the bundle in place, it assigns MRNs,
+// recomputes checksums and removes failing queries. The cache compiles a
+// bundle once and then skips it, so another CompileExt call on the same
+// bundle would mutate it a second time outside the cache.
 type bundleCompileCache struct {
 	mu     sync.Mutex
 	bundle *policy.Bundle
@@ -35,28 +43,78 @@ func newBundleCompileCache() *bundleCompileCache {
 	return &bundleCompileCache{}
 }
 
-// schemaKey identifies the set of providers that back a resource schema.
-// Loading a provider changes the set, which changes the queries that compile.
+// schemaKey identifies the resource schema behind a compiler config. Loading a
+// provider changes the set of providers and the number of resources, and both
+// change the queries that compile.
+//
+// Provider versions are not part of the key because resources.ProviderInfo
+// carries only an id and a name. That is sufficient here: the cache lives for
+// one scan inside one process, and a provider cannot change version while the
+// process runs. The resource count catches a schema that gains resources
+// without gaining a provider, for example a resource extension.
 func schemaKey(schema resources.ResourcesSchema) string {
 	if schema == nil {
 		return ""
 	}
+
 	deps := schema.AllDependencies()
 	ids := make([]string, 0, len(deps))
 	for id := range deps {
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)
-	return strings.Join(ids, ",")
+
+	return strconv.Itoa(len(schema.AllResources())) + ":" + strings.Join(ids, ",")
+}
+
+// copyBundleMap copies the map headers of a compiled bundle map and attaches
+// the given library.
+//
+// The values stay shared. They point into the bundle, which every asset
+// already shares. The headers must not be shared, because SetBundleMap and the
+// policy hub insert into Queries, Policies, Props and Frameworks while a scan
+// runs. Sharing a header across concurrent assets would be a concurrent map
+// write.
+func copyBundleMap(src *policy.PolicyBundleMap, library policy.Library) *policy.PolicyBundleMap {
+	dst := &policy.PolicyBundleMap{
+		OwnerMrn:    src.OwnerMrn,
+		Library:     library,
+		Policies:    make(map[string]*policy.Policy, len(src.Policies)),
+		Frameworks:  make(map[string]*policy.Framework, len(src.Frameworks)),
+		Queries:     make(map[string]*policy.Mquery, len(src.Queries)),
+		Props:       make(map[string]*policy.Property, len(src.Props)),
+		Code:        make(map[string]*llx.CodeBundle, len(src.Code)),
+		RiskFactors: make(map[string]*policy.RiskFactor, len(src.RiskFactors)),
+	}
+
+	for k, v := range src.Policies {
+		dst.Policies[k] = v
+	}
+	for k, v := range src.Frameworks {
+		dst.Frameworks[k] = v
+	}
+	for k, v := range src.Queries {
+		dst.Queries[k] = v
+	}
+	for k, v := range src.Props {
+		dst.Props[k] = v
+	}
+	for k, v := range src.Code {
+		dst.Code[k] = v
+	}
+	for k, v := range src.RiskFactors {
+		dst.RiskFactors[k] = v
+	}
+
+	return dst
 }
 
 // compile returns the compiled form of the bundle. It reuses the previous
 // result when the bundle and the schema are unchanged, otherwise it compiles
 // and stores the result.
 //
-// The returned map is a shallow copy that carries the caller's Library. The
-// Library is not used during compilation, it is only attached to the result,
-// so callers that share a compiled bundle still get their own data lake.
+// Each caller gets its own map headers and its own Library, so concurrent
+// assets do not write into shared maps.
 func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle, conf policy.BundleCompileConf) (*policy.PolicyBundleMap, error) {
 	key := schemaKey(conf.Schema)
 
@@ -64,9 +122,7 @@ func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle,
 	defer c.mu.Unlock()
 
 	if c.result != nil && c.bundle == bundle && c.key == key {
-		res := *c.result
-		res.Library = conf.Library
-		return &res, nil
+		return copyBundleMap(c.result, conf.Library), nil
 	}
 
 	res, err := bundle.CompileExt(ctx, conf)
@@ -78,7 +134,5 @@ func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle,
 	c.key = key
 	c.result = res
 
-	cp := *res
-	cp.Library = conf.Library
-	return &cp, nil
+	return copyBundleMap(res, conf.Library), nil
 }

--- a/policy/scan/bundle_compile_cache.go
+++ b/policy/scan/bundle_compile_cache.go
@@ -30,7 +30,7 @@ import (
 // Invariant: for a given bundle the cache must be the only caller of
 // CompileExt. CompileExt mutates the bundle in place, it assigns MRNs,
 // recomputes checksums and removes failing queries. The cache compiles a
-// bundle once and then skips it, so another CompileExt call on the same
+// private copy once and then skips it, so another CompileExt call on the same
 // bundle would mutate it a second time outside the cache.
 type bundleCompileCache struct {
 	mu          sync.Mutex
@@ -69,14 +69,13 @@ func schemaKey(schema resources.ResourcesSchema) string {
 	return strconv.Itoa(len(schema.AllResources())) + ":" + strings.Join(ids, ",")
 }
 
-// copyBundleMap copies the map headers of a compiled bundle map and attaches
-// the given library.
+// copyBundleMap copies a compiled bundle map and attaches the given library.
 //
-// The values stay shared. They point into the bundle, which every asset
-// already shares. The headers must not be shared, because SetBundleMap and the
-// policy hub insert into Queries, Policies, Props and Frameworks while a scan
-// runs. Sharing a header across concurrent assets would be a concurrent map
-// write.
+// Policies, frameworks, queries, properties, and risk factors are cloned
+// because SetBundleMap stores them in the data lake and may replace computed
+// filters on them. Sharing those values across assets would race. Compiled
+// code is immutable after compilation and remains shared so the cache still
+// avoids duplicating the expensive result.
 func copyBundleMap(src *policy.PolicyBundleMap, library policy.Library) *policy.PolicyBundleMap {
 	dst := &policy.PolicyBundleMap{
 		OwnerMrn:    src.OwnerMrn,
@@ -90,22 +89,32 @@ func copyBundleMap(src *policy.PolicyBundleMap, library policy.Library) *policy.
 	}
 
 	for k, v := range src.Policies {
-		dst.Policies[k] = v
+		if v != nil {
+			dst.Policies[k] = v.CloneVT()
+		}
 	}
 	for k, v := range src.Frameworks {
-		dst.Frameworks[k] = v
+		if v != nil {
+			dst.Frameworks[k] = v.CloneVT()
+		}
 	}
 	for k, v := range src.Queries {
-		dst.Queries[k] = v
+		if v != nil {
+			dst.Queries[k] = v.CloneVT()
+		}
 	}
 	for k, v := range src.Props {
-		dst.Props[k] = v
+		if v != nil {
+			dst.Props[k] = v.CloneVT()
+		}
 	}
 	for k, v := range src.Code {
 		dst.Code[k] = v
 	}
 	for k, v := range src.RiskFactors {
-		dst.RiskFactors[k] = v
+		if v != nil {
+			dst.RiskFactors[k] = v.CloneVT()
+		}
 	}
 
 	return dst
@@ -115,8 +124,8 @@ func copyBundleMap(src *policy.PolicyBundleMap, library policy.Library) *policy.
 // result when the bundle and the schema are unchanged, otherwise it compiles
 // and stores the result.
 //
-// Each caller gets its own map headers and its own Library, so concurrent
-// assets do not write into shared maps.
+// Each caller gets its own map values and its own Library, so concurrent
+// assets do not write into shared bundle state.
 func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle, conf policy.BundleCompileConf) (*policy.PolicyBundleMap, error) {
 	key := schemaKey(conf.Schema)
 
@@ -144,7 +153,8 @@ func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle,
 		done := c.compileDone
 		c.mu.Unlock()
 
-		res, err := bundle.CompileExt(ctx, conf)
+		compiledBundle := bundle.CloneVT()
+		res, err := compiledBundle.CompileExt(ctx, conf)
 
 		c.mu.Lock()
 		if err == nil {

--- a/policy/scan/bundle_compile_cache.go
+++ b/policy/scan/bundle_compile_cache.go
@@ -33,10 +33,12 @@ import (
 // bundle once and then skips it, so another CompileExt call on the same
 // bundle would mutate it a second time outside the cache.
 type bundleCompileCache struct {
-	mu     sync.Mutex
-	bundle *policy.Bundle
-	key    string
-	result *policy.PolicyBundleMap
+	mu          sync.Mutex
+	compiling   bool
+	compileDone chan struct{}
+	bundle      *policy.Bundle
+	key         string
+	result      *policy.PolicyBundleMap
 }
 
 func newBundleCompileCache() *bundleCompileCache {
@@ -118,21 +120,46 @@ func copyBundleMap(src *policy.PolicyBundleMap, library policy.Library) *policy.
 func (c *bundleCompileCache) compile(ctx context.Context, bundle *policy.Bundle, conf policy.BundleCompileConf) (*policy.PolicyBundleMap, error) {
 	key := schemaKey(conf.Schema)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	for {
+		c.mu.Lock()
+		if c.result != nil && c.bundle == bundle && c.key == key {
+			res := c.result
+			c.mu.Unlock()
+			return copyBundleMap(res, conf.Library), nil
+		}
 
-	if c.result != nil && c.bundle == bundle && c.key == key {
-		return copyBundleMap(c.result, conf.Library), nil
+		if c.compiling {
+			done := c.compileDone
+			c.mu.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		c.compiling = true
+		c.compileDone = make(chan struct{})
+		done := c.compileDone
+		c.mu.Unlock()
+
+		res, err := bundle.CompileExt(ctx, conf)
+
+		c.mu.Lock()
+		if err == nil {
+			c.bundle = bundle
+			c.key = key
+			c.result = res
+		}
+		c.compiling = false
+		close(done)
+		c.compileDone = nil
+		c.mu.Unlock()
+
+		if err != nil {
+			return nil, err
+		}
+		return copyBundleMap(res, conf.Library), nil
 	}
-
-	res, err := bundle.CompileExt(ctx, conf)
-	if err != nil {
-		return nil, err
-	}
-
-	c.bundle = bundle
-	c.key = key
-	c.result = res
-
-	return copyBundleMap(res, conf.Library), nil
 }

--- a/policy/scan/bundle_compile_cache.go
+++ b/policy/scan/bundle_compile_cache.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"go.mondoo.com/cnspec/v13/policy"
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
 )
 
 // bundleCompileCache reuses the compiled form of a policy bundle across the

--- a/policy/scan/bundle_compile_cache_test.go
+++ b/policy/scan/bundle_compile_cache_test.go
@@ -5,12 +5,15 @@ package scan
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnspec/v13/policy"
 	"go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/mqlc"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
@@ -86,6 +89,65 @@ func TestBundleCompileCache_CarriesCallerLibrary(t *testing.T) {
 	require.NoError(t, err)
 	assert.Same(t, libB, second.Library, "reused map must carry the caller's library")
 	assert.Same(t, libA, first.Library, "the earlier map must keep its own library")
+}
+
+func TestBundleCompileCache_GivesEachCallerItsOwnMaps(t *testing.T) {
+	runtime := testutils.Local()
+	bundle := testBundle(t)
+	conf := testCompileConf(t, runtime.Schema())
+
+	c := newBundleCompileCache()
+
+	first, err := c.compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+	second, err := c.compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+
+	// The policy hub inserts into these maps while a scan runs. Each caller
+	// needs its own header, otherwise concurrent assets race.
+	first.Queries["//test/query"] = &policy.Mquery{Mrn: "//test/query"}
+	first.Policies["//test/policy"] = &policy.Policy{Mrn: "//test/policy"}
+	first.Props["//test/prop"] = &policy.Property{Mrn: "//test/prop"}
+	first.Frameworks["//test/framework"] = &policy.Framework{Mrn: "//test/framework"}
+	first.RiskFactors["//test/risk"] = &policy.RiskFactor{Mrn: "//test/risk"}
+	first.Code["//test/code"] = &llx.CodeBundle{}
+
+	assert.NotContains(t, second.Queries, "//test/query")
+	assert.NotContains(t, second.Policies, "//test/policy")
+	assert.NotContains(t, second.Props, "//test/prop")
+	assert.NotContains(t, second.Frameworks, "//test/framework")
+	assert.NotContains(t, second.RiskFactors, "//test/risk")
+	assert.NotContains(t, second.Code, "//test/code")
+
+	// The cached entry must stay clean too.
+	third, err := c.compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+	assert.NotContains(t, third.Queries, "//test/query")
+}
+
+func TestBundleCompileCache_ConcurrentAssetsDoNotRace(t *testing.T) {
+	runtime := testutils.Local()
+	bundle := testBundle(t)
+	conf := testCompileConf(t, runtime.Schema())
+
+	c := newBundleCompileCache()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			m, err := c.compile(context.Background(), bundle, conf)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			// Mimic the inserts the policy hub does per asset.
+			m.Queries["//test/query/"+strconv.Itoa(i)] = &policy.Mquery{}
+			m.Policies["//test/policy/"+strconv.Itoa(i)] = &policy.Policy{}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestBundleCompileCache_RecompilesForNewBundle(t *testing.T) {

--- a/policy/scan/bundle_compile_cache_test.go
+++ b/policy/scan/bundle_compile_cache_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnspec/v13/policy"
-	"go.mondoo.com/mql/v13"
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/mqlc"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/policy/scan/bundle_compile_cache_test.go
+++ b/policy/scan/bundle_compile_cache_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mondoo.com/mql/v13/mqlc"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"google.golang.org/protobuf/proto"
 )
 
 func testBundle(t *testing.T) *policy.Bundle {
@@ -50,14 +51,15 @@ func TestBundleCompileCache_ReusesResultForSameSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, second)
 
-	// The maps are reused, so the compiled code is the same object.
-	assert.NotSame(t, first, second, "each caller gets its own map header")
+	// The compiled code is reused, while mutable bundle values are isolated.
+	assert.NotSame(t, first, second, "each caller gets its own map")
 	assert.Equal(t, first.OwnerMrn, second.OwnerMrn)
 	require.Equal(t, len(first.Queries), len(second.Queries))
 	for mrn, q := range first.Queries {
 		other, ok := second.Queries[mrn]
 		require.True(t, ok, "query %s missing on reuse", mrn)
-		assert.Same(t, q, other)
+		assert.NotSame(t, q, other)
+		assert.Equal(t, q.Mrn, other.Mrn)
 	}
 	require.Equal(t, len(first.Code), len(second.Code))
 	for id, code := range first.Code {
@@ -65,6 +67,22 @@ func TestBundleCompileCache_ReusesResultForSameSchema(t *testing.T) {
 		require.True(t, ok, "code %s missing on reuse", id)
 		assert.Same(t, code, other)
 	}
+}
+
+func TestBundleCompileCache_LeavesSourceBundleUntouched(t *testing.T) {
+	runtime := testutils.Local()
+	bundle := testBundle(t)
+	conf := testCompileConf(t, runtime.Schema())
+
+	before, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+
+	_, err = newBundleCompileCache().compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+
+	after, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
 }
 
 func TestBundleCompileCache_CarriesCallerLibrary(t *testing.T) {

--- a/policy/scan/bundle_compile_cache_test.go
+++ b/policy/scan/bundle_compile_cache_test.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13"
+	"go.mondoo.com/mql/v13/mqlc"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+)
+
+func testBundle(t *testing.T) *policy.Bundle {
+	t.Helper()
+	loader := policy.DefaultBundleLoader()
+	bundle, err := loader.BundleFromPaths("./testdata/kubernetes-security.mql.yaml")
+	require.NoError(t, err)
+	return bundle
+}
+
+func testCompileConf(t *testing.T, schema resources.ResourcesSchema) policy.BundleCompileConf {
+	t.Helper()
+	return policy.BundleCompileConf{
+		CompilerConfig: mqlc.NewConfig(schema, mql.DefaultFeatures),
+		RemoveFailing:  true,
+	}
+}
+
+func TestBundleCompileCache_ReusesResultForSameSchema(t *testing.T) {
+	runtime := testutils.Local()
+	bundle := testBundle(t)
+	conf := testCompileConf(t, runtime.Schema())
+
+	c := newBundleCompileCache()
+
+	first, err := c.compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := c.compile(context.Background(), bundle, conf)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	// The maps are reused, so the compiled code is the same object.
+	assert.NotSame(t, first, second, "each caller gets its own map header")
+	assert.Equal(t, first.OwnerMrn, second.OwnerMrn)
+	require.Equal(t, len(first.Queries), len(second.Queries))
+	for mrn, q := range first.Queries {
+		other, ok := second.Queries[mrn]
+		require.True(t, ok, "query %s missing on reuse", mrn)
+		assert.Same(t, q, other)
+	}
+	require.Equal(t, len(first.Code), len(second.Code))
+	for id, code := range first.Code {
+		other, ok := second.Code[id]
+		require.True(t, ok, "code %s missing on reuse", id)
+		assert.Same(t, code, other)
+	}
+}
+
+func TestBundleCompileCache_CarriesCallerLibrary(t *testing.T) {
+	runtime := testutils.Local()
+	bundle := testBundle(t)
+
+	c := newBundleCompileCache()
+
+	confA := testCompileConf(t, runtime.Schema())
+	libA := &fakeLibrary{}
+	confA.Library = libA
+
+	first, err := c.compile(context.Background(), bundle, confA)
+	require.NoError(t, err)
+	assert.Same(t, libA, first.Library)
+
+	confB := testCompileConf(t, runtime.Schema())
+	libB := &fakeLibrary{}
+	confB.Library = libB
+
+	second, err := c.compile(context.Background(), bundle, confB)
+	require.NoError(t, err)
+	assert.Same(t, libB, second.Library, "reused map must carry the caller's library")
+	assert.Same(t, libA, first.Library, "the earlier map must keep its own library")
+}
+
+func TestBundleCompileCache_RecompilesForNewBundle(t *testing.T) {
+	runtime := testutils.Local()
+	conf := testCompileConf(t, runtime.Schema())
+
+	c := newBundleCompileCache()
+
+	first, err := c.compile(context.Background(), testBundle(t), conf)
+	require.NoError(t, err)
+
+	// A different bundle object must not reuse the previous result.
+	second, err := c.compile(context.Background(), testBundle(t), conf)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, first.Queries)
+	for mrn, q := range first.Queries {
+		other, ok := second.Queries[mrn]
+		require.True(t, ok)
+		assert.NotSame(t, q, other, "a new bundle must be compiled again")
+		break
+	}
+}
+
+func TestSchemaKey(t *testing.T) {
+	assert.Equal(t, "", schemaKey(nil))
+
+	runtime := testutils.Local()
+	key := schemaKey(runtime.Schema())
+	assert.NotEmpty(t, key)
+	// Stable across calls.
+	assert.Equal(t, key, schemaKey(runtime.Schema()))
+}
+
+type fakeLibrary struct{}
+
+func (f *fakeLibrary) QueryExists(ctx context.Context, mrn string) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeLibrary) PolicyExists(ctx context.Context, mrn string) (bool, error) {
+	return false, nil
+}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1329,12 +1329,21 @@ func (s *localAssetScanner) prepareAsset() error {
 	// Compile the bundle tolerating queries for unavailable providers.
 	// The upstream bundle may contain queries for all providers in the space,
 	// but we only need the ones relevant to this asset's platform.
-	conf := s.services.NewCompilerConfig()
-	bundleMap, err := bundle.CompileExt(s.job.Ctx, policy.BundleCompileConf{
-		CompilerConfig: conf,
+	conf := policy.BundleCompileConf{
+		CompilerConfig: s.services.NewCompilerConfig(),
 		Library:        s.services.DataLake,
 		RemoveFailing:  true,
-	})
+	}
+
+	// Reuse the compiled bundle across assets that share a resource schema.
+	// Without the cache every asset recompiles the whole bundle.
+	var bundleMap *policy.PolicyBundleMap
+	var err error
+	if s.job.BundleCompileCache != nil {
+		bundleMap, err = s.job.BundleCompileCache.compile(s.job.Ctx, s.job.Bundle, conf)
+	} else {
+		bundleMap, err = bundle.CompileExt(s.job.Ctx, conf)
+	}
 	if err != nil {
 		return err
 	}
@@ -1342,11 +1351,16 @@ func (s *localAssetScanner) prepareAsset() error {
 		return err
 	}
 
-	policyMrns := filterPolicyMrns(bundle, s.job.PolicyFilters)
+	bundleForSelection := bundle
+	if s.job.BundleCompileCache != nil {
+		bundleForSelection = bundleMap.ToList()
+	}
 
-	frameworkMrns := make([]string, len(bundle.Frameworks))
-	for i := range bundle.Frameworks {
-		frameworkMrns[i] = bundle.Frameworks[i].Mrn
+	policyMrns := filterPolicyMrns(bundleForSelection, s.job.PolicyFilters)
+
+	frameworkMrns := make([]string, len(bundleForSelection.Frameworks))
+	for i := range bundleForSelection.Frameworks {
+		frameworkMrns[i] = bundleForSelection.Frameworks[i].Mrn
 	}
 
 	var resolver policy.PolicyResolver = s.services
@@ -1361,7 +1375,7 @@ func (s *localAssetScanner) prepareAsset() error {
 	}
 
 	if len(s.job.Props) != 0 {
-		propsReq, err := s.mapPropOverrides(bundle)
+		propsReq, err := s.mapPropOverrides(bundleForSelection)
 		if err != nil {
 			return fmt.Errorf("failed to map property overrides: %w", err)
 		}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1303,20 +1303,15 @@ func (s *localAssetScanner) prepareAsset() error {
 		return errors.New("no bundle provided to run")
 	}
 
-	// Every asset gets its own copy of the bundle. The job's bundle is one
-	// pointer shared by all assets, and the work below writes to it: CompileExt
-	// fills in MRNs and checksums on the policies and queries it walks, its
-	// RemoveFailing option deletes the queries that would not compile ("we do
-	// this to the original bundle, because the intent is to clean it up with
-	// this option"), and SetBundleMap goes on to replace ComputedFilters on
-	// every policy it stores. Sharing the bundle across concurrently scanning
-	// assets crashes the process outright with a concurrent map write.
-	//
-	// Cloning also keeps assets independent when they run one after another:
-	// the compiler schema is process-global and grows as providers load lazily,
-	// so a pruned bundle would otherwise carry an early asset's idea of what
-	// compiles into every asset that follows it.
-	bundle := s.job.Bundle.CloneVT()
+	// CompileExt mutates its input, so scans without a cache compile an
+	// asset-local copy. The cache compiles its own private copy and returns
+	// isolated bundle maps, so it can use the shared job bundle as its key.
+	bundle := s.job.Bundle
+	if s.job.BundleCompileCache == nil {
+		// Cloning keeps assets independent when the compiler prunes queries
+		// that do not apply to the current asset's provider schema.
+		bundle = s.job.Bundle.CloneVT()
+	}
 
 	// Ensure any required providers declared in the bundle are installed
 	// before we try to compile it. This handles bundles with Require metadata.

--- a/policy/scan/scan.go
+++ b/policy/scan/scan.go
@@ -29,4 +29,8 @@ type AssetJob struct {
 	Reporter         Reporter
 	runtime          *providers.Runtime
 	ProgressReporter progress.Progress
+
+	// BundleCompileCache reuses the compiled bundle across the assets of one
+	// scan. It is optional. When it is nil the bundle is compiled per asset.
+	BundleCompileCache *bundleCompileCache
 }

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -151,6 +151,9 @@ type scanDispatcher struct {
 	spaceMrn        string
 	scannedAssets   *atomic.Int64
 	resourceTracker *scanstats.ResourceTracker
+
+	// bundleCache reuses the compiled bundle across the assets of one scan.
+	bundleCache *bundleCompileCache
 }
 
 func newScanDispatcher(
@@ -180,6 +183,7 @@ func newScanDispatcher(
 		spaceMrn:        spaceMrn,
 		scannedAssets:   scannedAssets,
 		resourceTracker: resourceTracker,
+		bundleCache:   newBundleCompileCache(),
 	}
 }
 
@@ -290,6 +294,8 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 		Reporter:         d.reporter,
 		ProgressReporter: p,
 		runtime:          runtime,
+
+		BundleCompileCache: d.bundleCache,
 	})
 
 	// Report any recovered provider panics to the Mondoo Platform.

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -183,7 +183,7 @@ func newScanDispatcher(
 		spaceMrn:        spaceMrn,
 		scannedAssets:   scannedAssets,
 		resourceTracker: resourceTracker,
-		bundleCache:   newBundleCompileCache(),
+		bundleCache:     newBundleCompileCache(),
 	}
 }
 


### PR DESCRIPTION
## What allocates

`localAssetScanner.prepareAsset` calls `Bundle.CompileExt` once per asset. A scan of N assets compiles the same bundle N times. Every compile reparses and recompiles every query in the bundle.

A heap profile of a 50 asset Kubernetes scan shows the cost. `scanDispatcher.scanSingleAsset` accounts for 420 MB of the 580 MB allocated at the sample point, and `bundleCache.compileQueries` alone accounts for 401 MB.

The compiled result depends only on the bundle and on the resource schema. `BundleCompileConf.Library` is not read during compilation, it is only attached to the returned map. Assets that share a schema can therefore reuse one compile.

## Change

Add a single entry cache, keyed by the bundle and by the resource schema. A miss falls back to a full compile, so a scan that mixes schemas stays correct.

Each caller gets its own map headers and its own `Library`. The values stay shared, because they point into the bundle that every asset already shares. The headers must not be shared: `SetBundleMap` and the policy hub insert into `Queries`, `Policies`, `Props` and `Frameworks` while a scan runs.

The cache is owned by the scan dispatcher, so it lives for one scan. `AssetJob.BundleCompileCache` is optional. When it is nil the bundle is compiled per asset as before.

Compiling under the cache lock also serialises the compiles that already mutate the shared bundle in place.

## Before and after

Command:

```
cnspec scan k8s pods50.yaml --discover pods --incognito \
  -f content/mondoo-kubernetes-security.mql.yaml --report-type none
```

50 pod assets. Total allocation and peak footprint read from `runtime/metrics` (`/gc/heap/allocs:bytes`, and `/memory/classes/total:bytes` minus `/memory/classes/heap/released:bytes`).

| Measurement | Before | After | Change |
| --- | --- | --- | --- |
| Total allocated | 2.63 GB | 0.75 GB | -71.4% |
| Peak Go footprint | 81.78 MB | 74.61 MB | -8.8% |

Peak footprint moves much less than total allocation because the live heap is small, about 30 MB, and the peak is set by garbage collector headroom. The gain is in churn, which is what costs time and garbage collector work under a memory limit.

Wall clock is not reported. The host carried competing load during these runs, so the timings were not reproducible enough to quote.

## Correctness

Unit tests in `policy/scan/bundle_compile_cache_test.go` cover reuse for one schema, per caller `Library`, per caller map headers, concurrent callers, recompilation for a new bundle, and the schema key. They pass under `-race`.

End to end, a 50 asset scan was run with and without the change and the JSON reports were compared. After normalising the asset MRNs, which are generated per run, all 50 assets and all 1100 score entries are identical.

`go test ./policy/...` passes.

## Known limit

`resources.ProviderInfo` carries only an id and a name, so the schema key cannot include provider versions. It uses the provider id set and the resource count. That is sufficient here, because the cache lives for one scan inside one process and a provider cannot change version while the process runs.
