### PR TITLE
✨ content: add Active Directory, Jamf, and Weaviate security policies

### DIFF
--- a/content/mondoo-activedirectory-security.mql.yaml
+++ b/content/mondoo-activedirectory-security.mql.yaml
@@ -1,0 +1,361 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-activedirectory-security
+    name: Mondoo Active Directory Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: activedirectory
+    require:
+      - provider: activedirectory
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Active Directory password policy, account authentication, and privileged access
+    docs:
+      desc: |
+        The Mondoo Active Directory Security policy connects to a domain and reads the default domain password policy together with the domain's user accounts, so its checks reflect the settings the directory actually enforces rather than a documented intent.
+
+        From the password policy it evaluates the minimum length and whether reversible password encryption is enabled. From the user accounts it inspects the `userAccountControl` flags (accounts allowed to have an empty password, accounts exempt from Kerberos pre-authentication), privileged-group membership, and logon recency to find dormant standing privilege.
+
+        This policy provides security checks across three areas:
+        - Password policy strength
+        - Account authentication hygiene
+        - Privileged access
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Password Policy
+        filters: asset.platform == "activedirectory"
+        checks:
+          - uid: mondoo-activedirectory-security-password-min-length
+          - uid: mondoo-activedirectory-security-no-reversible-encryption
+      - title: Authentication
+        filters: asset.platform == "activedirectory"
+        checks:
+          - uid: mondoo-activedirectory-security-no-passwordless-accounts
+          - uid: mondoo-activedirectory-security-kerberos-preauth-required
+      - title: Privileged Access
+        filters: asset.platform == "activedirectory"
+        checks:
+          - uid: mondoo-activedirectory-security-no-stale-privileged-accounts
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-activedirectory-security-password-min-length
+    filters: asset.platform == "activedirectory"
+    title: Ensure the domain password policy requires at least 14 characters
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      activedirectory.passwordPolicy.minPasswordLength >= 14
+    docs:
+      desc: |-
+        This check ensures that the default domain password policy sets a minimum password length of at least 14 characters. A short minimum lets users choose passwords that offline cracking and online guessing can recover quickly.
+
+        **Why this matters**
+
+        - **Cracking resistance:** Each additional required character multiplies the search space an attacker must exhaust to recover a hash offline.
+        - **Guessing resistance:** Longer minimums push users away from short, predictable passwords that spraying attacks target first.
+        - **Baseline for the whole domain:** The default domain policy governs every account that is not covered by a stricter fine-grained policy, so it sets the floor for the environment.
+
+        **Risk mitigation**
+
+        - **Higher work factor:** A 14-character floor makes bulk offline cracking of captured hashes substantially more expensive.
+        - **Fewer trivial credentials:** Enforcing length at the domain level removes the weakest passwords without relying on user judgment.
+      audit: |-
+        ### Audit via PowerShell
+
+        1. On a domain-joined host with the ActiveDirectory module available, read the default domain password policy:
+
+           ```powershell
+           Get-ADDefaultDomainPasswordPolicy | Select-Object MinPasswordLength
+           ```
+
+        If `MinPasswordLength` is 14 or greater, the check passes. If it is less than 14, the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To raise the minimum password length using the Group Policy Management Console:
+
+            1. Open the Group Policy Management Console and edit the **Default Domain Policy**.
+            2. Navigate to **Computer Configuration > Policies > Windows Settings > Security Settings > Account Policies > Password Policy**.
+            3. Set **Minimum password length** to `14` (or higher) and close the editor so the policy replicates.
+        - id: cli
+          desc: |-
+            To raise the minimum password length using the ActiveDirectory PowerShell module:
+
+            ```powershell
+            Set-ADDefaultDomainPasswordPolicy -Identity <domain> -MinPasswordLength 14
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/minimum-password-length
+        title: Minimum password length
+  - uid: mondoo-activedirectory-security-no-reversible-encryption
+    filters: asset.platform == "activedirectory"
+    title: Ensure reversible password encryption is disabled domain-wide
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      activedirectory.passwordPolicy.reversibleEncryption == false
+    docs:
+      desc: |-
+        This check ensures that the default domain password policy does not store passwords using reversible encryption. Reversible encryption keeps a form of the password that can be decrypted back to the original, which is functionally equivalent to storing the password in plaintext.
+
+        **Why this matters**
+
+        - **Plaintext-equivalent storage:** A password held under reversible encryption can be recovered in full by anyone who obtains the stored value and the key.
+        - **Rarely needed:** The setting exists only for a few legacy protocols (such as CHAP or Digest authentication) and should stay off unless one of those explicitly requires it.
+        - **Domain-wide blast radius:** Enabling it in the default domain policy exposes every affected account's real password, not just a single hash to crack.
+
+        **Risk mitigation**
+
+        - **No recoverable secrets:** Disabling reversible encryption ensures stored credentials cannot be decrypted back to usable passwords.
+        - **Reduced breach impact:** A leaked directory database yields only hashes to attack offline, not directly usable plaintext.
+      audit: |-
+        ### Audit via PowerShell
+
+        1. On a domain-joined host with the ActiveDirectory module available, read the default domain password policy:
+
+           ```powershell
+           Get-ADDefaultDomainPasswordPolicy | Select-Object ReversibleEncryptionEnabled
+           ```
+
+        If `ReversibleEncryptionEnabled` is `False`, the check passes. If it is `True`, the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To disable reversible password encryption using the Group Policy Management Console:
+
+            1. Open the Group Policy Management Console and edit the **Default Domain Policy**.
+            2. Navigate to **Computer Configuration > Policies > Windows Settings > Security Settings > Account Policies > Password Policy**.
+            3. Set **Store passwords using reversible encryption** to **Disabled** and close the editor so the policy replicates.
+        - id: cli
+          desc: |-
+            To disable reversible password encryption using the ActiveDirectory PowerShell module:
+
+            ```powershell
+            Set-ADDefaultDomainPasswordPolicy -Identity <domain> -ReversibleEncryptionEnabled $false
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/store-passwords-using-reversible-encryption
+        title: Store passwords using reversible encryption
+  - uid: mondoo-activedirectory-security-no-passwordless-accounts
+    filters: asset.platform == "activedirectory"
+    title: Ensure no enabled account is allowed to have an empty password
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      activedirectory.users.where(enabled == true).all(passwordNotRequired == false)
+    docs:
+      desc: |-
+        This check ensures that no enabled user account carries the `PASSWD_NOTREQD` flag in its `userAccountControl`. An account with that flag set is exempt from the domain password policy and can be left with a blank password, allowing anyone who knows the account name to authenticate.
+
+        **Why this matters**
+
+        - **Authentication bypass:** An enabled account with an empty password is an open door that requires no credential to walk through.
+        - **Policy exemption:** The flag overrides length and complexity requirements, so a strong domain policy does not protect these accounts.
+        - **Easy to overlook:** The flag is often set on old service or migration accounts and lingers long after it is needed.
+
+        **Risk mitigation**
+
+        - **Credential required:** Clearing the flag forces every enabled account back under the domain password policy.
+        - **Smaller attack surface:** Removing passwordless accounts eliminates a class of logins that need no secret at all.
+      audit: |-
+        ### Audit via PowerShell
+
+        1. On a domain-joined host with the ActiveDirectory module available, list enabled accounts that are allowed to have no password:
+
+           ```powershell
+           Get-ADUser -Filter "Enabled -eq 'True' -and PasswordNotRequired -eq 'True'"
+           ```
+
+        If the command returns no accounts, the check passes. If it returns one or more accounts, the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To require a password for an affected account using the Active Directory Administrative Center:
+
+            1. Open the Active Directory Administrative Center and locate the affected user account.
+            2. Open the account's properties and clear the option that exempts it from requiring a password (the `PASSWD_NOTREQD` user account control flag).
+            3. Reset the account's password so it complies with the domain password policy, then save.
+        - id: cli
+          desc: |-
+            To require a password for every affected account using the ActiveDirectory PowerShell module:
+
+            ```powershell
+            Get-ADUser -Filter "PasswordNotRequired -eq 'True'" | Set-ADUser -PasswordNotRequired $false
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/windows/win32/adschema/a-useraccountcontrol
+        title: User-Account-Control attribute
+  - uid: mondoo-activedirectory-security-kerberos-preauth-required
+    filters: asset.platform == "activedirectory"
+    title: Ensure Kerberos pre-authentication is required for every account
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      activedirectory.users.where(enabled == true).all(kerberosPreAuthNotRequired == false)
+    docs:
+      desc: |-
+        This check ensures that no enabled account has the "Do not require Kerberos preauthentication" flag set. Accounts without pre-authentication are vulnerable to AS-REP roasting: an attacker can request authentication material for the account and take the encrypted response offline to crack the password.
+
+        **Why this matters**
+
+        - **AS-REP roasting:** Without pre-authentication, the key distribution center returns encrypted material to any requester, handing an attacker crackable data without a single login attempt.
+        - **Silent offline attack:** The cracking happens away from the domain, so it generates no failed-logon events to alert defenders.
+        - **Rarely justified:** The setting exists for a handful of legacy interoperability cases and is almost never needed in a modern domain.
+
+        **Risk mitigation**
+
+        - **No free ciphertext:** Requiring pre-authentication forces a requester to prove knowledge of the password before the KDC returns any encrypted material.
+        - **Restored visibility:** Authentication attempts are tied to a credential, keeping brute-force activity on the domain where it can be logged.
+      audit: |-
+        ### Audit via PowerShell
+
+        1. On a domain-joined host with the ActiveDirectory module available, list accounts that do not require Kerberos pre-authentication:
+
+           ```powershell
+           Get-ADUser -Filter "DoesNotRequirePreAuth -eq 'True'"
+           ```
+
+        If the command returns no accounts, the check passes. If it returns one or more accounts, the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To require Kerberos pre-authentication for an affected account using the Active Directory Administrative Center:
+
+            1. Open the Active Directory Administrative Center and locate the affected user account.
+            2. Open the account's properties and go to the **Account** options.
+            3. Clear **Do not require Kerberos preauthentication** and save.
+        - id: cli
+          desc: |-
+            To require Kerberos pre-authentication for every affected account using the ActiveDirectory PowerShell module:
+
+            ```powershell
+            Get-ADUser -Filter "DoesNotRequirePreAuth -eq 'True'" | Set-ADAccountControl -DoesNotRequirePreAuth $false
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/windows/win32/adschema/a-useraccountcontrol
+        title: User-Account-Control attribute
+  - uid: mondoo-activedirectory-security-no-stale-privileged-accounts
+    filters: asset.platform == "activedirectory"
+    title: Ensure privileged accounts are not stale or dormant
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      activedirectory.users.where(isPrivileged == true).all(isStale == false)
+    docs:
+      desc: |-
+        This check ensures that members of privileged groups such as Domain Admins, Enterprise Admins, and Schema Admins have logged on recently. A privileged account that has not authenticated in over 90 days is dormant standing privilege: high-value access that no one is using but an attacker still can.
+
+        **Why this matters**
+
+        - **Unwatched high-value targets:** Dormant admin accounts hold the most powerful rights in the domain while no legitimate user is watching them for misuse.
+        - **Attractive to attackers:** An unused privileged credential can be compromised and exercised without disrupting a real user who would notice being locked out.
+        - **Least privilege drift:** Membership in the most powerful groups should be minimal and current, not a collection of accounts kept "just in case."
+
+        **Risk mitigation**
+
+        - **Smaller privileged footprint:** Removing or disabling dormant admins shrinks the set of accounts that can take over the domain.
+        - **Current, accountable access:** Keeping privileged membership to actively used accounts makes each grant justifiable and auditable.
+      audit: |-
+        ### Audit via PowerShell
+
+        1. On a domain-joined host with the ActiveDirectory module available, enumerate members of a privileged group and review their last logon:
+
+           ```powershell
+           Get-ADGroupMember "Domain Admins" | Get-ADUser -Properties LastLogonDate | Select-Object Name, LastLogonDate
+           ```
+
+        If every privileged member has a `LastLogonDate` within the last 90 days, the check passes. If any member has not logged on in over 90 days (or has never logged on), the check fails.
+      remediation:
+        - id: gui
+          desc: |-
+            To remove dormant members from a privileged group using the Active Directory Administrative Center:
+
+            1. Open the Active Directory Administrative Center and locate the privileged group (for example **Domain Admins**).
+            2. Review each member's last logon and identify accounts that have been dormant for more than 90 days.
+            3. Remove the dormant accounts from the group, or disable them if the identity is no longer needed, then save.
+        - id: cli
+          desc: |-
+            To find and remove dormant privileged members using the ActiveDirectory PowerShell module:
+
+            ```powershell
+            Get-ADGroupMember "Domain Admins" | Get-ADUser -Properties LastLogonDate | Select-Object Name, LastLogonDate
+            Remove-ADGroupMember -Identity "Domain Admins" -Members <dormant-account>
+            ```
+    refs:
+      - url: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/plan/security-best-practices/appendix-b--privileged-accounts-and-groups-in-active-directory
+        title: Privileged accounts and groups in Active Directory

