### PR TITLE
🐛 k8s: fix remediation snippets that do not apply, parse, or satisfy their own check

### DIFF
--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -2111,7 +2111,7 @@ queries:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: examplePod
+          name: example-pod
           namespace: pod-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2156,7 +2156,7 @@ queries:
         apiVersion: apps/v1
         kind: DaemonSet
         metadata:
-          name: exampleDaemonSet
+          name: example-daemonset
           namespace: daemonset-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2201,7 +2201,7 @@ queries:
         apiVersion: apps/v1
         kind: ReplicaSet
         metadata:
-          name: exampleReplicaSet
+          name: example-replicaset
           namespace: replicaset-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2246,7 +2246,7 @@ queries:
         apiVersion: batch/v1
         kind: Job
         metadata:
-          name: exampleJob
+          name: example-job
           namespace: job-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2291,7 +2291,7 @@ queries:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: exampleDeployment
+          name: example-deployment
           namespace: deployment-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2336,7 +2336,7 @@ queries:
         apiVersion: apps/v1
         kind: StatefulSet
         metadata:
-          name: exampleStatefulset
+          name: example-statefulset
           namespace: statefulset-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2381,7 +2381,7 @@ queries:
         apiVersion: batch/v1
         kind: CronJob
         metadata:
-          name: exampleCronJob
+          name: example-cronjob
           namespace: cronjob-namespace # <--- Define a namespace for workloads
         ```
     refs:
@@ -2862,9 +2862,9 @@ queries:
         kubectl taint nodes <control-plane-node> node-role.kubernetes.io/control-plane:NoSchedule
         ```
 
-        Most Kubernetes distributions, including kubeadm, EKS, GKE, and AKS, apply this taint by default. If it has been removed, re-apply it and migrate any user workloads to worker nodes.
+        kubeadm applies this taint to every control plane node it bootstraps, so on a kubeadm-built cluster its absence means it was removed. Managed services such as EKS, GKE, and AKS run the control plane outside the cluster, so no control plane node appears in `kubectl get nodes` and there is nothing to taint. If the taint was removed, re-apply it and migrate any user workloads to worker nodes.
 
-        Adding the taint immediately evicts any running pods that do not tolerate it, so plan for a brief disruption to those workloads. Do not apply this on single-node clusters such as kind, minikube, or k3s. On a single node the control plane and your workloads share the same machine, and the taint would make everything unschedulable.
+        A `NoSchedule` taint keeps new pods off the node but leaves the ones already running there in place, so re-applying it does not by itself move existing workloads. Reschedule them by deleting them or by rolling their controller, and plan for a brief disruption when you do. Do not apply this on single-node clusters such as kind, minikube, or k3s. On a single node the control plane and your workloads share the same machine, and the taint would leave new pods unschedulable.
     refs:
       - url: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
         title: Kubernetes Taints and Tolerations

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -726,22 +726,31 @@ queries:
 
         By ensuring proper ownership and restrictive permissions on the kubelet configuration file, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
       audit: |
-        View the kubelet configuration file details:
+        The file evaluated here is the one the kubelet was started with, named by its `--config` argument and defaulting to `/var/lib/kubelet/config.yaml`. It is not `/etc/kubernetes/kubelet.conf`, which is the kubelet's kubeconfig.
 
-        ```console
-        $ ls -l /etc/kubernetes/kubelet.conf
-        -rw-r--r-- 1 root root 1155 Sep 21 15:03 /etc/kubernetes/kubelet.conf
-        ```
+        1. Confirm which file the running kubelet loaded:
+
+           ```bash
+           ps -ef | grep [k]ubelet | grep -o -- '--config=[^ ]*'
+           ```
+
+        2. Inspect its ownership and permissions:
+
+           ```bash
+           stat -c "%a %U:%G" /var/lib/kubelet/config.yaml
+           ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Update the ownership and permissions:
+            Update the ownership and permissions of the file named by the kubelet's `--config` argument. On kubeadm nodes that is `/var/lib/kubelet/config.yaml`:
 
             ```bash
