### PR TITLE
🧹 validation: name the pin-bumping workflow after what it does

### DIFF
--- a/.github/workflows/validation-dependency-updates.yaml
+++ b/.github/workflows/validation-dependency-updates.yaml
@@ -1,5 +1,5 @@
 ---
-name: Validation Dependency Updates
+name: Bump validation dependencies
 
 ## Opens pull requests for the pins the variant and remediation validators
 ## check against.
@@ -285,7 +285,7 @@ jobs:
           body: |
             Regenerated `cmd_data/azure_commands.json` with
             `dump_azure_commands.py` against the latest `azure-cli`, by the
-            weekly `Validation Dependency Updates` workflow.
+            weekly `Bump validation dependencies` workflow.
 
             The grammar decides which `az` subcommands and flags the validator
             accepts in `id: cli` remediation and in `audit:` blocks, so a stale
@@ -355,7 +355,7 @@ jobs:
           body: |
             Regenerated `cmd_data/vercel_commands.json` with
             `dump_vercel_commands.py` against the latest `vercel` CLI, by the
-            weekly `Validation Dependency Updates` workflow.
+            weekly `Bump validation dependencies` workflow.
 
             `vercel` is a Node.js CLI with no completion surface, so its
             grammar is parsed out of `--help` once and checked in rather than
@@ -416,7 +416,7 @@ jobs:
           branch: deps/validation/api-specs
           body: |
             Refreshed the Tailscale, Atlassian, and Vercel OpenAPI specs with
-            `dump_api_specs.py`, by the weekly `Validation Dependency Updates`
+            `dump_api_specs.py`, by the weekly `Bump validation dependencies`
             workflow.
 
             These three vendors serve their specs from live, unversioned

--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -63,7 +63,7 @@ jobs:
             python3 content/validation/check_upstream_versions.py --format markdown
             echo
             echo "Most of these already have a pull request: the weekly"
-            echo "\`Validation Dependency Updates\` workflow opens one per *kind* of pin"
+            echo "\`Bump validation dependencies\` workflow opens one per *kind* of pin"
             echo "it can bump mechanically, so rows sharing a \`Kind\` share a pull"
             echo "request. Rows marked \`(manual bump)\` do not — a checked-in"
             echo "grammar is refreshed by re-running its dump script against the new"

--- a/content/validation/bump_upstream_versions.py
+++ b/content/validation/bump_upstream_versions.py
@@ -119,7 +119,7 @@ def pr_branch(applied: list[dict]) -> str:
 
 def pr_body(applied: list[dict]) -> str:
     lines = [
-        "Opened by the weekly `Validation Dependency Updates` workflow.",
+        "Opened by the weekly `Bump validation dependencies` workflow.",
         "",
         "These pins decide what the remediation and IaC-variant validators check "
         "against. Nothing else watches them: Dependabot covers `gomod` and "


### PR DESCRIPTION
Renames the `Validation Dependency Updates` workflow to **`Bump validation dependencies`**.

## Why

The repo's other dependency-updating workflow is `cnquery-update.yml`, displayed as **`Bump mql`** — verb-first, named after the thing it moves. `Validation Dependency Updates` read as a category instead, so in the Actions list the two jobs that do the same kind of work looked unrelated.

The new name keeps the subject explicit, which matters here: these are the **validation process's own** dependencies — the linter releases and vendor CLIs installed by `validate-remediation.yaml`, the tflint rulesets and Terraform provider constraints in `validate_terraform_remediation.py`, the OpenAPI commit pins in `validators/openapi.py`, and the checked-in CLI grammars in `cmd_data/`. Not the module dependencies Dependabot already covers.

## What moves with it

The name is quoted in the pull request and issue bodies this workflow and `bump_upstream_versions.py` generate, so all six occurrences are updated together:

| File | Sites |
| --- | --- |
| `.github/workflows/validation-dependency-updates.yaml` | `name:` + 3 generated PR bodies |
| `.github/workflows/validation-upstream-drift.yaml` | 1 generated issue body |
| `content/validation/bump_upstream_versions.py` | 1 generated PR body |

## What deliberately does not move

- **The file name** stays `validation-dependency-updates.yaml`. `validate-remediation.yaml` and `validation-upstream-drift.yaml` both cross-reference it by file name in comments, and a file name that differs from the display name is already the norm here — `cnquery-update.yml` is `Bump mql`.
- **`Validator Upstream Drift`** keeps its name. It reports the drift table into a long-lived issue rather than bumping anything, so a `Bump` name would misdescribe it.

Both workflow files still parse as YAML and `bump_upstream_versions.py` still compiles.