--- a/content/mondoo-jamf-security.mql.yaml
+++ b/content/mondoo-jamf-security.mql.yaml
@@ -1,0 +1,358 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-jamf-security
+    name: Mondoo Jamf Pro Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: jamf
+    require:
+      - provider: jamf
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Harden Jamf Pro single sign-on, managed-device encryption, and endpoint hardening
+    docs:
+      desc: |
+        The Mondoo Jamf Pro Security policy connects to a Jamf Pro mobile device management (MDM) tenant and assesses its identity and endpoint posture. It reads the tenant's single sign-on settings and its managed-computer inventory, so the checks reflect how the fleet is actually configured rather than a documented intent.
+
+        This policy provides security checks across three areas:
+        - Single sign-on enforcement for the Jamf Pro console and enrollment
+        - FileVault disk encryption on managed Macs
+        - Endpoint hardening through the host firewall
+
+        Enforcing single sign-on keeps console and enrollment access tied to the organization's identity provider and its controls (MFA, conditional access), while FileVault encryption and the host firewall reduce the exposure of the managed endpoints themselves.
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Authentication
+        filters: asset.platform == "jamf"
+        checks:
+          - uid: mondoo-jamf-security-sso-enabled
+          - uid: mondoo-jamf-security-sso-bypass-disabled
+      - title: Endpoint Encryption
+        filters: asset.platform == "jamf"
+        checks:
+          - uid: mondoo-jamf-security-filevault-enabled
+      - title: Endpoint Hardening
+        filters: asset.platform == "jamf"
+        checks:
+          - uid: mondoo-jamf-security-firewall-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-jamf-security-sso-enabled
+    filters: asset.platform == "jamf"
+    title: Ensure Jamf Pro single sign-on is enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-d-person-entity-authentication
+      compliance/iso-27001-2022: iso-27001-2022-a-8-5
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-7
+      compliance/nist-csf-2: nist-csf-2-pr-aa-03
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-2
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a07
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-4-1-1
+    mql: |
+      jamf.sso.ssoEnabled == true
+    docs:
+      desc: |-
+        This check ensures that single sign-on is enabled so that the Jamf Pro console and device enrollment authenticate against the organization's identity provider rather than standalone local accounts. When SSO is off, access depends on local Jamf credentials that live outside the identity provider's controls.
+
+        **Why this matters**
+
+        - **Centralized identity:** SSO routes console and enrollment logins through the organization's identity provider, so account lifecycle, MFA, and conditional access apply uniformly.
+        - **Fewer standalone credentials:** Local Jamf accounts are provisioned, rotated, and de-provisioned outside central identity governance, and each one is an independent target.
+        - **Consistent policy:** Login controls enforced at the identity provider (device trust, network restrictions, step-up authentication) reach Jamf Pro only when SSO is in use.
+
+        **Risk mitigation**
+
+        - **Unified offboarding:** Disabling a user at the identity provider immediately removes their Jamf Pro access.
+        - **Stronger authentication:** MFA and conditional access enforced by the identity provider protect every console and enrollment login.
+      audit: |-
+        ### Audit via the Jamf Pro console
+
+        1. Sign in to the Jamf Pro console as an administrator.
+        2. Go to **Settings** > **Single Sign-On**.
+        3. Review whether single sign-on is enabled and bound to an identity provider.
+
+        If single sign-on is enabled, the check passes. If it is disabled, the check fails.
+
+        ### Audit via the API
+
+        1. Read the SSO settings from the Jamf Pro API:
+
+           ```bash
+           curl -s -H "Authorization: Bearer $JAMF_TOKEN" \
+             "https://YOUR_TENANT.jamfcloud.com/api/v1/sso"
+           ```
+
+        If the response reports single sign-on as enabled, the check passes. If it is disabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enable single sign-on in the Jamf Pro console:
+
+            1. Sign in to the Jamf Pro console as an administrator.
+            2. Go to **Settings** > **Single Sign-On**.
+            3. Enable single sign-on and bind it to your identity provider (configure the IdP metadata, entity ID, and certificate).
+            4. Save the configuration and verify a test login through the identity provider.
+        - id: api
+          desc: |-
+            To enable single sign-on through the Jamf Pro API, send the updated SSO settings with single sign-on enabled:
+
+            ```bash
+            curl -s -X PUT \
+              -H "Authorization: Bearer $JAMF_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://YOUR_TENANT.jamfcloud.com/api/v1/sso" \
+              --data '{"ssoEnabled": true}'
+            ```
+
+            Supply the full identity-provider configuration (metadata, entity ID, certificate) required by your tenant alongside the enable flag.
+    refs:
+      - url: https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/Single_Sign-On.html
+        title: Jamf Pro Single Sign-On
+  - uid: mondoo-jamf-security-sso-bypass-disabled
+    filters: asset.platform == "jamf"
+    title: Ensure Jamf Pro does not allow single sign-on to be bypassed
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      jamf.sso.ssoBypassAllowed == false
+    docs:
+      desc: |-
+        This check ensures that the "allow single sign-on to be bypassed" option is off so that users cannot fall back to local Jamf credentials and skip the identity provider's controls. When bypass is allowed, a user can sidestep MFA and conditional access simply by logging in with a local account.
+
+        **Why this matters**
+
+        - **No control bypass:** A failover to local credentials skips the MFA, device trust, and conditional-access checks the identity provider enforces.
+        - **Consistent enforcement:** With bypass disabled, every login is subject to the same identity-provider policy, closing a gap that only widens over time.
+        - **Attack surface:** Local fallback accounts are a standing set of credentials an attacker can target independently of the identity provider.
+
+        **Risk mitigation**
+
+        - **Enforced MFA:** Removing the bypass ensures multi-factor authentication cannot be skipped for console or enrollment access.
+        - **Reduced credential exposure:** Users authenticate only through the identity provider, so there is no local-credential path to compromise.
+      audit: |-
+        ### Audit via the Jamf Pro console
+
+        1. Sign in to the Jamf Pro console as an administrator.
+        2. Go to **Settings** > **Single Sign-On**.
+        3. Review the failover/bypass option that lets users authenticate with local Jamf credentials.
+
+        If single sign-on bypass is not allowed, the check passes. If bypass is allowed, the check fails.
+
+        ### Audit via the API
+
+        1. Read the SSO settings from the Jamf Pro API:
+
+           ```bash
+           curl -s -H "Authorization: Bearer $JAMF_TOKEN" \
+             "https://YOUR_TENANT.jamfcloud.com/api/v1/sso"
+           ```
+
+        If the response reports that single sign-on bypass is not allowed, the check passes. If bypass is allowed, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To disable single sign-on bypass in the Jamf Pro console:
+
+            1. Sign in to the Jamf Pro console as an administrator.
+            2. Go to **Settings** > **Single Sign-On**.
+            3. Clear the failover/bypass option that allows authentication with local Jamf credentials.
+            4. Save the configuration.
+        - id: api
+          desc: |-
+            To disable single sign-on bypass through the Jamf Pro API, send the updated SSO settings with bypass turned off:
+
+            ```bash
+            curl -s -X PUT \
+              -H "Authorization: Bearer $JAMF_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://YOUR_TENANT.jamfcloud.com/api/v1/sso" \
+              --data '{"ssoBypassAllowed": false}'
+            ```
+    refs:
+      - url: https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/Single_Sign-On.html
+        title: Jamf Pro Single Sign-On
+  - uid: mondoo-jamf-security-filevault-enabled
+    filters: asset.platform == "jamf"
+    title: Ensure managed computers have FileVault disk encryption enabled
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ekm-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-2-iv-encryption
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ac-1
+      compliance/nist-csf-2: nist-csf-2-pr-aa-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ia-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-5-10
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-8-3-1
+      compliance/soc2-2017: soc2-control-cc6-1-4
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      jamf.computerInventory.all(fileVault2Status == "VALID")
+    docs:
+      desc: |-
+        This check ensures that every managed computer reports a FileVault status of `VALID`, meaning the boot volume is fully encrypted with a valid, escrowed recovery key. `VALID` is the fully-encrypted, key-escrowed state; other states such as `VALID_BUT_DISABLED_BY_USER` or `NOT_APPLICABLE` indicate that encryption is not effectively in force. A lost or stolen unencrypted Mac exposes all of its local data.
+
+        **Why this matters**
+
+        - **Data-at-rest protection:** FileVault encrypts the entire boot volume, so a lost or stolen device does not surrender its contents to whoever holds it.
+        - **Recoverable keys:** An escrowed recovery key means the organization can recover an encrypted device without leaving encryption optional or unmanaged.
+        - **Effective state, not intent:** Requiring `VALID` distinguishes machines that are actually encrypted from those where a user or platform state left encryption off.
+
+        **Risk mitigation**
+
+        - **Loss and theft:** Encrypted volumes render the data on a misplaced or stolen Mac unreadable without the credentials or escrowed key.
+        - **Decommissioning:** Full-disk encryption reduces the risk of data remnants when devices are retired or reassigned.
+      audit: |-
+        ### Audit via the Jamf Pro console
+
+        1. Sign in to the Jamf Pro console as an administrator.
+        2. Go to **Computers** and build a search or Smart Group on the **FileVault 2 status** criterion.
+        3. Review the disk-encryption status reported for each managed computer.
+
+        If every managed computer reports FileVault status `VALID`, the check passes. If any computer reports another state, the check fails.
+
+        ### Audit via the API
+
+        1. Read the computer inventory with the disk-encryption section from the Jamf Pro API:
+
+           ```bash
+           curl -s -H "Authorization: Bearer $JAMF_TOKEN" \
+             "https://YOUR_TENANT.jamfcloud.com/api/v1/computers-inventory?section=DISK_ENCRYPTION"
+           ```
+
+        If every returned computer reports FileVault status `VALID`, the check passes. If any computer reports another state, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enforce FileVault encryption in the Jamf Pro console:
+
+            1. Sign in to the Jamf Pro console as an administrator.
+            2. Create a **Disk Encryption** configuration profile that enables FileVault and escrows the personal or institutional recovery key.
+            3. Scope the profile to all managed computers.
+            4. Deploy the profile and confirm that computers report FileVault status `VALID`.
+        - id: api
+          desc: |-
+            To enforce FileVault encryption through the Jamf Pro API, create a disk-encryption configuration profile and scope it to all computers. For example, create the FileVault configuration:
+
+            ```bash
+            curl -s -X POST \
+              -H "Authorization: Bearer $JAMF_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://YOUR_TENANT.jamfcloud.com/api/v1/disk-encryption-configurations" \
+              --data '{"name": "Enforce FileVault", "keyType": "Individual"}'
+            ```
+
+            Then scope the resulting configuration profile to all managed computers so the encryption policy applies fleet-wide.
+    refs:
+      - url: https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/FileVault.html
+        title: FileVault management with Jamf Pro
+  - uid: mondoo-jamf-security-firewall-enabled
+    filters: asset.platform == "jamf"
+    title: Ensure managed computers have the host firewall enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-protection
+      compliance/iso-27001-2022: iso-27001-2022-a-8-9
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-6
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-2-2-4
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    mql: |
+      jamf.computerInventory.all(firewallEnabled == true)
+    docs:
+      desc: |-
+        This check ensures that every managed computer has the macOS application firewall enabled, limiting the inbound network exposure of listening services. A Mac with the firewall off accepts unsolicited inbound connections to any service that happens to be listening.
+
+        **Why this matters**
+
+        - **Reduced attack surface:** The application firewall blocks unsolicited inbound connections, so only services the user or administrator allows are reachable.
+        - **Protection on untrusted networks:** Laptops routinely connect to coffee-shop, hotel, and conference networks where any peer can probe listening ports.
+        - **Defense in depth:** The host firewall backstops network controls, containing exposure when a device is off the corporate network.
+
+        **Risk mitigation**
+
+        - **Fewer reachable services:** Inbound-blocking limits what a nearby attacker can connect to and attempt to exploit.
+        - **Lateral-movement resistance:** A firewalled endpoint is harder to pivot to from a compromised peer on the same network.
+      audit: |-
+        ### Audit via the Jamf Pro console
+
+        1. Sign in to the Jamf Pro console as an administrator.
+        2. Go to **Computers** and build a search or Smart Group on the firewall status criterion.
+        3. Review the firewall state reported for each managed computer.
+
+        If every managed computer reports the firewall as enabled, the check passes. If any computer reports the firewall disabled, the check fails.
+
+        ### Audit via the API
+
+        1. Read the computer inventory with the security section from the Jamf Pro API:
+
+           ```bash
+           curl -s -H "Authorization: Bearer $JAMF_TOKEN" \
+             "https://YOUR_TENANT.jamfcloud.com/api/v1/computers-inventory?section=SECURITY"
+           ```
+
+        If every returned computer reports the firewall as enabled, the check passes. If any computer reports it disabled, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To enforce the host firewall in the Jamf Pro console:
+
+            1. Sign in to the Jamf Pro console as an administrator.
+            2. Create a **Security** configuration profile (or a policy) that enables the macOS application firewall.
+            3. Scope the profile to all managed computers.
+            4. Deploy the profile and confirm that computers report the firewall as enabled.
+        - id: api
+          desc: |-
+            To enforce the host firewall through the Jamf Pro API, create a configuration profile that enables the macOS application firewall and scope it to all computers:
+
+            ```bash
+            curl -s -X POST \
+              -H "Authorization: Bearer $JAMF_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://YOUR_TENANT.jamfcloud.com/api/v1/macos-configuration-profiles" \
+              --data '{"name": "Enable macOS Firewall"}'
+            ```
+
+            Attach a firewall payload (`com.apple.security.firewall`) that enables the firewall to the profile, then scope it to all managed computers.
+    refs:
+      - url: https://learn.jamf.com/en-US/bundle/jamf-pro-documentation-current/page/Computer_Configuration_Profiles.html
+        title: Computer configuration profiles

