### PR TITLE
✨ content: add SaaS and cloud platform security policies

### DIFF
--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -100,7 +100,11 @@ queries:
 
             ```hcl
             resource "clickhouse_service" "example" {
-              # ...
+              name           = "example"
+              cloud_provider = "aws"
+              region         = "us-east-1"
+              password_wo    = var.clickhouse_default_password
+
               ip_access = [
                 {
                   source      = "203.0.113.0/24"
@@ -112,6 +116,8 @@ queries:
     refs:
       - url: https://clickhouse.com/docs/en/cloud/security/setting-ip-filters
         title: ClickHouse Cloud IP access lists
+      - url: https://clickhouse.com/docs/cloud/manage/api/api-overview
+        title: ClickHouse Cloud API
   - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
     filters: asset.platform == "clickhousecloud"
     title: Ensure ClickHouse Cloud services enable transparent data encryption
@@ -167,8 +173,19 @@ queries:
 
             ```hcl
             resource "clickhouse_service" "example" {
-              # ...
-              encryption_key    = var.kms_key_arn
+              name           = "example"
+              cloud_provider = "aws"
+              region         = "us-east-1"
+              password_wo    = var.clickhouse_default_password
+
+              ip_access = [
+                {
+                  source      = "203.0.113.0/24"
+                  description = "office"
+                }
+              ]
+
+              encryption_key                     = var.kms_key_arn
               encryption_assumed_role_identifier = var.kms_role_arn
             }
             ```

--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -1,0 +1,177 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-clickhousecloud-security
+    name: Mondoo ClickHouse Cloud Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: clickhousecloud
+    require:
+      - provider: clickhousecloud
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden ClickHouse Cloud service network exposure and encryption at rest
+    docs:
+      desc: |
+        The Mondoo ClickHouse Cloud Security policy connects to a ClickHouse Cloud organization and assesses the security posture of its services: whether each service is reachable from any IP address and whether transparent data encryption is enabled.
+
+        These settings are read from the ClickHouse Cloud API, so the checks reflect the controls ClickHouse Cloud is actually enforcing rather than a file on disk.
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Network Access
+        filters: asset.platform == "clickhousecloud"
+        checks:
+          - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips
+      - title: Encryption
+        filters: asset.platform == "clickhousecloud"
+        checks:
+          - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips
+    filters: asset.platform == "clickhousecloud"
+    title: Ensure ClickHouse Cloud services are not open to all IP addresses
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      clickhousecloud.organization.services.all(openToAllIps == false)
+    docs:
+      desc: |-
+        This check ensures that no ClickHouse Cloud service is reachable from any IP address. A service is open to all IPs when its IP access list contains a wildcard entry such as `0.0.0.0/0` or `::/0`, which exposes the database endpoint to the entire internet.
+
+        **Why this matters**
+
+        - **Reduced exposure:** Restricting source IPs means only approved networks can even attempt to connect.
+        - **Credential-theft containment:** A leaked password cannot be used from outside the approved ranges.
+        - **Defense in depth:** Network restrictions complement authentication rather than replacing it.
+
+        **Risk mitigation**
+
+        - **Blocked off-network access:** Connection attempts from unapproved addresses are rejected.
+        - **Smaller attack surface:** Only approved networks can reach the service endpoint.
+      audit: |-
+        ### Audit via the ClickHouse Cloud console
+
+        1. Sign in to the ClickHouse Cloud console and open each service.
+        2. Go to **Settings** > **Security** > **IP access list**.
+        3. Confirm the list does not contain `0.0.0.0/0` or `::/0` and instead names specific approved ranges.
+
+        If no service allows all IP addresses, the check passes. If any service has a wildcard entry, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To restrict service network access in the ClickHouse Cloud console:
+
+            1. Open the service and go to **Settings** > **Security** > **IP access list**.
+            2. Remove any `0.0.0.0/0` or `::/0` entry.
+            3. Add specific CIDR ranges for the approved office, VPN, and application networks.
+        - id: api
+          desc: |-
+            To restrict service network access with the ClickHouse Cloud API, update the service's IP access list to specific ranges:
+
+            ```bash
+            curl -s -X PATCH \
+              -u "$CLICKHOUSE_KEY_ID:$CLICKHOUSE_KEY_SECRET" \
+              -H "Content-Type: application/json" \
+              --data '{"ipAccessList":{"add":[{"source":"203.0.113.0/24","description":"office"}],"remove":[{"source":"0.0.0.0/0"}]}}' \
+              "https://api.clickhouse.cloud/v1/organizations/$ORG_ID/services/$SERVICE_ID"
+            ```
+        - id: terraform
+          desc: |-
+            To restrict service network access with the ClickHouse Cloud Terraform provider, set an explicit `ip_access` list on the service:
+
+            ```hcl
+            resource "clickhouse_service" "example" {
+              # ...
+              ip_access = [
+                {
+                  source      = "203.0.113.0/24"
+                  description = "office"
+                }
+              ]
+            }
+            ```
+    refs:
+      - url: https://clickhouse.com/docs/en/cloud/security/setting-ip-filters
+        title: ClickHouse Cloud IP access lists
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
+    filters: asset.platform == "clickhousecloud"
+    title: Ensure ClickHouse Cloud services enable transparent data encryption
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-access-control-encryption-and-decryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-1
+      compliance/nist-csf-2: nist-csf-2-pr-ds-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-28
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-16
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-3-5-1
+      compliance/soc2-2017: soc2-control-cc6-1-11
+      compliance/vda-isa-5: vda-isa-5-5-1-1
+    mql: |
+      clickhousecloud.organization.services.all(hasTransparentDataEncryption == true)
+    docs:
+      desc: |-
+        This check ensures that every ClickHouse Cloud service has transparent data encryption enabled, so data stored on disk is encrypted at rest. Transparent data encryption protects the stored data if the underlying storage is ever accessed outside the service.
+
+        **Why this matters**
+
+        - **Data-at-rest protection:** Encrypted storage is unreadable without the keys, limiting exposure from storage-layer compromise.
+        - **Compliance:** Many frameworks require sensitive data to be encrypted at rest.
+        - **Key management:** Transparent data encryption integrates key management with the service rather than leaving data in cleartext.
+
+        **Risk mitigation**
+
+        - **Neutralized storage theft:** A copy of the underlying storage is useless without the encryption keys.
+        - **Consistent coverage:** Every service, not just some, protects its stored data.
+      audit: |-
+        ### Audit via the ClickHouse Cloud console
+
+        1. Sign in to the ClickHouse Cloud console and open each service.
+        2. Review the service's data encryption setting under **Settings** > **Security**.
+
+        If every service reports transparent data encryption enabled, the check passes. If any service has it disabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enable transparent data encryption in the ClickHouse Cloud console:
+
+            1. Transparent data encryption (including customer-managed keys) is selected when a service is created on supported tiers.
+            2. For an existing service, contact ClickHouse Cloud support or recreate the service on a tier that supports encryption at rest, then migrate the data.
+        - id: terraform
+          desc: |-
+            To provision a service with encryption at rest using the ClickHouse Cloud Terraform provider, configure the encryption key settings supported by the service resource:
+
+            ```hcl
+            resource "clickhouse_service" "example" {
+              # ...
+              encryption_key    = var.kms_key_arn
+              encryption_assumed_role_identifier = var.kms_role_arn
+            }
+            ```
+    refs:
+      - url: https://clickhouse.com/docs/en/cloud/security/cmek
+        title: ClickHouse Cloud data encryption

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -16,9 +16,9 @@ policies:
     summary: Harden HashiCorp Cloud Platform cluster network exposure and audit-log export
     docs:
       desc: |
-        The Mondoo HashiCorp Cloud Platform Security policy connects to an HCP organization and reads the live control-plane state of its managed Vault and Consul clusters. Because it evaluates what the HCP control plane reports for each cluster rather than a file on disk, the checks reflect the exposure the platform is actually serving.
+        The Mondoo HashiCorp Cloud Platform Security policy connects to an HCP organization and reads the live control-plane state of its managed Vault clusters. Because it evaluates what the HCP control plane reports for each cluster rather than a file on disk, the checks reflect the exposure the platform is actually serving.
 
-        This policy focuses on how HCP clusters are reachable and observed. It flags Vault and Consul clusters that expose an unrestricted public endpoint (a public endpoint is acceptable only when an IP allowlist restricts who can reach it), and it verifies that Vault clusters stream audit logs to an external destination so an authentication and secret-access trail is preserved off the cluster for detection and investigation.
+        This policy focuses on how HCP Vault clusters are reachable and observed. It flags clusters that expose an unrestricted public endpoint, which is acceptable only when an IP allowlist restricts who can reach it, and it verifies that clusters stream audit logs to an external destination so an authentication and secret-access trail is preserved off the cluster for detection and investigation.
 
         Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
     groups:
@@ -26,7 +26,6 @@ policies:
         filters: asset.platform == "hcp-organization"
         checks:
           - uid: mondoo-hcp-security-vault-no-public-endpoint
-          - uid: mondoo-hcp-security-consul-no-public-endpoint
       - title: Logging & Monitoring
         filters: asset.platform == "hcp-organization"
         checks:
@@ -78,13 +77,15 @@ queries:
 
         If every cluster either has its public endpoint disabled or has a non-empty IP allowlist, the check passes. If any cluster exposes a public endpoint with no allowlist, the check fails.
 
-        ### Audit via the hcp CLI
+        ### Audit via the HCP API
 
-        1. List the Vault clusters in the organization and inspect each cluster's public endpoint and allowlist:
+        1. List the Vault clusters in a project and read each cluster's public endpoint and allowlist:
 
            ```bash
