### PR TITLE
✨ scan: report CPU consumption alongside memory

### DIFF
--- a/docs/adr/0004-scan-memory-telemetry.md
+++ b/docs/adr/0004-scan-memory-telemetry.md
@@ -31,7 +31,7 @@ This ADR accepts that boundary rather than building a second transport. Adding m
 
 ### 2. Sampling: `runtime/metrics`, not `MemStats.Alloc`
 
-A new `scanstats.MemTracker` owns a process-wide high-water mark, updated by a single sampler goroutine started in `RunLocalScan` and stopped when it returns.
+A new `scanstats.MemTracker` owns a process-wide high-water mark, updated by a single sampler goroutine started in `RunLocalScan` and stopped when it returns. (Renamed to `ResourceTracker` when scan CPU telemetry was added alongside it — see #3301 — since the type now carries both.)
 
 The sampled quantity is the Go runtime footprint:
 
@@ -94,11 +94,13 @@ These metrics are collected unconditionally on the `UploadResultsV2` path. Makin
 
 ### 8. File layout
 
-- `policy/scanstats/mem.go` — `MemTracker`: sampling loop, high-water tracking, in-flight correlation, cgroup reader, and the snapshot that records into a `Collector`.
+- `policy/scanstats/tracker.go` — `MemTracker` (renamed `ResourceTracker` in #3301): sampling loop, high-water tracking, in-flight correlation, and the snapshot that records into a `Collector`.
+- `policy/scanstats/sample.go` — the `runtime/metrics` reads.
+- `policy/scanstats/cgroup.go` — the cgroup v2 reader.
 - `policy/scanstats/collector.go` — metric name constants and `AddString`, for the run identifier.
 - `policy/scanstats/context.go` — tracker propagation, mirroring the existing `ContextWithCollector`.
 - `policy/scan/local_scanner.go` — tracker construction, sampler lifecycle, recording the static concurrency settings.
-- `policy/scan/scan_pipeline.go` — registers the in-flight accessor; existing `logMemoryStats` is repointed at the tracker so there is a single source of truth for memory readings.
+- `policy/scan/scan_pipeline.go` — registers the in-flight accessor; existing `logMemoryStats` (renamed `logResourceStats` in #3301) is repointed at the tracker so there is a single source of truth for memory readings.
 - `internal/datalakes/sqlite/sqlite.go` — snapshots the tracker into the per-asset collector before upload.
 
 The tracker takes an injected sample function and an injected cgroup root, so high-water logic, in-flight correlation, and cgroup parsing (v2 present, absent, `max` literal, malformed) are all testable without a live runtime or a real `/sys`.

--- a/internal/datalakes/sqlite/sqlite.go
+++ b/internal/datalakes/sqlite/sqlite.go
@@ -47,11 +47,11 @@ func outputDirFromCtx(ctx context.Context) string {
 	return ""
 }
 
-// recordMemStats folds the run's memory tracker into this asset's collector.
+// recordResourceStats folds the run's memory tracker into this asset's collector.
 // Extracted so the wiring is testable without standing up a scan. A nil
-// tracker (no tracker on ctx) is a no-op — MemTracker methods are nil-safe.
-func recordMemStats(ctx context.Context, stats *scanstats.Collector) {
-	scanstats.MemTrackerFromContext(ctx).Record(stats)
+// tracker (no tracker on ctx) is a no-op — ResourceTracker methods are nil-safe.
+func recordResourceStats(ctx context.Context, stats *scanstats.Collector) {
+	scanstats.ResourceTrackerFromContext(ctx).Record(stats)
 }
 
 func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Asset, upstreamClient *upstream.UpstreamClient, f func(context.Context, *policy.LocalServices) error) error {
@@ -100,7 +100,7 @@ func WithServices(ctx context.Context, runtime llx.Runtime, asset *inventory.Ass
 
 		// Snapshot process memory as of this asset's completion. The values
 		// are process-wide, not this asset's cost — see ADR-0004.
-		recordMemStats(scanCtx, stats)
+		recordResourceStats(scanCtx, stats)
 
 		if upstream != nil {
 			scanDataPath, err := scanDataStore.Finalize()

--- a/internal/datalakes/sqlite/sqlite_resourcestats_test.go
+++ b/internal/datalakes/sqlite/sqlite_resourcestats_test.go
@@ -13,16 +13,16 @@ import (
 )
 
 func TestRecordMemStats_WritesTrackerIntoCollector(t *testing.T) {
-	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+	tr := scanstats.NewResourceTracker(scanstats.ResourceTrackerConfig{
 		RunID: "run-abc",
 		// Avoid reading the real /sys/fs/cgroup default on a containerized
 		// CI runner.
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 	})
-	ctx := scanstats.ContextWithMemTracker(context.Background(), tr)
+	ctx := scanstats.ContextWithResourceTracker(context.Background(), tr)
 
 	c := scanstats.New()
-	recordMemStats(ctx, c)
+	recordResourceStats(ctx, c)
 
 	stats := c.ToProto()
 	require.NotNil(t, stats)
@@ -39,6 +39,6 @@ func TestRecordMemStats_WritesTrackerIntoCollector(t *testing.T) {
 func TestRecordMemStats_NoTrackerOnContextIsNoop(t *testing.T) {
 	// Scans that never installed a tracker must still upload cleanly.
 	c := scanstats.New()
-	require.NotPanics(t, func() { recordMemStats(context.Background(), c) })
+	require.NotPanics(t, func() { recordResourceStats(context.Background(), c) })
 	require.Nil(t, c.ToProto())
 }

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -515,25 +515,25 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	if u, err := uuid.NewRandom(); err == nil {
 		runID = u.String()
 	}
-	memTracker := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+	resourceTracker := scanstats.NewResourceTracker(scanstats.ResourceTrackerConfig{
 		RunID:          runID,
 		Parallelism:    parallelism,
 		MaxConnections: maxConn,
 	})
-	ctx = scanstats.ContextWithMemTracker(ctx, memTracker)
+	ctx = scanstats.ContextWithResourceTracker(ctx, resourceTracker)
 
 	dispatcher := newScanDispatcher(
 		parallelism, connSem, s, explorer, job, upstream,
 		reporter, multiprogress, services, spaceMrn, &scannedAssets,
-		memTracker,
+		resourceTracker,
 	)
 	// Registered before Start so the sampler's immediate first sample —
 	// which can end up being the run's peak — already has an accessor to
 	// call, instead of recording an in-flight count of zero that would be
 	// indistinguishable from a legitimate zero.
-	memTracker.SetInFlightFunc(dispatcher.inFlight)
-	memTracker.Start(memSampleInterval)
-	defer memTracker.Stop()
+	resourceTracker.SetInFlightFunc(dispatcher.inFlight)
+	resourceTracker.Start(memSampleInterval)
+	defer resourceTracker.Stop()
 	batcher := newSyncBatcher(dispatcher, services, spaceMrn, s.recording, multiprogress)
 
 	scanCtx := &scanContext{

--- a/policy/scan/scan_pipeline.go
+++ b/policy/scan/scan_pipeline.go
@@ -141,16 +141,16 @@ type scanDispatcher struct {
 	wg      sync.WaitGroup
 
 	// Dependencies for scanning a single asset.
-	scanner       *LocalScanner
-	explorer      *discovery.AssetExplorer
-	job           *Job
-	upstream      *upstream.UpstreamConfig
-	reporter      Reporter
-	multiprogress progress.MultiProgress
-	services      *policy.Services
-	spaceMrn      string
-	scannedAssets *atomic.Int64
-	memTracker    *scanstats.MemTracker
+	scanner         *LocalScanner
+	explorer        *discovery.AssetExplorer
+	job             *Job
+	upstream        *upstream.UpstreamConfig
+	reporter        Reporter
+	multiprogress   progress.MultiProgress
+	services        *policy.Services
+	spaceMrn        string
+	scannedAssets   *atomic.Int64
+	resourceTracker *scanstats.ResourceTracker
 }
 
 func newScanDispatcher(
@@ -165,21 +165,21 @@ func newScanDispatcher(
 	services *policy.Services,
 	spaceMrn string,
 	scannedAssets *atomic.Int64,
-	memTracker *scanstats.MemTracker,
+	resourceTracker *scanstats.ResourceTracker,
 ) *scanDispatcher {
 	return &scanDispatcher{
-		scanSem:       make(chan struct{}, parallelism),
-		connSem:       connSem,
-		scanner:       scanner,
-		explorer:      explorer,
-		job:           job,
-		upstream:      up,
-		reporter:      reporter,
-		multiprogress: mp,
-		services:      services,
-		spaceMrn:      spaceMrn,
-		scannedAssets: scannedAssets,
-		memTracker:    memTracker,
+		scanSem:         make(chan struct{}, parallelism),
+		connSem:         connSem,
+		scanner:         scanner,
+		explorer:        explorer,
+		job:             job,
+		upstream:        up,
+		reporter:        reporter,
+		multiprogress:   mp,
+		services:        services,
+		spaceMrn:        spaceMrn,
+		scannedAssets:   scannedAssets,
+		resourceTracker: resourceTracker,
 	}
 }
 
@@ -313,7 +313,7 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 
 	// Break the allAssets → Asset reference so the proto data (connections,
 	// platform, labels, etc.) becomes GC-eligible immediately. The local
-	// `asset` variable still holds a reference for logMemoryStats below;
+	// `asset` variable still holds a reference for logResourceStats below;
 	// reporters that need the data (AggregateReporter) already captured
 	// their own reference via AddReport.
 	tracked.Asset = nil
@@ -321,18 +321,18 @@ func (d *scanDispatcher) scanSingleAsset(ctx context.Context, tracked *discovery
 	debug.FreeOSMemory()
 
 	if os.Getenv("DEBUG_PROVIDER_MEMORY") != "" {
-		d.logMemoryStats(asset)
+		d.logResourceStats(asset)
 	}
 }
 
-// logMemoryStats emits memory diagnostics after an asset scan completes.
+// logResourceStats emits memory diagnostics after an asset scan completes.
 // Only called when DEBUG_PROVIDER_MEMORY is set.
 //
-// Reads the run's MemTracker rather than sampling independently, so the
+// Reads the run's ResourceTracker rather than sampling independently, so the
 // logged numbers and the numbers reported upstream cannot disagree.
-func (d *scanDispatcher) logMemoryStats(asset *inventory.Asset) {
-	peakBytes, peakGoroutines, inFlightAtPeak := d.memTracker.Peaks()
-	snap := d.memTracker.Snapshot()
+func (d *scanDispatcher) logResourceStats(asset *inventory.Asset) {
+	peakBytes, peakGoroutines, inFlightAtPeak := d.resourceTracker.Peaks()
+	snap := d.resourceTracker.Snapshot()
 
 	ev := log.Info().
 		Str("asset", asset.Name).
@@ -354,8 +354,11 @@ func (d *scanDispatcher) logMemoryStats(asset *inventory.Asset) {
 	if snap.HasCgroupMax {
 		ev = ev.Uint64("cgroup_max_mb", snap.CgroupMax/1024/1024)
 	}
+	if snap.HasCPU {
+		ev = ev.Float64("cpu_busy_seconds", snap.CPUBusySeconds)
+	}
 
-	ev.Msg("memory after asset scan")
+	ev.Msg("resource usage after asset scan")
 
 	if ar, ok := d.reporter.(*AggregateReporter); ok {
 		rptBytes, rpBytes, vrBytes, aBytes := ar.AccumulatedBytes()

--- a/policy/scan/scan_pipeline_tracker_test.go
+++ b/policy/scan/scan_pipeline_tracker_test.go
@@ -32,26 +32,26 @@ func TestScanDispatcher_InFlightZeroWhenNoSemaphore(t *testing.T) {
 	require.Equal(t, 0, d.inFlight())
 }
 
-func TestLogMemoryStats_NoTrackerDoesNotPanic(t *testing.T) {
+func TestLogResourceStats_NoTrackerDoesNotPanic(t *testing.T) {
 	// DEBUG_PROVIDER_MEMORY can be set on a scan whose dispatcher was built
 	// without a tracker (unit tests, embedded callers).
 	d := &scanDispatcher{scannedAssets: &atomic.Int64{}}
 	require.NotPanics(t, func() {
-		d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
+		d.logResourceStats(&inventory.Asset{Name: "test-asset"})
 	})
 }
 
-func TestLogMemoryStats_UsesTrackerPeak(t *testing.T) {
-	tr := scanstats.NewMemTracker(scanstats.MemTrackerConfig{
+func TestLogResourceStats_UsesTrackerPeak(t *testing.T) {
+	tr := scanstats.NewResourceTracker(scanstats.ResourceTrackerConfig{
 		RunID:  "run-abc",
 		Sample: func() scanstats.Sample { return scanstats.Sample{RuntimeBytes: 4242, Goroutines: 17} },
 	})
 	tr.SetInFlightFunc(func() int { return 5 })
 	tr.Observe()
 
-	d := &scanDispatcher{scannedAssets: &atomic.Int64{}, memTracker: tr}
+	d := &scanDispatcher{scannedAssets: &atomic.Int64{}, resourceTracker: tr}
 
-	// logMemoryStats writes through the package-level zerolog logger, so
+	// logResourceStats writes through the package-level zerolog logger, so
 	// capture that global for the duration of the test (not parallel-safe)
 	// and assert on the emitted line, proving the logged values came from
 	// the tracker rather than an independent reader.
@@ -60,7 +60,7 @@ func TestLogMemoryStats_UsesTrackerPeak(t *testing.T) {
 	log.Logger = zerolog.New(buf)
 	defer func() { log.Logger = orig }()
 
-	d.logMemoryStats(&inventory.Asset{Name: "test-asset"})
+	d.logResourceStats(&inventory.Asset{Name: "test-asset"})
 
 	out := buf.String()
 	// goroutines_peak and in_flight_at_peak come only from the tracker;

--- a/policy/scanstats/cgroup.go
+++ b/policy/scanstats/cgroup.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// defaultCgroupRoot is the cgroup v2 unified hierarchy mount point.
+const defaultCgroupRoot = "/sys/fs/cgroup"
+
+// cgroupStats holds cgroup v2 memory readings. Each value carries a
+// presence flag: a value that could not be read is absent, never zero.
+// Reporting zero would be indistinguishable from a real measurement and
+// would corrupt any aggregate computed across a mixed fleet.
+type cgroupStats struct {
+	current, peak, max          uint64
+	hasCurrent, hasPeak, hasMax bool
+}
+
+// readCgroup reads cgroup v2 memory values from root, best-effort. Every
+// file is optional: non-Linux hosts have no cgroup at all, cgroup v1 has a
+// different layout, and memory.peak requires Linux 5.19 or later.
+func readCgroup(root string) cgroupStats {
+	var cg cgroupStats
+	cg.current, cg.hasCurrent = readCgroupValue(root, "memory.current")
+	cg.peak, cg.hasPeak = readCgroupValue(root, "memory.peak")
+	cg.max, cg.hasMax = readCgroupValue(root, "memory.max")
+	return cg
+}
+
+// readCgroupValue reads a single unsigned integer from a cgroup file. The
+// literal "max" means no limit and is reported as absent rather than as a
+// sentinel number.
+func readCgroupValue(root, name string) (uint64, bool) {
+	raw, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/policy/scanstats/cgroup_test.go
+++ b/policy/scanstats/cgroup_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeCgroupFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
+}
+
+func TestReadCgroup_AllPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "3402137600\n")
+	writeCgroupFile(t, dir, "memory.peak", "3500000000\n")
+	writeCgroupFile(t, dir, "memory.max", "4294967296\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.Equal(t, uint64(3402137600), cg.current)
+	require.True(t, cg.hasPeak)
+	require.Equal(t, uint64(3500000000), cg.peak)
+	require.True(t, cg.hasMax)
+	require.Equal(t, uint64(4294967296), cg.max)
+}
+
+func TestReadCgroup_AbsentDirectoryReportsNothing(t *testing.T) {
+	// Non-Linux hosts and cgroup v1 systems: every value must be absent,
+	// never zero. A zero would be read downstream as a real measurement.
+	cg := readCgroup(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.False(t, cg.hasCurrent)
+	require.False(t, cg.hasPeak)
+	require.False(t, cg.hasMax)
+}
+
+func TestReadCgroup_UnlimitedMaxIsAbsent(t *testing.T) {
+	// "max" means no limit. Reporting it as a number would invent a ceiling
+	// that does not exist and make headroom ratios meaningless.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "1024\n")
+	writeCgroupFile(t, dir, "memory.max", "max\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.False(t, cg.hasMax)
+}
+
+func TestReadCgroup_MissingPeakOnOlderKernel(t *testing.T) {
+	// memory.peak requires Linux 5.19+; the others must still be reported.
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "2048\n")
+	writeCgroupFile(t, dir, "memory.max", "8192\n")
+
+	cg := readCgroup(dir)
+	require.True(t, cg.hasCurrent)
+	require.False(t, cg.hasPeak)
+	require.True(t, cg.hasMax)
+}
+
+func TestReadCgroup_MalformedValueIsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	writeCgroupFile(t, dir, "memory.current", "not-a-number\n")
+
+	cg := readCgroup(dir)
+	require.False(t, cg.hasCurrent)
+}

--- a/policy/scanstats/collector.go
+++ b/policy/scanstats/collector.go
@@ -48,6 +48,19 @@ const (
 	MetricConcurrencyInFlightAtPeak = "cnspec.scan.concurrency.in_flight_at_peak" // unit: count
 	MetricConcurrencyParallelism    = "cnspec.scan.concurrency.parallelism"       // unit: count
 	MetricConcurrencyMaxConnections = "cnspec.scan.concurrency.max_connections"   // unit: count
+
+	// CPU metrics are cumulative over the run, not high-water marks like the
+	// memory ones: each is the difference between the run's first and latest
+	// observation. Note that "available" is CPU the process could have used
+	// (roughly GOMAXPROCS x wall time) — "busy" is what it actually burned.
+	MetricCPUBusySeconds      = "cnspec.scan.cpu.busy_seconds"      // unit: s
+	MetricCPUAvailableSeconds = "cnspec.scan.cpu.available_seconds" // unit: s
+	MetricCPUUserSeconds      = "cnspec.scan.cpu.user_seconds"      // unit: s
+	MetricCPUGCSeconds        = "cnspec.scan.cpu.gc_seconds"        // unit: s
+	MetricCPUScavengeSeconds  = "cnspec.scan.cpu.scavenge_seconds"  // unit: s
+	MetricCPUGCFraction       = "cnspec.scan.cpu.gc_fraction"       // gc / busy
+	MetricCPUUtilization      = "cnspec.scan.cpu.utilization"       // busy / available
+	MetricCPUGOMAXPROCS       = "cnspec.scan.cpu.gomaxprocs"        // unit: count
 )
 
 // Collector accumulates scan metrics. It is safe for concurrent use.

--- a/policy/scanstats/collector_test.go
+++ b/policy/scanstats/collector_test.go
@@ -90,4 +90,13 @@ func TestMemMetricNamesMatchWireContract(t *testing.T) {
 	require.Equal(t, "cnspec.scan.concurrency.in_flight_at_peak", MetricConcurrencyInFlightAtPeak)
 	require.Equal(t, "cnspec.scan.concurrency.parallelism", MetricConcurrencyParallelism)
 	require.Equal(t, "cnspec.scan.concurrency.max_connections", MetricConcurrencyMaxConnections)
+
+	require.Equal(t, "cnspec.scan.cpu.busy_seconds", MetricCPUBusySeconds)
+	require.Equal(t, "cnspec.scan.cpu.available_seconds", MetricCPUAvailableSeconds)
+	require.Equal(t, "cnspec.scan.cpu.user_seconds", MetricCPUUserSeconds)
+	require.Equal(t, "cnspec.scan.cpu.gc_seconds", MetricCPUGCSeconds)
+	require.Equal(t, "cnspec.scan.cpu.scavenge_seconds", MetricCPUScavengeSeconds)
+	require.Equal(t, "cnspec.scan.cpu.gc_fraction", MetricCPUGCFraction)
+	require.Equal(t, "cnspec.scan.cpu.utilization", MetricCPUUtilization)
+	require.Equal(t, "cnspec.scan.cpu.gomaxprocs", MetricCPUGOMAXPROCS)
 }

--- a/policy/scanstats/context.go
+++ b/policy/scanstats/context.go
@@ -20,18 +20,18 @@ func CollectorFromContext(ctx context.Context) *Collector {
 	return c
 }
 
-type memTrackerCtxKey struct{}
+type resourceTrackerCtxKey struct{}
 
-// ContextWithMemTracker returns a ctx carrying t so the datalake layer can
+// ContextWithResourceTracker returns a ctx carrying t so the datalake layer can
 // record process memory into a per-asset collector without threading the
 // tracker through every signature.
-func ContextWithMemTracker(ctx context.Context, t *MemTracker) context.Context {
-	return context.WithValue(ctx, memTrackerCtxKey{}, t)
+func ContextWithResourceTracker(ctx context.Context, t *ResourceTracker) context.Context {
+	return context.WithValue(ctx, resourceTrackerCtxKey{}, t)
 }
 
-// MemTrackerFromContext returns the MemTracker carried by ctx, or nil. Every
-// MemTracker method is nil-safe, so callers need not check.
-func MemTrackerFromContext(ctx context.Context) *MemTracker {
-	t, _ := ctx.Value(memTrackerCtxKey{}).(*MemTracker)
+// ResourceTrackerFromContext returns the ResourceTracker carried by ctx, or nil. Every
+// ResourceTracker method is nil-safe, so callers need not check.
+func ResourceTrackerFromContext(ctx context.Context) *ResourceTracker {
+	t, _ := ctx.Value(resourceTrackerCtxKey{}).(*ResourceTracker)
 	return t
 }

--- a/policy/scanstats/context_test.go
+++ b/policy/scanstats/context_test.go
@@ -58,25 +58,25 @@ func TestRecordKindCounts_NilCollector(t *testing.T) {
 	RecordKindCounts(nil, KindCounts{Checks: 5})
 }
 
-func TestContextWithMemTracker_RoundTrip(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{RunID: "run-abc"})
-	ctx := ContextWithMemTracker(context.Background(), tr)
-	require.Same(t, tr, MemTrackerFromContext(ctx))
+func TestContextWithResourceTracker_RoundTrip(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{RunID: "run-abc"})
+	ctx := ContextWithResourceTracker(context.Background(), tr)
+	require.Same(t, tr, ResourceTrackerFromContext(ctx))
 }
 
-func TestMemTrackerFromContext_AbsentReturnsNil(t *testing.T) {
-	// Must return a usable nil rather than panicking: every MemTracker
+func TestResourceTrackerFromContext_AbsentReturnsNil(t *testing.T) {
+	// Must return a usable nil rather than panicking: every ResourceTracker
 	// method is nil-safe, so callers need no branch.
-	tr := MemTrackerFromContext(context.Background())
+	tr := ResourceTrackerFromContext(context.Background())
 	require.Nil(t, tr)
 	require.NotPanics(t, func() { tr.Record(New()) })
 }
 
-func TestMemTrackerAndCollectorAreIndependentContextValues(t *testing.T) {
+func TestResourceTrackerAndCollectorAreIndependentContextValues(t *testing.T) {
 	c := New()
-	tr := NewMemTracker(MemTrackerConfig{RunID: "run-abc"})
-	ctx := ContextWithMemTracker(ContextWithCollector(context.Background(), c), tr)
+	tr := NewResourceTracker(ResourceTrackerConfig{RunID: "run-abc"})
+	ctx := ContextWithResourceTracker(ContextWithCollector(context.Background(), c), tr)
 
 	require.Same(t, c, CollectorFromContext(ctx))
-	require.Same(t, tr, MemTrackerFromContext(ctx))
+	require.Same(t, tr, ResourceTrackerFromContext(ctx))
 }

--- a/policy/scanstats/sample.go
+++ b/policy/scanstats/sample.go
@@ -1,0 +1,152 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import (
+	"runtime"
+	"runtime/metrics"
+)
+
+// Sample is one observation of this process's resource state.
+type Sample struct {
+	// RuntimeBytes is the Go runtime's memory footprint — the quantity the
+	// runtime accounts against GOMEMLIMIT, and the one the OOM killer acts
+	// on. Deliberately not MemStats.Alloc, which counts only live heap
+	// objects and so understates the real footprint.
+	RuntimeBytes uint64
+	Goroutines   int
+	CPU          CPUSample
+}
+
+// CPUSample is the CPU half of an observation. Every seconds field is
+// cumulative since process start, so a scan's usage is the difference between
+// two samples rather than a high-water mark — unlike the memory fields, which
+// are instantaneous and tracked as peaks.
+type CPUSample struct {
+	// Valid reports whether the runtime/metrics CPU names resolved.
+	//
+	// This deliberately does NOT key on "value > 0" the way the memory
+	// footprint's presence flag does. A live process always has a non-zero
+	// footprint, so zero there means "did not resolve"; but a scan short
+	// enough legitimately burns ~0 CPU-seconds, so zero here is a real
+	// measurement. Keying on value would silently drop fast scans.
+	Valid bool
+
+	// TotalSeconds is CPU *available* to the process, not CPU consumed: it
+	// includes IdleSeconds. CPU actually burned is TotalSeconds-IdleSeconds.
+	TotalSeconds    float64
+	IdleSeconds     float64
+	UserSeconds     float64
+	GCSeconds       float64
+	ScavengeSeconds float64
+
+	// GOMAXPROCS is a gauge, not a counter, so it is never differenced. On
+	// Linux the runtime derives it from the cgroup CPU quota and updates it
+	// as that quota changes, which makes it a usable stand-in for "how much
+	// CPU was this process actually allowed" — unless the GOMAXPROCS
+	// environment variable is set, which disables the automatic default.
+	GOMAXPROCS int
+}
+
+// Busy returns CPU-seconds actually consumed: total available minus idle.
+func (c CPUSample) Busy() float64 {
+	if c.TotalSeconds > c.IdleSeconds {
+		return c.TotalSeconds - c.IdleSeconds
+	}
+	return 0
+}
+
+// SampleFunc returns a current Sample. Injected so the tracker's logic is
+// testable without a live runtime.
+type SampleFunc func() Sample
+
+// runtime/metrics names read on every sample. The memory pair's difference is
+// the Go runtime's memory footprint (the quantity accounted against
+// GOMEMLIMIT); the /cpu/classes/* counters are cumulative CPU-seconds.
+const (
+	metricTotalBytes        = "/memory/classes/total:bytes"
+	metricHeapReleasedBytes = "/memory/classes/heap/released:bytes"
+
+	metricCPUTotalSeconds    = "/cpu/classes/total:cpu-seconds"
+	metricCPUIdleSeconds     = "/cpu/classes/idle:cpu-seconds"
+	metricCPUUserSeconds     = "/cpu/classes/user:cpu-seconds"
+	metricCPUGCSeconds       = "/cpu/classes/gc/total:cpu-seconds"
+	metricCPUScavengeSeconds = "/cpu/classes/scavenge/total:cpu-seconds"
+	metricGOMAXPROCS         = "/sched/gomaxprocs:threads"
+)
+
+// defaultSample reads the live process resource state.
+//
+// It uses runtime/metrics rather than runtime.ReadMemStats for two reasons:
+// ReadMemStats stops the world, which would perturb the very scan being
+// measured; and MemStats.Alloc counts only live heap objects, excluding
+// stacks and memory the runtime has retained but not returned to the OS, so
+// it systematically understates what the OOM killer acts on. Reading the CPU
+// classes in the same call makes them nearly free.
+func defaultSample() Sample {
+	// A fresh slice per call: metrics.Read writes into it, so a shared one
+	// would need its own lock and this is called once a second.
+	s := []metrics.Sample{
+		{Name: metricTotalBytes},
+		{Name: metricHeapReleasedBytes},
+		{Name: metricCPUTotalSeconds},
+		{Name: metricCPUIdleSeconds},
+		{Name: metricCPUUserSeconds},
+		{Name: metricCPUGCSeconds},
+		{Name: metricCPUScavengeSeconds},
+		{Name: metricGOMAXPROCS},
+	}
+	metrics.Read(s)
+
+	var total, released uint64
+	if s[0].Value.Kind() == metrics.KindUint64 {
+		total = s[0].Value.Uint64()
+	}
+	if s[1].Value.Kind() == metrics.KindUint64 {
+		released = s[1].Value.Uint64()
+	}
+
+	var footprint uint64
+	if total > released {
+		footprint = total - released
+	}
+
+	return Sample{
+		RuntimeBytes: footprint,
+		Goroutines:   runtime.NumGoroutine(),
+		CPU:          cpuFromMetrics(s[2:]),
+	}
+}
+
+// cpuFromMetrics builds a CPUSample from the CPU slice of a metrics read.
+// Valid is set only when every cpu-seconds name resolved to a float, so a
+// renamed or dropped runtime metric yields an absent CPU reading rather than
+// a plausible-looking zero.
+func cpuFromMetrics(s []metrics.Sample) CPUSample {
+	var cpu CPUSample
+
+	seconds := make([]float64, 5)
+	for i := range seconds {
+		if s[i].Value.Kind() != metrics.KindFloat64 {
+			return cpu
+		}
+		seconds[i] = s[i].Value.Float64()
+	}
+
+	cpu.Valid = true
+	cpu.TotalSeconds = seconds[0]
+	cpu.IdleSeconds = seconds[1]
+	cpu.UserSeconds = seconds[2]
+	cpu.GCSeconds = seconds[3]
+	cpu.ScavengeSeconds = seconds[4]
+
+	// GOMAXPROCS is reported separately from the cpu-seconds set: it is a
+	// gauge of a different kind, and its absence should not invalidate an
+	// otherwise good CPU reading.
+	if s[5].Value.Kind() == metrics.KindUint64 {
+		cpu.GOMAXPROCS = int(s[5].Value.Uint64())
+	}
+
+	return cpu
+}

--- a/policy/scanstats/sample_test.go
+++ b/policy/scanstats/sample_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scanstats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSample_ReturnsLiveValues(t *testing.T) {
+	s := defaultSample()
+
+	// A running Go process always has a non-zero footprint and at least
+	// this test's own goroutine. The stub returned a zero Sample.
+	require.Greater(t, s.RuntimeBytes, uint64(0))
+	require.Greater(t, s.Goroutines, 0)
+}
+
+// metricByName indexes a ScanStatistics for assertion by metric name.
+
+func TestDefaultSample_ReturnsLiveCPUValues(t *testing.T) {
+	s := defaultSample()
+
+	require.True(t, s.CPU.Valid, "every /cpu/classes name should resolve on a supported Go runtime")
+	require.Greater(t, s.CPU.TotalSeconds, 0.0, "a running process has consumed some wall-clock CPU capacity")
+	require.GreaterOrEqual(t, s.CPU.TotalSeconds, s.CPU.IdleSeconds,
+		"total is CPU available and includes idle, so it can never be the smaller of the two")
+	require.Greater(t, s.CPU.GOMAXPROCS, 0)
+}
+
+func TestCPUSample_BusyExcludesIdle(t *testing.T) {
+	// The trap this guards: /cpu/classes/total is CPU *available*, not CPU
+	// consumed. Reporting it as usage would overstate every scan by the idle
+	// share, which on a mostly-waiting scan is nearly all of it.
+	c := CPUSample{TotalSeconds: 10, IdleSeconds: 7}
+	require.Equal(t, 3.0, c.Busy())
+}
+
+func TestCPUSample_BusyNeverNegative(t *testing.T) {
+	c := CPUSample{TotalSeconds: 4, IdleSeconds: 9}
+	require.Equal(t, 0.0, c.Busy())
+}

--- a/policy/scanstats/tracker.go
+++ b/policy/scanstats/tracker.go
@@ -191,12 +191,12 @@ func (t *ResourceTracker) Snapshot() ResourceSnapshot {
 // cpuUsage is the run's CPU consumption: the difference between the latest
 // observation and the baseline taken at the run's first observation.
 type cpuUsage struct {
-	busy      float64
-	available float64
-	user      float64
-	gc        float64
-	scavenge  float64
-	gomaxprcs int
+	busy       float64
+	available  float64
+	user       float64
+	gc         float64
+	scavenge   float64
+	gomaxprocs int
 }
 
 // cpuUsageLocked computes the run's CPU deltas. Callers must hold t.mu.
@@ -217,12 +217,12 @@ func (t *ResourceTracker) cpuUsageLocked() (cpuUsage, bool) {
 	}
 
 	return cpuUsage{
-		busy:      delta(t.lastCPU.Busy(), t.cpuBaseline.Busy()),
-		available: delta(t.lastCPU.TotalSeconds, t.cpuBaseline.TotalSeconds),
-		user:      delta(t.lastCPU.UserSeconds, t.cpuBaseline.UserSeconds),
-		gc:        delta(t.lastCPU.GCSeconds, t.cpuBaseline.GCSeconds),
-		scavenge:  delta(t.lastCPU.ScavengeSeconds, t.cpuBaseline.ScavengeSeconds),
-		gomaxprcs: t.lastCPU.GOMAXPROCS,
+		busy:       delta(t.lastCPU.Busy(), t.cpuBaseline.Busy()),
+		available:  delta(t.lastCPU.TotalSeconds, t.cpuBaseline.TotalSeconds),
+		user:       delta(t.lastCPU.UserSeconds, t.cpuBaseline.UserSeconds),
+		gc:         delta(t.lastCPU.GCSeconds, t.cpuBaseline.GCSeconds),
+		scavenge:   delta(t.lastCPU.ScavengeSeconds, t.cpuBaseline.ScavengeSeconds),
+		gomaxprocs: t.lastCPU.GOMAXPROCS,
 	}, true
 }
 
@@ -326,8 +326,8 @@ func (t *ResourceTracker) Record(c *Collector) {
 		if cpu.available > 0 {
 			c.AddDouble(MetricCPUUtilization, "", cpu.busy/cpu.available)
 		}
-		if cpu.gomaxprcs > 0 {
-			c.AddInt(MetricCPUGOMAXPROCS, "count", int64(cpu.gomaxprcs))
+		if cpu.gomaxprocs > 0 {
+			c.AddInt(MetricCPUGOMAXPROCS, "count", int64(cpu.gomaxprocs))
 		}
 	}
 

--- a/policy/scanstats/tracker.go
+++ b/policy/scanstats/tracker.go
@@ -5,33 +5,13 @@ package scanstats
 
 import (
 	"math"
-	"os"
-	"path/filepath"
-	"runtime"
-	"runtime/metrics"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
 
-// Sample is one observation of this process's memory state.
-type Sample struct {
-	// RuntimeBytes is the Go runtime's memory footprint — the quantity the
-	// runtime accounts against GOMEMLIMIT, and the one the OOM killer acts
-	// on. Deliberately not MemStats.Alloc, which counts only live heap
-	// objects and so understates the real footprint.
-	RuntimeBytes uint64
-	Goroutines   int
-}
-
-// SampleFunc returns a current Sample. Injected so the high-water logic is
-// testable without a live runtime.
-type SampleFunc func() Sample
-
-// MemTrackerConfig configures a MemTracker. A zero Sample or CgroupRoot
-// falls back to the real process defaults.
-type MemTrackerConfig struct {
+// ResourceTrackerConfig configures a ResourceTracker. A zero Sample or
+// CgroupRoot falls back to the real process defaults.
+type ResourceTrackerConfig struct {
 	RunID          string
 	Parallelism    int
 	MaxConnections int
@@ -39,17 +19,23 @@ type MemTrackerConfig struct {
 	CgroupRoot     string
 }
 
-// MemTracker holds memory high-water marks for one scan run. A tracker is
-// created per scan run (per distributeJob call), not per process: for the
-// CLI these coincide, but a long-lived serve/queue process handling multiple
-// jobs gets a fresh tracker per job. Memory is process-wide while scanstats
-// Collectors are per-asset, so a single tracker is shared across every asset
-// scanned by its run; RunID is what lets the resulting per-asset records be
-// grouped back into the run they came from.
+// ResourceTracker holds resource usage for one scan run: memory high-water
+// marks and cumulative CPU. A tracker is created per scan run (per
+// distributeJob call), not per process: for the CLI these coincide, but a
+// long-lived serve/queue process handling multiple jobs gets a fresh tracker
+// per job. Usage is process-wide while scanstats Collectors are per-asset, so
+// a single tracker is shared across every asset scanned by its run; RunID is
+// what lets the resulting per-asset records be grouped back into the run they
+// came from.
+//
+// Memory and CPU are tracked differently because they are different kinds of
+// quantity. Memory is instantaneous, so the tracker keeps peaks. CPU counters
+// are cumulative since process start, so the tracker keeps a baseline taken
+// at the run's first observation and reports the difference.
 //
 // Every exported method is safe on a nil receiver: telemetry must never
 // panic a scan.
-type MemTracker struct {
+type ResourceTracker struct {
 	mu             sync.Mutex
 	peakRuntime    uint64
 	peakGoroutines int
@@ -65,9 +51,17 @@ type MemTracker struct {
 	// from a real measurement.
 	hasSample bool
 
+	// cpuBaseline is the first valid CPU reading of the run; lastCPU is the
+	// most recent. Their difference is the run's CPU usage. hasCPUBaseline
+	// tracks resolution rather than a non-zero value, because zero
+	// CPU-seconds is a legitimate reading for a very short scan.
+	cpuBaseline    CPUSample
+	lastCPU        CPUSample
+	hasCPUBaseline bool
+
 	inFlight func() int
 
-	cfg MemTrackerConfig
+	cfg ResourceTrackerConfig
 
 	stopOnce sync.Once
 	stop     chan struct{}
@@ -78,15 +72,15 @@ type MemTracker struct {
 	wg sync.WaitGroup
 }
 
-// NewMemTracker returns a tracker. Sampling does not start until Start.
-func NewMemTracker(cfg MemTrackerConfig) *MemTracker {
+// NewResourceTracker returns a tracker. Sampling does not start until Start.
+func NewResourceTracker(cfg ResourceTrackerConfig) *ResourceTracker {
 	if cfg.Sample == nil {
 		cfg.Sample = defaultSample
 	}
 	if cfg.CgroupRoot == "" {
 		cfg.CgroupRoot = defaultCgroupRoot
 	}
-	return &MemTracker{cfg: cfg, stop: make(chan struct{})}
+	return &ResourceTracker{cfg: cfg, stop: make(chan struct{})}
 }
 
 // SetInFlightFunc registers an accessor for the number of assets currently
@@ -96,7 +90,7 @@ func NewMemTracker(cfg MemTrackerConfig) *MemTracker {
 // f is invoked while the tracker's mutex is held, so it must not block, do
 // I/O, or call back into the tracker: the mutex is not reentrant, so a
 // callback into Peaks or Snapshot would self-deadlock.
-func (t *MemTracker) SetInFlightFunc(f func() int) {
+func (t *ResourceTracker) SetInFlightFunc(f func() int) {
 	if t == nil {
 		return
 	}
@@ -105,8 +99,9 @@ func (t *MemTracker) SetInFlightFunc(f func() int) {
 	t.mu.Unlock()
 }
 
-// Observe takes one sample and folds it into the high-water marks.
-func (t *MemTracker) Observe() {
+// Observe takes one sample, folds the memory readings into the high-water
+// marks, and advances the CPU counters.
+func (t *ResourceTracker) Observe() {
 	if t == nil {
 		return
 	}
@@ -128,12 +123,20 @@ func (t *MemTracker) Observe() {
 	if s.Goroutines > t.peakGoroutines {
 		t.peakGoroutines = s.Goroutines
 	}
+
+	if s.CPU.Valid {
+		if !t.hasCPUBaseline {
+			t.cpuBaseline = s.CPU
+			t.hasCPUBaseline = true
+		}
+		t.lastCPU = s.CPU
+	}
 }
 
 // Peaks returns the current high-water marks: runtime footprint bytes,
 // goroutine count, and the in-flight asset count at the moment the footprint
 // peak was set. Safe on a nil tracker, which reports zeroes.
-func (t *MemTracker) Peaks() (runtimeBytes uint64, goroutines int, inFlightAtPeak int) {
+func (t *ResourceTracker) Peaks() (runtimeBytes uint64, goroutines int, inFlightAtPeak int) {
 	if t == nil {
 		return 0, 0, 0
 	}
@@ -142,131 +145,92 @@ func (t *MemTracker) Peaks() (runtimeBytes uint64, goroutines int, inFlightAtPea
 	return t.peakRuntime, t.peakGoroutines, t.inFlightAtPeak
 }
 
-// MemSnapshot is a point-in-time view for diagnostics: the latest observed
-// runtime footprint plus best-effort cgroup readings. Presence flags follow
-// the same absent-never-zero rule as the recorded metrics.
-type MemSnapshot struct {
+// ResourceSnapshot is a point-in-time view for diagnostics: the latest
+// observed runtime footprint and CPU usage so far, plus best-effort cgroup
+// readings. Presence flags follow the same absent-never-zero rule as the
+// recorded metrics.
+type ResourceSnapshot struct {
 	RuntimeBytes     uint64
 	HasRuntime       bool
 	CgroupCurrent    uint64
 	HasCgroupCurrent bool
 	CgroupMax        uint64
 	HasCgroupMax     bool
+	CPUBusySeconds   float64
+	HasCPU           bool
 }
 
 // Snapshot returns the current diagnostic view. Safe on a nil tracker, which
 // reports everything absent.
-func (t *MemTracker) Snapshot() MemSnapshot {
+func (t *ResourceTracker) Snapshot() ResourceSnapshot {
 	if t == nil {
-		return MemSnapshot{}
+		return ResourceSnapshot{}
 	}
 
 	t.mu.Lock()
 	last, hasSample := t.lastRuntime, t.hasSample
+	cpu, hasCPU := t.cpuUsageLocked()
 	t.mu.Unlock()
 
 	// File I/O outside the lock: reading cgroup files under the tracker
 	// mutex would block the sampler goroutine.
 	cg := readCgroup(t.cfg.CgroupRoot)
 
-	return MemSnapshot{
+	return ResourceSnapshot{
 		RuntimeBytes:     last,
 		HasRuntime:       hasSample,
 		CgroupCurrent:    cg.current,
 		HasCgroupCurrent: cg.hasCurrent,
 		CgroupMax:        cg.max,
 		HasCgroupMax:     cg.hasMax,
+		CPUBusySeconds:   cpu.busy,
+		HasCPU:           hasCPU,
 	}
 }
 
-// defaultCgroupRoot is the cgroup v2 unified hierarchy mount point.
-const defaultCgroupRoot = "/sys/fs/cgroup"
-
-// cgroupStats holds cgroup v2 memory readings. Each value carries a
-// presence flag: a value that could not be read is absent, never zero.
-// Reporting zero would be indistinguishable from a real measurement and
-// would corrupt any aggregate computed across a mixed fleet.
-type cgroupStats struct {
-	current, peak, max          uint64
-	hasCurrent, hasPeak, hasMax bool
+// cpuUsage is the run's CPU consumption: the difference between the latest
+// observation and the baseline taken at the run's first observation.
+type cpuUsage struct {
+	busy      float64
+	available float64
+	user      float64
+	gc        float64
+	scavenge  float64
+	gomaxprcs int
 }
 
-// readCgroup reads cgroup v2 memory values from root, best-effort. Every
-// file is optional: non-Linux hosts have no cgroup at all, cgroup v1 has a
-// different layout, and memory.peak requires Linux 5.19 or later.
-func readCgroup(root string) cgroupStats {
-	var cg cgroupStats
-	cg.current, cg.hasCurrent = readCgroupValue(root, "memory.current")
-	cg.peak, cg.hasPeak = readCgroupValue(root, "memory.peak")
-	cg.max, cg.hasMax = readCgroupValue(root, "memory.max")
-	return cg
-}
-
-// readCgroupValue reads a single unsigned integer from a cgroup file. The
-// literal "max" means no limit and is reported as absent rather than as a
-// sentinel number.
-func readCgroupValue(root, name string) (uint64, bool) {
-	raw, err := os.ReadFile(filepath.Join(root, name))
-	if err != nil {
-		return 0, false
-	}
-	s := strings.TrimSpace(string(raw))
-	if s == "" || s == "max" {
-		return 0, false
-	}
-	v, err := strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	return v, true
-}
-
-// runtimeFootprintMetrics are the runtime/metrics names whose difference is
-// the Go runtime's memory footprint — the same quantity the runtime accounts
-// against GOMEMLIMIT.
-const (
-	metricTotalBytes        = "/memory/classes/total:bytes"
-	metricHeapReleasedBytes = "/memory/classes/heap/released:bytes"
-)
-
-// defaultSample reads the live process memory state.
+// cpuUsageLocked computes the run's CPU deltas. Callers must hold t.mu.
 //
-// It uses runtime/metrics rather than runtime.ReadMemStats for two reasons:
-// ReadMemStats stops the world, which would perturb the very scan being
-// measured; and MemStats.Alloc counts only live heap objects, excluding
-// stacks and memory the runtime has retained but not returned to the OS, so
-// it systematically understates what the OOM killer acts on.
-func defaultSample() Sample {
-	// A fresh slice per call: metrics.Read writes into it, so a shared one
-	// would need its own lock and this is called once a second.
-	s := []metrics.Sample{
-		{Name: metricTotalBytes},
-		{Name: metricHeapReleasedBytes},
-	}
-	metrics.Read(s)
-
-	var total, released uint64
-	if s[0].Value.Kind() == metrics.KindUint64 {
-		total = s[0].Value.Uint64()
-	}
-	if s[1].Value.Kind() == metrics.KindUint64 {
-		released = s[1].Value.Uint64()
+// Each delta is clamped at zero. The counters are monotonic within a process
+// so a negative difference should be impossible, but reporting a negative
+// CPU-seconds figure would be worse than reporting none.
+func (t *ResourceTracker) cpuUsageLocked() (cpuUsage, bool) {
+	if !t.hasCPUBaseline {
+		return cpuUsage{}, false
 	}
 
-	var footprint uint64
-	if total > released {
-		footprint = total - released
+	delta := func(now, base float64) float64 {
+		if now > base {
+			return now - base
+		}
+		return 0
 	}
 
-	return Sample{
-		RuntimeBytes: footprint,
-		Goroutines:   runtime.NumGoroutine(),
-	}
+	return cpuUsage{
+		busy:      delta(t.lastCPU.Busy(), t.cpuBaseline.Busy()),
+		available: delta(t.lastCPU.TotalSeconds, t.cpuBaseline.TotalSeconds),
+		user:      delta(t.lastCPU.UserSeconds, t.cpuBaseline.UserSeconds),
+		gc:        delta(t.lastCPU.GCSeconds, t.cpuBaseline.GCSeconds),
+		scavenge:  delta(t.lastCPU.ScavengeSeconds, t.cpuBaseline.ScavengeSeconds),
+		gomaxprcs: t.lastCPU.GOMAXPROCS,
+	}, true
 }
 
 // Start begins sampling every interval until Stop. It takes one sample
-// immediately so a scan shorter than a single tick still reports a value.
-func (t *MemTracker) Start(interval time.Duration) {
+// immediately so a scan shorter than a single tick still reports a value —
+// and so the CPU baseline is taken at the start of the run rather than a
+// tick into it.
+func (t *ResourceTracker) Start(interval time.Duration) {
 	if t == nil {
 		return
 	}
@@ -291,7 +255,7 @@ func (t *MemTracker) Start(interval time.Duration) {
 // Stop ends sampling and waits for the sampling goroutine to exit, so that
 // once it returns no further observations can occur. Safe to call more than
 // once, and on a nil tracker.
-func (t *MemTracker) Stop() {
+func (t *ResourceTracker) Stop() {
 	if t == nil {
 		return
 	}
@@ -316,7 +280,7 @@ func addBytes(c *Collector, name string, v uint64) {
 //
 // Values that could not be measured are omitted rather than recorded as
 // zero: a zero cannot be told apart from a real measurement downstream.
-func (t *MemTracker) Record(c *Collector) {
+func (t *ResourceTracker) Record(c *Collector) {
 	if t == nil || c == nil {
 		return
 	}
@@ -330,6 +294,7 @@ func (t *MemTracker) Record(c *Collector) {
 	t.mu.Lock()
 	peak, last, hasSample := t.peakRuntime, t.lastRuntime, t.hasSample
 	goroutines, inFlight := t.peakGoroutines, t.inFlightAtPeak
+	cpu, hasCPU := t.cpuUsageLocked()
 	t.mu.Unlock()
 
 	if t.cfg.RunID != "" {
@@ -343,6 +308,27 @@ func (t *MemTracker) Record(c *Collector) {
 		addBytes(c, MetricMemRuntimePeak, peak)
 		addBytes(c, MetricMemRuntimeAtFinish, last)
 		c.AddInt(MetricMemGoroutinesPeak, "count", int64(goroutines))
+	}
+
+	if hasCPU {
+		c.AddDouble(MetricCPUBusySeconds, "s", cpu.busy)
+		c.AddDouble(MetricCPUAvailableSeconds, "s", cpu.available)
+		c.AddDouble(MetricCPUUserSeconds, "s", cpu.user)
+		c.AddDouble(MetricCPUGCSeconds, "s", cpu.gc)
+		c.AddDouble(MetricCPUScavengeSeconds, "s", cpu.scavenge)
+
+		// Ratios are omitted rather than reported as zero when their
+		// denominator is zero: a fabricated 0.0 fraction reads downstream as
+		// "no time in GC" when the truth is "not enough CPU to say".
+		if cpu.busy > 0 {
+			c.AddDouble(MetricCPUGCFraction, "", cpu.gc/cpu.busy)
+		}
+		if cpu.available > 0 {
+			c.AddDouble(MetricCPUUtilization, "", cpu.busy/cpu.available)
+		}
+		if cpu.gomaxprcs > 0 {
+			c.AddInt(MetricCPUGOMAXPROCS, "count", int64(cpu.gomaxprcs))
+		}
 	}
 
 	c.AddInt(MetricConcurrencyInFlightAtPeak, "count", int64(inFlight))

--- a/policy/scanstats/tracker_test.go
+++ b/policy/scanstats/tracker_test.go
@@ -5,7 +5,6 @@ package scanstats
 
 import (
 	"math"
-	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -33,8 +32,8 @@ func fakeSampler(samples ...Sample) SampleFunc {
 	}
 }
 
-func TestMemTracker_TracksHighWaterNotLatest(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_TracksHighWaterNotLatest(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		Sample: fakeSampler(
 			Sample{RuntimeBytes: 100, Goroutines: 10},
 			Sample{RuntimeBytes: 900, Goroutines: 90},
@@ -53,9 +52,9 @@ func TestMemTracker_TracksHighWaterNotLatest(t *testing.T) {
 	require.Equal(t, uint64(300), tr.lastRuntime)
 }
 
-func TestMemTracker_InFlightCapturedAtPeakNotAtLastSample(t *testing.T) {
+func TestResourceTracker_InFlightCapturedAtPeakNotAtLastSample(t *testing.T) {
 	inFlight := 0
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		Sample: fakeSampler(
 			Sample{RuntimeBytes: 100},
 			Sample{RuntimeBytes: 900}, // peak happens here
@@ -76,93 +75,22 @@ func TestMemTracker_InFlightCapturedAtPeakNotAtLastSample(t *testing.T) {
 	require.Equal(t, 48, tr.inFlightAtPeak)
 }
 
-func TestMemTracker_NilReceiverIsSafe(t *testing.T) {
-	var tr *MemTracker
+func TestResourceTracker_NilReceiverIsSafe(t *testing.T) {
+	var tr *ResourceTracker
 	require.NotPanics(t, func() {
 		tr.Observe()
 		tr.SetInFlightFunc(func() int { return 1 })
 	})
 }
 
-func TestMemTracker_NoInFlightFuncDoesNotPanic(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_NoInFlightFuncDoesNotPanic(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		Sample: fakeSampler(Sample{RuntimeBytes: 100}),
 	})
 	require.NotPanics(t, func() { tr.Observe() })
 	require.Equal(t, 0, tr.inFlightAtPeak)
 }
 
-func writeCgroupFile(t *testing.T, dir, name, contents string) {
-	t.Helper()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
-}
-
-func TestReadCgroup_AllPresent(t *testing.T) {
-	dir := t.TempDir()
-	writeCgroupFile(t, dir, "memory.current", "3402137600\n")
-	writeCgroupFile(t, dir, "memory.peak", "3500000000\n")
-	writeCgroupFile(t, dir, "memory.max", "4294967296\n")
-
-	cg := readCgroup(dir)
-	require.True(t, cg.hasCurrent)
-	require.Equal(t, uint64(3402137600), cg.current)
-	require.True(t, cg.hasPeak)
-	require.Equal(t, uint64(3500000000), cg.peak)
-	require.True(t, cg.hasMax)
-	require.Equal(t, uint64(4294967296), cg.max)
-}
-
-func TestReadCgroup_AbsentDirectoryReportsNothing(t *testing.T) {
-	// Non-Linux hosts and cgroup v1 systems: every value must be absent,
-	// never zero. A zero would be read downstream as a real measurement.
-	cg := readCgroup(filepath.Join(t.TempDir(), "does-not-exist"))
-	require.False(t, cg.hasCurrent)
-	require.False(t, cg.hasPeak)
-	require.False(t, cg.hasMax)
-}
-
-func TestReadCgroup_UnlimitedMaxIsAbsent(t *testing.T) {
-	// "max" means no limit. Reporting it as a number would invent a ceiling
-	// that does not exist and make headroom ratios meaningless.
-	dir := t.TempDir()
-	writeCgroupFile(t, dir, "memory.current", "1024\n")
-	writeCgroupFile(t, dir, "memory.max", "max\n")
-
-	cg := readCgroup(dir)
-	require.True(t, cg.hasCurrent)
-	require.False(t, cg.hasMax)
-}
-
-func TestReadCgroup_MissingPeakOnOlderKernel(t *testing.T) {
-	// memory.peak requires Linux 5.19+; the others must still be reported.
-	dir := t.TempDir()
-	writeCgroupFile(t, dir, "memory.current", "2048\n")
-	writeCgroupFile(t, dir, "memory.max", "8192\n")
-
-	cg := readCgroup(dir)
-	require.True(t, cg.hasCurrent)
-	require.False(t, cg.hasPeak)
-	require.True(t, cg.hasMax)
-}
-
-func TestReadCgroup_MalformedValueIsAbsent(t *testing.T) {
-	dir := t.TempDir()
-	writeCgroupFile(t, dir, "memory.current", "not-a-number\n")
-
-	cg := readCgroup(dir)
-	require.False(t, cg.hasCurrent)
-}
-
-func TestDefaultSample_ReturnsLiveValues(t *testing.T) {
-	s := defaultSample()
-
-	// A running Go process always has a non-zero footprint and at least
-	// this test's own goroutine. The stub returned a zero Sample.
-	require.Greater(t, s.RuntimeBytes, uint64(0))
-	require.Greater(t, s.Goroutines, 0)
-}
-
-// metricByName indexes a ScanStatistics for assertion by metric name.
 func metricByName(t *testing.T, c *Collector) map[string]*policy.Metric {
 	t.Helper()
 	stats := c.ToProto()
@@ -174,13 +102,13 @@ func metricByName(t *testing.T, c *Collector) map[string]*policy.Metric {
 	return out
 }
 
-func TestMemTracker_RecordWritesPeaksAndRunConstants(t *testing.T) {
+func TestResourceTracker_RecordWritesPeaksAndRunConstants(t *testing.T) {
 	dir := t.TempDir()
 	writeCgroupFile(t, dir, "memory.current", "3402137600\n")
 	writeCgroupFile(t, dir, "memory.peak", "3500000000\n")
 	writeCgroupFile(t, dir, "memory.max", "4294967296\n")
 
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		RunID:          "run-abc",
 		Parallelism:    16,
 		MaxConnections: 50,
@@ -213,8 +141,8 @@ func TestMemTracker_RecordWritesPeaksAndRunConstants(t *testing.T) {
 	require.Equal(t, int64(4294967296), m[MetricMemCgroupMax].GetIntValue())
 }
 
-func TestMemTracker_RecordOmitsCgroupMetricsWhenUnavailable(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_RecordOmitsCgroupMetricsWhenUnavailable(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		RunID:      "run-abc",
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 100, Goroutines: 10}),
@@ -233,8 +161,8 @@ func TestMemTracker_RecordOmitsCgroupMetricsWhenUnavailable(t *testing.T) {
 	require.Contains(t, m, MetricMemRuntimePeak)
 }
 
-func TestMemTracker_RecordOmitsRunIDWhenUnset(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_RecordOmitsRunIDWhenUnset(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 100}),
 	})
@@ -245,18 +173,18 @@ func TestMemTracker_RecordOmitsRunIDWhenUnset(t *testing.T) {
 	require.NotContains(t, metricByName(t, c), MetricRunID)
 }
 
-func TestMemTracker_RecordNilSafe(t *testing.T) {
-	var tr *MemTracker
+func TestResourceTracker_RecordNilSafe(t *testing.T) {
+	var tr *ResourceTracker
 	c := New()
 	require.NotPanics(t, func() { tr.Record(c) })
 	require.Nil(t, c.ToProto())
 
-	real := NewMemTracker(MemTrackerConfig{Sample: fakeSampler(Sample{RuntimeBytes: 1})})
+	real := NewResourceTracker(ResourceTrackerConfig{Sample: fakeSampler(Sample{RuntimeBytes: 1})})
 	require.NotPanics(t, func() { real.Record(nil) })
 }
 
-func TestMemTracker_StartStopObservesAndIsIdempotent(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_StartStopObservesAndIsIdempotent(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 500, Goroutines: 5}),
 	})
@@ -271,17 +199,17 @@ func TestMemTracker_StartStopObservesAndIsIdempotent(t *testing.T) {
 	tr.Stop()
 	require.NotPanics(t, func() { tr.Stop() }) // double Stop must not panic
 
-	var nilTr *MemTracker
+	var nilTr *ResourceTracker
 	require.NotPanics(t, func() {
 		nilTr.Start(time.Millisecond)
 		nilTr.Stop()
 	})
 }
 
-func TestMemTracker_RecordOmitsRuntimeMetricsWhenNoSampleEverResolved(t *testing.T) {
+func TestResourceTracker_RecordOmitsRuntimeMetricsWhenNoSampleEverResolved(t *testing.T) {
 	// A zero-byte sample simulates every runtime/metrics name failing to
 	// resolve: defaultSample falls back to 0 rather than a real footprint.
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		RunID:      "run-abc",
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 0, Goroutines: 0}),
@@ -304,8 +232,8 @@ func TestMemTracker_RecordOmitsRuntimeMetricsWhenNoSampleEverResolved(t *testing
 	require.Contains(t, m, MetricConcurrencyMaxConnections)
 }
 
-func TestMemTracker_RecordRefreshesAtFinishRatherThanUsingStaleSample(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_RecordRefreshesAtFinishRatherThanUsingStaleSample(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample: fakeSampler(
 			Sample{RuntimeBytes: 100, Goroutines: 1},
@@ -326,12 +254,12 @@ func TestMemTracker_RecordRefreshesAtFinishRatherThanUsingStaleSample(t *testing
 	require.Equal(t, int64(200), m[MetricMemRuntimePeak].GetIntValue())
 }
 
-func TestMemTracker_SnapshotReportsPresentAndAbsentCgroupValues(t *testing.T) {
+func TestResourceTracker_SnapshotReportsPresentAndAbsentCgroupValues(t *testing.T) {
 	dir := t.TempDir()
 	writeCgroupFile(t, dir, "memory.current", "1048576\n")
 	writeCgroupFile(t, dir, "memory.max", "2097152\n")
 
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: dir,
 		Sample:     fakeSampler(Sample{RuntimeBytes: 555, Goroutines: 5}),
 	})
@@ -346,8 +274,8 @@ func TestMemTracker_SnapshotReportsPresentAndAbsentCgroupValues(t *testing.T) {
 	require.Equal(t, uint64(2097152), snap.CgroupMax)
 }
 
-func TestMemTracker_SnapshotReportsAbsentWhenCgroupRootMissing(t *testing.T) {
-	tr := NewMemTracker(MemTrackerConfig{
+func TestResourceTracker_SnapshotReportsAbsentWhenCgroupRootMissing(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 0, Goroutines: 0}),
 	})
@@ -359,16 +287,16 @@ func TestMemTracker_SnapshotReportsAbsentWhenCgroupRootMissing(t *testing.T) {
 	require.False(t, snap.HasCgroupMax)
 }
 
-func TestMemTracker_SnapshotNilReceiverIsSafe(t *testing.T) {
-	var tr *MemTracker
-	var snap MemSnapshot
+func TestResourceTracker_SnapshotNilReceiverIsSafe(t *testing.T) {
+	var tr *ResourceTracker
+	var snap ResourceSnapshot
 	require.NotPanics(t, func() { snap = tr.Snapshot() })
-	require.Equal(t, MemSnapshot{}, snap)
+	require.Equal(t, ResourceSnapshot{}, snap)
 }
 
-func TestMemTracker_StartTakesAnImmediateSample(t *testing.T) {
+func TestResourceTracker_StartTakesAnImmediateSample(t *testing.T) {
 	// A scan shorter than one tick must still report something.
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample:     fakeSampler(Sample{RuntimeBytes: 777, Goroutines: 7}),
 	})
@@ -390,7 +318,7 @@ func TestRecord_OmitsByteValuesThatCannotBeRepresented(t *testing.T) {
 	writeCgroupFile(t, dir, "memory.current", "1024\n")
 	writeCgroupFile(t, dir, "memory.max", "18446744073709551615\n") // 2^64-1
 
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: dir,
 		Sample:     fakeSampler(Sample{RuntimeBytes: 1 << 63, Goroutines: 3}),
 	})
@@ -413,7 +341,7 @@ func TestRecord_KeepsLargestRepresentableByteValue(t *testing.T) {
 	dir := t.TempDir()
 	writeCgroupFile(t, dir, "memory.current", "9223372036854775807\n") // 2^63-1
 
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: dir,
 		Sample:     fakeSampler(Sample{RuntimeBytes: 100, Goroutines: 1}),
 	})
@@ -424,9 +352,9 @@ func TestRecord_KeepsLargestRepresentableByteValue(t *testing.T) {
 	require.Equal(t, int64(math.MaxInt64), metricByName(t, c)[MetricMemCgroupCurrent].GetIntValue())
 }
 
-func TestMemTracker_StopWaitsForSamplerToExit(t *testing.T) {
+func TestResourceTracker_StopWaitsForSamplerToExit(t *testing.T) {
 	var samples atomic.Int64
-	tr := NewMemTracker(MemTrackerConfig{
+	tr := NewResourceTracker(ResourceTrackerConfig{
 		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
 		Sample: func() Sample {
 			samples.Add(1)
@@ -442,4 +370,143 @@ func TestMemTracker_StopWaitsForSamplerToExit(t *testing.T) {
 	after := samples.Load()
 	time.Sleep(20 * time.Millisecond)
 	require.Equal(t, after, samples.Load())
+}
+
+// cpuAt builds a Sample carrying a resolved CPU reading. The memory side is
+// held non-zero so the runtime metrics stay present and do not interfere with
+// what the CPU assertions are measuring.
+func cpuAt(total, idle, user, gc, scavenge float64) Sample {
+	return Sample{
+		RuntimeBytes: 1000,
+		Goroutines:   5,
+		CPU: CPUSample{
+			Valid:           true,
+			TotalSeconds:    total,
+			IdleSeconds:     idle,
+			UserSeconds:     user,
+			GCSeconds:       gc,
+			ScavengeSeconds: scavenge,
+			GOMAXPROCS:      8,
+		},
+	}
+}
+
+func TestResourceTracker_RecordReportsCPUDeltaNotAbsoluteCounters(t *testing.T) {
+	// The counters are cumulative since PROCESS start, so a scan that begins
+	// in an already-warm process must not be charged for CPU burned before it
+	// started. The baseline is taken at the first observation.
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample: fakeSampler(
+			cpuAt(100, 60, 30, 8, 2),  // baseline: 40 busy already burned
+			cpuAt(130, 75, 45, 12, 3), // now: 55 busy => this run used 15
+		),
+	})
+	tr.Observe() // baseline
+	tr.Observe() // advances to the second sample
+
+	c := New()
+	tr.Record(c) // Record observes again; sampler repeats the last value
+	m := metricByName(t, c)
+
+	require.InDelta(t, 15.0, m[MetricCPUBusySeconds].GetDoubleValue(), 0.0001)
+	require.InDelta(t, 30.0, m[MetricCPUAvailableSeconds].GetDoubleValue(), 0.0001)
+	require.InDelta(t, 15.0, m[MetricCPUUserSeconds].GetDoubleValue(), 0.0001)
+	require.InDelta(t, 4.0, m[MetricCPUGCSeconds].GetDoubleValue(), 0.0001)
+	require.InDelta(t, 1.0, m[MetricCPUScavengeSeconds].GetDoubleValue(), 0.0001)
+	require.Equal(t, int64(8), m[MetricCPUGOMAXPROCS].GetIntValue())
+}
+
+func TestResourceTracker_RecordComputesCPUFractions(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample: fakeSampler(
+			cpuAt(0, 0, 0, 0, 0),
+			cpuAt(100, 60, 30, 10, 0), // 40 busy of 100 available, 10 in GC
+		),
+	})
+	tr.Observe()
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	require.InDelta(t, 0.25, m[MetricCPUGCFraction].GetDoubleValue(), 0.0001)  // 10 / 40
+	require.InDelta(t, 0.40, m[MetricCPUUtilization].GetDoubleValue(), 0.0001) // 40 / 100
+}
+
+func TestResourceTracker_RecordKeepsZeroCPUForVeryShortScan(t *testing.T) {
+	// The distinction that separates CPU from memory: a live process always
+	// has a non-zero memory footprint, so zero there means "did not resolve"
+	// and is omitted. But a scan short enough legitimately burns ~0
+	// CPU-seconds, so a zero CPU delta is a REAL measurement and must be
+	// reported. Omitting it would silently drop every fast scan.
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(cpuAt(100, 100, 0, 0, 0)),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	require.Contains(t, m, MetricCPUBusySeconds)
+	require.Equal(t, 0.0, m[MetricCPUBusySeconds].GetDoubleValue())
+	// The ratios, by contrast, are omitted: their denominator is zero, and a
+	// fabricated 0.0 would read as "no time in GC" rather than "cannot say".
+	require.NotContains(t, m, MetricCPUGCFraction)
+	require.NotContains(t, m, MetricCPUUtilization)
+}
+
+func TestResourceTracker_RecordOmitsCPUWhenNeverResolved(t *testing.T) {
+	// CPU.Valid false stands for a runtime that renamed or dropped one of the
+	// /cpu/classes names. Absent, never zero.
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(Sample{RuntimeBytes: 1000, Goroutines: 5}),
+	})
+	tr.Observe()
+
+	c := New()
+	tr.Record(c)
+	m := metricByName(t, c)
+
+	for _, name := range []string{
+		MetricCPUBusySeconds, MetricCPUAvailableSeconds, MetricCPUUserSeconds,
+		MetricCPUGCSeconds, MetricCPUScavengeSeconds, MetricCPUGCFraction,
+		MetricCPUUtilization, MetricCPUGOMAXPROCS,
+	} {
+		require.NotContains(t, m, name)
+	}
+	// The memory side is unaffected by CPU being unavailable.
+	require.Contains(t, m, MetricMemRuntimePeak)
+}
+
+func TestResourceTracker_SnapshotReportsCPUBusySeconds(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample: fakeSampler(
+			cpuAt(10, 5, 3, 1, 0),
+			cpuAt(30, 15, 10, 3, 0), // busy goes 5 -> 15, so the run used 10
+		),
+	})
+	tr.Observe()
+	tr.Observe()
+
+	snap := tr.Snapshot()
+	require.True(t, snap.HasCPU)
+	require.InDelta(t, 10.0, snap.CPUBusySeconds, 0.0001)
+}
+
+func TestResourceTracker_SnapshotReportsCPUAbsentBeforeAnyObservation(t *testing.T) {
+	tr := NewResourceTracker(ResourceTrackerConfig{
+		CgroupRoot: filepath.Join(t.TempDir(), "absent"),
+		Sample:     fakeSampler(cpuAt(10, 5, 3, 1, 0)),
+	})
+
+	snap := tr.Snapshot()
+	require.False(t, snap.HasCPU)
+	require.Equal(t, 0.0, snap.CPUBusySeconds)
 }


### PR DESCRIPTION
Extends the scan telemetry from #3274 with CPU usage. Read from the same `runtime/metrics` call the memory sampler already makes, so the marginal cost is a handful of float reads once a second.

Renames `MemTracker` → `ResourceTracker` (and `MemSnapshot` → `ResourceSnapshot`), since the type now carries both, and splits the file it lived in — which was about to outgrow itself — into `tracker.go`, `sample.go`, `cgroup.go`.

## New metrics

`cnspec.scan.cpu.{busy,available,user,gc,scavenge}_seconds`, `cnspec.scan.cpu.{gc_fraction,utilization,gomaxprocs}`. No proto change; `policy.Metric` is namespace-based.

## Three ways CPU differs from memory

These drove the design and are where the bugs would have been.

**Cumulative, not instantaneous.** Memory is a level, so the tracker keeps peaks. The `/cpu/classes/*` counters accumulate since *process* start, so the tracker takes a baseline at the run's first observation and reports the difference. Without that, a scan starting in an already-warm process is charged for CPU burned before it began.

**`total` is CPU available, not CPU consumed** — it includes idle. Burned CPU is `total − idle`, which is what `busy_seconds` reports. Reporting `total` as usage would overstate every scan by its idle share, which for an I/O-bound scan is nearly all of it.

**The presence rule inverts.** A live process always has a non-zero memory footprint, so zero there means "did not resolve" and is omitted. But a scan short enough legitimately burns ~0 CPU-seconds, so **zero CPU is a real measurement** and must be reported. Presence tracks whether the metric names *resolved*, not whether the value is non-zero — keying on value would silently drop every fast scan. There's a test named for exactly this.

Ratios are omitted when their denominator is zero rather than reported as `0.0`, which would read as "no time in GC" when the truth is "not enough CPU to say".

## Verified end to end

A local scan, as the values landed upstream:

```
duration           15173 ms
gomaxprocs         12
available_seconds  181.18    (~= 15.17s x 12 cores)
busy_seconds       1.192     (= user 1.016 + gc 0.176 + scavenge 0)
gc_fraction        0.148
utilization        0.0066
```

The arithmetic cross-checks three independent ways: `available` matches wall-time × GOMAXPROCS, the three classes sum exactly to `busy`, and `busy` matches the local `DEBUG_PROVIDER_MEMORY` line to the digit.

It's also immediately informative — **utilization 0.66%** says scans are overwhelmingly waiting rather than computing, while **~15% of the CPU they do burn goes to GC**.

## Testing

12 new tests. `make test/lint` 0 issues; `policy/scanstats`, `policy/scan`, `internal/datalakes/sqlite`, `policy` all pass under `-race`.

## Notes for review

- `DEBUG_PROVIDER_MEMORY` keeps its name (renaming an operator-facing env var isn't worth it) but now also logs `cpu_busy_seconds`; the log message changed to "resource usage after asset scan".
- No ADR this time, by request. The design rationale lives in the code comments and this description.
