### PR TITLE
🐛 content: fix remediation defects in the vercel, portainer, and grafana policies

### DIFF
--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -106,14 +106,26 @@ queries:
         ```
 
         A passing response lists every entry in `serviceAccounts[]` with a `role` of `Viewer` or `Editor`; a failing response includes at least one entry where `role` equals `Admin`.
-      remediation: |
-        Review all service accounts and downgrade any with the Admin role to Viewer or Editor:
+      remediation:
+        - id: console
+          desc: |
+            To downgrade Admin service accounts using the Grafana UI:
 
-        1. Navigate to **Administration > Users and access > Service accounts** in the Grafana UI.
-        2. Identify service accounts with the **Admin** role.
-        3. Change the role to **Viewer** or **Editor** depending on the service account's purpose.
-        4. Update any automation that depended on Admin-only API endpoints so it works with the reduced role.
-        5. If a workflow genuinely requires the Admin role, document it as an accepted exception. The service account continues to be reported by this check until its role is downgraded.
+            1. Navigate to **Administration > Users and access > Service accounts**.
+            2. Identify service accounts with the **Admin** role.
+            3. Change the role to **Viewer** or **Editor** depending on the service account's purpose.
+            4. Update any automation that depended on Admin-only API endpoints so it works with the reduced role.
+            5. If a workflow genuinely requires the Admin role, document it as an accepted exception. The service account continues to be reported by this check until its role is downgraded.
+        - id: api
+          desc: |
+            To downgrade a service account through the Grafana HTTP API:
+
+            ```bash
+            curl -s -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"role":"Viewer"}' \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/administration/service-accounts/
         title: Grafana Service Accounts
@@ -172,24 +184,26 @@ queries:
         ```
 
         A passing response returns tokens that each include an `expiration` timestamp; a failing response includes at least one token with no `expiration` value.
-      remediation: |
-        Replace non-expiring service account tokens with tokens that have a defined expiration:
+      remediation:
+        - id: console
+          desc: |
+            To replace non-expiring service account tokens using the Grafana UI:
 
-        1. Navigate to **Administration > Users and access > Service accounts** in the Grafana UI.
-        2. For each service account, review its tokens.
-        3. Delete tokens without an expiration date.
-        4. Create new tokens that expire within 90 days or less.
-        5. Update any systems that use the old token with the new token value.
+            1. Navigate to **Administration > Users and access > Service accounts**.
+            2. For each service account, review its tokens.
+            3. Delete tokens without an expiration date.
+            4. Create new tokens that expire within 90 days or less.
+            5. Update any systems that use the old token with the new token value.
+        - id: api
+          desc: |
+            To create a replacement token with a 90-day expiration through the Grafana HTTP API:
 
-        Via the API:
-
-        ```bash
-        # Create a token with a 90-day expiration
-        curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d '{"name":"rotated-token","secondsToLive":7776000}' \
-          "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens"
-        ```
+            ```bash
+            curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"name":"rotated-token","secondsToLive":7776000}' \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens
         title: Grafana Service Account Tokens
@@ -246,21 +260,28 @@ queries:
         ```
 
         A passing response returns tokens that all show `hasExpired` set to `false`; a failing response includes at least one token with `hasExpired` set to `true`.
-      remediation: |
-        Remove expired service account tokens:
+      remediation:
+        - id: console
+          desc: |
+            To remove expired service account tokens using the Grafana UI:
 
-        1. Navigate to **Administration > Users and access > Service accounts** in the Grafana UI.
-        2. For each service account, review its tokens and identify expired ones.
-        3. Delete all expired tokens.
-        4. If the associated integration is still active, create a new token with proper expiration and update the integration.
+            1. Navigate to **Administration > Users and access > Service accounts**.
+            2. For each service account, review its tokens and identify expired ones.
+            3. Delete all expired tokens.
+            4. If the associated integration is still active, create a new token with proper expiration and update the integration.
+        - id: api
+          desc: |
+            To delete an expired token through the Grafana HTTP API:
 
-        Via the API:
+            ```bash
+            # List the account's tokens to find the expired one's ID
+            curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens"
 
-        ```bash
-        # Delete an expired token
-        curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-          "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens/$TOKEN_ID"
-        ```
+            # Delete the expired token
+            curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens/$TOKEN_ID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens
         title: Grafana Service Account Tokens
@@ -320,25 +341,28 @@ queries:
         ```
 
         A passing response shows every entry in `serviceAccounts[]` with `isDisabled` set to `true` reporting a `tokens` count of `0`; a failing response includes a disabled service account with a `tokens` count greater than `0`.
-      remediation: |
-        Delete all tokens from disabled service accounts:
+      remediation:
+        - id: console
+          desc: |
+            To delete all tokens from disabled service accounts using the Grafana UI:
 
-        1. Navigate to **Administration > Users and access > Service accounts** in the Grafana UI.
-        2. Filter for disabled service accounts.
-        3. For each disabled account, delete all associated tokens.
-        4. If the service account is no longer needed, delete it entirely.
+            1. Navigate to **Administration > Users and access > Service accounts**.
+            2. Filter for disabled service accounts.
+            3. For each disabled account, delete all associated tokens.
+            4. If the service account is no longer needed, delete it entirely.
+        - id: api
+          desc: |
+            To list and delete the tokens still attached to a disabled service account through the Grafana HTTP API:
 
-        Via the API:
+            ```bash
+            # List tokens still attached to a disabled service account
+            curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens"
 
-        ```bash
-        # List tokens still attached to a disabled service account
-        curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
-          "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens"
-
-        # Delete each remaining token
-        curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-          "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens/$TOKEN_ID"
-        ```
+            # Delete each remaining token
+            curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+              "https://grafana.example.com/api/serviceaccounts/$SA_ID/tokens/$TOKEN_ID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/administration/service-accounts/
         title: Grafana Service Accounts
