### PR TITLE
🧹 content: give every security check an impact and compliance tags

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.12.0
+    version: 12.12.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -6880,6 +6880,21 @@ queries:
     title: Ensure RDS clusters have no active security recommendations
     impact: 90
     filters: asset.platform == "aws-rds-dbcluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: false
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: false
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: false
+      compliance/nist-sp-800-171: false
+      compliance/owasp-top-10-2025: false
+      compliance/pci-dss-4: false
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: aws.rds.dbcluster.recommendations.where(category == "security" && status == "active") == empty
     docs:
       desc: |
@@ -7736,6 +7751,21 @@ queries:
     title: Ensure RDS instances are not reachable from the internet
     impact: 87
     filters: asset.platform == "aws-rds-dbinstance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       aws.rds.dbinstance.exposure.internetReachable == false
     docs:
@@ -10303,6 +10333,21 @@ queries:
     title: Ensure load balancers are not unexpectedly internet-reachable
     impact: 80
     filters: asset.platform == "aws-elb-loadbalancer"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       aws.elb.loadbalancer.exposure.internetReachable == false
     docs:
@@ -20084,6 +20129,21 @@ queries:
     title: Ensure IAM Access Analyzer has no active external-access findings
     impact: 80
     filters: asset.platform == "aws"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       aws.iam.accessAnalyzer.findings.where( status == "ACTIVE" ) == []
     docs:
@@ -27528,6 +27588,21 @@ queries:
     title: Ensure EKS control-plane egress is customer-routed
     impact: 60
     filters: asset.platform == "aws-eks-cluster"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-2
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       aws.eks.cluster.controlPlaneEgressMode == "CUSTOMER_ROUTED"
     docs:
@@ -33649,6 +33724,21 @@ queries:
     title: Ensure DocumentDB instances are not reachable from the internet
     impact: 85
     filters: asset.platform == "aws-documentdb-instance"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       aws.documentdb.instance.exposure.internetReachable == false
     docs:
@@ -34124,6 +34214,21 @@ queries:
     title: Ensure Cognito custom domains enforce TLS 1.2 or higher
     impact: 70
     filters: asset.platform == "aws-cognito-userpool"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
       aws.cognito.userPool.domain == null || aws.cognito.userPool.domain.tlsSecurityPolicy == "" || aws.cognito.userPool.domain.tlsSecurityPolicy != "TLS_V1"
     docs:
@@ -54222,6 +54327,21 @@ queries:
     title: Ensure EC2 instances are not reachable from the internet
     impact: 87
     filters: asset.platform == "aws"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       aws.ec2.instances.all( exposure.internetReachable == false )
     docs:

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.5.1
+    version: 2.5.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -424,6 +424,21 @@ queries:
     title: Ensure Droplets are not reachable from the internet
     impact: 85
     filters: asset.platform == "digitalocean"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       digitalocean.droplets.all( exposure.internetReachable == false )
     docs:

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 2.3.0
+    version: 2.3.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -454,6 +454,21 @@ queries:
     title: Ensure servers are not reachable from the internet
     impact: 85
     filters: asset.platform == "hetzner-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       hetzner.servers.all( exposure.internetReachable == false )
     docs:

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-openstack-security
     name: Mondoo OpenStack Security
-    version: 1.5.1
+    version: 1.5.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -841,6 +841,21 @@ queries:
     title: Ensure compute servers are not reachable from the internet
     impact: 85
     filters: asset.platform == "openstack-project"
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-7
     mql: |
       openstack.servers.all( exposure.internetReachable == false )
     docs:

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: phoenix-plcnext
     name: Phoenix PLCnext Security Policy
-    version: 1.1.3
+    version: 1.2.0
     license: BUSL-1.1
     tags:
       benchmark: Mondoo Phoenix PLCnext
@@ -80,6 +80,22 @@ policies:
 queries:
   - uid: phoenix-plcnext-01
     title: Ensure latest PLCnext Firmware is installed
