### PR TITLE
🐛 freebsd: fix remediation that cannot reach the state the check demands

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -2749,7 +2749,7 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set the correct ownership and permissions on all SSH private host key files. The pattern matches only the private keys, because every public key file ends in `.pub` rather than `key`, so the public keys stay readable:
+            Set the correct ownership and permissions on all SSH private host key files. The glob `ssh_host_*key` matches only the private keys. A public key filename such as `ssh_host_ed25519_key.pub` ends with `.pub`, not `key`, so it falls outside the pattern and stays readable:
 
             ```bash
             find /etc/ssh -name 'ssh_host_*key' -exec chown root:wheel {} \;

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -306,14 +306,15 @@ queries:
 
         If unrestricted, core dumps can be exploited to extract secrets from crashed privileged processes. Disabling the `savecore` service prevents the system from automatically saving crash dumps, reducing the risk of sensitive data exposure.
       audit: |
-        To verify that the `savecore` service is not active, run the following commands:
+        To verify that the `savecore` service is not active, run the following command:
 
         ```bash
-        service savecore status
         sysrc -n savecore_enable
         ```
 
-        If `service savecore status` reports the service is not running and `savecore_enable` is `NO`, the check passes. If the service is running or `savecore_enable` is `YES`, the check fails.
+        If `savecore_enable` is `NO`, the check passes. If it is `YES`, the check fails.
+
+        The `savecore` rc script runs once at boot to extract a kernel crash dump and then exits. It defines no `status` directive and leaves no process behind, so the rc variable is the authoritative source for whether it runs on the next boot.
       remediation:
         - id: cli
           desc: |
@@ -323,8 +324,9 @@ queries:
 
             ```bash
             sysrc savecore_enable="NO"
-            service savecore stop
             ```
+
+            The rc script runs once at boot and exits, so there is no running daemon to stop and the change takes effect on the next boot.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -335,7 +337,6 @@ queries:
 
             echo "Disabling savecore service..."
             sysrc savecore_enable="NO"
-            service savecore onestop 2>/dev/null || true
 
             echo "savecore service disabled."
             ```
@@ -343,7 +344,7 @@ queries:
           desc: |
             To disable the `savecore` service using Ansible:
 
-            1. Add the following tasks to a playbook targeting the FreeBSD host.
+            1. Add the following task to a playbook targeting the FreeBSD host.
             2. Run the playbook.
 
             ```yaml
@@ -357,11 +358,6 @@ queries:
                   community.general.sysrc:
                     name: savecore_enable
                     value: 'NO'
-
-                - name: Stop the savecore service
-                  ansible.builtin.service:
-                    name: savecore
-                    state: stopped
             ```
         - id: chef
           desc: |
@@ -1478,12 +1474,14 @@ queries:
             service inetd reload
             ```
 
-            If `inetd` is not needed at all, disable it:
+            If `inetd` is not needed at all, stop it and then disable it:
 
             ```bash
-            sysrc inetd_enable="NO"
             service inetd stop
+            sysrc inetd_enable="NO"
             ```
+
+            Stop before you disable. Once `inetd_enable` is `NO`, `service inetd stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -1719,12 +1717,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable and stop the NIS server:
+            Stop the NIS server, then disable it so it does not come back at boot:
 
             ```bash
-            sysrc nis_server_enable="NO"
             service ypserv stop
+            sysrc nis_server_enable="NO"
             ```
+
+            Stop before you disable. Once `nis_server_enable` is `NO`, `service ypserv stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -1819,12 +1819,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable and stop `rpcbind`:
+            Stop `rpcbind`, then disable it so it does not come back at boot:
 
             ```bash
-            sysrc rpcbind_enable="NO"
             service rpcbind stop
