### PR TITLE
🐛 m365: fix remediation snippets that the Graph, Exchange and Terraform APIs reject

### DIFF
--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -180,13 +180,14 @@ queries:
             Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess", "Policy.Read.All", "Application.Read.All"
             ```
 
-            2. Create a new Conditional Access policy for sign-in risk. When the sign-in frequency interval is `everyTime`, the `value` and `type` properties must be omitted:
+            2. Create a new Conditional Access policy for sign-in risk. `clientAppTypes` is a required property of the conditions object, so the request fails without it. When the sign-in frequency interval is `everyTime`, `authenticationType` must be supplied and the `value` and `type` properties must be omitted:
 
             ```powershell
             $params = @{
                 displayName = "Sign-in risk policy - Require MFA for medium and high risk"
                 state = "enabled"
                 conditions = @{
+                    clientAppTypes = @("all")
                     users = @{
                         includeUsers = @("All")
                         excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
@@ -220,6 +221,7 @@ queries:
               state        = "enabled"
 
               conditions {
+                client_app_types = ["all"]
                 users {
                   included_users = ["All"]
                   excluded_users = [azuread_user.breakglass.object_id]
@@ -391,13 +393,14 @@ queries:
             Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess", "Policy.Read.All"
             ```
 
-            2. Create a new Conditional Access policy for user risk:
+            2. Create a new Conditional Access policy for user risk. `clientAppTypes` is a required property of the conditions object, so the request fails without it. When the sign-in frequency interval is `everyTime`, `authenticationType` must be supplied and the `value` and `type` properties must be omitted:
 
             ```powershell
             $params = @{
                 displayName = "User risk policy - Require MFA and password change for high risk users"
                 state = "enabled"
                 conditions = @{
+                    clientAppTypes = @("all")
                     users = @{
                         includeUsers = @("All")
                         excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
@@ -415,6 +418,7 @@ queries:
                     signInFrequency = @{
                         isEnabled = $true
                         frequencyInterval = "everyTime"
+                        authenticationType = "primaryAndSecondaryAuthentication"
                     }
                 }
             }
@@ -430,6 +434,7 @@ queries:
               state        = "enabled"
 
               conditions {
+                client_app_types = ["all"]
                 users {
                   included_users = ["All"]
                   excluded_users = [azuread_user.breakglass.object_id]
@@ -831,13 +836,14 @@ queries:
             )
             ```
 
-            3. Create the Conditional Access policy. Exclude at least one emergency access account, and consider creating the policy with `state = "enabledForReportingButNotEnforced"` first to validate impact:
+            3. Create the Conditional Access policy. `clientAppTypes` is a required property of the conditions object, so the request fails without it. Exclude at least one emergency access account, and consider creating the policy with `state = "enabledForReportingButNotEnforced"` first to validate impact:
 
             ```powershell
             $params = @{
                 displayName = "Require MFA for administrative roles"
                 state = "enabled"
                 conditions = @{
+                    clientAppTypes = @("all")
                     users = @{
                         includeRoles = $adminRoles
                         excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
@@ -886,6 +892,7 @@ queries:
               state        = "enabled"
 
               conditions {
+                client_app_types = ["all"]
                 users {
                   included_roles = [for role in data.azuread_directory_roles.admin_roles.roles : role.template_id if contains(local.admin_role_names, role.display_name)]
                   excluded_users = [azuread_user.breakglass.object_id]
@@ -1048,13 +1055,14 @@ queries:
             Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess", "Policy.Read.All"
             ```
 
-            2. Create a Conditional Access policy requiring MFA for all users. Exclude at least one emergency access account:
+            2. Create a Conditional Access policy requiring MFA for all users. `clientAppTypes` is a required property of the conditions object, so the request fails without it. Exclude at least one emergency access account:
 
             ```powershell
             $params = @{
                 displayName = "Require MFA for all users"
                 state = "enabled"
                 conditions = @{
+                    clientAppTypes = @("all")
                     users = @{
                         includeUsers = @("All")
                         excludeUsers = @("<breakglass-account-id>")  # Replace with your emergency access account
@@ -1080,6 +1088,7 @@ queries:
               state        = "enabled"
 
               conditions {
+                client_app_types = ["all"]
                 users {
                   included_users = ["All"]
                   excluded_users = [azuread_user.breakglass.object_id]
@@ -1357,18 +1366,20 @@ queries:
           desc: |
             **Using Terraform (azuread provider)**
 
-            Declare each Global Administrator assignment explicitly so the count is reviewable in source control:
+            Declare each Global Administrator assignment explicitly so the count is reviewable in source control. Key the `for_each` map by a static name rather than building a set from the user object IDs. Terraform rejects a `for_each` whose keys are only known after apply, so a set built from `object_id` values fails at plan time:
 
             ```hcl
             locals {
               global_admin_template_id = "62e90394-69f5-4237-9190-012177145e10"
+
+              global_admins = {
+                admin_one = azuread_user.admin_one.object_id
+                admin_two = azuread_user.admin_two.object_id
+              }
             }
 
             resource "azuread_directory_role_assignment" "global_admins" {
-              for_each = toset([
-                azuread_user.admin_one.object_id,
-                azuread_user.admin_two.object_id,
-              ])
+              for_each            = local.global_admins
               role_id             = local.global_admin_template_id
               principal_object_id = each.value
             }
@@ -1628,7 +1639,19 @@ queries:
             New-MgDeviceManagementDeviceConfiguration -BodyParameter $workProfileParams
             ```
 
-            3. Assign policies to appropriate device groups.
+            3. Update the profiles that already enforce a shorter length. Creating a new profile leaves existing ones untouched, and this check evaluates every profile, so a single remaining profile with a shorter minimum keeps it failing:
+
+            ```powershell
+            # Review the existing profiles and their minimum lengths
+            Get-MgDeviceManagementDeviceConfiguration |
+              Select-Object Id, DisplayName, @{n="Type";e={$_.AdditionalProperties."@odata.type"}}
+
+            # Raise the minimum on a profile that enforces fewer than 8 characters,
+            # passing the parameter set that matches that profile's type
+            Update-MgDeviceManagementDeviceConfiguration -DeviceConfigurationId <policy-id> -BodyParameter $windowsParams
+            ```
+
+            4. Assign policies to appropriate device groups.
         # No Terraform remediation: Intune device configuration has no resource in the azuread Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad
@@ -2370,6 +2393,7 @@ queries:
             New-AntiPhishPolicy -Name "Organization Anti-Phishing Policy" `
               -EnableMailboxIntelligence $true `
               -EnableMailboxIntelligenceProtection $true `
+              -MailboxIntelligenceProtectionAction Quarantine `
               -EnableSpoofIntelligence $true `
               -EnableFirstContactSafetyTips $true `
               -PhishThresholdLevel 2
@@ -2379,6 +2403,8 @@ queries:
               -AntiPhishPolicy "Organization Anti-Phishing Policy" `
               -RecipientDomainIs "example.com"
             ```
+
+            `MailboxIntelligenceProtectionAction` defaults to `NoAction`, which has the same effect as leaving mailbox intelligence protection off. Set it explicitly so detected impersonation attempts are acted on.
         # No Terraform remediation: Exchange Online anti-phishing policies have no Terraform provider.
     refs:
       - url: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about


### PR DESCRIPTION
Deep audit of every `remediation:` block in `content/mondoo-m365-security.mql.yaml`. Five defects found and fixed; each was confirmed against an authoritative oracle before filing, and the evidence is quoted below. Everything else in the file was checked and left alone.

---

## 1. `clientAppTypes` is required and missing from four of five Conditional Access policies

Affects both the PowerShell and the Terraform snippet of:

- Enable Microsoft Entra ID Protection sign-in risk policies
- Enable Microsoft Entra ID Protection user risk policies
- Ensure MFA is enabled for all users in administrative roles
- Ensure multi-factor authentication (MFA) is enabled for all users

`Enable Conditional Access policies to block legacy authentication` already set it, which is why the omission was easy to miss.

**Oracle 1 — Microsoft Graph `conditionalAccessConditionSet` resource type:**

> | clientAppTypes | conditionalAccessClientApp collection | Client application types included in the policy. The possible values are: `all`, `browser`, `mobileAppsAndDesktopClients`, `exchangeActiveSync`, `easSupported`, `other`. **Required.** |

<https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessconditionset>

Every example on the "Create conditionalAccessPolicy" page carries it, including the PowerShell tab:

```powershell
$params = @{ displayName = "Access to EXO requires MFA"; state = "enabled"; conditions = @{ clientAppTypes = @("mobileAppsAndDesktopClients","browser") ...
```

**Oracle 2 — the `hashicorp/azuread` provider schema (`~> 3.0`, the version this repo's Terraform validator pins):**

```
$ terraform providers schema -json | jq '...conditions.block.attributes'
"client_app_types req=true"
```

**Oracle 3 — `terraform validate` on the snippet as it shipped:**

```
╷
│ Error: Missing required argument
│
│   on snip.tf line 10, in resource "azuread_conditional_access_policy" "sign_in_risk_policy":
│   10:   conditions {
│
│ The argument "client_app_types" is required, but no definition was found.
╵
```

After adding `client_app_types = ["all"]`: `Success! The configuration is valid.`

**Why the fix is correct.** `all` is the value Microsoft's own templates use for a policy that is not specifically scoped to a client app type, and it is the widest scope, so it cannot narrow the policy the reader intended. The `-terraform-hcl` variants still behave correctly after the change, verified by running each check against its own snippet (see section 6).

Note this was invisible to CI: `content/validation/remediation/code/terraform.py` runs `tflint`, which does not check required arguments, and there is no tflint ruleset for `azuread` at all.

---

## 2. User risk PowerShell sets `frequencyInterval = "everyTime"` without `authenticationType`

**Oracle — `signInFrequencySessionControl` resource type:**

> | authenticationType | signInFrequencyAuthenticationType | The possible values are `primaryAndSecondaryAuthentication`, `secondaryAuthentication`, `unknownFutureValue`. **This property isn't required when using frequencyInterval with the value of `timeBased`.** |

<https://learn.microsoft.com/en-us/graph/api/resources/signinfrequencysessioncontrol>

Microsoft's own v1.0 `Get conditionalAccessPolicy` response for an `everyTime` policy shows exactly the shape:

```json
"signInFrequency": {
    "value": null,
    "type": null,
    "authenticationType": "primaryAndSecondaryAuthentication",
    "frequencyInterval": "everyTime",
    "isEnabled": true
}
```

<https://learn.microsoft.com/en-us/graph/api/conditionalaccesspolicy-get>

The sign-in risk snippet in this same file already sets `authenticationType`, and the user risk **Terraform** snippet sets `sign_in_frequency_authentication_type = "primaryAndSecondaryAuthentication"`. Only the user risk PowerShell body was missing it. Added, and the prose that explains the `everyTime` rule is now on both snippets rather than just one.

---

## 3. `for_each = toset([...])` over object IDs fails at plan time

The Global Administrator remediation built a `for_each` set out of `azuread_user.*.object_id`. Terraform cannot key a `for_each` on values that are unknown until apply. Reproduced with the `null` provider so the failure is provider-independent:

```
$ terraform plan
╷
│ Error: Invalid for_each argument
│
│   on main.tf line 7, in resource "null_resource" "global_admins":
│    7:   for_each = toset([null_resource.admin_one.id, null_resource.admin_two.id])
│     ├────────────────
│     │ null_resource.admin_one.id is a string, known only after apply
│     │ null_resource.admin_two.id is a string, known only after apply
│
│ The "for_each" set includes values derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
╵
```

Rewritten to a map keyed by a static name. Map *keys* must be known at plan time; map *values* may not be. Same reproduction with the map form plans cleanly (`Plan: 4 to add`), and `terraform validate` passes on the azuread version of the snippet.

`tflint` does not plan, so this also passed CI.

---

## 4. Anti-phishing policy enables mailbox intelligence protection but takes no action

`New-AntiPhishPolicy ... -EnableMailboxIntelligenceProtection $true` without `-MailboxIntelligenceProtectionAction` produces a policy that detects impersonation and then does nothing with it.

**Oracle — `New-AntiPhishPolicy`, the `-MailboxIntelligenceProtectionAction` parameter:**

> - NoAction: **This value is the default. This value has the same result as setting the EnableMailboxIntelligenceProtection parameter to $false.**

<https://learn.microsoft.com/en-us/powershell/module/exchangepowershell/new-antiphishpolicy>

The console remediation for this same check already says "Configure actions for detected impersonation attempts (quarantine recommended)"; the PowerShell version did not. Added `-MailboxIntelligenceProtectionAction Quarantine` and a one-line explanation of the default.

---

## 5. Minimum password length remediation never fixes the profiles that fail the check

The check evaluates every profile:

```
microsoft.devicemanagement.deviceConfigurations.where(platformType == "windows10").all(settings.passwordMinimumLength >= 8)
```

The PowerShell remediation only ran `New-MgDeviceManagementDeviceConfiguration` for each platform. Creating a compliant profile does not change an existing profile that enforces four characters, so the check keeps failing after the reader follows the instructions exactly. The causal chain was broken: check fails because an existing profile is short; the snippet adds a different profile; the short one is untouched.

Added a step that lists existing profiles and updates them with `Update-MgDeviceManagementDeviceConfiguration`, and renumbered the assignment step. The Android encryption remediation in this same file already showed both the create and the update path, so this brings the two into line.

---

## Checked and found correct

These looked like defects at first pass and verified clean. Recording them so the coverage is legible.

**Terraform snippets pass their own checks.** Each `-terraform-hcl` variant was run against its own remediation snippet with the `client_app_types` fix applied, using `mql run terraform <dir> -c '<mql>'`. All five return `[ok] value: true`. Cross-checks confirm no snippet falsely satisfies a neighbouring check: the block-legacy-auth query against the all-users MFA snippet returns `[failed]`, and the user-risk query against the sign-in-risk snippet returns `[failed]`.

**`included_roles` built from a `for` expression.** Suspected the MQL `arguments['included_roles'] != empty` would read null against an unresolved HCL expression and fail the check on its own remediation. Ran it: `[ok] value: true`. No defect.

**`azuread_directory_role_assignment.role_id` given a role template ID.** The schema description says "The object ID of the directory role", which reads like the hardcoded `62e90394-...` template ID is wrong. The provider's own documentation contradicts the description: the built-in-role example uses `role_id = azuread_directory_role.example.template_id` and carries the note "Note the use of the `template_id` attribute when referencing built-in roles." Correct as written.

**`New-SafeAttachmentPolicy -Enable $true -Action Block`.** `-Enable` is not deprecated and `Block` is still a legal `-Action`. The doc's own Example 1 uses `-Enable $true` and states "The value $true for the Enable parameter is required so the policy actually uses the default Action parameter value of Block". Correct.

**`New-SafeLinksPolicy` parameters.** `-EnableSafeLinksForEmail`, `-EnableSafeLinksForOffice`, `-EnableSafeLinksForTeams`, `-TrackClicks` and `-AllowClickThrough` all appear verbatim in the current SYNTAX block. Correct.

**`New-AntiPhishPolicy` parameters.** `-EnableSpoofIntelligence`, `-EnableMailboxIntelligence`, `-EnableMailboxIntelligenceProtection`, `-EnableFirstContactSafetyTips` and `-PhishThresholdLevel` are all in the current SYNTAX block, and `2` is a documented `PhishThresholdLevel` value ("2: Aggressive"). Correct.

**`New-TransportRule -SentToScope NotInOrganization -RouteMessageOutboundRequireTls $true -Priority 0`.** All three parameters and the `NotInOrganization` value are documented. The check requires `state == "Enabled"`, and the `-Enabled` parameter documents "$true: The new rule is enabled. **This value is the default.**", so the rule the snippet creates does satisfy the check. Correct.

**`New-DkimSigningConfig -DomainName "example.com" -Enabled $true`.** Both parameters are positional and required in the SYNTAX block, and the doc's Example 1 is the same command. Correct.

**`Remove-MgDirectoryRoleMemberByRef -DirectoryRoleId -DirectoryObjectId`.** Both parameters are mandatory in the Delete parameter set and the doc's own example uses exactly this form. Correct.

**Angle-bracket placeholders such as `-DeviceConfigurationId <policy-id>`.** These are a hard parse error for the PowerShell parser ("The '<' operator is reserved for future use"), but both `code/powershell.py` and `code/bash.py` substitute `<placeholder>` tokens before parsing, by explicit design and comment. This is an established repo-wide convention, not a defect in this file, so it was left alone.

**Undeclared references such as `azuread_user.breakglass`.** `terraform validate` errors on these ("A managed resource "azuread_user" "breakglass" has not been declared in the root module"), but the repo's Terraform validator contract is `tflint`, and every provider policy in `content/` writes remediation snippets this way. Changing it in this one file would be inconsistent, so it was left alone and is flagged here rather than fixed.

**Console navigation paths.** The Entra, Intune, Defender, Purview, Exchange and SharePoint admin center paths were compared against current vendor documentation and match.

---

## Validation

Run from the worktree, all green:

```
cnspec policy lint ./content/mondoo-m365-security.mql.yaml   → valid policy bundle(s)
python3 content/validation/remediation/code/powershell.py m365 → 65 passed, 0 failed
python3 content/validation/remediation/code/terraform.py m365   → 8 passed, 0 failed
python3 content/validation/remediation/commands/validate.py azure → 723 passed, 0 failed
make test/content/lint                                          → valid policy bundle(s)
```

Plus, outside CI, `terraform validate` against `hashicorp/azuread ~> 3.0` on every Terraform snippet, and `mql run terraform` of each `-terraform-hcl` check against its own snippet.

The policy `version:` is deliberately unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
