### PR TITLE
🐛 oci: stop the CLI remediation from deleting the rules it does not mention

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.5.0
+    version: 4.6.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -460,11 +460,11 @@ queries:
             oci iam policy get --policy-id POLICY_OCID --query 'data.statements' > statements.json
             ```
 
-            2. Edit `statements.json`, replacing the `manage all-resources in tenancy` statement with scoped statements, then resubmit the full list. The list must include every statement you want to keep, for example:
+            2. Edit `statements.json`, replacing the `manage all-resources in tenancy` statement with scoped statements such as `Allow group NetworkAdmins to manage virtual-network-family in compartment NetworkCompartment`. Resubmit the edited file so every statement you kept is preserved:
 
             ```bash
             oci iam policy update --policy-id POLICY_OCID \
-              --statements '["Allow group NetworkAdmins to manage virtual-network-family in compartment NetworkCompartment","Allow group ComputeAdmins to manage instance-family in compartment ComputeCompartment"]'
+              --statements file://statements.json
             ```
         - id: terraform
           desc: |
@@ -1292,11 +1292,11 @@ queries:
               --query 'data."ingress-security-rules"' > ingress-rules.json
             ```
 
-            2. Edit `ingress-rules.json`, replacing the all-protocols rule from `0.0.0.0/0` with scoped rules. The full list must include every rule you want to keep, for example:
+            2. Edit `ingress-rules.json`, replacing the all-protocols rule from `0.0.0.0/0` with scoped rules such as `{"source":"10.0.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"10.0.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -1441,11 +1441,11 @@ queries:
               --query 'data."ingress-security-rules"' > ingress-rules.json
             ```
 
-            2. Edit `ingress-rules.json` to add explicit `tcpOptions` port ranges, then resubmit the full list. The list must include every rule you want to keep, for example:
+            2. Edit `ingress-rules.json` so every `0.0.0.0/0` TCP rule carries an explicit `tcpOptions` port range, such as `{"source":"0.0.0.0/0","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"0.0.0.0/0","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -1603,11 +1603,11 @@ queries:
               --query 'data."egress-security-rules"' > egress-rules.json
             ```
 
-            2. Edit `egress-rules.json`, replacing the all-protocols rule to `0.0.0.0/0` with scoped rules, then resubmit the full list. The list must include every rule you want to keep, for example:
+            2. Edit `egress-rules.json`, replacing the all-protocols rule to `0.0.0.0/0` with scoped rules such as `{"destination":"10.0.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --egress-security-rules '[{"destination":"10.0.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --egress-security-rules file://egress-rules.json
             ```
         - id: terraform
           desc: |
@@ -1849,11 +1849,11 @@ queries:
             oci iam policy get --policy-id POLICY_OCID --query 'data.statements' > statements.json
             ```
 
-            2. Edit `statements.json`, replacing the `manage all-resources in compartment` statement with scoped statements, then resubmit the full list. The list must include every statement you want to keep, for example:
+            2. Edit `statements.json`, replacing the `manage all-resources in compartment` statement with scoped statements such as `Allow group DevOps to manage instance-family in compartment Production`. Resubmit the edited file so every statement you kept is preserved:
 
             ```bash
             oci iam policy update --policy-id POLICY_OCID \
-              --statements '["Allow group DevOps to manage instance-family in compartment Production","Allow group DevOps to manage virtual-network-family in compartment Production"]'
+              --statements file://statements.json
             ```
         - id: terraform
           desc: |
@@ -2262,11 +2262,22 @@ queries:
             5. Edit the TCP ingress rule for port 22 from 0.0.0.0/0 to use a specific trusted source CIDR block (e.g., your corporate network or bastion subnet).
         - id: cli
           desc: |
-            To restrict SSH ingress in a VCN security list using the OCI CLI, update the security list with a rule that restricts the source CIDR:
+            To restrict SSH ingress in a VCN security list using the OCI CLI, narrow the source CIDR on the port 22 rule.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
 
             ```bash