-           hcp vault-secrets clusters list
-           hcp vault clusters read --cluster <cluster-name>
+           curl -s \
+             --header "Authorization: Bearer $HCP_API_TOKEN" \
+             "https://api.cloud.hashicorp.com/vault/2020-11-25/organizations/$HCP_ORG_ID/projects/$HCP_PROJECT_ID/clusters" \
+             | jq '.clusters[] | {id: .id, public_endpoint: .config.network_config.public_ipv4_enabled, allowlist: .config.network_config.ip_allowlist}'
            ```
 
         If no cluster reports a public endpoint without an accompanying IP allowlist, the check passes. If any cluster does, the check fails.
@@ -96,13 +97,6 @@ queries:
             1. Open **Vault** and select the affected cluster.
             2. Open the cluster's **Networking** configuration.
             3. Either disable the public endpoint, or add an IP allowlist that limits access to your known operator and application CIDR ranges.
-        - id: cli
-          desc: |-
-            To restrict Vault cluster exposure with the `hcp` CLI, update the cluster's public endpoint or allowlist:
-
-            ```bash
-            hcp vault clusters update --cluster <cluster-name> --public-endpoint=false
-            ```
         - id: terraform
           desc: |-
             To restrict Vault cluster exposure with the `hashicorp/hcp` Terraform provider, disable the public endpoint or set a restrictive IP allowlist on the `hcp_vault_cluster` resource:
@@ -125,99 +119,8 @@ queries:
     refs:
       - url: https://developer.hashicorp.com/hcp/docs/vault
         title: HCP Vault
-  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
-  - uid: mondoo-hcp-security-consul-no-public-endpoint
-    filters: asset.platform == "hcp-organization"
-    title: Ensure HCP Consul clusters are not exposed without an IP allowlist
-    impact: 80
-    tags:
-      compliance/bsi-sys-1-5: false
-      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
-      compliance/dora: dora-art-9
-      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
-      compliance/iso-27001-2022: iso-27001-2022-a-8-3
-      compliance/nis-2: nis-2-21-2-i
-      compliance/nist-csf-1: nist-csf-1-pr-ac-4
-      compliance/nist-csf-2: nist-csf-2-pr-aa-05
-      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
-      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
-      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
-      compliance/pci-dss-4: pcidss-requirement-7-2-1
-      compliance/soc2-2017: soc2-control-cc6-1-3
-      compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      hcp.projects.all(consulClusters.all(publicEndpoint == false || ipAllowlist != empty))
-    docs:
-      desc: |-
-        This check ensures that no HCP Consul cluster exposes an unrestricted public endpoint. A public endpoint is acceptable only when an IP allowlist restricts which source addresses can reach the cluster; a public endpoint with no allowlist places the service mesh control plane on the open internet.
-
-        **Why this matters**
-
-        - **Reduced attack surface:** A publicly reachable Consul API and UI are exposed to continuous internet scanning and exploitation attempts.
-        - **Network-layer control:** An IP allowlist limits reachability to known operator and application networks, blocking connections from everywhere else.
-        - **Defense in depth:** Restricting the network path complements Consul's ACL and mTLS controls rather than depending on them alone.
-
-        **Risk mitigation**
-
-        - **Blast-radius containment:** A stolen token or misconfigured ACL cannot be exercised by an attacker who cannot reach the cluster.
-        - **Fewer exposure paths:** Disabling the public endpoint entirely, where a private path exists, removes the internet-facing surface completely.
-      audit: |-
-        ### Audit via the HCP portal
-
-        1. Sign in to the HashiCorp Cloud Platform portal and open **Consul**.
-        2. Select each cluster and open its **Networking** (public access) configuration.
-        3. Note whether the public endpoint is enabled and whether an IP allowlist (CIDR allowlist) is configured.
-
-        If every cluster either has its public endpoint disabled or has a non-empty IP allowlist, the check passes. If any cluster exposes a public endpoint with no allowlist, the check fails.
-
-        ### Audit via the hcp CLI
-
-        1. List the Consul clusters in the organization and inspect each cluster's public endpoint and allowlist:
-
-           ```bash
-           hcp consul clusters list
-           hcp consul clusters read --cluster <cluster-name>
-           ```
-
-        If no cluster reports a public endpoint without an accompanying IP allowlist, the check passes. If any cluster does, the check fails.
-      remediation:
-        - id: console
-          desc: |-
-            To restrict Consul cluster exposure in the HCP portal:
-
-            1. Open **Consul** and select the affected cluster.
-            2. Open the cluster's **Networking** configuration.
-            3. Either disable the public endpoint, or add an IP allowlist that limits access to your known operator and application CIDR ranges.
-        - id: cli
-          desc: |-
-            To restrict Consul cluster exposure with the `hcp` CLI, update the cluster's public endpoint or allowlist:
-
-            ```bash
-            hcp consul clusters update --cluster <cluster-name> --public-endpoint=false
-            ```
-        - id: terraform
-          desc: |-
-            To restrict Consul cluster exposure with the `hashicorp/hcp` Terraform provider, disable the public endpoint or set a restrictive IP allowlist on the `hcp_consul_cluster` resource:
-
-            ```hcl
-            resource "hcp_consul_cluster" "example" {
-              cluster_id = "example-consul-cluster"
-              hvn_id     = hcp_hvn.example.hvn_id
-              tier       = "development"
-
-              # keep the cluster off the public internet
-              public_endpoint = false
-
-              # or, if a public endpoint is required, restrict who can reach it
-              ip_allowlist {
-                address     = "203.0.113.0/24"
-                description = "corporate egress"
-              }
-            }
-            ```
-    refs:
-      - url: https://developer.hashicorp.com/hcp/docs/consul
-        title: HCP Consul
+      - url: https://developer.hashicorp.com/hcp/api-docs/vault
+        title: HCP Vault API reference
   # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
   - uid: mondoo-hcp-security-vault-audit-log-export
     filters: asset.platform == "hcp-organization"
@@ -263,12 +166,15 @@ queries:
 
         If every cluster has audit-log streaming configured to a destination, the check passes. If any cluster has no audit-log export, the check fails.
 
-        ### Audit via the hcp CLI
+        ### Audit via the HCP API
 
         1. List the Vault clusters and inspect each cluster's audit-log streaming configuration:
 
            ```bash
