### PR TITLE
🐛 content: fix remediation defects in the dns, email, http and tls policies

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -212,16 +212,16 @@ queries:
             }
 
             resource "aws_route53_record" "ns" {
-              zone_id = aws_route53_zone.primary.zone_id
-              name    = "example.com"
-              type    = "NS"
-              ttl     = 172800
-              records = [
-                "ns1.example.com",
-                "ns2.example.com",
-              ]
+              allow_overwrite = true
+              zone_id         = aws_route53_zone.primary.zone_id
+              name            = "example.com"
+              type            = "NS"
+              ttl             = 172800
+              records         = aws_route53_zone.primary.name_servers
             }
             ```
+
+            Route 53 creates the apex `NS` record as soon as the hosted zone exists, so a plain `aws_route53_record` of type `NS` at the apex fails to apply with a "but it already exists" error. `allow_overwrite = true` lets the same run manage the record. Reading the values from `name_servers` also keeps them the hostnames Route 53 assigned, which is what this check requires. Where you run your own nameservers, list their hostnames instead and publish an `A` or `AAAA` record for each.
     refs:
       - url: https://www.cisa.gov/dns-security
         title: CISA DNS Security
@@ -656,21 +656,34 @@ queries:
             To declare redundant nameservers with Terraform:
 
             ```hcl
+            resource "aws_route53_zone" "primary" {
+              name = "example.com"
+            }
+
             resource "aws_route53_record" "ns" {
-              zone_id = aws_route53_zone.primary.zone_id
-              name    = "example.com"
-              type    = "NS"
-              ttl     = 172800
-              records = [
-                "ns1.example.com",
-                "ns2.example.com",
-                "ns3.example.net",
-                "ns4.example.net",
-              ]
+              allow_overwrite = true
+              zone_id         = aws_route53_zone.primary.zone_id
+              name            = "example.com"
+              type            = "NS"
+              ttl             = 172800
+              records         = aws_route53_zone.primary.name_servers
+            }
+
+            resource "aws_route53domains_registered_domain" "primary" {
+              domain_name = "example.com"
+
+              dynamic "name_server" {
+                for_each = aws_route53_zone.primary.name_servers
+                content {
+                  name = name_server.value
+                }
+              }
             }
             ```
 
-            Publishing the NS set in the zone is only half of it — the registrar's delegation must list the same nameservers. Where the registrar has a Terraform provider, manage the delegation there too; otherwise update it in the registrar's control panel.
+            Route 53 assigns four nameservers on distinct networks when the hosted zone is created and publishes them as the apex `NS` record, so the redundancy comes from the zone itself. Managing that record in Terraform needs `allow_overwrite = true`, because the record already exists the moment the zone does. Do not substitute hostnames of your own choosing: replacing the set with nameservers that do not serve the zone breaks resolution for the whole domain.
+
+            Publishing the NS set in the zone is only half of it, because the registrar's delegation must list the same nameservers. The `aws_route53domains_registered_domain` resource does that for domains registered with Route 53. For a registrar with no Terraform provider, copy the `name_servers` output into its control panel.
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc1034#section-4.1
         title: 'RFC 1034: Domain Names - Concepts and Facilities'

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -551,10 +551,10 @@ queries:
             To measure the published record:
 
             ```bash
-            dig +short TXT lunalectric.com | grep 'v=spf1' | wc -c
+            dig +short TXT lunalectric.com | grep 'v=spf1' | tr -d '"' | tr -d '\n' | wc -c
             ```
 
-            The record starting with `v=spf1` must be 255 characters or fewer.
+            The record starting with `v=spf1` must be 255 characters or fewer. Strip the quotes and the trailing newline before counting, because `dig +short` wraps each string in double quotes and `wc -c` otherwise reports three characters more than the record actually holds. A record dig prints as two quoted strings is already over the 255-character limit for a single DNS string, which is what this check measures.
         - id: terraform
           desc: |
             To keep the record short under Terraform, prefer explicit addresses over deep include chains:

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -108,11 +108,15 @@ queries:
             **Using NGINX**
 
             1. Open your NGINX configuration file (typically found at `/etc/nginx/nginx.conf` or in a site-specific file under `/etc/nginx/sites-available/`).
-            2. Inside the `server` or `location` block, add the following line:
+            2. Inside the `server` block, add the following line:
 
                 ```nginx
