### PR TITLE
🐛 gcp: fix Terraform remediation naming resources the provider does not have

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.9.1
+    version: 9.10.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -32543,6 +32543,9 @@ queries:
           _['secret_manager_stored_password'] != ""
         )
       )
+  # No Terraform variants: Datastream private-connection routes have no resource
+  # in the hashicorp/google or hashicorp/google-beta provider, so there is
+  # nothing for an HCL, plan, or state scan to match.
   - uid: mondoo-gcp-security-datastream-routes-no-public-cidr
     title: Ensure Datastream private-connection routes do not advertise public CIDRs
     impact: 80
@@ -32566,18 +32569,6 @@ queries:
         tags:
           mondoo.com/filter-title: GCP Project
           mondoo.com/filter-icon: gcp
-      - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl
-        tags:
-          mondoo.com/filter-title: Terraform HCL
-          mondoo.com/filter-icon: terraform
-      - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-plan
-        tags:
-          mondoo.com/filter-title: Terraform Plan
-          mondoo.com/filter-icon: terraform
-      - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-state
-        tags:
-          mondoo.com/filter-title: Terraform State
-          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that Datastream private-connection routes advertise only RFC1918 destination addresses. Routes inside a Datastream private connection determine which destinations are reachable through the VPC peer; a route pointing to a public address or `0.0.0.0` defeats the purpose of private connectivity by routing traffic outside the private IP space.
@@ -32620,18 +32611,6 @@ queries:
 
         A passing private connection returns only routes whose `destinationAddress` begins with `10.`, `192.168.`, or `172.16.` through `172.31.`. A failing private connection returns at least one route with a public or `0.0.0.0` destination address.
       remediation:
-        - id: terraform
-          desc: |
-            ```hcl
-            resource "google_datastream_route" "src" {
-              route_id              = "src-route"
-              location              = "us-central1"
-              private_connection    = google_datastream_private_connection.pc.private_connection_id
-              display_name          = "src-route"
-              destination_address   = "10.0.0.10"
-              destination_port      = 3306
-            }
-            ```
         - id: console
           desc: |
             1. Go to **Datastream > Private connections** and select the affected private connection.