-           hcp vault clusters read --cluster <cluster-name>
+           curl -s \
+             --header "Authorization: Bearer $HCP_API_TOKEN" \
+             "https://api.cloud.hashicorp.com/vault/2020-11-25/organizations/$HCP_ORG_ID/projects/$HCP_PROJECT_ID/clusters" \
+             | jq '.clusters[] | {id: .id, audit_log_export: .config.audit_log_export_config}'
            ```
 
         If every cluster reports an audit-log streaming destination, the check passes. If any cluster reports none, the check fails.
@@ -280,38 +186,28 @@ queries:
             1. Open **Vault** and select the affected cluster.
             2. Open the cluster's **Audit logs** configuration.
             3. Configure audit-log streaming to a supported destination (for example a cloud logging or object-storage service) and enable it.
-        - id: cli
-          desc: |-
-            To enable Vault audit-log streaming with the `hcp` CLI, configure a streaming destination on the cluster:
-
-            ```bash
-            hcp vault clusters update --cluster <cluster-name> --audit-log-streaming-enabled=true
-            ```
         - id: terraform
           desc: |-
-            To export Vault audit logs with the `hashicorp/hcp` Terraform provider, define a log-streaming destination and reference it from the `hcp_vault_cluster` audit-log configuration:
+            To export Vault audit logs with the `hashicorp/hcp` Terraform provider, add an `audit_log_config` block to the `hcp_vault_cluster` resource naming the destination to stream to:
 
             ```hcl
