### PR TITLE
✨ content: add self-hosted database security policies

### DIFF
--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -1,0 +1,314 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-cassandra-security
+    name: Mondoo Apache Cassandra Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: cassandra
+    require:
+      - provider: cassandra
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Apache Cassandra authentication, authorization, encryption, and audit logging
+    docs:
+      desc: |
+        The Mondoo Apache Cassandra Security policy connects to a running Cassandra cluster and assesses its effective, runtime security configuration. It reads the cluster's live settings from the `system_views.settings` virtual table and inspects the roles and permissions defined in the `system_auth` keyspace, so the checks reflect the configuration the cluster is actually enforcing rather than a file on disk.
+
+        This policy provides security checks across four areas:
+        - Authentication of client connections
+        - Authorization and permission enforcement
+        - Client-to-node transport encryption
+        - Audit logging of database activity
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "cassandra"
+        checks:
+          - uid: mondoo-cassandra-security-authentication-enabled
+      - title: Access Control
+        filters: asset.platform == "cassandra"
+        checks:
+          - uid: mondoo-cassandra-security-authorization-enabled
+      - title: Transport Encryption
+        filters: asset.platform == "cassandra"
+        checks:
+          - uid: mondoo-cassandra-security-client-encryption-enabled
+      - title: Logging & Monitoring
+        filters: asset.platform == "cassandra"
+        checks:
+          - uid: mondoo-cassandra-security-audit-logging-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-cassandra-security-authentication-enabled
+    filters: asset.platform == "cassandra"
+    title: Ensure Cassandra enables authentication
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      cassandra.cluster.security.authenticationEnabled == true
+    docs:
+      desc: |-
+        This check ensures that the configured authenticator is not `AllowAllAuthenticator`, so clients must present valid credentials before they can connect. With `AllowAllAuthenticator`, any client that reaches the cluster connects with no credentials at all.
+
+        **Why this matters**
+
+        - **No anonymous access:** Requiring authentication ties every connection to a known role rather than allowing open access to anyone on the network.
+        - **Credential enforcement:** `PasswordAuthenticator` validates a username and password before granting a session.
+        - **Foundation for authorization:** Permission enforcement is meaningless without an authenticated identity to enforce it against.
+
+        **Risk mitigation**
+
+        - **Reduced exposure:** An attacker who reaches the CQL port can no longer connect without stealing or guessing a credential.
+        - **Attributable access:** Authenticated sessions can be tied to a role for logging and investigation.
+      audit: |-
+        ### Audit via cqlsh
+
+        1. Connect with `cqlsh` and read the effective `authenticator` setting:
+
+           ```sql
+           SELECT name, value FROM system_views.settings WHERE name = 'authenticator';
+           ```
+
+        On older versions that do not expose `system_views.settings`, inspect the `authenticator` value in `cassandra.yaml` instead.
+
+        If the value is `PasswordAuthenticator` (or another real authenticator), the check passes. If it is `AllowAllAuthenticator`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To require authentication in the cluster configuration:
+
+            1. In `cassandra.yaml`, set:
+
+               ```yaml
+               authenticator: PasswordAuthenticator
+               ```
+            2. Perform a rolling restart of the cluster so every node picks up the new setting.
+            3. Create roles with passwords so authorized clients can connect:
+
+               ```sql
+               CREATE ROLE app WITH PASSWORD = 'strong-password' AND LOGIN = true;
+               ```
+    refs:
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/security/authentication.html
+        title: Cassandra Authentication
+  - uid: mondoo-cassandra-security-authorization-enabled
+    filters: asset.platform == "cassandra"
+    title: Ensure Cassandra enforces authorization
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      cassandra.cluster.security.authorizationEnabled == true
+    docs:
+      desc: |-
+        This check ensures that the configured authorizer is not `AllowAllAuthorizer`, so that `GRANT` and `REVOKE` permissions are actually enforced. With `AllowAllAuthorizer`, every authenticated role has full access to every keyspace and table, defeating least privilege.
+
+        **Why this matters**
+
+        - **Least privilege:** `CassandraAuthorizer` lets you grant each role only the permissions it needs rather than full access to everything.
+        - **Separation of duties:** Distinct roles for application access and administration limit what a single credential can do.
+        - **Enforced permissions:** `GRANT` and `REVOKE` statements have no effect unless a real authorizer evaluates them.
+
+        **Risk mitigation**
+
+        - **Contained credentials:** A leaked application credential cannot read or alter data outside the permissions granted to its role.
+        - **Blast radius:** Compromise of one role no longer implies control of the entire cluster.
+      audit: |-
+        ### Audit via cqlsh
+
+        1. Connect with `cqlsh` and read the effective `authorizer` setting:
+
+           ```sql
+           SELECT name, value FROM system_views.settings WHERE name = 'authorizer';
+           ```
+
+        If the value is `CassandraAuthorizer`, the check passes. If it is `AllowAllAuthorizer`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enforce authorization in the cluster configuration:
+
+            1. In `cassandra.yaml`, set:
+
+               ```yaml
+               authorizer: CassandraAuthorizer
+               ```
+            2. Perform a rolling restart of the cluster so every node picks up the new setting.
+            3. Grant least-privilege permissions to each role:
+
+               ```sql
+               GRANT SELECT ON KEYSPACE app_data TO app;
+               ```
+    refs:
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/security/authorization.html
+        title: Cassandra Authorization
+  - uid: mondoo-cassandra-security-client-encryption-enabled
+    filters: asset.platform == "cassandra"
+    title: Ensure Cassandra encrypts client-to-node traffic
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      cassandra.cluster.security.clientEncryptionEnabled == true
+    docs:
+      desc: |-
+        This check ensures that client-to-node TLS is enabled so that credentials and query data are encrypted in transit between drivers and nodes. Without it, everything a client sends and receives crosses the network in cleartext.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, CQL statements, and result sets from network eavesdropping.
+        - **Integrity in transit:** It prevents tampering with statements and responses on the wire.
+        - **Compliance:** Many frameworks require encryption of sensitive data in transit for database traffic.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via cqlsh
+
+        1. Connect with `cqlsh` and read the effective client encryption options:
+
+           ```sql
+           SELECT name, value FROM system_views.settings WHERE name = 'client_encryption_options';
+           ```
+
+        On older versions that do not expose `system_views.settings`, inspect the `client_encryption_options` block in `cassandra.yaml` instead.
+
+        If the value shows `enabled=true`, the check passes. If it shows `enabled=false`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable client-to-node encryption in the cluster configuration:
+
+            1. Provide a keystore and truststore for the node's TLS certificate and trusted CAs.
+            2. In `cassandra.yaml`, set the client encryption options:
+
+               ```yaml
+               client_encryption_options:
+                 enabled: true
+                 keystore: conf/keystore.jks
+                 keystore_password: <keystore-password>
+                 truststore: conf/truststore.jks
+                 truststore_password: <truststore-password>
+               ```
+            3. Perform a rolling restart of the cluster so every node picks up the new setting.
+    refs:
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
+        title: Cassandra TLS/SSL Encryption
+  - uid: mondoo-cassandra-security-audit-logging-enabled
+    filters: asset.platform == "cassandra"
+    title: Ensure Cassandra enables audit logging
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      cassandra.cluster.security.auditLoggingEnabled == true
+    docs:
+      desc: |-
+        This check ensures that audit logging is on, producing a trail of authentication, DML, and DDL events for detection and investigation. Without it, there is no record of who connected, what they queried, or what schema changes were made.
+
+        **Why this matters**
+
+        - **Attributable activity:** Audit records tie authentication, queries, and schema changes to a role and source, which is essential for investigating misuse.
+        - **Detection:** A log of login and query activity supports alerting on anomalous or unauthorized behavior.
+        - **Compliance evidence:** Audit frameworks require logging of access to systems that hold sensitive data.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** A trail of events narrows down the source and timeline of suspicious activity.
+        - **Deterrence:** Logged, attributable access discourages misuse by authorized users.
+      audit: |-
+        ### Audit via cqlsh
+
+        1. Connect with `cqlsh` and read the effective audit logging options:
+
+           ```sql
+           SELECT name, value FROM system_views.settings WHERE name = 'audit_logging_options';
+           ```
+
+        Alternatively, run `nodetool getauditlog` on a node to see whether audit logging is active.
+
+        If the value shows `enabled=true`, the check passes. If it shows `enabled=false`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable audit logging in the cluster configuration:
+
+            1. In `cassandra.yaml`, set the audit logging options with a logger such as `BinAuditLogger`:
+
+               ```yaml
+               audit_logging_options:
+                 enabled: true
+                 logger:
+                   - class_name: BinAuditLogger
+               ```
+            2. Perform a rolling restart of the cluster so every node picks up the new setting.
+        - id: cli
+          desc: |-
+            To enable audit logging at runtime on a node without a restart, use `nodetool`:
+
+            ```bash
+            nodetool enableauditlog
+            ```
+    refs:
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/audit_logging.html
+        title: Cassandra Audit Logging

