### PR TITLE
🐛 gcp: fix remediation snippets and the checks that cannot confirm them

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.10.0
+    version: 9.11.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -639,7 +639,7 @@ queries:
             2. Update the instance:
 
               ```bash
-              gcloud compute instances set-service-account INSTANCE_NAME --service-account=SERVICE_ACCOUNT --scopes [SCOPE1,SCOPE2...]
+              gcloud compute instances set-service-account INSTANCE_NAME --service-account=SERVICE_ACCOUNT --scopes=SCOPE1,SCOPE2
               ```
 
             3. Restart the instance:
@@ -1035,6 +1035,17 @@ queries:
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_instance' || nameLabel == 'google_compute_project_metadata')
     mql: |
+      # Instance metadata overrides project metadata, so an instance that sets
+      # enable-oslogin to false disables OS Login regardless of the project setting.
+      terraform.resources('google_compute_instance').none(
+        arguments.metadata['enable-oslogin'] == /false/i
+      )
+      # Enabling OS Login project-wide covers every instance in the project, so
+      # either the project metadata or every instance carries the key.
+      terraform.resources('google_compute_project_metadata').any(
+        arguments.metadata['enable-oslogin'] == /true/i
+      ) ||
+      terraform.resources('google_compute_instance') != empty &&
       terraform.resources('google_compute_instance').all(
         arguments.metadata != empty &&
         arguments.metadata['enable-oslogin'] == /true/i
@@ -1043,6 +1054,13 @@ queries:
     filters: |
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_instance' || type == 'google_compute_project_metadata')
     mql: |
+      terraform.plan.resourceChanges.where(type == 'google_compute_instance').none(
+        change.after.metadata['enable-oslogin'] == /false/i
+      )
+      terraform.plan.resourceChanges.where(type == 'google_compute_project_metadata').any(
+        change.after.metadata['enable-oslogin'] == /true/i
+      ) ||
+      terraform.plan.resourceChanges.where(type == 'google_compute_instance') != empty &&
       terraform.plan.resourceChanges.where(type == 'google_compute_instance').all(
         change.after.metadata['enable-oslogin'] == /true/i
       )
@@ -1050,6 +1068,13 @@ queries:
     filters: |
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_instance' || type == 'google_compute_project_metadata')
     mql: |
+      terraform.state.resources.where(type == 'google_compute_instance').none(
+        values.metadata['enable-oslogin'] == /false/i
+      )
+      terraform.state.resources.where(type == 'google_compute_project_metadata').any(
+        values.metadata['enable-oslogin'] == /true/i
+      ) ||
+      terraform.state.resources.where(type == 'google_compute_instance') != empty &&
       terraform.state.resources.where(type == 'google_compute_instance').all(
         values.metadata['enable-oslogin'] == /true/i
       )
@@ -1938,12 +1963,12 @@ queries:
             1. Retrieve the current dataset access configuration:
 
             ```bash
-            bq show --format=prettyjson PROJECT_ID:DATASET_ID
+            bq show --format=prettyjson PROJECT_ID:DATASET_ID > dataset.json
             ```
 
-            2. Review the `access` array in the output and identify entries with `"specialGroup": "allAuthenticatedUsers"` or `"iamMember": "allUsers"`.
+            2. Open `dataset.json`, find the `access` array, and delete every entry with `"specialGroup": "allAuthenticatedUsers"`, `"specialGroup": "allUsers"`, or an `"iamMember"` of either.
 
-            3. Remove the public access entries and update the dataset:
+            3. Apply the edited file back to the dataset:
 
             ```bash
             bq update --source=dataset.json PROJECT_ID:DATASET_ID
@@ -2280,10 +2305,16 @@ queries:
             bq show --format=prettyjson PROJECT_ID:DATASET_ID.TABLE_ID
             ```
 
-            2. To copy a table with CMEK encryption:
+            2. A table's encryption cannot be changed in place, so copy it into a CMEK-encrypted table:
 
             ```bash
             bq cp --destination_kms_key=projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY PROJECT_ID:DATASET_ID.SOURCE_TABLE PROJECT_ID:DATASET_ID.DEST_TABLE
+            ```
+
+            3. The copy leaves the original table in place, still under Google-managed encryption. After verifying the copy, repoint queries and views at it, then remove the original:
+
+            ```bash
+            bq rm --table PROJECT_ID:DATASET_ID.SOURCE_TABLE
             ```
     refs:
       - url: https://cloud.google.com/bigquery/docs/best-practices-security
@@ -2736,12 +2767,12 @@ queries:
             1. Retrieve the current dataset access configuration:
 
             ```bash
-            bq show --format=prettyjson PROJECT_ID:DATASET_ID
+            bq show --format=prettyjson PROJECT_ID:DATASET_ID > dataset.json
             ```
 
-            2. Review the `access` array and identify entries with `"domain"` fields.
+            2. Open `dataset.json` and find the `access` array entries that carry a `"domain"` field.
 
-            3. Remove domain-wide access entries and replace them with specific group or user access. Save the modified configuration and update:
+            3. Replace each of those entries with a specific `"groupByEmail"` or `"userByEmail"` grant, then apply the edited file back to the dataset:
 
             ```bash
             bq update --source=dataset.json PROJECT_ID:DATASET_ID
@@ -5971,7 +6002,6 @@ queries:
             To ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible in Terraform, ensure that IAM policy resources for KMS crypto keys do not include `allUsers` or `allAuthenticatedUsers` as members:
 
             ```hcl
-            # Good example - specific users/service accounts only
             resource "google_kms_crypto_key_iam_binding" "crypto_key" {
               crypto_key_id = google_kms_crypto_key.key.id
               role          = "roles/cloudkms.cryptoKeyEncrypter"
@@ -5981,19 +6011,9 @@ queries:
                 "serviceAccount:my-service@project.iam.gserviceaccount.com",
               ]
             }