+            sysrc rpcbind_enable="NO"
             ```
+
+            Stop before you disable. Once `rpcbind_enable` is `NO`, `service rpcbind stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -1923,14 +1925,16 @@ queries:
 
             The NFS server is not a single process. It is several cooperating daemons: `nfsd` serves file data, `mountd` handles mount requests and reads `/etc/exports`, and `rpcbind` advertises which ports those services listen on. Disabling only `nfsd` can leave `mountd` and `rpcbind` running, so the network surface stays partly open.
 
-            Disable and stop both the NFS daemon and `mountd`:
+            Stop both the NFS daemon and `mountd`, then disable them so they do not come back at boot:
 
             ```bash
-            sysrc nfs_server_enable="NO"
-            sysrc mountd_enable="NO"
             service nfsd stop
             service mountd stop
+            sysrc nfs_server_enable="NO"
+            sysrc mountd_enable="NO"
             ```
+
+            Stop before you disable. Once `nfs_server_enable` is `NO`, `service nfsd stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot. The same applies to `mountd` and `mountd_enable`.
 
             If no other RPC services are needed on this host, also disable `rpcbind` using the dedicated rpcbind check in this policy. Leave `rpcbind` running only if another service requires it.
         - id: sh
@@ -2030,12 +2034,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable and stop the SNMP daemon:
+            Stop the SNMP daemon, then disable it so it does not come back at boot:
 
             ```bash
-            sysrc snmpd_enable="NO"
             service snmpd stop
+            sysrc snmpd_enable="NO"
             ```
+
+            Stop before you disable. Once `snmpd_enable` is `NO`, `service snmpd stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
 
             Or remove the package entirely:
 
@@ -2242,7 +2248,7 @@ queries:
         - url: https://man.freebsd.org/cgi/man.cgi?query=rc.conf&sektion=5
           title: FreeBSD rc.conf(5)
       desc: |
-        This check verifies that IMAP/POP3 mail access services (`dovecot` and `cyrus_imapd`) are not running or enabled.
+        This check verifies that the IMAP and POP3 mail access services Dovecot and Cyrus IMAP are not running or enabled.
 
         **Why this matters**
 
@@ -2252,26 +2258,30 @@ queries:
 
         ```bash
         service dovecot status
-        service cyrus_imapd status
+        service imapd status
         sysrc -n dovecot_enable cyrus_imapd_enable
         ```
 
-        If neither `dovecot` nor `cyrus_imapd` is running or enabled, the check passes. If either service is running or enabled, the check fails.
+        The cyrus-imapd port installs its rc script as `imapd` while keeping `cyrus_imapd_enable` as the rc.conf variable, so the service name and the rc variable differ.
+
+        If neither service is running or enabled, the check passes. If either one is running or enabled, the check fails.
       remediation:
         - id: cli
           desc: |
             **Using the CLI**
 
-            Disable and stop mail access services:
+            Stop the mail access services, then disable them so they do not come back at boot:
 
             ```bash
-            sysrc dovecot_enable="NO"
             service dovecot stop
-            sysrc cyrus_imapd_enable="NO"
             service imapd stop
+            sysrc dovecot_enable="NO"
+            sysrc cyrus_imapd_enable="NO"
             ```
 
             The cyrus-imapd port installs its rc script as `imapd` while keeping `cyrus_imapd_enable` as the rc.conf variable, so the two names differ by design.
+
+            Stop before you disable. Once the rc variable is `NO`, `service ... stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
         - id: sh
           desc: |
             **Using a Shell Script**
@@ -2378,12 +2388,14 @@ queries:
           desc: |
             **Using the CLI**
 
-            Disable and stop the proxy server:
+            Stop the proxy server, then disable it so it does not come back at boot:
 
             ```bash
-            sysrc squid_enable="NO"
             service squid stop
