### PR TITLE
🐛 azure: fix a second batch of remediation and variant defects

### DIFF
--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -18772,6 +18772,12 @@ queries:
             To ensure Azure Batch accounts have diagnostic settings enabled in Terraform:
 
             ```hcl
+            resource "azurerm_batch_account" "example" {
+              name                = "examplebatch"
+              location            = azurerm_resource_group.example.location
+              resource_group_name = azurerm_resource_group.example.name
+            }
+
             resource "azurerm_monitor_diagnostic_setting" "example" {
               name                       = "example-diagnostics"
               target_resource_id         = azurerm_batch_account.example.id
@@ -18833,7 +18839,6 @@ queries:
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_batch_account")
     mql: |
       terraform.plan.resourceChanges.where(type == "azurerm_monitor_diagnostic_setting").any(
-        change.after['target_resource_id'] == null ||
         change.after['target_resource_id'].contains("/batchAccounts/")
       )
   - uid: mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-state
@@ -23235,19 +23240,25 @@ queries:
   - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_postgresql_flexible_server")
     mql: |
+      # Delegating a subnet puts the server in VNet-integrated mode, where Azure
+      # turns public access off and azurerm computes the flag rather than taking
+      # it from configuration. The MySQL sibling already accepts both shapes.
       terraform.resources("azurerm_postgresql_flexible_server").all(
+        arguments['delegated_subnet_id'] != empty ||
         arguments['public_network_access_enabled'] == false
       )
   - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "azurerm_postgresql_flexible_server")
     mql: |
       terraform.plan.resourceChanges.where(type == "azurerm_postgresql_flexible_server").all(
+        change.after['delegated_subnet_id'] != empty ||
         change.after['public_network_access_enabled'] == false
       )
   - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "azurerm_postgresql_flexible_server")
     mql: |
       terraform.state.resources.where(type == "azurerm_postgresql_flexible_server").all(
+        values['delegated_subnet_id'] != empty ||
         values['public_network_access_enabled'] == false
       )
   - uid: mondoo-azure-security-postgresql-flexible-server-public-access-disabled-bicep
@@ -28373,7 +28384,13 @@ queries:
               --query "[?contains(permissions[0].actions, '*')].{Name:roleName, Actions:permissions[0].actions}"
             ```
 