-
-            # Avoid - public access
-            resource "google_kms_crypto_key_iam_binding" "crypto_key_bad" {
-              crypto_key_id = google_kms_crypto_key.key.id
-              role          = "roles/cloudkms.cryptoKeyEncrypter"
-
-              members = [
-                "allUsers",                    # Remove this
-                "allAuthenticatedUsers",       # Remove this
-                "user:jane@example.com",
-              ]
-            }
             ```
+
+            Delete `allUsers` and `allAuthenticatedUsers` from the `members` list of every KMS IAM resource in the configuration. Either one grants the bound role to anyone on the internet, so leaving it alongside named principals does not narrow it.
 
             **Prevention:**
 
@@ -6797,9 +6817,11 @@ queries:
   - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' &&
-        terraform.resources('google_dns_managed_zone') != empty
+        terraform.resources('google_dns_managed_zone').where(arguments['visibility'] == 'public' || arguments['visibility'] == empty) != empty
     mql: |
-      terraform.resources('google_dns_managed_zone').where(arguments['visibility'] == 'public' || arguments['visibility'] == empty) != empty
+      # DNSSEC applies to public zones only. Selecting them in the filter keeps a
+      # configuration that declares only private zones out of scope instead of
+      # failing it for a control that does not apply.
       terraform.resources('google_dns_managed_zone').where(arguments['visibility'] == 'public' || arguments['visibility'] == empty).all(
         blocks.where(type == 'dnssec_config').any(arguments['state'] == 'on')
       )
@@ -8266,15 +8288,7 @@ queries:
             }
             ```
 
-            Avoid configurations like this:
-
-            ```hcl
-            # BAD: No ports specified means all ports are open
-            allow {
-              protocol = "tcp"
-              # Missing ports = all TCP ports allowed
-            }
-            ```
+            An `allow` block that names a protocol but no `ports` opens every port for that protocol, so a rule reachable from `0.0.0.0/0` must always list explicit ports.
         - id: console
           desc: |
             To ensure firewall rules do not allow unrestricted internet ingress using the Google Cloud Console:
@@ -8611,7 +8625,7 @@ queries:
         values['master_authorized_networks_config'] != empty
       )
   - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled
-    title: Ensure Stackdriver Kubernetes Engine Monitoring is enabled on GKE clusters
+    title: Ensure Cloud Logging is enabled on GKE clusters
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
@@ -9140,7 +9154,6 @@ queries:
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_container_cluster')
     mql: |
       terraform.plan.resourceChanges.where(type == 'google_container_cluster').all(
-        change.after.workload_identity_config != empty &&
         change.after.workload_identity_config != empty
       )
   - uid: mondoo-gcp-security-gke-workload-identity-enabled-terraform-state
@@ -9148,7 +9161,6 @@ queries:
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_container_cluster')
     mql: |
       terraform.state.resources.where(type == 'google_container_cluster').all(
-        values.workload_identity_config != empty &&
         values.workload_identity_config != empty
       )
   - uid: mondoo-gcp-security-gke-private-cluster-enabled
