### PR TITLE
🐛 content: fix network-device remediation that cannot satisfy its own check

### DIFF
--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -508,6 +508,8 @@ queries:
 
             Console authorization has no method list of its own. It reuses the method list already configured for command and exec authorization, so configure those first or console logins are authorized against nothing. Keep a working session open while you apply this, because a method list that cannot reach its server leaves the console unable to authorize any command.
 
+            The method lists below name `group tacacs+`, which requires TACACS+ servers already defined with `tacacs-server host`. Substitute the method list your environment uses, such as `group radius local`, if you do not run TACACS+. Keep `local` as the final method so the console still authorizes when no AAA server answers.
+
             Enter global configuration mode, configure the authorization method lists, then extend them to the serial console:
 
             ```text

--- a/content/mondoo-arista-eos-security.mql.yaml
+++ b/content/mondoo-arista-eos-security.mql.yaml
@@ -478,7 +478,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-3-1
       compliance/vda-isa-5: vda-isa-5-4-2-1
     mql: |
-      arista.eos.aaa.authorizationConsoleCommands != empty
+      arista.eos.aaa.serialConsoleAuthorization == true
     docs:
       desc: |
         This check verifies that AAA authorization is enabled for console access. Console authorization controls which commands users can execute after they authenticate, enforcing the principle of least privilege.
@@ -498,20 +498,23 @@ queries:
 
         1. Connect to the switch and enter privileged EXEC mode.
         2. Run `show running-config section aaa` to display the AAA configuration.
-        3. Confirm the output includes `aaa authorization console`.
+        3. Confirm the output includes `aaa authorization serial-console`.
 
-        If the `aaa authorization console` line is present, the check passes. If it is absent, the check fails.
+        If the `aaa authorization serial-console` line is present, the check passes. If it is absent, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using the CLI**
 
-            Enter global configuration mode and enable AAA authorization for console access:
+            Console authorization has no method list of its own. It reuses the method list already configured for command and exec authorization, so configure those first or console logins are authorized against nothing. Keep a working session open while you apply this, because a method list that cannot reach its server leaves the console unable to authorize any command.
+
+            Enter global configuration mode, configure the authorization method lists, then extend them to the serial console:
 
             ```text
             configure
-            aaa authorization console
-            aaa authorization commands all default local
+            aaa authorization exec default group tacacs+ local
+            aaa authorization commands all default group tacacs+ local
+            aaa authorization serial-console
             ```
 
             Return to privileged EXEC mode and save the configuration. EOS does not save running-config automatically, so without this step the change is lost on the next reload:

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -664,13 +664,16 @@ queries:
             commit
             ```
 
-            Assign the policy to each local user together with the user's password:
+            Assign the policy to each local user, then set that user's credential as a secret. The policy is common to the password and the secret, so it is enforced either way, but only the secret is stored as a one-way hash. A credential stored with `password` uses the reversible type 7 encoding and is recoverable by anyone who can read the configuration:
 
             ```text
             configure terminal
-            username <user> password-policy <policy-name> password <password>
+            username <user> password-policy <policy-name>
+            username <user> secret <password>
             commit
             ```
+
+            Remove any leftover `username <user> password ...` entry so the account keeps only the hashed secret.
     refs:
       - url: https://www.cisco.com/c/en/us/td/docs/routers/asr9000/software/security/configuration/guide/b-system-security-cg-asr9000/configuring-aaa-services.html
         title: Cisco IOS-XR AAA Configuration Guide
@@ -1114,7 +1117,7 @@ queries:
             commit
             ```
 
-            Then remove the default community strings and configure a unique community string restricted by that ACL. Confirm the exact keyword order for `RO`, `IPv4`, and the ACL name against the SNMP configuration guide for your IOS-XR release, because it has varied between releases:
+            Then remove the default community strings and configure a unique community string restricted by that ACL. The access level comes first, then the `IPv4` keyword, then the name of the access-list:
 
             ```text
             configure terminal

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -343,7 +343,7 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: vda-isa-5-5-1-2
     mql: |
