### PR TITLE
🐛 ai: fix remediation that does not resolve the finding in ai, mcp, and vllm

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -3185,8 +3185,8 @@ queries:
            cat ~/.cursor/mcp.json
            cat ~/.config/github-copilot/mcp.json ~/.config/github-copilot/intellij/mcp.json
            cat ~/.codeium/windsurf/mcp_config.json
-           cat ~/.gemini/settings.json
-           ls ~/.codex/.tmp/plugins/
+           cat ~/.gemini/antigravity/mcp_config.json
+           cat ~/.codex/.tmp/plugins/plugins/*/.mcp.json
            ```
 
         The endpoint passes when every configured MCP server name appears in the approved allow-list. Any server name outside the allow-list is a failing result.
@@ -3196,18 +3196,18 @@ queries:
             To remove unapproved MCP servers, delete the server entry from the location each agent actually reads:
 
             - Claude Code: run `claude mcp remove example-server` to delete the server from the user configuration in `~/.claude.json`, and remove any project-scoped entry from the repository's `.mcp.json`. Then delete the stale cache file `~/.claude/mcp-needs-auth-cache.json` so the removed server no longer appears in the inventory; Claude Code rebuilds it on next start.
-            - OpenAI Codex: MCP servers can be defined in `~/.codex/config.toml` under `[mcp_servers.<name>]` tables and bundled by installed plugins under `~/.codex/.tmp/plugins/`. Remove the TOML table for a directly configured server, and uninstall the plugin that ships an unapproved server.
+            - OpenAI Codex: Codex loads MCP servers from two places. Installed plugins declare them in a `.mcp.json` file under `~/.codex/.tmp/plugins/plugins/<plugin>/`, so uninstall the plugin that declares an unapproved server or delete its plugin directory. Servers configured directly live in `~/.codex/config.toml` under an `[mcp_servers.<name>]` table, so remove that table as well.
             - Cursor: edit `~/.cursor/mcp.json` (`%USERPROFILE%\.cursor\mcp.json` on Windows) and delete the entry under `mcpServers`.
             - GitHub Copilot: edit `~/.config/github-copilot/mcp.json` and, if present, `~/.config/github-copilot/intellij/mcp.json`, and delete the entry under `mcpServers`.
             - Windsurf: edit `~/.codeium/windsurf/mcp_config.json` (`%USERPROFILE%\.codeium\windsurf\` on Windows) and delete the entry under `mcpServers`.
-            - Gemini CLI: edit `~/.gemini/settings.json` (`%USERPROFILE%\.gemini\settings.json` on Windows) and delete the entry under `mcpServers`.
+            - Gemini CLI: edit `~/.gemini/antigravity/mcp_config.json` (`%USERPROFILE%\.gemini\antigravity\mcp_config.json` on Windows) and delete the entry under `mcpServers`.
         - id: ansible
           desc: |
             To surgically remove an unapproved MCP server entry from AI agent configuration files with Ansible:
 
-            This playbook deletes a single named MCP server from each agent's `mcpServers` object using a JSON patch, leaving the rest of the configuration file intact, and removes the Claude Code MCP cache file so the deleted server no longer appears in its inventory. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. Each patched file is backed up before modification.
+            This playbook deletes a single named MCP server from each agent's top-level `mcpServers` object, leaving the rest of the configuration file intact, and removes the Claude Code MCP cache file so the deleted server no longer appears in its inventory. Set `unapproved_mcp_server` to the server name to remove, and edit `mcp_config_files` to match your environment. Each rewritten file is backed up before modification.
 
-            The `mcpServers` path is not the same in every agent. Claude Code's `~/.claude.json` nests MCP servers per project rather than only at the top level, so a top-level `/mcpServers` patch can silently no-op and leave a project-scoped server in place; the `failed_when: false` guard hides that. For Claude Code, prefer running `claude mcp remove <name>` (covered by the command-line remediation) instead of patching the file, and confirm the project-scoped path for any agent whose configuration does not expose servers at top-level `mcpServers`.
+            The `mcpServers` path is not the same in every agent. Claude Code's `~/.claude.json` nests MCP servers per project rather than only at the top level, so a top-level rewrite leaves a project-scoped server in place. For Claude Code, prefer running `claude mcp remove <name>`, which the command-line remediation above covers, and confirm the project-scoped path for any agent whose configuration does not expose servers at top-level `mcpServers`. OpenAI Codex is absent from the list because its servers are declared in per-plugin `.mcp.json` files under `~/.codex/.tmp/plugins/plugins/`, which are removed by uninstalling the plugin rather than by editing a shared configuration file.
 
             ```yaml
             ---
@@ -3219,17 +3219,32 @@ queries:
                   - "{{ ansible_env.HOME }}/.claude.json"
                   - "{{ ansible_env.HOME }}/.cursor/mcp.json"
                   - "{{ ansible_env.HOME }}/.config/github-copilot/mcp.json"
-                  - "{{ ansible_env.HOME }}/.gemini/settings.json"
+                  - "{{ ansible_env.HOME }}/.config/github-copilot/intellij/mcp.json"
+                  - "{{ ansible_env.HOME }}/.codeium/windsurf/mcp_config.json"
+                  - "{{ ansible_env.HOME }}/.gemini/antigravity/mcp_config.json"
               tasks:
-                - name: Remove the unapproved server from each agent's mcpServers object
-                  community.general.json_patch:
+                - name: Read each agent's MCP configuration
+                  ansible.builtin.slurp:
                     src: "{{ item }}"
-                    operations:
-                      - op: remove
-                        path: "/mcpServers/{{ unapproved_mcp_server }}"
-                    backup: true
                   loop: "{{ mcp_config_files }}"
+                  register: mcp_configs
                   failed_when: false
+
+                - name: Remove the unapproved server from each agent's mcpServers object
+                  vars:
+                    config: "{{ item.content | b64decode | from_json }}"
+                  ansible.builtin.copy:
+                    dest: "{{ item.source }}"
+                    content: >-
+                      {{ config | combine({'mcpServers': config.mcpServers | dict2items
+                         | rejectattr('key', 'equalto', unapproved_mcp_server)
+                         | items2dict}) | to_nice_json }}
+                    backup: true
+                    mode: "0600"
+                  loop: "{{ mcp_configs.results }}"
+                  when:
+                    - item.content is defined
+                    - config.mcpServers is defined
 
                 - name: Remove the stale Claude Code MCP cache
                   ansible.builtin.file:

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -96,11 +96,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Send a `tools/list` request to the server endpoint:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
            ```
 
@@ -123,7 +126,15 @@ queries:
             ```json
             {
               "name": "lookup_customer",
-              "description": "Look up a customer record by ID. Provide the customer identifier as input; do not include real names, addresses, or payment card numbers in tool metadata."
+              "description": "Look up a customer record by ID. Provide the customer identifier as input; do not include real names, addresses, or payment card numbers in tool metadata.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "customer_id": { "type": "string", "maxLength": 64 }
+                },
+                "required": ["customer_id"],
+                "additionalProperties": false
+              }
             }
             ```
     refs:
@@ -185,11 +196,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the tool and prompt definitions:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
            ```
 
@@ -219,7 +233,15 @@ queries:
             ```json
             {
               "name": "search_orders",
-              "description": "Search the orders table by customer ID and return up to 50 matching orders sorted by date."
+              "description": "Search the orders table by customer ID and return up to 50 matching orders sorted by date.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "customer_id": { "type": "string", "maxLength": 64 }
+                },
+                "required": ["customer_id"],
+                "additionalProperties": false
+              }
             }
             ```
     refs:
@@ -282,11 +304,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the tool definitions and search for links:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -Eo 'https?://[^"]+'
            ```
 
@@ -308,7 +333,15 @@ queries:
             ```json
             {
               "name": "fetch_report",
-              "description": "Fetch a report by ID from the analytics service."
+              "description": "Fetch a report by ID from the analytics service.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "report_id": { "type": "string", "maxLength": 64 }
+                },
+                "required": ["report_id"],
+                "additionalProperties": false
+              }
             }
             ```
     refs:
@@ -366,11 +399,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the tool definitions:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
            ```
 
@@ -469,11 +505,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the tool and prompt definitions:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
            ```
 
@@ -556,11 +595,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the tool definitions and screen for non-ASCII characters:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -P '[^\x00-\x7F]'
            ```
 
@@ -664,11 +706,14 @@ queries:
 
         The MCP specification defines several transports. The HTTP example below assumes a Streamable HTTP transport listening on `localhost:3000/mcp`. Replace the host, port, and path with the values your server uses. Servers that use the stdio or SSE transport do not expose a fixed HTTP endpoint for raw `curl`, so drive them with an MCP client such as the MCP Inspector instead.
 
+        The specification requires the client to send an `Accept` header listing both `application/json` and `text/event-stream` on every request, so a server that enforces it rejects a request that omits the header. A server that returns an `Mcp-Session-Id` during initialization additionally requires that header and an `MCP-Protocol-Version` header on every later request, which raw `curl` cannot supply without first completing the initialization handshake. Use the MCP Inspector against those servers.
+
         1. Retrieve the resource definitions:
 
            ```bash
            curl -s -X POST http://localhost:3000/mcp \
              -H 'Content-Type: application/json' \
+             -H 'Accept: application/json, text/event-stream' \
              -d '{"jsonrpc":"2.0","id":1,"method":"resources/list"}'
            ```
 
@@ -684,7 +729,7 @@ queries:
             For every entry returned by `resources/list` and `resources/templates/list`, set a non-empty `name` and `description`, and ensure the description contains neither explicit content nor personally identifiable information.
 
             1. Walk the resource and resource-template registrations in your MCP server and fill in any missing `name` or `description` values.
-            2. Rewrite descriptions that contain real names, addresses, payment data, or explicit language. Use synthetic placeholders such as `<report-id>` or `example@example.com` in any sample text.
+            2. Rewrite descriptions that contain real names, addresses, payment data, or explicit language. Use synthetic placeholders such as `report-id` or `example@example.com` in any sample text. Avoid angle-bracket placeholders, because `<` and `>` are Unicode symbol characters that Unicode safety screening of metadata rejects.
             3. Treat resource URIs and descriptions as values that flow into model context. Do not embed credentials, internal hostnames, or customer identifiers in either field.
             4. If you list resources from a dynamic backend, validate `name` and `description` at registration time and skip resources that fail validation rather than emitting an empty placeholder.
             5. Restart the MCP server so the registry re-emits the corrected resources.

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -372,12 +372,12 @@ queries:
 
         ### Audit via server configuration
 
-        1. Inspect the `vllm serve` launch command for the `--enable-server-load-tracking` flag, which creates the `/load` endpoint.
+        1. Inspect the `vllm serve` launch command for the `--enable-server-load-tracking` flag. The flag decides whether the server counts in-flight requests, not whether the route exists, so its absence does not remove `/load`.
         2. Review the reverse proxy, API gateway, ingress, or firewall configuration for a rule that restricts `/load` to trusted monitoring or autoscaling components.
 
         A passing result shows `/load` blocked or limited to trusted infrastructure; a failing result shows it reachable by anonymous clients.
       remediation: |
-        Remove the `--enable-server-load-tracking` flag from the vLLM launch command when load data is not required; the `/load` endpoint only exists while that flag is set. Restarting the server to change launch flags cancels in-flight requests, so drain traffic at the load balancer or proxy first. If load data is required for autoscaling or monitoring, keep the flag but restrict `/load` to trusted infrastructure at the reverse proxy, API gateway, ingress, or firewall:
+        Block `/load` at the reverse proxy, API gateway, ingress, or firewall. vLLM registers the `/load` route on every server and serves it outside the scope of the built-in API key, so removing `--enable-server-load-tracking` does not take the endpoint away. Dropping that flag only stops the server from counting in-flight requests, leaving `/load` answering anonymous callers with a zero load figure. Restrict the route to the monitoring or autoscaling components that need it:
 
         ```nginx
         location = /load {
@@ -625,12 +625,22 @@ queries:
 
         ### Audit via server configuration
 
-        1. Inspect the `vllm serve` launch command and environment for settings that enable operational control endpoints.
+        1. Inspect the server environment for the `VLLM_SERVER_DEV_MODE` environment variable, which is what registers `/pause` and `/resume`. `/scale_elastic_ep` has no such switch and is registered on every server that supports generation.
         2. Review the reverse proxy, API gateway, ingress, or firewall configuration for an authentication or deny rule covering `/pause`, `/resume`, and `/scale_elastic_ep`.
 
         A passing result shows operational control routes blocked or limited to an authenticated administrative plane; a failing result shows them reachable by anonymous clients.
       remediation: |
-        Block operational control routes from untrusted networks. If operational routes are required, expose them only through an authenticated administrative plane and restrict access to trusted operators or automation.
+        Remove the `VLLM_SERVER_DEV_MODE` environment variable from the server environment. vLLM registers `/pause` and `/resume` only while it is set, so unsetting it removes both routes outright. Delete the `Environment=VLLM_SERVER_DEV_MODE=1` line from systemd units and the matching `environment:` or `env:` entry from Docker Compose and Kubernetes manifests, then restart the server. Restarting vLLM cancels in-flight requests, so drain traffic at the load balancer or proxy first.
+
+        `/scale_elastic_ep` is registered on every server that supports generation and sits outside the scope of the built-in API key, so it has to be blocked upstream at the reverse proxy, API gateway, ingress controller, or firewall:
+
+        ```nginx
+        location ~ ^/(pause|resume|scale_elastic_ep|is_scaling_elastic_ep)$ {
+            deny all;
+        }
+        ```
+
+        If operational routes are required, expose them only through an authenticated administrative plane and restrict access to trusted operators or automation.
     refs:
       - url: https://docs.vllm.ai/en/latest/serving/security.html
         title: vLLM Security
@@ -682,12 +692,12 @@ queries:
 
         ### Audit via server configuration
 
-        1. Inspect the `vllm serve` launch command and environment for whatever enables profiling in your release. Depending on the version this is the `VLLM_TORCH_PROFILER_DIR` environment variable, a `--profiler-config` flag, or another setting, so confirm the enablement mechanism for your version against `vllm serve --help` and the profiling documentation for that release.
+        1. Inspect the `vllm serve` launch command for the `--profiler-config` flag, which selects a profiler and is what registers the profiler routes. Releases before 0.13.0 used the `VLLM_TORCH_PROFILER_DIR` environment variable instead, so inspect the server environment as well when an older release is running.
         2. Review the reverse proxy, API gateway, ingress, or firewall rules for entries that block `/start_profile` and `/stop_profile`.
 
         A passing result shows profiler routes disabled or blocked from untrusted clients; a failing result shows them reachable anonymously.
       remediation: |
-        Remove profiler configuration from production launch commands. The `/start_profile` and `/stop_profile` routes only exist while profiling is enabled, so confirm that whatever enables profiling in your release is absent. Depending on the version this means unsetting the `VLLM_TORCH_PROFILER_DIR` environment variable, removing a `--profiler-config` flag, or both, so check the profiling enablement mechanism for your version against `vllm serve --help` and the profiling documentation for that release:
+        Remove profiler configuration from production launch commands. The `/start_profile` and `/stop_profile` routes are registered only when a profiler is selected. From vLLM 0.13.0 onward that selection is the `--profiler-config` flag, so drop the flag from the launch command. Releases before 0.13.0 read the `VLLM_TORCH_PROFILER_DIR` environment variable instead, and current releases no longer read it at all, so unset it as well when you are not certain which release is running:
 
         ```bash
         unset VLLM_TORCH_PROFILER_DIR


### PR DESCRIPTION
Remediation deep dive over `mondoo-ai-security`, `mondoo-mcp-security`, and `mondoo-vllm-security`. Every `remediation:` block in the three policies was read and traced back to the system that owns the answer: the mql provider source for the AI endpoint checks, the vLLM upstream argparse and router registration for the vLLM checks, and the MCP specification schema for the MCP checks. Nine defects found. Everything else is listed at the bottom as checked and correct.

---

## 1. The Gemini MCP remediation edits a file the check never reads

`mondoo-ai-security-no-unapproved-mcp-servers` inspects `gemini.mcpServers`. That resource reads one file:

```go
// mql providers/os/resources/gemini.go:65-70
func (r *mqlGemini) mcpServers() ([]interface{}, error) {
	afs := connectionAfs(r.MqlRuntime)
	configDir := r.ConfigPath.Data

	// Gemini stores MCP config in antigravity/mcp_config.json
	data, err := afs.ReadFile(filepath.Join(configDir, "antigravity", "mcp_config.json"))
```

The audit told the operator to `cat ~/.gemini/settings.json`, the CLI remediation told them to edit `~/.gemini/settings.json`, and the Ansible playbook patched `~/.gemini/settings.json`. None of the three touches `~/.gemini/antigravity/mcp_config.json`, so an unapproved Gemini server survives every documented fix and the check keeps failing.

All three now name `~/.gemini/antigravity/mcp_config.json`.

## 2. The Ansible playbook calls a module that does not exist

The playbook used `community.general.json_patch` as a task module. `json_patch` in `community.general` is a **filter plugin**, not a module:

```
$ curl -s "https://api.github.com/repos/ansible-collections/community.general/contents/plugins/modules?ref=main" | ...
['syspatch.py']          # every module whose name contains "json" or "patch"
total modules: 577
$ ... contents/plugin/filter ...
['json_diff.yml', 'json_patch.py', 'json_patch.yml', 'json_patch_recipe.yml', 'json_query.py']
```

`https://docs.ansible.com/.../json_patch_module.html` returns 404; `json_patch_filter.html` resolves and documents it as a filter added in community.general 10.3.0.

Reproduced with the collection actually installed:

```
$ ansible-galaxy collection install community.general -p ./collections
$ ANSIBLE_COLLECTIONS_PATH=./collections ansible-playbook -i localhost, -c local old.yml
[ERROR]: couldn't resolve module/action 'community.general.json_patch'. This often
indicates a misspelling, missing collection, or incorrect module path.
```

Because the task carried `failed_when: false`, the failure was swallowed and the playbook reported success while removing nothing.

**Why CI stayed green.** `content/validation/remediation/code/ansible.py` runs ansible-lint offline and drops `syntax-check[unknown-module]` from the results, with the comment "offline mode can't resolve collections". A fabricated module name is exactly what that ignore hides.

The replacement uses `ansible.builtin.slurp` plus a `dict2items | rejectattr | items2dict` rewrite, so it depends on nothing outside `ansible.builtin`. Verified end to end against fixture configs:

```
TASK [Remove the unapproved server from each agent's mcpServers object] ********
skipping: [localhost] => (.claude.json — file not found)
changed:  [localhost] => (.cursor/mcp.json)
skipping: [localhost] => (github-copilot/mcp.json — no mcpServers key)
changed:  [localhost] => (.codeium/windsurf/mcp_config.json)
changed:  [localhost] => (.gemini/antigravity/mcp_config.json)

$ cat home/.cursor/mcp.json
{
    "mcpServers": {
        "keep-me": { "command": "y" }
    },
    "other": 1
}
```

The unapproved entry is gone, the approved entry and the unrelated top-level key survive, missing files and files without an `mcpServers` object are skipped rather than failing, and `backup: true` leaves a timestamped copy.

## 3. The Ansible playbook covered four of the six agents the check inspects

`mcp_config_files` listed Claude Code, Cursor, Copilot, and Gemini. The check also reads:

- `windsurf.mcpServers` → `~/.codeium/windsurf/mcp_config.json` (`windsurf.go:76`)
- `githubCopilot.mcpServers` → `~/.config/github-copilot/intellij/mcp.json` as well as the top-level file (`github_copilot.go:65-66`)

Both are plain JSON with a top-level `mcpServers` object, exactly the shape the task handles, and both are named in the CLI remediation. Running the playbook on a host whose only unapproved server was configured in Windsurf left the check failing. Both files are now in the list.

## 4. The Codex remediation names a file that holds no MCP servers

The old bullet said MCP servers "can be defined in `~/.codex/config.toml` under `[mcp_servers.<name>]` tables". `openai_codex.go` reads `config.toml` for exactly two keys:

```go
// codexConfig captures the top-level model settings from config.toml.
type codexConfig struct {
	Model         string `toml:"model"`
	ModelProvider string `toml:"model_provider"`
}
```

The servers come from per-plugin files, and the path has a doubled segment that the old text and the old audit both got wrong:

```go
pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")   // 4 call sites
mcpPath := filepath.Join(dir.path, ".mcp.json")
```

The audit's `ls ~/.codex/.tmp/plugins/` therefore printed a single directory named `plugins` rather than the plugin list. Audit and remediation now name `~/.codex/.tmp/plugins/plugins/<plugin>/.mcp.json` and lead with uninstalling the plugin; the `config.toml` table is kept as a secondary step for directly configured servers.

## 5. Removing `--enable-server-load-tracking` does not remove `/load`

`mondoo-vllm-security-load-not-exposed` said the endpoint "only exists while that flag is set". It does not. The route is registered unconditionally:

```python
# vllm/entrypoints/serve/instrumentator/basic.py
@router.get("/load")
async def get_server_load_metrics(request: Request):
    return JSONResponse(content={"server_load": request.app.state.server_load_metrics})
```

```python
# vllm/entrypoints/serve/instrumentator/__init__.py
def register_instrumentator_api_routers(app: FastAPI):
    from .basic import router as basic_router
    app.include_router(basic_router)          # no flag guard
```

and the counter it reads is initialised regardless of the flag:

```python
# vllm/entrypoints/openai/api_server.py:456-457
state.enable_server_load_tracking = args.enable_server_load_tracking
state.server_load_metrics = 0
```

`/load` also does not start with any of vLLM's guarded prefixes, so the built-in API key does not cover it either. Dropping the flag leaves the route answering anonymous callers with `{"server_load": 0}` and the check still failing. The remediation now leads with the upstream block, which is the only thing that closes it, and the audit no longer claims the flag creates the endpoint.

## 6. The profiler remediation targets a variable current vLLM no longer reads

The shipped snippet was `unset VLLM_TORCH_PROFILER_DIR`. That variable is gone from vLLM's environment registry, and the profiler routes are gated on a flag instead:

```python
# vllm/engine/arg_utils.py:1652
vllm_group.add_argument("--profiler-config", **vllm_kwargs["profiler_config"])
```

```python
# vllm/entrypoints/serve/profile/api_router.py
profiler_config = getattr(app.state.args, "profiler_config", None)
if profiler_config is not None and profiler_config.profiler is not None:
    app.include_router(router)
```

Bisecting release tags on `envs.py` and `arg_utils.py`: `--profiler-config` landed in v0.13.0, and `VLLM_TORCH_PROFILER_DIR` was absent from `envs.py` from v0.16.0 onward. On any current release the old snippet is a no-op. The remediation now names `--profiler-config` as the thing to drop and keeps the environment variable as the pre-0.13.0 case.

## 7. The operational-control remediation missed the switch that removes two of its three routes

The old text was one sentence: block them upstream. Two of the three named routes are dev-mode gated and vanish entirely without an upstream rule:

```python
# vllm/entrypoints/serve/dev/rlhf/api_router.py
@router.post("/pause")
@router.post("/resume")
```

registered only from `register_vllm_dev_api_routers`, which `api_server.py:224-228` calls under `if envs.VLLM_SERVER_DEV_MODE:`. `/scale_elastic_ep` is different: `elastic_ep_attach_router(app)` runs whenever `"generate" in supported_tasks`, so it exists on every ordinary generative server and does need the upstream rule. The remediation now splits the two cases and ships the nginx block for the half that cannot be turned off.

## 8. Three MCP tool snippets are invalid tool definitions

`inputSchema` is required on `Tool` in the MCP schema, with a literal object type:

```typescript
export interface Tool extends BaseMetadata {
  description?: string;
  inputSchema: {          // no `?`
    type: "object";
    properties?: { [key: string]: object };
    required?: string[];
  };
```

The `lookup_customer`, `search_orders`, and `fetch_report` snippets shipped `name` and `description` only. An operator who pasted one produced a tool that violates the spec and that fails `mondoo-mcp-tool-parameters` in the same policy, which asserts `inputSchema.type == "object"`. Each snippet now carries a constrained schema in the shape the tool-parameters remediation recommends.

## 9. Every JSON-RPC audit example omits a header the spec makes a MUST

From the Streamable HTTP transport section of the specification:

> The client **MUST** include an `Accept` header, listing both `application/json` and `text/event-stream` as supported content types.

> If an `Mcp-Session-Id` is returned by the server during initialization, clients using the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on all of their subsequent HTTP requests.

All seven `curl` examples sent only `Content-Type`, so a server that enforces the requirement rejects them and the auditor cannot reproduce the finding. Each example now sends the `Accept` header, and the shared preamble states the session and protocol-version requirements and points at the MCP Inspector for servers that enforce them.

Minor, same policy: the resource-validation remediation recommended the placeholder `<report-id>` while the `pii-detection` remediation in the same file warns against angle-bracket placeholders and the adjacent code block uses `{report_id}`. Made consistent.

---

## Checked and found correct

Candidates that looked wrong and verified as fine, so nobody re-files them:

**vLLM**

- `--disable-fastapi-docs` removing `/docs`, `/redoc`, and `/openapi.json`. Confirmed: `FastAPI(openapi_url=None, docs_url=None, redoc_url=None, lifespan=lifespan)`. The newer `--enable-offline-docs` flag re-adds `/docs`, but `api_server.py:199` tests `disable_fastapi_docs` **first**, so disable wins and the remediation is complete.
- `--allowed-origins '["https://app.example.com"]'`. Confirmed: `cli_args.py:277` defaults to `["*"]`, and `:344/:347` set `type = json.loads` and delete `nargs`, so a single JSON-list string is exactly the right form.
- `--api-key` plus the `VLLM_API_KEY` alternative. Confirmed, including the precedence comment "Ensure --api-key option from CLI takes precedence over VLLM_API_KEY".
- `--enable-tokenizer-info-endpoint` gating `/tokenizer_info`. Confirmed at `serve/tokenize/api_router.py:97-98`.
- `VLLM_SERVER_DEV_MODE` gating `/server_info`, the cache reset routes, `/sleep`, `/wake_up`, `/is_sleeping`, and `/collective_rpc`. All six confirmed in the five dev routers.
- The claim that `--api-key` does not cover `/tokenize`, `/detokenize`, `/invocations`, `/pooling`, `/classify`, `/score`, `/rerank`, `/metrics`, or `/version`. Confirmed: `GUARDED_PREFIX = ("/v1", "/v2", "/inference", "/cohere")` and a plain `startswith` test. The nginx deny list in the custom-inference remediation covers exactly the right set, and `/inference` really is guarded, so that check's hedge is accurate.

**AI**

- Every agent config directory in the policy matches the provider default: `.roo`, `.cline`, `.kiro`, `.continue`, `.trae`, `.config/opencode`, `.pi/agent`, `.vibe`, `.gemini/antigravity`, `.bob`, `.openclaw`, `.snowflake/cortex`, `.junie`, `.augment`, `.warp`, `.kilocode`, `.openhands`, `.qwen`, `.cursor`, `.claude`, `.config/github-copilot`, `.config/goose`, `.codex`, `.config/zed`, `.codeium/windsurf`.
- The Windows PowerShell paths such as `$env:USERPROFILE\.config\goose` look wrong for Windows but are right: `initConfigPath` joins the target home with the same relative directory on every platform, so the Windows layout really is `%USERPROFILE%\.config\goose`.
- Cline and Warp reading skills from the shared `~/.agents/skills` directory rather than their own config folder, which the audit and remediation prose both call out. Confirmed in `ai_agents.go:45-50` and `:310-314`.
- The VS Code extension identifiers: `codeium.codeium`, `tabnine.tabnine-vscode`, `supermaven.supermaven`, `continue.continue`, `saoudrizwan.claude-dev`, `sourcegraph.cody-ai`, `openai.chatgpt`, `anthropic.claude-code`, `rooveterinaryinc.roo-cline`, `kilocode.kilo-code`, `anysphere.cursorpyright`.

**MCP**

- The Unicode remediation calling `` ` ``, `=`, `<`, `>`, and `$` Symbol-category characters. Correct: U+0060 is Sk, `=`/`<`/`>` are Sm, `$` is Sc.
- The static-resource versus resource-template distinction in the resource-validation snippets. Confirmed against the schema: `Resource` requires `uri`, `ResourceTemplate` requires `uriTemplate`.

## Observed, not fixed

`content/CLAUDE.md` asks macOS and Windows checks for `gui`, `cli`, `ansible`, and `script`. `mondoo-ai-security` has no `script` entry anywhere, and most of the per-agent checks have no `gui` entry. That is a coverage gap across roughly thirty checks rather than a correctness defect, so it is out of scope here and worth its own pass.

## Validation

```
cnspec policy lint ./content/mondoo-ai-security.mql.yaml     → valid policy bundle(s)
cnspec policy lint ./content/mondoo-mcp-security.mql.yaml    → valid policy bundle(s)
cnspec policy lint ./content/mondoo-vllm-security.mql.yaml   → valid policy bundle(s)
python3 content/validation/remediation/code/ansible.py ai    → all PASS
python3 content/validation/remediation/code/bash.py all      → exit 0
python3 content/validation/remediation/code/powershell.py all → exit 0
typos content/mondoo-{ai,mcp,vllm}-security.mql.yaml         → exit 0
```

The three policies are not in the `TARGETS` of the CLI/API commands validator, so it is unaffected. No `version:` bump: this is a bug fix, and a merge is not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