@@ -10916,8 +10928,15 @@ queries:
   # The check passes when either form enforces iam.automaticIamGrantsForDefaultServiceAccounts.
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl
     filters: |
-      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_project_organization_policy' || nameLabel == 'google_org_policy_policy')
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_project_default_service_accounts' || nameLabel == 'google_project_organization_policy' || nameLabel == 'google_org_policy_policy')
     mql: |
+      # google_project_default_service_accounts is the resource that actually
+      # disables the accounts. The org policy only stops future default accounts
+      # from receiving the Editor role, so it cannot close this check on its own.
+      # DEPRIVILEGE strips roles but leaves the account enabled, so it does not count.
+      terraform.resources('google_project_default_service_accounts').any(
+        arguments['action'] == 'DISABLE' || arguments['action'] == 'DELETE'
+      ) ||
       terraform.resources('google_project_organization_policy').where(arguments['constraint'] == 'iam.automaticIamGrantsForDefaultServiceAccounts'
       ).any(
         blocks.where(type == 'boolean_policy').any(arguments['enforced'] == true)
@@ -10930,8 +10949,11 @@ queries:
       )
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-plan
     filters: |
-      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_project_default_service_accounts' || type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
     mql: |
+      terraform.plan.resourceChanges.where(type == 'google_project_default_service_accounts').any(
+        change.after['action'] == 'DISABLE' || change.after['action'] == 'DELETE'
+      ) ||
       terraform.plan.resourceChanges.where(
         type == 'google_project_organization_policy' &&
         change.after.constraint == 'iam.automaticIamGrantsForDefaultServiceAccounts'
@@ -10952,8 +10974,11 @@ queries:
       )
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-state
     filters: |
-      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_project_default_service_accounts' || type == 'google_project_organization_policy' || type == 'google_org_policy_policy')
     mql: |
+      terraform.state.resources.where(type == 'google_project_default_service_accounts').any(
+        values['action'] == 'DISABLE' || values['action'] == 'DELETE'
+      ) ||
       terraform.state.resources.where(
         type == 'google_project_organization_policy' &&
         values.constraint == 'iam.automaticIamGrantsForDefaultServiceAccounts'
@@ -19697,7 +19722,7 @@ queries:
             gcloud projects get-iam-policy PROJECT_ID --format=json > policy.json
             ```
 
-            Add the audit config to the policy JSON:
+            Merge the following `auditConfigs` block into `policy.json`, alongside the existing `bindings` and `etag` fields. Do not replace the file with this block: `set-iam-policy` writes whatever the file contains, so a file holding only `auditConfigs` removes every IAM binding in the project.
 
             ```json
             {
@@ -23174,11 +23199,13 @@ queries:
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
     mql: |
+      # An EGRESS rule that omits destination_ranges applies to 0.0.0.0/0, the most
+      # permissive case there is, so an absent list must not pass.
       terraform.resources('google_compute_firewall').where(
         arguments.direction == "EGRESS" &&
         blocks.where(type == 'allow').any(arguments.protocol == "all")
       ).all(
-        arguments['destination_ranges'] == empty ||
+        arguments['destination_ranges'] != empty &&
         arguments['destination_ranges'].none(_ == "0.0.0.0/0") &&
         arguments['destination_ranges'].none(_ == "::/0")
       )
@@ -23191,7 +23218,7 @@ queries:
         change.after['direction'] == "EGRESS" &&
         change.after['allow'].any(_['protocol'] == "all")
       ).all(
-        change.after['destination_ranges'] == empty ||
+        change.after['destination_ranges'] != empty &&
         change.after['destination_ranges'].none(_ == "0.0.0.0/0") &&
         change.after['destination_ranges'].none(_ == "::/0")
       )
@@ -23204,7 +23231,7 @@ queries:
         values['direction'] == "EGRESS" &&
         values['allow'].any(_['protocol'] == "all")
       ).all(
-        values['destination_ranges'] == empty ||
+        values['destination_ranges'] != empty &&
         values['destination_ranges'].none(_ == "0.0.0.0/0") &&
         values['destination_ranges'].none(_ == "::/0")
       )
@@ -23342,10 +23369,11 @@ queries:
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_compute_firewall')
     mql: |
