### PR TITLE
🐛 macos: fix remediation steps that cannot resolve their own finding

### DIFF
--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -1595,27 +1595,43 @@ queries:
           desc: |
             **Using Ansible**
 
-            A bare `fdesetup enable` prompts for a password and cannot run unattended. Use deferred enablement, which activates FileVault at the user's next logout and writes the recovery key to a file you must collect and escrow:
+            A bare `fdesetup enable` prompts for a password and cannot run unattended. Use deferred enablement, which activates FileVault at the user's next logout:
 
             ```yaml
             ---
-            - name: Enable FileVault
+            - name: Configure deferred FileVault enablement
               hosts: all
               become: true
               tasks:
                 - name: Enable FileVault at next logout
                   ansible.builtin.command: fdesetup enable -defer /var/db/filevault-recovery.plist
+            ```
+
+            The recovery key is not generated when this task runs. `fdesetup` writes the property list only once the designated user supplies their password at logout, which is why collecting it is a second pass rather than the next task in the same play. Run the following play after the users have logged out:
+
+            ```yaml
+            ---
+            - name: Escrow the FileVault recovery key
+              hosts: all
+              become: true
+              tasks:
+                - name: Check whether the user has completed enablement
+                  ansible.builtin.stat:
+                    path: /var/db/filevault-recovery.plist
+                  register: filevault_recovery
                 - name: Fetch the recovery key for escrow
                   ansible.builtin.fetch:
                     src: /var/db/filevault-recovery.plist
                     dest: filevault-keys/
+                  when: filevault_recovery.stat.exists
                 - name: Remove the local recovery key copy
                   ansible.builtin.file:
                     path: /var/db/filevault-recovery.plist
                     state: absent
+                  when: filevault_recovery.stat.exists
             ```
 