-            chown root:root /etc/kubernetes/kubelet.conf
-            chmod 600 /etc/kubernetes/kubelet.conf
+            chown root:root /var/lib/kubelet/config.yaml
+            chmod 600 /var/lib/kubelet/config.yaml
             ```
         - id: ansible
           desc: |
@@ -756,7 +765,7 @@ queries:
               tasks:
                 - name: Ensure kubelet configuration file has correct ownership and permissions
                   ansible.builtin.file:
-                    path: /etc/kubernetes/kubelet.conf
+                    path: /var/lib/kubelet/config.yaml
                     owner: root
                     group: root
                     mode: '0600'
@@ -770,8 +779,8 @@ queries:
             set -e
 
             echo "Securing kubelet configuration file..."
-            chown root:root /etc/kubernetes/kubelet.conf
-            chmod 600 /etc/kubernetes/kubelet.conf
+            chown root:root /var/lib/kubelet/config.yaml
+            chmod 600 /var/lib/kubelet/config.yaml
             ```
     refs:
       - url: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
@@ -827,18 +836,27 @@ queries:
 
         By ensuring proper ownership and restrictive permissions on the kubelet's certificate authorities file, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
       audit: |
-        View the ownership and permissions:
+        The file evaluated here is the one named by `authentication.x509.clientCAFile` in the kubelet configuration, so read that path before inspecting anything. The path differs by distribution: kubeadm nodes use `/etc/kubernetes/pki/ca.crt` and GKE nodes use `/etc/srv/kubernetes/pki/ca-certificates.crt`.
 
-        ```console
-        $ ls -l /etc/srv/kubernetes/pki/ca-certificates.crt
-        -rw------- 1 root root 1159 Sep 13 04:14 /etc/srv/kubernetes/pki/ca-certificates.crt
-        ```
+        1. Read the configured path:
+
+           ```bash
+           awk '/x509:/{f=1} f && /clientCAFile:/{print $2; exit}' /var/lib/kubelet/config.yaml
+           ```
+
+        2. Inspect the ownership and permissions of that file:
+
+           ```bash
+           stat -c "%a %U:%G" /etc/srv/kubernetes/pki/ca-certificates.crt
+           ```
+
+        If the output is `600 root:root`, the check passes. If the permissions are more permissive than `600`, or the file is not owned by `root:root`, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using CLI**
 
-            Set the appropriate ownership and permissions:
+            Set the ownership and permissions on the file named by `authentication.x509.clientCAFile` in the kubelet configuration. The path below is the GKE default; substitute the path your node reports:
 
             ```bash
             chown root:root /etc/srv/kubernetes/pki/ca-certificates.crt
@@ -1597,17 +1615,20 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
             - name: vol
               hostPath:
-                - path: /var/run/docker.sock
+                path: /var/run/docker.sock
           containers:
             - name: app
               image: images.my-company.example/app:v1.2.3
@@ -1616,17 +1637,26 @@ queries:
                   name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+            - name: config
+              configMap:
+                name: app-config
+          containers:
+            - name: app
+              image: images.my-company.example/app:v1.2.3
+              volumeMounts:
+                - mountPath: /etc/app
+                  name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -1667,36 +1697,56 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: vol
+                      hostPath:
+                        path: /var/run/docker.sock
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /var/run/docker.sock
+                          name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: config
+                      configMap:
+                        name: app-config
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /etc/app
+                          name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -1734,36 +1784,52 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/docker.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/docker.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -1801,36 +1867,52 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/docker.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/docker.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -1868,36 +1950,52 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/docker.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/docker.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -1935,36 +2033,52 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/docker.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/docker.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2002,36 +2116,52 @@ queries:
 
         By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/docker.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/docker.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/docker.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/docker.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/docker.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2069,17 +2199,20 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
             - name: vol
               hostPath:
-                - path: /run/containerd/containerd.sock
+                path: /run/containerd/containerd.sock
           containers:
             - name: app
               image: images.my-company.example/app:v1.2.3
@@ -2088,17 +2221,26 @@ queries:
                   name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+            - name: config
+              configMap:
+                name: app-config
+          containers:
+            - name: app
+              image: images.my-company.example/app:v1.2.3
+              volumeMounts:
+                - mountPath: /etc/app
+                  name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2136,36 +2278,56 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: vol
+                      hostPath:
+                        path: /run/containerd/containerd.sock
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /run/containerd/containerd.sock
+                          name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: config
+                      configMap:
+                        name: app-config
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /etc/app
+                          name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2203,36 +2365,52 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /run/containerd/containerd.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /run/containerd/containerd.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2270,36 +2448,52 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /run/containerd/containerd.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /run/containerd/containerd.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2337,36 +2531,52 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /run/containerd/containerd.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /run/containerd/containerd.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2404,36 +2614,52 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /run/containerd/containerd.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /run/containerd/containerd.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2471,36 +2697,52 @@ queries:
 
         By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /run/containerd/containerd.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /run/containerd/containerd.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /run/containerd/containerd.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/run/containerd/containerd.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /run/containerd/containerd.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2538,17 +2780,20 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
             - name: vol
               hostPath:
-                - path: /var/run/crio/crio.sock
+                path: /var/run/crio/crio.sock
           containers:
             - name: app
               image: images.my-company.example/app:v1.2.3
@@ -2557,17 +2802,26 @@ queries:
                   name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
         apiVersion: v1
         kind: Pod
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
           volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+            - name: config
+              configMap:
+                name: app-config
+          containers:
+            - name: app
+              image: images.my-company.example/app:v1.2.3
+              volumeMounts:
+                - mountPath: /etc/app
+                  name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2605,36 +2859,56 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: vol
+                      hostPath:
+                        path: /var/run/crio/crio.sock
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /var/run/crio/crio.sock
+                          name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  volumes:
+                    - name: config
+                      configMap:
+                        name: app-config
+                  containers:
+                    - name: app
+                      image: images.my-company.example/app:v1.2.3
+                      volumeMounts:
+                        - mountPath: /etc/app
+                          name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2672,36 +2946,52 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/crio/crio.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/crio/crio.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2739,36 +3029,52 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/crio/crio.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/crio/crio.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2806,36 +3112,52 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/crio/crio.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/crio/crio.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2873,36 +3195,52 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/crio/crio.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/crio/crio.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: ReplicaSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -2940,36 +3278,52 @@ queries:
 
         By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
       audit: |
-        A pod `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
+        A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock
-          containers:
-            - name: app
-              image: images.my-company.example/app:v1.2.3
-              volumeMounts:
-                - mountPath: /var/run/crio/crio.sock
-                  name: vol
+          template:
+            spec:
+              volumes:
+                - name: vol
+                  hostPath:
+                    path: /var/run/crio/crio.sock
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /var/run/crio/crio.sock
+                      name: vol
         ```
       remediation: |
-        Remove any `hostPath` volume that mounts `/var/run/crio/crio.sock` from the pod's `volumes` list. The manifest below marks the entry that must be deleted:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
 
         ```yaml
         ---