+            sysrc squid_enable="NO"
             ```
+
+            Stop before you disable. Once `squid_enable` is `NO`, `service squid stop` is refused with a message pointing at `onestop`, and the daemon keeps running until the next reboot.
 
             Or remove the package entirely:
 
@@ -2737,11 +2749,11 @@ queries:
           desc: |
             **Using the CLI**
 
-            Set the correct ownership and permissions on all SSH private host key files. The `! -name '*.pub'` guard excludes the public key files so they are not tightened to 0600, which would prevent clients from reading them:
+            Set the correct ownership and permissions on all SSH private host key files. The pattern matches only the private keys, because every public key file ends in `.pub` rather than `key`, so the public keys stay readable:
 
             ```bash
-            find /etc/ssh -name 'ssh_host_*key' ! -name '*.pub' -exec chown root:wheel {} \;
-            find /etc/ssh -name 'ssh_host_*key' ! -name '*.pub' -exec chmod 0600 {} \;
+            find /etc/ssh -name 'ssh_host_*key' -exec chown root:wheel {} \;
+            find /etc/ssh -name 'ssh_host_*key' -exec chmod 0600 {} \;
             ```
         - id: sh
           desc: |
@@ -2752,8 +2764,8 @@ queries:
             set -e
 
             echo "Setting permissions on SSH private host key files..."
-            find /etc/ssh -name 'ssh_host_*key' ! -name '*.pub' -exec chown root:wheel {} \;
-            find /etc/ssh -name 'ssh_host_*key' ! -name '*.pub' -exec chmod 0600 {} \;
+            find /etc/ssh -name 'ssh_host_*key' -exec chown root:wheel {} \;
+            find /etc/ssh -name 'ssh_host_*key' -exec chmod 0600 {} \;
 
             echo "SSH private host key file permissions configured."
             ```
@@ -4462,17 +4474,20 @@ queries:
     mql: |
       sshd.config.params["ClientAliveInterval"] >= 1
       sshd.config.params["ClientAliveInterval"] <= 300
+      sshd.config.params["ClientAliveCountMax"] >= 1
       sshd.config.params["ClientAliveCountMax"] <= 3
     docs:
       refs:
         - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
-        This check verifies that `ClientAliveInterval` is between 1 and 300 seconds and `ClientAliveCountMax` is 3 or less, ensuring idle SSH sessions are terminated.
+        This check verifies that `ClientAliveInterval` is between 1 and 300 seconds and `ClientAliveCountMax` is between 1 and 3, ensuring idle SSH sessions are terminated.
 
         **Why this matters**
 
         Idle SSH sessions left unattended can be hijacked by an attacker with local access to the terminal. Configuring an idle timeout ensures that inactive sessions are automatically disconnected, reducing the window of opportunity for session hijacking.
+
+        A `ClientAliveCountMax` of `0` is rejected. OpenSSH treats zero as disabling connection termination, so the daemon never drops an unresponsive session no matter how short the interval is.
       audit: |
         To verify the SSH idle timeout settings in effect, run the following command:
 
@@ -4480,7 +4495,7 @@ queries:
         sshd -T | grep -iE '^clientalive'
         ```
 
-        If `ClientAliveInterval` is between `1` and `300` seconds and `ClientAliveCountMax` is `3` or less, the check passes. Otherwise the check fails.
+        If `ClientAliveInterval` is between `1` and `300` seconds and `ClientAliveCountMax` is between `1` and `3`, the check passes. Otherwise the check fails.
       remediation:
         - id: cli
           desc: |
@@ -6223,15 +6238,15 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to put syslogd in secure mode so it stops listening for remote log messages:
+            Use this Chef Infra recipe code to put syslogd in secure mode so it stops listening for remote log messages. `sysrc` appends with `+=` so any other flags the host already sets, such as a bind address, survive the change:
 
             ```ruby
             service 'syslogd' do
               action :nothing
             end
 
