### PR TITLE
🐛 content: fix remediation defects in the network device policies

### DIFF
--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -393,7 +393,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            The most maintainable approach on BIG-IP 13.0 and later is a cipher group built from F5's `f5-secure` cipher rule, which resolves to ECDHE key exchange with AES-GCM suites only. To configure one using the BIG-IP Configuration utility:
+            The most maintainable approach on BIG-IP 13.0 and later is a cipher group built from F5's `f5-secure` cipher rule, which represents the cipher string `ECDHE:RSA:!SSLV3:!RC4:!EXP:!DES` and so excludes every suite this check flags. To configure one using the BIG-IP Configuration utility:
 
             1. Navigate to **Local Traffic → Ciphers → Groups** and click **Create**
             2. Give the group a name, add the `f5-secure` rule to the **Allowed** column, and click **Finished**
@@ -402,12 +402,12 @@ queries:
             5. In the **Ciphers** setting, select **Cipher Group** and choose the group you created
             6. Click **Update**
 
-            If you must specify a cipher string directly instead of a group, select **Cipher String** and enter a list restricted to AES-GCM suites, for example `ECDHE+AES-GCM:DHE+AES-GCM`. Prefer GCM, an authenticated AEAD mode, over the older CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext as part of decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
+            `f5-secure` removes the weak suites but still permits RSA key exchange and AES-CBC suites. For a stricter posture, select **Cipher String** instead of **Cipher Group** and enter a list restricted to AES-GCM suites, for example `ECDHE+AES-GCM:DHE+AES-GCM`. Prefer GCM, an authenticated AEAD mode, over the older CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext as part of decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
 
             **Note**: Clients that support only the removed cipher suites can no longer connect to virtual servers using this profile. Validate the change against your client population in a maintenance window.
         - id: cli
           desc: |
-            On BIG-IP 13.0 and later, the recommended approach is a cipher group built from F5's `f5-secure` cipher rule, which resolves to ECDHE key exchange with AES-GCM suites only:
+            On BIG-IP 13.0 and later, the recommended approach is a cipher group built from F5's `f5-secure` cipher rule, which represents the cipher string `ECDHE:RSA:!SSLV3:!RC4:!EXP:!DES` and so excludes every suite this check flags:
 
             1. Open an SSH session to the BIG-IP and enter the tmsh shell.
             2. Create a cipher group that allows the `f5-secure` rule:
@@ -420,7 +420,7 @@ queries:
                ```text
                tmsh modify ltm profile client-ssl <profile-name> cipher-group secure-gcm ciphers none
                ```
-            4. Confirm the group resolves to AES-GCM suites only and that no weak suites remain:
+            4. Confirm the group resolves to the expected suites and that no weak suites remain:
 
                ```text
                tmsh show ltm cipher group secure-gcm
@@ -431,7 +431,7 @@ queries:
                tmsh save sys config
                ```
 
-            If your release does not support cipher groups, set an inline cipher string restricted to AES-GCM suites instead with `tmsh modify ltm profile client-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`, then verify the expansion with `tmm --clientciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`. Prefer GCM, an authenticated AEAD mode, over CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext during decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
+            `f5-secure` removes the weak suites but still permits RSA key exchange and AES-CBC suites. If your release does not support cipher groups, or you want a stricter posture, set an inline cipher string restricted to AES-GCM suites instead with `tmsh modify ltm profile client-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`, then verify the expansion with `tmm --clientciphers 'ECDHE+AES-GCM:DHE+AES-GCM'`. Prefer GCM, an authenticated AEAD mode, over CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext during decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS.
     refs:
       - url: https://my.f5.com/manage/s/article/K13156
         title: F5 - Configuring the cipher strength for SSL profiles
@@ -501,9 +501,11 @@ queries:
             1. Navigate to **Local Traffic → Profiles → SSL → Server**
             2. Click on the affected profile
             3. Set the **Configuration** selector to **Advanced**