-                add_header X-Content-Type-Options "nosniff";
+                add_header X-Content-Type-Options "nosniff" always;
                 ```
+
+                Put the directive in the `server` block rather than in a nested `location`. NGINX inherits `add_header` from the enclosing level only while the current level declares none of its own, so one `add_header` inside a `location` discards every header the `server` block sets for requests routed there. Where a `location` genuinely needs its own header, repeat the whole set inside it.
+
+                The `always` flag sends the header on error responses as well. Without it NGINX omits the header from a 404 or 500, and an error page whose type a browser is free to sniff is exactly the case this header exists to close.
 
             3. Save the file and reload NGINX:
 
@@ -210,11 +214,15 @@ queries:
             The `default-src 'self'` value shown below is only a starting skeleton, not a finished policy. On its own it blocks inline styles and scripts, CDNs, analytics, fonts, and embedded media that most real sites depend on. Treat it as the strict baseline you start from, then enumerate the exact sources your application actually loads and add the directives for them, such as the specific `script-src`, `style-src`, `img-src`, and `connect-src` origins your pages request. This is why report-only rollout matters: the violation reports tell you which sources to add before you enforce.
 
             1. Open your NGINX configuration file, typically `/etc/nginx/nginx.conf` or a site-specific file under `/etc/nginx/sites-available/`.
-            2. Inside the `server` or `location` block, add a report-only policy to observe violations without blocking content:
+            2. Inside the `server` block, add a report-only policy to observe violations without blocking content:
 
                 ```nginx
-                add_header Content-Security-Policy-Report-Only "default-src 'self';";
+                add_header Content-Security-Policy-Report-Only "default-src 'self';" always;
                 ```
+
+                Put the directive in the `server` block rather than in a nested `location`. NGINX inherits `add_header` from the enclosing level only while the current level declares none of its own, so one `add_header` inside a `location` discards every header the `server` block sets for requests routed there. Where a `location` genuinely needs its own header, repeat the whole set inside it.
+
+                The `always` flag sends the header on error responses as well. Without it NGINX omits the header from a 404 or 500, leaving error pages outside the policy.
 
             3. Save the file and reload NGINX:
 
@@ -226,7 +234,7 @@ queries:
             5. Once the policy no longer reports violations for legitimate traffic, replace the report-only directive with the enforcing header:
 
                 ```nginx
-                add_header Content-Security-Policy "default-src 'self';";
+                add_header Content-Security-Policy "default-src 'self';" always;
                 ```
 
             6. Save the file and reload NGINX:
@@ -376,12 +384,33 @@ queries:
           desc: |
             **Using IIS**
 
+            IIS 10.0 version 1709 and later carry a native HSTS setting on the site. Use it rather than the `HTTP Response Headers` feature: a custom response header is emitted on the site's plain HTTP binding as well, and RFC 6797 requires that an HSTS host never send the header over non-secure transport. The native setting adds the header only when IIS answers an HTTPS request.
+
             1. Confirm the site and everything under its hostname is fully reachable over HTTPS. Browsers that receive this header refuse plain HTTP for the duration of `max-age`.
-            2. Open the IIS Manager.
-            3. Select your site and go to the `HTTP Response Headers` feature.
-            4. Click `Add` in the right pane.
-            5. Set the name to `Strict-Transport-Security` and the value to `max-age=31536000; includeSubDomains`. Add `includeSubDomains` only after verifying that every subdomain serves HTTPS. Add the `preload` directive only if you intend to submit the domain to browser preload lists; that is a long-term commitment that is slow to reverse.
-            6. Click OK. The change takes effect immediately.
+            2. There is no IIS Manager page for this setting, so configure it with `appcmd.exe`. Replace `Contoso` with your site name and keep `/commit:apphost`, which writes the value to the right section of `applicationHost.config`:
+
+                ```cmd
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.enabled:True" /commit:apphost
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.max-age:31536000" /commit:apphost
+                ```
+
+            3. Enable `includeSubDomains` only after verifying that every subdomain serves HTTPS:
+
+                ```cmd
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.includeSubDomains:True" /commit:apphost
+                ```
+
+                Enable the `preload` attribute only if you intend to submit the domain to browser preload lists; that is a long-term commitment that is slow to reverse.
+
+            4. The resulting `applicationHost.config` entry looks like this:
+
+                ```xml
+                <site name="Contoso" id="1">
+                  <hsts enabled="true" max-age="31536000" includeSubDomains="true" />
+                </site>
+                ```
+
+            5. The setting applies to the next request. On IIS releases older than 10.0 version 1709 the `<hsts>` element does not exist, so emit the header from the application or from a URL Rewrite outbound rule conditioned on `HTTPS` being `on`.
     refs:
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
@@ -992,14 +1021,18 @@ queries:
             X-Frame-Options is a legacy header. The modern equivalent is the Content-Security-Policy `frame-ancestors` directive, which modern browsers prefer when both are present and which supports finer-grained origin control. Deploy `frame-ancestors` alongside X-Frame-Options so legacy browsers that do not honor CSP still get clickjacking protection.
 
             1. Open your NGINX configuration file.
-            2. Inside the `server` or `location` block, add both headers:
+            2. Inside the `server` block, add both headers:
 
                 ```nginx
