### PR TITLE
🐛 github: fix remediation defects in the GitHub and GitLab policies

### DIFF
--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -137,7 +137,7 @@ queries:
             )"
             ```
 
-            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
+            The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project
         title: Adding support resources to your project
@@ -226,7 +226,7 @@ queries:
             )"
             ```
 
-            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
+            The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project
         title: Adding a CODE_OF_CONDUCT.md to your project
@@ -289,7 +289,7 @@ queries:
             gh repo edit OWNER/REPO --description "A brief description of the repository"
             ```
     refs:
-      - url: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-repositories
+      - url: https://docs.github.com/en/repositories/creating-and-managing-repositories/about-repositories
         title: About repositories
   - uid: mondoo-github-repository-best-practices-gitignore
     title: Ensure repository has a .gitignore file
@@ -373,7 +373,7 @@ queries:
               -f content="$(gh api /gitignore/templates/Go --jq '.source' | base64 | tr -d '\n')"
             ```
 
-            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
+            The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
       - url: https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
         title: Ignoring files
@@ -457,7 +457,7 @@ queries:
               -f content="$(printf '%s' "$NEW_CONTENT" | base64 | tr -d '\n')"
             ```
 
-            Use `printf '%s'` rather than `echo` so README content containing backticks, `$`, or backslashes (common in code fences) is preserved instead of being interpreted by the shell. The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns; the GitHub contents API rejects base64 content that contains newlines.
+            Use `printf '%s'` rather than `echo` so backticks, `$`, and backslashes in the README are preserved instead of being interpreted by the shell. Code fences make those characters common. The `tr -d '\n'` step keeps the encoded value on a single line, because GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns.
         # No Terraform remediation: the fix appends an authors section to an existing README.md, and github_repository_file would overwrite the entire file with static content.
     refs:
       - url: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
@@ -536,7 +536,7 @@ queries:
             )"
             ```
 
-            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
+            The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
       - url: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
         title: About READMEs
@@ -618,7 +618,7 @@ queries:
 
             Replace the placeholder steps with real installation and usage instructions for your project.
 
-            Use `printf '%s'` rather than `echo` so README content containing backticks, `$`, or backslashes (common in code fences) is preserved instead of being interpreted by the shell. The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns; the GitHub contents API rejects base64 content that contains newlines.
+            Use `printf '%s'` rather than `echo` so backticks, `$`, and backslashes in the README are preserved instead of being interpreted by the shell. Code fences make those characters common. The `tr -d '\n'` step keeps the encoded value on a single line, because GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns.
         # No Terraform remediation: the fix appends a getting started section to an existing README.md, and github_repository_file would overwrite the entire file with static content.
     refs:
       - url: https://docs.github.com/en/repositories/creating-and-managing-repositories/best-practices-for-repositories
@@ -709,7 +709,7 @@ queries:
               -f content="$(gh api /licenses/apache-2.0 --jq '.body' | base64 | tr -d '\n')"
             ```
 
-            The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.
+            The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
       - url: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository
         title: Adding a license to a repository

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -211,7 +211,7 @@ queries:
 
             Warning: When you require two-factor authentication, members, outside collaborators, and billing managers who have not enabled two-factor authentication are removed from the organization. Confirm your own account has two-factor authentication enabled and notify affected users before turning on enforcement.
 
-            For more details, see [Enforcing two-factor authentication for your organization](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/enforcing-two-factor-authentication-for-your-organization) in the GitHub documentation.
+            For more details, see [Requiring two-factor authentication in your organization](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/requiring-two-factor-authentication-in-your-organization) in the GitHub documentation.
         # No Terraform remediation: github_organization_settings has no two-factor-enforcement argument. Earlier versions of this remediation referenced `enforce_two_factor_authentication`, which is not a real argument and would fail terraform plan with "Unsupported argument".
         # No CLI remediation: the update-an-organization endpoint (PATCH /orgs/{org}) does not accept a two_factor_requirement_enabled parameter; the field is read-only in the REST API. Two-factor enforcement can only be enabled by an owner in the web UI.
     refs:
@@ -349,7 +349,7 @@ queries:
         2. Go to **Settings** > **Member privileges**.
         3. Review the "Base permissions" setting.
 
-        If base permissions are set to "Read" (or a more restrictive value), the check passes. If they are set to "Write," "Admin," or "No permission" as a misconfiguration, the check fails.
+        If base permissions are set to "Read," the check passes. If they are set to "No permission," "Write," or "Admin," the check fails.
 
         ### Audit via CLI
 
@@ -802,7 +802,7 @@ queries:
               -F "restrictions=null"
             ```
     refs:
-      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule
+      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
         title: GitHub Branch Protection Rules
   - uid: mondoo-github-repository-security-prevent-force-pushes-default-branch
     title: Ensure repository does not allow force pushes to the default branch
@@ -1927,7 +1927,7 @@ queries:
             2. Define the configuration for Dependabot, including the package ecosystems and update schedule.
             3. Save the changes.
 
-            For more details, see [Configuring Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-up-to-date-automatically/configuration-options-for-dependency-updates) in the GitHub documentation.
+            For more details, see [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1969,8 +1969,8 @@ queries:
     refs:
       - url: https://docs.github.com/en/code-security
         title: GitHub Code Security
-      - url: https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/configuring-dependabot-auto-triage-rules
-        title: Configuring Dependabot auto-triage rules
+      - url: https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules
+        title: About Dependabot auto-triage rules
   - uid: mondoo-github-organization-security-fork-private-repos
     title: Ensure organization members cannot fork private repositories
     impact: 80
@@ -3187,7 +3187,7 @@ queries:
             3. Review each open alert and take action:
                - **Fix the vulnerability**: Implement the suggested fix and push the change.
                - **Dismiss false positives**: If the alert is a false positive, dismiss it with a reason.
-            4. For repositories without code scanning, enable it via **Settings** > **Code security and analysis** > **Code scanning**.
+            4. For repositories without code scanning, go to **Settings**. In the sidebar under "Security," click **Advanced Security**, then set up CodeQL analysis under "Code Security."
 
             For more details, see [Managing code scanning alerts](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/managing-code-scanning-alerts-for-your-repository) in the GitHub documentation.
         - id: cli
@@ -3283,7 +3283,7 @@ queries:
                - If a patched version is available, update the dependency in your manifest file.
                - If Dependabot security updates are enabled, review and merge the suggested pull request.
                - If the alert is a false positive, dismiss it with documented justification.
-            5. Ensure Dependabot alerts are enabled via **Settings** > **Code security and analysis**.
+            5. Ensure Dependabot alerts are enabled. Go to **Settings**, and in the sidebar under "Security," click **Advanced Security**.
 
             For more details, see [Viewing and updating Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts) in the GitHub documentation.
         - id: cli
@@ -3399,7 +3399,7 @@ queries:
               5. Under that option, check **Require approvals** and set the required number of approvals to at least 1.
               6. Click **Save changes**.
 
-            For more details, see [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
+            For more details, see [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) and [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3430,9 +3430,9 @@ queries:
               -F "restrictions=null"
             ```
     refs:
-      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule
+      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
         title: Managing a branch protection rule
-      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/about-protected-branches
+      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
         title: About protected branches
   - uid: mondoo-github-repository-security-require-pull-request-reviews-github
     filters: asset.platform == "github-repo"
@@ -3580,9 +3580,9 @@ queries:
               -F "restrictions=null"
             ```
     refs:
-      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule
+      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
         title: Managing a branch protection rule
-      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/about-protected-branches
+      - url: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
         title: About protected branches
   - uid: mondoo-github-repository-security-block-creations-default-branch-github
     filters: asset.platform == "github-repo"
@@ -4055,8 +4055,8 @@ queries:
             3. Choose a streaming destination and provide its connection details.
             4. Use **Check endpoint** to verify connectivity, then enable the stream.
 
-            For more details, see [Streaming the audit log for your organization](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/streaming-the-audit-log-for-your-organization) in the GitHub documentation.
+            For more details, see [Streaming the audit log](https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise) in the GitHub documentation.
         # No Terraform remediation: the GitHub Terraform provider exposes no resource for organization audit-log streaming; it is managed only via the GitHub UI and the audit-log-streams REST API.
     refs:
-      - url: https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/streaming-the-audit-log-for-your-organization
-        title: Streaming the audit log for your organization
+      - url: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise
+        title: Streaming the audit log

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -694,7 +694,7 @@ queries:
 
             To require merge request approvals using the `glab` CLI:
 
-            Create an approval rule that requires at least one approval. The rule-based approval API is the supported way to set the requirement, because the project-level `approvals_before_merge` field on the `/approvals` endpoint is read-only and no longer accepts updates:
+            Create an approval rule that requires at least one approval. The rule-based approval API is the supported way to set the requirement. The project-level `approvals_before_merge` attribute on the `/approvals` endpoint still exists, but GitLab deprecated it in 12.3 and directs callers to approval rules instead:
 
             ```bash
             glab api --method POST projects/PROJECT_ID/approval_rules \
@@ -1195,7 +1195,7 @@ queries:
             4. For the default branch, ensure **Allowed to force push** is disabled.
             5. Click **Protect** or **Save changes**.
 
-            For more details, see [Protected branches](https://docs.gitlab.com/user/project/protected_branches.html).
+            For more details, see [Protected branches](https://docs.gitlab.com/user/project/repository/branches/protected/).
         - id: cli
           desc: |
             To disable force push on the default branch using the `glab` CLI:
@@ -1357,8 +1357,8 @@ queries:
 
             For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project).
     refs:
-      - url: https://docs.gitlab.com/ci/security/
-        title: GitLab CI/CD Security
+      - url: https://docs.gitlab.com/user/application_security/
+        title: GitLab Application Security
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
   - uid: mondoo-gitlab-security-pipeline-must-succeed-gitlab
@@ -2563,10 +2563,10 @@ queries:
         Query the security settings with the `glab` CLI:
 
         ```bash
-        glab api projects/PROJECT_ID/security_settings | jq '.pre_receive_secret_detection_enabled'
+        glab api projects/PROJECT_ID/security_settings | jq '.secret_push_protection_enabled'
         ```
 
-        A passing project returns `true`. A failing project returns `false`.
+        A passing project returns `true`. A failing project returns `false`. On GitLab instances older than 17.11 the field is named `pre_receive_secret_detection_enabled`.
       remediation:
         - id: gitlab
           desc: |
@@ -2587,8 +2587,10 @@ queries:
 
             ```bash
             glab api --method PUT projects/PROJECT_ID/security_settings \
-              -f pre_receive_secret_detection_enabled=true
+              -f secret_push_protection_enabled=true
             ```
+
+            GitLab renamed this attribute from `pre_receive_secret_detection_enabled` in 17.11. Use the old name on instances older than that.
 
             For more details, see the [Project security settings API](https://docs.gitlab.com/api/project_security_settings.html).
         - id: terraform


### PR DESCRIPTION
Audit of every `remediation:` and `audit:` block in `mondoo-github-security.mql.yaml`, `mondoo-github-best-practices.mql.yaml`, and `mondoo-gitlab-security.mql.yaml`. Each finding below was confirmed against an authoritative oracle before it was filed; the last section lists the candidates that verified as *correct* and were dropped.

No `version:` bumps. No MQL changed — the diff is prose, CLI attribute names, and URLs.

---

## 1. The base64 note in the best-practices policy is wrong on both counts

Six remediation blocks in `mondoo-github-best-practices.mql.yaml` carried this explanation:

> The `tr -d '\n'` step strips the line breaks that BSD or macOS `base64` inserts every 76 columns. The GitHub contents API rejects base64 content that contains newlines, so without it the command fails on macOS.

**Claim A — "BSD or macOS `base64` inserts line breaks every 76 columns" — is backwards.** BSD `base64` emits one line unless you ask it not to:

```
$ python3 -c "print('a'*5000,end='')" | base64 | wc -l
       1
$ base64 --help
Usage:	base64 [-Ddh] [-b num] [-i in_file] [-o out_file]
  -b, --break       break encoded output up into lines of length num
```

The implementation that wraps is GNU coreutils, the default on most Linux distributions. From the coreutils manual for `-w`/`--wrap`:

> During encoding, wrap lines after cols characters. This must be a positive number. The default is to wrap after 76 characters. Use the value 0 to disable line wrapping altogether.

So the note told the reader who actually needs `tr` (Linux) that they don't, and the reader who doesn't (macOS) that the command fails without it.

**Claim B — "The GitHub contents API rejects base64 content that contains newlines" — is false.** Verified against the live API. First, the same bytes encoded wrapped and unwrapped produce the *same* blob SHA, so the decoder tolerates the newlines:

```
POST /repos/.../git/blobs  clean   -> {"sha":"7acfaa61995c6b414befc0b534f93199e0f2ecfe"}
POST /repos/.../git/blobs  wrapped -> {"sha":"7acfaa61995c6b414befc0b534f93199e0f2ecfe"}
```

Then the contents endpoint itself, with 76-column-wrapped base64, in a throwaway private repo that was deleted immediately afterward:

```
PUT /repos/.../contents/PROBE.md   rc=0
{"content":{"name":"PROBE.md","path":"PROBE.md","size":367, ...}}

$ gh api /repos/.../contents/PROBE.md --jq '.content' | base64 -d | head -3
# Security Policy

Report vulnerabilities to security@example.com
```

The 367-byte file round-tripped byte-identical.

**Fix.** The `| tr -d '\n'` pipeline itself is fine and stays; only the false justification is replaced with the verified one. This also removes a `(...)` aside that `content/CLAUDE.md` bans.

**Consequence for `mondoo-github-security.mql.yaml`:** three `base64` snippets there (org security policy, repo security policy, Dependabot config) have *no* `tr -d '\n'`. My first hypothesis was that they were broken. Claim B disproves it — they are correct as written, and I left them alone.

## 2. GitLab renamed the secret push protection attribute in 17.11

`mondoo-gitlab-security-secret-push-protection` read and wrote `pre_receive_secret_detection_enabled`. From `doc/api/project_security_settings.md` on `master`:

```
## Update the `secret_push_protection_enabled` setting
- [Renamed](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/185310) from `pre_receive_secret_detection_enabled` in GitLab 17.11.

PUT /projects/:id/security_settings

| `secret_push_protection_enabled` | boolean | Yes | Enables secret push protection for the project. |
```

The documented GET response body contains `secret_push_protection_enabled` and no longer contains the old name.

So the audit command read a key the API does not return (jq yields `null`, which the audit text reads as neither pass nor fail), and the remediation sent an attribute the endpoint does not accept while omitting the one it marks **required**. Both now use the current name, with a one-line note for instances older than 17.11.

The check's own MQL (`gitlab.project.preReceiveSecretDetectionEnabled`) is a provider field name, not an API attribute, and is untouched. The Terraform snippet's `pre_receive_secret_detection_enabled` is the provider's argument name and is confirmed present in the pinned schema, so it is untouched too.

## 3. The base-permissions audit contradicted its own check

`mondoo-github-organization-security-default-permission-level` audits with:

> If base permissions are set to "Read" (or a more restrictive value), the check passes. If they are set to "Write," "Admin," or "No permission" as a misconfiguration, the check fails.

The check is `github.organization.defaultRepositoryPermission == "read"`, so "No permission" (`none`) **fails**. The first sentence says it passes, the second says it fails. The CLI half of the same audit already said "If the command returns `read`, the check passes. If it returns any other value, the check fails."

Rewritten to match the check. The `(...)` aside goes with it.

## 4. Two repository-level remediation steps pointed at a settings page GitHub renamed

`no-open-code-scanning-alerts` step 4 and `no-open-critical-dependabot-alerts` step 5 both routed the reader to **Settings** > **Code security and analysis**. GitHub's current docs:

> "In the 'Security' section of the sidebar, click **Advanced Security**." — *Configuring default setup for code scanning*
> "In the "Security" section of the sidebar, click **Advanced Security**." — *Configuring Dependabot alerts*

This is also internally inconsistent: the eight org-level checks in the same file already describe "Code security and analysis" as the *legacy* page, and that framing is deliberate and correct, so those were left alone. Only the two repository-level steps presenting it as the current path were updated.

## 5. Ten dead documentation links

Every `https://` URL in the three files was swept with `curl -L -o /dev/null -w '%{http_code}'`. Ten resolved to something other than 200 (excluding `example.com` placeholders). Replacements were each verified to return 200, and for the two GitLab ones the source file was confirmed present or absent in `gitlab-org/gitlab` so a Cloudflare 403 could not be mistaken for a live page.

| Was | Now |
|---|---|
| `…/authentication/…-2fa/enforcing-two-factor-authentication-for-your-organization` (404) | `…/organizations/…/requiring-two-factor-authentication-in-your-organization` |
| `…/dependabot-auto-triage-rules/configuring-dependabot-auto-triage-rules` (404) | `…/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules` |
| `…/keeping-your-dependencies-up-to-date-automatically/configuration-options-for-dependency-updates` (404) | `…/dependabot/working-with-dependabot/dependabot-options-reference` |
| `…/managing-security-settings-for-your-organization/streaming-the-audit-log-for-your-organization` (404, ×2) | `…/admin/monitoring-activity-in-your-enterprise/…/streaming-the-audit-log-for-your-enterprise` |
| `…/managing-a-branch-protection-rule` and `…/managing-a-branch-protection-rule/{managing-a-branch-protection-rule,about-protected-branches}` (404, ×6) | `…/managing-protected-branches/…` |
| `…/customizing-your-repository/about-repositories` (404) | `…/creating-and-managing-repositories/about-repositories` |
| `https://docs.gitlab.com/user/project/protected_branches.html` (403) | `https://docs.gitlab.com/user/project/repository/branches/protected/` |
| `https://docs.gitlab.com/ci/security/` (403) | `https://docs.gitlab.com/user/application_security/` |

The org-level audit-log-streaming page no longer exists at all: `gh api /repos/github/docs/contents/content/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization` lists nine files and none of them is a streaming page, while `search/code` finds exactly one surviving `streaming-the-audit-log` document, the enterprise one. The console click-path in the check is unchanged.

For GitLab, `doc/user/project/protected_branches.md` and `doc/ci/security/{_index,index}.md` all return 404 from `gitlab-org/gitlab` raw on `master`, while `doc/user/project/repository/branches/protected.md` and `doc/user/application_security/_index.md` return 200.

## 6. `approvals_before_merge` is deprecated, not read-only

`mondoo-gitlab-security-approvals-required` justified the rule-based fix by asserting the field "is read-only and no longer accepts updates". `doc/api/merge_request_approvals.md` still lists it as a writable attribute of `POST /projects/:id/approvals`:

```
| `approvals_before_merge` (deprecated) | integer | No | The number of required approvals before a merge request can merge.
  [Deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/11132) in GitLab 12.3.
  [Create an approval rule](#create-an-approval-rule-for-a-project) instead.
  <!-- Do not remove line until field is actually removed --> |
```

The recommendation (use approval rules) is right; only the reason was wrong. Reworded to say deprecated, which is what the docs say.

---

## Checked and found correct

Candidates that looked wrong and verified out. These were **not** changed.

- **`base64` snippets in `mondoo-github-security.mql.yaml` without `tr -d '\n'`.** Disproven by the contents-API probe in §1. Correct as written.
- **"Click the **Security and quality** tab"** in both security-policy remediations. This reads like a stale tab name, but GitHub's *Adding a security policy to your repository* still says verbatim: "Under the repository name, click the **Security and quality** tab."
- **`gh api -F "required_status_checks[contexts][]=ci/build"`** and the other bracketed nested fields across seven branch-protection remediations. Verified by inspecting the request gh actually builds:
  ```
  {"enforce_admins": true,
   "required_pull_request_reviews": {"required_approving_review_count": 1},
   "required_status_checks": {"contexts": ["ci/build"], "strict": true},
   "restrictions": null}
  ```
  Exactly the shape the endpoint documents, including `-F ...=null` producing JSON `null` rather than the string.
- **`sha_pinning_required`** on `/repos/{owner}/{repo}/actions/permissions`. This is a 2025 feature and looked speculative. Live: `{"enabled":true,"allowed_actions":"all","sha_pinning_required":false}`. The UI label "Require actions to be pinned to a full-length commit SHA" under Settings > Actions > General is likewise current.
- **`PATCH /projects/:id/job_token_scope -f enabled=true`** paired with a check on `inbound_enabled`. The mismatched names suggested the remediation was toggling the outbound scope. GitLab's docs say `enabled` is the inbound control: "Restricts job token access to allowlisted projects only. Set to `false` to allow access from all projects."
- **The `projectSetContinuousVulnerabilityScanning` GraphQL mutation.** Confirmed by introspecting gitlab.com: the mutation exists, `ProjectSetContinuousVulnerabilityScanningInput` has `{clientMutationId, projectPath, enable}` and the payload has `{clientMutationId, continuousVulnerabilityScanningEnabled, errors}`, which is exactly the snippet.
- **Every Terraform argument in all 56 HCL snippets**, checked against `terraform providers schema -json` for the pinned `integrations/github ~> 6.0` and `gitlabhq/gitlab ~> 19.0`, and re-run through the repo's own validator: `30 passed, 0 failed` (github) and `26 passed, 0 failed` (gitlab). This covered the ones most likely to be invented — `github_actions_repository_permissions.sha_pinning_required`, `github_repository_environment.prevent_self_review`, `github_branch_protection.restrict_pushes.blocks_creations`, `required_status_checks.contexts` (still present in v6, not removed with the `checks` migration), and `gitlab_project.pre_receive_secret_detection_enabled`.
- **`continuous_vulnerability_scans_enabled`**, adjacent to the renamed field in §2, is still the current name in the documented GET response.
- **Alert dismissal enums** across the three alert checks: `resolution=revoked` (secret scanning), `dismissed_reason="won't fix"` (code scanning), `dismissed_reason="tolerable_risk"` (Dependabot). All valid for their respective endpoints.
- **The "legacy Code security and analysis" sentences** on the eight org-level checks. They are explicitly framed as the pre-security-configurations path and are accurate.

## Validation

```
cnspec policy lint ./content/mondoo-github-security.mql.yaml ./content/mondoo-github-best-practices.mql.yaml ./content/mondoo-gitlab-security.mql.yaml
  → valid policy bundle(s)

make test/content/lint                                      → valid policy bundle(s)
content/validation/remediation/code/terraform.py github     → 30 passed, 0 failed
content/validation/remediation/code/terraform.py gitlab     → 26 passed, 0 failed
content/validation/remediation/code/bash.py all             → no failures in these three policies
URL sweep over all three files                              → every non-placeholder URL returns 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
