### PR TITLE
🐛 content: fix SaaS remediation paths that name settings the consoles do not have

### DIFF
--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -618,9 +618,9 @@ queries:
         1. Sign in to the Google Admin console at admin.google.com using an administrator account.
         2. Go to **Apps** > **Google Workspace** > **Calendar**.
         3. Open **Sharing settings** and review **External sharing options for primary calendars**.
-        4. Confirm the setting is **Only free/busy information** or a more restrictive option rather than full public sharing.
+        4. Confirm the setting is **Only free/busy information (hide event details)** rather than one of the **Share all information** options.
 
-        A passing result shows external sharing limited to free/busy or disabled; a failing result shows calendar details shared with everyone.
+        A passing result shows external sharing limited to free/busy; a failing result shows calendar details shared with everyone. This setting governs what users may share, so also confirm no individual calendar carries a public access rule, which is what the check reads.
 
         ### Audit via API
 
@@ -639,10 +639,10 @@ queries:
 
             1. Sign in to the [Google Admin console](https://admin.google.com/).
             2. Go to **Apps** > **Google Workspace** > **Calendar**.
-            3. Under **Sharing settings**, set **External sharing options for primary calendars** to **No sharing** to prevent users from publishing calendars, or to **Only free/busy information** if external scheduling visibility is required.
+            3. Under **Sharing settings**, set **External sharing options for primary calendars** to **Only free/busy information (hide event details)**, the most restrictive external option Google offers. The remaining options all begin with **Share all information** and expose event details outside the organization. There is no external option that disables sharing outright; **No sharing** exists only under **Internal sharing options for primary calendars**.
             4. Click **Save**.
 
-            The organization-wide setting limits future sharing, but calendars that users already made public keep their public access rule, and even free/busy public access leaves a calendar publicly visible. Remove the existing public access rule on each affected calendar:
+            That organization-wide setting limits future sharing but does not satisfy this check on its own. Calendars users already made public keep their existing public access rule, and free/busy public access still leaves a calendar publicly visible, which is what the check reads. Remove the existing public access rule on each affected calendar:
 
             1. Have the user open [Google Calendar](https://calendar.google.com/).
             2. Click the three dots next to the calendar name and select **Settings and sharing**.

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -163,11 +163,12 @@ queries:
 
             Before you remove any super admin grant, confirm that at least one other verified super admin retains working access, and confirm your own continued access before revoking your own grant. Removing the last super admin, or revoking your own without a tested alternative, can leave the org without full administrative control.
 
-            1. In the Admin Console, open the administrators area. In the current Admin Console the exact navigation label varies, so look for the administrators or admin-roles section under Security.
-            2. Filter the admin list by the super administrator role to see every user and group that grants super admin access.
-            3. For each group that grants super admin, open the group and review who holds it. Note that removing a member from the group is not the same as removing the group's admin-role assignment: as long as the group still carries the super admin role, remaining and future members inherit it. To stop a group from granting super admin entirely, remove the admin-role assignment from the group rather than emptying its membership.
-            4. For users who still need administrative rights, assign a narrower standard role scoped to their job instead of super admin. Confirm the exact role names available in your org, since admin-role labels have changed across Okta releases.
-            5. Review super admin assignments on a recurring schedule so unneeded grants are revoked promptly.
+            1. In the Admin Console, go to **Security > Administrators**.
+            2. Under **Admin Roles**, select the **Super** filter to display only super admins. The **Admin** tab lists grants by **Users** and by **Groups**, so review both.
+            3. Next to each user entry that no longer needs full control, select **Edit** to open the **Edit Administrator** window, assign a role other than super admin, and select **Update Administrator**.
+            4. For each group that grants super admin, open the group and review who holds it. Removing a member from the group is not the same as removing the group's admin-role assignment: as long as the group still carries the super admin role, remaining and future members inherit it. To stop a group from granting super admin entirely, remove the admin-role assignment from the group rather than emptying its membership.
+            5. Remove the owners from every group that carries the super admin role. A group owner can add members, and each new member inherits the group's admin roles, so an owner is an ungoverned path to super admin that the member count does not show. Go to **Directory > Groups**, open the group, select the **Owners** tab, and select **X** next to each owner. This check requires those groups to have no owners at all, so a group that keeps an owner continues to fail even after the membership is trimmed.
+            6. Review super admin assignments on a recurring schedule so unneeded grants are revoked promptly.
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/healthinsight/healthinsight-security-task-recomendations.htm
         title: HealthInsight tasks and recommendations
@@ -638,9 +639,9 @@ queries:
 
         1. In the Admin Console, go to **Security > Multifactor**.
         2. Select **Factor Enrollment** and review the policy list.
-        3. Confirm that an active policy applies to the Everyone group and has at least one factor set to required.
+        3. Confirm that at least one policy is active and assigned to the Everyone group, then open it and confirm it sets at least one factor to required.
 
-        A passing result shows an active enrollment policy covering all users with a required factor; a failing result shows no such policy or a policy with only optional factors.
+        A passing result shows an active enrollment policy assigned to the Everyone group; a failing result shows no active policy scoped to all users. The scan verdict rests on that assignment, so review the factor settings by hand as well, because a policy scoped to Everyone that requires nothing still leaves users unprotected.
 
         ### Audit via API
 
@@ -651,11 +652,13 @@ queries:
           "https://$OKTA_ORG.okta.com/api/v1/policies?type=MFA_ENROLL"
         ```
 
-        A passing response includes a policy with `status` of `ACTIVE` whose `conditions.people.groups.include` contains the Everyone group ID and whose settings require a factor; a failing response has no active policy meeting those conditions.
+        A passing response includes a policy with `status` of `ACTIVE` whose `conditions.people.groups.include` contains the Everyone group ID; a failing response has no active policy scoped to that group. Inspect that policy's `settings.factors` on Okta Classic Engine, or `settings.authenticators` on Okta Identity Engine, to confirm a factor is set to `REQUIRED`.
       remediation:
         - id: console
           desc: |
             ### Require a factor for all users in an MFA enrollment policy
+
+            Step 2 is what makes this check pass, because the verdict rests on whether an active enrollment policy is scoped to the Everyone group. Step 3 is what makes that policy actually protect anyone, so complete both.
 
             1. On Okta Identity Engine orgs, go to **Security > Authenticators** and select the **Enrollment** tab. On Okta Classic Engine orgs, go to **Security > Multifactor** and select **Factor Enrollment**.
             2. Confirm that an active enrollment policy is assigned to the **Everyone** group. If none is, edit a policy and add the Everyone group under **Assigned to groups**.
@@ -1012,8 +1015,8 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
-        2. Review the **Report Suspicious Activity** option.
+        1. In the Admin Console, go to **Security > General**.
+        2. In the **Security notification emails** section, review **Report suspicious activity via email**.
         3. Confirm the option is enabled.
 
         A passing result shows Suspicious Activity Reporting enabled; a failing result shows the option turned off.
@@ -1035,7 +1038,7 @@ queries:
           desc: |
             ### Enable suspicious activity reporting
 
-            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
+            1. In the Admin Console, go to **Security > General**.
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **Report suspicious activity via email** to **Enabled**. This adds a Report Suspicious Activity button to the new sign-on, authenticator enrolled, authenticator reset, and password changed notification emails.
             4. Select **Save**.
@@ -1121,8 +1124,8 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
-        2. Review the option that emails users about sign-in from a new device.
+        1. In the Admin Console, go to **Security > General**.
+        2. In the **Security notification emails** section, review **New sign-on notification email**.
         3. Confirm the option is enabled.
 
         A passing result shows new device sign-on notifications enabled; a failing result shows the option turned off.
@@ -1144,7 +1147,7 @@ queries:
           desc: |
             ### Enable sign-on notification emails for end users
 
-            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
+            1. In the Admin Console, go to **Security > General**.
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **New sign-on notification email** to **Enabled**.
             4. Select **Save**.
@@ -1226,8 +1229,8 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
-        2. Review the option that emails users about MFA factor enrollment.
+        1. In the Admin Console, go to **Security > General**.
+        2. In the **Security notification emails** section, review **MFA enrolled notification email**, which Okta Identity Engine orgs label **Authenticator enrolled notification email**.
         3. Confirm the option is enabled.
 
         A passing result shows factor enrollment notifications enabled; a failing result shows the option turned off.
@@ -1249,9 +1252,9 @@ queries:
           desc: |
             ### Enable factor enrollment notifications for end users
 
-            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
+            1. In the Admin Console, go to **Security > General**.
             2. Scroll to the **Security notification emails** section and select **Edit**.
-            3. Set **MFA enrolled notification email** to **Enabled**.
+            3. Set **MFA enrolled notification email** to **Enabled**. Okta Identity Engine orgs label this setting **Authenticator enrolled notification email**.
             4. Select **Save**.
         - id: terraform
           desc: |
@@ -1331,8 +1334,8 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
-        2. Review the option that emails users about MFA factor resets.
+        1. In the Admin Console, go to **Security > General**.
+        2. In the **Security notification emails** section, review **MFA reset notification email**, which Okta Identity Engine orgs label **Authenticator reset notification email**.
         3. Confirm the option is enabled.
 
         A passing result shows factor reset notifications enabled; a failing result shows the option turned off.
@@ -1354,9 +1357,9 @@ queries:
           desc: |
             ### Enable factor reset notifications for end users
 
-            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
+            1. In the Admin Console, go to **Security > General**.
             2. Scroll to the **Security notification emails** section and select **Edit**.
-            3. Set **MFA reset notification email** to **Enabled**.
+            3. Set **MFA reset notification email** to **Enabled**. Okta Identity Engine orgs label this setting **Authenticator reset notification email**.
             4. Select **Save**.
         - id: terraform
           desc: |
@@ -1436,8 +1439,8 @@ queries:
       audit: |
         ### Audit via Admin Console
 
-        1. In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
-        2. Review the option that emails users when their password is changed.
+        1. In the Admin Console, go to **Security > General**.
+        2. In the **Security notification emails** section, review **Password changed notification email**.
         3. Confirm the option is enabled.
 
         A passing result shows password changed notifications enabled; a failing result shows the option turned off.
@@ -1459,7 +1462,7 @@ queries:
           desc: |
             ### Enable password changed notifications for end users
 
-            1. In the Admin Console, open the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".
+            1. In the Admin Console, go to **Security > General**.
             2. Scroll to the **Security notification emails** section and select **Edit**.
             3. Set **Password changed notification email** to **Enabled**.
             4. Select **Save**.
@@ -3503,10 +3506,10 @@ queries:
         ### Audit via Admin Console
 
         1. In the Admin Console, go to **Security > General**.
-        2. Locate the **Okta ThreatInsight Settings** section.
-        3. Read the configured **Action** value.
+        2. Locate the **Okta ThreatInsight settings** section.
+        3. Read the configured action.
 
-        A passing result shows the action set to **Log and block**; a failing result shows **Log only** or that ThreatInsight is disabled.
+        A passing result shows **Log and enforce security based on threat level**; a failing result shows **Log authentication attempts from malicious IPs**, which records without enforcing, or **No Action**, which disables enforcement entirely.
 
         ### Audit via API
 
@@ -3524,10 +3527,10 @@ queries:
             ### Configure ThreatInsight to block suspicious login attempts
 
             1. In the Admin Console, go to **Security > General**.
-            2. In the **Okta ThreatInsight Settings** section, select **Edit**.
-            3. Under **Action**, select **Log and block**.
+            2. In the **Okta ThreatInsight settings** section, select **Edit**.
+            3. Select **Log and enforce security based on threat level**. This is the only setting that maps to the `block` action the check reads. **Log authentication attempts from malicious IPs** records the attempt and lets it through, and **No Action** disables enforcement while data collection continues.
             4. Optionally, add trusted network zones to the exclude list to prevent false positives.
-            5. Select **Save**.
+            5. Select **Save**. The change can take a few minutes to take effect.
         - id: terraform
           desc: |
             ```hcl
@@ -3859,10 +3862,11 @@ queries:
             Organization admin access in Okta can be granted to individual users and to groups. This check evaluates groups that hold the role, so pay particular attention to group-based assignments.
 
             1. In the Admin Console, go to **Security > Administrators**.
-            2. Filter the admin list by the **Organization Administrator** role to see every user and group that grants the role.
+            2. Under **Admin Roles**, filter the admin list by the org admin role to see every user and group that grants it. The **Admin** tab lists grants by **Users** and by **Groups**, so review both.
             3. For each group that grants the role, go to **Directory > Groups**, open the group, and remove members who do not require full org admin access.
-            4. For users who still need administrative rights, assign a more specific role such as Help Desk Admin, Application Admin, or Read-Only Admin based on their actual responsibilities.
-            5. Periodically review org admin assignments to keep the role aligned with least privilege.
+            4. Remove the owners from every group that carries the org admin role. A group owner can add members, and each new member inherits the group's admin roles, so an owner is an ungoverned path to org admin that the member count does not show. In the same group, select the **Owners** tab and select **X** next to each owner. This check requires those groups to have no owners at all, so a group that keeps an owner continues to fail even after the membership is trimmed.
+            5. For users who still need administrative rights, assign a more specific role such as Help Desk Admin, App Admin, or Read-only Admin based on their actual responsibilities.
+            6. Periodically review org admin assignments to keep the role aligned with least privilege.
     refs:
       - url: https://help.okta.com/en-us/Content/Topics/Security/Administrators.htm
         title: Administrators

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -180,14 +180,17 @@ queries:
 
         A passing response shows every member with `is_admin` or `is_owner` set to `true` also having `has_2fa` set to `true` and `two_factor_type` set to `app`; a failing response shows an administrator with `has_2fa` false or `two_factor_type` set to `sms`.
       remediation: |
-        Slack does not provide a workspace setting that forces a specific two-factor method, so each administrator must switch their own account from SMS to an authentication app:
+        Slack lets a workspace owner bar SMS as a second factor for the whole workspace, which is the durable fix. Enrolled accounts that already use SMS are not converted automatically, so pair the workspace setting with a pass over the existing administrators:
 
-        1. Sign in to your Slack workspace as an owner or admin and open **Tools & settings > Manage members**.
-        2. Review the **2FA** column to identify administrators using SMS or no second factor. The **2FA** column is not shown on every plan and may be absent on Enterprise Grid; when it is missing, use the API audit above to identify affected administrators.
-        3. Ask each affected administrator to open their [account settings](https://slack.com/account/settings), expand **Two-Factor Authentication**, and select the option to use an authentication app such as Google Authenticator or 1Password.
-        4. Confirm in **Manage members** that every admin and owner now shows an authentication app as their 2FA method.
+        1. Sign in to your Slack workspace as a workspace owner.
+        2. Click **Admin** in the sidebar and select **Workspace settings**, then open the **Security** tab.
+        3. Next to **Two-factor authentication for email sign-in**, click **Edit**.
+        4. Select **Authenticator apps only** so members cannot use SMS for two-factor authentication, then click **Save**.
+        5. Open **Tools & settings > Manage members** and review the **2FA** column to identify administrators still using SMS or no second factor. The **2FA** column is not shown on every plan and may be absent on Enterprise Grid; when it is missing, use the API audit above to identify affected administrators.
+        6. Ask each affected administrator to open their [account settings](https://slack.com/account/settings), expand **Two-Factor Authentication**, and switch to an authentication app such as Google Authenticator or 1Password.
+        7. Confirm in **Manage members** that every admin and owner now shows an authentication app as their 2FA method.
 
-        If your workspace or organization signs in through single sign-on, the per-account Slack two-factor settings are unavailable. Enforce multi-factor authentication in your identity provider instead, and require an authenticator app or a phishing-resistant method for administrator accounts there.
+        If your workspace or organization signs in through single sign-on, this control still applies to administrators. Slack requires two-factor authentication from the owners and admins who can sign in with an email address and password and bypass single sign-on, which is exactly the population this check evaluates. Enforce multi-factor authentication in your identity provider as well, and require an authenticator app or a phishing-resistant method for administrator accounts there.
 
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
@@ -240,7 +243,7 @@ queries:
 
         1. Sign in to your Slack workspace as an owner or admin.
         2. Open **Tools & settings > Manage members** and review the **2FA** column for each active member.
-        3. To confirm enforcement, open **Tools & settings > Workspace settings** and select the **Authentication** tab, then verify that two-factor authentication is required for all members.
+        3. To confirm enforcement, click **Admin** in the sidebar, select **Workspace settings**, open the **Security** tab, and verify that **Require members to have 2FA set up** is checked under **Two-factor authentication for email sign-in**.
 
         A passing result shows two-factor authentication required for the workspace and enabled for every active member; a failing result shows an active member without two-factor authentication or workspace enforcement turned off.
 
@@ -258,14 +261,14 @@ queries:
         Require two-factor authentication for the whole workspace so every member must enroll:
 
         1. Sign in to your Slack workspace as a workspace owner.
-        2. Click your workspace name and open **Tools & settings > Workspace settings**.
-        3. Select the **Authentication** tab.
-        4. Next to **Workspace-wide two-factor authentication**, click **Expand**, then activate two-factor authentication for the workspace.
-        5. Members who have not yet enrolled are signed out and prompted to set up two-factor authentication the next time they sign in.
+        2. Click **Admin** in the sidebar and select **Workspace settings**, then open the **Security** tab.
+        3. Next to **Two-factor authentication for email sign-in**, click **Edit**.
+        4. Check **Require members to have 2FA set up**. To also bar SMS as a second factor, select **Authenticator apps only**.
+        5. Click **Save**. Slack emails and notifies members to help them enroll, and new members must set up two-factor authentication before they can sign in at all.
 
-        **Warning:** Activating workspace-wide two-factor authentication immediately signs out every member who has not already enrolled and blocks them from working until they complete enrollment. Notify members in advance, and consider enabling it outside core working hours so unenrolled users are not interrupted mid-task.
+        **Warning:** Members who do not enroll within 24 hours of the setting being saved are signed out and cannot sign in again until they complete enrollment. Notify members in advance so the deadline does not strand anyone mid-task.
 
-        If your workspace signs in through single sign-on, enforce multi-factor authentication in your identity provider instead, because Slack two-factor authentication is unavailable when SSO is enabled.
+        If your workspace signs in through single sign-on, this setting still applies to the owners and admins who can sign in with an email address and password and bypass single sign-on. Enforce multi-factor authentication in your identity provider for the members who reach Slack through single sign-on.
 
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:


### PR DESCRIPTION
Remediation deep dive over `mondoo-okta-security`, `mondoo-slack-security`, `mondoo-atlassian-security`, and `mondoo-google-workspace-security`. These four policies are almost entirely console click-through, so the audit weighted toward the question that matters for them: does following the navigation path land you on the setting the check actually reads?

Ten defects, each verified against the vendor's own documentation and quoted below. No `version:` bumps.

---

## 1. Okta ThreatInsight: the remediation names an action that does not exist

`mondoo-okta-security-threatinsight-action-block`

Audit and remediation both told operators to set **Action** to **Log and block**, and described the failing state as **Log only**. Neither string is an Okta option.

[Configure Okta ThreatInsight](https://help.okta.com/en-us/content/topics/security/threat-insight/configure-threatinsight.htm), verbatim:

> 3. Select "Edit" to view available actions:
>    - **No Action**: Disables ThreatInsight enforcement while data collection continues
>    - **Log authentication attempts from malicious IPs**: Records sign-in attempts from potentially malicious sources in System Log
>    - **Log and enforce security based on threat level**: Applies threat-based restrictions or blocks

The check reads `okta.organization.threatInsightSettings.action == "block"`. The only console option that produces `block` is **Log and enforce security based on threat level**. An operator hunting for a "Log and block" radio finds nothing, and the nearest-looking option, **Log authentication attempts from malicious IPs**, maps to `audit` and leaves the check failing. Fixed both places, and named the other two options so the wrong one is not picked by resemblance.

## 2. Okta security notification emails: the path was hedged, and hedged wrongly

`mondoo-okta-security-enable-suspicious-activity-reporting`, `-sign-on-notifications-for-end-users`, `-factor-enrollment-notifications`, `-factor-reset-notifications-for-end-users`, `-password-changed-notifications-for-end-users`

All five carried this in both `audit:` and `remediation:`, ten occurrences in total:

> In the Admin Console, locate the security notification email settings. The exact location varies in the current Admin Console and has historically lived under **Settings > Account**, so if it is not there look under the other Settings sections or search the console for "notification emails".

Okta documents the path exactly, and it is not under Settings. [Suspicious Activity Reporting](https://help.okta.com/oie/en-us/content/topics/security/suspicious-activity-reporting.htm):

> 1. "In the Admin Console, go to Security > General."
> 2. "In the Security notification emails section, click Edit."
> 3. "Select either Enabled or Disabled from the dropdown beside the option that you want to enable or disable."

[Sign-on notifications for end users](https://help.okta.com/en-us/content/topics/security/healthinsight/notifications-signon.htm) gives the same path and confirms the toggle label:

> 1. "In the Admin Console, go to Security > General."
> 2. "Under Security Notification Emails, click Edit."
> 3. "Set New sign-on notification email to Enabled."

Replaced all ten with `Security > General`, and made the audit step name the specific toggle rather than paraphrasing it.

The toggle labels the policy already used are correct on Classic Engine. [General Security](https://help.okta.com/en/prod/Content/Topics/Security/Security_General.htm) lists them verbatim: "New sign-on notification email", "MFA enrolled notification email", "MFA reset notification email", "Password changed notification email", "Report suspicious activity via email". Identity Engine renames the two MFA ones. [Authenticator enrolled notification email](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/healthinsight/notifications-authenticator-enroll.htm):

> **Exact Option Label:** "Authenticator enrolled notification email"

So those two checks now carry both labels, matching how the rest of this policy already splits Identity Engine from Classic Engine.

## 3. Okta super-admin remediation hedged navigation its own reference documents exactly

`mondoo-okta-security-limit-super-admins`

The remediation said:

> 1. In the Admin Console, open the administrators area. In the current Admin Console the exact navigation label varies, so look for the administrators or admin-roles section under Security.
> 4. ... Confirm the exact role names available in your org, since admin-role labels have changed across Okta releases.

Meanwhile the `audit:` block on the same check confidently said **Security > Administrators**, so the two halves disagreed. The audit was right, and Okta's [Limit the number of super admins](https://help.okta.com/oie/en-us/content/topics/security/healthinsight/limit-admins.htm) page gives the whole procedure:

> "In the Admin Console, go to Security > Administrators. Under Admin Roles, select the Super filter to display only super admins."
> 1. "Next to each user entry, click Edit. The Edit Administrator window appears."
> 2. "From the list of admin roles, assign a role other than super admin to the user."
> 3. "Click Update Administrator."

Replaced the hedges with those steps.

## 4. Okta admin-group checks: no remediation step addressed the owners clause

`mondoo-okta-security-limit-super-admins`, `mondoo-okta-security-limit-org-admins`

Both queries have two conjuncts:

```coffee
okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < props.mondooOktaSecurityMaxOktaSuperAdmins && owners.length == 0)
okta.groups.where(roles.contains(type == "ORG_ADMIN")).all(members.length < props.maxOrgAdmins && owners.length == 0)
```

`okta.group.owners` is a real field (`~/.config/mondoo/providers/okta/okta.resources.json` lists `owner` and `owners` on `okta.group`), and both `desc:` blocks explain why it is asserted:

> The check also confirms that groups carrying the super admin role have no group owners. Group ownership is an indirect grant: an owner can add members, and those members inherit every administrator role the group carries.

But every remediation step was about member count and role assignment. A group with two members and one owner fails, and following the documented fix end to end leaves it failing, with nothing in the remediation to explain why. Added the missing step to both, with the console path Okta documents:

> "To manage group owners in the Okta Admin Console, go to Directory > Groups, select a group to open the Group page, and go to the Owners tab on the Group page." / "To delete a group owner ... click X for the group owner."

([Configure Okta group owners](https://help.okta.com/oie/en-us/content/topics/identity-governance/group-owner-config.htm))

Also corrected the role names in the org-admin step to Okta's own spellings from [Standard administrator roles and permissions](https://help.okta.com/en-us/content/topics/security/administrators-admin-comparison.htm): App Admin and Read-only Admin, not "Application Admin" and "Read-Only Admin".

## 5. Okta MFA enrollment: the audit promised a check the query does not perform

`mondoo-okta-security-okta-mfa-access`

The audit said a passing response has a policy

> whose `conditions.people.groups.include` contains the Everyone group ID **and whose settings require a factor**

The runtime query never looks at factors:

```coffee
everyoneGroupId = okta.groups.where( profile['name'] == "Everyone" ).map(id)[0]
okta.policies.mfaEnroll.any( status == "ACTIVE" && conditions['people']['groups']['include'].contains(everyoneGroupId) )
```

An active enrollment policy scoped to Everyone that requires nothing at all passes. The remediation compounded it by presenting "set at least one factor to **Required**" as the fix, when the assignment in the previous step is what moves the verdict.

Corrected the audit to describe what is evaluated, kept the factor review as an explicit manual step, and marked which remediation step satisfies the check. This follows the pattern already used in `mondoo-googleworkspace-security-two-step-verification-enforced`, which says outright that allowing self-enrollment "is a prerequisite only and does not by itself make the check pass".

**Not fixed here, flagged for a follow-up:** the title, "Require at least one factor in every MFA enrollment policy", describes the Terraform siblings, which do assert a required factor, rather than the runtime query. Bringing the runtime query up to the title would change scoring on live orgs and needs testing against a real tenant on both engines, so it does not belong in a documentation pass.

## 6. Slack: the remediation denied the existence of the setting that fixes it

`mondoo-slack-security-admins-secure-2fa-methods`

The check asserts `twoFactorType == "app"` for every admin. The remediation opened by ruling out the org-level fix:

> Slack does not provide a workspace setting that forces a specific two-factor method, so each administrator must switch their own account from SMS to an authentication app

Slack does provide one. [Mandatory workspace two-factor authentication](https://slack.com/help/articles/212221668-Mandatory-workspace-two-factor-authentication):

> Check the box labeled "Require members to have 2FA set up." Optionally, select "Authenticator apps only" to restrict SMS-based 2FA methods.

and [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication):

> "owners can prevent members from using SMS as their 2FA method."

The rewritten remediation leads with **Authenticator apps only** and keeps the per-account pass, because the setting does not convert already-enrolled SMS accounts.

## 7. Slack: workspace 2FA enforcement is on a different tab under a different name

`mondoo-slack-security-use-strong-factors`

The remediation used the retired UI:

> 3. Select the **Authentication** tab.
> 4. Next to **Workspace-wide two-factor authentication**, click **Expand**

The current flow, from the same Slack article:

> **Menu Path:** From your desktop, navigate to **Admin** → **Workspace settings** → **Security**.
> Next to "Two-factor authentication for email sign-in," click **Edit**.

Neither the tab nor the setting name existed as written. Fixed in the remediation and in the matching audit step.

## 8. Slack: the lockout warning overstated the disruption

`mondoo-slack-security-use-strong-factors`

> **Warning:** Activating workspace-wide two-factor authentication immediately signs out every member who has not already enrolled and blocks them from working until they complete enrollment.

Slack documents a grace period:

> "People who don't set up 2FA within 24 hours will be signed out of Slack and prompted to set up 2FA before they can sign in again."

A warning that predicts an instant workspace-wide lockout is a reason not to apply the fix. Corrected to the documented 24 hours.

## 9. Slack: both checks told SSO customers the control does not apply to them

`mondoo-slack-security-use-strong-factors`, `mondoo-slack-security-admins-secure-2fa-methods`

> because Slack two-factor authentication is unavailable when SSO is enabled
> If your workspace or organization signs in through single sign-on, the per-account Slack two-factor settings are unavailable.

Slack says the opposite:

> "For workspaces or orgs with SSO enabled, only owners and admins who are able to sign in via email and password and bypass SSO are required to set up 2FA."

Owners and admins who can bypass SSO are precisely the population `admins-secure-2fa-methods` evaluates, so the advice told operators to disregard the finding in the case where it is most actionable. Both now say the control still applies to those accounts, and keep the IdP guidance for members who reach Slack through SSO.

## 10. Google Workspace: "No sharing" is not an external sharing option

`mondoo-googleworkspace-security-calendar-no-public-sharing`

> 3. Under **Sharing settings**, set **External sharing options for primary calendars** to **No sharing** to prevent users from publishing calendars

[Set Google Calendar sharing options](https://knowledge.workspace.google.com/admin/calendar/set-google-calendar-sharing-options) lists the external options:

> 1. "Only free/busy information (hide event details)"
> 2. "Share all information, but outsiders cannot change calendars"
> 3. "Share all information, and outsiders can change calendars"
> 4. "Share all information, and allow managing of calendars"
>
> **There is no "No sharing" option for external sharing.** ... Internal sharing offers a complete "No sharing" option, while external sharing does not.

Step 3 sent operators looking for a control on the wrong list. Corrected to the real most-restrictive external value and said where **No sharing** does live. The block already went on to explain that the org-wide setting does not clear existing public ACL rules; that is now stated as "does not satisfy this check on its own", since the ACL rule is what the query reads.

---

## Checked and found correct

Candidates that looked wrong and verified as fine, so they were dropped rather than filed:

- **Okta password policy console paths.** "Security > Authenticators and select Password" on Identity Engine, "Security > Authentication" + Password tab on Classic. [Configure the password authenticator](https://help.okta.com/oie/en-us/content/topics/identity-engine/authenticators/configure-password.htm) confirms "In the Admin Console, go to Security > Authenticators", and the setting groups the policy names (Minimum length, complexity requirements, Common password check, Age, Lock out) all match. The minute-vs-hour note on minimum password age is right too.
- **Okta Global Session Policy.** "Security > Global Session Policy" and the rule field "Establish the user session with" both confirmed against [Edit a global session policy](https://help.okta.com/oie/en-us/content/topics/identity-engine/policies/edit-global-session-policy.htm).
- **Okta `Security > Administrators` in the audit blocks.** Verified verbatim, including "Under Admin Roles, select the Super filter". Only the remediation half was hedged.
- **Okta default blocklist zone.** `BlockedIpZone` and the `Gateway IPs` field are real; the network-zone remediation stands.
- **Okta Terraform snippets.** All 32 pass `content/validation/remediation/code/terraform.py okta` against the pinned `okta/okta ~> 6.0` schema, including the `$${user.userName}` escape in the SAML example, which is correct HCL for a literal `${...}`.
- **Every Okta, Slack, and Atlassian API call.** 29 + 8 + 4 endpoints re-validated against the checked-in OpenAPI specs after the edits.
- **Atlassian "Insights > API token activity".** Suspected stale; it is current. [Track user API token activity](https://support.atlassian.com/organization-administration/docs/track-user-api-token-usage-in-your-organization/): "go to Atlassian Administration, select your organization ... then select Insights, then API token activity", with created / expires / last-used columns and a "Revoke" action, exactly as documented. **No changes to `mondoo-atlassian-security` at all** — its console paths, warnings, and the token-revocation API call all held up.
- **Slack "Tools & settings > Manage members".** Still a documented path for workspace-level role management, so it was left alone even though the 2FA settings moved.
- **Google Workspace 2SV, super-admin, API-controls, domains, and connected-app paths.** Spot-checked and left unchanged.

## Validation

```
cnspec policy lint          ./content ./content/querypacks   → valid policy bundle(s)
validate.py okta                                             → 29 passed, 0 failed
validate.py slack                                            → 8 passed, 0 failed
validate.py atlassian                                        → 4 passed, 0 failed
code/terraform.py okta                                       → 32 passed, 0 failed
typos                                                        → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