--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -1,0 +1,165 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-clickhousedb-security
+    name: Mondoo ClickHouse Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: clickhousedb
+    require:
+      - provider: clickhousedb
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden self-hosted ClickHouse account authentication and transport encryption
+    docs:
+      desc: |
+        The Mondoo ClickHouse Security policy connects to a self-hosted ClickHouse server and assesses its authentication and transport posture: whether every account requires a password and whether the secure native TCP port is enabled.
+
+        Settings are read from the server's `system` tables, so the checks reflect the server's effective configuration rather than a file on disk.
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "clickhousedb"
+        checks:
+          - uid: mondoo-clickhousedb-security-users-have-passwords
+      - title: Transport Encryption
+        filters: asset.platform == "clickhousedb"
+        checks:
+          - uid: mondoo-clickhousedb-security-secure-tcp-port-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-clickhousedb-security-users-have-passwords
+    filters: asset.platform == "clickhousedb"
+    title: Ensure every ClickHouse account requires a password
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      clickhousedb.instance.users.all(hasPassword == true)
+    docs:
+      desc: |-
+        This check ensures that every ClickHouse account requires a password to authenticate. An account with no password can be reached with no credential at all, so anyone who can connect to the server is served as that account.
+
+        **Why this matters**
+
+        - **No unauthenticated access:** Requiring a password stops anonymous connections from acting as a real account.
+        - **Attributable activity:** Authenticated sessions tie queries to a known identity.
+        - **Defense against network exposure:** If the port is reachable, a password is the control that still stands.
+
+        **Risk mitigation**
+
+        - **Blocked anonymous use:** A client that reaches the port cannot operate without valid credentials.
+        - **Reduced blast radius:** Compromise requires a credential rather than mere network reachability.
+      audit: |-
+        ### Audit via clickhouse-client
+
+        1. List accounts and whether they require a password by querying the `system.users` table:
+
+           ```sql
+           SELECT name, auth_type FROM system.users;
+           ```
+
+        If no account reports `no_password`, the check passes. If any account allows password-less authentication, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To require a password for an account with SQL, set an authentication method:
+
+            ```sql
+            ALTER USER analyst IDENTIFIED WITH sha256_password BY '<strong-password>';
+            ```
+        - id: config
+          desc: |-
+            To require passwords through server configuration, define each account under `users.xml` (or a file in `users.d/`) with a `password_sha256_hex` (or `password`) element rather than an empty `<password></password>`, then reload:
+
+            ```xml
+            <users>
+              <analyst>
+                <password_sha256_hex>...</password_sha256_hex>
+              </analyst>
+            </users>
+            ```
+    refs:
+      - url: https://clickhouse.com/docs/en/operations/access-rights
+        title: ClickHouse access control and account management
+  - uid: mondoo-clickhousedb-security-secure-tcp-port-enabled
+    filters: asset.platform == "clickhousedb"
+    title: Ensure ClickHouse enables the secure native TCP port
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      clickhousedb.instance.serverSettings.where(name == "tcp_port_secure").any(value != "0" && value != "")
+    docs:
+      desc: |-
+        This check ensures that the secure (TLS) native TCP port is configured, so native-protocol clients can connect over an encrypted channel. When `tcp_port_secure` is set, credentials and query data are protected in transit rather than crossing the network in cleartext on the plain `tcp_port`.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials and result sets from network eavesdropping.
+        - **Integrity:** An encrypted channel resists tampering and session hijacking.
+        - **Compliance:** Frameworks require sensitive database traffic to be encrypted in transit.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Login credentials are not exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** With a trusted certificate, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via clickhouse-client
+
+        1. Read the configured secure TCP port from the `system.server_settings` table:
+
+           ```sql
+           SELECT name, value FROM system.server_settings WHERE name = 'tcp_port_secure';
+           ```
+
+        If `tcp_port_secure` is set to a non-zero port, the check passes. If it is `0` or unset, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable the secure native TCP port, configure TLS and set `tcp_port_secure` in the server configuration (`config.xml` or a file in `config.d/`), then restart:
+
+            ```xml
+            <clickhouse>
+              <tcp_port_secure>9440</tcp_port_secure>
+              <openSSL>
+                <server>
+                  <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>
+                  <privateKeyFile>/etc/clickhouse-server/server.key</privateKeyFile>
+                </server>
+              </openSSL>
+            </clickhouse>
+            ```
+    refs:
+      - url: https://clickhouse.com/docs/en/guides/sre/configuring-ssl
+        title: ClickHouse configuring SSL-TLS