-                add_header X-Frame-Options "SAMEORIGIN";
-                add_header Content-Security-Policy "frame-ancestors 'self';";
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header Content-Security-Policy "frame-ancestors 'self';" always;
                 ```
 
                 Use `frame-ancestors 'none'` to forbid all framing, the CSP equivalent of `DENY`.
+
+                Put the directives in the `server` block rather than in a nested `location`. NGINX inherits `add_header` from the enclosing level only while the current level declares none of its own, so one `add_header` inside a `location` discards every header the `server` block sets for requests routed there. Where a `location` genuinely needs its own header, repeat the whole set inside it.
+
+                The `always` flag sends the headers on error responses as well. Without it NGINX omits them from a 404 or 500, leaving those pages framable.
 
                 If you already serve a Content-Security-Policy header, do not add a second `add_header Content-Security-Policy` line. NGINX `add_header` is additive, so a second directive emits two CSP headers and browsers enforce the most restrictive intersection, which can break the page. Instead, add `frame-ancestors 'self'` to the single existing CSP value.
 
@@ -1103,11 +1136,15 @@ queries:
             **Using NGINX**
 
             1. Open your NGINX configuration file.
-            2. Inside the `server` or `location` block, add:
+            2. Inside the `server` block, add:
 
                 ```nginx