@@ -397,16 +421,33 @@ queries:
         ```
 
         A passing response returns three or fewer entries where `role` equals `Admin`; a failing response returns more than three entries with `role` set to `Admin`.
-      remediation: |
-        Review the list of organization administrators and downgrade users who do not require Admin access:
+      remediation:
+        - id: console
+          desc: |
+            To downgrade organization administrators who do not require Admin access using the Grafana UI:
 
-        1. Navigate to **Administration > Users and access > Users** in the Grafana UI.
-        2. Identify users with the **Admin** role.
-        3. For each user, evaluate whether Admin access is operationally required.
-        4. Change unnecessary Admin users to **Editor** or **Viewer** roles.
-        5. Document the justification for each remaining Admin user.
+            1. Navigate to **Administration > Users and access > Users**.
+            2. Identify users with the **Admin** role.
+            3. For each user, evaluate whether Admin access is operationally required.
+            4. Change unnecessary Admin users to **Editor** or **Viewer** roles.
+            5. Document the justification for each remaining Admin user.
 
-        This check allows up to 3 organization administrators. If your organization requires more, adjust the threshold to match your operational needs.
+            This check allows up to 3 organization administrators. If your organization requires more, adjust the threshold to match your operational needs.
+        - id: api
+          desc: |
+            To change a user's organization role through the Grafana HTTP API:
+
+            ```bash
+            # List the organization's users to find the user ID
+            curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+              "https://grafana.example.com/api/org/users"
+
+            # Downgrade the user to Editor
+            curl -s -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"role":"Editor"}' \
+              "https://grafana.example.com/api/org/users/$USER_ID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/
         title: Grafana Roles and Permissions
@@ -463,27 +504,29 @@ queries:
         ```
 
         A passing response contains no entry where `login` equals `admin` and `role` equals `Admin`; a failing response includes an entry with `login` set to `admin` and `role` set to `Admin`.
-      remediation: |
-        Replace or rename the default admin login so no Admin-role user signs in as `admin`:
+      remediation:
+        - id: console
+          desc: |
+            To replace or rename the default admin login so no Admin-role user signs in as `admin`:
 
-        1. Sign in to Grafana with a server administrator account.
-        2. Navigate to **Administration > Users and access > Users** and create a new user with a unique login name.
-        3. Grant the new user the **Admin** organization role and enable the **Grafana Admin** server permission so server-level administration is preserved.
-        4. Sign out, then sign in as the new user and confirm both organization and server administration pages are accessible.
-        5. Edit the default `admin` user and change its login to a unique name, or delete the account once you confirm nothing depends on it.
+            1. Sign in to Grafana with a server administrator account.
+            2. Navigate to **Administration > Users and access > Users** and create a new user with a unique login name.
+            3. Grant the new user the **Admin** organization role and enable the **Grafana Admin** server permission so server-level administration is preserved.
+            4. Sign out, then sign in as the new user and confirm both organization and server administration pages are accessible.
+            5. Edit the default `admin` user and change its login to a unique name, or delete the account once you confirm nothing depends on it.
 
-        > **Warning:** Never delete the default admin before the replacement account holds the Grafana Admin server permission and you have verified it in step 4, or you lose server-level administration.
+            > **Warning:** Never delete the default admin before the replacement account holds the Grafana Admin server permission and you have verified it in step 4, or you lose server-level administration.
 
-        For new self-hosted installations, set a unique admin login and a strong password before first startup. Prefer environment variables over a plaintext password in `grafana.ini`:
+            For new self-hosted installations, set a unique admin login and a strong password before first startup. Prefer environment variables over a plaintext password in `grafana.ini`:
 
-        ```bash
-        export GF_SECURITY_ADMIN_USER="your_unique_admin_name"
-        export GF_SECURITY_ADMIN_PASSWORD="strong_random_password"
-        ```
+            ```bash
+            export GF_SECURITY_ADMIN_USER="your_unique_admin_name"
+            export GF_SECURITY_ADMIN_PASSWORD="strong_random_password"
+            ```
 
-        These settings correspond to `admin_user` and `admin_password` in the `[security]` section and only take effect when Grafana initializes its database at first startup. Changing them later does not rename an existing admin user.
+            These settings correspond to `admin_user` and `admin_password` in the `[security]` section and only take effect when Grafana initializes its database at first startup. Changing them later does not rename an existing admin user.
 
-        On Grafana Cloud you have no access to `grafana.ini` or the server process, so the default `admin` account does not apply in the same way. Manage administrators through the Grafana Cloud UI or the HTTP API instead.
+            On Grafana Cloud you have no access to `grafana.ini` or the server process, so the default `admin` account does not apply in the same way. Manage administrators through the Grafana Cloud UI or the HTTP API instead.
     refs:
       - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
         title: Grafana Authentication Configuration
@@ -539,29 +582,32 @@ queries:
         2. Select each datasource. If it still shows an **Access** setting, confirm it is set to **Server (default)**, which corresponds to proxy mode.
 
         Recent Grafana versions removed the **Access** setting from the UI for most datasource types, so the API audit above is the authoritative check. A passing result shows every datasource using Server access mode; a failing result shows one or more datasources set to Browser access mode.
-      remediation: |
-        Switch datasources from direct to proxy access mode. Browser access mode sends datasource credentials to the user's browser and requires the datasource to be reachable from the client network, so proxy mode keeps credentials server-side and shields internal endpoints. Recent Grafana versions removed the **Access** setting from the UI for most datasource types, so the API or provisioning path is the primary way to change it.
+      remediation:
+        - id: console
+          desc: |
+            Switch datasources from direct to proxy access mode. Browser access mode sends datasource credentials to the user's browser and requires the datasource to be reachable from the client network, so proxy mode keeps credentials server-side and shields internal endpoints.
 
-        Via the API, fetch the datasource definition, set `access` to `proxy`, and update it:
+            Recent Grafana versions removed the **Access** setting from the UI for most datasource types, so the API path below is the primary way to change it. If the datasource still shows an **Access** setting in the UI, you can change it there:
 
-        ```bash
-        curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
-          "https://grafana.example.com/api/datasources/uid/$DS_UID" > datasource.json
+            1. Navigate to **Connections > Data sources**.
+            2. Select the datasource configured with direct access and set **Access** to **Server (default)**.
+            3. Save and test the datasource connection.
 
-        # Edit datasource.json and set "access": "proxy", then:
-        curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d @datasource.json \
-          "https://grafana.example.com/api/datasources/uid/$DS_UID"
-        ```
+            For self-hosted Grafana datasources defined through provisioning files, set `access: proxy` in the provisioning YAML and restart Grafana to apply the change. On Grafana Cloud you cannot edit provisioning files or restart the server, so manage datasources through the API or the UI instead.
+        - id: api
+          desc: |
+            To switch a datasource to proxy access mode through the Grafana HTTP API, fetch its definition, set `access` to `proxy`, and put it back:
 
-        For self-hosted Grafana datasources defined through provisioning files, set `access: proxy` in the provisioning YAML and restart Grafana to apply the change. On Grafana Cloud you cannot edit provisioning files or restart the server, so manage datasources through the API or the UI instead.
+            ```bash
+            curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID" > datasource.json
 