--- a/content/mondoo-elasticsearch-security.mql.yaml
+++ b/content/mondoo-elasticsearch-security.mql.yaml
@@ -1,0 +1,332 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-elasticsearch-security
+    name: Mondoo Elasticsearch Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: elasticsearch
+    require:
+      - provider: elasticsearch
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Elasticsearch security features, anonymous access, transport encryption, and auditing
+    docs:
+      desc: |
+        The Mondoo Elasticsearch Security policy connects to a running Elasticsearch cluster and reads its cluster info, health, and security usage APIs to assess whether the cluster enforces its core protections. Because it reads the cluster's live state, the checks reflect the configuration the nodes are actually running.
+
+        This policy provides security checks across four areas:
+        - Whether the security features are enabled at all
+        - Whether anonymous access is disabled
+        - Whether TLS protects the HTTP and transport layers
+        - Whether security audit logging is enabled
+
+        A self-hosted Elasticsearch cluster ships with these protections off in some distributions, so a cluster left at its defaults can perform no authentication or authorization and expose every index to any client that can reach it.
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "elasticsearch"
+        checks:
+          - uid: mondoo-elasticsearch-security-security-features-enabled
+      - title: Access Control
+        filters: asset.platform == "elasticsearch"
+        checks:
+          - uid: mondoo-elasticsearch-security-anonymous-access-disabled
+      - title: Transport Encryption
+        filters: asset.platform == "elasticsearch"
+        checks:
+          - uid: mondoo-elasticsearch-security-tls-enabled
+      - title: Logging & Monitoring
+        filters: asset.platform == "elasticsearch"
+        checks:
+          - uid: mondoo-elasticsearch-security-audit-logging-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-elasticsearch-security-security-features-enabled
+    filters: asset.platform == "elasticsearch"
+    title: Ensure Elasticsearch security features are enabled
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      elasticsearch.cluster.security.enabled == true
+    docs:
+      desc: |-
+        This check ensures that the Elasticsearch security features (X-Pack security) are enabled. When security is disabled, the cluster performs no authentication or authorization, so any client that can reach it has full access to every index and cluster operation.
+
+        **Why this matters**
+
+        - **No access control when off:** With security disabled, there are no users, roles, or permissions; the network path is the only thing standing between an attacker and all of your data.
+        - **Foundation for other controls:** Authentication, authorization, TLS, and audit logging all depend on the security features being turned on first.
+        - **Defaults are not safe everywhere:** Some distributions and older versions ship with security off, leaving a fresh cluster fully open.
+
+        **Risk mitigation**
+
+        - **Authenticated access only:** Enabling security forces every request to present a credential tied to a known identity.
+        - **Role-based restrictions:** With security on, roles and privileges can limit what each authenticated identity may read or change.
+      audit: |-
+        ### Audit via cURL
+
+        1. Query the security usage from the X-Pack usage API with credentials:
+
+           ```bash
+           curl -s -u USER:PASS https://HOST:9200/_xpack/usage | jq .security.enabled
+           ```
+
+        2. Alternatively, confirm the setting on each node's configuration file:
+
+           ```bash
+           grep xpack.security.enabled /etc/elasticsearch/elasticsearch.yml
+           ```
+
+        If the usage API returns `true` (or `xpack.security.enabled: true` is set), the check passes. If it returns `false`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable the security features:
+
+            1. On every node, set the following in `elasticsearch.yml`:
+
+               ```yaml
+               xpack.security.enabled: true
+               ```
+            2. Restart Elasticsearch on each node so the change takes effect.
+            3. Set the built-in user passwords so authenticated access works, using `elasticsearch-setup-passwords` for a new cluster or `elasticsearch-reset-password` to reset an existing user:
+
+               ```bash
+               bin/elasticsearch-setup-passwords interactive
+               bin/elasticsearch-reset-password -u elastic
+               ```
+    refs:
+      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
+        title: Elasticsearch security settings
+  - uid: mondoo-elasticsearch-security-anonymous-access-disabled
+    filters: asset.platform == "elasticsearch"
+    title: Ensure Elasticsearch disables anonymous access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      elasticsearch.cluster.security.anonymousAccessEnabled == false
+    docs:
+      desc: |-
+        This check ensures that no anonymous role is configured, so unauthenticated requests are rejected rather than served as an anonymous user. When anonymous access is enabled, any request that arrives without credentials is treated as the anonymous role and carries whatever privileges that role was granted.
+
+        **Why this matters**
+
+        - **Unauthenticated data access:** An anonymous role with read privileges lets anyone on the network path query indices without ever presenting a credential.
+        - **Privilege inheritance:** The anonymous user gets exactly the permissions of its configured roles, which are easy to over-grant and hard to notice.
+        - **Weakens every other control:** Anonymous access bypasses the identity model that authorization, auditing, and rate limiting all rely on.
+
+        **Risk mitigation**
+
+        - **Credential enforcement:** Disabling anonymous access forces every client to authenticate before any data is returned.
+        - **Attribution:** Rejecting unauthenticated requests ensures each served request maps to a known identity that can be logged and investigated.
+      audit: |-
+        ### Audit via cURL
+
+        1. Send an unauthenticated request to the cluster root and observe the HTTP status:
+
+           ```bash
+           curl -s -o /dev/null -w "%{http_code}" https://HOST:9200/
+           ```
+
+        2. Alternatively, check for any anonymous configuration keys on each node:
+
+           ```bash
+           grep xpack.security.authc.anonymous /etc/elasticsearch/elasticsearch.yml
+           ```
+
+        If the unauthenticated request returns `401`, anonymous access is disabled and the check passes. If it returns `200`, anonymous access is enabled and the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To disable anonymous access:
+
+            1. Remove any `xpack.security.authc.anonymous.roles` setting from `elasticsearch.yml`, or force unauthenticated requests to be rejected with a `401` instead of falling back to the anonymous role:
+
+               ```yaml
+               xpack.security.authc.anonymous.authz_exception: true
+               ```
+            2. Restart Elasticsearch on each node so the change takes effect.
+    refs:
+      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/anonymous-access.html
+        title: Enabling anonymous access
+  - uid: mondoo-elasticsearch-security-tls-enabled
+    filters: asset.platform == "elasticsearch"
+    title: Ensure Elasticsearch enables TLS on HTTP and transport layers
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      elasticsearch.cluster.security.httpTlsEnabled == true
+      elasticsearch.cluster.security.transportTlsEnabled == true
+    docs:
+      desc: |-
+        This check ensures that TLS is enabled on both the HTTP/REST layer, which protects client credentials and query data, and the transport layer, which protects node-to-node traffic and prevents rogue nodes from joining the cluster. Both layers must be encrypted for the cluster to be safe on an untrusted network.
+
+        **Why this matters**
+
+        - **Confidentiality of client traffic:** HTTP-layer TLS encrypts the credentials and query data that clients send to the REST API, keeping them off the wire in cleartext.
+        - **Cluster integrity:** Transport-layer TLS authenticates and encrypts node-to-node communication, so an attacker cannot read replicated data or introduce a rogue node into the cluster.
+        - **Defense in depth:** Encrypting only one layer leaves the other exposed; both are needed to protect the full data path.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** With HTTP TLS on, authentication material is never sent in the clear to the REST API.
+        - **Rogue-node resistance:** Transport TLS with certificate verification blocks unauthorized nodes from joining and intercepting cluster data.
+      audit: |-
+        ### Audit via cURL
+
+        1. Confirm the HTTP layer requires TLS: an `https://` request should succeed while a plain `http://` request to the same port is refused:
+
+           ```bash
+           curl -s -o /dev/null -w "%{http_code}" -u USER:PASS https://HOST:9200/
+           curl -s http://HOST:9200/
+           ```
+
+        2. Alternatively, confirm both settings on each node's configuration file:
+
+           ```bash
+           grep -E 'xpack.security.(http|transport).ssl.enabled' /etc/elasticsearch/elasticsearch.yml
+           ```
+
+        If the `https://` request succeeds, the `http://` request is refused, and both `xpack.security.http.ssl.enabled: true` and `xpack.security.transport.ssl.enabled: true` are set, the check passes. Otherwise it fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable TLS on both layers:
+
+            1. Generate certificates for the nodes with `elasticsearch-certutil`:
+
+               ```bash
+               bin/elasticsearch-certutil ca
+               bin/elasticsearch-certutil cert --ca elastic-stack-ca.p12
+               ```
+            2. On every node, enable both the HTTP and transport SSL blocks in `elasticsearch.yml` and point them at the generated certificates:
+
+               ```yaml
+               xpack.security.http.ssl.enabled: true
+               xpack.security.http.ssl.keystore.path: http.p12
+               xpack.security.transport.ssl.enabled: true
+               xpack.security.transport.ssl.verification_mode: certificate
+               xpack.security.transport.ssl.keystore.path: elastic-certificates.p12
+               xpack.security.transport.ssl.truststore.path: elastic-certificates.p12
+               ```
+            3. Restart Elasticsearch on each node so the change takes effect.
+    refs:
+      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html
+        title: Set up basic security plus HTTPS
+  - uid: mondoo-elasticsearch-security-audit-logging-enabled
+    filters: asset.platform == "elasticsearch"
+    title: Ensure Elasticsearch enables audit logging
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      elasticsearch.cluster.security.auditLoggingEnabled == true
+    docs:
+      desc: |-
+        This check ensures that security audit logging is enabled so the cluster records authentication successes and failures and access events for detection and investigation. Audit logging is off by default, so a cluster left at its defaults keeps no record of who accessed what.
+
+        **Why this matters**
+
+        - **Attributable access:** Audit records tie authentication and access events to source addresses and identities, which is essential for investigating misuse.
+        - **Detection of attacks:** Logged authentication failures reveal brute-force and credential-stuffing attempts that would otherwise go unnoticed.
+        - **Compliance evidence:** Audit frameworks require a record of access to systems that hold sensitive data.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** A record of authentication and access events narrows down the source and timeline of suspicious activity.
+        - **Deterrence and detection:** Auditing supports alerting on anomalous access patterns and off-hours activity.
+      audit: |-
+        ### Audit via cURL
+
+        1. Query the security usage from the X-Pack usage API with credentials:
+
+           ```bash
+           curl -s -u USER:PASS https://HOST:9200/_xpack/usage | jq .security.audit.enabled
+           ```
+
+        2. Alternatively, confirm the setting on each node's configuration file:
+
+           ```bash
+           grep xpack.security.audit.enabled /etc/elasticsearch/elasticsearch.yml
+           ```
+
+        If the usage API returns `true` (or `xpack.security.audit.enabled: true` is set), the check passes. If it returns `false`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable audit logging:
+
+            1. On every node, set the following in `elasticsearch.yml`:
+
+               ```yaml
+               xpack.security.audit.enabled: true
+               ```
+            2. Optionally, tune which events are captured with `xpack.security.audit.logfile.events.*`:
+
+               ```yaml
+               xpack.security.audit.logfile.events.include: [access_denied, authentication_failed, authentication_success]
+               ```
+            3. Restart Elasticsearch on each node so the change takes effect.
+    refs:
+      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/auditing-settings.html
+        title: Auditing security settings