-            resource "hcp_log_streaming_destination" "example" {
-              name = "vault-audit-logs"
-
-              cloudwatch {
-                external_id    = "example-external-id"
-                region         = "us-east-1"
-                role_arn       = "arn:aws:iam::123456789012:role/hcp-log-streaming"
-                log_group_name = "hcp-vault-audit"
-              }
-            }
-
             resource "hcp_vault_cluster" "example" {
               cluster_id = "example-vault-cluster"
               hvn_id     = hcp_hvn.example.hvn_id
 
               audit_log_config {
-                streaming_destination_id = hcp_log_streaming_destination.example.id
+                cloudwatch_region            = "us-east-1"
+                cloudwatch_group_name        = "hcp-vault-audit"
+                cloudwatch_stream_name       = "example-vault-cluster"
+                cloudwatch_access_key_id     = var.cloudwatch_access_key_id
+                cloudwatch_secret_access_key = var.cloudwatch_secret_access_key
               }
             }
             ```
+
+            The block also accepts Datadog, Elasticsearch, Grafana, New Relic, Splunk, and generic HTTP destinations through their own argument sets; configure whichever destination the organization already collects logs in.
     refs:
       - url: https://developer.hashicorp.com/hcp/docs/vault/audit-logs
         title: HCP Vault audit logs
+      - url: https://developer.hashicorp.com/hcp/api-docs/vault
+        title: HCP Vault API reference

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -1,0 +1,317 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-hcp-security
+    name: Mondoo HashiCorp Cloud Platform Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: hcp-organization
+    require:
+      - provider: hcp
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden HashiCorp Cloud Platform cluster network exposure and audit-log export
+    docs:
+      desc: |
+        The Mondoo HashiCorp Cloud Platform Security policy connects to an HCP organization and reads the live control-plane state of its managed Vault and Consul clusters. Because it evaluates what the HCP control plane reports for each cluster rather than a file on disk, the checks reflect the exposure the platform is actually serving.
+
+        This policy focuses on how HCP clusters are reachable and observed. It flags Vault and Consul clusters that expose an unrestricted public endpoint (a public endpoint is acceptable only when an IP allowlist restricts who can reach it), and it verifies that Vault clusters stream audit logs to an external destination so an authentication and secret-access trail is preserved off the cluster for detection and investigation.
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Network Exposure
+        filters: asset.platform == "hcp-organization"
+        checks:
+          - uid: mondoo-hcp-security-vault-no-public-endpoint
+          - uid: mondoo-hcp-security-consul-no-public-endpoint
+      - title: Logging & Monitoring
+        filters: asset.platform == "hcp-organization"
+        checks:
+          - uid: mondoo-hcp-security-vault-audit-log-export
+    scoring_system: highest impact
+queries:
+  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
+  - uid: mondoo-hcp-security-vault-no-public-endpoint
+    filters: asset.platform == "hcp-organization"
+    title: Ensure HCP Vault clusters are not exposed without an IP allowlist
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      hcp.projects.all(vaultClusters.all(publicEndpoint == false || ipAllowlist != empty))
+    docs:
+      desc: |-
+        This check ensures that no HCP Vault cluster exposes an unrestricted public endpoint. A cluster may keep its public endpoint enabled only when an IP allowlist restricts which source addresses can reach it; a public endpoint with no allowlist puts the secrets engine on the open internet.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** A publicly reachable Vault API is exposed to internet-wide scanning, credential-stuffing, and exploitation attempts around the clock.
+        - **Network-layer control:** An IP allowlist limits reachability to known operator and application networks, keeping everyone else from ever completing a connection.
+        - **Defense in depth:** Restricting the network path complements Vault's own authentication and policy controls rather than relying on them alone.
+
+        **Risk mitigation**
+
+        - **Blast-radius containment:** Even with a leaked token, an attacker outside the allowlisted ranges cannot reach the cluster to use it.
+        - **Fewer exposure paths:** Disabling the public endpoint entirely, where a private path exists, removes the internet-facing surface completely.
+      audit: |-
+        ### Audit via the HCP portal
+
+        1. Sign in to the HashiCorp Cloud Platform portal and open **Vault**.
+        2. Select each cluster and open its **Networking** (public access) configuration.
+        3. Note whether the public endpoint is enabled and whether an IP allowlist (CIDR allowlist) is configured.
+
+        If every cluster either has its public endpoint disabled or has a non-empty IP allowlist, the check passes. If any cluster exposes a public endpoint with no allowlist, the check fails.
+
+        ### Audit via the hcp CLI
+
+        1. List the Vault clusters in the organization and inspect each cluster's public endpoint and allowlist:
+
+           ```bash
+           hcp vault-secrets clusters list
+           hcp vault clusters read --cluster <cluster-name>
+           ```
+
+        If no cluster reports a public endpoint without an accompanying IP allowlist, the check passes. If any cluster does, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To restrict Vault cluster exposure in the HCP portal:
+
+            1. Open **Vault** and select the affected cluster.
+            2. Open the cluster's **Networking** configuration.
+            3. Either disable the public endpoint, or add an IP allowlist that limits access to your known operator and application CIDR ranges.
+        - id: cli
+          desc: |-
+            To restrict Vault cluster exposure with the `hcp` CLI, update the cluster's public endpoint or allowlist:
+
+            ```bash
+            hcp vault clusters update --cluster <cluster-name> --public-endpoint=false
+            ```
+        - id: terraform
+          desc: |-
+            To restrict Vault cluster exposure with the `hashicorp/hcp` Terraform provider, disable the public endpoint or set a restrictive IP allowlist on the `hcp_vault_cluster` resource:
+
+            ```hcl
+            resource "hcp_vault_cluster" "example" {
+              cluster_id = "example-vault-cluster"
+              hvn_id     = hcp_hvn.example.hvn_id
+
+              # keep the cluster off the public internet
+              public_endpoint = false
+
+              # or, if a public endpoint is required, restrict who can reach it
+              ip_allowlist {
+                address     = "203.0.113.0/24"
+                description = "corporate egress"
+              }
+            }
+            ```
+    refs:
+      - url: https://developer.hashicorp.com/hcp/docs/vault
+        title: HCP Vault
+  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
+  - uid: mondoo-hcp-security-consul-no-public-endpoint
+    filters: asset.platform == "hcp-organization"
+    title: Ensure HCP Consul clusters are not exposed without an IP allowlist
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      hcp.projects.all(consulClusters.all(publicEndpoint == false || ipAllowlist != empty))
+    docs:
+      desc: |-
+        This check ensures that no HCP Consul cluster exposes an unrestricted public endpoint. A public endpoint is acceptable only when an IP allowlist restricts which source addresses can reach the cluster; a public endpoint with no allowlist places the service mesh control plane on the open internet.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** A publicly reachable Consul API and UI are exposed to continuous internet scanning and exploitation attempts.
+        - **Network-layer control:** An IP allowlist limits reachability to known operator and application networks, blocking connections from everywhere else.
+        - **Defense in depth:** Restricting the network path complements Consul's ACL and mTLS controls rather than depending on them alone.
+
+        **Risk mitigation**
+
+        - **Blast-radius containment:** A stolen token or misconfigured ACL cannot be exercised by an attacker who cannot reach the cluster.
+        - **Fewer exposure paths:** Disabling the public endpoint entirely, where a private path exists, removes the internet-facing surface completely.
+      audit: |-
+        ### Audit via the HCP portal
+
+        1. Sign in to the HashiCorp Cloud Platform portal and open **Consul**.
+        2. Select each cluster and open its **Networking** (public access) configuration.
+        3. Note whether the public endpoint is enabled and whether an IP allowlist (CIDR allowlist) is configured.
+
+        If every cluster either has its public endpoint disabled or has a non-empty IP allowlist, the check passes. If any cluster exposes a public endpoint with no allowlist, the check fails.
+
+        ### Audit via the hcp CLI
+
+        1. List the Consul clusters in the organization and inspect each cluster's public endpoint and allowlist:
+
+           ```bash
+           hcp consul clusters list
+           hcp consul clusters read --cluster <cluster-name>
+           ```
+
+        If no cluster reports a public endpoint without an accompanying IP allowlist, the check passes. If any cluster does, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To restrict Consul cluster exposure in the HCP portal:
+
+            1. Open **Consul** and select the affected cluster.
+            2. Open the cluster's **Networking** configuration.
+            3. Either disable the public endpoint, or add an IP allowlist that limits access to your known operator and application CIDR ranges.
+        - id: cli
+          desc: |-
+            To restrict Consul cluster exposure with the `hcp` CLI, update the cluster's public endpoint or allowlist:
+
+            ```bash
+            hcp consul clusters update --cluster <cluster-name> --public-endpoint=false
+            ```
+        - id: terraform
+          desc: |-
+            To restrict Consul cluster exposure with the `hashicorp/hcp` Terraform provider, disable the public endpoint or set a restrictive IP allowlist on the `hcp_consul_cluster` resource:
+
+            ```hcl
+            resource "hcp_consul_cluster" "example" {
+              cluster_id = "example-consul-cluster"
+              hvn_id     = hcp_hvn.example.hvn_id
+              tier       = "development"
+
+              # keep the cluster off the public internet
+              public_endpoint = false
+
+              # or, if a public endpoint is required, restrict who can reach it
+              ip_allowlist {
+                address     = "203.0.113.0/24"
+                description = "corporate egress"
+              }
+            }
+            ```
+    refs:
+      - url: https://developer.hashicorp.com/hcp/docs/consul
+        title: HCP Consul
+  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
+  - uid: mondoo-hcp-security-vault-audit-log-export
+    filters: asset.platform == "hcp-organization"
+    title: Ensure HCP Vault clusters export audit logs
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-1
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      hcp.projects.all(vaultClusters.all(auditLogExport != empty))
+    docs:
+      desc: |-
+        This check ensures that every HCP Vault cluster streams its audit logs to an external destination. Audit logs record authentication events and every secret access, so exporting them off the cluster preserves the trail even if the cluster itself is tampered with or destroyed.
+
+        **Why this matters**
+
+        - **Attributable access:** Vault audit logs tie every request to an identity, token, and path, which is essential for investigating misuse of secrets.
+        - **Tamper resistance:** Streaming logs to an external destination keeps a copy beyond the reach of anyone who compromises the cluster.
+        - **Compliance evidence:** Audit frameworks require retained, reviewable access logs for systems that broker sensitive credentials.
+
+        **Risk mitigation**
+
+        - **Faster incident response:** An off-cluster record of authentication and secret access narrows the source and timeline of suspicious activity.
+        - **Detection coverage:** Exported logs can feed a SIEM to alert on anomalous secret reads, failed authentication bursts, and off-hours access.
+      audit: |-
+        ### Audit via the HCP portal
+
+        1. Sign in to the HashiCorp Cloud Platform portal and open **Vault**.
+        2. Select each cluster and open its **Audit logs** (streaming) configuration.
+        3. Confirm that a streaming destination is configured and enabled.
+
+        If every cluster has audit-log streaming configured to a destination, the check passes. If any cluster has no audit-log export, the check fails.
+
+        ### Audit via the hcp CLI
+
+        1. List the Vault clusters and inspect each cluster's audit-log streaming configuration:
+
+           ```bash
+           hcp vault clusters read --cluster <cluster-name>
+           ```
+
+        If every cluster reports an audit-log streaming destination, the check passes. If any cluster reports none, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To export Vault audit logs in the HCP portal:
+
+            1. Open **Vault** and select the affected cluster.
+            2. Open the cluster's **Audit logs** configuration.
+            3. Configure audit-log streaming to a supported destination (for example a cloud logging or object-storage service) and enable it.
+        - id: cli
+          desc: |-
+            To enable Vault audit-log streaming with the `hcp` CLI, configure a streaming destination on the cluster:
+
+            ```bash
+            hcp vault clusters update --cluster <cluster-name> --audit-log-streaming-enabled=true
+            ```
+        - id: terraform
+          desc: |-
+            To export Vault audit logs with the `hashicorp/hcp` Terraform provider, define a log-streaming destination and reference it from the `hcp_vault_cluster` audit-log configuration:
+
+            ```hcl
+            resource "hcp_log_streaming_destination" "example" {
+              name = "vault-audit-logs"
+
+              cloudwatch {
+                external_id    = "example-external-id"
+                region         = "us-east-1"
+                role_arn       = "arn:aws:iam::123456789012:role/hcp-log-streaming"
+                log_group_name = "hcp-vault-audit"
+              }
+            }
+
+            resource "hcp_vault_cluster" "example" {
+              cluster_id = "example-vault-cluster"
+              hvn_id     = hcp_hvn.example.hvn_id
+
+              audit_log_config {
+                streaming_destination_id = hcp_log_streaming_destination.example.id
+              }
+            }
+            ```
+    refs:
+      - url: https://developer.hashicorp.com/hcp/docs/vault/audit-logs
+        title: HCP Vault audit logs

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -1,0 +1,292 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-neon-security
+    name: Mondoo Neon Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: neon-organization
+    require:
+      - provider: neon
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Neon organization multi-factor authentication, network exposure, and password storage
+    docs:
+      desc: |
+        The Mondoo Neon Security policy connects to a Neon serverless Postgres organization and reads its organization settings along with the configuration of every project it contains. Because it evaluates what the Neon API reports for the organization and its projects, the checks reflect the controls Neon is actually enforcing rather than a file on disk.
+
+        This policy focuses on the account-level guardrails that protect a Neon organization and the databases it hosts. It verifies that the organization requires multi-factor authentication for its members, so a stolen password alone cannot reach the control plane. It confirms that projects block public connections, keeping databases reachable only through configured private networking or allowed IP ranges rather than from anywhere on the internet. It also checks whether Neon retains project role passwords, since password storage widens the blast radius of a control-plane or API-key compromise.
+
+        Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "neon-organization"
+        checks:
+          - uid: mondoo-neon-security-org-require-mfa
+      - title: Network Access
+        filters: asset.platform == "neon-organization"
+        checks:
+          - uid: mondoo-neon-security-project-block-public-connections
+      - title: Data Protection
+        filters: asset.platform == "neon-organization"
+        checks:
+          - uid: mondoo-neon-security-project-no-stored-passwords
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-neon-security-org-require-mfa
+    filters: asset.platform == "neon-organization"
+    title: Ensure the Neon organization requires multi-factor authentication
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      neon.organizations.all(requireMfa == true)
+    docs:
+      desc: |-
+        This check ensures that every Neon organization the API key can see requires members to use multi-factor authentication. When MFA is required at the organization level, a stolen or guessed password alone cannot access the control plane, because a second factor is always demanded.
+
+        **Why this matters**
+
+        - **Credential theft resistance:** Passwords are phished, reused, and leaked constantly; a mandatory second factor stops a valid password from being enough to sign in.
+        - **Organization-wide coverage:** Requiring MFA at the organization level closes the gap left when it is only encouraged, so no member can opt out.
+        - **Control-plane protection:** Organization members can create projects, rotate credentials, and reach databases, so their accounts are high-value targets that warrant strong authentication.
+
+        **Risk mitigation**
+
+        - **Account-takeover containment:** Even after a password compromise, an attacker without the second factor cannot access the organization.
+        - **Consistent enforcement:** A single organization setting guarantees the control applies to current and future members alike.
+      audit: |-
+        ### Audit via the Neon Console
+
+        1. Sign in to the Neon Console and open **Organization** > **Settings**.
+        2. Locate the multi-factor authentication (MFA) requirement.
+        3. Confirm that MFA is required for organization members.
+
+        If MFA is required, the check passes. If it is not required, the check fails.
+
+        ### Audit via the API
+
+        1. Query the organization with the Neon API and read the `require_mfa` setting:
+
+           ```bash
+           curl -s \
+             --header "Authorization: Bearer $NEON_API_KEY" \
+             --header "Accept: application/json" \
+             "https://console.neon.tech/api/v2/organizations/<org_id>"
+           ```
+
+        If MFA is required for the organization, the check passes. If it is not required, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To require multi-factor authentication in the Neon Console:
+
+            1. Open **Organization** > **Settings**.
+            2. Enable the requirement that members use multi-factor authentication.
+            3. Save the change and confirm existing members enroll a second factor.
+        - id: cli
+          desc: |-
+            To require multi-factor authentication with the `neonctl` CLI, update the organization settings where supported:
+
+            ```bash
+            neonctl orgs update --org-id <org_id> --require-mfa
+            ```
+        - id: terraform
+          desc: |-
+            To require multi-factor authentication with the Neon Terraform provider, set the organization MFA requirement on the organization resource:
+
+            ```hcl
+            resource "neon_organization" "example" {
+              id          = "<org_id>"
+              require_mfa = true
+            }
+            ```
+    refs:
+      - url: https://neon.tech/docs/manage/organizations
+        title: Neon Organizations
+  - uid: mondoo-neon-security-project-block-public-connections
+    filters: asset.platform == "neon-organization"
+    title: Ensure Neon projects block public connections
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      neon.projects.all(blockPublicConnections == true)
+    docs:
+      desc: |-
+        This check ensures that every Neon project blocks public connections. When public connections are blocked, the database is reachable only through the configured private networking or allowed IP ranges rather than from anywhere on the internet.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** A database open to the public internet is exposed to credential-stuffing, brute-force, and exploitation attempts from any source; blocking public connections removes that exposure.
+        - **Network-layer control:** Restricting access to private networking or an allowlist confines connectivity to known application and operator networks.
+        - **Defense in depth:** Even with strong authentication, keeping the database off the public internet removes an entire class of remote attacks.
+
+        **Risk mitigation**
+
+        - **Smaller exposure window:** An attacker who obtains a connection string still cannot reach the database from an unapproved network.
+        - **Contained blast radius:** Private-only connectivity limits lateral movement toward the data even if other controls fail.
+      audit: |-
+        ### Audit via the Neon Console
+
+        1. Sign in to the Neon Console and open each project.
+        2. Go to **Settings** > **Network Security**.
+        3. Confirm that public connections are blocked and that allowed IPs or private networking are configured.
+
+        If public connections are blocked, the check passes. If public connections are allowed, the check fails.
+
+        ### Audit via the API
+
+        1. Query each project with the Neon API and read the setting that blocks public connections:
+
+           ```bash
+           curl -s \
+             --header "Authorization: Bearer $NEON_API_KEY" \
+             --header "Accept: application/json" \
+             "https://console.neon.tech/api/v2/projects/<project_id>"
+           ```
+
+        If public connections are blocked for the project, the check passes. If they are allowed, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To block public connections in the Neon Console:
+
+            1. Open the affected project and go to **Settings** > **Network Security**.
+            2. Enable the option to block public connections.
+            3. Configure the allowed IP ranges or private networking that legitimate clients need, then save the change.
+        - id: cli
+          desc: |-
+            To block public connections with the `neonctl` CLI, update the project settings:
+
+            ```bash
+            neonctl projects update <project_id> --block-public-connections
+            ```
+        - id: terraform
+          desc: |-
+            To block public connections with the Neon Terraform provider, set the network configuration on the `neon_project` resource:
+
+            ```hcl
+            resource "neon_project" "example" {
+              name = "example"
+
+              block_public_connections = true
+            }
+            ```
+    refs:
+      - url: https://neon.tech/docs/introduction/ip-allow
+        title: Neon IP Allow
+  - uid: mondoo-neon-security-project-no-stored-passwords
+    filters: asset.platform == "neon-organization"
+    title: Ensure Neon does not retain project role passwords
+    impact: 60
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-2
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      neon.projects.all(storePasswords == false)
+    docs:
+      desc: |-
+        This check ensures that no Neon project has password storage enabled, so Neon does not retain role passwords in a form its API can return. Retaining role passwords widens the blast radius of a control-plane or API-key compromise, because an attacker who reaches the API could read them. Note that some workflows rely on stored passwords for connection-string retrieval, so treat this as a hardening control weighed against that need.
+
+        **Why this matters**
+
+        - **Reduced secret exposure:** A password that is never stored cannot be read back from the control plane, so an API-key or account compromise does not hand over usable database credentials.
+        - **Smaller blast radius:** Not retaining role passwords limits how far a single control-plane compromise can reach into the databases themselves.
+        - **Least retention:** Keeping only what is necessary reduces the set of secrets an attacker can ever obtain from the platform.
+
+        **Risk mitigation**
+
+        - **Credential-theft containment:** With no stored passwords, a leaked API key cannot be turned directly into database access.
+        - **Deliberate trade-off:** Where a workflow needs connection-string retrieval, the exception is explicit and can be scoped rather than applied by default everywhere.
+      audit: |-
+        ### Audit via the Neon Console
+
+        1. Sign in to the Neon Console and open each project.
+        2. Go to **Settings** and locate the option that stores role passwords.
+        3. Confirm that password storage is disabled.
+
+        If password storage is disabled, the check passes. If it is enabled, the check fails.
+
+        ### Audit via the API
+
+        1. Query each project with the Neon API and read the setting that controls storing role passwords:
+
+           ```bash
+           curl -s \
+             --header "Authorization: Bearer $NEON_API_KEY" \
+             --header "Accept: application/json" \
+             "https://console.neon.tech/api/v2/projects/<project_id>"
+           ```
+
+        If password storage is disabled for the project, the check passes. If it is enabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To stop retaining role passwords in the Neon Console:
+
+            1. Open the affected project and go to **Settings**.
+            2. Disable the option that stores role passwords.
+            3. Save the change, keeping in mind that workflows relying on stored connection strings will need another way to retrieve credentials.
+        - id: cli
+          desc: |-
+            To disable stored role passwords with the `neonctl` CLI, update the project settings:
+
+            ```bash
+            neonctl projects update <project_id> --no-store-passwords
+            ```
+        - id: terraform
+          desc: |-
+            To disable stored role passwords with the Neon Terraform provider, set the store-passwords option on the `neon_project` resource:
+
+            ```hcl
+            resource "neon_project" "example" {
+              name = "example"
+
+              store_passwords = false
+            }
+            ```
+    refs:
+      - url: https://neon.tech/docs/manage/projects
+        title: Neon Projects

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -100,23 +100,6 @@ queries:
             1. Open **Organization** > **Settings**.
             2. Enable the requirement that members use multi-factor authentication.
             3. Save the change and confirm existing members enroll a second factor.
-        - id: cli
-          desc: |-
-            To require multi-factor authentication with the `neonctl` CLI, update the organization settings where supported:
-
-            ```bash
-            neonctl orgs update --org-id <org_id> --require-mfa
-            ```
-        - id: terraform
-          desc: |-
-            To require multi-factor authentication with the Neon Terraform provider, set the organization MFA requirement on the organization resource:
-
-            ```hcl
-            resource "neon_organization" "example" {
-              id          = "<org_id>"
-              require_mfa = true
-            }
-            ```
     refs:
       - url: https://neon.tech/docs/manage/organizations
         title: Neon Organizations
@@ -186,10 +169,10 @@ queries:
             3. Configure the allowed IP ranges or private networking that legitimate clients need, then save the change.
         - id: cli
           desc: |-
-            To block public connections with the `neonctl` CLI, update the project settings:
+            To block public connections with the Neon CLI, update the project settings:
 
             ```bash