-        If the datasource still shows an **Access** setting in the UI, you can also change it there:
-
-        1. Navigate to **Connections > Data sources** in the Grafana UI.
-        2. Select the datasource configured with direct access and set **Access** to **Server (default)**.
-        3. Save and test the datasource connection.
+            # Edit datasource.json and set "access": "proxy", then:
+            curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @datasource.json \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/datasources/
         title: Grafana Datasources
@@ -618,17 +664,34 @@ queries:
         ```
 
         A passing response shows every datasource with `basicAuth` set to `false`; a failing response includes at least one datasource with `basicAuth` set to `true`.
-      remediation: |
-        Replace basic authentication with stronger authentication methods:
+      remediation:
+        - id: console
+          desc: |
+            To replace basic authentication with a stronger method using the Grafana UI:
 
-        1. Navigate to **Connections > Data sources** in the Grafana UI.
-        2. For each datasource using basic authentication, switch to an alternative method:
-           - **API key or bearer token**: Configure token-based access in the datasource settings.
-           - **TLS client certificates**: Use mutual TLS for datasource authentication.
-           - **OAuth or managed identity**: Use identity provider integration where supported.
-        3. Disable the **Basic Auth** toggle for the datasource.
-        4. Remove the stored basic auth credentials.
-        5. Test the datasource connection.
+            1. Navigate to **Connections > Data sources**.
+            2. For each datasource using basic authentication, switch to an alternative method:
+               - **API key or bearer token**: Configure token-based access in the datasource settings.
+               - **TLS client certificates**: Use mutual TLS for datasource authentication.
+               - **OAuth or managed identity**: Use identity provider integration where supported.
+            3. Disable the **Basic Auth** toggle for the datasource.
+            4. Remove the stored basic auth credentials.
+            5. Test the datasource connection.
+        - id: api
+          desc: |
+            To turn basic authentication off through the Grafana HTTP API, fetch the datasource definition, set `basicAuth` to `false`, and put it back. Configure the replacement credential in the same request so the datasource does not lose access:
+
+            ```bash
+            curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID" > datasource.json
+
+            # Edit datasource.json, set "basicAuth": false, and add the replacement
+            # credential under secureJsonData, then:
+            curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @datasource.json \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/datasources/
         title: Grafana Datasources
@@ -688,14 +751,30 @@ queries:
         ```
 
         A passing response shows every datasource with a non-empty `url` using the `https://` scheme or pointing to localhost; a failing response includes a datasource whose `url` uses `http://` for a remote host.
-      remediation: |
-        Update datasource URLs to use HTTPS:
+      remediation:
+        - id: console
+          desc: |
+            To move datasource URLs to HTTPS using the Grafana UI:
 
-        1. Navigate to **Connections > Data sources** in the Grafana UI.
-        2. For each datasource with an HTTP URL, update it to HTTPS.
-        3. Ensure the datasource endpoint has a valid TLS certificate.
-        4. If using self-signed certificates, add the issuing CA certificate under the datasource TLS settings instead of enabling Skip TLS Verify.
-        5. Save and test the datasource connection.
+            1. Navigate to **Connections > Data sources**.
+            2. For each datasource with an HTTP URL, update it to HTTPS.
+            3. Ensure the datasource endpoint has a valid TLS certificate.
+            4. If using self-signed certificates, add the issuing CA certificate under the datasource TLS settings instead of enabling Skip TLS Verify.
+            5. Save and test the datasource connection.
+        - id: api
+          desc: |
+            To move a datasource URL to HTTPS through the Grafana HTTP API, fetch its definition, rewrite `url`, and put it back:
+
+            ```bash
+            curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID" > datasource.json
+
+            # Edit datasource.json and change "url" to the https:// endpoint, then:
+            curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @datasource.json \
+              "https://grafana.example.com/api/datasources/uid/$DS_UID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-database-encryption/
         title: Grafana Security Configuration
@@ -752,25 +831,28 @@ queries:
         ```
 
         A passing response returns a policy with a non-empty `receiver` value; a failing response returns a policy whose `receiver` is empty or absent.
-      remediation: |
-        Configure a default receiver in the notification policy:
+      remediation:
+        - id: console
+          desc: |
+            To configure a default receiver in the notification policy using the Grafana UI:
 
-        1. Navigate to **Alerting > Notification policies** in the Grafana UI.
-        2. Edit the **Default policy** and set the **Default contact point** to a receiver such as email, Slack, or PagerDuty.
-        3. Verify that the selected contact point is properly configured and send a test notification.
+            1. Navigate to **Alerting > Notification policies**.
+            2. Edit the **Default policy** and set the **Default contact point** to a receiver such as email, Slack, or PagerDuty.
+            3. Verify that the selected contact point is properly configured and send a test notification.
+        - id: api
+          desc: |
+            To set the root receiver through the Grafana HTTP API, fetch the current policy tree, set its `receiver`, and put it back. The update replaces the entire policy tree, so always start from the current tree to preserve existing routes:
 
-        Via the API, fetch the current policy tree, set the root `receiver`, and update it. The update replaces the entire policy tree, so always start from the current tree to preserve existing routes:
+            ```bash
+            curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              "https://grafana.example.com/api/v1/provisioning/policies" > policies.json
 
-        ```bash
-        curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
-          "https://grafana.example.com/api/v1/provisioning/policies" > policies.json
-
-        # Edit policies.json and set the top-level "receiver", then:
-        curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d @policies.json \
-          "https://grafana.example.com/api/v1/provisioning/policies"
-        ```
+            # Edit policies.json and set the top-level "receiver", then:
+            curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @policies.json \
+              "https://grafana.example.com/api/v1/provisioning/policies"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/notification-policies/
         title: Grafana Notification Policies
@@ -827,12 +909,29 @@ queries:
         ```
 
         A passing response shows every contact point with `disableResolveMessage` set to `false`; a failing response includes at least one contact point with `disableResolveMessage` set to `true`.
-      remediation: |
-        Enable resolve messages for all contact points:
+      remediation:
+        - id: console
+          desc: |
+            To enable resolve messages for all contact points using the Grafana UI:
 