-                add_header Referrer-Policy "strict-origin-when-cross-origin";
+                add_header Referrer-Policy "strict-origin-when-cross-origin" always;
                 ```
+
+                Put the directive in the `server` block rather than in a nested `location`. NGINX inherits `add_header` from the enclosing level only while the current level declares none of its own, so one `add_header` inside a `location` discards every header the `server` block sets for requests routed there. Where a `location` genuinely needs its own header, repeat the whole set inside it.
+
+                The `always` flag sends the header on error responses as well. Without it NGINX omits the header from a 404 or 500, and those URLs are the ones most likely to carry a token in the query string.
 
             3. Save and reload NGINX:
 
@@ -1231,10 +1268,22 @@ queries:
           desc: |
             **Using IIS**
 
-            1. Open the IIS Manager.
-            2. Select your site and go to `HTTP Response Headers`.
-            3. Update `Strict-Transport-Security` so `max-age` is at least `31536000`, for example `max-age=31536000; includeSubDomains`. Do not add the `preload` directive unless you intend to submit the domain to browser preload lists, which is a long-term commitment that is slow to reverse.
-            4. Click OK. The change takes effect immediately.
+            The HSTS header on IIS 10.0 version 1709 and later comes from the site's native HSTS setting, not from the `HTTP Response Headers` feature, so raise `max-age` there.
+
+            1. Set `max-age` to at least one year, which is 31536000 seconds. Replace `Contoso` with your site name:
+
+                ```cmd
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.max-age:31536000" /commit:apphost
+                ```
+
+            2. Leave the other attributes as they are. In particular, do not enable `preload` unless you intend to submit the domain to browser preload lists, which is a long-term commitment that is slow to reverse.
+            3. Confirm the stored value:
+
+                ```cmd
+                appcmd.exe list config -section:system.applicationHost/sites
+                ```
+
+            4. The setting applies to the next request. If the site still carries a `Strict-Transport-Security` entry under `HTTP Response Headers`, remove it, because that copy is also sent over plain HTTP and can override the intended `max-age`.
     refs:
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
@@ -1325,11 +1374,23 @@ queries:
           desc: |
             **Using IIS**
 
+            The `includeSubDomains` directive on IIS 10.0 version 1709 and later is an attribute of the site's native HSTS setting, not a value you type into the `HTTP Response Headers` feature.
+
             1. Inventory every subdomain of this domain and confirm each one is fully reachable over HTTPS. After this change, browsers refuse plain HTTP to all subdomains for the full `max-age`, which makes any HTTP-only subdomain unreachable.
-            2. Open the IIS Manager.
-            3. Select your site and go to `HTTP Response Headers`.
-            4. Update `Strict-Transport-Security` to `max-age=31536000; includeSubDomains`. Do not add the `preload` directive unless you intend to submit the domain to browser preload lists, which is a long-term commitment that is slow to reverse.
-            5. Click OK. The change takes effect immediately.
+            2. Set the attribute. Replace `Contoso` with your site name:
+
+                ```cmd
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.includeSubDomains:True" /commit:apphost
+                ```
+
+            3. Confirm `max-age` is still at least 31536000, since preload eligibility needs both:
+
+                ```cmd
+                appcmd.exe list config -section:system.applicationHost/sites
+                ```
+
+            4. Do not enable `preload` unless you intend to submit the domain to browser preload lists, which is a long-term commitment that is slow to reverse.
+            5. The setting applies to the next request.
     refs:
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
@@ -1428,12 +1489,28 @@ queries:
 
             HSTS preload is a long-term commitment. Once the domain is on browser preload lists, every browser refuses plain HTTP for the entire registrable domain and all of its subdomains, and removal from the lists takes months to propagate. Only proceed if every current and future subdomain will serve HTTPS. Preload list eligibility requires `max-age` of at least 31536000 and the `includeSubDomains` directive.
 
+            On IIS 10.0 version 1709 and later, `preload` is an attribute of the site's native HSTS setting rather than a value typed into the `HTTP Response Headers` feature.
+
             1. Confirm every subdomain of the registrable domain serves HTTPS and that you accept the long-term commitment described above.
-            2. Open the IIS Manager.
-            3. Select your site and go to `HTTP Response Headers`.
-            4. Update `Strict-Transport-Security` to `max-age=31536000; includeSubDomains; preload`.
-            5. Click OK. The change takes effect immediately.
-            6. After deploying the header, submit your domain at https://hstspreload.org/.
+            2. Set all three attributes, since the preload list rejects a domain missing any of them. Replace `Contoso` with your site name:
+
+                ```cmd
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.enabled:True" /commit:apphost
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.max-age:31536000" /commit:apphost
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.includeSubDomains:True" /commit:apphost
+                appcmd.exe set config -section:system.applicationHost/sites "/[name='Contoso'].hsts.preload:True" /commit:apphost
+                ```
+
+            3. The resulting `applicationHost.config` entry looks like this:
+
+                ```xml
+                <site name="Contoso" id="1">
+                  <hsts enabled="true" max-age="31536000" includeSubDomains="true" preload="true" />
+                </site>
+                ```
+
+            4. The setting applies to the next request.
+            5. After deploying the header, submit your domain at https://hstspreload.org/.
     refs:
       - url: https://hstspreload.org/
         title: HSTS Preload List Submission

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -964,9 +964,10 @@ queries:
                 systemctl reload httpd     # RHEL/CentOS
                 ```
 