-            neonctl projects update <project_id> --block-public-connections
+            neon projects update <project_id> --block-public-connections
             ```
         - id: terraform
           desc: |-
@@ -199,12 +182,14 @@ queries:
             resource "neon_project" "example" {
               name = "example"
 
-              block_public_connections = true
+              block_public_connections = "yes"
             }
             ```
     refs:
       - url: https://neon.tech/docs/introduction/ip-allow
         title: Neon IP Allow
+      - url: https://neon.com/docs/cli/projects
+        title: Neon CLI projects command
   - uid: mondoo-neon-security-project-no-stored-passwords
     filters: asset.platform == "neon-organization"
     title: Ensure Neon does not retain project role passwords
@@ -266,27 +251,33 @@ queries:
           desc: |-
             To stop retaining role passwords in the Neon Console:
 
-            1. Open the affected project and go to **Settings**.
-            2. Disable the option that stores role passwords.
-            3. Save the change, keeping in mind that workflows relying on stored connection strings will need another way to retrieve credentials.
-        - id: cli
+            1. Create a replacement project with password storage turned off. The Neon API accepts `store_passwords` only when the project is created, so an existing project keeps the setting it was created with.
+            2. Migrate the databases and roles from the affected project to the replacement.
+            3. Delete the original project, keeping in mind that workflows relying on stored connection strings will need another way to retrieve credentials.
+        - id: api
           desc: |-