-        apiVersion: v1
-        kind: Pod
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: example
+          namespace: example-namespace
         spec:
-          volumes:
-            - name: vol
-              hostPath:
-                - path: /var/run/crio/crio.sock  # <--- this shouldn't be there
+          template:
+            spec:
+              volumes:
+                - name: config
+                  configMap:
+                    name: app-config
+              containers:
+                - name: app
+                  image: images.my-company.example/app:v1.2.3
+                  volumeMounts:
+                    - mountPath: /etc/app
+                      name: config
         ```
     refs:
       - url: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
@@ -6759,7 +7113,7 @@ queries:
         metadata:
           name: example-app
         spec:
-          serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+          serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
           containers:
             - name: example-app
               image: index.docker.io/yournamespace/repository
@@ -6862,7 +7216,7 @@ queries:
             spec:
               template:
                 spec:
-                  serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+                  serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
                   containers:
                     - name: example-app
                       image: index.docker.io/yournamespace/repository
@@ -6963,7 +7317,7 @@ queries:
         spec:
           template:
             spec:
-              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
               containers:
                 - name: example-app
                   image: index.docker.io/yournamespace/repository
@@ -7062,7 +7416,7 @@ queries:
         spec:
           template:
             spec:
-              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
               containers:
                 - name: example-app
                   image: index.docker.io/yournamespace/repository
@@ -7161,7 +7515,7 @@ queries:
         spec:
           template:
             spec:
-              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
               containers:
                 - name: example-app
                   image: index.docker.io/yournamespace/repository
@@ -7260,7 +7614,7 @@ queries:
         spec:
           template:
             spec:
-              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
               containers:
                 - name: example-app
                   image: index.docker.io/yournamespace/repository
@@ -7359,7 +7713,7 @@ queries:
         spec:
           template:
             spec:
-              serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
+              serviceAccountName: some-account # <-- Set the name of the ServiceAccount created for the Pod
               containers:
                 - name: example-app
                   image: index.docker.io/yournamespace/repository
@@ -8988,7 +9342,7 @@ queries:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: examplePod
+          name: example-pod
           namespace: example-namespace
         spec:
           containers:
@@ -9577,7 +9931,7 @@ queries:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: examplePod
+          name: example-pod
           namespace: example-namespace
         spec:
           containers:
@@ -11009,17 +11363,19 @@ queries:
           name: example
           namespace: example-namespace
         spec:
-          template:
+          jobTemplate:
             spec:
-              containers:
-                - volumeMounts:
-                  - mountPath: /host
-                    name: hostpath-volume
-                    readOnly: true # <-- ensure readOnly is set to true
-              volumes:
-                - hostPath:
-                    path: /etc
-                  name: hostpath-volume
+              template:
+                spec:
+                  containers:
+                    - volumeMounts:
+                      - mountPath: /host
+                        name: hostpath-volume
+                        readOnly: true # <-- ensure readOnly is set to true
+                  volumes:
+                    - hostPath:
+                        path: /etc
+                      name: hostpath-volume
         ```
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/
@@ -11697,19 +12053,27 @@ queries:
 
         If the command returns no output, the check passes. If any PersistentVolume name is listed, that volume uses `hostPath` and the check fails.
       remediation: |