-      junos.sshConfig.keyExchanges.containsNone(["diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"])
+      junos.sshConfig.keyExchanges.containsNone(["dh-group1-sha1", "group-exchange-sha1", "diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"])
     docs:
       desc: |
         This check verifies that weak SSH key exchange algorithms are not configured. Strong key exchange algorithms ensure that session keys are securely negotiated and that past sessions remain protected.
@@ -370,13 +370,13 @@ queries:
 
         3. Inspect the `key-exchange` statements in the output.
 
-        If no `key-exchange` statement lists `diffie-hellman-group1-sha1` or `diffie-hellman-group-exchange-sha1`, the check passes. If either of these weak algorithms is configured, the check fails.
+        Junos names the two legacy exchanges `dh-group1-sha1` and `group-exchange-sha1`. If no `key-exchange` statement lists either of them, the check passes. If either weak algorithm is configured, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using the CLI**
 
-            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. The `group-exchange-sha2` keyword selects the SHA-256 variant of Diffie-Hellman group exchange, which replaces the weak SHA-1 `group-exchange-sha1` that this check flags. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
+            Enter configuration mode with `configure exclusive` so no other administrator can commit a conflicting change mid-session. The `set` command appends to the existing key-exchange list, so first remove the current list including any weak entries, then configure only strong algorithms. The `group-exchange-sha2` keyword selects the SHA-256 variant of Diffie-Hellman group exchange, which replaces the weak SHA-1 `group-exchange-sha1`. The other weak exchange to remove is `dh-group1-sha1`. Commit with automatic rollback so an algorithm mismatch with your SSH client cannot lock you out:
 
             ```text
             configure exclusive


### PR DESCRIPTION
Audit of every `remediation:` block in the five network-device policies: `mondoo-cisco-iosxe-security`, `mondoo-cisco-iosxr-security`, `mondoo-cisco-nxos-security`, `mondoo-arista-eos-security`, `mondoo-junos-security`. That is 164 checks, each with exactly one `- id: cli` entry, all of them read.

Three defects, each verified against the vendor's own command reference and, where the verdict depends on it, against the provider's parser. Everything else that looked wrong is listed at the bottom with the evidence that cleared it.

---

## 1. arista: the console-authorization fix configures a knob the check does not read

**Check:** `mondoo-arista-eos-security-aaa-authorization-console`

```coffee
arista.eos.aaa.authorizationConsoleCommands != empty
```

**Remediation before this PR:**

```text
configure
aaa authorization console
aaa authorization commands all default local
```

`authorizationConsoleCommands` is populated by exactly one regex in the provider, and neither of those two lines matches it. From `providers/arista/resources/eos/security.go`:

```go
aaaAuthzConsoleCommandsRe = regexp.MustCompile(
    `^aaa authorization console commands\s+(\S+)\s+(\S+)\s+(.+)$`)