-            To disable stored role passwords with the `neonctl` CLI, update the project settings:
+            Password storage is fixed when the project is created, so an existing project cannot be updated in place. Create the replacement project with `store_passwords` off and migrate the data to it:
 
             ```bash
-            neonctl projects update <project_id> --no-store-passwords
+            curl -s -X POST \
+              --header "Authorization: Bearer $NEON_API_KEY" \
+              --header "Content-Type: application/json" \
+              --data '{"project":{"name":"example","store_passwords":false}}' \
+              "https://console.neon.tech/api/v2/projects"
             ```
         - id: terraform
           desc: |-
-            To disable stored role passwords with the Neon Terraform provider, set the store-passwords option on the `neon_project` resource:
+            To create a project that does not retain role passwords with the Neon Terraform provider, set `store_password` on the `neon_project` resource. The setting applies at creation, so changing it on an existing project replaces that project:
 
             ```hcl
             resource "neon_project" "example" {
               name = "example"
 
-              store_passwords = false
+              store_password = "no"
             }
             ```
     refs:
       - url: https://neon.tech/docs/manage/projects
         title: Neon Projects
+      - url: https://neon.com/docs/reference/api-reference
+        title: Neon API reference

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -86,17 +86,6 @@ queries:
             1. Open **Team settings** and go to the **Security** section.
             2. Enable **Enforce multi-factor authentication**.
             3. Save the change and confirm existing members enroll a second factor.
-        - id: terraform
-          desc: |-
-            To enforce multi-factor authentication with the `netlify/netlify` Terraform provider, set the team security option that requires MFA where the provider exposes it:
-
-            ```hcl
-            resource "netlify_team" "example" {
-              name = "<team-name>"
-
-              enforce_mfa = true
-            }
-            ```
     refs:
       - url: https://docs.netlify.com/accounts-and-billing/team-management/team-level-security/
         title: Netlify team-level security
@@ -151,17 +140,6 @@ queries:
             1. Open the affected site and go to **Site configuration > Domain management > HTTPS**.
             2. Provision an SSL/TLS certificate for the site if one is not already in place.
             3. Enable **Force HTTPS** so all HTTP requests redirect to HTTPS.