-        1. Navigate to **Alerting > Contact points** in the Grafana UI.
-        2. For each contact point, ensure the **Disable resolve message** toggle is turned off.
-        3. Save the contact point configuration.
+            1. Navigate to **Alerting > Contact points**.
+            2. For each contact point, ensure the **Disable resolve message** toggle is turned off.
+            3. Save the contact point configuration.
+        - id: api
+          desc: |
+            To re-enable resolve messages through the Grafana HTTP API, fetch the contact point, set `disableResolveMessage` to `false`, and put it back. The update replaces the whole contact point, so start from the current definition to preserve its settings:
+
+            ```bash
+            # List the contact points to find the one to change and its UID
+            curl -s -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              "https://grafana.example.com/api/v1/provisioning/contact-points"
+
+            # Send the contact point back with resolve messages enabled
+            curl -s -X PUT -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @contact-point.json \
+              "https://grafana.example.com/api/v1/provisioning/contact-points/$CONTACT_POINT_UID"
+            ```
     refs:
       - url: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/contact-points/
         title: Grafana Contact Points

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -141,8 +141,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id           = portainer_environment.example.id
-              allow_privileged_mode = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_privileged_mode = false
+              }
             }
             ```
     refs:
@@ -156,15 +159,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_privileged_mode != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_privileged_mode != true)
+      )
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_privileged_mode != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_privileged_mode"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_privileged_mode != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_privileged_mode"] != true)
+      )
 
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users
     title: Ensure regular users cannot bind-mount host paths
@@ -243,8 +254,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id       = portainer_environment.example.id
-              allow_bind_mounts = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_bind_mounts = false
+              }
             }
             ```
     refs:
@@ -258,15 +272,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_bind_mounts != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_bind_mounts != true)
+      )
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_bind_mounts != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_bind_mounts"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_bind_mounts != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_bind_mounts"] != true)
+      )
 
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users
     title: Ensure regular users cannot map host devices into containers
@@ -345,8 +367,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id          = portainer_environment.example.id
-              allow_device_mapping = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_device_mapping = false
+              }
             }
             ```
     refs:
@@ -360,15 +385,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_device_mapping != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_device_mapping != true)
+      )
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_device_mapping != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_device_mapping"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_device_mapping != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_device_mapping"] != true)
+      )
 
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users
     title: Ensure regular users cannot share host namespaces
@@ -447,8 +480,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id          = portainer_environment.example.id
-              allow_host_namespace = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_host_namespace = false
+              }
             }
             ```
     refs:
@@ -462,15 +498,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_host_namespace != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_host_namespace != true)
+      )
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_host_namespace != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_host_namespace"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_host_namespace != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_host_namespace"] != true)
+      )
 
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users
     title: Ensure regular users cannot add Linux capabilities to containers
@@ -549,8 +593,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id                  = portainer_environment.example.id
-              allow_container_capabilities = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_container_capabilities = false
+              }
             }
             ```
     refs:
@@ -564,15 +611,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_container_capabilities != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_container_capabilities != true)
+      )
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_container_capabilities != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_container_capabilities"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_container_capabilities != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_container_capabilities"] != true)
+      )
 
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users
     title: Ensure regular users cannot browse volume contents
@@ -651,8 +706,11 @@ queries:
 
             ```hcl
             resource "portainer_endpoint_settings" "example" {
-              endpoint_id          = portainer_environment.example.id
-              allow_volume_browser = false
+              endpoint_id = portainer_environment.example.id
+
+              security_settings {
+                allow_volume_browser = false
+              }
             }
             ```
     refs:
@@ -666,15 +724,23 @@ queries:
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "portainer_endpoint_settings")
     mql: |
-      terraform.resources("portainer_endpoint_settings").all(arguments.allow_volume_browser != true)
+      terraform.resources("portainer_endpoint_settings").all(
+        blocks.where(type == "security_settings").all(arguments.allow_volume_browser != true)
+      )
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(change.after.allow_volume_browser != true)
+      terraform.plan.resourceChanges.where(type == "portainer_endpoint_settings").all(
+        change.after["security_settings"] == empty ||
+        change.after["security_settings"].all(_["allow_volume_browser"] != true)
+      )
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_endpoint_settings")
     mql: |
-      terraform.state.resources.where(type == "portainer_endpoint_settings").all(values.allow_volume_browser != true)
+      terraform.state.resources.where(type == "portainer_endpoint_settings").all(
+        values["security_settings"] == empty ||
+        values["security_settings"].all(_["allow_volume_browser"] != true)
+      )
 
   # ----------------------------------------------------------------------------
   # Authentication
@@ -851,12 +917,11 @@ queries:
             3. Save the changes.
         - id: terraform
           desc: |
-            To enforce a minimum password length with the Portainer Terraform provider:
+            To enforce a minimum password length for internally managed accounts with the Portainer Terraform provider:
 
             ```hcl
             resource "portainer_settings" "example" {
-              authentication_method = 1
-              auth_settings {
+              internal_auth_settings {
                 required_password_length = 12
               }
             }
@@ -877,21 +942,35 @@ queries:
       - uid: mondooPortainerSecurityMinPasswordLength
         mql: "12"
     mql: |
-      terraform.resources("portainer_settings").all(arguments.required_password_length == empty || arguments.required_password_length >= props.mondooPortainerSecurityMinPasswordLength)
+      terraform.resources("portainer_settings").all(
+        blocks.where(type == "internal_auth_settings").all(
+          arguments.required_password_length == empty || arguments.required_password_length >= props.mondooPortainerSecurityMinPasswordLength
+        )
+      )
   - uid: mondoo-portainer-security-settings-minimum-password-length-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "portainer_settings")
     props:
       - uid: mondooPortainerSecurityMinPasswordLength
         mql: "12"
     mql: |
-      terraform.plan.resourceChanges.where(type == "portainer_settings").all(change.after.required_password_length == empty || change.after.required_password_length >= props.mondooPortainerSecurityMinPasswordLength)
+      terraform.plan.resourceChanges.where(type == "portainer_settings").all(
+        change.after["internal_auth_settings"] == empty ||
+        change.after["internal_auth_settings"].all(
+          _["required_password_length"] == empty || _["required_password_length"] >= props.mondooPortainerSecurityMinPasswordLength
+        )
+      )
   - uid: mondoo-portainer-security-settings-minimum-password-length-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "portainer_settings")
     props:
       - uid: mondooPortainerSecurityMinPasswordLength
         mql: "12"
     mql: |