-            4. In the **Ciphers** setting, select **Cipher String** and enter a list built only from strong suites, for example:
-               `ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES`
+            4. In the **Ciphers** setting, select **Cipher String** and enter a list restricted to AES-GCM suites:
+               `ECDHE+AES-GCM:DHE+AES-GCM`
             5. Click **Update**
+
+            This matches the standard the client SSL profiles enforce. Prefer GCM, an authenticated AEAD mode, over the older CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext as part of decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS. Append `:ECDHE+AES:DHE+AES` only for backends that cannot negotiate GCM, and track those backends for upgrade.
 
             **Note**: Backend pool members that support only the removed cipher suites can no longer complete TLS handshakes with the BIG-IP. Confirm backend cipher support before applying the change.
         - id: cli
@@ -514,18 +516,20 @@ queries:
             2. Update the cipher string on the server SSL profile:
 
                ```text
-               tmsh modify ltm profile server-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
+               tmsh modify ltm profile server-ssl <profile-name> ciphers 'ECDHE+AES-GCM:DHE+AES-GCM'
                ```
             3. From the advanced shell, list the cipher suites the string expands to and confirm no weak suites remain:
 
                ```text
-               tmm --serverciphers 'ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES'
+               tmm --serverciphers 'ECDHE+AES-GCM:DHE+AES-GCM'
                ```
             4. Save the configuration:
 
                ```text
                tmsh save sys config
                ```
+
+            This matches the standard the client SSL profiles enforce. Prefer GCM, an authenticated AEAD mode, over the older CBC suites such as `ECDHE+AES` or `DHE+AES`. GCM authenticates the ciphertext during decryption, which closes the padding-oracle and timing weaknesses such as BEAST and Lucky 13 that affect CBC suites in TLS. Append `:ECDHE+AES:DHE+AES` only for backends that cannot negotiate GCM, and track those backends for upgrade.
     refs:
       - url: https://my.f5.com/manage/s/article/K13156
         title: F5 - Configuring the cipher strength for SSL profiles

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -1107,13 +1107,7 @@ queries:
         - Blocked lateral movement attempts from compromised internal hosts go unnoticed.
         - Compliance frameworks such as PCI DSS and NIST 800-53 AU-2 require logging of denied access attempts.
       audit: |
-        ### Audit via the FortiGate web interface
-
-        1. Log in to the FortiGate web interface.
-        2. Navigate to **Policy & Objects > Firewall Policy**.
-        3. Locate the **Implicit Deny** policy at the bottom of the policy table and check whether **Log Violation Traffic** is enabled.
-
-        A passing result shows implicit deny logging enabled. A failing result shows it disabled.
+        Implicit deny logging is the `fwpolicy-implicit-log` option in `config log setting`, a global log setting rather than a property of a firewall policy, and it is not exposed in the FortiGate web interface. Audit it from the CLI.
 
         ### Audit via FortiOS CLI
 
@@ -1126,19 +1120,14 @@ queries:
 
         A passing result reports `fwpolicy-implicit-log` set to `enable`. A failing result reports `disable`.
       remediation:
-        - id: console
-          desc: |
-            **Using the FortiGate web interface**
-
-            1. Navigate to **Policy & Objects > Firewall Policy**
-            2. Locate the **Implicit Deny** policy at the bottom of the policy table and click **Edit**
-            3. Enable **Log Violation Traffic**
-            4. Click **OK**
+        # No console remediation: fwpolicy-implicit-log lives in "config log setting" as a global log setting and is not exposed in the FortiGate web interface. The GUI "Log Violation Traffic" toggle sets logtraffic on a user-created deny policy, which is a different config node and leaves fwpolicy-implicit-log unchanged.
         - id: cli
           desc: |
             **Using the CLI**
 
             On a multi-VDOM device, first run `config global`.
+
+            The implicit deny logging option is available only in the CLI:
 
             ```text
             config log setting
@@ -1749,13 +1738,25 @@ queries:
             show firewall policy
             ```
 
-            Delete an unused policy:
+            Delete a policy that is no longer needed:
 
             ```text
             config firewall policy
                 delete <policy-id>
             end
             ```