-        - id: terraform
-          desc: |-
-            To force HTTPS with the `netlify/netlify` Terraform provider, enable the forced TLS option on the site's domain settings where the provider exposes it:
-
-            ```hcl
-            resource "netlify_site" "example" {
-              name = "<site-name>"
-
-              force_ssl = true
-            }
-            ```
     refs:
       - url: https://docs.netlify.com/domains-https/https-ssl/
         title: Netlify HTTPS/SSL

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -1,0 +1,167 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-netlify-security
+    name: Mondoo Netlify Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: netlify-account
+    require:
+      - provider: netlify
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Enforce Netlify account multi-factor authentication and HTTPS on published sites
+    docs:
+      desc: |
+        The Mondoo Netlify Security policy connects to a Netlify account and reads its team accounts and published sites. Because it evaluates what the Netlify API reports for the account and its sites, the checks reflect the controls Netlify is actually enforcing rather than a file on disk.
+
+        This policy focuses on the account-level guardrails that protect a Netlify team and its visitors. It verifies that every team account enforces multi-factor authentication for its members, so a stolen password alone cannot sign in. It also confirms that every published site forces HTTPS, so visitors never exchange data with the site over an unencrypted connection.
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "netlify-account"
+        checks:
+          - uid: mondoo-netlify-security-account-enforce-mfa
+      - title: Transport Encryption
+        filters: asset.platform == "netlify-account"
+        checks:
+          - uid: mondoo-netlify-security-sites-force-ssl
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-netlify-security-account-enforce-mfa
+    filters: asset.platform == "netlify-account"
+    title: Ensure Netlify accounts enforce multi-factor authentication
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      # enforceMfa is a string, and not_enforced is its only documented negative
+      # value; every other value requires enrollment. Test the sentinel rather
+      # than guessing how the positive case is spelled.
+      netlify.accounts.all(enforceMfa != "not_enforced")
+    docs:
+      desc: |-
+        This check ensures that every Netlify team account enforces multi-factor authentication for its members. When MFA is enforced at the team level, a stolen or guessed password alone cannot sign in, because a second factor is always demanded. Note that MFA enforcement is a Netlify paid-team capability.
+
+        **Why this matters**
+
+        - **Credential theft resistance:** Passwords are phished, reused, and leaked constantly; a mandatory second factor stops a valid password from being enough to log in.
+        - **Team-wide coverage:** Enforcing MFA at the team level closes the gap left when it is only encouraged, so no member can opt out.
+        - **Privileged-account protection:** Netlify team members can deploy sites, change domains, and manage build settings, so their accounts are high-value targets that warrant strong authentication.
+
+        **Risk mitigation**
+
+        - **Account-takeover containment:** Even after a password compromise, an attacker without the second factor cannot access the team.
+        - **Consistent enforcement:** A single team setting guarantees the control applies to current and future members alike.
+      audit: |-
+        ### Audit via the Netlify UI
+
+        1. Sign in to the Netlify UI and open **Team settings**.
+        2. Open the **Security** section.
+        3. Confirm that **Enforce multi-factor authentication** is on for the team.
+
+        If MFA enforcement is on, the check passes. If it is off, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enforce multi-factor authentication in the Netlify UI:
+
+            1. Open **Team settings** and go to the **Security** section.
+            2. Enable **Enforce multi-factor authentication**.
+            3. Save the change and confirm existing members enroll a second factor.
+        - id: terraform
+          desc: |-
+            To enforce multi-factor authentication with the `netlify/netlify` Terraform provider, set the team security option that requires MFA where the provider exposes it:
+
+            ```hcl
+            resource "netlify_team" "example" {
+              name = "<team-name>"
+
+              enforce_mfa = true
+            }
+            ```
+    refs:
+      - url: https://docs.netlify.com/accounts-and-billing/team-management/team-level-security/
+        title: Netlify team-level security
+  - uid: mondoo-netlify-security-sites-force-ssl
+    filters: asset.platform == "netlify-account"
+    title: Ensure Netlify sites force HTTPS
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-2-ii-transmission-security-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-1-2
+    mql: |
+      netlify.sites.all(forceSsl == true)
+    docs:
+      desc: |-
+        This check ensures that every Netlify site forces HTTPS. When forced HTTPS is enabled, HTTP requests are redirected to HTTPS and visitors never exchange data with the site over an unencrypted connection, keeping page content and form submissions confidential in transit.
+
+        **Why this matters**
+
+        - **Eavesdropping resistance:** Traffic sent over plain HTTP can be read and modified by anyone on the network path; forcing HTTPS encrypts it end to end.
+        - **Tamper protection:** HTTPS prevents on-path injection of malicious scripts or ads into pages served to visitors.
+        - **Consistent posture:** Forcing the redirect closes the window where a visitor first lands on the insecure HTTP version of a page.
+
+        **Risk mitigation**
+
+        - **Credential and data confidentiality:** Login forms and other submitted data are protected from interception in transit.
+        - **Trust and integrity:** Visitors always receive the authenticated, encrypted version of the site rather than a downgraded one.
+      audit: |-
+        ### Audit via the Netlify UI
+
+        1. Sign in to the Netlify UI and open each site.
+        2. Go to **Site configuration > Domain management > HTTPS**.
+        3. Confirm that **Force HTTPS** is enabled for the site.
+
+        If forced HTTPS is enabled, the check passes. If it is disabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To force HTTPS in the Netlify UI:
+
+            1. Open the affected site and go to **Site configuration > Domain management > HTTPS**.
+            2. Provision an SSL/TLS certificate for the site if one is not already in place.
+            3. Enable **Force HTTPS** so all HTTP requests redirect to HTTPS.
+        - id: terraform
+          desc: |-
+            To force HTTPS with the `netlify/netlify` Terraform provider, enable the forced TLS option on the site's domain settings where the provider exposes it:
+
+            ```hcl
+            resource "netlify_site" "example" {
+              name = "<site-name>"
+
+              force_ssl = true
+            }
+            ```
+    refs:
+      - url: https://docs.netlify.com/domains-https/https-ssl/
+        title: Netlify HTTPS/SSL

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -32,6 +32,9 @@ policies:
           - uid: mondoo-netlify-security-sites-force-ssl
     scoring_system: highest impact
 queries:
+  # No Terraform variant or remediation: MFA enforcement has no Terraform surface. The netlify/netlify provider
+  # exposes no team security resource, and the public Netlify API carries no MFA field, so the UI is the only
+  # place the setting can be read or changed.
   - uid: mondoo-netlify-security-account-enforce-mfa
     filters: asset.platform == "netlify-account"
     title: Ensure Netlify accounts enforce multi-factor authentication
@@ -89,6 +92,10 @@ queries:
     refs:
       - url: https://docs.netlify.com/accounts-and-billing/team-management/team-level-security/
         title: Netlify team-level security
+  # No Terraform variant or remediation: the netlify/netlify provider has no site resource and its
+  # netlify_site_domain_settings resource has no forced-TLS attribute, so forced HTTPS cannot be expressed in
+  # HCL. The API does carry force_ssl on the site, which is why the remediation below uses it. Revisit if the
+  # provider grows the attribute.
   - uid: mondoo-netlify-security-sites-force-ssl
     filters: asset.platform == "netlify-account"
     title: Ensure Netlify sites force HTTPS
@@ -132,6 +139,19 @@ queries:
         3. Confirm that **Force HTTPS** is enabled for the site.
 
         If forced HTTPS is enabled, the check passes. If it is disabled, the check fails.