-      terraform.state.resources.where(type == "portainer_settings").all(values.required_password_length == empty || values.required_password_length >= props.mondooPortainerSecurityMinPasswordLength)
+      terraform.state.resources.where(type == "portainer_settings").all(
+        values["internal_auth_settings"] == empty ||
+        values["internal_auth_settings"].all(
+          _["required_password_length"] == empty || _["required_password_length"] >= props.mondooPortainerSecurityMinPasswordLength
+        )
+      )
 
   - uid: mondoo-portainer-security-settings-session-timeout-finite
     title: Ensure user sessions expire after a finite period

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -167,7 +167,7 @@ queries:
               name = "example"
 
               vercel_authentication = {
-                deployment_type = "standard_protection"
+                deployment_type = "standard_protection_new"
               }
             }
             ```
@@ -255,7 +255,7 @@ queries:
               name = "example"
 
               password_protection = {
-                deployment_type = "standard_protection"
+                deployment_type = "standard_protection_new"
                 password        = var.preview_password
               }
             }
@@ -344,7 +344,7 @@ queries:
               name = "example"
 
               trusted_ips = {
-                deployment_type = "all"
+                deployment_type = "all_deployments"
                 protection_mode = "trusted_ip_required"
                 addresses = [
                   { value = "203.0.113.0/24" }
@@ -435,7 +435,7 @@ queries:
               name = "example"
 
               trusted_ips = {
-                deployment_type = "all"
+                deployment_type = "all_deployments"
                 protection_mode = "trusted_ip_required"
                 addresses = [
                   { value = "203.0.113.0/24", note = "office" },
@@ -960,21 +960,19 @@ queries:
             ```
         - id: terraform
           desc: |
-            To scope firewall IP rules in Terraform, define only the specific ranges on the `vercel_firewall_config` resource and omit any all-addresses allow entry:
+            To scope firewall IP rules in Terraform, declare only the specific ranges on the `vercel_firewall_config` resource and omit any all-addresses entry. The IP rule actions the provider accepts are `bypass`, `log`, `challenge`, and `deny`, so an exception that skips filtering is a `bypass` rule bound to a narrow range:
 
             ```hcl
             resource "vercel_firewall_config" "example" {
               project_id = vercel_project.example.id
               enabled    = true
 
-              ip_rules = {
-                rules = [
-                  {
-                    action = "allow"
-                    ip     = "203.0.113.0/24"
-                    hostname = "*"
-                  }
-                ]
+              ip_rules {
+                rule {
+                  action   = "bypass"
+                  ip       = "203.0.113.0/24"
+                  hostname = "*"
+                }
               }
             }
             ```
@@ -1057,9 +1055,16 @@ queries:
             # Revoke the non-expiring token
             vercel tokens remove <token-id>
             ```
-        # No Terraform remediation: personal API tokens are account credentials that
-        # the vercel Terraform provider does not manage; they are created and revoked
-        # through the dashboard or the REST API only.
+        - id: terraform
+          desc: |
+            To manage a token with an explicit lifetime in Terraform, set `expires_at` on the `vercel_user_token` resource. The value is a Unix timestamp in milliseconds, so pick the shortest lifetime the consumer can work with and move it forward on each rotation:
+
+            ```hcl
+            resource "vercel_user_token" "ci_deployments" {
+              name       = "ci-deployments"
+              expires_at = 1798761600000
+            }
+            ```
     refs:
       - url: https://vercel.com/docs/rest-api/reference/welcome/api-scopes
         title: Vercel access token documentation
@@ -1132,9 +1137,9 @@ queries:
             vercel tokens ls
             vercel tokens remove <token-id>
             ```
-        # No Terraform remediation: personal API tokens are account credentials that
-        # the vercel Terraform provider does not manage; they are created and revoked
-        # through the dashboard or the REST API only.
+        # No Terraform remediation: the fix is to stop a token existing, and the
+        # vercel_user_token resource expresses that by being deleted rather than by
+        # carrying an attribute a snippet could show.
     refs:
       - url: https://vercel.com/docs/rest-api/reference/welcome/api-scopes
         title: Vercel access token documentation
@@ -1213,9 +1218,16 @@ queries:
             # Inspect a specific store
             vercel blob get-store <store-id>
             ```
-        # No Terraform remediation: Vercel Blob stores and their access level are
-        # provisioned through the dashboard and the Blob SDK; the vercel Terraform
-        # provider does not expose a Blob store resource.
+        - id: terraform
+          desc: |
+            To keep a Blob store private in Terraform, set `access` to `private` on the `vercel_blob_store` resource:
+
+            ```hcl
+            resource "vercel_blob_store" "assets" {
+              name   = "assets"
+              access = "private"
+            }
+            ```
     refs:
       - url: https://vercel.com/docs/vercel-blob
         title: Vercel Blob documentation
@@ -1285,9 +1297,16 @@ queries:
             3. Let Vercel reissue an auto-renewing certificate for the domain.
         - id: cli
           desc: |
-            To issue a Vercel-managed certificate that renews automatically, remove the stale certificate and let Vercel reissue one:
+            To issue a Vercel-managed certificate that renews automatically, find the stale certificate, remove it, and let Vercel reissue one:
 
             ```bash
+            # Find the certificate's ID
+            vercel certs ls
+
+            # Remove the certificate that does not renew
+            vercel certs rm <cert-id>
+
+            # Let Vercel issue a managed certificate for the domain
             vercel certs issue <domain>
             ```
         # No Terraform remediation: TLS certificates are issued and auto-renewed by
@@ -1365,10 +1384,14 @@ queries:
             To inspect and verify a domain through the `vercel` CLI:
 
             ```bash
+            # Show the verification challenge and DNS configuration
             vercel domains inspect <domain>
+
+            # Complete verification once the records have propagated
+            vercel domains verify <domain>
             ```
 
-            Add the DNS records the command reports at your DNS provider, then re-run it to confirm the domain reaches a verified state.
+            Add the DNS records the inspect command reports at your DNS provider, then run the verify command to complete the handshake.
         # No Terraform remediation: domain ownership verification is a DNS-record and
         # dashboard workflow tied to the registrar; the vercel Terraform provider does
         # not manage the verification handshake for a team domain.
@@ -1531,8 +1554,10 @@ queries:
               "https://api.vercel.com/v1/projects/<project-id>/protection-bypass?teamId=<team-id>" \
               --data '{ "revoke": { "secret": "<bypass-secret>", "regenerate": false } }'
             ```