@@ -32650,6 +32629,10 @@ queries:
               --destination-address=10.0.0.10 \
               --destination-port=3306
             ```
+        # No Terraform remediation: Datastream private-connection routes have no
+        # resource in the hashicorp/google or hashicorp/google-beta provider. The
+        # private connection itself is manageable, but its routes are only
+        # reachable through the API and gcloud.
     refs:
       - url: https://cloud.google.com/datastream/docs/private-connectivity
         title: Datastream private connectivity
@@ -32660,27 +32643,6 @@ queries:
         routes.all(
           destinationAddress.find(/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/) != []
         )
-      )
-  - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl
-    filters: |
-      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_datastream_route')
-    mql: |
-      terraform.resources('google_datastream_route').all(
-        arguments.destination_address.find(/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/) != []
-      )
-  - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-plan
-    filters: |
-      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_datastream_route')
-    mql: |
-      terraform.plan.resourceChanges.where(type == 'google_datastream_route').all(
-        change.after['destination_address'].find(/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/) != []
-      )
-  - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-state
-    filters: |
-      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_datastream_route')
-    mql: |
-      terraform.state.resources.where(type == 'google_datastream_route').all(
-        values['destination_address'].find(/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/) != []
       )
   # No Terraform variants: this check resolves the GCS bucket referenced by a
   # google_datastream_connection_profile (gcs profile) and then evaluates the
@@ -36030,10 +35992,11 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            To ensure an API Gateway config has an attached OpenAPI document in Terraform:
+            To ensure an API Gateway config has an attached OpenAPI document in Terraform. API Gateway resources are published only in the `google-beta` provider, so the resource has to name it explicitly:
 
             ```hcl
             resource "google_api_gateway_api_config" "default" {
+              provider      = google-beta
               api           = google_api_gateway_api.default.api_id
               api_config_id = "my-config"
 
@@ -36969,7 +36932,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            To require CMEK on Dataflow jobs in Terraform, set `kms_key_name` on the job resource:
+            To require CMEK on Dataflow jobs in Terraform, set `kms_key_name` on the job resource. `google_dataflow_flex_template_job` is published only in the `google-beta` provider, so it has to name that provider explicitly:
 
             ```hcl
             resource "google_dataflow_job" "default" {
@@ -36980,6 +36943,7 @@ queries:
             }
 
             resource "google_dataflow_flex_template_job" "flex" {
+              provider                = google-beta
               name                    = "flex-pipeline"
               container_spec_gcs_path = "gs://templates/flex-spec.json"
               kms_key_name            = google_kms_crypto_key.dataflow.id
@@ -37555,7 +37519,7 @@ queries:
       remediation:
         - id: terraform
           desc: |
-            To require CMEK on Vertex AI training and runtime assets in Terraform, set `encryption_spec` on each resource type:
+            To require CMEK on Vertex AI training and runtime assets in Terraform, set `encryption_spec` on each resource type. `google_vertex_ai_metadata_store` is published only in the `google-beta` provider, so it has to name that provider explicitly:
 
             ```hcl
             resource "google_vertex_ai_tensorboard" "default" {
@@ -37568,6 +37532,7 @@ queries:
             }
 
             resource "google_vertex_ai_metadata_store" "default" {
+              provider = google-beta
               name     = "metadata-store"
               region   = "us-central1"
 

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -68,6 +68,7 @@ PROVIDER_MAP = {
     "azuread": ("hashicorp/azuread", "~> 3.0"),
     "azapi": ("azure/azapi", "~> 2.0"),
     "google": ("hashicorp/google", "~> 7.0"),
+    "google-beta": ("hashicorp/google-beta", "~> 7.0"),
     "oci": ("oracle/oci", "~> 8.0"),
     "github": ("integrations/github", "~> 6.0"),
     "gitlab": ("gitlabhq/gitlab", "~> 19.0"),
@@ -207,11 +208,20 @@ def extract_hcl_blocks(content: str, filepath: Path) -> list[HclBlock]:
 # ---------------------------------------------------------------------------
 
 def detect_providers(hcl_code: str) -> set[str]:
-    """Detect provider prefixes from resource/data block type names."""
+    """Detect provider local names a snippet needs.
+
+    Most come from the resource/data block type name, whose prefix is the
+    provider. A resource can also name a provider explicitly with
+    `provider = google-beta`, which is the only way to reach a beta-only
+    resource type; that local name has to be declared too, or the generated
+    configuration references a provider it never required.
+    """
     prefixes = set()
     for m in re.finditer(
         r'(?:resource|data)\s+"([a-z][a-z0-9]*)_', hcl_code
     ):
+        prefixes.add(m.group(1))
+    for m in re.finditer(r'^\s*provider\s*=\s*([a-z][a-z0-9-]*)\s*$', hcl_code, re.M):
         prefixes.add(m.group(1))
     return prefixes
 

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -221,7 +221,9 @@ def detect_providers(hcl_code: str) -> set[str]:
         r'(?:resource|data)\s+"([a-z][a-z0-9]*)_', hcl_code
     ):
         prefixes.add(m.group(1))
-    for m in re.finditer(r'^\s*provider\s*=\s*([a-z][a-z0-9-]*)\s*$', hcl_code, re.M):
+    # Both spellings occur: the modern unquoted reference and the legacy quoted
+    # string form, which Terraform still parses.
+    for m in re.finditer(r'^\s*provider\s*=\s*"?([a-z][a-z0-9-]*)"?\s*$', hcl_code, re.M):
         prefixes.add(m.group(1))
     return prefixes
 

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/fail/public/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/fail/public/main.tf
@@ -1,9 +1,0 @@
-# Non-compliant: route destination is a public IP address.
-resource "google_datastream_route" "public" {
-  display_name          = "route-to-public"
-  location              = "us-central1"
-  private_connection    = "projects/my-project/locations/us-central1/privateConnections/datastream-pc"
-  route_id              = "route-to-public"
-  destination_address   = "203.0.113.25"
-  destination_port      = 3306
-}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/pass/private-10/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/pass/private-10/main.tf
@@ -1,9 +1,0 @@
-# Compliant: route destination is inside the 10.0.0.0/8 private range.
-resource "google_datastream_route" "compliant" {
-  display_name          = "route-to-source"
-  location              = "us-central1"
-  private_connection    = "projects/my-project/locations/us-central1/privateConnections/datastream-pc"
-  route_id              = "route-to-source"
-  destination_address   = "10.20.30.40"
-  destination_port      = 3306
-}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/pass/private-172/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-datastream-routes-no-public-cidr-terraform-hcl/pass/private-172/main.tf
@@ -1,9 +1,0 @@
-# Compliant: route destination is inside the 172.16.0.0/12 private range.
-resource "google_datastream_route" "compliant" {
-  display_name          = "route-to-source"
-  location              = "us-central1"
-  private_connection    = "projects/my-project/locations/us-central1/privateConnections/datastream-pc"
-  route_id              = "route-to-source"
-  destination_address   = "172.16.8.5"
-  destination_port      = 5432
-}


### PR DESCRIPTION
Four checks in `mondoo-gcp-security` ship Terraform that cannot be applied against the pinned providers. Found by comparing every `resource "..."` in `content/` against `terraform providers schema -json` at each pinned constraint.

## Three beta-only resources with no `google-beta` declaration

| Resource | Check | `hashicorp/google` | `hashicorp/google-beta` |
|---|---|---|---|
| `google_api_gateway_api_config` | `apigateway-config-requires-authentication` | absent | present |
| `google_dataflow_flex_template_job` | `dataflow-job-cmek-encryption` | absent | present |
| `google_vertex_ai_metadata_store` | `vertex-ai-job-cmek-encryption` | absent | present |

The snippets declare nothing but `hashicorp/google`, so terraform rejects them with *provider does not support resource type*. Each resource now carries `provider = google-beta`, and the prose says why.

The sibling resources in the same snippets (`google_dataflow_job`, `google_vertex_ai_tensorboard`, `google_vertex_ai_featurestore`) are GA and are left alone, so only the beta resource takes the override.

## One resource that exists nowhere

`google_datastream_route` is in neither provider:

```
hashicorp/google      datastream resources: connection_profile, private_connection, stream
hashicorp/google-beta datastream resources: connection_profile, private_connection, stream
```

Datastream private connections are manageable in Terraform; their **routes** are reachable only through the API and `gcloud`. All three Terraform variants of `datastream-routes-no-public-cidr` filtered on that type:

```
filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_datastream_route')
```

A filter that matches nothing means the check never runs, and in a report that is indistinguishable from a check that passed. The variants, their fixtures, and the Terraform remediation are removed and replaced with the `# No Terraform variants:` and `# No Terraform remediation:` comments the content rules require. The runtime `-gcp` variant and the console/gcloud remediation are untouched, so the control still holds where it can actually be evaluated.

## Validator gap this closes

`detect_providers` derived `required_providers` purely from resource-name prefixes, so `google_*` always resolved to `hashicorp/google` and there was no way to express a beta-only snippet — a `provider = google-beta` reference would have been undeclared in the generated config. It now also reads explicit `provider =` references, and `google-beta` is in `PROVIDER_MAP`.

Note this is only half the gap. tflint still does not flag an unknown *resource type*, which is why all four of these passed the validator. I plan a follow-up that asserts resource-type existence against the provider schema, which would have caught all 26 occurrences the sweep found across 4 policies.

## Verification

| Gate | Result |
|---|---|
| `cnspec policy lint` | valid |
| terraform validator (tflint) | 1,566 pass / 0 fail, including the three `google-beta` snippets |
| All GCP Terraform fixtures | `ok` (133s) |
| Fixture coverage gate | `ok` |
| Compliance mappings, bundle smoke scans | `ok` |
| `typos` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)