-            execute 'set syslogd_flags in rc.conf' do
-              command 'sysrc syslogd_flags="-s"'
+            execute 'add -s to syslogd_flags in rc.conf' do
+              command 'sysrc syslogd_flags+=" -s"'
               not_if 'sysrc -n syslogd_flags | grep -q -- -s'
               notifies :restart, 'service[syslogd]', :delayed
             end

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -815,6 +815,7 @@ queries:
       sshd.config.params {
         _["ClientAliveInterval"] >= 1
         _["ClientAliveInterval"] <= 300
+        _["ClientAliveCountMax"] >= 1
         _["ClientAliveCountMax"] <= 3
       }
     docs:
@@ -827,7 +828,7 @@ queries:
         ClientAliveCountMax 3
         ```
 
-        Closing idle sessions matters because an unattended logged-in terminal, for example an operator who walked away, is an open path for anyone with physical access to the engineering station. Do not set `ClientAliveCountMax` to 0. OpenSSH treats 0 as disabling the keepalive termination mechanism, so idle sessions would never be closed. Validate the configuration with `sshd -t`, then restart the SSH service to apply the change. Restarting SSH ends active shell sessions but does not affect the running PLC program. Keep your current session open until you confirm a new login works.
+        Closing idle sessions matters because an unattended logged-in terminal, for example an operator who walked away, is an open path for anyone with physical access to the engineering station. Do not set `ClientAliveCountMax` to 0. OpenSSH treats 0 as disabling connection termination, so idle sessions would never be closed and this check rejects that value. Validate the configuration with `sshd -t`, then restart the SSH service to apply the change. Restarting SSH ends active shell sessions but does not affect the running PLC program. Keep your current session open until you confirm a new login works.
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation


### PR DESCRIPTION
Deep-dive audit of every `remediation:` block in five policies: `mondoo-freebsd-security`, `mondoo-phoenix-plcnext-security`, `mondoo-edr-policy`, `mondoo-shodan`, and `terraform-deprecations`. Every claim below is checked against an authoritative oracle, with the output quoted. Candidates that verified as correct are listed at the end rather than filed.

Defects were found in the FreeBSD policy and one in the PLCnext policy. The EDR, Shodan, and Terraform-deprecations policies came out clean.

No `version:` bump: this is a bug fix, and a merge is not a release.

---

## 1. Eight CLI remediation blocks disable the rc variable *before* stopping the service, so the service never stops

**Where:** the `- id: cli` block of `core-dump-backtraces-are-disabled`, `nis-server-is-not-enabled`, `rpcbind-is-not-enabled`, `nfs-server-is-not-enabled`, `snmp-server-is-not-enabled`, `imap-and-pop3-server-is-not-enabled`, `web-proxy-server-is-not-enabled`, and the "disable inetd entirely" step of `ftp-server-is-not-enabled`.

Every one of them read like this:

```bash
sysrc rpcbind_enable="NO"
service rpcbind stop
```

`service(8)` runs the rc script through `rc.subr`, and `run_rc_command` refuses any directive once the rcvar is off. From [`libexec/rc/rc.subr`](https://cgit.freebsd.org/src/plain/libexec/rc/rc.subr):

```sh
if ! checkyesno ${rcvar}; then
	[ "$rc_arg" = "start" ] && _run_rc_offcmd
	if [ -z "${rc_quiet}" ]; then
		echo -n "Cannot '${rc_arg}' $name. Set ${rcvar} to "
		echo -n "YES in /etc/rc.conf or use 'one${rc_arg}' "
		echo "instead of '${rc_arg}'."
	fi
	return 0