-            4. If your CA still publishes OCSP responders, turn on OCSP stapling so clients can confirm revocation status without a third-party round-trip. Stapling has no effect for certificates without an OCSP URL:
+            4. If your CA still publishes OCSP responders, turn on OCSP stapling so clients can confirm revocation status without a third-party round-trip. Stapling has no effect for certificates without an OCSP URL. `SSLStaplingCache` is a server-config directive and must sit in the global scope rather than inside the `<VirtualHost>` block you edited in step 3, otherwise Apache refuses to start with `SSLStaplingCache cannot occur within <VirtualHost> section`:
 
                 ```apache
+                # Global scope, outside every <VirtualHost>
                 SSLUseStapling          on
                 SSLStaplingCache        shmcb:/run/ocsp(128000)
                 SSLStaplingResponderTimeout 5
@@ -1375,17 +1376,20 @@ queries:
 
             1. Open your HAProxy configuration file (typically `/etc/haproxy/haproxy.cfg`).
 
-            2. In the `global` section or your `bind` lines, add:
+            2. In the `global` section, add:
 
                 ```haproxy
                 ssl-default-bind-options ssl-min-ver TLSv1.2
                 ```
 
-                Or for specific frontends:
+                `ssl-default-bind-options` is a `global` keyword and sets the default for every `bind` line. To raise the floor on one frontend instead, put the `ssl-min-ver` option directly on that `bind` line:
 
                 ```haproxy
-                bind *:443 ssl crt /path/to/cert.pem ssl-min-ver TLSv1.2
+                frontend https-in
+                    bind *:443 ssl crt /etc/haproxy/certs/yourdomain.com.pem ssl-min-ver TLSv1.2
                 ```
+
+                The two keywords are not interchangeable. `ssl-default-bind-options` on a `bind` line makes HAProxy refuse to start with `unknown keyword 'ssl-default-bind-options'`.
 
             3. Save the file and restart HAProxy:
 


### PR DESCRIPTION
Full remediation audit of the four protocol-level policies: `mondoo-dns-security`,
`mondoo-email-security`, `mondoo-http-security`, `mondoo-tls-security`. Every
`- id:` entry was read, and every claim below was reproduced against the software
that owns it before it was filed. Output is quoted.

Nothing here changes a `mql:` query or a policy `version:`.

---

## 1. dns: apex `NS` snippets cannot apply

`mondoo-dns-security-no-ip-for-ns-mx-records` and `mondoo-dns-security-ns-redundancy`
both published an apex `NS` record with a plain `aws_route53_record`. Route 53 creates
that record with the zone, so the apply fails.

The AWS provider documents this and gives the fix, in its own canonical example:

> **NS and SOA Record Management**
>
> When creating Route 53 zones, the `NS` and `SOA` records for the zone are automatically created. Enabling the `allow_overwrite` argument will allow managing these records in a single Terraform run without the requirement for `terraform import`.

```terraform
resource "aws_route53_record" "example" {
  allow_overwrite = true
  name            = "test.example.com"
  ttl             = 172800
  type            = "NS"
  zone_id         = aws_route53_zone.example.zone_id

  records = [
    aws_route53_zone.example.name_servers[0],
    ...
  ]
}
```

Source: `website/docs/r/route53_record.html.markdown`, hashicorp/terraform-provider-aws `main`.
`allow_overwrite` confirmed present in the pinned `~> 6.0` schema:

```
$ terraform providers schema -json | jq '... .aws_route53_record.block.attributes | keys'
aws_route53_record allow_overwrite: True
```

**The `ns-redundancy` snippet had a second, worse problem.** It listed
`ns1.example.com`, `ns2.example.com`, `ns3.example.net`, `ns4.example.net`. Applied
against a real zone with `allow_overwrite` added, that would replace the delegation
with four nameservers that do not serve the zone, taking the whole domain off the
internet. It now reads `aws_route53_zone.primary.name_servers` and manages the
registrar delegation with `aws_route53domains_registered_domain`, whose
`name_server { name = ... }` block shape was confirmed against the same schema dump.

Both snippets re-verified: `content/validation/remediation/code/terraform.py dns` →
`8 passed, 0 failed`.

---

## 2. tls: `ssl-default-bind-options` is a `global` keyword, not a `bind` option

`mondoo-tls-security-no-weak-tls-versions`, HAProxy block, said:

> In the `global` section **or your `bind` lines**, add:
> ```haproxy
> ssl-default-bind-options ssl-min-ver TLSv1.2
> ```

Taking the second option stops HAProxy from starting:

```
$ haproxy -c -f b.cfg
HAProxy version 3.0.26-9c2603415 2026/07/29
[ALERT] (7) : config : parsing [/cfg/b.cfg:8] : 'bind *:443' in section 'frontend':
              unknown keyword 'ssl-default-bind-options'.