-        Replace hostPath PersistentVolumes with a proper storage backend:
+        Replace hostPath PersistentVolumes with a proper storage backend. A PersistentVolume that pins data to one node's filesystem looks like this:
 
         ```yaml
-        # Instead of:
+        ---
         apiVersion: v1
         kind: PersistentVolume
         metadata:
           name: example-pv
         spec:
+          capacity:
+            storage: 10Gi
+          accessModes:
+            - ReadWriteOnce
           hostPath:
             path: /data/app
+        ```
 
-        # Use a CSI driver or cloud storage:
+        Back the same volume with a CSI driver or cloud storage instead. Delete the hostPath PersistentVolume and apply the replacement, keeping the claim's capacity and access modes the same so the workload's PersistentVolumeClaim still binds:
+
+        ```yaml
+        ---
         apiVersion: v1
         kind: PersistentVolume
         metadata:


### PR DESCRIPTION
Audit of every `remediation:` block in `content/mondoo-kubernetes-security.mql.yaml` (183 checks) and `content/mondoo-kubernetes-best-practices.mql.yaml` (49 checks). Eight defects found and fixed. No `mql:` or `filters:` block changed, and the policy `version:` lines are untouched.

Method: every YAML snippet in both policies was extracted and scanned with `cnspec scan k8s <snippet> -f <policy>`, and the outcome of the check that ships the snippet was recorded. That is the closed-loop question `scans/remediation_closes_check_test.go` asks for Terraform, CloudFormation and Bicep variants — it never reaches these policies, because it iterates IaC variant suffixes and the Kubernetes policies have none. Nothing in CI was looking at these snippets.

---

## 1. `hostPath` documented as a list, so the manifest is not loadable at all

21 checks: `mondoo-kubernetes-security-{pod,cronjob,statefulset,deployment,job,replicaset,daemonset}-{docker,containerd,crio}-socket`.

Both the `audit:` and the `remediation:` manifest wrote:

```yaml
volumes:
  - name: vol
    hostPath:
      - path: /var/run/docker.sock
```

`hostPath` is a `HostPathVolumeSource` object, not a list. Scanning that manifest:

```
$ cnspec scan k8s pod-listform.yaml -f content/mondoo-kubernetes-security.mql.yaml
Asset: (Kubernetes Pod) default/docs-example
x llx: encountered a primitive with no type information, coercing to null
! Error:          Container should not mount the Docker socket
! Error:          Container should not mount the containerd socket
...   (every check on the Pod errors)
```

The same file with `path:` as a mapping key loads and the check behaves:

```
$ cnspec scan k8s pod-objform.yaml -f content/mondoo-kubernetes-security.mql.yaml
✕ CRITICAL (100): Container should not mount the Docker socket
```

The repository's own fixture for this check already uses the object form (`content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-docker-socket/fail/docker-socket/pod.yaml`), so the docs and the fixtures disagreed.

## 2. The socket manifests showed `kind: Pod` for all seven workload kinds

Same 21 checks. `mondoo-kubernetes-security-deployment-docker-socket` binds to `k8s.deployment` and runs on `asset.platform == "k8s-deployment"`, but its remediation showed a bare `kind: Pod`. A reader following it edits `spec.volumes` at the wrong level, and scanning the snippet leaves the check unevaluated.

Each manifest now uses its own kind and nesting (`spec.jobTemplate.spec.template.spec` for CronJob, `spec.template.spec` for the controllers, `spec` for Pod) and carries `metadata.name` / `metadata.namespace` so it is a complete, scannable object.

## 3. The socket remediation manifest *was* the violation

The block was introduced with "The manifest below marks the entry that must be deleted" and then showed the hostPath mount with a `# <--- this shouldn't be there` comment. Applied as printed, it recreates the finding. It now shows the corrected object, with the offending volume and its `volumeMounts` entry gone.

