### PR TITLE
🐛 aws: point the SSM document sharing check at a resource that exists

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.12.1
+    version: 12.13.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -60606,13 +60606,19 @@ queries:
             ```
         - id: terraform
           desc: |
-            To restrict SSM document sharing in Terraform, ensure `aws_ssm_document_permission` resources do not share with all accounts:
+            To restrict SSM document sharing in Terraform, set the document's `permissions` map to name the accounts it is shared with. `account_ids` is a comma-separated string; the literal `All` shares the document publicly:
 
             ```hcl
-            resource "aws_ssm_document_permission" "example" {
-              document_name = aws_ssm_document.example.name
-              permission    = "Share"
-              account_ids   = ["123456789012"]
+            resource "aws_ssm_document" "example" {
+              name            = "example-document"
+              document_type   = "Command"
+              document_format = "YAML"
+              content         = file("${path.module}/example-document.yaml")
+
+              permissions = {
+                type        = "Share"
+                account_ids = "123456789012,123456789013"
+              }
             }
             ```
     refs:
@@ -60625,22 +60631,28 @@ queries:
         permissions.none(_['accountIds'].any(_ == "All" || _ == "all"))
       )
   - uid: mondoo-aws-security-ssm-document-not-public-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ssm_document_permission")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ssm_document")
     mql: |
-      terraform.resources("aws_ssm_document_permission").all(
-        arguments.account_ids.none(_ == "All" || _ == "all")
+      terraform.resources("aws_ssm_document").all(
+        arguments['permissions'] == null ||
+        arguments['permissions']['account_ids'] == null ||
+        arguments['permissions']['account_ids'] != /(?i)(^|,)\s*all\s*($|,)/
       )
   - uid: mondoo-aws-security-ssm-document-not-public-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ssm_document_permission")
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ssm_document")
     mql: |
-      terraform.plan.resourceChanges.where(type == "aws_ssm_document_permission").all(
-        change.after.account_ids.none(_ == "All" || _ == "all")
+      terraform.plan.resourceChanges.where(type == "aws_ssm_document").all(
+        change.after['permissions'] == null ||
+        change.after['permissions']['account_ids'] == null ||
+        change.after['permissions']['account_ids'] != /(?i)(^|,)\s*all\s*($|,)/
       )
   - uid: mondoo-aws-security-ssm-document-not-public-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ssm_document_permission")
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ssm_document")
     mql: |
-      terraform.state.resources.where(type == "aws_ssm_document_permission").all(
-        values.account_ids.none(_ == "All" || _ == "all")
+      terraform.state.resources.where(type == "aws_ssm_document").all(
+        values['permissions'] == null ||
+        values['permissions']['account_ids'] == null ||
+        values['permissions']['account_ids'] != /(?i)(^|,)\s*all\s*($|,)/
       )
   - uid: mondoo-aws-security-ssm-patch-baseline-reject-action
     title: Ensure SSM patch baselines block rejected patches

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/fail/all/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/fail/all/main.tf
@@ -1,6 +1,12 @@
-# Non-compliant: document is shared publicly with "All".
-resource "aws_ssm_document_permission" "fail_example" {
-  document_name   = "example-document"
-  permission_type = "Share"
-  account_ids     = ["All"]
+# Non-compliant: the permissions map shares the document publicly with "All".
+resource "aws_ssm_document" "fail_example" {
+  name            = "example-document"
+  document_type   = "Command"
+  document_format = "YAML"
+  content         = "schemaVersion: '2.2'"
+
+  permissions = {
+    type        = "Share"
+    account_ids = "All"
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/pass/basic/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/pass/basic/main.tf
@@ -1,6 +1,12 @@
-# Compliant: document is shared only with specific account IDs.
-resource "aws_ssm_document_permission" "pass_example" {
-  document_name   = "example-document"
-  permission_type = "Share"
-  account_ids     = ["111122223333", "444455556666"]
+# Compliant: the document is shared only with named account IDs.
+resource "aws_ssm_document" "pass_example" {
+  name            = "example-document"
+  document_type   = "Command"
+  document_format = "YAML"
+  content         = "schemaVersion: '2.2'"
+
+  permissions = {
+    type        = "Share"
+    account_ids = "111122223333,444455556666"
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/pass/not-shared/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-ssm-document-not-public-terraform-hcl/pass/not-shared/main.tf
@@ -1,0 +1,7 @@
+# Compliant: the document declares no permissions map, so it is not shared.
+resource "aws_ssm_document" "pass_private" {
+  name            = "private-document"
+  document_type   = "Command"
+  document_format = "YAML"
+  content         = "schemaVersion: '2.2'"
+}


### PR DESCRIPTION
`aws_ssm_document_permission` is not a resource in the AWS provider. Sharing is a `permissions` map on `aws_ssm_document` itself:

```
$ terraform providers schema -json   # hashicorp/aws ~> 6.0
resources matching /ssm.*(doc|perm)/ : ['aws_ssm_document']
aws_ssm_document.permissions          : {"type": ["map","string"], "optional": true}
```

## Impact

All three Terraform variants of `mondoo-aws-security-ssm-document-not-public` filtered on that type:

```
filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ssm_document_permission")
```

A filter that matches nothing means the check never runs — it cannot fail, and in a report it is indistinguishable from a check that passed. HCL naming the type does not plan, and it can appear in neither a plan nor a state file, so all three variants were dead. The remediation told the reader to write it as well.

## The fix

`account_ids` inside the map is a **comma-separated string**, not a list, so the assertion is a regex over that string rather than a list operation:

```coffee
terraform.resources("aws_ssm_document").all(
  arguments['permissions'] == null ||
  arguments['permissions']['account_ids'] == null ||
  arguments['permissions']['account_ids'] != /(?i)(^|,)\s*all\s*($|,)/
)
```

The two null guards come first deliberately: an absent `permissions` map means the document is not shared, which passes, and `!= regex` on an unresolved field would pass for the wrong reason.

Fixtures updated to the real resource, plus a new `pass/not-shared` case for a document with no `permissions` map at all — the common compliant shape the old fixtures never covered.

## Why nothing caught it

tflint has rulesets only for aws, azurerm and google, and none flags an unknown resource type. A schema-based sweep of all of `content/` found **26 such occurrences across 4 policies**; the rest are going out as their own policy PRs, with a follow-up to teach `remediation/code/terraform.py` to assert resource-type existence.

## Verification

| Gate | Result |
|---|---|
| `cnspec policy lint` | valid |
| SSM fixtures (fail/all, pass/basic, pass/not-shared) | all pass |
| Fixture coverage gate | `ok` |
| terraform validator (tflint) | 0 failures |
| AWS command validator | 0 failures |
| `typos` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)