+    impact: 95
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-8
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-id-ra-1
+      compliance/nist-csf-2: nist-csf-2-id-ra-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a03
+      compliance/pci-dss-4: pcidss-requirement-6-3-3
+      compliance/soc2-2017: soc2-control-cc7-1-2
+      compliance/vda-isa-5: vda-isa-5-5-2-5
     mql: |
       // A missing or malformed arpversion file fails cleanly via the else
       // branch instead of erroring inside version(null).
@@ -123,6 +139,22 @@ queries:
         title: The PLCnext Runtime
   - uid: phoenix-plcnext-02
     title: Ensure Firewall is active
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-20
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-5
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-1-3-1
+      compliance/soc2-2017: soc2-control-cc6-6-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
       nftables.tables.contains(name == "plcnext_filter")
       nftables.tables.contains(name == "plcnext_ip6_filter")
@@ -160,11 +192,27 @@ queries:
         title: Additional firewall filters via nftables
   - uid: phoenix-plcnext-03
     title: Ensure only strong Key Exchange algorithms are used
+    impact: 100
     props:
       - uid: PLCKexAlgos
         title: Define the hardened key exchange algorithms for all SSH configurations
         mql: |
           return ["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256"]
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.kexs != empty
       sshd.config.kexs.containsOnly(props.PLCKexAlgos)
@@ -187,11 +235,27 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-04
     title: Ensure only strong MAC algorithms are used
+    impact: 80
     props:
       - uid: PLCMacAlgos
         title: Define the accepted MAC algorithms
         mql: |
           return ["hmac-sha2-512-etm@openssh.com","hmac-sha2-256-etm@openssh.com","umac-128-etm@openssh.com","hmac-sha2-512","hmac-sha2-256"]
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.macs != empty
       sshd.config.macs.containsOnly(props.PLCMacAlgos)
@@ -214,11 +278,27 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-05
     title: Ensure only strong ciphers are used
+    impact: 100
     props:
       - uid: PLCSshdCiphers
         title: Define the hardened ciphers for all SSH configurations
         mql: |
           return ["chacha20-poly1305@openssh.com","aes256-gcm@openssh.com","aes128-gcm@openssh.com","aes256-ctr","aes192-ctr","aes128-ctr"]
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.ciphers != empty
       sshd.config.ciphers.containsOnly(props.PLCSshdCiphers)
@@ -241,6 +321,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-06
     title: Ensure current system time is synchronized
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-06
+      compliance/dora: false
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-17
+      compliance/nis-2: false
+      compliance/nist-csf-1: false
+      compliance/nist-csf-2: false
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-45
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-10-6-1
+      compliance/soc2-2017: false
+      compliance/vda-isa-5: false
     mql: |
       processes.any(executable == /ntpd/)
       file("/etc/ntp.conf").content == /(server|pool)\s+\S+/
@@ -272,6 +368,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-07
     title: Ensure secure permissions on SSH private host key files are set
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
@@ -301,6 +413,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-08
     title: Ensure secure permissions on SSH public host key files are set
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
       files.
         find(from: "/etc/ssh", type: "file").
@@ -326,6 +454,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-09
     title: Ensure SSH Protocol is set to 2
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc7-1-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params["Protocol"] == 2
     docs:
@@ -345,6 +489,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-10
     title: Ensure SSH LogLevel is appropriate
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params["LogLevel"] == /INFO|VERBOSE/
     docs:
@@ -373,6 +533,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-11
     title: Ensure SSH X11 forwarding is disabled
+    impact: 50
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params["X11Forwarding"] == "no"
     docs:
@@ -392,6 +568,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-12
     title: Ensure SSH MaxAuthTries is set to 4 or less
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["MaxAuthTries"] <= 4
     docs:
@@ -411,6 +603,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-13
     title: Ensure SSH IgnoreRhosts is enabled
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["IgnoreRhosts"] == "yes"
     docs:
@@ -432,6 +640,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-14
     title: Ensure SSH HostbasedAuthentication is disabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["HostbasedAuthentication"] == "no"
     docs:
@@ -453,6 +677,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-15
     title: Ensure SSH root login is disabled or set to prohibit-password