--- a/content/mondoo-mongodb-security.mql.yaml
+++ b/content/mondoo-mongodb-security.mql.yaml
@@ -1,0 +1,335 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-mongodb-security
+    name: Mondoo MongoDB Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: mongo
+    require:
+      - provider: mongo
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden MongoDB authentication, access control, transport encryption, and server surface area
+    docs:
+      desc: |
+        The Mondoo MongoDB Security policy connects to a running MongoDB server and reads its security configuration directly from the server, so the checks reflect the settings the server is actually enforcing rather than a file on disk.
+
+        This policy provides security checks across four areas:
+        - Authentication of client connections
+        - Role-based access control
+        - Transport encryption with TLS
+        - Server-side JavaScript surface area
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "mongo"
+        checks:
+          - uid: mondoo-mongodb-security-authentication-enabled
+      - title: Access Control
+        filters: asset.platform == "mongo"
+        checks:
+          - uid: mondoo-mongodb-security-authorization-enabled
+      - title: Transport Encryption
+        filters: asset.platform == "mongo"
+        checks:
+          - uid: mondoo-mongodb-security-require-tls
+      - title: Surface Area
+        filters: asset.platform == "mongo"
+        checks:
+          - uid: mondoo-mongodb-security-server-side-javascript-disabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-mongodb-security-authentication-enabled
+    filters: asset.platform == "mongo"
+    title: Ensure MongoDB requires client authentication
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      mongo.instance.authenticationEnabled == true
+    docs:
+      desc: |-
+        This check ensures that the server is started with authorization enabled (`security.authorization: enabled` or `--auth`), so that clients must authenticate before they can run commands. Without it, anyone who can reach the MongoDB port connects with full access and no credentials.
+
+        **Why this matters**
+
+        - **No anonymous access:** Requiring authentication ties every connection to a known user rather than allowing open access to anyone on the network.
+        - **Credential enforcement:** Clients must present a valid username and password (or another configured mechanism) before a session is granted.
+        - **Foundation for authorization:** Role-based access control is meaningless without an authenticated identity to enforce it against.
+
+        **Risk mitigation**
+
+        - **Reduced exposure:** An attacker who reaches the MongoDB port can no longer connect without stealing or guessing a credential.
+        - **Attributable access:** Authenticated sessions can be tied to a user for logging and investigation.
+      audit: |-
+        ### Audit via mongosh
+
+        1. Connect with `mongosh` and read the server's command-line and configuration options:
+
+           ```javascript
+           db.adminCommand({ getCmdLineOpts: 1 })
+           ```
+
+        2. Inspect the returned `security.authorization` value (or the `--auth` flag under `argv`).
+
+        On servers where `mongosh` access is restricted, inspect the `security.authorization` setting in `mongod.conf` instead.
+
+        If authorization is `enabled`, the check passes. If it is `disabled` or absent, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To require authentication in the server configuration:
+
+            1. Connect while access control is still open and create an administrative user first, so you are not locked out:
+
+               ```javascript
+               use admin
+               db.createUser({
+                 user: "admin",
+                 pwd: passwordPrompt(),
+                 roles: [ { role: "userAdminAnyDatabase", db: "admin" } ]
+               })
+               ```
+            2. In `mongod.conf`, enable authorization:
+
+               ```yaml
+               security:
+                 authorization: enabled
+               ```
+            3. Restart the `mongod` service so the new setting takes effect.
+        - id: cli
+          desc: |-
+            To create the initial administrative user before enabling authentication, connect with `mongosh` and run:
+
+            ```javascript
+            use admin
+            db.createUser({
+              user: "admin",
+              pwd: passwordPrompt(),
+              roles: [ { role: "userAdminAnyDatabase", db: "admin" } ]
+            })
+            ```
+
+            Then enable `security.authorization` in `mongod.conf` and restart `mongod` so authentication is enforced.
+    refs:
+      - url: https://www.mongodb.com/docs/manual/core/authentication/
+        title: MongoDB Authentication
+  - uid: mondoo-mongodb-security-authorization-enabled
+    filters: asset.platform == "mongo"
+    title: Ensure MongoDB enforces role-based access control
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      mongo.instance.authorizationEnabled == true
+    docs:
+      desc: |-
+        This check ensures that role-based access control is enforced, so that users receive only the privileges their roles grant. Without it, every authenticated client has full access to every database, defeating least privilege.
+
+        **Why this matters**
+
+        - **Least privilege:** Role-based access control lets you grant each user only the permissions it needs rather than full access to everything.
+        - **Separation of duties:** Distinct roles for application access and administration limit what a single credential can do.
+        - **Enforced permissions:** Built-in and custom roles have effect only when access control is active.
+
+        **Risk mitigation**
+
+        - **Contained credentials:** A leaked application credential cannot read or alter data outside the permissions granted to its role.
+        - **Blast radius:** Compromise of one user no longer implies control of the entire deployment.
+      audit: |-
+        ### Audit via mongosh
+
+        1. Connect with `mongosh` and read the server's configuration options:
+
+           ```javascript
+           db.adminCommand({ getCmdLineOpts: 1 })
+           ```
+
+        2. Inspect the returned `security.authorization` value and confirm role-based access control is active.
+
+        On servers where `mongosh` access is restricted, inspect the `security.authorization` setting in `mongod.conf` instead.
+
+        If authorization is `enabled`, the check passes. If it is `disabled` or absent, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enforce role-based access control in the server configuration:
+
+            1. In `mongod.conf`, enable authorization:
+
+               ```yaml
+               security:
+                 authorization: enabled
+               ```
+            2. Restart the `mongod` service so the new setting takes effect.
+            3. Grant least-privilege built-in or custom roles to each user:
+
+               ```javascript
+               use admin
+               db.grantRolesToUser("appuser", [ { role: "readWrite", db: "app_data" } ])
+               ```
+    refs:
+      - url: https://www.mongodb.com/docs/manual/core/authorization/
+        title: MongoDB Role-Based Access Control
+  - uid: mondoo-mongodb-security-require-tls
+    filters: asset.platform == "mongo"
+    title: Ensure MongoDB requires TLS for client connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      mongo.instance.tlsMode == "requireTLS"
+    docs:
+      desc: |-
+        This check ensures that the server's `net.tls.mode` is `requireTLS`, so that all client and intra-cluster connections are encrypted in transit. Weaker modes such as `allowTLS` and `preferTLS` still accept plaintext connections, leaving credentials and query data exposed on the network.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, commands, and result sets from network eavesdropping.
+        - **Integrity in transit:** It prevents tampering with statements and responses on the wire.
+        - **No plaintext fallback:** `requireTLS` rejects unencrypted connections outright, unlike the permissive modes that still allow them.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via mongosh
+
+        1. Connect with `mongosh` and read the server's TLS configuration:
+
+           ```javascript
+           db.adminCommand({ getCmdLineOpts: 1 })
+           ```
+
+        2. Inspect the returned `net.tls.mode` value.
+
+        On servers where `mongosh` access is restricted, inspect the `net.tls.mode` setting in `mongod.conf` instead.
+
+        If the mode is `requireTLS`, the check passes. If it is `allowTLS`, `preferTLS`, or `disabled`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To require TLS in the server configuration:
+
+            1. Provide a combined certificate and private key file readable only by the `mongod` user.
+            2. In `mongod.conf`, set the TLS mode and certificate:
+
+               ```yaml
+               net:
+                 tls:
+                   mode: requireTLS
+                   certificateKeyFile: /etc/ssl/mongodb.pem
+               ```
+            3. Restart the `mongod` service so the new setting takes effect.
+    refs:
+      - url: https://www.mongodb.com/docs/manual/core/security-transport-encryption/
+        title: MongoDB TLS/SSL
+  - uid: mondoo-mongodb-security-server-side-javascript-disabled
+    filters: asset.platform == "mongo"
+    title: Ensure MongoDB disables server-side JavaScript
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-protection
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      mongo.instance.javascriptEnabled == false
+    docs:
+      desc: |-
+        This check ensures that server-side JavaScript execution (`security.javascriptEnabled`) is disabled, removing the `$where`, `mapReduce`, and `$function` attack surface when the application does not need it. Server-side JavaScript lets a query run arbitrary code inside the database process.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** Disabling server-side JavaScript removes operators that can execute arbitrary code, closing an injection path.
+        - **Hardened defaults:** Most applications never use `$where`, `mapReduce`, or `$function`, so the feature is pure exposure when left on.
+        - **Defense in depth:** It limits what an attacker can do even if a malicious query reaches the server.
+
+        **Risk mitigation**
+
+        - **No arbitrary code execution:** A crafted `$where` or `$function` payload can no longer run JavaScript inside the database.
+        - **Contained injection:** Query injection that relies on server-side JavaScript is neutralized.
+      audit: |-
+        ### Audit via mongosh
+
+        1. Connect with `mongosh` and read the server's security configuration:
+
+           ```javascript
+           db.adminCommand({ getCmdLineOpts: 1 })
+           ```
+
+        2. Inspect the returned `security.javascriptEnabled` value.
+
+        On servers where `mongosh` access is restricted, inspect the `security.javascriptEnabled` setting in `mongod.conf` instead.
+
+        If server-side JavaScript is `false`, the check passes. If it is `true` or absent (enabled by default), the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To disable server-side JavaScript in the server configuration:
+
+            1. In `mongod.conf`, disable JavaScript execution:
+
+               ```yaml
+               security:
+                 javascriptEnabled: false
+               ```
+            2. Restart the `mongod` service so the new setting takes effect.
+    refs:
+      - url: https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.javascriptEnabled
+        title: MongoDB security.javascriptEnabled