All 42 rewritten blocks were re-scanned. Every `audit:` manifest now fails its check (it demonstrates the violation) and every `remediation:` manifest passes it:

```
mondoo-kubernetes-security-pod-docker-socket        [audit] -> fail   [remediation] -> pass
mondoo-kubernetes-security-cronjob-docker-socket    [audit] -> fail   [remediation] -> pass
...  21 checks, same result for all of them
```

## 4. CronJob hostPath read-only remediation omitted `spec.jobTemplate`

`mondoo-kubernetes-security-cronjob-hostpath-readonly`. The manifest nested the pod template at `spec.template.spec`, which is a Deployment/StatefulSet path. `CronJobSpec` has no `template` field; the pod template lives at `spec.jobTemplate.spec.template.spec`, which is what the other six CronJob snippets in this policy use.

The consequence is not cosmetic. Scanning the documented manifest:

```
Asset: (Kubernetes CronJob) example-namespace/example
. Skipped:        CronJobs should mount any host path volumes as read-only
```

The check the snippet exists to satisfy never runs. With `jobTemplate` restored:

```
✓ CronJobs should mount any host path volumes as read-only
```

This was the single `skip` in a sweep of every snippet in the policy that produces a scannable asset; the other 34 all passed.

## 5. Service-account remediation lost the `#` on its callout

7 checks: `mondoo-kubernetes-security-{pod,cronjob,statefulset,deployment,job,replicaset,daemonset}-serviceaccount`.

```yaml
serviceAccountName: some-account <-- Set the name of the ServiceAccount created for the Pod
```

There is no `#`, so this is not a comment. Parsed:

```
>>> yaml.safe_load(doc)['spec']['serviceAccountName']
'some-account <-- Set the name of the ServiceAccount created for the Pod'
```

The value is a 68-character string with spaces, which is not a valid ServiceAccount reference. Every other callout in these two policies uses `# <--`. Added the `#`.

## 6. The kubelet-configuration remediation secured a file the check never reads

`mondoo-kubernetes-security-secure-kubelet-config`. The check evaluates `kubelet.configFile`. In the provider that resolves from the kubelet's `--config` argument, defaulting to `/var/lib/kubelet/config.yaml` — `mql/providers/os/resources/kubelet.go`:

```go
const defaultKubeletConfig = "/var/lib/kubelet/config.yaml"
...
configFilePath := defaultKubeletConfig
if kubeletConfigFilePath, ok := kubeletFlags["config"]; ok {
    ...
    configFilePath = path
}
```

`/etc/kubernetes/kubelet.conf` is never consulted; it is the kubelet's kubeconfig, a different file. All three remediation entries (`cli`, `ansible`, `bash`) and the audit block targeted it, so an operator who ran them saw the finding stay failed. This policy already says the right thing elsewhere: the nine kubelet-setting checks all open with "back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`".

The audit block now also shows how to confirm which file the running kubelet loaded, rather than asserting a path.

## 7. Two PersistentVolume documents in one block, one of them the violation

`mondoo-kubernetes-security-no-hostpath-persistent-volumes`. The fenced block held a "# Instead of:" PV and a "# Use a CSI driver" PV with no `---` between them, making it one document with duplicate top-level keys:

```
$ python3 -c "...strict duplicate-key loader..." pv-doc.yaml
ERROR: duplicate key 'apiVersion'
  in "pv-doc.yaml", line 11, column 1
```

A lenient parser takes last-wins and silently discards the first example; Kubernetes' own strict decoding rejects it. The first document was also the exact hostPath PV the check forbids. Split into a "this is what the problem looks like" block and a replacement block, each a single valid document. Both now parse under a duplicate-key-rejecting loader. Also added the `capacity` and `accessModes` the first example was missing, so the two are comparable.