--- a/content/mondoo-weaviate-security.mql.yaml
+++ b/content/mondoo-weaviate-security.mql.yaml
@@ -1,0 +1,156 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+policies:
+  - uid: mondoo-weaviate-security
+    name: Mondoo Weaviate Security
+    version: 1.0.0
+    license: BUSL-1.1
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: weaviate
+    require:
+      - provider: weaviate
+    authors:
+      - name: Mondoo, Inc.
+        email: hello@mondoo.com
+    summary: Secure Weaviate vector database access control and authentication
+    docs:
+      desc: |
+        The Mondoo Weaviate Security policy connects to a running Weaviate vector database and assesses its access-control posture: whether the server answers unauthenticated requests and whether role-based access control is enforced.
+
+        A vector database backs retrieval-augmented generation (RAG) and semantic search, so it holds embeddings derived from potentially sensitive source data. Leaving it open to unauthenticated access exposes that data and lets anyone read, poison, or delete the collections an LLM application depends on.
+
+        Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
+    groups:
+      - title: Access Control
+        filters: asset.platform == "weaviate"
+        checks:
+          - uid: mondoo-weaviate-security-anonymous-access-disabled
+          - uid: mondoo-weaviate-security-rbac-enabled
+    scoring_system: highest impact
+queries:
+  - uid: mondoo-weaviate-security-anonymous-access-disabled
+    filters: asset.platform == "weaviate"
+    title: Ensure Weaviate does not allow anonymous access
+    impact: 90
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-1
+      compliance/owasp-llm-top-10-2025: owasp-llm-top-10-2025-llm08
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-1-3
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      weaviate.instance.anonymousAccessEnabled == false
+    docs:
+      desc: |-
+        This check ensures that the Weaviate server rejects unauthenticated requests. When anonymous access is enabled, any client that can reach the network endpoint can read, modify, or delete data without presenting credentials.
+
+        **Why this matters**
+
+        - **Data exposure:** Embeddings and their associated objects often derive from sensitive source documents; anonymous read access leaks that data to anyone on the network.
+        - **Data poisoning:** Without authentication, an attacker can insert or alter vectors, corrupting the results a retrieval-augmented generation pipeline returns.
+        - **Availability:** Anonymous write access lets anyone delete collections the application depends on.
+
+        **Risk mitigation**
+
+        - **Authenticated access only:** Requiring credentials ensures every request is tied to a known identity.
+        - **Attribution:** Authenticated requests can be logged and attributed, supporting detection and investigation.
+      audit: |-
+        ### Audit via the REST API
+
+        1. Query the server's metadata without credentials and observe whether it responds:
+
+           ```bash
+           curl -s -o /dev/null -w "%{http_code}" http://WEAVIATE_HOST:8080/v1/meta
+           ```
+
+        If the request is rejected (for example `401`), anonymous access is disabled and the check passes. If it returns `200` without credentials, anonymous access is enabled and the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To disable anonymous access, set the environment variable on the Weaviate server and restart it:
+
+            ```bash
+            export AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false
+            ```
+
+            Configure at least one authentication method (API keys or OIDC) at the same time so authorized clients can still connect, for example:
+
+            ```bash
+            export AUTHENTICATION_APIKEY_ENABLED=true
+            export AUTHENTICATION_APIKEY_ALLOWED_KEYS=<generated-key>
+            export AUTHENTICATION_APIKEY_USERS=admin@example.com
+            ```
+    refs:
+      - url: https://weaviate.io/developers/weaviate/configuration/authentication
+        title: Weaviate authentication
+  - uid: mondoo-weaviate-security-rbac-enabled
+    filters: asset.platform == "weaviate"
+    title: Ensure Weaviate enforces role-based access control
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-a-1-access-control
+      compliance/iso-27001-2022: iso-27001-2022-a-8-3
+      compliance/nis-2: nis-2-21-2-i
+      compliance/nist-csf-1: nist-csf-1-pr-ac-4
+      compliance/nist-csf-2: nist-csf-2-pr-aa-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-ac-6
+      compliance/nist-sp-800-171: nist-sp-800-171--3-1-5
+      compliance/owasp-llm-top-10-2025: owasp-llm-top-10-2025-llm08
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a01
+      compliance/pci-dss-4: pcidss-requirement-7-2-1
+      compliance/soc2-2017: soc2-control-cc6-3-1
+      compliance/vda-isa-5: vda-isa-5-4-2-1
+    mql: |
+      weaviate.instance.rbacEnabled == true
+    docs:
+      desc: |-
+        This check ensures that role-based access control (RBAC) is enabled so that authenticated users are granted only the permissions their role requires, rather than every authenticated client having full access.
+
+        **Why this matters**
+
+        - **Least privilege:** RBAC lets you grant read-only access to consumers of a collection while restricting write and admin operations to a small set of principals.
+        - **Blast radius:** Without RBAC, any valid credential typically carries full control of every collection on the server.
+        - **Separation of duties:** Distinct roles for ingestion, query, and administration limit what a single compromised credential can do.
+
+        **Risk mitigation**
+
+        - **Contained credentials:** A leaked read-only key cannot be used to alter or delete data.
+        - **Scoped automation:** Application service identities can be limited to the collections and actions they need.
+      audit: |-
+        ### Audit via the REST API
+
+        1. Read the server's modules and authorization configuration from its metadata endpoint (with credentials):
+
+           ```bash
+           curl -s -H "Authorization: Bearer $WEAVIATE_API_KEY" http://WEAVIATE_HOST:8080/v1/meta
+           ```
+
+        If role-based access control is enabled on the server, the check passes. If authorization is left at the default all-or-nothing admin list, the check fails.
+      remediation:
+        - id: config
+          desc: |-
+            To enable RBAC, set the environment variables on the Weaviate server and restart it, then define roles and assign them to users:
+
+            ```bash
+            export AUTHORIZATION_RBAC_ENABLED=true
+            export AUTHORIZATION_ADMIN_USERS=admin@example.com
+            ```
+
+            After enabling RBAC, create roles with the minimum permissions each principal needs and assign them, rather than granting admin broadly.
+    refs:
+      - url: https://weaviate.io/developers/weaviate/configuration/authorization
+        title: Weaviate authorization