--- a/content/mondoo-mssql-security.mql.yaml
+++ b/content/mondoo-mssql-security.mql.yaml
@@ -1,0 +1,289 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-mssql-security
+    name: Mondoo Microsoft SQL Server Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: mssql
+    require:
+      - provider: mssql
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Microsoft SQL Server encryption, authentication, surface area, and audit logging
+    docs:
+      desc: |
+        The Mondoo Microsoft SQL Server Security policy connects to a running SQL Server instance and assesses its effective configuration: the authentication mode, transport encryption, `sp_configure` surface-area options, and login auditing.
+
+        This policy provides security checks across four areas:
+        - Transport encryption for client connections
+        - Authentication mode
+        - Server surface area (dangerous features disabled)
+        - Login audit logging
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Transport Encryption
+        filters: asset.platform == "mssql"
+        checks:
+          - uid: mondoo-mssql-security-force-encryption-enabled
+      - title: Authentication
+        filters: asset.platform == "mssql"
+        checks:
+          - uid: mondoo-mssql-security-windows-authentication-mode
+      - title: Surface Area
+        filters: asset.platform == "mssql"
+        checks:
+          - uid: mondoo-mssql-security-xp-cmdshell-disabled
+      - title: Logging & Monitoring
+        filters: asset.platform == "mssql"
+        checks:
+          - uid: mondoo-mssql-security-login-auditing-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-mssql-security-force-encryption-enabled
+    filters: asset.platform == "mssql"
+    title: Ensure SQL Server forces encryption for client connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      mssql.server.forceEncryption == true
+    docs:
+      desc: |-
+        This check ensures that the SQL Server instance has Force Encryption enabled, so the server requires an encrypted TLS channel for all client connections rather than leaving encryption to each client's discretion.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, query text, and result sets from network eavesdropping.
+        - **No opportunistic downgrade:** Forcing encryption at the server prevents a client from negotiating an unencrypted session.
+        - **Compliance:** Frameworks require sensitive database traffic to be encrypted in transit.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** Login credentials are no longer exposed to anyone on the network path.
+        - **Man-in-the-middle resistance:** Combined with a trusted server certificate, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via SQL Server Configuration Manager
+
+        1. Open **SQL Server Configuration Manager**.
+        2. Under **SQL Server Network Configuration**, right-click **Protocols for <instance>** and choose **Properties**.
+        3. On the **Flags** tab, review **Force Encryption**.
+
+        If **Force Encryption** is **Yes**, the check passes. If it is **No**, the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To force encryption using SQL Server Configuration Manager:
+
+            1. Install a trusted server certificate for the instance and grant the SQL Server service account read access to its private key.
+            2. Open **SQL Server Configuration Manager** > **SQL Server Network Configuration** > **Protocols for <instance>** > **Properties**.
+            3. On the **Certificate** tab select the certificate, and on the **Flags** tab set **Force Encryption** to **Yes**.
+            4. Restart the SQL Server service.
+    refs:
+      - url: https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-sql-server-encryption
+        title: Configure SQL Server Database Engine for encrypting connections
+  - uid: mondoo-mssql-security-windows-authentication-mode
+    filters: asset.platform == "mssql"
+    title: Ensure SQL Server uses Windows Authentication mode
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      mssql.server.isMixedModeAuthEnabled == false
+    docs:
+      desc: |-
+        This check ensures that the instance uses Windows Authentication mode rather than mixed mode. In mixed mode, SQL logins authenticate with a username and password managed by SQL Server; in Windows Authentication mode, only Windows and Active Directory principals may connect, so identity is centralized in the directory.
+
+        **Why this matters**
+
+        - **Centralized identity:** Windows Authentication delegates authentication to Active Directory, which enforces password policy, lockout, and Kerberos protections that SQL logins do not receive by default.
+        - **Smaller credential surface:** SQL logins add a separate set of passwords that can be brute-forced against the database endpoint directly.
+        - **Stronger protocols:** Windows Authentication uses Kerberos or NTLM rather than passing SQL-login credentials to the server.
+
+        **Risk mitigation**
+
+        - **No standalone SQL passwords:** Removing SQL logins eliminates a common brute-force and credential-stuffing target.
+        - **Policy enforcement:** Directory-managed accounts inherit enterprise password and lockout policy.
+      audit: |-
+        ### Audit via T-SQL
+
+        1. Query the authentication mode with `sqlcmd` (or SSMS):
+
+           ```sql
+           SELECT SERVERPROPERTY('IsIntegratedSecurityOnly') AS windows_auth_only;
+           ```
+
+        If the value is `1` (Windows Authentication only), the check passes. If it is `0` (mixed mode), the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To switch to Windows Authentication mode using SSMS:
+
+            1. In SQL Server Management Studio, right-click the server and choose **Properties**.
+            2. On the **Security** page, under **Server authentication**, select **Windows Authentication mode**.
+            3. Click **OK** and restart the SQL Server service.
+            4. Before switching, confirm that a Windows login with sysadmin rights exists so you are not locked out.
+        - id: cli
+          desc: |-
+            To switch to Windows Authentication mode via the registry (requires a service restart), set `LoginMode` to `1`:
+
+            ```powershell
+            # 1 = Windows Authentication, 2 = mixed mode
+            Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.MSSQLSERVER\MSSQLServer' -Name LoginMode -Value 1
+            Restart-Service -Name 'MSSQLSERVER'
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/change-server-authentication-mode
+        title: Change server authentication mode
+  - uid: mondoo-mssql-security-xp-cmdshell-disabled
+    filters: asset.platform == "mssql"
+    title: Ensure the xp_cmdshell surface-area option is disabled
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-protection
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      mssql.server.configurations.where(name == "xp_cmdshell").all(valueInUse == 0)
+    docs:
+      desc: |-
+        This check ensures that the `xp_cmdshell` server configuration option is disabled. When enabled, `xp_cmdshell` lets a sufficiently privileged database session run arbitrary operating-system commands under the SQL Server service account.
+
+        **Why this matters**
+
+        - **Blocks OS command execution from SQL:** With `xp_cmdshell` off, a compromised database login or a SQL injection flaw cannot pivot into shell commands on the host.
+        - **Reduces surface area:** It is disabled by default; leaving it on keeps a powerful, rarely needed capability available to attackers.
+        - **Limits blast radius:** Commands would otherwise run with the privileges of the SQL Server service account, not the caller.
+
+        **Risk mitigation**
+
+        - **Injection containment:** A SQL injection vulnerability can no longer escalate to host command execution through this path.
+        - **Least functionality:** Removing unused capabilities shrinks the attack surface of the instance.
+      audit: |-
+        ### Audit via T-SQL
+
+        1. Read the running value of `xp_cmdshell`:
+
+           ```sql
+           SELECT value_in_use FROM sys.configurations WHERE name = 'xp_cmdshell';
+           ```
+
+        If `value_in_use` is `0`, the check passes. If it is `1`, the check fails.
+      remediation:
+        - id: cli
+          desc: |-
+            To disable `xp_cmdshell` with T-SQL:
+
+            ```sql
+            EXEC sp_configure 'show advanced options', 1;
+            RECONFIGURE;
+            EXEC sp_configure 'xp_cmdshell', 0;
+            RECONFIGURE;
+            ```
+        - id: gui
+          desc: |-
+            To disable `xp_cmdshell` using the Surface Area Configuration in SSMS:
+
+            1. In SQL Server Management Studio, right-click the server and choose **Facets**.
+            2. Open the **Surface Area Configuration** facet.
+            3. Set **XPCmdShellEnabled** to **False** and click **OK**.
+    refs:
+      - url: https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/xp-cmdshell-server-configuration-option
+        title: xp_cmdshell server configuration option
+  - uid: mondoo-mssql-security-login-auditing-enabled
+    filters: asset.platform == "mssql"
+    title: Ensure SQL Server audits failed login attempts
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      ["Failed", "All"].contains( mssql.server.loginAuditLevel )
+    docs:
+      desc: |-
+        This check ensures that the instance's login auditing level records failed login attempts (a level of `Failed` or `All`). SQL Server writes these records to the SQL Server error log, producing an audit trail of authentication activity.
+
+        **Why this matters**
+
+        - **Brute-force detection:** A record of failed logins is the primary signal for password-guessing and credential-stuffing against SQL logins.
+        - **Attributable access:** Login records tie authentication attempts to accounts and times, supporting investigations.
+        - **Compliance evidence:** Audit frameworks require logging of access attempts to systems holding sensitive data.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** A trail of failed logins narrows down the source and timeline of an attack.
+        - **Alerting:** Logged failures can drive alerts on repeated or off-hours attempts.
+      audit: |-
+        ### Audit via T-SQL
+
+        1. Read the configured login audit level:
+
+           ```sql
+           EXEC xp_instance_regread N'HKEY_LOCAL_MACHINE', N'Software\Microsoft\MSSQLServer\MSSQLServer', N'AuditLevel';
+           ```
+
+        A value of `2` (failed logins) or `3` (all logins) passes the check. A value of `0` (none) or `1` (successful only) fails it.
+      remediation:
+        - id: gui
+          desc: |-
+            To enable login auditing using SSMS:
+
+            1. In SQL Server Management Studio, right-click the server and choose **Properties**.
+            2. On the **Security** page, under **Login auditing**, select **Failed logins only** (or **Both failed and successful logins**).
+            3. Click **OK** and restart the SQL Server service.
+    refs:
+      - url: https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/server-properties-security-page
+        title: Server Properties (Security Page)

--- a/content/mondoo-opensearch-security.mql.yaml
+++ b/content/mondoo-opensearch-security.mql.yaml
@@ -1,0 +1,254 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-opensearch-security
+    name: Mondoo OpenSearch Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: opensearch
+    require:
+      - provider: opensearch
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden OpenSearch anonymous access, authentication realms, and audit logging
+    docs:
+      desc: |
+        The Mondoo OpenSearch Security policy connects to a running OpenSearch cluster and reads the security-plugin configuration APIs to assess how the cluster authenticates clients and records their activity. Because it reads the security plugin's live configuration rather than a file on disk, the checks reflect the settings the cluster is actually enforcing.
+
+        This policy provides security checks across three areas:
+        - Anonymous access to the cluster
+        - Authentication realms that verify client credentials
+        - Audit logging of authentication and access events
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Access Control
+        filters: asset.platform == "opensearch"
+        checks:
+          - uid: mondoo-opensearch-security-anonymous-access-disabled
+      - title: Authentication
+        filters: asset.platform == "opensearch"
+        checks:
+          - uid: mondoo-opensearch-security-authentication-realm-enabled
+      - title: Logging & Monitoring
+        filters: asset.platform == "opensearch"
+        checks:
+          - uid: mondoo-opensearch-security-audit-logging-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-opensearch-security-anonymous-access-disabled
+    filters: asset.platform == "opensearch"
+    title: Ensure OpenSearch disables anonymous access
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      opensearch.cluster.security.anonymousAccessEnabled == false
+    docs:
+      desc: |-
+        This check ensures that anonymous authentication is disabled in the security plugin, so unauthenticated requests are rejected rather than served as the anonymous user. When anonymous access is enabled, any client that can reach the network endpoint is mapped to the anonymous backend role and can act without presenting credentials.
+
+        **Why this matters**
+
+        - **Data exposure:** Indices often hold logs, application data, and other sensitive records; anonymous read access leaks that data to anyone on the network.
+        - **Data tampering:** Without authentication, an attacker can index, modify, or delete documents that applications depend on.
+        - **Attribution:** Requests served as the anonymous user cannot be tied to a specific identity, undermining detection and investigation.
+
+        **Risk mitigation**
+
+        - **Authenticated access only:** Rejecting anonymous requests ensures every operation is tied to a known identity.
+        - **Reduced exposure:** Combined with tight network rules, this prevents unauthenticated clients from reaching cluster data.
+      audit: |-
+        ### Audit via cURL
+
+        1. Read the security configuration and inspect the anonymous authentication flag:
+
+           ```bash
+           curl -s -u admin:PASS -k https://HOST:9200/_plugins/_security/api/securityconfig | jq '.config.dynamic.http.anonymous_auth_enabled'
+           ```
+
+        If the value is `false`, anonymous access is disabled and the check passes. If it is `true`, anonymous access is enabled and the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To disable anonymous access, set the flag in the security plugin's dynamic configuration:
+
+            1. In `config.yml`, set:
+
+               ```yaml
+               config:
+                 dynamic:
+                   http:
+                     anonymous_auth_enabled: false
+               ```
+        - id: cli
+          desc: |-
+            To apply the updated configuration to the cluster, run `securityadmin.sh` with the edited file:
+
+            ```bash
+            ./securityadmin.sh -f config.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
+            ```
+    refs:
+      - url: https://opensearch.org/docs/latest/security/access-control/anonymous-authentication/
+        title: OpenSearch anonymous authentication
+  - uid: mondoo-opensearch-security-authentication-realm-enabled
+    filters: asset.platform == "opensearch"
+    title: Ensure OpenSearch has an authentication realm enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      opensearch.cluster.security.enabledAuthRealms != empty
+    docs:
+      desc: |-
+        This check ensures that at least one authentication realm is enabled in the security plugin, so clients must present credentials that are actually verified against a backend rather than the cluster having no configured authenticator. An authentication domain (authc) ties an HTTP authenticator to a backend that validates the supplied credentials.
+
+        **Why this matters**
+
+        - **Verified identity:** An enabled realm forces clients to prove who they are against an internal user database, LDAP, or an identity provider.
+        - **No open cluster:** Without an enabled realm, credentials are never checked and the cluster effectively accepts any caller.
+        - **Foundation for authorization:** Roles and permissions can only be enforced once a client's identity has been established.
+
+        **Risk mitigation**
+
+        - **Credential enforcement:** Every request is authenticated against a backend before it is served.
+        - **Attribution:** Verified identities can be logged and tied to actions, supporting detection and investigation.
+      audit: |-
+        ### Audit via cURL
+
+        1. Read the security configuration and inspect the configured authentication domains:
+
+           ```bash
+           curl -s -u admin:PASS -k https://HOST:9200/_plugins/_security/api/securityconfig | jq '.config.dynamic.authc'
+           ```
+
+        If at least one domain has `http_enabled: true`, an authentication realm is enabled and the check passes. If no domain is enabled, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable an authentication realm, define and enable an authc domain in the security plugin's dynamic configuration:
+
+            1. In `config.yml`, define and enable an authc domain, for example `basic_internal_auth_domain`:
+
+               ```yaml
+               config:
+                 dynamic:
+                   authc:
+                     basic_internal_auth_domain:
+                       http_enabled: true
+                       http_authenticator:
+                         type: basic
+                         challenge: true
+                       authentication_backend:
+                         type: internal
+               ```
+        - id: cli
+          desc: |-
+            To apply the updated configuration to the cluster, run `securityadmin.sh` with the edited file:
+
+            ```bash
+            ./securityadmin.sh -f config.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
+            ```
+    refs:
+      - url: https://opensearch.org/docs/latest/security/configuration/configuration/
+        title: OpenSearch backend configuration
+  - uid: mondoo-opensearch-security-audit-logging-enabled
+    filters: asset.platform == "opensearch"
+    title: Ensure OpenSearch enables audit logging
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      opensearch.cluster.security.auditLoggingEnabled == true
+    docs:
+      desc: |-
+        This check ensures that the security plugin's audit logging is enabled, recording authentication and access events for detection and investigation. Audit logs capture who connected, what they requested, and whether the request was authorized, producing the trail needed to reconstruct activity after an incident.
+
+        **Why this matters**
+
+        - **Attributable access:** Audit records tie requests to identities and source addresses, which is essential for investigating misuse.
+        - **Detection:** Logged authentication failures and privileged actions support alerting on brute-force and anomalous activity.
+        - **Compliance evidence:** Audit frameworks require logging of access to systems that hold sensitive data.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** A record of requests narrows down the source and timeline of suspicious activity.
+        - **Deterrence and accountability:** Logged access discourages misuse and supports after-the-fact review.
+      audit: |-
+        ### Audit via cURL
+
+        1. Read the audit configuration and inspect whether auditing is enabled:
+
+           ```bash
+           curl -s -u admin:PASS -k https://HOST:9200/_plugins/_security/api/audit | jq '.config.enabled'
+           ```
+
+        If the value is `true`, audit logging is enabled and the check passes. If it is `false`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable audit logging, configure the audit sink and turn on auditing in the security plugin's configuration:
+
+            1. In `opensearch.yml`, set the audit log type (for example, write audit events to an internal index):
+
+               ```yaml
+               plugins.security.audit.type: internal_opensearch
+               ```
+            2. In `audit.yml`, enable auditing and select the categories to record:
+
+               ```yaml
+               config:
+                 enabled: true
+               ```
+        - id: cli
+          desc: |-
+            To apply the audit configuration to the cluster, run `securityadmin.sh` with the edited file:
+
+            ```bash
+            ./securityadmin.sh -f audit.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
+            ```
+    refs:
+      - url: https://opensearch.org/docs/latest/security/audit-logs/index/
+        title: OpenSearch audit logs

--- a/content/mondoo-redis-security.mql.yaml
+++ b/content/mondoo-redis-security.mql.yaml
@@ -1,0 +1,249 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-redis-security
+    name: Mondoo Redis Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: redisdb
+    require:
+      - provider: redisdb
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Redis and Valkey authentication, network exposure, and transport encryption
+    docs:
+      desc: |
+        The Mondoo Redis Security policy connects to a running Redis or Valkey server and assesses its effective, runtime state. It reads the server's live `INFO` output, its `CONFIG GET` parameters, and the access-control users from `ACL LIST`, so the checks reflect the configuration the server is actually enforcing rather than a file on disk.
+
+        This policy provides security checks across three areas:
+        - Authentication strength, enforced through access-control (ACL) passwords
+        - Network exposure, governed by protected mode
+        - Transport encryption for client connections via TLS
+
+        Left with a passwordless default user, protected mode off, and no TLS, a Redis or Valkey server on a reachable network hands full read and write access to anyone who can open a socket to its port, with every command and credential crossing the wire in cleartext.
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Transport Encryption
+        filters: asset.platform == "redisdb"
+        checks:
+          - uid: mondoo-redis-security-tls-enabled
+      - title: Authentication
+        filters: asset.platform == "redisdb"
+        checks:
+          - uid: mondoo-redis-security-authentication-required
+      - title: Network Surface Area
+        filters: asset.platform == "redisdb"
+        checks:
+          - uid: mondoo-redis-security-protected-mode-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-redis-security-tls-enabled
+    filters: asset.platform == "redisdb"
+    title: Ensure Redis enables TLS for client connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      redisdb.instance.tlsEnabled == true
+    docs:
+      desc: |-
+        This check ensures that the server has a TLS listener enabled so that client connections can be encrypted in transit. Without TLS, the `AUTH` password and every command and result crosses the network in cleartext.
+
+        **Why this matters**
+
+        - **Confidentiality in transit:** TLS protects credentials, command text, keys, and values from anyone able to observe the network path.
+        - **Integrity in transit:** It prevents tampering with commands and responses on the wire.
+        - **Compliance:** Many frameworks require encryption of sensitive data in transit for database traffic.
+
+        **Risk mitigation**
+
+        - **No cleartext credentials:** The password sent during `AUTH` is no longer exposed to a network eavesdropper.
+        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+      audit: |-
+        ### Audit via redis-cli
+
+        1. Read the configured TLS port:
+
+           ```bash
+           redis-cli CONFIG GET tls-port
+           ```
+
+        If `tls-port` is a nonzero value, TLS is enabled and the check passes. If it is `0`, TLS is disabled and the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable TLS in the server configuration:
+
+            1. Provide a server certificate, private key, and CA certificate readable only by the Redis user.
+            2. In `redis.conf`, enable the TLS listener, disable the plaintext port, and point at the certificate files:
+
+               ```ini
+               tls-port 6379
+               port 0
+               tls-cert-file /etc/redis/tls/redis.crt
+               tls-key-file /etc/redis/tls/redis.key
+               tls-ca-cert-file /etc/redis/tls/ca.crt
+               ```
+            3. Restart the server so the TLS listener is bound.
+        - id: cli
+          desc: |-
+            TLS cannot be bootstrapped purely at runtime, because the certificate and key files must be present and the listener must be bound before clients connect. Set the TLS parameters in `redis.conf` as shown in the configuration remediation, then apply them with a reload:
+
+            ```bash
+            redis-cli CONFIG SET tls-port 6379
+            redis-cli CONFIG SET port 0
+            ```
+
+            If the certificate files were not already loaded at startup, restart the server so the new TLS listener takes effect.
+    refs:
+      - url: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
+        title: Redis TLS
+  - uid: mondoo-redis-security-authentication-required
+    filters: asset.platform == "redisdb"
+    title: Ensure every enabled Redis user requires a password
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      redisdb.instance.users.where(enabled == true).all(nopass == false)
+    docs:
+      desc: |-
+        This check ensures that no enabled access-control (ACL) user carries the `nopass` flag. A `nopass`, enabled user, especially the built-in `default` user, lets anyone who can reach the port authenticate as that user with whatever access its rules grant.
+
+        **Why this matters**
+
+        - **No anonymous access:** A `nopass` default user means possession of a network path is enough to run commands, defeating authentication entirely.
+        - **Blast radius:** A passwordless user with `~* +@all` hands full control of every key and administrative command to any client that connects.
+        - **Least privilege of authentication:** Every enabled identity should prove itself with a credential before it can issue commands.
+
+        **Risk mitigation**
+
+        - **Credential enforcement:** Requiring a password on every enabled user forces each client to authenticate.
+        - **Reduced exposure:** Combined with protected mode and tight bind rules, this prevents unauthenticated connections from the network.
+      audit: |-
+        ### Audit via redis-cli
+
+        1. List the configured access-control users and their flags:
+
+           ```bash
+           redis-cli ACL LIST
+           ```
+
+        If no enabled user line contains the `nopass` flag, the check passes. If any enabled user is marked `nopass`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To require a password for every enabled user in the server configuration:
+
+            1. In the ACL file (or the `user` directives in `redis.conf`), give each enabled user a password and remove the `nopass` flag. For the built-in default user:
+
+               ```conf
+               user default on >STRONGPASS ~* +@all
+               ```
+            2. Restart the server or reload the ACLs so the new rules take effect.
+        - id: cli
+          desc: |-
+            To set a password on an enabled user at runtime and persist it, replace `nopass` by assigning a password and then rewrite the configuration:
+
+            ```bash
+            redis-cli ACL SETUSER default on '>STRONGPASS' && redis-cli CONFIG REWRITE
+            ```
+    refs:
+      - url: https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/
+        title: Redis ACL
+  - uid: mondoo-redis-security-protected-mode-enabled
+    filters: asset.platform == "redisdb"
+    title: Ensure Redis protected mode is enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-protection
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      redisdb.instance.protectedMode == true
+    docs:
+      desc: |-
+        This check ensures that protected mode is turned on. Protected mode refuses connections from non-loopback clients when no password and no explicit `bind` address are configured, so turning it off on an exposed server removes a key safety net that guards an otherwise open instance.
+
+        **Why this matters**
+
+        - **Default safety net:** Protected mode is the guard that stops a freshly started, unconfigured server from answering remote clients with no credentials.
+        - **Defense in depth:** It backs up the authentication and bind controls, so a misconfiguration in one does not immediately expose the server.
+        - **Reduced attack surface:** With protected mode on, an accidentally exposed instance still rejects remote unauthenticated connections.
+
+        **Risk mitigation**
+
+        - **No accidental exposure:** A server bound to all interfaces without a password still refuses remote clients while protected mode is on.
+        - **Contained misconfiguration:** Turning it off should be a deliberate act paired with authentication and bind rules, not a silent default.
+      audit: |-
+        ### Audit via redis-cli
+
+        1. Read the protected-mode setting:
+
+           ```bash
+           redis-cli CONFIG GET protected-mode
+           ```
+
+        If the value is `yes`, protected mode is enabled and the check passes. If it is `no`, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable protected mode in the server configuration:
+
+            1. In `redis.conf`, set:
+
+               ```ini
+               protected-mode yes
+               ```
+            2. Restart the server so the setting takes effect.
+        - id: cli
+          desc: |-
+            To enable protected mode at runtime and persist it to the configuration file:
+
+            ```bash
+            redis-cli CONFIG SET protected-mode yes && redis-cli CONFIG REWRITE
+            ```
+    refs:
+      - url: https://redis.io/docs/latest/operate/oss_and_stack/management/security/
+        title: Redis security


### PR DESCRIPTION
## What this does

Seven policies that connect to a **running database server** and assess its effective, live configuration rather than a file on disk.

| Policy | Provider | Checks |
|---|---|---|
| `mondoo-cassandra-security` | `cassandra` | authentication (A07), authorization (A01), client encryption (A04), audit logging (A09) |
| `mondoo-clickhousedb-security` | `clickhousedb` | account passwords (A07), secure TCP port (A04) |
| `mondoo-elasticsearch-security` | `elasticsearch` | security features enabled (A01), anonymous access (A01), HTTP + transport TLS (A04), audit logging (A09) |
| `mondoo-opensearch-security` | `opensearch` | anonymous access (A01), authentication realms (A07), audit logging (A09) |
| `mondoo-redis-security` | `redisdb` | TLS (A04), passwordless users (A07), protected mode (A02) |
| `mondoo-mongodb-security` | `mongo` | authentication (A07), authorization (A01), `requireTLS` (A04), server-side JavaScript (A02) |
| `mondoo-mssql-security` | `mssql` | force encryption (A04), Windows auth mode (A07), `xp_cmdshell` (A02), login auditing (A09) |

Every check ships full `desc`/`audit`/`remediation` docs using vendor-native tooling (`cqlsh`, `mongosh`, `sqlcmd`, `redis-cli`, the Elasticsearch and OpenSearch APIs) and carries the compliance tag set the OWASP parity invariant requires.

## Scope

Split out of a larger branch; each part branches off `main` independently, no stacking. See #3243 for the running-server checks added to the existing PostgreSQL, MySQL, and Grafana policies.

## Validation

- `cnspec policy lint ./content` — no new findings against a pristine-`main` baseline. Every field used was checked against the installed provider schema.
- `go test ./content/validation/...` — passes, including the OWASP parity test.