The check itself is scoped to `asset.platform == "k8s-cluster"`, so neither snippet can be closed-loop verified against a manifest scan.

## 8. Object names Kubernetes rejects

`name: examplePod`, `exampleDeployment`, `exampleDaemonSet`, `exampleReplicaSet`, `exampleJob`, `exampleStatefulset`, `exampleCronJob` — 7 checks in the best-practices policy plus `mondoo-kubernetes-security-pod-capability-net-raw` and `-pod-capability-sys-admin`.

Per [Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/), an RFC 1123 subdomain name must "contain only lowercase alphanumeric characters, '-' or '.'". `kubectl apply` rejects these with `metadata.name: Invalid value`. Lowercased to `example-pod`, `example-deployment`, and so on.

## 9. `NoSchedule` described as evicting running pods

`mondoo-kubernetes-best-practices-control-plane-taint`. The remediation said:

> Adding the taint immediately evicts any running pods that do not tolerate it

[Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) on `NoSchedule`: "No new Pods will be scheduled on the tainted node unless they have a matching toleration. Pods currently running on the node are **not** evicted." Eviction is `NoExecute`. The advice was wrong in the direction that matters: an operator re-applying the taint would believe the workloads had moved off the control plane node when they had not.

The same paragraph said "Most Kubernetes distributions, including kubeadm, EKS, GKE, and AKS, apply this taint by default." EKS, GKE and AKS run the control plane outside the cluster; no control plane node appears in `kubectl get nodes`, so there is no node carrying that taint and the check passes vacuously on those clusters. Rewrote both sentences.

---

## Checked and found correct

Candidates that looked wrong and verified as fine, so they are not in the diff:

- **Every `kubectl` invocation in both policies.** `python3 content/validation/remediation/commands/validate.py kubernetes` is green across all subcommands and flags, including `kubectl create secret tls <name> --cert=tls.crt --key=tls.key -n <ns> --dry-run=client -o yaml | kubectl apply -f -`, `kubectl taint nodes <node> node-role.kubernetes.io/control-plane:NoSchedule`, and `kubectl create role ... --verb=... --resource=... --resource-name=...`.
- **Permission modes against the checks that read them.** `chmod 600` for `admin.conf`, `scheduler.conf`, `controller-manager.conf` and `kube-apiserver.yaml` matches those checks' `user_readable == true` / `user_executable == false` / no group or other bits. `chmod 700` plus `chown etcd:etcd` for `/var/lib/etcd` matches `secure-etcd-data-dir`, which requires `user_executable == true` on the directory.
- **`--event-qps=0` for `kubelet-event-record-qps`.** The check asserts `eventRecordQPS == 0` and the remediation already explains that `0` removes the rate limit rather than disabling events.
- **The digest-pinning advice in the `*-imagepull` remediation.** The check requires `imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':')`. A `repo@sha256:<digest>` reference contains a colon and does not match `/:latest/`, so following the stronger advice does not trip the check.
- **`--insecure-port` guidance in `https-api-server`.** The flag really was removed in Kubernetes 1.20, and the remediation already says so and recommends upgrading rather than editing a flag that no longer exists.
- **The `PodSecurity` admission remediation.** It correctly leads with namespace labelling rather than the API server flag, and correctly notes the plugin is on by default from 1.25.
- **The guard chains and `!= empty` idioms** in the socket, hostPort and hostPath checks. Left alone; `mql:` is unchanged throughout this PR.

## Observed, not changed

Around 100 of the remaining snippets are `spec:`-only fragments with no `metadata:` and, in the hostPort and capability families, `containers:` entries with no `name` or `image`. They are illustrative rather than applyable, and because they produce no asset the closed loop cannot evaluate them either. Making them complete manifests is a larger, purely-stylistic sweep and is deliberately out of this change.

## Validation

```
cnspec policy lint ./content/mondoo-kubernetes-security.mql.yaml ./content/mondoo-kubernetes-best-practices.mql.yaml   → valid policy bundle(s)
python3 content/validation/remediation/commands/validate.py kubernetes                                                → all PASS
python3 content/validation/remediation/code/bash.py kubernetes                                                        → 22 passed, 0 failed
typos content/mondoo-kubernetes-security.mql.yaml content/mondoo-kubernetes-best-practices.mql.yaml                    → clean
```

Plus the snippet sweep described above: 21 audit manifests fail their check, 21 remediation manifests pass theirs, and `cronjob-hostpath-readonly` moved from skipped to passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
