### PR TITLE
🐛 windows: fix remediations that write keys the check never reads

### DIFF
--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -229,7 +229,7 @@ queries:
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("SeDebugPrivilege = \S+", "SeDebugPrivilege = ") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("SeDebugPrivilege = \S+", "SeDebugPrivilege = ") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -254,7 +254,7 @@ queries:
                 - name: Remove SeDebugPrivilege assignment
                   ansible.windows.win_powershell:
                     script: |
-                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'SeDebugPrivilege = \S+', 'SeDebugPrivilege = ' | Out-File C:\Windows\Temp\secpol-import.cfg
+                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'SeDebugPrivilege = \S+', 'SeDebugPrivilege = ' | Out-File C:\Windows\Temp\secpol-import.cfg -Encoding Unicode
 
                 - name: Import updated security policy
                   ansible.windows.win_command:
@@ -5367,7 +5367,7 @@ queries:
               hosts: windows
               tasks:
                 - name: Set PasswordHistorySize to 24
-                  ansible.windows.win_security_policy:
+                  community.windows.win_security_policy:
                     section: System Access
                     key: PasswordHistorySize
                     value: 24
@@ -5488,7 +5488,7 @@ queries:
               hosts: windows
               tasks:
                 - name: Set MaximumPasswordAge to 365
-                  ansible.windows.win_security_policy:
+                  community.windows.win_security_policy:
                     section: System Access
                     key: MaximumPasswordAge
                     value: 365
@@ -5605,7 +5605,7 @@ queries:
               hosts: windows
               tasks:
                 - name: Set MinimumPasswordAge to 1
-                  ansible.windows.win_security_policy:
+                  community.windows.win_security_policy:
                     section: System Access
                     key: MinimumPasswordAge
                     value: 1
@@ -5732,13 +5732,13 @@ queries:
               hosts: windows
               tasks:
                 - name: Set minimum password length via secedit
-                  ansible.windows.win_security_policy:
+                  community.windows.win_security_policy:
                     section: System Access
                     key: MinimumPasswordLength
                     value: 14
             ```
 
-            Note: The `win_security_policy` module requires the `ansible.windows` collection. Alternatively, use the win_shell module with secedit commands.
+            Note: The `win_security_policy` module ships in the `community.windows` collection, so install it with `ansible-galaxy collection install community.windows`. Alternatively, use the `ansible.windows.win_shell` module with `secedit` commands.
         - id: chef
           desc: |
             **Using Chef Infra**
@@ -5976,7 +5976,7 @@ queries:
               hosts: windows
               tasks:
                 - name: Set LSAAnonymousNameLookup to 0 (Disabled)
-                  ansible.windows.win_security_policy:
+                  community.windows.win_security_policy:
                     section: System Access
                     key: LSAAnonymousNameLookup
                     value: 0
@@ -6562,17 +6562,27 @@ queries:
           desc: |
             **Using Ansible**
 
+            **Warning:**
+
+            Do not clear this list on a domain controller. Domain controllers require the `LSARPC`, `NETLOGON`, and `SAMR` pipes for legacy authentication. The first task below reads the product type so the following two tasks can branch on it, where `2` identifies a domain controller.
+
             ```yaml
             - name: Configure Named Pipes that can be accessed anonymously
               hosts: windows
               tasks:
-                - name: Clear NullSessionPipes on member servers
+                - name: Read the operating system product type
+                  ansible.windows.win_powershell:
+                    script: (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
+                  changed_when: false
+                  register: product_type
+
+                - name: Clear NullSessionPipes on member servers and workstations
                   ansible.windows.win_regedit:
                     path: HKLM:\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters
                     name: NullSessionPipes
                     data: []
                     type: multistring
-                  when: not is_domain_controller
+                  when: product_type.output[0] != 2
 
                 - name: Allow only required pipes on domain controllers
                   ansible.windows.win_regedit:
@@ -6583,7 +6593,7 @@ queries:
                       - NETLOGON
                       - SAMR
                     type: multistring
-                  when: is_domain_controller
+                  when: product_type.output[0] == 2
             ```
         - id: chef
           desc: |
@@ -6900,7 +6910,7 @@ queries:
         2. Navigate to `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters`.
         3. Inspect the `NullSessionShares` value.
 
-        The system passes when `NullSessionShares` is empty (no value configured). It fails if the value is missing or set differently.
+        The system passes when `NullSessionShares` lists no shares, and also when the value is absent, because an absent value grants no anonymous access. It fails when any share is listed.
 
         ### Audit via PowerShell
 
@@ -6911,7 +6921,7 @@ queries:
            Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters' -Name 'NullSessionShares'
            ```
 
-        The system passes when `NullSessionShares` is empty (no value configured). It fails if the value is missing or set differently.
+        The system passes when `NullSessionShares` lists no shares, and also when the value is absent, because an absent value grants no anonymous access. It fails when any share is listed.
       remediation:
         - id: grouppolicy
           desc: |
@@ -6935,7 +6945,7 @@ queries:
             ```powershell
             $RegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters'
             $Name         = 'NullSessionShares'
-            $Value        = ''
+            $Value        = @()
 
             # Create the key if it does not exist
             If (-NOT (Test-Path $RegistryPath)) {
@@ -8282,7 +8292,7 @@ queries:
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("PasswordComplexity = \d+", "PasswordComplexity = 1") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("PasswordComplexity = \d+", "PasswordComplexity = 1") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -8307,7 +8317,7 @@ queries:
                 - name: Set PasswordComplexity to 1
                   ansible.windows.win_powershell:
                     script: |
-                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'PasswordComplexity = \d+', 'PasswordComplexity = 1' | Out-File C:\Windows\Temp\secpol-import.cfg
+                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'PasswordComplexity = \d+', 'PasswordComplexity = 1' | Out-File C:\Windows\Temp\secpol-import.cfg -Encoding Unicode
 
                 - name: Import updated security policy
                   ansible.windows.win_command:
@@ -9826,7 +9836,7 @@ queries:
             ```powershell
             $Temp = [System.Environment]::GetEnvironmentVariable('TEMP','Machine')
             secedit /export /cfg $Temp\secpol-export.cfg
-            (gc $Temp\secpol-export.cfg) -replace("ClearTextPassword = \d+", "ClearTextPassword = 0") | Out-File $Temp\secpol-import.cfg
+            (gc $Temp\secpol-export.cfg) -replace("ClearTextPassword = \d+", "ClearTextPassword = 0") | Out-File $Temp\secpol-import.cfg -Encoding Unicode
             secedit /import /db $Temp\secpol-db.sdb /cfg $Temp\secpol-import.cfg
             secedit /configure /db $Temp\secpol-db.sdb
             gpupdate /force
@@ -9851,7 +9861,7 @@ queries:
                 - name: Set ClearTextPassword to 0
                   ansible.windows.win_powershell:
                     script: |
-                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'ClearTextPassword = \d+', 'ClearTextPassword = 0' | Out-File C:\Windows\Temp\secpol-import.cfg
+                      (Get-Content C:\Windows\Temp\secpol-export.cfg) -replace 'ClearTextPassword = \d+', 'ClearTextPassword = 0' | Out-File C:\Windows\Temp\secpol-import.cfg -Encoding Unicode
 
                 - name: Import updated security policy
                   ansible.windows.win_command:
@@ -10440,17 +10450,25 @@ queries:
 
         1. Open the Local Group Policy Editor (`gpedit.msc`).
         2. Navigate to **Computer Configuration** > **Administrative Templates** > **System** > **Device Guard** > **Turn on Virtualization Based Security**.
-        3. Confirm the policy is **Enabled** and that **Virtualization Based Protection of Code Integrity** is set to **Enabled with UEFI lock** (or **Enabled without lock**).
+        3. Confirm the policy is **Enabled** and that **Virtualization Based Protection of Code Integrity** is set to **Enabled with UEFI lock** or **Enabled without lock**.
 
         ### Audit via PowerShell
 
-        1. Query the running Device Guard status:
+        1. Read the Device Guard policy value that the Group Policy setting writes:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard' -Name 'HypervisorEnforcedCodeIntegrity'
+           ```
+
+        The system passes when `HypervisorEnforcedCodeIntegrity` is `1` for enabled with UEFI lock, or `2` for enabled without lock. It fails when the value is missing or set to `0`.
+
+        2. Confirm that the configured policy is in effect on the running system:
 
            ```powershell
            (Get-CimInstance -ClassName Win32_DeviceGuard -Namespace root\Microsoft\Windows\DeviceGuard).SecurityServicesRunning
            ```
 
-        If the returned services include `2` (Hypervisor-Enforced Code Integrity), Memory Integrity is running and the check passes. If it does not, the check fails.
+        A returned service list that includes `2` confirms Memory Integrity is running. A configured policy that is not yet running usually means the system has not been restarted, or the hardware does not support Virtualization-Based Security.
       remediation:
         - id: grouppolicy
           desc: |-
@@ -10458,26 +10476,47 @@ queries:
 
             1. Open the Group Policy Editor and go to **Computer Configuration** > **Administrative Templates** > **System** > **Device Guard** > **Turn on Virtualization Based Security**.
             2. Set the policy to **Enabled**.
-            3. Set **Virtualization Based Protection of Code Integrity** to **Enabled with UEFI lock**.
-            4. Apply the policy and restart the system.
+            3. Set **Select Platform Security Level** to **Secure Boot**.
+            4. Set **Virtualization Based Protection of Code Integrity** to **Enabled with UEFI lock**.
+            5. Apply the policy and restart the system.
         - id: powershell
           desc: |-
-            To enable Memory Integrity by setting the Device Guard registry values, then restart:
+            Memory Integrity rides on Virtualization-Based Security, so turning it on means enabling VBS as well. Set all three Device Guard policy values under `HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard`, which is the key the Group Policy setting above writes, then restart:
 
             ```powershell
-            $p = 'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity'
+            $p = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
             New-Item -Path $p -Force | Out-Null
-            New-ItemProperty -Path $p -Name 'Enabled' -Value 1 -PropertyType DWord -Force
+            New-ItemProperty -Path $p -Name 'EnableVirtualizationBasedSecurity' -Value 1 -PropertyType DWord -Force
+            New-ItemProperty -Path $p -Name 'RequirePlatformSecurityFeatures' -Value 1 -PropertyType DWord -Force
+            New-ItemProperty -Path $p -Name 'HypervisorEnforcedCodeIntegrity' -Value 1 -PropertyType DWord -Force
             ```
+
+            `HypervisorEnforcedCodeIntegrity` takes `1` for enabled with UEFI lock and `2` for enabled without lock. Choose `2` if you need to be able to turn Memory Integrity back off remotely. `RequirePlatformSecurityFeatures` takes `1` for Secure Boot and `3` for Secure Boot with DMA protection; `3` leaves VBS off entirely on hardware without an IOMMU.
         - id: ansible
           desc: |-
-            To enable Memory Integrity with Ansible:
+            To enable Memory Integrity with Ansible, set the three Device Guard policy values that the Group Policy setting writes:
 
             ```yaml
+            - name: Enable Virtualization Based Security
+              ansible.windows.win_regedit:
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
+                name: EnableVirtualizationBasedSecurity
+                data: 1
+                type: dword
+              notify: reboot
+
+            - name: Require Secure Boot as the platform security level
+              ansible.windows.win_regedit:
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
+                name: RequirePlatformSecurityFeatures
+                data: 1
+                type: dword
+              notify: reboot
+
             - name: Enable HVCI (Memory Integrity)
               ansible.windows.win_regedit:
-                path: HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity
-                name: Enabled
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
+                name: HypervisorEnforcedCodeIntegrity
                 data: 1
                 type: dword
               notify: reboot
@@ -10486,15 +10525,15 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `Enabled` registry value that backs this policy to `1`:
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the Device Guard policy values that back this policy, including the Virtualization-Based Security values Memory Integrity depends on:
 
             ```ruby
-            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity' do
-              values [{
-                name: 'Enabled',
-                type: :dword,
-                data: 1,
-              }]
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard' do
+              values [
+                { name: 'EnableVirtualizationBasedSecurity', type: :dword, data: 1 },
+                { name: 'RequirePlatformSecurityFeatures', type: :dword, data: 1 },
+                { name: 'HypervisorEnforcedCodeIntegrity', type: :dword, data: 1 },
+              ]
               recursive true
               action :create
             end
@@ -10543,17 +10582,25 @@ queries:
 
         1. Open the Local Group Policy Editor (`gpedit.msc`).
         2. Navigate to **Computer Configuration** > **Administrative Templates** > **System** > **Device Guard** > **Turn on Virtualization Based Security**.
-        3. Confirm **Credential Guard Configuration** is set to **Enabled with UEFI lock** (or **Enabled without lock**).
+        3. Confirm **Credential Guard Configuration** is set to **Enabled with UEFI lock** or **Enabled without lock**.
 
         ### Audit via PowerShell
 
-        1. Query the running Device Guard status:
+        1. Read the Device Guard policy value that the Group Policy setting writes:
+
+           ```powershell
+           Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard' -Name 'LsaCfgFlags'
+           ```
+
+        The system passes when `LsaCfgFlags` is `1` for enabled with UEFI lock, or `2` for enabled without lock. It fails when the value is missing or set to `0`.
+
+        2. Confirm that the configured policy is in effect on the running system:
 
            ```powershell
            (Get-CimInstance -ClassName Win32_DeviceGuard -Namespace root\Microsoft\Windows\DeviceGuard).SecurityServicesRunning
            ```
 
-        If the returned services include `1` (Credential Guard), it is running and the check passes. If it does not, the check fails.
+        A returned service list that includes `1` confirms Credential Guard is running. A configured policy that is not yet running usually means the system has not been restarted, or the hardware does not support Virtualization-Based Security.
       remediation:
         - id: grouppolicy
           desc: |-
@@ -10561,24 +10608,46 @@ queries:
 
             1. Open the Group Policy Editor and go to **Computer Configuration** > **Administrative Templates** > **System** > **Device Guard** > **Turn on Virtualization Based Security**.
             2. Set the policy to **Enabled**.
-            3. Set **Credential Guard Configuration** to **Enabled with UEFI lock**.
-            4. Apply the policy and restart the system.
+            3. Set **Select Platform Security Level** to **Secure Boot**.
+            4. Set **Credential Guard Configuration** to **Enabled with UEFI lock**.
+            5. Apply the policy and restart the system.
         - id: powershell
           desc: |-
-            To enable Credential Guard by setting the Device Guard registry values, then restart:
+            Credential Guard rides on Virtualization-Based Security, so turning it on means enabling VBS as well. Set all three Device Guard policy values under `HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard`, which is the key the Group Policy setting above writes, then restart:
 
             ```powershell
-            $p = 'HKLM:\SYSTEM\CurrentControlSet\Control\LSA'
+            $p = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
+            New-Item -Path $p -Force | Out-Null
+            New-ItemProperty -Path $p -Name 'EnableVirtualizationBasedSecurity' -Value 1 -PropertyType DWord -Force
+            New-ItemProperty -Path $p -Name 'RequirePlatformSecurityFeatures' -Value 1 -PropertyType DWord -Force
             New-ItemProperty -Path $p -Name 'LsaCfgFlags' -Value 1 -PropertyType DWord -Force
             ```
+
+            `LsaCfgFlags` takes `1` for enabled with UEFI lock and `2` for enabled without lock. Choose `2` if you need to be able to turn Credential Guard back off remotely, because a UEFI lock can only be cleared from the firmware. Enable Credential Guard before the device joins a domain; if it is turned on afterwards, the user and device secrets may already have been exposed.
         - id: ansible
           desc: |-
-            To enable Credential Guard with Ansible:
+            To enable Credential Guard with Ansible, set the three Device Guard policy values that the Group Policy setting writes:
 
             ```yaml
+            - name: Enable Virtualization Based Security
+              ansible.windows.win_regedit:
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
+                name: EnableVirtualizationBasedSecurity
+                data: 1
+                type: dword
+              notify: reboot
+
+            - name: Require Secure Boot as the platform security level
+              ansible.windows.win_regedit:
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
+                name: RequirePlatformSecurityFeatures
+                data: 1
+                type: dword
+              notify: reboot
+
             - name: Enable Credential Guard
               ansible.windows.win_regedit:
-                path: HKLM:\SYSTEM\CurrentControlSet\Control\LSA
+                path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard
                 name: LsaCfgFlags
                 data: 1
                 type: dword
@@ -10588,15 +10657,15 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the `LsaCfgFlags` registry value that backs this policy to `1`:
+            This setting takes effect after the next restart. Use this Chef Infra recipe code to set the Device Guard policy values that back this policy, including the Virtualization-Based Security values Credential Guard depends on:
 
             ```ruby
-            registry_key 'HKLM\SYSTEM\CurrentControlSet\Control\LSA' do
-              values [{
-                name: 'LsaCfgFlags',
-                type: :dword,
-                data: 1,
-              }]
+            registry_key 'HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard' do
+              values [
+                { name: 'EnableVirtualizationBasedSecurity', type: :dword, data: 1 },
+                { name: 'RequirePlatformSecurityFeatures', type: :dword, data: 1 },
+                { name: 'LsaCfgFlags', type: :dword, data: 1 },
+              ]
               recursive true
               action :create
             end


### PR DESCRIPTION
A remediation audit of the three Windows policies. Every `remediation:` entry in
`mondoo-windows-security.mql.yaml` (90 checks, 355 entries),
`mondoo-windows-workstation-security.mql.yaml` and
`mondoo-windows-11-compatibility.mql.yaml` was read and each registry path, value
name, value type, cmdlet, Ansible module FQCN and Chef resource was resolved
against an oracle. Six defects; all in `mondoo-windows-security.mql.yaml`.

---

## 1. Memory Integrity remediation writes a key the check never reads

`mondoo-windows-security-memory-integrity-hvci-enabled` asserts:

```coffee
[1, 2].contains( windows.deviceGuard.hypervisorEnforcedCodeIntegrity )
```

`windows.deviceGuard` reads exactly one key. From the installed provider schema
(`~/.config/mondoo/providers/os/os.resources.json`, resource `windows.deviceGuard`):

> Device Guard Group Policy values under `HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard`.

and in `providers/os/resources/windows_deviceguard.go`:

```go
const deviceGuardPolicyKey = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard`
...
hypervisorEnforcedCodeIntegrity: regIntPtr(items, "HypervisorEnforcedCodeIntegrity"),
```

The `powershell`, `ansible` and `chef` entries wrote

```
HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity  →  Enabled = 1
```

Different hive path **and** a different value name. That is Microsoft's non-policy
registry method, documented at
[Enable virtualization-based protection of code integrity](https://learn.microsoft.com/windows/security/hardware-security/enable-virtualization-based-protection-of-code-integrity#how-to-turn-on-memory-integrity):

```cmd
reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" /v "Enabled" /t REG_DWORD /d 1 /f
```

Causal chain: the check reads `…\SOFTWARE\Policies\…\DeviceGuard!HypervisorEnforcedCodeIntegrity`;
the snippet writes `…\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\…!Enabled`;
the policy value stays absent, the field resolves `null`, `[1,2].contains(null)` is
false, and the check **still fails after the operator applies the documented fix**.
The `grouppolicy` entry was already correct, because the GPO writes the policy key.

Second problem in the same snippets: they set only the HVCI scenario value and
never enable Virtualization-Based Security, which HVCI runs inside. Microsoft's
own registry recipe sets `EnableVirtualizationBasedSecurity` and
`RequirePlatformSecurityFeatures` alongside it.

**Fix.** All three surfaces now write the key the Group Policy setting writes and
the check reads, with the two VBS values HVCI depends on:

```powershell
$p = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard'
New-Item -Path $p -Force | Out-Null
New-ItemProperty -Path $p -Name 'EnableVirtualizationBasedSecurity' -Value 1 -PropertyType DWord -Force
New-ItemProperty -Path $p -Name 'RequirePlatformSecurityFeatures' -Value 1 -PropertyType DWord -Force
New-ItemProperty -Path $p -Name 'HypervisorEnforcedCodeIntegrity' -Value 1 -PropertyType DWord -Force
```

Value names and key confirmed against
[Policy CSP - DeviceGuard](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard#requireplatformsecurityfeatures),
which gives the Group Policy mapping for each element:

> | Registry Key Name | `SOFTWARE\Policies\Microsoft\Windows\DeviceGuard` |
> | ADMX File Name | `DeviceGuard.admx` |

The `audit:` block had the matching problem: it told the reader the verdict comes
from `Win32_DeviceGuard.SecurityServicesRunning`, which is running state, not the
configuration the check evaluates. It now reads the policy value first and keeps
the running-state query as a confirmation step. The Group Policy steps also gained
the **Select Platform Security Level** step that turns VBS on.

## 2. Credential Guard remediation writes a key the check never reads

Identical defect, same resource. `mondoo-windows-security-credential-guard-enabled`
asserts `[1, 2].contains( windows.deviceGuard.credentialGuardConfig )`, and the
provider resolves that field from `LsaCfgFlags` **under the policy key**:

```go
credentialGuardConfig: regIntPtr(items, "LsaCfgFlags"),   // deviceGuardPolicyKey
```

The snippets wrote `HKLM:\SYSTEM\CurrentControlSet\Control\LSA!LsaCfgFlags`. Right
value name, wrong key: that is again Microsoft's non-policy method, from
[Configure Credential Guard](https://learn.microsoft.com/windows/security/identity-protection/credential-guard/configure#enable-credential-guard):

> **Key path**: `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa` **Key name**: `LsaCfgFlags`

It also omitted `EnableVirtualizationBasedSecurity`, which the same Microsoft table
lists as a required companion value. Both fixed the same way as defect 1, against
[Policy CSP - DeviceGuard § LsaCfgFlags](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard#lsacfgflags):

> | Registry Key Name | `SOFTWARE\Policies\Microsoft\Windows\DeviceGuard` |

## 3. `ansible.windows.win_security_policy` is not a module

Five Ansible playbooks called `ansible.windows.win_security_policy`, and the note
under one of them asserted the collection outright:

> Note: The `win_security_policy` module requires the `ansible.windows` collection.

`win_security_policy` lives in **community.windows**, not `ansible.windows`. From
[the module page](https://docs.ansible.com/projects/ansible/latest/collections/community/windows/win_security_policy_module.html):

> This module is part of the `community.windows` collection. To install it, use:
> `ansible-galaxy collection install community.windows`. To use it in a playbook,
> specify: `community.windows.win_security_policy`.

An FQCN that resolves to nothing fails the play at task load with
`couldn't resolve module/action`, so none of these five playbooks ever ran. Fixed
in all five, and the note now names the right collection and the right install
command. The other Windows module FQCNs in these files were checked at the same
time and are all correct: `ansible.windows.win_regedit`, `win_command`,
`win_powershell`, `win_file`, `win_service`, `win_optional_feature`.

Affected checks: `enforce-password-history-…`, `maximum-password-age-…`,
`minimum-password-age-…`, `minimum-password-length-…`,
`network-access-allow-anonymous-sidname-translation-…`.

## 4. Named-pipes Ansible playbook branches on a variable nothing defines

`mondoo-windows-security-network-access-named-pipes-that-can-be-accessed-anonymously-is-set-to-none`
shipped two tasks gated on `when: is_domain_controller` / `when: not is_domain_controller`
with no task, fact, or var anywhere in the playbook that produces it. Ansible
fails the task with `'is_domain_controller' is undefined`, so neither branch runs
and nothing is remediated.

The `powershell` and `chef` entries for the same check both derive the branch
themselves, from `Win32_OperatingSystem.ProductType` and Ohai's
`node['kernel']['os_info']['product_type']` respectively. The playbook now does the
same, using the module already used elsewhere in this policy:

```yaml
- name: Read the operating system product type
  ansible.windows.win_powershell:
    script: (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType
  changed_when: false
  register: product_type
```

`output` is the documented return key of `ansible.windows.win_powershell`
("Any output stream object is instead returned as a list in `output`"), so
`product_type.output[0]` is the `ProductType` integer, and `2` identifies a domain
controller, matching the branch the two sibling entries already use. The
domain-controller warning that the `grouppolicy`, `powershell` and `chef` entries
all carry was missing here too, and has been added.

## 5. Three `secedit` snippets write the import file in the wrong encoding

`secedit /import` requires a Unicode `.inf`. Five of the eight `secedit` snippets in
this policy pass `-Encoding Unicode` and carry a note saying so:

> The `Out-File` command writes the import file as Unicode, which `secedit` requires.

Three did not, contradicting that note in the same file:

- `mondoo-windows-security-2.2.19-l1-ensure-debug-programs-is-empty`
- `mondoo-windows-security-password-must-meet-complexity-requirements-is-set-to-enabled`
- `mondoo-windows-security-store-passwords-using-reversible-encryption-is-set-to-disabled`

`Out-File` has no stable default. From
[Out-File](https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/out-file):

> **-Encoding** … Default value: `UTF8NoBOM`

and from
[about_Character_Encoding](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_character_encoding#character-encoding-in-windows-powershell):

> `Out-File` and the redirection operators `>` and `>>` create UTF-16LE

So the omission is silently harmless under Windows PowerShell 5.1 and silently
breaks under PowerShell 7, where the file lands as UTF-8 and `secedit /import`
rejects it. Added `-Encoding Unicode` to all six affected `Out-File` calls (three
`powershell` entries and the three matching `ansible` `win_powershell` scripts).

## 6. `NullSessionShares` PowerShell writes a one-element list instead of an empty one

`mondoo-windows-security-network-access-shares-that-can-be-accessed-anonymously-is-set-to-none`
requires the value to be empty. Its `ansible` and `chef` entries both write `[]`;
the `powershell` entry wrote

```powershell
$Value        = ''
...
New-ItemProperty -Path $RegistryPath -Name $Name -Value $Value -PropertyType MultiString -Force
```

`-Value ''` with `-PropertyType MultiString` is a single-element `[string[]]`, not
an empty one. The sibling `NullSessionPipes` check in the same file already writes
`$Value = @()` for the same intent. Changed to `@()` so all three surfaces write
the same end state.

The `audit:` text for this check also contradicted itself in one sentence:

> The system passes when `NullSessionShares` is empty (no value configured). It
> fails if the value is missing or set differently.

The check is `…data == empty`, and `== empty` is true for an absent value.
Verified:

```
$ mql run -c 'a = {"x": 1}
a["y"] == empty'
[ok] value: _

$ mql run -c 'a = {"x": 1}
a["y"] != empty'
[failed] a[y] != empty
  expected: != _
  actual:   _
```

So an absent value passes. Reworded to say that, in both audit paths.

---

## Checked and found correct

Investigated with an oracle, found sound, and deliberately not changed:

- **All 27 `auditpol` subcategory GUIDs** in the `powershell` and `ansible`
  entries, against the canonical Microsoft subcategory GUID list. Every one
  matches its named subcategory, and every `/success:` `/failure:` pair matches its
  check's `mql`, title, and audit text. The `chef` `windows_audit_policy`
  subcategory strings match `auditpol`'s own names, including
  `Plug and Play Events` for the check titled "PNP Activity".
- **Every registry-backed check's path and value name.** For all 28 checks whose
  `mql` is a `registrykey.property(...)` read, the remediation writes the same key
  and the same value name that the query reads. The two Device Guard checks above
  were the only mismatches.
- **All RDP checks.** `windows.rdp` reads
  `HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services` first
  (`rdpPolicyPath` in `providers/os/resources/windows_rdp.go`), which is exactly
  where all twelve RDP remediations write, so each fix satisfies its own check.
  `DeleteTempDirsOnExit = 1` for a check titled "…is set to 'Disabled'" reads
  backwards but is right: Disabled means temp folders *are* deleted.
- **Event Log `Retention` written as `REG_DWORD`.** Investigated whether
  `EventLog.admx` writes `Retention` as `REG_SZ`, which would make the four DWORD
  snippets diverge from Group Policy. Microsoft's own references
  ([Policy CSP - EventLogService](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-eventlogservice#controleventlogbehavior),
  the Windows security baseline table) give the key, the value name, and the
  expected value but not the registry type; `Format: chr` there describes the MDM
  SyncML payload, not the registry value. Not verifiable to the standard this audit
  requires, so not filed. The provider is indifferent in any case:
  `registryItemInt` in `windows_eventlog.go` accepts both the DWORD and the string
  form, so the check reaches the same verdict either way.
- **`mondoo-windows-workstation-security`** end to end. The BitLocker cmdlets
  (`Add-BitLockerKeyProtector -RecoveryPasswordProtector`,
  `Backup-BitLockerKeyProtector -KeyProtectorId`, `Enable-BitLocker -TpmProtector`
  / `-PasswordProtector`, `Enable-BitLockerAutoUnlock`,
  `BackupToAAD-BitLockerKeyProtector`), the Defender cmdlets and
  `HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection` value
  names, and the `AUOptions` / `ScheduledInstallDay` pair all check out, and the
  Group Policy path for Configure Automatic Updates matches the current ADMX
  location. No defects.
- **`mondoo-windows-11-compatibility`** end to end. Every remediation there is
  hardware or firmware guidance; `mbr2gpt /validate /allowFullOS`,
  `Suspend-BitLocker -RebootCount`, `$env:firmware_type` and `Get-Tpm` are all real
  and correctly used, and the stated Windows 11 minimums match Microsoft's
  requirements page. No defects.
- **Chef `windows_security_policy` `secoption` names.** All seven
  (`PasswordHistorySize`, `MaximumPasswordAge`, `MinimumPasswordAge`,
  `MinimumPasswordLength`, `PasswordComplexity`, `ClearTextPassword`,
  `LSAAnonymousNameLookup`) are in the resource's allowed set.
- **`props` defaults against their snippets.** `mondooWindowsSecurityMaxIdleTime`
  defaults to `900000` and the snippet writes `900000`;
  `mondooWindowsSecurityMinimumPasswordLength` defaults to `14` and the snippet
  writes `14`, with a note telling the operator to keep the two in step.

## Validation

```
cnspec policy lint ./content/mondoo-windows-security.mql.yaml                 → valid policy bundle(s)
cnspec policy lint ./content/mondoo-windows-workstation-security.mql.yaml
       ./content/mondoo-windows-11-compatibility.mql.yaml                     → valid policy bundle(s)
python3 content/validation/remediation/code/powershell.py windows            → 165 passed, 0 failed
python3 content/validation/remediation/code/chef.py windows                  →  87 passed, 0 failed
python3 content/validation/remediation/code/ansible.py windows               →  88 passed, 0 failed
typos content/mondoo-windows-security.mql.yaml                               → clean
```

The policy `version:` is unchanged: this is a bug fix, not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