-            oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"10.0.0.0/24","protocol":"6","tcpOptions":{"destinationPortRange":{"min":22,"max":22}},"isStateless":false}]'
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, changing the source on the port 22 rule from `0.0.0.0/0` to a trusted CIDR such as `{"source":"10.0.0.0/24","protocol":"6","tcpOptions":{"destinationPortRange":{"min":22,"max":22}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
+
+            ```bash
+            oci network security-list update --security-list-id <security-list-ocid> \
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -2422,11 +2433,22 @@ queries:
             5. Edit the TCP ingress rule for port 3389 from 0.0.0.0/0 to use a specific trusted source CIDR block.
         - id: cli
           desc: |
-            To restrict RDP ingress in a VCN security list using the OCI CLI, update the security list with a rule that restricts the source CIDR:
+            To restrict RDP ingress in a VCN security list using the OCI CLI, narrow the source CIDR on the port 3389 rule.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
 
             ```bash
-            oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"10.0.0.0/24","protocol":"6","tcpOptions":{"destinationPortRange":{"min":3389,"max":3389}},"isStateless":false}]'
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, changing the source on the port 3389 rule from `0.0.0.0/0` to a trusted CIDR such as `{"source":"10.0.0.0/24","protocol":"6","tcpOptions":{"destinationPortRange":{"min":3389,"max":3389}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
+
+            ```bash
+            oci network security-list update --security-list-id <security-list-ocid> \
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -2576,11 +2598,22 @@ queries:
             5. Edit UDP ingress rules from 0.0.0.0/0 to specify destination port ranges, allowing only the ports required for your workload.
         - id: cli
           desc: |
-            To restrict unrestricted UDP ingress rules in a VCN security list using the OCI CLI, update the security list with rules that include specific port ranges:
+            To restrict unrestricted UDP ingress rules in a VCN security list using the OCI CLI, give every public UDP rule an explicit port range.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
 
             ```bash
-            oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"10.0.0.0/16","protocol":"17","udpOptions":{"destinationPortRange":{"min":53,"max":53}},"isStateless":false}]'
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json` so each `0.0.0.0/0` UDP rule carries a `udpOptions` port range, such as `{"source":"10.0.0.0/16","protocol":"17","udpOptions":{"destinationPortRange":{"min":53,"max":53}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
+
+            ```bash
+            oci network security-list update --security-list-id <security-list-ocid> \
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -2728,11 +2761,11 @@ queries:
               --query 'data."ingress-security-rules"' > ingress-rules.json
             ```
 
-            2. Edit `ingress-rules.json`, setting `isStateless` to `false` on the rule from `0.0.0.0/0`, then resubmit the full list. The list must include every rule you want to keep, for example:
+            2. Edit `ingress-rules.json`, setting `"isStateless": false` on the rule from `0.0.0.0/0` and leaving the other rules untouched. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --ingress-security-rules '[{"source":"0.0.0.0/0","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -2877,11 +2910,11 @@ queries:
               --query 'data."egress-security-rules"' > egress-rules.json
             ```
 
-            2. Edit `egress-rules.json` to add explicit `tcpOptions` port ranges, then resubmit the full list. The list must include every rule you want to keep, for example:
+            2. Edit `egress-rules.json` so every `0.0.0.0/0` TCP rule carries an explicit `tcpOptions` port range, such as `{"destination":"0.0.0.0/0","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id SECURITY_LIST_OCID \
-              --egress-security-rules '[{"destination":"0.0.0.0/0","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --egress-security-rules file://egress-rules.json
             ```
         - id: terraform
           desc: |
@@ -4289,7 +4322,7 @@ queries:
     title: Ensure load balancers that run HTTP listeners also expose HTTPS
     impact: 70
     filters: |
-      asset.platform == "oci-loadbalancer"
+      asset.platform == "oci-loadbalancer" &&
       oci.loadBalancer.loadBalancer.listeners.any(protocol == "HTTP")
     tags:
       compliance/bsi-sys-1-5: false
@@ -4589,7 +4622,7 @@ queries:
             1. Open **Developer Services** → **Kubernetes Clusters (OKE)** → select the cluster.
             2. **Upgrade Available** → review the target version and upgrade path.
             3. Upgrade the control plane first, then each node pool (recreate nodes or use blue/green rollout).
-            4. Re-run the check to confirm `availableKubernetesUpgrades` length is at most two.
+            4. Confirm the cluster is within two releases of the newest version OKE offers, which is what keeps it on a supported track.
         - id: cli
           desc: |
             Upgrade the OKE control plane:
@@ -5641,12 +5674,21 @@ queries:
             4. Verify the DB continues to reach OCI services through the service gateway.
         - id: cli
           desc: |
-            Update the route table to drop the IGW default route:
+            **Warning: `--route-rules` replaces the entire existing set of route rules.** Whatever you pass becomes the whole route table, so any rule you omit is deleted, including routes the database depends on. Retrieve the current rules first, remove only the internet-gateway route, then resubmit the rest.
+
+            1. Export the current route rules so you keep every route you still need:
+
+            ```bash
+            oci network route-table get --rt-id <route-table-ocid> \
+              --query 'data."route-rules"' > route-rules.json
+            ```
+
+            2. Edit `route-rules.json`, deleting the rule whose destination is `0.0.0.0/0` and whose target is an internet gateway. Where the database still needs egress, replace it with a NAT or service gateway route such as `{"destination":"all-<region>-services-in-oracle-services-network","destinationType":"SERVICE_CIDR_BLOCK","networkEntityId":"<service-gateway-ocid>"}`. Resubmit the edited file so every route you kept is preserved:
 
             ```bash
             oci network route-table update \
               --rt-id <route-table-ocid> \
-              --route-rules '[{"destination":"all-<region>-services-in-oracle-services-network","destinationType":"SERVICE_CIDR_BLOCK","networkEntityId":"<service-gateway-ocid>"}]'
+              --route-rules file://route-rules.json
             ```
         # No Terraform remediation: this check requires three-hop cross-resource traversal from `oci_database_db_system` to its subnet to the subnet's route table to inspect individual route rules; this graph walk is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
@@ -5773,8 +5815,8 @@ queries:
         title: OCI - Managing Secrets
   - uid: mondoo-oci-security-vault-secrets-rotation-enabled-oci
     filters: |
-      asset.platform == "oci-vault-secret"
-      oci.vault.secret.state == "ACTIVE"
+      asset.platform == "oci-vault-secret" &&
+      oci.vault.secret.state == "ACTIVE" &&
       time.now - oci.vault.secret.created > 365 * time.day
     mql: |
       oci.vault.secret.isScheduledRotationEnabled == true
@@ -5814,7 +5856,7 @@ queries:
     title: Ensure OCI Vault active secret versions are not past their expiry time
     impact: 60
     filters: |
-      asset.platform == "oci-vault-secret"
+      asset.platform == "oci-vault-secret" &&
       oci.vault.secret.state == "ACTIVE"
     tags:
       compliance/bsi-sys-1-5: false
@@ -6680,11 +6722,19 @@ queries:
             oci iam policy list --compartment-id <tenancy-ocid> --all --query "data[].{Name:name, Statements:statements}" --output json
             ```
 
-            Replace the statements on each offending policy:
+            **Warning: `--statements` replaces the COMPLETE set of statements on the policy.** Whatever you pass becomes the entire statement list, so any statement you omit is silently dropped. Retrieve the current statements first, replace only the `any-user` statement, then resubmit every statement you want to keep.
+
+            1. Export the current statements so you keep every statement you still need:
+
+            ```bash
+            oci iam policy get --policy-id <policy-ocid> --query 'data.statements' > statements.json
+            ```
+
+            2. Edit `statements.json`, replacing each `Allow any-user ...` statement with a group- or service-scoped one such as `Allow group <group-name> to read buckets in compartment <compartment-name>`. Resubmit the edited file so every statement you kept is preserved:
 
             ```bash
             oci iam policy update --policy-id <policy-ocid> \
-              --statements '["Allow group <group-name> to read buckets in compartment <compartment-name>"]'
+              --statements file://statements.json
             ```
         - id: terraform
           desc: |
@@ -6832,11 +6882,11 @@ queries:
             oci iam policy get --policy-id <policy-ocid> --query 'data.statements' > statements.json
             ```
 
-            2. Edit `statements.json`, removing the `Endorse`/`Admit` statements, then resubmit the full list. The list must include every statement you want to keep, for example:
+            2. Edit `statements.json`, removing the `Endorse` and `Admit` statements and leaving the rest untouched. Resubmit the edited file so every statement you kept is preserved:
 
             ```bash
             oci iam policy update --policy-id <policy-ocid> \
-              --statements '["Allow group AppReaders to read objects in compartment AppData"]'
+              --statements file://statements.json
             ```
         - id: terraform
           desc: |
@@ -6972,11 +7022,22 @@ queries:
             4. If an application outside OCI needs DB access, provision an OCI Service Gateway, VPN, or FastConnect path rather than opening the port.
         - id: cli
           desc: |
-            Replace the ingress rules on the security list with a scoped set. The `--ingress-security-rules` parameter replaces the entire ingress rule set. Export the current rules first with `oci network security-list get` and include every rule you intend to keep in the JSON array:
+            Replace the ingress rules on the security list with a scoped set.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
+
+            ```bash
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, restricting each database-port rule to an internal source such as `{"source":"10.10.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":5432,"max":5432}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id <security-list-ocid> \
-              --ingress-security-rules '[{"source":"10.10.0.0/16","protocol":"6","tcpOptions":{"destinationPortRange":{"min":5432,"max":5432}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -7154,11 +7215,22 @@ queries:
             3. If file-sharing is actually required, provision a VPN or FastConnect path and scope the security-list rule to the resulting private CIDR block.
         - id: cli
           desc: |
-            Replace the security list's ingress rules with a set that omits these ports. The `--ingress-security-rules` parameter replaces the entire ingress rule set. Export the current rules first with `oci network security-list get` and include every rule you intend to keep in the JSON array:
+            Replace the security list's ingress rules with a set that omits these ports.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
+
+            ```bash
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, deleting the public legacy-port rules or restricting them to an internal source such as `{"source":"10.0.0.0/8","protocol":"6","tcpOptions":{"destinationPortRange":{"min":445,"max":445}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id <security-list-ocid> \
-              --ingress-security-rules '[{"source":"10.0.0.0/8","protocol":"6","tcpOptions":{"destinationPortRange":{"min":445,"max":445}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -7334,11 +7406,22 @@ queries:
             3. For monitoring use cases, limit the source to your NOC / monitoring subnet rather than `0.0.0.0/0`.
         - id: cli
           desc: |
-            Replace the security list's ingress rules with a set whose ICMP rule is scoped. The `--ingress-security-rules` parameter overwrites the full rule set, so include every rule you intend to keep alongside the scoped ICMP rule:
+            Replace the security list's ingress rules with a set whose ICMP rule is scoped.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
+
+            ```bash
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, giving each public ICMP rule an `icmpOptions` type and code, such as `{"source":"10.0.0.0/8","protocol":"1","icmpOptions":{"type":3,"code":4},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id <security-list-ocid> \
-              --ingress-security-rules '[{"source":"10.0.0.0/8","protocol":"1","icmpOptions":{"type":3,"code":4},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -7484,11 +7567,22 @@ queries:
             4. Consider disabling IPv6 entirely on the VCN if no workload on it uses IPv6.
         - id: cli
           desc: |
-            Replace the ingress rules with a scoped IPv6 set. The `--ingress-security-rules` parameter replaces the entire ingress rule set, including the IPv4 rules. Export the current rules first with `oci network security-list get` and include every rule you intend to keep in the JSON array:
+            Replace the ingress rules with a scoped IPv6 set. The export below covers the IPv4 rules as well, which the same parameter would otherwise delete.
+
+            **Warning: `--ingress-security-rules` replaces the COMPLETE set of ingress rules.** Whatever you pass becomes the entire ingress rule list, so any rule you omit is deleted. Retrieve the current rules first, edit only the offending rule, then resubmit the full list.
+
+            1. Export the current ingress rules so you keep every rule you still need:
+
+            ```bash
+            oci network security-list get --security-list-id <security-list-ocid> \
+              --query 'data."ingress-security-rules"' > ingress-rules.json
+            ```
+
+            2. Edit `ingress-rules.json`, scoping each `::/0` rule to a trusted prefix and an explicit port range, such as `{"source":"2001:db8:abcd::/48","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}`. Resubmit the edited file so every rule you kept is preserved:
 
             ```bash
             oci network security-list update --security-list-id <security-list-ocid> \
-              --ingress-security-rules '[{"source":"2001:db8:abcd::/48","protocol":"6","tcpOptions":{"destinationPortRange":{"min":443,"max":443}},"isStateless":false}]'
+              --ingress-security-rules file://ingress-rules.json
             ```
         - id: terraform
           desc: |
@@ -8331,7 +8425,7 @@ queries:
         title: OCI - API Gateway Mutual TLS
   - uid: mondoo-oci-security-apigateway-deployment-mtls-verified-oci
     filters: |
-      asset.platform == "oci-apigateway-deployment"
+      asset.platform == "oci-apigateway-deployment" &&
       oci.apigateway.deployment.mtlsAllowedSans.length > 0
     mql: |
       oci.apigateway.deployment.mtlsIsVerifiedCertificateRequired == true
@@ -10032,11 +10126,23 @@ queries:
             6. In tenancies where the legacy **Identity & Security > Authentication Settings** page is available, apply the same values there, because this check evaluates the tenancy authentication policy. If the page is not available, use the CLI command in the CLI remediation to update the authentication policy directly.
         - id: cli
           desc: |
-            To strengthen the password policy using the OCI CLI, update the authentication policy:
+            A tenancy on identity domains keeps a password policy per domain, and that is the one its users authenticate against. Set both the legacy tenancy policy and every domain policy, or the domain users stay on the weaker settings.
+
+            1. Update the legacy tenancy authentication policy:
 
             ```bash
             oci iam authentication-policy update --compartment-id <tenancy-ocid> \
               --password-policy '{"minimumPasswordLength": 14, "isUppercaseCharactersRequired": true, "isLowercaseCharactersRequired": true, "isNumericCharactersRequired": true, "isSpecialCharactersRequired": true, "isUsernameContainmentAllowed": false}'
+            ```
+
+            2. Update the password policy in each identity domain, using that domain's own endpoint:
+
+            ```bash
+            oci identity-domains password-policy patch \
+              --endpoint https://<domain-url> \
+              --password-policy-id <password-policy-id> \
+              --schemas '["urn:ietf:params:scim:api:messages:2.0:PatchOp"]' \
+              --operations '[{"op":"replace","path":"minLength","value":14},{"op":"replace","path":"minUpperCase","value":1},{"op":"replace","path":"minLowerCase","value":1},{"op":"replace","path":"minNumerals","value":1},{"op":"replace","path":"minSpecialChars","value":1},{"op":"replace","path":"userNameDisallowed","value":true}]'
             ```
         - id: terraform
           desc: |
@@ -11558,7 +11664,15 @@ queries:
             3. Front any required inbound access with a load balancer, API gateway, or the OCI Bastion service.
         - id: cli
           desc: |
-            Unassign the ephemeral public IP from the instance's VNIC by clearing its private IP association:
+            Remove the public IP from the instance's VNIC. Which command applies depends on the IP's lifetime, which `oci network public-ip get` reports as `lifetime`.
+
+            An ephemeral public IP cannot be unassigned; deleting it is what releases it from the VNIC:
+
+            ```bash
+            oci network public-ip delete --public-ip-id <public-ip-ocid> --force
+            ```
+
+            A reserved public IP is unassigned by clearing its private IP association, which returns it to your pool:
 
             ```bash
             oci network public-ip update --public-ip-id <public-ip-ocid> --private-ip-id ""


### PR DESCRIPTION
A full read of every remediation block in `mondoo-oci-security` — all 99 checks, all four methods, prose included — against the check that recommends it. **19 defects**, dominated by one systemic problem.

## The systemic defect: commands that delete what they do not mention

OCI's update APIs replace list parameters wholesale. Oracle documents this in the CLI itself:

```
$ oci network security-list update --help
  Note that the `egressSecurityRules` or `ingressSecurityRules` objects you
  provide replace the entire existing objects.

$ oci network route-table update --help
  Note that the `routeRules` object you provide replaces the entire existing
  set of rules.
```

Sixteen commands passed an inline array containing only the one rule the finding is about. Run as written, they delete every other ingress rule, egress rule, policy statement, or route on the resource. On a production security list that is an outage; on a route table it strands the database.

The policy already half-knew this, in three tiers of drift:

| State | Checks | What was wrong |
|---|---|---|
| Warns, numbers the steps, exports to a file | 8 | The final command passes an inline array, so **the exported file is never used**. A reader who follows steps 1 and 2 edits a file the command ignores. |
| Warns in prose only | 4 | No export command shown, inline array. |
| No warning at all | 4 | `ssh`, `rdp`, `udp` ingress and `iam-no-any-user-policies`. |

The correct shape already exists in the same file: the four API Gateway checks export the spec and pass `--specification file://specification.json`. Every block now follows that pattern — warn, export, edit, resubmit the file — with the example rule moved into the prose so the reader still sees what a scoped rule looks like without it becoming the entire list.

<details>
<summary>The sixteen checks</summary>

Exported but ignored the file: `vcn-no-unrestricted-ingress-all-protocols`, `vcn-no-unrestricted-ingress-all-tcp-ports`, `vcn-no-unrestricted-egress-all-protocols`, `vcn-no-unrestricted-egress-all-tcp-ports`, `vcn-no-stateless-ingress-from-internet`, `iam-no-overly-permissive-policies`, `iam-no-broad-compartment-policies`, `iam-no-cross-tenant-policies`

Warned but never exported: `vcn-no-unrestricted-ingress-db-ports`, `vcn-no-unrestricted-ingress-legacy-admin-ports`, `vcn-no-unrestricted-icmp-ingress`, `vcn-no-unrestricted-ipv6-ingress`

No warning: `vcn-no-unrestricted-ssh-ingress`, `vcn-no-unrestricted-rdp-ingress`, `vcn-no-unrestricted-udp-ingress`, `iam-no-any-user-policies`
</details>

## Three individual defects

**`dbsystem-subnet-no-internet-gateway`** passed a lone service-gateway rule to `--route-rules`. Same full-replace parameter, and no warning at all. The documented fix removes the internet-gateway route *and* every other route the DB system depends on. Now exports `route-rules.json`, deletes only the IGW rule, and resubmits.

**`compute-instance-not-internet-reachable`** said "unassign the **ephemeral** public IP" and then ran the reserved-IP operation:

```
$ oci network public-ip update --help
  * Unassign a reserved public IP from a private IP …
  Regarding ephemeral public IPs:
  * If you want to unassign an ephemeral public IP from its private IP, use
    [DeletePublicIp], which unassigns and deletes the ephemeral public IP.
```

The command cannot do what the sentence above it claims. Both paths are now shown, keyed off the `lifetime` field that `public-ip get` reports.

**`iam-password-policy-strong`** asserts the legacy tenancy authentication policy **and** `oci.identity.domains.all(passwordPolicy…)`. The CLI only updated the former, so on any tenancy using identity domains — where users actually authenticate — the check stayed failing after following the fix. The console prose already covered both surfaces; the CLI now does too, via `oci identity-domains password-policy patch`.

## Content-rule fixes

- `oke-supported-kubernetes-version` told the reader to "confirm `availableKubernetesUpgrades` length is at most two". Policy prose is read next to a single finding and must not name MQL fields; reworded to describe the condition.
- Four multi-line `filters:` joined with the explicit `&&` the content rules ask for. None has an `||` tail, so the precedence trap documented for the AWS RDS filters does not apply — I checked each one rather than applying the rule blindly.

## What I checked and did *not* change

Reading the prose corrected several things a scan would have flagged:

- **`iam-mfa-enabled-for-active-users`** and **`iam-user-emails-verified`** have read-only CLI blocks, but both correctly explain that enrollment and verification are end-user actions and give the command that identifies who is outstanding. Correct as written.
- **`compute-metadata-no-secrets`** already uses `file://` and warns that `ssh_authorized_keys` and `user_data` must be resubmitted unchanged. Correct.
- **`nsg-no-unrestricted-admin-ports`** uses `nsg rules remove` with explicit rule IDs, which is not a replace operation. Correct, and the contrast is why the security-list blocks stand out.
- **`functions-config-no-credentials`**'s console block embeds a Python snippet, which reads oddly out of context but is a legitimate sub-step of the click-through.

## Verification

| Gate | Result |
|---|---|
| `cnspec policy lint` | valid, no warnings |
| OCI command validator | **260 pass / 0 fail** (was 249; the new export and domain commands add 11) |
| shellcheck | 3,564 pass / 0 fail |
| tflint | 1,567 pass / 0 fail |
| Compliance mappings, bundle smoke scans | `ok` |
| `typos` | clean |

No check logic changed, so no fixture or closed-loop movement is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
