### PR TITLE
🐛 content: aggregate provider schemas before the IaC suites scan in parallel

### DIFF
--- a/content/bundles_test.go
+++ b/content/bundles_test.go
@@ -56,6 +56,30 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// Aggregate the provider schemas once, serially, against a harder failure in
+	// the same area. The coordinator takes its two locks in opposite orders on two
+	// paths the parallel suites run at the same time:
+	//
+	//	compiling MQL         Schema.Lookup -> unsafeLoadAll -> coordinator.LoadSchema
+	//	                        holds the schema lock, wants the coordinator lock
+	//	starting a provider   GetRunningProvider -> unsafeStartProvider -> Schema.Add
+	//	                        holds the coordinator lock, wants the schema lock
+	//
+	// Interleaved, that is a deadlock, and a mutex cannot be timed out: the scans
+	// do not fail, they stop, and the shard runs to the test binary's timeout an
+	// hour later with four checks still "running".
+	//
+	// Lookup only reaches LoadSchema while the aggregate is older than the last
+	// provider install, so one Lookup here — after the installs above, before any
+	// parallel scan — leaves the compile path on its read-only branch, and the two
+	// orders stop interleaving. It has to be Lookup rather than LoadSchema:
+	// LoadSchema populates the provider, but only the Lookup path refreshes the
+	// aggregate and moves the timestamp that gates it.
+	//
+	// This is a workaround for the lock ordering in providers/coordinator.go and
+	// providers/extensible_schema.go, and can go once that is fixed upstream.
+	providers.Coordinator.Schema().Lookup("asset")
+
 	// Run tests
 	exitVal := m.Run()
 	os.Exit(exitVal)


### PR DESCRIPTION
Follow-up to #3298, which merged before this was diagnosed. The failure is live on `main`.

## The failure

Shard 1/4 of `TestRemediationSatisfiesCheck` ran for **63 minutes** and died on the test binary's hour timeout, while the other three shards finished the same workload in **seven**:

```
remediation (shard 0/4): success  04:31:47 -> 04:38:16
remediation (shard 1/4): failure  04:31:46 -> 05:35:06   <-- 63 min
remediation (shard 2/4): success  04:31:48 -> 04:38:36
remediation (shard 3/4): success  04:31:47 -> 04:38:17
```

Four checks were still listed as running at the timeout. None of them is a content problem — each passes on its own in under a second.

## Root cause

Not a slow scan and not a wedged provider: the blocked goroutines are in `sync.Mutex.Lock`. mql's coordinator takes its two locks in **opposite orders** on two paths the parallel suites run simultaneously:

| path | holds | wants |
|---|---|---|
| compiling MQL — `Schema.Lookup` → `unsafeLoadAll` → `coordinator.LoadSchema` | schema lock | coordinator lock |
| starting a provider — `GetRunningProvider` → `unsafeStartProvider` → `Schema.Add` | coordinator lock | schema lock |

Interleaved, that is a textbook ABBA deadlock. A mutex cannot be timed out, so the scans do not fail — they stop, and nothing recovers until the binary's own timeout fires an hour later.

The same signature (`extensible_schema.go:42`, `coordinator.go:379`, `sync.Mutex.Lock`) is present in the CI dump from the failing shard and in local reproductions.

## The change

`Lookup` only reaches `LoadSchema` while the aggregate is older than the last provider install. One `Lookup` in `TestMain`, after the installs and before any parallel scan, refreshes it — so the compile path stays on its read-only branch and the two lock orders never interleave.

It has to be `Lookup` and not `LoadSchema`: `LoadSchema` populates the provider, but only the `Lookup` path refreshes the aggregate and moves the timestamp that gates it. Warming with `LoadSchema` was tried and deadlocks exactly as before.

This sits next to the existing `providers.ListAll()` warm-up in `TestMain`, which is there for a related race in the same area.

## Measurements

The four checks that hung in CI, run alternating baseline/patched with the provider process table cleared between each run:

| | runs | result |
|---|---|---|
| unpatched (`main`) | **12** | all deadlocked, hit the timeout (~183s at `-timeout 3m`) |
| patched | **3** | all passed, 1-8s |

## This is a workaround

The lock ordering is the actual bug and belongs upstream in `providers/coordinator.go` and `providers/extensible_schema.go`. This can be removed once that is fixed — the comment in the code says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