fi
```

Note the `return 0`: the second command prints an advisory, exits successfully, and does not stop anything.

**Causal chain.** The check asserts two things:

```coffee
service("rpcbind").running == false
service("rpcbind").enabled == false
```

An asset fails it with `running == true` and `enabled == true`. The documented sequence fixes `enabled`, then the `stop` is refused, so `running` stays `true` and **the check still fails after the operator follows the remediation exactly**. The daemon stays on the network until the next reboot.

The `- id: sh` blocks in these same checks already use `service X onestop`, which sidesteps the guard, so the ordering hazard was known; only the CLI blocks got it wrong. The Chef blocks use `action %i(stop disable)`, which is already stop-then-disable and is correct.

**Fix:** stop first, then disable, plus one sentence naming the `onestop` guard so the ordering does not get "tidied" back later.

```bash
service rpcbind stop
sysrc rpcbind_enable="NO"
```

## 2. `savecore` has no `status` directive and no daemon to stop

**Where:** `mondoo-freebsd-security-core-dump-backtraces-are-disabled`, `audit:` and the `cli`, `sh`, and `ansible` remediation blocks.

The audit told the reader to run `service savecore status`, and the remediation to run `service savecore stop`. [`libexec/rc/rc.d/savecore`](https://cgit.freebsd.org/src/plain/libexec/rc/rc.d/savecore) is a one-shot boot-time script:

```sh
name="savecore"
rcvar="savecore_enable"
start_cmd="savecore_start"
start_precmd="savecore_prestart"
stop_cmd=":"
```

Two consequences, both verifiable from that file plus `rc.subr`:

- It sets neither `command` nor `procname`, and `rc.subr` only appends `status` and `poll` to `_keywords` when a process name exists. `service savecore status` is therefore an unknown directive, not a status report.
- `stop_cmd=":"` is a no-op even when it is reached, and after step 1 above it is not reached at all.

**Fix:** the audit now reads `sysrc -n savecore_enable`, which is the authoritative source for whether the script runs on the next boot, and the remediation drops the meaningless stop from all three blocks and says why.

## 3. The IMAP/POP3 audit names a service that does not exist

**Where:** `mondoo-freebsd-security-imap-and-pop3-server-is-not-enabled`, `audit:` and `desc:`.

The audit ran `service cyrus_imapd status`. `cyrus_imapd` is the **rc.conf variable**, not the rc script. From [`mail/cyrus-imapd38/Makefile`](https://cgit.freebsd.org/ports/plain/mail/cyrus-imapd38/Makefile):

```make
USE_RC_SUBR=	imapd
```

so the port installs `/usr/local/etc/rc.d/imapd`. The script itself keeps the variable name ([`files/imapd.in`](https://cgit.freebsd.org/ports/plain/mail/cyrus-imapd38/files/imapd.in)):

```sh
name="cyrus_imapd"
rcvar=cyrus_imapd_enable
```

`service cyrus_imapd status` fails with `cyrus_imapd does not exist in /etc/rc.d or the local startup directories`. The check's own MQL already uses the right name, `service("imapd")`, and the `cli` remediation already used `service imapd stop` and explained the split, so only the audit and the `desc:` were out of step.

**Fix:** `service imapd status`, and the split between the script name and the rc variable is now stated in the audit too.

## 4. The syslogd Chef recipe discards any other syslogd flags the host sets

**Where:** `mondoo-freebsd-security-syslogd-is-not-accepting-remote-messages`, `- id: chef`.

```ruby
command 'sysrc syslogd_flags="-s"'
```

This is a plain assignment, so a host running `syslogd_flags="-b 127.0.0.1"` loses its bind address on converge. The `cli` and `sh` blocks in the same check both use the append form, and [sysrc(8)](https://man.freebsd.org/cgi/man.cgi?query=sysrc&sektion=8) documents it:

> In addition (but unlike sysctl(8)), `name+=value` is supported for adding items to values (see APPENDING VALUES)

**Fix:** `sysrc syslogd_flags+=" -s"`, matching the other two blocks in the same check. The `not_if` guard already prevents repeated appends.

## 5. Two SSH idle-timeout checks accept the one value that disables the idle timeout

**Where:** `mondoo-freebsd-security-ssh-idle-timeout-interval-is-configured` and `phoenix-plcnext-18`.

Both asserted only an upper bound:

```coffee
sshd.config.params["ClientAliveCountMax"] <= 3
```

[sshd_config(5)](https://man.openbsd.org/sshd_config#ClientAliveCountMax) is explicit:

> Setting a zero ClientAliveCountMax disables connection termination.

So `ClientAliveCountMax 0` means sshd never drops an unresponsive session, and both checks passed it while being titled "Ensure SSH idle timeout interval is configured". The PLCnext check contradicted its own remediation, which already told the reader "Do not set `ClientAliveCountMax` to 0."

Verified against the compiler that the bound behaves as intended and that the documented remediation value still passes:

```
$ mql run local -c '{a: "0" >= 1, b: "0" <= 3, c: "3" >= 1, d: "3" <= 3}'
{
  a:   any: false
  b:   any: true
  c:   any: true
  d:   any: true
}
```

Row `b` is the bug: the old upper bound alone passes `0`. Row `a` is the fix. Rows `c`/`d` confirm the `ClientAliveCountMax 3` that both remediation blocks recommend still satisfies the tightened check, so the closed loop holds.

**Fix:** add `>= 1` to both checks and state the reason in each `desc:`.

## 6. The SSH private-host-key remediation prose contradicted itself

**Where:** `mondoo-freebsd-security-permissions-on-ssh-private-host-key-files-are-configured`, `cli` and `sh`.

The CLI prose claimed the `! -name '*.pub'` guard "excludes the public key files so they are not tightened to 0600". It does nothing: `-name 'ssh_host_*key'` requires the basename to end in `key`, and `ssh_host_ed25519_key.pub` ends in `b`. The Chef block three entries down states the true reason, so the same check told the reader two different things:

> The glob matches only the private keys, because the public keys end in `.pub`

**Fix:** drop the inert guard from the `cli` and `sh` snippets and align the sentence with the Chef note.

---

## Checked and found correct

These were investigated as suspected defects and verified as correct. They are recorded so the coverage is legible.

**`terraform-deprecations` — clean, verified end to end.** Every replacement named in the remediation was resolved against a real provider, and the whole loop was run:

```
$ terraform init && terraform validate
Success! The configuration is valid.