-            Store the fetched recovery keys in a secure escrow location. If the recovery key is lost and a user forgets their password, the encrypted data cannot be recovered. In MDM-managed fleets, prefer enabling FileVault through an MDM profile with institutional key escrow instead.
+            The `stat` guard matters in both directions: without it the fetch fails on every host whose user has not logged out yet, and the removal task deletes the escrow file on a host where the fetch never ran. Store the fetched recovery keys in a secure escrow location. If the recovery key is lost and a user forgets their password, the encrypted data cannot be recovered. In MDM-managed fleets, prefer enabling FileVault through an MDM profile with institutional key escrow instead.
 
             Note: To pass this check and ensure users cannot turn encryption off, the Device Management profile property [`dontAllowFDEDisable` must be set to true](https://developer.apple.com/documentation/devicemanagement/fdefilevaultoptions).
 
@@ -1776,7 +1792,7 @@ queries:
            /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
            ```
 
-        A passing result reports `Stealth mode enabled`. A failing result reports `Stealth mode disabled`.
+        A passing result reports `Firewall stealth mode is on`. A failing result reports `Firewall stealth mode is off`.
       remediation:
         - id: cli
           desc: |
@@ -2000,14 +2016,23 @@ queries:
           desc: |
             **Using the CLI**
 
-            Run these commands to enable `auditd`:
+            On macOS 14 and later the audit subsystem is disabled by default and no `/etc/security/audit_control` is installed, so clearing the launchd override on its own leaves `auditd` unable to start. Provision the configuration file from the template Apple ships, clear the override, then restart:
+
+            ```bash
+            sudo cp -n /etc/security/audit_control.example /etc/security/audit_control
+            sudo launchctl enable system/com.apple.auditd
+            ```
+
+            Restart the system to finish. `auditd` reads `/etc/security/audit_control` only at startup, so it does not begin collecting events until the restart completes. The `cp -n` form leaves an existing configuration file untouched.
+
+            On macOS 13 and earlier the configuration file is already present and the daemon can be started in place instead:
 
             ```bash
             sudo launchctl enable system/com.apple.auditd
             sudo launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.auditd.plist
             ```
 
-            The `enable` command clears the disabled override so the daemon starts again, and `bootstrap` loads it now. The `bootstrap` command reports an error if the service is already loaded; that error is harmless. On older macOS versions you can use the legacy form `sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist`.
+            The `enable` command clears the disabled override so the daemon starts again, and `bootstrap` loads it now. The `bootstrap` command reports an error if the service is already loaded; that error is harmless.
 
             **Impact:**
 
@@ -2016,7 +2041,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            To enable `auditd` using Ansible, you can use the following playbook:
+            To enable `auditd` using Ansible, you can use the following playbook. It provisions the configuration file that macOS 14 and later no longer install, clears the launchd override, and restarts the host so `auditd` picks the configuration up:
 
             ```yaml
             ---
@@ -2024,16 +2049,22 @@ queries:
               hosts: all
               become: true
               tasks:
+                - name: Provision the audit configuration file if it is missing
+                  ansible.builtin.copy:
+                    src: /etc/security/audit_control.example
+                    dest: /etc/security/audit_control
+                    remote_src: true
+                    force: false
+                    owner: root
+                    group: wheel
+                    mode: '0600'
                 - name: Clear the disabled override on the audit daemon
                   ansible.builtin.command: launchctl enable system/com.apple.auditd
-                - name: Load the audit daemon
-                  ansible.builtin.command: launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.auditd.plist
-                  register: bootstrap_result
-                  failed_when: false
-                  changed_when: bootstrap_result.rc == 0
+                - name: Restart so the audit daemon starts with the new configuration
+                  ansible.builtin.reboot:
             ```
 
-            The `bootstrap` task exits non-zero harmlessly when the daemon is already loaded; that failure is suppressed with `failed_when: false`, and `changed` is reported only when it actually loads the service. The `enable` task runs `launchctl` through `ansible.builtin.command`, which always reports `changed` even when the daemon is already enabled, so this playbook is not fully idempotent.
+            `force: false` leaves an existing configuration file untouched, so the task is safe to re-run and does not overwrite a tuned retention policy. The `enable` task runs `launchctl` through `ansible.builtin.command`, which always reports `changed` even when the daemon is already enabled, so this playbook is not fully idempotent.
 
             **Impact:**
 
@@ -2220,15 +2251,7 @@ queries:
 
         Without these protections, AirDrop may inadvertently expose the system to potential threats, undermining its overall security posture.
       audit: |
-        ### Audit via Finder
-
-        1. Open **Finder**.
-        2. Select **Go**, then **AirDrop**.
-        3. Review the **Allow me to be discovered by** setting.
-
-        A passing result shows **No One** selected. A failing result shows **Contacts Only** or **Everyone**.
-
-        ### Audit via CLI
+        Verify that AirDrop is turned off from the macOS shell. The **Allow me to be discovered by** control in Finder and the **AirDrop** control in **System Settings** set discoverability only, so neither answers this question.
 
         1. Open the **Terminal** app.
         2. Read the AirDrop preference for the logged-in user:
@@ -2237,7 +2260,13 @@ queries:
            defaults read com.apple.NetworkBrowser DisableAirDrop
            ```
 
-        A passing result returns `1`. A failing result returns `0` or reports that the key does not exist.
+        3. On a managed Mac, read the restriction delivered by a configuration profile instead:
+
+           ```bash
+           defaults read /Library/Managed\ Preferences/com.apple.applicationaccess allowAirDrop
+           ```
+
+        A passing result returns `1` for `DisableAirDrop`, or `0` for `allowAirDrop`. A failing result returns `0` for `DisableAirDrop`, or reports that neither key exists.
       remediation:
         - id: cli
           desc: |
@@ -2264,10 +2293,7 @@ queries:
           desc: |
             **Using the GUI**
 
-            1. Open **Finder**
-            2. Select **Go**
-            3. Select **AirDrop**
-            4. Set **Allow me to be discovered by:** to **No One**
+            macOS provides no graphical control for the preference that turns AirDrop off. The **Allow me to be discovered by** control in Finder and the **AirDrop** control in **System Settings** under **General**, **AirDrop & Handoff** change discoverability only. They leave AirDrop itself available and do not resolve this finding. Use the CLI command above, or deploy a configuration profile with the `com.apple.applicationaccess` payload that sets `allowAirDrop` to false.
 
             **Impact:**
 
@@ -2649,7 +2675,13 @@ queries:
           desc: |
             **Using the CLI**
 
-            Edit the `/etc/security/audit_control` file to set the audit retention length. The `expire-after` parameter controls how long audit logs are retained.
+            On macOS 14 and later no `/etc/security/audit_control` is installed until you provision one, so create it from the template Apple ships before editing it:
+
+            ```bash
+            sudo cp -n /etc/security/audit_control.example /etc/security/audit_control
+            ```
+
+            The `cp -n` form leaves an existing configuration file untouched. Then edit the file to set the audit retention length. The `expire-after` parameter controls how long audit logs are retained.
 
             ```bash
             sudo vi /etc/security/audit_control
@@ -2682,7 +2714,7 @@ queries:
           desc: |
             **Using Ansible**
 
-            To set the audit retention length using Ansible, you can use the following playbook:
+            To set the audit retention length using Ansible, you can use the following playbook. The first task provisions the configuration file that macOS 14 and later no longer install, because `lineinfile` fails outright on a path that does not exist:
 
             ```yaml
             ---
@@ -2690,6 +2722,15 @@ queries:
               hosts: all
               become: true
               tasks:
+                - name: Provision the audit configuration file if it is missing
+                  ansible.builtin.copy:
+                    src: /etc/security/audit_control.example
+                    dest: /etc/security/audit_control
+                    remote_src: true
+                    force: false
+                    owner: root
+                    group: wheel
+                    mode: '0600'
                 - name: Set audit retention to 60 days
                   ansible.builtin.lineinfile:
                     path: /etc/security/audit_control
@@ -2757,13 +2798,19 @@ queries:
         Verify the maximum password age from the macOS shell.
 
         1. Open the **Terminal** app.
-        2. Read the global password policy:
+        2. Read the account policies, which is where macOS records a policy delivered by a configuration profile:
+
+           ```bash
+           pwpolicy -getaccountpolicies
+           ```
+
+        3. Read the legacy global policy, which still applies on hosts configured before account policies replaced it:
 
            ```bash
            pwpolicy -n /Local/Default -getglobalpolicy
            ```
 
-        A passing result shows `maxMinutesUntilChangePassword` set to `525600` (365 days) or fewer minutes. A failing result shows a larger value or no expiration policy.
+        A passing result shows a `policyCategoryPasswordChange` entry expiring the password after 365 days or fewer, or `maxMinutesUntilChangePassword` set to `525600` minutes or fewer. A failing result shows a longer interval or no expiration policy at all. Apple marks the global policy commands deprecated, so on a Mac whose policy arrives by configuration profile the legacy command prints nothing and only the account policies show the setting.
       remediation:
         - id: cli
           desc: |
@@ -2780,6 +2827,8 @@ queries:
             ```bash
             sudo pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=43200"
             ```
+
+            Apple marks `-setglobalpolicy` deprecated in favor of account policies. On a managed Mac, deploy an MDM passcode configuration profile that sets `maxPINAgeInDays` to 365 or less, which is the form macOS records and reports through `pwpolicy -getaccountpolicies`.
 
             **Impact:**
 
@@ -2867,13 +2916,19 @@ queries:
         Verify the password history depth from the macOS shell.
 
         1. Open the **Terminal** app.
-        2. Read the global password policy:
+        2. Read the account policies, which is where macOS records a policy delivered by a configuration profile:
+
+           ```bash
+           pwpolicy -getaccountpolicies
+           ```
+
+        3. Read the legacy global policy, which still applies on hosts configured before account policies replaced it:
 
            ```bash
            pwpolicy -n /Local/Default -getglobalpolicy
            ```
 
-        A passing result shows `usingHistory` set to `15` or greater. A failing result shows a smaller value or no history policy.
+        A passing result shows a `policyCategoryPasswordContent` entry with a history depth of 15 or greater, or `usingHistory` set to `15` or greater. A failing result shows a smaller value or no history policy. Apple marks the global policy commands deprecated, so on a Mac whose policy arrives by configuration profile the legacy command prints nothing and only the account policies show the setting.
       remediation:
         - id: cli
           desc: |
@@ -2890,6 +2945,8 @@ queries:
             ```bash
             sudo pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=15"
             ```
+
+            Apple marks `-setglobalpolicy` deprecated in favor of account policies. On a managed Mac, deploy an MDM passcode configuration profile that sets `pinHistory` to 15 or more, which is the form macOS records and reports through `pwpolicy -getaccountpolicies`.
 
             **Impact:**
 
@@ -3163,13 +3220,19 @@ queries:
         Verify the minimum password length from the macOS shell.
 
         1. Open the **Terminal** app.
-        2. Read the global password policy:
+        2. Read the account policies, which is where macOS records a policy delivered by a configuration profile:
+
+           ```bash
+           pwpolicy -getaccountpolicies
+           ```
+
+        3. Read the legacy global policy, which still applies on hosts configured before account policies replaced it:
 
            ```bash
            pwpolicy -n /Local/Default -getglobalpolicy
            ```
 
-        A passing result shows `minChars` set to `15` or greater. A failing result shows a smaller value or no minimum length policy.
+        A passing result shows a `policyCategoryPasswordContent` entry with a `minimumLength` of 15 or greater, or `minChars` set to `15` or greater. A failing result shows a smaller value or no minimum length policy. Apple marks the global policy commands deprecated, so on a Mac whose policy arrives by configuration profile the legacy command prints nothing and only the account policies show the setting.
       remediation:
         - id: cli
           desc: |
@@ -3181,11 +3244,13 @@ queries:
             sudo pwpolicy -n /Local/Default -setglobalpolicy "minChars=15"
             ```
 
+            Apple marks `-setglobalpolicy` deprecated in favor of account policies. On a managed Mac, deploy an MDM passcode configuration profile that sets `minLength` to 15 or more, which is the form macOS records and reports through `pwpolicy -getaccountpolicies`.
+
             **Impact:**
 
             Enforcing a minimum password length may inconvenience users accustomed to shorter passwords. However, the security benefits outweigh the potential inconvenience, especially in environments handling sensitive data.
 
-            **Note:** This setting cannot be configured through the System Preferences GUI. Use the CLI command above or deploy an MDM configuration profile to enforce minimum password length policies.
+            **Note:** This setting cannot be configured through System Settings. Use the CLI command above or deploy an MDM configuration profile to enforce minimum password length policies.
         - id: ansible
           desc: |
             **Using Ansible**


### PR DESCRIPTION
## What this is

A remediation audit of every `remediation:` block in `content/mondoo-macos-security.mql.yaml` — 96 blocks across 34 checks. Everything below was verified against Apple's own tooling on a real Mac (macOS 26.5.2, build 25F84), against the mql provider source that backs each check, or both. Candidates that verified as correct were dropped and are listed at the end.

No `version:` bump.

---

## Defect 1 — AirDrop: the GUI remediation changes a different preference than the check reads

**What the check reads.** `mondoo-macos-security-ensure-airdrop-is-disabled` passes on one of three things: the per-user `com.apple.NetworkBrowser` key `DisableAirDrop`, the MDM restriction `com.apple.applicationaccess` / `allowAirDrop == false`, or the managed `/Library/Managed Preferences/com.apple.NetworkBrowser.plist` form of the same key.

**What the GUI block told operators to do.** Open Finder, Go, AirDrop, and set **Allow me to be discovered by** to **No One**.

That control is AirDrop *discoverability*. It is not `DisableAirDrop`, and nothing in the graphical path writes `DisableAirDrop`. macOS 26 drives that pane from `AirDropHandoffExtension.appex`, and the only preference symbols in it are the discoverability ones:

```
$ strings /System/Library/ExtensionKit/Extensions/AirDropHandoffExtension.appex/Contents/MacOS/AirDropHandoffExtension \
    | grep -i -E "DiscoverableMode|DisableAirDrop|NetworkBrowser"
discoverableMode
setDiscoverableMode:
SFAirDropDiscoverableMode
```

No `DisableAirDrop`, no `com.apple.NetworkBrowser`. The only binary on the system that references both is `sharingd`, the daemon that consumes the key:

```
$ strings /usr/libexec/sharingd | grep -x -E "DisableAirDrop|com.apple.NetworkBrowser"
com.apple.NetworkBrowser
DisableAirDrop
```

So an operator who follows the GUI remediation changes discoverability, leaves AirDrop itself available, and the check still fails. The console path was also stale: on macOS 13 and later the discoverability control lives in System Settings under General, AirDrop & Handoff, not only in Finder.

**Fix.** The `gui` block now uses the "no graphical control" form already used elsewhere in this file for Bonjour advertising, firewall logging, NFS, and password policy: it names the discoverability control explicitly, says why it does not resolve the finding, and points at the CLI command or a `com.apple.applicationaccess` profile setting `allowAirDrop` to false. The `audit:` block was carrying the same wrong claim and is corrected alongside it, with the managed-preferences read added so an auditor on a managed Mac can see the setting the check evaluates.

---

## Defect 2 — Security auditing: the remediation does not enable auditing on macOS 14 or later

`mondoo-macos-security-enable-security-auditing` asserts `service('com.apple.auditd').enabled == true`. The remediation was:

```bash
sudo launchctl enable system/com.apple.auditd
sudo launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.auditd.plist
```

Apple's own man page states what is actually required, and it is three steps, not two:

```
$ man audit
DEPRECATION NOTICE
     The audit(4) subsystem has been deprecated since macOS 11.0, disabled
     since macOS 14.0, and WILL BE REMOVED in a future version of macOS.
     ...
     On this version of macOS, you can re-enable audit(4) by renaming or
     copying /etc/security/audit_control.example to
     /etc/security/audit_control, re-enabling the system/com.apple.auditd
     service by running launchctl enable system/com.apple.auditd as root, and
     rebooting.
```

The remediation omitted the `audit_control` provisioning and the reboot. Without a configuration file `auditd` has nothing to read, and it reads it only at startup, so `bootstrap` on its own does not leave the check passing.

**Fix.** The CLI block now leads with the macOS 14-and-later procedure (`cp -n` from `audit_control.example`, `launchctl enable`, then restart), keeps the in-place `bootstrap` form for macOS 13 and earlier, and states that the restart is what makes the change take effect. `cp -n` is the right verb here and is real on macOS:

```
$ man cp
     -n    Do not overwrite an existing file.  (The -n option overrides any
           previous -f or -i options.)
```

The Ansible playbook gains a matching `ansible.builtin.copy` task with `remote_src: true` and `force: false`, followed by `ansible.builtin.reboot`.

---

## Defect 3 — Audit retention: both remediation paths edit a file they never establish exists

`mondoo-macos-security-ensure-security-auditing-retention` reads `expire-after` out of `/etc/security/audit_control`. The remediation opened that path in `vi`, offered a `sed -i ''` one-liner as the scripted alternative, and the Ansible playbook drove `ansible.builtin.lineinfile` at it directly.

Same oracle as Defect 2: on macOS 14 and later Apple ships only `audit_control.example`, and the file the remediation edits does not exist until someone provisions it. `sed -i ''` on a missing path fails, and `lineinfile` without `create: true` fails with a "destination does not exist" error rather than creating the file. This is the "a step reads a file no earlier step produced" case.

**Fix.** Both paths now provision the file from Apple's template first — `sudo cp -n /etc/security/audit_control.example /etc/security/audit_control` in the CLI block, and a `force: false` copy task ahead of the `lineinfile` task in the playbook. The copy sets `0600 root:wheel`, which is also what the sibling check `mondoo-macos-security-control-access-to-audit-records` requires of that file, so the two remediations no longer fight each other.

---

## Defect 4 — FileVault: the Ansible playbook fetches a recovery key that does not exist yet, then deletes the path

The playbook ran three tasks in one play: `fdesetup enable -defer /var/db/filevault-recovery.plist`, then `ansible.builtin.fetch` of that path, then `ansible.builtin.file: state: absent` of that path.

`fdesetup` does not write the plist when the deferred-enable command runs. From the man page:

```
$ man fdesetup
DEFERRED ENABLEMENT
     The -defer option can be used with the enable command option to delay
     enabling FileVault until after the current (or next) local user logs in
     or out ...
     As recovery key information is not generated until the user password is
     obtained, the -defer option requires a path where this information will
     be written to.
```

So on the run that configures deferral, the fetch executes seconds later against a path that does not exist and fails on every host. The removal task then targets the escrow file unconditionally — on a host where enablement completed between runs but the fetch had already errored out, that deletes the only copy of the recovery key.

**Fix.** The playbook is split into the configuration play and a separate collection play run after users have logged out, with an `ansible.builtin.stat` register guarding both the fetch and the removal. The prose explains why the collection is a second pass rather than the next task.

---

## Defect 5 — Firewall stealth mode: the audit quotes strings the getter does not print

`mondoo-macos-security-enable-firewall-stealth-mode` told auditors that `socketfilterfw --getstealthmode` reports `Stealth mode enabled` or `Stealth mode disabled`. It does not:

```
$ /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
Firewall stealth mode is on
```

Both string families exist in the binary, but `Stealth mode enabled ` / `Stealth mode disabled ` are the confirmation output of `--setstealthmode`, while the getter uses the `Firewall stealth mode is %s` format:

```
$ strings /usr/libexec/ApplicationFirewall/socketfilterfw | grep -i "stealth mode"
...
Firewall stealth mode is %s
...
Stealth mode disabled
Stealth mode enabled
```

**Fix.** The audit now quotes the getter's actual output.

---

## Defect 6 — Password policy: the audit reads a deprecated command that shows nothing on a managed Mac

The three password checks (`password-age`, `password-history`, `set-a-minimum-password-length`) all read `macos.globalAccountPolicies`, which the provider implements as:

```go
// providers/os/resources/macos.go
cmd, err := conn.RunCommand("pwpolicy -getaccountpolicies")
```

Their `audit:` blocks told auditors to run `pwpolicy -n /Local/Default -getglobalpolicy` instead. Apple marks that command deprecated:

```
$ man pwpolicy
   Commands
     -getglobalpolicy             Get global policies.  DEPRECATED.
     -setglobalpolicy             Set global policies.  DEPRECATED.
```

and on a Mac whose password policy arrives by configuration profile the deprecated getter prints nothing while the account policies show the live setting:

```
$ pwpolicy -n /Local/Default -getglobalpolicy
                                    # no output

$ pwpolicy -getaccountpolicies
Getting global account policies
...
        <key>policyCategoryPasswordChange</key>
        <array>
                <dict>
                        <key>policyIdentifier</key>
                        <string>ProfilePayload:...:maxPINAgeInDays</string>
                        <key>policyParameters</key>
                        <dict>
                                <key>policyAttributeExpiresEveryNDays</key>
                                <integer>365</integer>
                        </dict>
                </dict>
        </array>
```

An auditor following the documented steps therefore cannot see the policy the check evaluates.

**Fix.** Each of the three `audit:` blocks now reads `pwpolicy -getaccountpolicies` first and keeps the legacy getter as the secondary step for hosts configured before account policies replaced it, and says which one applies where. Each `cli` remediation gains a sentence noting that `-setglobalpolicy` is deprecated and naming the MDM passcode-profile key that lands in account policies. The `-setglobalpolicy` commands themselves are left in place: I could not test whether macOS still translates them into account policies without changing this machine's password policy, so under the "verify, never guess" rule they are documented as deprecated rather than removed. A parenthetical aside in the password-age audit was rewritten at the same time, per `content/CLAUDE.md`.

---

## Checked and found correct

Every CLI invocation in the file was resolved against the tool that owns it on macOS 26.5.2. These looked like candidates and verified as correct, so they were dropped:

- **`systemsetup -f -setremotelogin off`** — the `-f` flag looked invented; the binary documents it verbatim: `Use "systemsetup -f -setremotelogin off" to suppress prompting when turning remote login off. Requires Full Disk Access privileges.` The Full Disk Access caveat in the remediation is also the binary's own wording.
- **`systemsetup -setremoteappleevents off`** — present in the binary's command table (`-setremoteappleevents` → `setRemoteAppleEvents:`), and Remote Apple Events is still a Sharing pane entry on macOS 26 (`Sharing.appex` carries `Remote Apple Events On`/`Off`), so the GUI path is current too.
- **`spctl --global-enable`** — absent from `spctl`'s printed usage, which now advertises only `--global-disable | --disable-status`. The symbol is still in the binary (`global-enable`, `master-enable`), and running it returns `Operation not permitted`, which is exactly the Sequoia restriction the remediation already warns about and already routes around with a configuration profile. Correct as written.
- **`AssetCacheManagerUtil deactivate`** and `status` — both in the binary's verb list.
- **`nfsd disable`** — `usage: nfsd ... commands: enable, disable, start, stop, restart, update, status, checkexports, verbose`.
- **`cupsctl --no-share-printers`** — `--[no-]share-printers   Turn printer sharing on/off`.
- **`socketfilterfw --setglobalstate/--setstealthmode/--setloggingmode/--setblockall`** — all real. `--getblockall`'s quoted output (`Firewall has block all state set to disabled.`) matches the live run exactly; `--getglobalstate`'s (`Firewall is enabled.`) matches modulo the trailing `(State = 1)`.
- **`softwareupdate -i -a` with `-R`** — `-R | --restart  Automatically restart (or shut down) if required to complete installation.`
- **`fdesetup enable -defer file_path`** — real option, correctly described. Only the playbook's task ordering was wrong.
- **`dsenableroot -d`** — matches the man page synopsis and the described prompt behavior; the Ansible `expect` treatment of that prompt is appropriate.
- **`defaults write ... com.apple.nat NAT -dict Enabled -int 0`** — the nested `-int` inside `-dict` looked like it would be taken literally. It is not; the value is written as a typed integer:
  ```
  $ defaults write /tmp/nattest.plist NAT -dict Enabled -int 0
  $ plutil -convert xml1 -o - /tmp/nattest.plist
      <key>NAT</key>
      <dict>
              <key>Enabled</key>
              <integer>0</integer>
      </dict>
  ```
- **Install-log retention Ansible regex** — `'(^\* file .*)ttl=\d+(\s*)$'` matches the shipped file, whose single directive line is `* file /var/log/install.log format='...' rotate=seq compress file_max=50M size_only ttl=365`.
- **Bonjour, content caching, media sharing, Wi-Fi menu bar, software update `defaults` keys** — each remediation writes the same domain and key its check reads.
- **Sudo timeout** — `Defaults timestamp_timeout=0` via `visudo`, and the `lineinfile` task's `validate: 'visudo -cf %s'`, both match what `sudoers.defaults.where(parameter == "timestamp_timeout")` evaluates.
- **`Directory Utility` GUI path** — `/System/Library/CoreServices/Applications/Directory Utility.app` still exists on macOS 26.
- **Guard chains and `.all()` shapes** in the MQL were read but not flagged; none of them are the precedence false positive.

## Validation

```
$ cnspec policy lint ./content/mondoo-macos-security.mql.yaml
→ valid policy bundle(s)

$ python3 content/validation/remediation/code/ansible.py macos
36 passed, 0 failed

$ python3 content/validation/remediation/code/bash.py all
3556 passed, 0 failed
```

There is no macOS grammar validator under `content/validation/remediation/commands/`, which is why every CLI claim above was resolved against the binary or man page directly.