[ALERT] (7) : config : Fatal errors found in configuration.
```

The same run confirmed the `global` form and the per-`bind` `ssl-min-ver` form both
parse clean. The block now presents them as the two distinct keywords they are and
names the error, so a reader who hits it recognises it.

---

## 3. tls: `SSLStaplingCache` in a `<VirtualHost>` aborts Apache

`mondoo-tls-security-cert-not-revoked`, Apache block. Step 3 has the reader editing
`SSLCertificateFile` / `SSLCertificateKeyFile`, which live in a `<VirtualHost>` in
every real deployment. Step 4 then handed them a stapling block with no scope note.

```
$ httpd -t -c "Include /cfg/vhost-stapling.conf"     # Apache/2.4.68 (Unix)
AH00526: Syntax error on line 8 of /cfg/vhost-stapling.conf:
SSLStaplingCache cannot occur within <VirtualHost> section

$ httpd -t -c "Include /cfg/global-stapling.conf"    # same directives, global scope
Syntax OK
```

The sibling `mondoo-tls-security-cert-ocsp-configured` block already warned about
this ("must live in the global scope, not per-vhost"). The two now agree.

---

## 4. http: `add_header` in a `location` deletes the rest of the policy's headers

Four checks told the reader to add the header "inside the `server` **or `location`**
block": `x-content-type-options-nosniff`, `content-security-policy`, `x-frame-options`,
`referrer-policy`.

NGINX inherits `add_header` from the enclosing level *only while the current level
declares none of its own*. So following the `location` option strips every header the
`server` block sets — including the other headers this same policy requires.
Reproduced on nginx/1.29.8 with a `server`-level header and one `location` that adds
its own:

```
-- /inherited --
X-Server-Level: yes
-- /overridden --
X-Location-Level: yes          # X-Server-Level is gone
```

Same run, the missing `always` flag:

```
-- 200 response --
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
X-With-Always: nosniff
-- 404 response --
HTTP/1.1 404 Not Found
X-With-Always: nosniff         # the un-flagged header is absent
```

The snippets now say `server` block, explain the inheritance rule and what to do when
a `location` genuinely needs its own header, and carry `always` — matching the HSTS
snippets in this policy, which already had it.

---

## 5. http: IIS HSTS was configured on the wrong surface

The four HSTS checks added `Strict-Transport-Security` through IIS Manager's
`HTTP Response Headers` feature. That emits the header on the site's plain HTTP
binding too, which RFC 6797 §7.2 forbids:

> An HSTS Host MUST NOT include the STS header field in HTTP responses conveyed over non-secure transport.

IIS has had a native setting for this since IIS 10.0 version 1709, and it is
HTTPS-only by construction:

> The `<hsts>` element of the `<site>` element contains attributes that allow you to configure HTTP Strict Transport Security (HSTS) settings for a site on IIS 10.0 version 1709 and later.
>
> `enabled` — ... If HSTS is enabled, the **Strict-Transport-Security** HTTP response header is added **when IIS replies an HTTPS request** to the web site.
>
> There is no user interface that lets you configure the `<hsts>` element of the `<site>` element for IIS 10.0 version 1709.

Source: [HSTS settings for a Web Site `<hsts>`](https://learn.microsoft.com/en-us/iis/configuration/system.applicationhost/sites/site/hsts).

That last line also means the old click-path could not have been followed as written.
The blocks now use `appcmd.exe ... /commit:apphost` (the form Microsoft's own sample
code uses), show the resulting `applicationHost.config`, and say what to do on IIS
releases that predate the element. `max-age`, `includeSubDomains` and `preload` are
each set on the check that asks for them.

---

## 6. email: the SPF length command overcounts by three

`mondoo-email-security-spf-length` piped `dig +short` straight into `wc -c` under the
instruction "must be 255 characters or fewer". `dig +short` wraps each string in
double quotes and adds a newline:

```
$ dig +short TXT google.com | grep 'v=spf1'
"v=spf1 include:_spf.google.com ~all"
$ dig +short TXT google.com | grep 'v=spf1' | wc -c
      38