-        # No Terraform remediation: protection-bypass secrets are imperative runtime
-        # credentials with no vercel Terraform provider resource to manage them.
+        # No Terraform remediation: the fix is to stop a bypass existing, and the
+        # vercel_project_protection_bypass resource expresses that by being deleted
+        # rather than by carrying an attribute a snippet could show. Bypasses created
+        # outside Terraform are revoked through the dashboard or the REST API.
     refs:
       - url: https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
         title: Vercel protection bypass for automation documentation
@@ -1614,8 +1639,9 @@ queries:
               "https://api.vercel.com/v2/teams/<team-id>" \
               --data '{ "strictDeploymentProtectionSettings": { "enabled": true }, "strictPasswordProtectionSettings": { "enabled": true } }'
             ```
-        # No Terraform remediation: these team-wide governance toggles have no
-        # resource in the vercel Terraform provider; they are set via the API or dashboard.
+        # No Terraform remediation: vercel_team_config manages team configuration but
+        # exposes neither strict deployment-protection nor strict password-protection
+        # settings, so they are set via the API or dashboard.
     refs:
       - url: https://vercel.com/docs/security/deployment-protection
         title: Vercel deployment protection documentation

--- a/content/validation/remediation/commands/openapi.py
+++ b/content/validation/remediation/commands/openapi.py
@@ -727,8 +727,15 @@ API_PROVIDERS = {
     "grafana": {
         # Grafana is self-hosted; the policy's examples use the
         # documentation placeholder host below.
+        #
+        # The policy documents its fixes as `curl` calls against the same API
+        # its audit steps read, so both are validated (remediation_ids + the
+        # default include_audit). Without the remediation_ids entry only the
+        # audit calls are seen, and the calls that actually change something
+        # ship unchecked.
         "policies": ["mondoo-grafana-security.mql.yaml"],
         "host": "https://grafana.example.com",
+        "remediation_ids": ("api",),
         "specs": [{
             "name": "grafana",
             "url": (

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/fail/too-short/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/fail/too-short/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_settings" "this" {
-  authentication_method    = 1
-  required_password_length = 8
+  authentication_method = 1
+
+  internal_auth_settings {
+    required_password_length = 8
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/pass/absent/main.tf
@@ -1,4 +1,4 @@
-# required_password_length is unset; the check only flags an explicit weak value.
+# No internal_auth_settings block is declared, so no weak required length is set.
 resource "portainer_settings" "this" {
   authentication_method = 2
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/pass/compliant/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-minimum-password-length-terraform-hcl/pass/compliant/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_settings" "this" {
-  authentication_method    = 1
-  required_password_length = 12
+  authentication_method = 1
+
+  internal_auth_settings {
+    required_password_length = 12
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/fail/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/fail/enabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id       = 1
-  allow_bind_mounts = true
+  endpoint_id = 1
+
+  security_settings {
+    allow_bind_mounts = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,5 +1,8 @@
 # allow_bind_mounts is unset, so regular users cannot mount host paths.
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id                  = 1
-  allow_privileged_mode        = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_privileged_mode = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-terraform-hcl/pass/disabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id       = 1
-  allow_bind_mounts = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/fail/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/fail/enabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id                  = 1
-  allow_container_capabilities = true
+  endpoint_id = 1
+
+  security_settings {
+    allow_container_capabilities = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,5 +1,8 @@
 # allow_container_capabilities is unset, so regular users cannot add caps.
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id       = 1
-  allow_bind_mounts = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-terraform-hcl/pass/disabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id                  = 1
-  allow_container_capabilities = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_container_capabilities = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/fail/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/fail/enabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id         = 1
-  allow_device_mapping = true
+  endpoint_id = 1
+
+  security_settings {
+    allow_device_mapping = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,5 +1,8 @@
 # allow_device_mapping is unset, so regular users cannot map host devices.
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id       = 1
-  allow_bind_mounts = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-device-mapping-for-regular-users-terraform-hcl/pass/disabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id         = 1
-  allow_device_mapping = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_device_mapping = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/fail/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/fail/enabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id         = 1
-  allow_host_namespace = true
+  endpoint_id = 1
+
+  security_settings {
+    allow_host_namespace = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,5 +1,8 @@
 # allow_host_namespace is unset, so regular users cannot share the host namespace.
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id       = 1
-  allow_bind_mounts = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-host-namespace-for-regular-users-terraform-hcl/pass/disabled/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "prod" {
-  endpoint_id         = 1
-  allow_host_namespace = false
+  endpoint_id = 1
+
+  security_settings {
+    allow_host_namespace = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/fail/explicit-true/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/fail/explicit-true/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id           = portainer_environment.example.id
-  allow_privileged_mode = true
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_privileged_mode = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id       = portainer_environment.example.id
-  allow_bind_mounts = false
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/pass/explicit-false/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-terraform-hcl/pass/explicit-false/main.tf
@@ -1,5 +1,8 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id           = portainer_environment.example.id
-  allow_privileged_mode = false
-  allow_bind_mounts     = false
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_privileged_mode = false
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/fail/explicit-true/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/fail/explicit-true/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id          = portainer_environment.example.id
-  allow_volume_browser = true
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_volume_browser = true
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/pass/absent/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id       = portainer_environment.example.id
-  allow_bind_mounts = false
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_bind_mounts = false
+  }
 }

--- a/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/pass/explicit-false/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-portainer-security/mondoo-portainer-security-settings-no-volume-browser-for-regular-users-terraform-hcl/pass/explicit-false/main.tf
@@ -1,4 +1,7 @@
 resource "portainer_endpoint_settings" "example" {
-  endpoint_id         = portainer_environment.example.id
-  allow_volume_browser = false
+  endpoint_id = portainer_environment.example.id
+
+  security_settings {
+    allow_volume_browser = false
+  }
 }


### PR DESCRIPTION
Every remediation block in `mondoo-vercel-security`, `mondoo-portainer-security`, and `mondoo-grafana-security` was audited against an authoritative oracle: `terraform providers schema -json` and `terraform validate` for every HCL snippet, the checked-in `vercel` CLI grammar for every `vercel` command, and the pinned Grafana / Portainer / Vercel OpenAPI specs for every REST call.

Nine defects, each with the oracle output quoted. All of them shipped green because tflint does not know a provider's schema and the command validator never saw the Grafana policy.

---

## 1. Portainer: six snippets set attributes the provider does not have at that level

`portainer_endpoint_settings` has no top-level `allow_privileged_mode`, `allow_bind_mounts`, `allow_device_mapping`, `allow_host_namespace`, `allow_container_capabilities`, or `allow_volume_browser`. They live in a `security_settings` block.

```
$ terraform validate      # portainer/portainer 1.34.3
Error: Unsupported argument

  on main.tf line 8, in resource "portainer_endpoint_settings" "bad":
   8:   allow_privileged_mode = false