+      # An EGRESS rule that omits destination_ranges reaches 0.0.0.0/0, so it belongs
+      # in the same selection as one that names the open range explicitly.
       terraform.resources('google_compute_firewall').where(
-        arguments.direction == "EGRESS" &&
-        arguments['destination_ranges'] != empty &&
-        arguments['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
+        arguments.direction == "EGRESS" && arguments['destination_ranges'] == empty ||
+        arguments.direction == "EGRESS" && arguments['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
       ).all(
         blocks.where(type == 'allow').none(arguments.protocol == "all") &&
         blocks.where(type == 'allow').all(arguments['ports'] != empty)
@@ -23355,10 +23383,8 @@ queries:
       asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_compute_firewall')
     mql: |
       terraform.plan.resourceChanges.where(
-        type == 'google_compute_firewall' &&
-        change.after['direction'] == "EGRESS" &&
-        change.after['destination_ranges'] != empty &&
-        change.after['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
+        type == 'google_compute_firewall' && change.after['direction'] == "EGRESS" && change.after['destination_ranges'] == empty ||
+        type == 'google_compute_firewall' && change.after['direction'] == "EGRESS" && change.after['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
       ).all(
         change.after['allow'].none(_['protocol'] == "all") &&
         change.after['allow'].all(_['ports'] != empty && _['ports'].length > 0)
@@ -23368,10 +23394,8 @@ queries:
       asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_compute_firewall')
     mql: |
       terraform.state.resources.where(
-        type == 'google_compute_firewall' &&
-        values['direction'] == "EGRESS" &&
-        values['destination_ranges'] != empty &&
-        values['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
+        type == 'google_compute_firewall' && values['direction'] == "EGRESS" && values['destination_ranges'] == empty ||
+        type == 'google_compute_firewall' && values['direction'] == "EGRESS" && values['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
       ).all(
         values['allow'].none(_['protocol'] == "all") &&
         values['allow'].all(_['ports'] != empty && _['ports'].length > 0)

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl/fail/project-on-instance-off/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl/fail/project-on-instance-off/main.tf
@@ -1,0 +1,26 @@
+# Non-compliant: instance metadata overrides the project setting and turns OS Login off.
+resource "google_compute_project_metadata" "default" {
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "app-vm"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    enable-oslogin = "FALSE"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl/pass/project-metadata/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-compute-instances-oslogin-enabled-terraform-hcl/pass/project-metadata/main.tf
@@ -1,0 +1,22 @@
+# Compliant: OS Login enabled project-wide, which covers every instance.
+resource "google_compute_project_metadata" "default" {
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "app-vm"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-firewall-no-egress-all-ports-terraform-hcl/fail/no-dest-no-ports/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-firewall-no-egress-all-ports-terraform-hcl/fail/no-dest-no-ports/main.tf
@@ -1,0 +1,12 @@
+# Non-compliant: no destination_ranges means 0.0.0.0/0, and the allow block
+# names no ports, so every TCP port is reachable on the internet.
+resource "google_compute_firewall" "egress_open" {
+  name    = "egress-open"
+  network = "default"
+
+  direction = "EGRESS"
+
+  allow {
+    protocol = "tcp"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-hcl/fail/no-dest/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-firewall-no-unrestricted-egress-terraform-hcl/fail/no-dest/main.tf
@@ -1,3 +1,5 @@
+# Non-compliant: an EGRESS rule with no destination_ranges applies to 0.0.0.0/0,
+# so allowing every protocol reaches the whole internet.
 resource "google_compute_firewall" "egress_no_dest" {
   name    = "egress-all-no-dest"
   network = "default"

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl/fail/deprivilege-only/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl/fail/deprivilege-only/main.tf
@@ -1,0 +1,5 @@
+# Non-compliant: DEPRIVILEGE strips roles but leaves the default accounts enabled.
+resource "google_project_default_service_accounts" "deprivilege" {
+  project = "example-project"
+  action  = "DEPRIVILEGE"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl/pass/default-service-accounts-disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-iam-default-service-accounts-disabled-terraform-hcl/pass/default-service-accounts-disabled/main.tf
@@ -1,0 +1,5 @@
+# Compliant: the default service accounts are disabled outright.
+resource "google_project_default_service_accounts" "disable_default" {
+  project = "example-project"
+  action  = "DISABLE"
+}

--- a/content/validation/scans/remediation-budget.json
+++ b/content/validation/scans/remediation-budget.json
@@ -212,10 +212,6 @@
     "reason": "the documented fix does not make this check pass"
   },
   {
-    "uid": "mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-terraform-hcl",
-    "reason": "the documented fix does not make this check pass"
-  },
-  {
     "uid": "mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl",
     "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
   },


### PR DESCRIPTION
Deep dive into the remediation blocks in `content/mondoo-gcp-security.mql.yaml`, checking each candidate against an authoritative oracle: `gcloud --help` for the installed SDK, `terraform providers schema -json` for `hashicorp/google ~> 7.0`, `terraform validate` itself, and Google Cloud documentation.

Every check from the top of the file through `cloud-build-worker-pool-private` was read in full (roughly 250 of the policy's 297). The remaining ~40 were pattern-scanned for the defect classes established here (anti-pattern examples inside apply-me fences, export-then-edit-a-file-that-was-never-written, and `== empty` disjuncts that neutralise a check); none matched.

Version 9.10.0 → 9.11.0.

## Findings

### 1. Egress firewall rules: omitting `destination_ranges` is the most permissive case, and it passed

Google's firewall documentation is explicit: for an egress rule with no destination ranges, "Google Cloud uses the default destination IPv4 address range `0.0.0.0/0` (any IPv4 address)."

Two checks got this backwards:

**`firewall-no-unrestricted-egress`** asserted:

```coffee
arguments['destination_ranges'] == empty ||
arguments['destination_ranges'].none(_ == "0.0.0.0/0") && ...none(_ == "::/0")
```

So an egress rule with `protocol = "all"` and no `destination_ranges` — allow-everything to the entire internet — **passed**. The repo even carried this as a `pass/` fixture (`pass/no-dest`), which is how the bug was preserved. The `== empty` disjunct is removed and the fixture moved to `fail/`.

**`firewall-no-egress-all-ports`** has the same default on the selection side: its `.where()` required `destination_ranges != empty`, so a rule that omitted the field was filtered out and never evaluated at all. The selection now covers both spellings:

```coffee
arguments.direction == "EGRESS" && arguments['destination_ranges'] == empty ||
arguments.direction == "EGRESS" && arguments['destination_ranges'].any(_ == "0.0.0.0/0" || _ == "::/0")
```

Both fixed across `-terraform-hcl`, `-plan`, and `-state`, with a new `fail/no-dest-no-ports` fixture.

### 2. `cloud-kms-cryptokeys-not-publicly-accessible` — the remediation snippet creates a publicly readable key

The `hcl` fence contained a "Good example" binding **and** an "Avoid - public access" binding whose `members` list was literally:

```hcl
members = [
  "allUsers",                    # Remove this
  "allAuthenticatedUsers",       # Remove this
  "user:jane@example.com",
]
```

Applying the remediation as shown grants `roles/cloudkms.cryptoKeyEncrypter` to everyone on the internet. This is why the variant sat in `remediation-budget.json` as "the documented fix does not make this check pass". The anti-pattern resource is removed from the fence and described in prose instead; the budget entry is dropped.

### 3. `firewall-no-overly-permissive-ingress` — the second fence is not applicable Terraform

The "Avoid configurations like this" fence was a bare `allow { ... }` block with no enclosing resource:

```
$ terraform validate
Error: Unsupported block type
  on main.tf line 2: allow {
```

The repo's tflint-based validator concatenates every fence in a block and still passes it, so this class of defect ships unnoticed. Replaced with prose.

### 4. `iam-default-service-accounts-disabled` — the check credited the resource that does not disable anything

Runtime asserts `serviceAccount.disabled == true`. The Terraform variants recognised only `google_project_organization_policy` / `google_org_policy_policy` for `iam.automaticIamGrantsForDefaultServiceAccounts` — a policy that the remediation's own prose says "does not disable default service accounts that already exist".

Meanwhile `google_project_default_service_accounts`, which is shown in the same remediation block and is the resource that actually disables them, matched no variant at all.

Added, verified against the `google ~> 7.0` schema (`action` valid values: `DEPRIVILEGE`, `DELETE`, `DISABLE`):

```coffee
terraform.resources('google_project_default_service_accounts').any(
  arguments['action'] == 'DISABLE' || arguments['action'] == 'DELETE'
) || ... (org policy branches unchanged)
```

`DEPRIVILEGE` is deliberately excluded: it strips roles but leaves the account enabled, so it does not satisfy the check's stated control. Two fixtures added, one for each outcome.

### 5. `compute-instances-oslogin-enabled` — project-wide OS Login, the recommended control, was not recognised

The filter matched `google_compute_project_metadata`, but the MQL only asserted on `google_compute_instance`. Enabling OS Login project-wide — the first thing the remediation tells you to do — left every instance failing unless each also carried the key, and only `.all()`-on-empty saved the project-metadata-only case.

Nothing rejected the inverse either: instance metadata overrides project metadata, so `enable-oslogin = "FALSE"` on an instance silently disabled OS Login under a compliant project setting.

Now two statements: no instance may set it false, and either the project metadata or every instance must set it true. Two fixtures added.

### 6. `cloud-dns-dnssec-enabled` — a private-zones-only configuration failed a control that does not apply

The first MQL statement required at least one public zone to exist, so a configuration declaring only private zones failed. DNSSEC is a public-zone control, and the runtime variant already selects public zones in its filter. Moved the same selection into `filters:` and dropped the statement.

### 7. `bq show` wrote to stdout, `bq update --source` read a file nothing created

Two checks (`bigquery-dataset-not-publicly-accessible`, `bigquery-dataset-no-domain-wide-access`) told the reader to:

```bash
bq show --format=prettyjson PROJECT_ID:DATASET_ID     # prints to the terminal
...
bq update --source=dataset.json PROJECT_ID:DATASET_ID # reads a file that does not exist
```

Added the `> dataset.json` redirect and made the edit step say which entries to delete. Contrast `binary-authorization-*` in the same policy, which does `gcloud container binauthz policy export > policy.yaml` correctly, so the omission here is a slip rather than a convention.

### 8. `audit-logging-enabled-all-services` — the JSON block is a fragment, presented as the file

Step 1 writes the whole IAM policy to `policy.json`. The next block shows only an `auditConfigs` array under "Add the audit config to the policy JSON", and the final step runs `gcloud projects set-iam-policy PROJECT_ID policy.json`. A reader who saves that block as `policy.json` removes every IAM binding in the project. Now says explicitly to merge, and why replacing is destructive.

### 9. `bigquery-tables-cmek-encryption` — `bq cp` leaves the unencrypted table behind

The CLI block ended at `bq cp --destination_kms_key=... SOURCE DEST`. That creates an encrypted copy; the original stays under Google-managed encryption and the check still fails. The console block already said "recreate it ... and copy the data". Added the closing step (repoint consumers, then `bq rm --table` the original).

### 10. `gke-cluster-stackdriver-logging-enabled` — the title named the wrong product

Title said "Ensure Stackdriver Kubernetes Engine **Monitoring** is enabled". The check reads `cluster.loggingEnabled` / `logging_service`, and all three remediation blocks say "Cloud Logging" and use `--logging=SYSTEM,WORKLOAD`. Retitled to match what it checks.

### 11. `instances-are-not-configured-use-default-service-account` — malformed flag in the CLI example

`--scopes [SCOPE1,SCOPE2...]` used a space and bracketed placeholder. The sibling check writes `--scopes=logging-write,monitoring`. Normalised.

### 12. `gke-workload-identity-enabled` — condition repeated verbatim

`change.after.workload_identity_config != empty && change.after.workload_identity_config != empty` in the plan and state variants. Deduplicated.

## Checked and found correct

Recorded because each looked like a defect and was not:

- `gcloud compute firewall-rules update` accepts **both** `--allow` and `--rules` (help lines 9 and 112), so the two snippets that use different flags are both valid.
- `google_cloudfunctions_function` (gen 1) does carry `kms_key_name`, so the CMEK check is not unreachable for gen-1 functions.
- `google_organization_policy` still exists in `google ~> 7.0`, deprecated but present.
- `memorystore-backup-cmek-encryption` sharing its variant body with `memorystore-cmek-encryption` is deliberate: backup collections inherit the source instance's key, which the remediation states.

## Validation

| Check | Result |
|---|---|
| `cnspec policy lint ./content/mondoo-gcp-security.mql.yaml` | valid |
| `validate.py gcp` (gcloud grammar) | 787 passed, 0 failed |
| `remediation/code/terraform.py gcp` | 276 passed, 0 failed |
| `TestTerraformVariants` (gcp, full suite) | pass |
| `TestRemediationSatisfiesCheck` | pass with the KMS budget entry removed |
| `typos` | clean |

`remediation-budget.json` shrinks by one entry.