$ terraform providers schema -json | jq '.provider_schemas["registry.terraform.io/hashicorp/cloudinit"].data_source_schemas | keys'
["cloudinit_config"]
```

`templatefile` and `data "cloudinit_config"` both exist and validate. The remediation's "after" snippet was then scanned with the check's own MQL and passes, and the "before" snippet fails, so the documented fix genuinely closes the finding:

```
$ mql run terraform ./after -c '<the check MQL>'
[ok] value: true   (x4)

$ mql run terraform ./before -c '<the check MQL>'
[failed] [].none()
  actual: [ 0: terraform.settings.requiredProvider name="template" source="hashicorp/template" ]
[failed] [].none()
  actual: [ 0: terraform.block labels=["template_file", "init"] type="data" ]
```

**`mondoo-shodan` — clean.** Every CLI invocation was checked against the click decorators in the Shodan CLI source rather than from memory. `shodan scan submit <ip address>` takes variadic netblocks (`@click.argument('netblocks', metavar='<ip address>', nargs=-1)`), `shodan host <ip address>` and `shodan domain <domain>` both exist as top-level commands with exactly the arguments used. The `- id: host` remediation id is unique to this policy but is a deliberate choice: the fix happens on the scanned host, not in a Shodan console.

**`mondoo-edr-policy` — clean.** Each vendor command was checked against vendor documentation: `falconctl -s --cid=` on Linux, `/Applications/Falcon.app/Contents/Resources/falconctl license` on macOS, `WindowsSensor.exe /install /quiet /norestart CID=` on Windows, `Set-Service -StartupType Automatic`, `launchctl bootstrap system` / `launchctl print system/...`, and `ansible.windows.win_service: start_mode: auto`. All real, all correctly spelled, all belonging to the subcommand they appear under.

**`.all()` on the Sophos package list in the EDR policy** looked like a quantifier bug, since every other multi-name vendor in the same check uses `.any()`. Dropped: Sophos Central genuinely installs both `Sophos Endpoint Defense` and `Sophos Endpoint Agent`, the Defender exclusion filter is consistent with it, and the line survived a previous pass specifically titled "fix quantifier logic bugs" (c0162642). Not filed without a way to verify the installed package set.

**`sed -i ''` throughout the FreeBSD shell snippets** is the usual reflex flag, since it is a syntax error under GNU sed. It is correct here: FreeBSD `sed(1)` takes the backup extension as the argument to `-i`, and `''` requests no backup. These snippets run on FreeBSD.

**`sysctl -f /etc/sysctl.conf` in every FreeBSD Chef recipe.** Confirmed against [sysctl(8)](https://man.freebsd.org/cgi/man.cgi?query=sysctl&sektion=8):

> `sysctl [-bdeFhlNnoTtqWx] [-B bufsize] [-f filename] name[=value[,value]]...`
> Specify a file which contains a pair of name and value in each line.

**Every FreeBSD sysctl name in the policy** was checked to be the FreeBSD spelling rather than the Linux one, since these diverge: `net.inet.ip.forwarding`, `net.inet6.ip6.forwarding`, `net.inet.ip.redirect`, `net.inet6.ip6.redirect`, `net.inet.icmp.drop_redirect`, `net.inet6.icmp6.rediraccept`, `net.inet.ip.accept_sourceroute`, `net.inet.tcp.syncookies`, `net.inet6.ip6.accept_rtadv`, `net.inet.icmp.bmcastecho`, `kern.elf64.aslr.enable`. All correct, and each remediation writes the same key the check reads.

**Every FreeBSD rc.conf variable** likewise: `savecore_enable`, `nis_server_enable`, `rpcbind_enable`, `nfs_server_enable`, `mountd_enable`, `snmpd_enable`, `dovecot_enable`, `cyrus_imapd_enable`, `squid_enable`, `inetd_enable`, `syslogd_enable`, `syslogd_flags`, `firewall_enable`, `firewall_type`, `firewall_myservices`, `firewall_allowservices`, `ntpd_enable`, `ntpd_sync_on_start`, `dumpdev`. All real, and each pairs with the right rc script name.

**`service inetd reload`** in the FTP, telnet, and TFTP remediation. Confirmed against [`libexec/rc/rc.d/inetd`](https://cgit.freebsd.org/src/plain/libexec/rc/rc.d/inetd), which declares `extra_commands="reload"`.

**The ipfw `workstation` profile snippet.** `firewall_myservices="22/tcp"` uses the modern `port/proto` form rather than the pre-FreeBSD-10 bare-port form, and `firewall_allowservices` accepts `any` or a CIDR. The CLI block already warns about lockout and shows the restricted form.

**`postfix.inetInterfaces.containsOnly([...])` against its remediation.** The fix writes `inet_interfaces = localhost`, which is in the accepted set, so the check passes afterwards.

**PLCnext `ssh -Q kex` / `ssh -Q mac` / `ssh -Q cipher`** in the cipher, MAC, and key-exchange remediation. All three are real query arguments, and the algorithm lists in the remediation are byte-identical to the `props` the checks compare against, so following the remediation satisfies the check.

## Validation

```
$ cnspec policy lint ./content/mondoo-freebsd-security.mql.yaml ./content/mondoo-phoenix-plcnext-security.mql.yaml
→ valid policy bundle(s)

$ make test/content/lint
→ valid policy bundle(s)          # content/ and content/querypacks

$ python3 content/validation/remediation/code/bash.py freebsd
125 passed, 0 failed

$ python3 content/validation/remediation/code/ansible.py freebsd
56 passed, 0 failed

$ python3 content/validation/remediation/code/chef.py freebsd
47 passed, 0 failed
```

The commands validator has no `freebsd`, `plcnext`, or `shodan` target, and neither policy carries IaC variants, so the fixture and closed-loop suites do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