+
+            Re-enable a policy that should be active instead:
+
+            ```text
+            config firewall policy
+                edit <policy-id>
+                    set status enable
+                next
+            end
+            ```
+
+            Re-enabling a policy puts it back into the match order at its existing sequence number, so confirm the traffic it permits is still intended before running this.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/954936/firewall-policies
         title: FortiOS firewall policies

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -376,12 +376,15 @@ queries:
           desc: |
             To restrict management services to trusted source addresses using the RouterOS CLI:
 
-            Set the `address` field on each enabled service to your administrative network(s). For example, to limit SSH and WinBox to a management subnet:
+            Set the `address` field on every service that `/ip service print` reports as enabled. The field takes a comma-separated list of IPv4 and IPv6 prefixes, so several administrative networks can be permitted at once:
 
             ```text
-            /ip service set ssh address=192.168.88.0/24
-            /ip service set winbox address=192.168.88.0/24
+            /ip service set ssh address=192.168.88.0/24,10.10.0.0/24
+            /ip service set winbox address=192.168.88.0/24,10.10.0.0/24
+            /ip service set www-ssl address=192.168.88.0/24,10.10.0.0/24
             ```
+
+            A service left with an empty `address` still accepts connections from any host, so repeat the command for each remaining enabled service.
     refs:
       - url: https://help.mikrotik.com/docs/display/ROS/Services
         title: MikroTik RouterOS Services
@@ -499,9 +502,9 @@ queries:
       remediation:
         - id: cli
           desc: |
-            To remove the default admin account using the RouterOS CLI:
+            To disable the default admin account using the RouterOS CLI:
 
-            First create a replacement administrator account and confirm you can log in with it:
+            First create a replacement administrator account and confirm you can log in with it, so disabling `admin` does not leave the device without an administrator:
 
             ```text
             /user add name=netadmin group=full password=<strong-password>
@@ -630,7 +633,17 @@ queries:
           desc: |
             To set a non-default SNMP trap community using the RouterOS CLI:
 
+            The `trap-community` setting selects one of the communities defined under `/snmp community`, so the community has to exist before it can be selected. Create it first, scoped to the hosts allowed to reach the agent:
+
             ```text
+            /snmp community add name=<unique-community-string> address=<management-subnet> read-access=yes write-access=no
+            /snmp set trap-community=<unique-community-string>
+            ```
+
+            RouterOS ships with a community named `public`. If you would rather not add a second entry, rename the shipped one and select that instead. This also changes the string existing pollers must present, so update them at the same time:
+
+            ```text
+            /snmp community set [find name=public] name=<unique-community-string> address=<management-subnet> write-access=no
             /snmp set trap-community=<unique-community-string>
             ```
 
@@ -820,7 +833,9 @@ queries:
           desc: |
             To add a default-deny rule to the input chain using the RouterOS CLI:
 
-            Add accept rules for the traffic the router must handle (for example established/related connections and management access from trusted sources) **before** adding the final drop, then append the drop:
+            **Warning**: the drop rule takes effect the moment it is added and ends any management session whose source address is not covered by an accept rule above it. Enter Safe Mode first by pressing `[CTRL]+[X]` in the terminal or clicking **Safe Mode** in WinBox. RouterOS undoes every change made during a Safe Mode session if that session ends abnormally, so a rule that locks you out is rolled back once the connection drops.
+
+            Add the accept rules **before** the drop. The router has to accept established and related connections so replies to its own traffic are not discarded, and management access from your trusted sources so administration keeps working. Append the drop last:
 
             ```text
             /ip firewall filter add chain=input connection-state=established,related action=accept


### PR DESCRIPTION
Remediation deep dive across the four network-device policies: `mondoo-fortios-security`, `mondoo-panos-security`, `mondoo-mikrotik-security`, `mondoo-bigip-security`. Every `remediation:` block was read and every command path resolved against the vendor's own reference before anything was changed. Six defects; each section quotes the oracle.

No `version:` bumps.

---