-            Update the role to use specific actions:
+            Export the offending role so there is a file to edit:
+
+            ```bash
+            az role definition list --name <RoleName> --custom-role-only --output json > role.json
+            ```
+
+            `az role definition list` returns an array, so trim `role.json` down to the single role object and replace the `*` entry in its `actions` array with the specific operations the role needs. Then apply it:
 
             ```bash
             az role definition update --role-definition @role.json
@@ -28555,13 +28572,17 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To ensure custom roles do not allow role creation using the Azure CLI, remove the role definition write permission from custom roles:
+            To ensure custom roles do not allow role creation using the Azure CLI, export the role so there is a file to edit:
+
+            ```bash
+            az role definition list --name <RoleName> --custom-role-only --output json > role.json
+            ```
+
+            `az role definition list` returns an array, so trim `role.json` down to the single role object and delete `Microsoft.Authorization/roleDefinitions/write` from its `actions` array. Then apply it:
 
             ```bash
             az role definition update --role-definition @role.json
             ```
-
-            Ensure `Microsoft.Authorization/roleDefinitions/write` is not in the `actions` array.
         - id: bicep
           desc: |
             To ensure custom roles do not allow role creation in Bicep:

--- a/content/validation/scans/fixtures/iac-variants/mondoo-azure-security/mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-hcl/pass/vnet-integrated/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-azure-security/mondoo-azure-security-postgresql-flexible-server-public-access-disabled-terraform-hcl/pass/vnet-integrated/main.tf
@@ -1,0 +1,15 @@
+# Compliant: delegating a subnet puts the server in VNet-integrated mode, where
+# Azure turns public network access off.
+resource "azurerm_postgresql_flexible_server" "example" {
+  name                = "example-psqlflexibleserver"
+  resource_group_name = "example-rg"
+  location            = "eastus"
+  version             = "13"
+  storage_mb          = 32768
+  sku_name            = "GP_Standard_D4s_v3"
+
+  administrator_login    = "psqladmin"
+  administrator_password = "H@Sh1CoR3!"
+  delegated_subnet_id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/psql"
+  private_dns_zone_id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Network/privateDnsZones/example.postgres.database.azure.com"
+}

--- a/content/validation/scans/remediation-budget.json
+++ b/content/validation/scans/remediation-budget.json
@@ -172,10 +172,6 @@
     "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
   },
   {
-    "uid": "mondoo-azure-security-batch-diagnostic-settings-enabled-terraform-hcl",
-    "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
-  },
-  {
     "uid": "mondoo-azure-security-datafactory-public-access-disabled-terraform-hcl",
     "reason": "the documented fix does not make this check pass"
   },


### PR DESCRIPTION
Continues the deep dive from #3344 into `content/mondoo-azure-security.mql.yaml`. That PR covered the first ~100 checks; this one picks up at `firewall-policy-configured` and works through the rest of the policy.

Every check from `firewall-policy-configured` through `postgresql-flexible-server-password-auth-disabled` was read in full. The remainder was pattern-scanned for the defect classes this review has established — anti-pattern examples inside apply-me fences, commands that read a file no earlier step writes, deny rules placed at a priority number that cannot take effect, and `== null` disjuncts that neutralise a check. The `@file` and priority hits from that scan are the findings below; the rest resolved as correct.

## Findings

### 1. `az role definition update --role-definition @role.json` — nothing ever writes `role.json`

Two checks tell the reader to apply a file that no step creates.

`custom-rbac-roles-least-privilege` lists the offending roles to the terminal and then jumps straight to the update:

```bash
az role definition list --custom-role-only --query "[?contains(permissions[0].actions, '*')]..."   # prints to stdout
az role definition update --role-definition @role.json                                            # reads a file that does not exist
```

`custom-roles-no-role-creation` is worse: its CLI block is only the `update` line, with no preceding command at all.

Both now export the role first, and say what to change in it:

```bash
az role definition list --name <RoleName> --custom-role-only --output json > role.json
```

The note that `az role definition list` returns an **array** matters: `--role-definition @file` wants a single role object, so the export has to be trimmed before it will apply. Same defect class as the `bq show` / `bq update --source` pair fixed in #3345, and the same shape the OCI review found in #3332.

### 2. `batch-diagnostic-settings-enabled` — the Terraform snippet omits the resource its own filter selects on

```
filters: terraform.resources.contains(nameLabel == "azurerm_batch_account")
mql:     terraform.resources("azurerm_monitor_diagnostic_setting").any(...)
```

The fence declared only the diagnostic setting. With no `azurerm_batch_account` in the document the filter never matches, so applying the remediation leaves the check unevaluated rather than passing — which is exactly the reason recorded for it in `remediation-budget.json`. Added the Batch account to the fence; the budget entry is removed.

### 3. `batch-diagnostic-settings-enabled` (terraform-plan) — an unknown target satisfied a Batch-specific check

```coffee
change.after['target_resource_id'] == null ||
change.after['target_resource_id'].contains("/batchAccounts/")
```

In a plan the target id is frequently an unknown computed reference, so it lands as `null` and the first disjunct passes. The effect is that **any** diagnostic setting anywhere in the plan satisfies a check about Batch accounts. The `-terraform-hcl` and `-terraform-state` variants have no such hole. Removed the disjunct so the plan variant asserts what the other two do.

### 4. `postgresql-flexible-server-public-access-disabled` — VNet-integrated servers failed

The MySQL sibling accepts either shape:

```coffee
arguments['delegated_subnet_id'] != empty ||
arguments['public_network_access_enabled'] == false
```

and its remediation says so in as many words: "When `delegated_subnet_id` is set, public network access is automatically disabled."

The PostgreSQL variant required the explicit `false` only. Delegating a subnet puts the server in VNet-integrated mode, where Azure turns public access off and azurerm computes the flag rather than reading it from configuration — so the identical, correct configuration failed for PostgreSQL and passed for MySQL. Aligned the three PostgreSQL variants with the MySQL ones, with a new `pass/vnet-integrated` fixture.

## Checked and found correct

- `aks-auto-upgrade-enabled` and `aks-node-os-auto-upgrade-enabled` read `azure.subscription.aks.cluster.autoUpgradeProfile.…` rather than `…aksService.cluster.…`. That looked like a typo but is the documented workaround for the greedy resource-path trap in `content/CLAUDE.md`: `azure.subscription.aksService.cluster.autoUpgradeProfile` **is** a resource name, so the compiler would build a bare resource whose accessor never runs. `azure.subscription.aks` is a real field on `azure.subscription` (confirmed in the installed provider schema), and no resource is named `azure.subscription.aks.cluster.autoUpgradeProfile`, so the path resolves as field access. Left alone.
- The `DenyAllOutbound` rule at priority 4096 in `nsg-no-unrestricted-egress` is correct: it is the catch-all *after* the specific allow at priority 100, which is the opposite of the ordering bug fixed in #3344.

## Validation

| Check | Result |
|---|---|
| `cnspec policy lint ./content/mondoo-azure-security.mql.yaml` | valid |
| `validate.py azure` (CLI grammar) | 723 passed, 0 failed |
| `remediation/code/terraform.py azure` | 299 passed, 0 failed |
| `TestTerraformVariants` (affected checks) | pass |
| `TestRemediationSatisfiesCheck` | pass with the Batch budget entry removed |
| `typos` | clean |

`remediation-budget.json` shrinks by one entry.