### PR DESCRIPTION
## What this does

Three policies covering directory identity, managed endpoints, and the vector database behind RAG workloads.

| Policy | Provider | Checks |
|---|---|---|
| `mondoo-activedirectory-security` | `activedirectory` | domain minimum password length (A07), reversible encryption disabled (A04), no enabled account allowed an empty password (A07), Kerberos pre-authentication required (A07), no stale privileged accounts (A01) |
| `mondoo-jamf-security` | `jamf` | single sign-on enabled (A07) and its bypass disabled (A07), FileVault disk encryption (A04), host firewall (A02) |
| `mondoo-weaviate-security` | `weaviate` | anonymous access disabled (A01 · **LLM08**), role-based access control enforced (A01 · **LLM08**) |

The Weaviate checks give the OWASP Top 10 for LLM Applications its first coverage of **LLM08 (Vector and Embedding Weaknesses)**: an unauthenticated vector store exposes the embeddings and source passages a RAG pipeline retrieves over, and lets an attacker poison what the model is grounded on.

Every check ships full `desc`/`audit`/`remediation` docs using vendor-native tooling and carries the compliance tag set the OWASP parity invariant requires.

## Scope

Split out of a larger branch; each part branches off `main` independently, no stacking. See #3243 for the running-server checks added to the existing PostgreSQL, MySQL, and Grafana policies.

## Validation

- `cnspec policy lint ./content` — no new findings against a pristine-`main` baseline. Every field used was checked against the installed provider schema.
- `go test ./content/validation/...` — passes, including the OWASP parity test.
- The Active Directory remediation uses the string form of `Get-ADUser -Filter`; the script-block form fails PSScriptAnalyzer, which the `validate-powershell` job runs.