```

`aaa authorization commands all default local` populates `AuthorizationCommands`, a different field. `aaa authorization console` populates nothing at all — the only other console-related branch in that parser is an exact string match on a different line:

```go
if line == "aaa authorization serial-console" {
    cfg.SerialConsoleAuthorization = true
```

So the documented fix leaves `authorizationConsoleCommands` empty and the check still fails.

The obvious repair — emit `aaa authorization console commands …` — is not available, because that line is not EOS syntax. From the Arista EOS User Manual command reference (EOS-4.20.1F, p.192):

> **aaa authorization console**
> The `aaa authorization console` command configures the switch to authorize commands entered through the console. By default, commands entered through the console do not require authorization.
>
> **Command Syntax**
> `aaa authorization console`
> `no aaa authorization console`
> `default aaa authorization console`

A bare toggle, no `commands` sub-token, no method list. The same manual (p.176) explains where the method comes from:

> To require authorization of commands entered on the console, enter `aaa authorization console`. By default, EOS does not verify authorization of commands entered on the console port.

and the command's own example:

> This command configures the switch to authorize commands entered on the console, **using the method specified through a previously executed aaa authorization command**.

Current EOS spells that toggle `aaa authorization serial-console`. Arista's own [AVD `eos_cli_config_gen` input model](https://avd.arista.com/5.0/roles/eos_cli_config_gen/docs/input-variables.html) exposes `aaa_authorization.serial_console`, `aaa_authorization.commands.all_default` and `aaa_authorization.config_commands`, and has no key that could produce `aaa authorization console commands`. The [EOS 4.36 User Security](https://www.arista.com/en/um-eos/eos-user-security) material describes `aaa authorization serial-console` as the command that "requires authorization of commands entered on the console".

**Fix.** Point the check at `serialConsoleAuthorization`, which the provider populates from a line EOS actually emits, and rewrite the remediation to configure the method lists console authorization reuses before turning the toggle on:

```text
configure
aaa authorization exec default group tacacs+ local
aaa authorization commands all default group tacacs+ local
aaa authorization serial-console
```

The audit step now looks for `aaa authorization serial-console` rather than `aaa authorization console`. The added prose spells out the dependency the EOS manual states, since a reader who enters only the toggle gets console authorization against no method list.

---

## 2. cisco: the IOS-XR password-policy example creates a user that fails a sibling check

**Check:** `mondoo-cisco-iosxr-security-password-policy-configured` — `cisco.iosxr.passwordPolicies.length > 0`

**Remediation before this PR**, second snippet:

```text
configure terminal
username <user> password-policy <policy-name> password <password>
commit
```

That is the pattern flagged by `mondoo-cisco-iosxr-security-users-encrypted-passwords` in the same file:

```coffee
cisco.iosxr.users.all(
  secretType.notIn(["0", ""])
)
```

`password` and `secret` are separate fields on the resource, not two spellings of one. From the installed provider schema (`~/.config/mondoo/providers/networkdevices/networkdevices.resources.json`, `cisco.iosxr.user`):

```
passwordType | Encoding of the password field: 0 (cleartext) or 7 (Vigenere cipher).
               Type 7 is trivially reversible and should not be used.
secretType   | Encoding of the enable-style secret: 5 (MD5), 8 (SHA256), 9 (scrypt),
               or 10 (SHA512).
```

An account created with `password` has no secret, so `secretType` is `""`, `notIn(["0", ""])` is false, and the very account the remediation tells the operator to create fails the sibling check. Following one remediation opens a finding on another.

The command was not wrong, only the credential form. Cisco documents the policy as applying to both: the IOS-XR AAA services guide states that a `policy` option "is added to the existing `username` command to apply the password policy to the user. **This policy is common to the password and the secret.** After applying the policy to the user, the system validates any change to the secret or password against that particular policy," and that from Release 7.2.1 the `aaa password-policy` options "are applicable to user password as well as secret."

**Fix.** Split the assignment so the policy is applied and the credential is stored as a hashed secret:

```text
configure terminal
username <user> password-policy <policy-name>
username <user> secret <password>
commit
```

plus a line telling the operator to remove any leftover `username <user> password …` entry, since IOS-XR keeps both attributes on the account if both were ever configured.

---

## 3. junos: the weak key-exchange list uses names Junos never stores

**Check:** `mondoo-junos-security-ssh-no-weak-key-exchanges`

```coffee
junos.sshConfig.keyExchanges.containsNone(["diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"])
```

`keyExchanges` reads the configured `key-exchange` statements. From the provider schema (`junos.sshConfig`):

> **keyExchanges** — Key-exchange methods the SSH server will negotiate. Empty means the platform default set is used.

Those are Junos configuration keywords, and Junos does not use the OpenSSH wire names. From [Remote Access Overview](https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-software-remote-access-overview.html), the key-exchange methods supported by default are:

```
curve25519-sha256
ecdh-sha2-nistp256
ecdh-sha2-nistp384
ecdh-sha2-nistp521
group-exchange-sha2
dh-group14-sha1
```

and the two legacy methods that can be configured for backward compatibility are `group-exchange-sha1` and `dh-group1-sha1`.

So `set system services ssh key-exchange dh-group1-sha1` produces the weakest configuration this check exists to catch, and `containsNone(["diffie-hellman-group1-sha1", …])` finds no match and returns `[ok]`. The check reports compliant on the exact input it is meant to fail.

The remediation prose already knew the real names, which is how the mismatch surfaced. It read:

> The `group-exchange-sha2` keyword selects the SHA-256 variant of Diffie-Hellman group exchange, which replaces the weak SHA-1 `group-exchange-sha1` **that this check flags**.

The check did not flag `group-exchange-sha1`.

**Fix.** Add the two Junos keywords to the list, keeping the existing entries so nothing that reports the OpenSSH spelling regresses:

```coffee
junos.sshConfig.keyExchanges.containsNone(["dh-group1-sha1", "group-exchange-sha1", "diffie-hellman-group1-sha1", "diffie-hellman-group-exchange-sha1"])
```

The audit text now names the Junos keywords an auditor will actually see in `show configuration system services ssh`, and the remediation prose no longer claims the check flags something it did not.

The remediation's own five `set` lines were already correct and are unchanged — they are exactly Juniper's default-supported set minus `dh-group14-sha1`.

---

## 4. cleanup: an IOS-XR hedge that resolves

`mondoo-cisco-iosxr-security-snmp-no-public-community` told the operator:

> Confirm the exact keyword order for `RO`, `IPv4`, and the ACL name against the SNMP configuration guide for your IOS-XR release, because it has varied between releases

It has not. The order in the snippet is the documented one, in the Cisco NCS 540 System Management guide and in the CIS Cisco IOS XR 7.x benchmark, which both give `snmp-server community {community_string} RO IPv4 {snmp_access-list}`; Cisco's own worked example is `snmp-server community snmpcomm123 RO SystemOwner IPv4 SNMP-ALLOW`. Replaced the hedge with a sentence stating the order, so the operator can paste the snippet instead of going to look it up.

---

## Checked and found correct

Everything below was a real candidate that verified clean. Listing it so the coverage is legible.

**Retracted after verification**

- **IOS-XR type 6 ordering.** `password6 encryption aes` before `key config-key password-encryption` looked backwards, since the primary key must exist before secrets are stored. It matches Cisco: the [Implementing Type 6 Password Encryption](https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/24xx/configuration/guide/b-system-security-cg-cisco8000-24xx/implementing-type-6-password-encryption.html) procedure is (1) execute `password6 encryption aes` and commit, (2) create the primary key with `key config-key password-encryption`. Left alone.
- **IOS-XR `aaa accounting commands default start-stop group tacacs+`.** Suspected a missing privilege level, since IOS-XE requires `aaa accounting commands <level> default …`. IOS-XR does not: Cisco's IOS-XR examples are `aaa accounting commands default start-stop group tacacs+`. Left alone.
- **NX-OS `userpassphrase min-length 15 max-length 127`.** The N9K configuration command reference grammar is an alternation, `[no] userpassphrase { min-length <min-len> | max-length <max-len> }`, which suggested the two cannot share a line. Cisco's own configuration example is the combined form `switch(config)# userpassphrase min-length 20 max-length 127`. Left alone.
- **Junos `set system syslog host <h> transport tls`.** Suspected the container form `transport protocol tls` plus a mandatory `tls-profile`, by analogy with `set security log transport protocol tls`. Juniper's [transport (System Syslog)](https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/system-syslog-host-transport.html) statement takes `tcp`, `tls` and `udp` as direct sub-statements, so `transport tls` is right. The paired `port 6514` matches the provider's own note that Junos defaults to "514 for udp and tcp, 6514 for tls". Left alone.
- **Junos SSH cipher list.** All five values in the remediation are in Junos's default-supported set: `chacha20-poly1305@openssh.com`, `aes128-ctr`, `aes192-ctr`, `aes256-ctr`, `aes128-gcm@openssh.com`, `aes256-gcm@openssh.com`. Left alone.
- **IOS-XE `ip ssh time-out 60`.** Both `time-out` and `timeout` appear in Cisco IOS documentation, and `ip ssh time-out 60` is Cisco's own worked example. Not a defect.
- **IOS-XR OSPF `authentication keychain <name>`.** Cisco's syntax block is `authentication [message-digest [keychain keychain] | null]`, which reads as though `keychain` is only legal inside `message-digest`, but third-party IOS-XR examples show a bare area-level keychain form and one shows `authentication key-chain`. Three candidate spellings, no authoritative resolution, so no claim filed. Worth noting for whoever owns the provider: the parser is anchored on `^\s+authentication keychain`, which is what the current remediation emits, so remediation and check are at least consistent today.
- **Arista `logging level security debugging`.** Could not confirm `security` is a valid EOS logging facility from the manual chapters available. The check only requires one `logging level` line and `logging level all informational` on the line above satisfies it, so nothing was changed on an unverified basis.

**Verified correct, no change**

- **Persistence.** Every IOS-XE and IOS-XR snippet ends in `write memory` or `commit`; every NX-OS and Arista snippet carries the explicit `copy running-config startup-config` / `write memory` step with the "NX-OS/EOS does not save running-config automatically" note; every Junos snippet ends in `commit`, with `commit confirmed 5` followed by a confirming `commit` on the lockout-capable ones. No fix in any of the five files is lost on reload.
- **Config mode.** Checked every snippet for mode errors. The IOS-XR RSA key generation and license installation on Junos are correctly documented as operational-mode commands that need no commit; the NX-OS `encryption re-encrypt obfuscated` block correctly sits outside the preceding `configure terminal` block. `line aux 0`, `line con 0`, `line vty 0 15` (IOS-XE), `line default` / `line console` (IOS-XR), `line vty` / `line console` (NX-OS), `management console` / `management ssh` / `management api http-commands` / `management defaults` / `management security` (EOS) are all entered from global config, as written.
- **NOS cross-contamination.** Specifically hunted for IOS-XE syntax in the IOS-XR and NX-OS files. None found. IOS-XR uses `ssh server v2`, `no cdp`, `access-class ingress`, `password clear`, `ipv4 access-list` with sequence-numbered entries, and `commit`; NX-OS uses `feature ssh` / `feature tacacs+`, `ssh key rsa 2048 force`, `snmp-server globalEnforcePriv`, `copp profile strict`, `system login block-for … attempts … within …`, `use-vrf management`, and `copy running-config startup-config`. Each is that platform's own form.
- **Fix targets the field the check reads.** Walked the causal chain for all 164. Beyond the three above, each snippet changes the setting its check inspects: `service tcp-keepalives-in`/`-out` against `configuration.service.tcpKeepalives*Enabled`, `archive`/`log config`/`logging enable` against `logging.configurationChangesLoggingEnabled`, `login on-failure log` against `logging.logUnsuccessfulLogin`, `enable algorithm-type scrypt secret` against `configuration.enableSecret.type == "secret"`, `snmp-server globalEnforcePriv` against `snmp.settings.encryptionEnforced`, `no boot poap enable` against `boot.poapEnabled`, and so on.
- **Regex-matched Arista checks.** The four checks that match running-config lines by regex are satisfied by their own snippets: `aaa accounting commands all default start-stop logging` matches `/aaa accounting commands all default start-stop/` (unanchored), and the same for the exec and system accounting pairs; `aaa authentication login console group radius local` matches `/aaa authentication login console group/`.
- **Lockout warnings.** The destructive fixes all carry them, and they are placed before the snippet rather than after: AAA new model and default login lists (IOS-XE), VTY transport and access-class (all four platforms), Telnet shutdown (EOS), root-login deny and `host-inbound-traffic system-services all` removal (Junos), SNMP community rotation and ACL binding (all), BGP and OSPF authentication (all). The Junos untrust-zone fix correctly stages the deletes and the SSH re-add into a single commit.
- **`no username` then recreate (IOS-XE).** The claim that IOS-XE rejects an account holding both a password and a secret is correct, which is why the account has to be removed and recreated rather than amended; the snippet keeps the two commands adjacent and warns about the window between them.

**Validation run**

```
cnspec policy lint ./content/mondoo-arista-eos-security.mql.yaml   → valid policy bundle(s)
cnspec policy lint ./content/mondoo-cisco-iosxr-security.mql.yaml  → valid policy bundle(s)
cnspec policy lint ./content/mondoo-junos-security.mql.yaml        → valid policy bundle(s)
make test/content/lint                                            → valid policy bundle(s)
```

No remediation validator under `content/validation/remediation/` targets these five policies — the CLI grammars there cover cloud CLIs, and the code-block linters cover terraform/bicep/cloudformation/bash/powershell/chef/ansible. These policies ship only `- id: cli` entries containing device configuration, so there is nothing to add them to. There are no IaC variants and no fixtures in these files.

No `version:` line was touched.