An argument named "allow_privileged_mode" is not expected here.
```

`terraform providers schema -json`:

```
=== portainer_endpoint_settings
  attr endpoint_id number req
  BLOCK security_settings list
     attr allow_bind_mounts bool opt
     attr allow_container_capabilities bool opt
     attr allow_device_mapping bool opt
     attr allow_host_namespace bool opt
     attr allow_privileged_mode bool opt
     attr allow_volume_browser bool opt
```

All six snippets now nest the attribute in `security_settings { }`.

## 2. Portainer: the same wrong path made all eighteen Terraform variants pass vacuously

The HCL, plan, and state variants of those six checks read `arguments.allow_privileged_mode`, `change.after.allow_privileged_mode`, and `values.allow_privileged_mode`. In real Terraform that path is always `null`, and `null != true` is true, so **every one of the eighteen variants passed on every input**, including a config that explicitly enables privileged mode. The fixtures did not catch it because they were written against the same invented shape.

Verified with the mql Terraform provider that the nested block is reachable and that the corrected queries reach opposite verdicts:

```
$ mql run terraform . -c 'terraform.resources("portainer_endpoint_settings") { arguments blocks { type arguments } }'
terraform.resources.list: [
  0: {
    blocks: [ 0: { type: "security_settings"
                   arguments: { allow_bind_mounts: false
                                allow_privileged_mode: true } } ]
    arguments: { endpoint_id: 1.000000 } } ]

# privileged mode enabled
$ mql run terraform . -c 'terraform.resources("portainer_endpoint_settings").all(blocks.where(type == "security_settings").all(arguments.allow_privileged_mode != true))'
[failed] terraform.resources.all()