+    impact: 100
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["PermitRootLogin"] == "no" || sshd.config.params["PermitRootLogin"] == "prohibit-password"
     docs:
@@ -485,6 +725,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-16
     title: Ensure SSH PermitEmptyPasswords is disabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["PermitEmptyPasswords"] == "no"
     docs:
@@ -504,6 +760,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-17
     title: Ensure SSH PermitUserEnvironment is disabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["PermitUserEnvironment"] == "no"
     docs:
@@ -523,6 +795,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-18
     title: Ensure SSH Idle Timeout Interval is configured
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params {
         _["ClientAliveInterval"] >= 1
@@ -547,6 +835,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-19
     title: Ensure SSH LoginGraceTime is set to one minute or less
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-7
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params {
         _["LoginGraceTime"] >= 1
@@ -569,6 +873,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-20
     title: Ensure SSH access is limited
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params["AllowUsers"] != empty || sshd.config.params["AllowGroups"] != empty || sshd.config.params["DenyUsers"] != empty || sshd.config.params["DenyGroups"] != empty
     docs:
@@ -603,6 +923,22 @@ queries:
         title: CISA Industrial Control Systems Security
   - uid: phoenix-plcnext-21
     title: Ensure SSH warning banner is configured
+    impact: 30
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-06
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ac-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-17
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-12
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-5
+      compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
       sshd.config.params["Banner"] != empty
       sshd.config.params["Banner"] != "none"
@@ -626,6 +962,22 @@ queries:
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-22
     title: Ensure SSH password authentication is disabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-14
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-or-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-j
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-3
     mql: |
       sshd.config.params["PasswordAuthentication"] == "no"
       sshd.config.params["PubkeyAuthentication"] == "yes"

--- a/content/mondoo-postgresql-security.mql.yaml
+++ b/content/mondoo-postgresql-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-postgresql-security
     name: Mondoo PostgreSQL Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -99,6 +99,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -224,6 +225,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -379,6 +381,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -498,6 +501,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -619,6 +623,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -735,6 +740,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -878,6 +884,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -1015,6 +1022,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -1151,6 +1159,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -1270,6 +1279,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-3
@@ -1406,6 +1416,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -1542,6 +1553,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ds-02
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
@@ -1675,6 +1687,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ir-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
@@ -1817,6 +1830,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-03
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -1929,6 +1943,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -2070,6 +2085,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-aa-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
       compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
@@ -2208,6 +2224,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-4
       compliance/nist-sp-800-171: nist-sp-800-171--3-5-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -2334,6 +2351,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -2451,6 +2469,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -2570,6 +2589,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -2686,6 +2706,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -2802,6 +2823,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -2921,6 +2943,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-2
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -3043,6 +3066,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-3
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-2
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -3159,6 +3183,7 @@ queries:
       compliance/nist-csf-2: false
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-9
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-3-1
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -3296,6 +3321,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-04
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-12
       compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
@@ -3452,6 +3478,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -3589,6 +3616,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-01
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-5
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
@@ -3713,6 +3741,7 @@ queries:
       compliance/nist-csf-2: nist-csf-2-pr-ps-05
       compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
       compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: false
       compliance/vda-isa-5: false


### PR DESCRIPTION
## What this is

An audit of **all 3,124 checks** in `content/` for `impact:` and `compliance/*` tags, and a fix for every gap that is drift.

## The gap, and where the line is

| Gap | Count | Verdict |
|---|---|---|
| `security` checks with no compliance tags | 33 | drift — fixed |
| `security` checks missing only `owasp-top-10-2025` | 29 | drift — fixed |
| `security` checks missing `impact:` | 22 | drift — fixed |
| `best-practices` checks with no compliance tags | 92 | **by design — left alone** |

The gap splits cleanly on `mondoo.com/category`: every `security` policy is near-fully tagged, every `best-practices` policy carries exactly zero. A second, independent source confirms the boundary is deliberate rather than drift — none of the seven `best-practices` policies appears as a `policy_dependency` in any framework map under `cnspec-enterprise-policies/frameworks/maps/*/cnspec.mql.yaml`. So this PR closes the security-policy drift only.

`terraform-deprecations` is also left without `impact:`, per review feedback.

## What was mapped, and against what

Every mapping is anchored to a check whose control objective is *identical*, not merely adjacent — never to a neighbour in the same file.

- **`mondoo-phoenix-plcnext-security` (22 checks)** — the policy shipped with neither `impact:` nor tags. Twenty of its checks are byte-identical to checks in `mondoo-linux-security`, `mondoo-freebsd-security` and `mondoo-fortios-security`, so each adopts the mapping and impact already verified for its twin. `phoenix-plcnext-09` (SSH Protocol 2) and `-22` (key-only auth) have no twin and were mapped from control text; `-22` uses CCM `iam-14` *Strong Authentication* (\"adopt digital certificates\") and 800-171 `3.5.2` rather than the password-policy controls its siblings use.
- **The `-not-internet-reachable` family (7 checks, aws/digitalocean/hetzner/openstack)** — a check family added in one pass with tags forgotten across all of it. Mapped to the dominant form already in `mondoo-aws-security` (`ivs-03` / `a-8-20` / `3-13-6` / `sc-7` / `1-3-1`), which is also the better fit on the control text: PCI 1.3.1 restricts inbound traffic to only what is necessary, and 800-171 3.13.6 is deny-by-default. (The `3-13-5` / `1-4-2` variant used by a few siblings describes DMZ subnet architecture, which is a looser fit.)
- **`aws-security-eks-control-plane-egress-customer-routed`** — same family, but PCI **1.3.2** (outbound restricted) since the assertion is about egress.
- **`aws-security-cognito-domain-min-tls-1-2`** — the TLS-floor family, anchored on `cloudfront-minimum-tls-version`.
- **`aws-security-access-analyzer-no-external-access-findings`** — anchored on `ram-no-external-principals`, deliberately **not** on the neighbouring `iam-access-analyzer-enabled`. That check asserts the detector is turned on (a detection objective, `log-03`/`au-6`); this one asserts nothing is shared with an external principal, which is least privilege (`ac-6` / `3-1-5`).
- **`aws-security-rds-cluster-no-active-security-recommendations`** — resolved to `false` across all fourteen, mirroring the resolution already recorded on its instance-level sibling `rds-instance-no-active-security-recommendation`. Flagging it here in case you'd rather both were mapped to vulnerability management (ISO 8.8 / SI-2 / PCI 6.3.3) instead — it's a one-line change either way.
- **`mondoo-postgresql-security` (29 checks)** — carried thirteen of the standard fourteen and no `owasp-top-10-2025` at all, which `content/CLAUDE.md` already calls out as drift. Rather than assign categories by feel, I derived them: for every check in the corpus, I counted which OWASP category the repo pairs with each 800-53 control. The correlation is near-deterministic — `au-3`/`au-9`/`au-12` → `a09` (100%), `sc-8` → `a04` (203/232), `sc-7` → `a01` (357/504), `ia-2`/`ia-4` → `a07`, `cm-7` → `a02` — and each result was cross-checked against the near-identical `mondoo-mysql-security` and `mondoo-mariadb-security` policies, which are fully tagged.

## Verification

- **All 428 control references were checked to exist** in the framework definitions under `cnspec-enterprise-policies/frameworks/` before being written. This matters because a non-existent control uid is silent: it lints clean, passes CI, and just maps to nothing. Nothing in `content/validation/` covers it today.
- `cnspec policy lint` — valid on all six bundles. The two `standalone function in a WHERE clause` warnings on `mondoo-aws-security` are **pre-existing on `main`** (verified by linting `main`'s copy).
- `go test ./content/validation/compliance` — ok
- `go test ./content/validation/scans` — ok
- Re-running the audit shows 0 remaining gaps in `security` policies.

Policy versions bumped: phoenix `1.1.3 → 1.2.0` (minor: 22 checks gained `impact:`, which changes scoring), the other five patch-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)