## 1. MikroTik: the SNMP trap-community fix names a community that does not exist

`mondoo-mikrotik-security-snmp-no-default-trap-community` shipped a one-line fix:

```text
/snmp set trap-community=<unique-community-string>
```

`trap-community` is not a free-text field. It is a **selector over the entries in `/snmp community`**. From the RouterOS SNMP documentation, the property description is:

> **trap-community** — "Which communities configured in the *community* menu to use when" sending traps

and the same page documents `/snmp community` as a separate item list with its own `name`, `address`, `security`, `read-access`, `write-access` properties, shipping a default entry named **`public`**.

So the documented fix sets the selector to a name that was never created. The check (`mikrotik.snmp.trapCommunity != "public"`) is not satisfied by a command that does not apply.

**Fix**: create the community first, scoped to the management hosts, then select it. A rename path for the shipped `public` entry is documented as the alternative for operators who do not want a second entry, with a note that it changes the string existing pollers must present.

```text
/snmp community add name=<unique-community-string> address=<management-subnet> read-access=yes write-access=no
/snmp set trap-community=<unique-community-string>
```

Source: [SNMP — RouterOS documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/8978519/SNMP)

## 2. MikroTik: the default-deny input rule has no lockout warning

`mondoo-mikrotik-security-firewall-input-drop-rule` is the single most lockout-prone remediation in these four policies. It appends `chain=input action=drop`, which takes effect immediately and severs any management session whose source is not covered by an accept rule above it. It carried an ordering note but no warning, while the FortiOS and PAN-OS policies already carry lockout warnings on far less dangerous changes (see #2801 and #2866).

RouterOS has a native mitigation, and it is documented:

> "The 'Safe Mode' button in the Winbox GUI allows you to enter Safe Mode, while in the CLI, you can access it by either using the keyboard shortcut F4 or pressing [CTRL]+[X]."
> "All configuration changes that are made (also from other login sessions), while the router is in safe mode, are automatically undone if the safe mode session terminates abnormally."

**Fix**: added the warning and the Safe Mode instruction, and rewrote the ordering sentence to drop its parenthetical aside per the authoring rules.

Source: [Console — RouterOS documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/8978498/Console)

## 3. MikroTik: the source-restriction fix covers two services, the check requires all of them

`mondoo-mikrotik-security-services-source-restricted` asserts `mikrotik.services.where(disabled == false).all(address != "")`. The fix set `address` on `ssh` and `winbox` only, so following it verbatim on a device with `www-ssl` or `api-ssl` enabled leaves the check failing.

The docs also show `address` takes a list, which the snippet did not convey:

> **address** (*IP address/netmask | IPv6/0..128*) — "List of IP/IPv6 prefixes from which the service is accessible"
> `[admin@dzeltenais_burkaans] /ip/service/set api address=10.5.101.0/24,2001:db8:fade::/64`

**Fix**: the snippet now shows the comma-separated list form across three services and states explicitly that a service left with an empty `address` still accepts connections from any host.

Source: [Services — RouterOS documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services)

## 4. MikroTik: the admin-account fix is introduced as a removal and performs a disable

`mondoo-mikrotik-security-default-admin-disabled` opened with "To **remove** the default admin account" and then ran `/user disable admin`. Corrected to "disable", and the reason the replacement account has to come first is now stated rather than implied.

## 5. FortiOS: the implicit-deny console fix changes a different config node

`mondoo-fortios-security-log-implicit-deny` reads `fortios.log.setting.fwpolicyImplicitLog`. The console remediation said:

> 1. Navigate to **Policy & Objects > Firewall Policy**
> 2. Locate the **Implicit Deny** policy at the bottom of the policy table and click **Edit**
> 3. Enable **Log Violation Traffic**

Causal chain: the check fails because `fwpolicy-implicit-log` is `disable`. `fwpolicy-implicit-log` lives in `config log setting` and is **global**. "Log Violation Traffic" in the GUI sets `logtraffic` on an individual firewall policy, a different config node. Nothing in those four steps writes `fwpolicy-implicit-log`, so an operator who follows the console path sees the check still fail.

Fortinet's own KB separates the two cases and gives only a CLI answer for the implicit deny:

> **(a) Implicit Deny Policy Logging — CLI Command:** `set fwpolicy-implicit-log enable`
> **(b) User-Created Deny Policy Logging — GUI Method:** "create a Deny Policy and enable the option 'Log Violation Traffic'"

**Fix**: replaced the console entry with a `# No console remediation:` comment explaining the config-node mismatch, and rewrote the audit block the same way. This is exactly the pattern `mondoo-fortios-security-log-extended-format` and `mondoo-fortios-security-log-no-user-anonymization` already use for two other `config log setting` options in this same policy.

Source: [Fortinet — How to configure the logging of Denied Traffic](https://community.fortinet.com/t5/FortiGate/Technical-Tip-How-to-configure-the-logging-of-Denied-Traffic-to/ta-p/197227)

## 6. FortiOS: the disabled-policy CLI fix documents only half the console fix

`mondoo-fortios-security-no-disabled-policies` passes on `status == "enable"`. The console entry offers both branches, "Delete it if it is no longer needed / Enable it if it should be active"; the CLI entry only showed `delete`. Added the `set status enable` branch with a note that re-enabling restores the rule at its existing sequence number.

## 7. BIG-IP: `f5-secure` is described as something it is not

`mondoo-bigip-security-client-ssl-secure-ciphers` told operators, in both the console and CLI entries, that `f5-secure` is a rule

> "which resolves to ECDHE key exchange with AES-GCM suites only"

It is neither. From the pre-built cipher rule table in the BIG-IP SSL Administration guide:

| Cipher Rule Name | Associated Cipher String |
|---|---|
| `f5-aes` | `AES` |
| `f5-default` | `DEFAULT` |
| `f5-ecc` | `ECDHE:ECDHE_ECDSA` |
| `f5-secure` | `ECDHE:RSA:!SSLV3:!RC4:!EXP:!DES` |

`RSA` is an allowed key exchange, and nothing in the string restricts the mode to GCM, so AES-CBC suites are permitted. The recommendation itself is still sound for this check, because `!RC4`, `!EXP` and `!DES` cover exactly what the check flags, but the description was wrong and it contradicted the paragraph directly below it telling the reader to prefer GCM over CBC.

**Fix**: both entries now quote the real cipher string, state that `f5-secure` still permits RSA key exchange and AES-CBC, and present the GCM-only cipher string as the stricter option rather than as a fallback.

Source: [SSL Traffic Management — BIG-IP 16.0 documentation](https://techdocs.f5.com/en-us/bigip-16-0-0/big-ip-system-ssl-administration/ssl-traffic-management.html)

## 8. BIG-IP: server SSL guidance contradicts its own description

`mondoo-bigip-security-server-ssl-secure-ciphers` states in `desc`:

> "Server SSL profiles should enforce the same cipher standards as client SSL profiles."

Its remediation then recommended `ECDHE+AES-GCM:DHE+AES-GCM:ECDHE+AES:DHE+AES`, which includes precisely the two CBC suites the client-side sibling warns against by name. Aligned to `ECDHE+AES-GCM:DHE+AES-GCM` with the same GCM rationale, and the CBC suites are now documented as an explicit exception for backends that cannot negotiate GCM. Both strings still satisfy the check, so this is a consistency fix, not a correctness one, and it is the lowest-severity item here.

---

## Checked and found correct

Candidates that looked wrong and verified as fine. These were dropped rather than filed.

**PAN-OS — no defects found.** Every `set`/`request` path was resolved:

- `set network profiles zone-protection-profile <p> scan 8001 action block-ip duration 3600 track-by source` — the `block-ip` sub-options are real: *"if you select Block IP, you must also configure the Track By (source or source-and-destination) and Duration options"*. ([Configure Reconnaissance Protection](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-admin/zone-protection-and-dos-protection/configure-zone-protection-to-increase-network-security/configure-reconnaissance-protection))
- The scan-ID legend in that same block is correct: *"Threat-ID 8001 (SCAN: TCP Port Scan) detects a TCP port scan, Threat-ID 8002 (SCAN: Host Sweep) detects a host sweep, and Threat-ID 8003 (SCAN: UDP Port Scan) detects a UDP port scan."*
- `request anti-virus upgrade` / `request content upgrade` / `request wildfire upgrade` / `request license fetch` / `request restart system`, the `configure` … `commit` framing on every config-mode block, the `delete <list>` before `set <list>` idiom for replacing wildcard members, the IKEv1 `dpd` vs IKEv2 `dpd` split matching the check's three-way version branch, and the tunnel-interface-IP prerequisite before enabling tunnel monitoring — all correct.

**BIG-IP:**

- `tmsh create sys crypto key <name> key-size 2048` — `create key [name] options: … key-size [512 | 1024 | 2048 | 4096]`, valid standalone with no `gen-csr`/`gen-certificate`. ([sys crypto key](https://clouddocs.f5.com/cli/tmsh-reference/v16/modules/sys/sys_crypto_key.html))
- `tmsh create sys crypto csr <name> key <name> common-name <cn>` — I expected this to be wrong and it is not. `sys crypto csr` is a real component and the reference's own example is `create csr example key testkey.key common-name "My Company Inc." country "US" challenge-password "abcd"`. ([sys crypto csr](https://clouddocs.f5.com/cli/tmsh-reference/v14/modules/sys/sys_crypto_csr.html))
- `tmsh show ltm cipher group <name>` — `show` is a documented verb, and `create group my_group { allow add { f5-default } }` confirms the `allow add` syntax. ([ltm cipher group](https://clouddocs.f5.com/cli/tmsh-reference/v16/modules/ltm/ltm_cipher_group.html))
- `cipher-group <g> ciphers none` — documented; K01770517 shows client-ssl profiles configured `with cipher-group f5-default and ciphers none`.
- The VLAN source-checking note — verified, not invented: *"the system verifies that the return route to an initial packet is the same VLAN from which the packet originated, and the system performs this verification only if the Auto Last Hop option is disabled."*

**MikroTik:**

- `/ip service set www-ssl tls-version=only-1.2` — `tls-version (any | only-1.2; Default: any)`. Both the check's `!= "any"` assertion and the fix are right.
- The WiFi fix writes the field the check reads: the provider maps `authenticationTypes` to `security.authentication-types`, which is what `/interface/wifi/set … security.authentication-types=wpa2-psk,wpa3-psk` writes.
- `address != ""` on services and users is **not** the null-unsafe `!= ""` trap — the provider declares `address` as a non-optional `string`, so an unset value is `""` and not `null`.

**FortiOS:**

- `unselect allowaccess telnet` and the warning against `unset allowaccess`, the multi-VDOM `config global` preamble, `execute backup full-config tftp` / `execute restore image tftp`, the `set type custom` + `config ntpserver` nesting, `log-neighbour-changes` in its British spelling on both BGP and OSPF, and pairing `utm-status enable` with an `ssl-ssh-profile` — all resolved correctly and were left alone.

**Dropped for lack of an oracle** (per the brief, not filed): whether the FortiOS 7.x `config system dns` `protocol dot` form maps onto the `dnsOverTls` field the check reads. `docs.fortinet.com` renders client-side and the `fortios` provider source is not in the `mql` tree, so there was no way to confirm the mapping either way.

## Validation

```
cnspec policy lint ./content/mondoo-{fortios,panos,mikrotik,bigip}-security.mql.yaml   # valid policy bundle(s), all four
make test/content/lint                                                                 # valid policy bundle(s)
make test/content/commands                                                             # exit 0
python3 -c typos check over the three edited files                                      # clean
```

None of these four policies appears in the `TARGETS` of any validator under `content/validation/remediation/`, and no fenced block in this diff changed language, so nothing new becomes lintable. No IaC variants exist in these policies, so no fixture suites apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