$ dig +short TXT google.com | grep 'v=spf1' | tr -d '"' | tr -d '\n' | wc -c
      35
```

A 253-character record measured 256 and read as failing. The pipeline now strips both,
and the text notes that a record dig prints as two quoted strings is already over the
per-string limit the check measures.

---

## Checked and found correct

These looked like defects and are not. Recording them so the coverage is legible and
nobody re-opens them.

| Candidate | Verdict |
|---|---|
| Every `SSLCipherSuite` / `ssl_ciphers` / `ssl-default-bind-ciphers` string in the policy | All six parse. `openssl ciphers` on `!RC4`, `!NULL:!aNULL:!eNULL`, `!EXPORT:!EXPORT40:!EXPORT56`, `!ADH:!aNULL`, `!DES:!3DES:!RC2:!IDEA`, `!kRSA` each returned a suite list, no errors. OpenSSL 3.6.3. |
| HAProxy `crt-list` with a negative SNI filter on the default cert (`no-sni-certificate-leak`) | Works exactly as documented. Ran it: no SNI → `CN=yourdomain.com`; SNI `host.internal.example.com` → `CN=host.internal.example.com`. The negative filter does not disqualify the entry from being the default. |
| `ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:...` (`tls13-supported`) | Valid `global` keyword, config parses. |
| `ocsp-update on` in a crt-list (`cert-not-revoked`, HAProxy) | Valid on HAProxy 3.0, config parses. |
| `apt-get install libnginx-mod-http-headers-more-filter` (`obfuscate-server`) | Real package. Debian bookworm candidate `1:0.34-3`. |
| `load_module modules/ngx_http_headers_more_filter_module.so;` | Exactly what the Debian package's own `modules-enabled` snippet contains, and it resolves against the `--prefix=/usr/share/nginx` build. |
| `more_clear_headers Server;` in the `http` block | Correct context and it works: `curl -sI` returned no `Server` header at all. |
| `cloudflare_zone_dnssec` and `cloudflare_dns_record` (`dnssec-enabled`, `no-cname-for-root-domain`) | Both present in the pinned cloudflare `~> 5.0` schema, with the `name` / `content` / `proxied` / `ttl` attributes the snippets use. |
| The apex `CNAME` in the Cloudflare snippet under a check that forbids apex CNAMEs | Not self-contradictory. `proxied = true` makes Cloudflare answer with its own address records, so `dns.records.where(type == "CNAME")` is empty at the wire. The block already explains the flattening. |
| `ssl_stapling` / `ssl_stapling_verify` / `ssl_trusted_certificate` / `resolver` (nginx, two checks) | Config parses; the only output is the expected `"ssl_stapling" ignored, no OCSP responder URL in the certificate`, which is a property of the test cert. |
| `ssl_reject_handshake on;` (`no-sni-certificate-leak`) | Valid, parses on nginx 1.29. |
| Google Workspace MX preferences 1/5/5/10/10 | Match Google's published set. |
| Apache `Header always set` / `Header set` / `Header unset`, `SSLProtocol -all +TLSv1.2 +TLSv1.3` | All parse under Apache 2.4.68 with `headers` and `ssl` loaded. |
| `removeServerHeader="true"` under `<requestFiltering>` (`obfuscate-server`, IIS) | Real attribute, and the block already scopes it to IIS 10 and later. |
| `ServerTokens Full` + `SecServerSignature` (`obfuscate-server`, Apache) | Genuinely required in that order by ModSecurity, and the block already carries the "verify the module loaded or you are leaking the version" warning. |

## Validation

```
cnspec policy lint ./content/mondoo-{dns,email,http,tls}-security.mql.yaml   # valid policy bundle(s), all four
python3 content/validation/remediation/code/terraform.py dns                 # 8 passed, 0 failed
python3 content/validation/remediation/code/terraform.py email               # 16 passed, 0 failed
python3 content/validation/remediation/code/bash.py all                      # exit 0
```

`mondoo-tls-security` and `mondoo-http-security` carry no IaC snippets, so no fixture
or closed-loop suite applies to them.