# bind mounts disabled in the same fixture
$ mql run terraform . -c '...all(arguments.allow_bind_mounts != true))'
[ok] value: true
```

Plan and state serialize the block as a list, so those variants guard with `== empty ||` before `.all()`, per the nested-block rule in `content/CLAUDE.md`. Confirmed against a real plan JSON and a `terraform show -json` state document, both reaching `[failed]` on the enabling input and `[ok]` on the compliant one, with an omitted block passing through the guard.

The eighteen HCL fixtures were rewritten to the real shape. All 44 Portainer scenarios pass:

```
$ go test -tags iac_variants ./content/validation/scans -run 'TestTerraformVariants/mondoo-portainer-security'
--- PASS: TestTerraformVariants (4.04s)   # 44 subtests, all PASS
```

## 3. Portainer: the password-length snippet used a block that does not exist, and flipped the instance to internal authentication

```
$ terraform validate
Error: Unsupported block type

  on main.tf line 12, in resource "portainer_settings" "bad2":
  12:   auth_settings {

Blocks of type "auth_settings" are not expected here. Did you mean
"oauth_settings"?
```

The real block is `internal_auth_settings`. The three variants read `required_password_length` at the top level, so they were vacuous the same way as #2.

The snippet also carried `authentication_method = 1`. `portainer_settings` is a singleton, so an operator pasting this remediation would switch their instance from LDAP or OAuth to Portainer's internal user database — which is precisely what the sibling check `mondoo-portainer-security-settings-external-authentication` fails on. Dropped, and the intro now says the setting applies to internally managed accounts.

## 4. Vercel: `trusted_ips.deployment_type = "all"` is not a value the provider accepts

Two checks shipped it.

```
$ terraform validate      # vercel/vercel 5.11.0
Error: Invalid Attribute Value Match

  with vercel_project.example,
  on t1.tf line 5, in resource "vercel_project" "example":
   5:     deployment_type = "all"

Attribute trusted_ips.deployment_type value must be one of:
["standard_protection_new" "standard_protection" "all_deployments"
"only_production_deployments" "only_preview_deployments"], got: "all"
```

`all` is the *API* enum, which the neighbouring `- id: api` snippet uses correctly. The Terraform equivalent is `all_deployments`.

## 5. Vercel: `vercel_firewall_config.ip_rules` is a block, and `allow` is not one of its actions

```
$ terraform validate
Error: Unsupported argument

  on main.tf line 18, in resource "vercel_firewall_config" "example":
  18:       ip_rules = {

An argument named "ip_rules" is not expected here. Did you mean to define a
block of type "ip_rules"?
```

Corrected to block syntax, whose inner block is `rule` (singular, list), not `rules`. With that fixed the action was rejected too:

```
Attribute ip_rules.rule[0].action value must be one of: ["bypass" "log"
"challenge" "deny"], got: "allow"
```

The check is about entries that wave through every source address, and the doc prose already says "narrow it to the specific ranges that genuinely need to bypass filtering". The snippet now shows a `bypass` rule bound to a single CIDR, and the intro states which actions the provider accepts.

## 6. Vercel: the deployment type recommended for Vercel Authentication and password protection is the provider's legacy value

The provider's own schema description:

> The deployment environment to protect. The default value is `standard_protection_new` (Standard Protection). Must be one of `standard_protection_new` (Standard Protection), `standard_protection` (Legacy Standard Protection), `all_deployments`, `only_preview_deployments`, or `none`.

Both snippets used `standard_protection`, while the `- id: console` step directly above them says to choose **Standard Protection**. A reader following the console got Standard Protection and a reader following Terraform got the legacy variant. Both now use `standard_protection_new`.

## 7. Vercel: three "No Terraform remediation" comments named resources that exist

`terraform providers schema -json` lists all three:

| Comment claimed | Actually in the provider |
|---|---|
| "the vercel Terraform provider does not manage" personal API tokens | `vercel_user_token`, with `expires_at` — "The Unix timestamp in milliseconds when the token should expire." |
| "does not expose a Blob store resource" | `vercel_blob_store`, with `access` — "Whether blobs should be created with `public` or `private` access." |
| protection-bypass secrets have "no vercel Terraform provider resource" | `vercel_project_protection_bypass` |

Two of them become real Terraform remediation: `vercel_user_token` with `expires_at` for the token-expiration check, and `vercel_blob_store` with `access = "private"` for the public-Blob check. Both validate.

For the two checks whose fix is *removal* (stale tokens, protection bypasses) the resource exists but the fix is deleting it, not setting an attribute — the comments now say that instead of denying the resource exists. `vercel_team_config` likewise exists but carries neither strict-protection toggle, so that comment now names the gap precisely rather than claiming there is no resource.

## 8. Vercel: two CLI blocks were missing the step their own prose describes

- The certificate remediation said "remove the stale certificate and let Vercel reissue one" and then showed only `vercel certs issue <domain>`. Added `vercel certs ls` and `vercel certs rm <cert-id>`.
- The domain remediation told the reader to re-run `vercel domains inspect` to confirm verification. The CLI has a dedicated subcommand for this; from the checked-in grammar (`vercel` 59.1.3):

  ```
  'domains' -> {"subcommands": ["add", "buy", "check", "inspect", "list", "move",
                "price", "remove", "search", "transfer-in", "verify"], ...}
  ```

  The block now runs `vercel domains verify <domain>` after `inspect`.

## 9. Grafana: none of its remediation calls were validated, because of how the block was written

`common.py` extracts bash fences only from `- id: <method>` entries:

```python
pattern = re.compile(
    rf"- id: (?:{id_alt})\s*\n\s+desc: \|\s*\n"
```

The Grafana policy used a plain `remediation: |` scalar throughout, so its `POST /api/serviceaccounts/{id}/tokens`, `DELETE .../tokens/{id}`, `PUT /api/datasources/uid/{uid}` and `PUT /api/v1/provisioning/policies` calls were invisible to the validator. The 11 checks it reported were all `audit:` reads.

All eleven remediation blocks are now `- id: console` and `- id: api` entries, which is the shape `content/CLAUDE.md` prescribes, and `openapi.py` gained `"remediation_ids": ("api",)` for the provider so the change calls are checked. Four checks that had UI-only remediation gained an API path verified against the pinned spec (`PATCH /api/serviceaccounts/{serviceAccountId}` with `UpdateServiceAccountForm.role`, `PATCH /api/org/users/{user_id}` with `UpdateOrgUserCommand.role`, `PUT /api/v1/provisioning/contact-points/{UID}`, and the datasource fetch-edit-put pattern for basic auth and TLS).

The token-creation call was also missing `-X POST`; the validator defaults to GET when `-X` is absent, and `/serviceaccounts/{id}/tokens` serves both verbs, so it would have validated as the wrong operation.

Coverage went from 11 calls to 29:

```
$ python3 content/validation/remediation/commands/validate.py grafana
29 passed, 0 failed     # was 11 passed, 0 failed
```

---

## Checked and found correct

Candidates that looked wrong and verified as correct, so they are not in the diff:

- **`trusted_ips.protection_mode = "trusted_ip_required"` against a check that passes on `"additional"`.** Not a mismatch: the provider's enum is `trusted_ip_required` / `trusted_ip_optional` and the API's is `additional` / `exclusive`; `trusted_ip_required` is the Terraform spelling of `additional`. The `- id: api` snippet on the same check correctly sends `"protectionMode": "additional"`.
- **Portainer `tls_enabled != false` rather than `== true`** in the agent-TLS variants, with a comment explaining the provider default. Left alone; asserting `== true` would fail every environment relying on the secure default.
- **Every remaining Portainer and Vercel HCL snippet.** `portainer_settings` (`authentication_method`, `user_session_timeout`, `trust_on_first_connect`, `enable_edge_compute_features`, `enforce_edge_id`, `disable_kube_shell`), `portainer_user`, `portainer_environment`, `vercel_project` (`git_fork_protection`, `public_source`, `node_version`), `vercel_project_environment_variable`, `vercel_shared_environment_variable` — all validate against the pinned providers unchanged.
- **Remediation snippets that reference `vercel_project.example` or `portainer_environment.example` without declaring them.** `terraform validate` reports "Reference to undeclared resource", but this is the documentation convention across the repo and the closed-loop harness accommodates it deliberately; the snippets document wiring into a project the reader already has.
- **Every Grafana field name in an audit block** (`hasExpired`, `expiration`, `serviceAccounts[].tokens`, `disableResolveMessage`, `basicAuth`, `access`), each present in the pinned Grafana OpenAPI spec.
- **`secondsToLive: 7776000`** for a 90-day token — 90 × 86400, and `AddServiceAccountTokenCommand` takes exactly `name` and `secondsToLive`.
- **`GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`** and the claim that they only take effect at first database initialization. Correct, and correctly mapped to `admin_user` / `admin_password` in `[security]`.
- **`vercel env add ... --sensitive --value`, `vercel env rm ... --yes`, `vercel tokens ls/remove`, `vercel blob list-stores/get-store`.** All present in the checked-in `vercel` 59.1.3 grammar.
- **The `vercel.project.firewall.ipRules.none(action == "allow" ...)` check itself.** The Terraform provider restricts IP-rule actions to bypass/log/challenge/deny, which raises a question about the runtime `"allow"`, but the provider's validator constrains the Terraform surface, not the API, and I could not verify the live API enum. Not filed.

## Validation run

```
cnspec policy lint ./content/{mondoo-portainer-security,mondoo-vercel-security,mondoo-grafana-security}.mql.yaml   # valid
make test/content/lint                                                    # valid (2 pre-existing warnings, also on main)
python3 content/validation/remediation/commands/validate.py grafana        # 29 passed, 0 failed
python3 content/validation/remediation/commands/validate.py portainer      # 15 passed, 0 failed
python3 content/validation/remediation/commands/validate.py vercel         # 48 passed, 0 failed
python3 content/validation/remediation/code/terraform.py portainer         # 14 passed, 0 failed
python3 content/validation/remediation/code/terraform.py vercel            # 13 passed, 0 failed
go test -tags iac_variants ./content/validation/scans -run 'TestTerraformVariants/mondoo-portainer-security'      # PASS, 44 scenarios
go test -tags iac_variants ./content/validation/scans -run 'TestRemediationSatisfiesCheck/mondoo-portainer-security'  # PASS, 14 variants
go test -tags iac_variants ./content/validation/scans -run 'TestTerraformVariantCoverage'   # PASS
go test ./content/validation/...                                          # PASS
typos                                                                     # clean
```

No policy `version:` was bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