+
+        ### Audit via the Netlify API
+
+        1. List the sites and read each site's `force_ssl` field:
+
+           ```bash
+           curl -s \
+             --header "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+             "https://api.netlify.com/api/v1/sites" \
+             | jq '.[] | {name, force_ssl}'
+           ```
+
+        If every site reports `force_ssl` as true, the check passes. If any site reports false, the check fails.
       remediation:
         - id: console
           desc: |-
@@ -140,6 +160,19 @@ queries:
             1. Open the affected site and go to **Site configuration > Domain management > HTTPS**.
             2. Provision an SSL/TLS certificate for the site if one is not already in place.
             3. Enable **Force HTTPS** so all HTTP requests redirect to HTTPS.
+        - id: api
+          desc: |-
+            To force HTTPS with the Netlify API, set `force_ssl` on the site. The site needs a provisioned certificate before the redirect can be enforced:
+
+            ```bash
+            curl -s -X PATCH \
+              --header "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+              --header "Content-Type: application/json" \
+              --data '{"force_ssl":true}' \
+              "https://api.netlify.com/api/v1/sites/$SITE_ID"
+            ```
     refs:
       - url: https://docs.netlify.com/domains-https/https-ssl/
         title: Netlify HTTPS/SSL
+      - url: https://open-api.netlify.com/#tag/site/operation/updateSite
+        title: Netlify API updateSite

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -50,12 +50,16 @@ TARGETS = {
     # Only aws/azurerm/google have tflint rulesets; the rest are checked by
     # the terraform preset's syntax and declaration rules alone.
     "alibaba": [CONTENT_DIR / "mondoo-alibaba-security.mql.yaml"],
+    "clickhousecloud": [CONTENT_DIR / "mondoo-clickhousecloud-security.mql.yaml"],
     "cloudflare": [CONTENT_DIR / "mondoo-cloudflare-security.mql.yaml"],
     "databricks": [CONTENT_DIR / "mondoo-databricks-security.mql.yaml"],
     "digitalocean": [CONTENT_DIR / "mondoo-digitalocean-security.mql.yaml"],
     "dns": [CONTENT_DIR / "mondoo-dns-security.mql.yaml"],
     "email": [CONTENT_DIR / "mondoo-email-security.mql.yaml"],
+    "hcp": [CONTENT_DIR / "mondoo-hcp-security.mql.yaml"],
     "hetzner": [CONTENT_DIR / "mondoo-hetzner-security.mql.yaml"],
+    "neon": [CONTENT_DIR / "mondoo-neon-security.mql.yaml"],
+    "netlify": [CONTENT_DIR / "mondoo-netlify-security.mql.yaml"],
     "openstack": [CONTENT_DIR / "mondoo-openstack-security.mql.yaml"],
     "portainer": [CONTENT_DIR / "mondoo-portainer-security.mql.yaml"],
     "snowflake": [CONTENT_DIR / "mondoo-snowflake-security.mql.yaml"],
@@ -94,10 +98,17 @@ PROVIDER_MAP = {
     # purpose rather than by preference. Revisit it once 2.x has a stable
     # release, otherwise the mirror keeps resolving to 1.x indefinitely.
     "alicloud": ("aliyun/alicloud", "~> 1.288"),
+    "clickhouse": ("ClickHouse/clickhouse", "~> 3.0"),
     "cloudflare": ("cloudflare/cloudflare", "~> 5.0"),
     "databricks": ("databricks/databricks", "~> 1.0"),
     "digitalocean": ("digitalocean/digitalocean", "~> 2.0"),
     "hcloud": ("hetznercloud/hcloud", "~> 1.0"),
+    "hcp": ("hashicorp/hcp", "~> 0.114"),
+    # Neon has no official provider. kislerdm/neon is the one Neon's own docs
+    # point at, and the only one of the two community providers that carries
+    # `block_public_connections`; terraform-community-providers/neon does not.
+    "neon": ("kislerdm/neon", "~> 0.15"),
+    "netlify": ("netlify/netlify", "~> 0.4"),
     "openstack": ("terraform-provider-openstack/openstack", "~> 3.0"),
     "portainer": ("portainer/portainer", "~> 1.0"),
     "snowflake": ("snowflakedb/snowflake", "~> 2.0"),


### PR DESCRIPTION
## What this does

Four policies that read the live configuration of a managed platform through its API.

| Policy | Provider | Checks |
|---|---|---|
| `mondoo-clickhousecloud-security` | `clickhousecloud` | services not open to every IP (A01), transparent data encryption (A04) |
| `mondoo-neon-security` | `neon` | organization MFA (A07), blocked public connections (A01), no retained project role passwords (A04) |
| `mondoo-netlify-security` | `netlify` | account MFA enforcement (A07), forced HTTPS on sites (A04) |
| `mondoo-hcp-security` | `hcp` | Vault clusters without a public endpoint or behind an IP allowlist (A01), Vault audit log export (A09) |

Every check ships full `desc`/`audit`/`remediation` docs using vendor-native tooling and carries the compliance tag set the OWASP parity invariant requires.

Two notes on the MQL:

- The Netlify MFA check tests `enforceMfa != "not_enforced"` rather than guessing the positive spelling. The provider documents that sentinel as the only negative value and leaves the enrolled values open, so testing the sentinel is the safe form.
- The HCP endpoint check accepts either no public endpoint *or* a non-empty IP allowlist, since a cluster fronted by an allowlist is not openly reachable.

## Two products dropped as end-of-life

- **Equinix Metal** — the `mondoo-equinix-security` policy is removed.
- **HCP Consul Dedicated** — reached [end-of-life on 12 November 2025](https://support.hashicorp.com/hc/en-us/articles/34859329877011-HCP-Consul-Dedicated-End-Of-Life). Its check is removed from the HCP policy; the Consul API version stamps all 404, so it could never have returned data.

## Remediation validation

The second commit registers these policies with `content/validation/remediation/code/terraform.py`. They were previously invisible to it: `bash.py` covers all of `content/` by glob, but the Terraform and CLI validators are allowlist-driven, so their snippets would have shipped unchecked with CI green.

Registering them failed **8 of 11** HCL snippets against the real provider schemas, and checking the CLI snippets against the shipped binaries turned up more. Details are in the commit message; the summary:

- `clickhouse_service` omitted every required argument behind a `# ...` comment.
- The `hcp_vault_cluster` audit-log snippet conflated two unrelated mechanisms.
- `neon_project` used `store_passwords` (the attribute is `store_password`) and booleans where the provider takes `'yes'`/`'no'` string enums.
- `neon_organization`, `netlify_team` and `netlify_site` do not exist in any published provider — those snippets are removed, console remediation stands.
- `neonctl orgs update --require-mfa`, `neonctl projects update --no-store-passwords`, and every `hcp vault ...` command were invented. The `hcp` CLI has no `vault` or `consul` command group at all, in the v0.11.0 binary or the docs.

Command and API reference links are added to the checks that carry a command.

## Scope

Split out of a larger branch; each part branches off `main` independently, no stacking. See #3243 for the running-server checks added to the existing PostgreSQL, MySQL, and Grafana policies.

## Validation

- `cnspec policy lint ./content` — no new findings against a pristine-`main` baseline.
- `content/validation/remediation/code/terraform.py {clickhousecloud,hcp,neon,netlify}` — 6 passed, 0 failed.
- `content/validation/remediation/code/bash.py all` — 3585 passed, 0 failed.
- `go test ./content/validation/...` — passes, including the OWASP parity test.
