### PR TITLE
🐛 content: fix remediation defects in the virtualization policies

### DIFF
--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -230,6 +230,15 @@ queries:
             curl -fsS -u admin \
               "https://prism-central.example.com:9440/api/clustermgmt/v4.0/config/clusters"
             ```
+        - id: cli
+          desc: |
+            To enable encryption-in-transit using the CLI, run on a Controller VM. The cluster applies the setting to every node, so expect a rolling change:
+
+            ```bash
+            ncli cluster edit-params enable-intransit-encryption=true
+            ```
+
+            Confirm the result with `ncli cluster get-params` on a Controller VM.
 
   - uid: mondoo-nutanix-security-cluster-external-key-management
     title: Ensure clusters use an external key management server
@@ -296,6 +305,16 @@ queries:
             4. Rekey the cluster so the data encryption keys are protected by the external KMS.
 
             Adding a server alone does not change the key manager type; the cluster must also be switched to the external KMS in the Data-at-Rest Encryption settings. To confirm the configured key management servers afterward, run `ncli key-management-server list` on a Controller VM.
+        - id: cli
+          desc: |
+            To register the external key management server and switch the cluster to it using the CLI, run on a Controller VM. Addresses take the form `<ipaddress>` or `<ipaddress:port>`, and port 5696 is used when no port is given:
+
+            ```bash
+            ncli key-management-server add name=<kms-name> address-list=kms.example.com:5696
+            ncli key-management-server change-key-management-server-type key-management-server-type=ekm
+            ```
+
+            The `ekm` value selects the external key manager; `lkm` is the cluster's local key manager. Upload the client and CA certificates for the server in Prism before switching, then confirm the result with `ncli key-management-server list`.
 
   - uid: mondoo-nutanix-security-cluster-ssh-password-login-disabled
     title: Ensure password-based SSH login to clusters is disabled
@@ -1982,6 +2001,15 @@ queries:
             2. Open Settings, then Data-at-Rest Encryption, and click Edit Configuration.
             3. Enable encryption at the level the cluster supports: cluster-wide where only that scope is offered, or per container on clusters whose capability allows it, then save.
             4. Confirm each user container reports encryption as enabled. On a Controller VM, `ncli container ls` lists each container with its encryption state.
+        - id: cli
+          desc: |
+            To enable software encryption on a single storage container using the CLI, run on a Controller VM. A key management configuration must already be in place, and encryption cannot be turned off again once it is enabled:
+
+            ```bash
+            ncli container edit name=<container-name> enable-software-encryption=true
+            ```
+
+            Confirm the result with `ncli container ls`, which lists each container with its encryption state.
 
   - uid: mondoo-nutanix-security-storage-container-nfs-allowlist
     title: Ensure storage container NFS allowlists are restricted
@@ -2045,13 +2073,14 @@ queries:
             3. Add only the specific subnets that require access, or clear the per-container list so the container inherits the restricted global allowlist.
         - id: cli
           desc: |
-            To confirm the container allowlist using the CLI, run on a Controller VM:
+            To remove an open entry from a container's NFS allowlist and replace it with the specific subnets that need access, run on a Controller VM:
 
             ```bash
-            ncli container ls
+            ncli container remove-from-nfs-whitelist name=<container-name> ip-subnet-masks="0.0.0.0/0.0.0.0"
+            ncli container add-to-nfs-whitelist name=<container-name> ip-subnet-masks="10.20.0.0/255.255.0.0"
             ```
 
-            Each user container should show its NFS allowlist limited to specific subnets or inherited from the restricted global allowlist.
+            Removing every per-container entry leaves the container inheriting the restricted global allowlist. Confirm the result with `ncli container ls`, which lists each container with its NFS allowlist.
 
   - uid: mondoo-nutanix-security-storage-container-replication-factor
     title: Ensure storage containers use a replication factor of at least 2

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -1628,20 +1628,21 @@ queries:
             **Using the CLI**
 
             Register an ACME account and order a Let's Encrypt certificate for
-            this node.
-
-            **Verify the ACME flag syntax for your PVE 8.x version first.** The
-            way ACME domains are set on `pvenode config set` has drifted across
-            Proxmox VE releases. Confirm the documented form for your version
-            with `pvenode config set --help`; on current builds the per-domain
-            flag form `pvenode config set -acmedomain0=<fqdn>` is documented.
-            Substitute the verified flag below:
+            this node, then restart the API proxy so it serves the new
+            certificate:
 
             ```bash
             pvenode acme account register default <email>
             pvenode config set --acme domains=<fqdn>
             pvenode acme cert order
+            systemctl restart pveproxy
             ```
+
+            `--acme` takes a property string, so several domains are given as a
+            semicolon-separated list. The per-domain form
+            `pvenode config set --acmedomain0 <fqdn>` sets the same
+            configuration one domain at a time and additionally accepts an
+            `alias` and a validation `plugin`.
         - id: bash
           desc: |
             **Using a Bash Script**
@@ -1765,13 +1766,8 @@ queries:
             ```
 
             If the node also serves an ACME certificate that is close to
-            expiry, renew it as well.
-
-            **Verify the ACME renew subcommand for your PVE 8.x version first.**
-            `pvenode acme cert renew` is not present on every PVE 8.x build.
-            Confirm the available verbs with `pvenode acme help`; if `renew` is
-            absent, re-order the certificate instead with
-            `pvenode acme cert order --force`. Substitute the verified command:
+            expiry, renew it as well. `--force` renews even when expiry is more
+            than 30 days away:
 
             ```bash
             pvenode acme cert renew --force

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -463,13 +463,13 @@ queries:
           desc: |
             To remove the configuration for the dvfilter network API using the vSphere Client:
 
-            1. From the vSphere web client, select the host and select `Configure` then expand `System`
+            1. From the vSphere Client, select the host and select `Configure` then expand `System`.
             2. Select `Advanced System Settings` then `Edit`.
             3. Search for `Net.DVFilterBindIpAddress` in the filter.
-            4. Set `Net.DVFilterBindIpAddress` has an empty value.
-            5. If an appliance is being used, make sure the value of this parameter is set to the proper IP address.
-            6. Enter the proper IP address.
-            7. Select `OK`.
+            4. Clear the value so `Net.DVFilterBindIpAddress` is empty.
+            5. Select `OK`.
+
+            Where a dvfilter-based security appliance is deployed, this parameter is required. In that case set it to the appliance's IP address rather than clearing it, and exempt the host from this check.
 
             **Impact:**
 
@@ -637,6 +637,15 @@ queries:
             **Impact:**
 
             Some third-party tools may utilize the Managed Object Browser (MOB). Disabling MOB may cause those tools to malfunction.
+        - id: powershell
+          desc: |
+            To disable the Managed Object Browser on all hosts using PowerCLI:
+
+            ```powershell
+            Get-VMHost | Get-AdvancedSetting -Name Config.HostAgent.plugins.solo.enableMob | Set-AdvancedSetting -Value $false
+            ```
+
+            PowerCLI writes the setting through the same host API the vSphere Client uses, so it is a supported alternative to the client. A host already in lockdown mode rejects the change; take it out of lockdown mode, disable the MOB, then re-enable lockdown mode.
         # No Terraform remediation: the Managed Object Browser toggle is a runtime host advanced setting with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host lockdown mode.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-normal-lockdown-mode-is-enabled
@@ -715,7 +724,22 @@ queries:
             **Impact:**
 
             With lockdown mode enabled the host will only be accessible through vCenter preventing 'local' access.
-        # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
+        - id: terraform
+          desc: |
+            To put a host into Normal lockdown mode with Terraform, set `lockdown` to `normal` on the `vsphere_host` resource:
+
+            ```hcl
+            resource "vsphere_host" "esxi" {
+              hostname   = "esxi-01.example.com"
+              username   = "root"
+              password   = var.esxi_password
+              datacenter = data.vsphere_datacenter.dc.id
+
+              lockdown = "normal"
+            }
+            ```
+
+            The argument accepts `disabled`, `normal`, and `strict`, and it defaults to `disabled`, so a host that never sets it stays out of lockdown mode.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the ntpd time-synchronization daemon.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-ntp-time-synchronization-is-configured-properly
     filters: asset.platform == "vmware-esxi"
@@ -1304,7 +1328,22 @@ queries:
             **Impact:**
 
             Strict lockdown mode disables the DCUI. If the host loses connectivity to vCenter Server, recovery can require reinstalling ESXi, so confirm recovery procedures before applying this at scale.
-        # No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
+        - id: terraform
+          desc: |
+            To put a host into Strict lockdown mode with Terraform, set `lockdown` to `strict` on the `vsphere_host` resource:
+
+            ```hcl
+            resource "vsphere_host" "esxi" {
+              hostname   = "esxi-01.example.com"
+              username   = "root"
+              password   = var.esxi_password
+              datacenter = data.vsphere_datacenter.dc.id
+
+              lockdown = "strict"
+            }
+            ```
+
+            The argument accepts `disabled`, `normal`, and `strict`, and it defaults to `disabled`, so a host that never sets it stays out of lockdown mode.
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.DcuiTimeOut.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-dcui-timeout-is-set-to-600-seconds-or-less
     filters: asset.platform == "vmware-esxi"
@@ -1523,6 +1562,32 @@ queries:
             **Impact:**
 
             Connections from IP addresses and ranges that are not explicitly set will be denied. Take care to ensure appropriate IPs/IP address ranges are allowed.
+        - id: cli
+          desc: |
+            To restrict a firewall ruleset to specific networks using the ESXi shell:
+
+            1. Connect to the ESXi host with SSH and list the rulesets that currently allow every address:
+
+               ```bash
+               esxcli network firewall ruleset list
+               ```
+
+            2. Add the networks that must reach the service, then turn off the allow-all setting. Adding the allowed networks first keeps the ruleset reachable at every point in the sequence:
+
+               ```bash
+               esxcli network firewall ruleset allowedip add --ruleset-id=sshServer --ip-address=192.0.2.0/24
+               esxcli network firewall ruleset set --ruleset-id=sshServer --allowed-all=false
+               ```
+
+            3. Confirm the result:
+
+               ```bash
+               esxcli network firewall ruleset allowedip list
+               ```
+
+            Repeat for each enabled ruleset, substituting its own ruleset ID and the networks that need access.
+
+            **Warning:** Restricting the `sshServer` ruleset from an SSH session can cut off the session you are using. Include the address you are connecting from, or run this from the host console.
         # No Terraform remediation: the host firewall ruleset configuration is runtime host state with no Terraform resource.
   # No Terraform variants: the vsphere Terraform provider does not manage the ESXi host SSL machine certificate or its validity period.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-ssl-certificate-is-not-expired-or-expiring-soon
@@ -2073,9 +2138,11 @@ queries:
             ```bash
             esxcli system snmp set --communities ""
             esxcli system snmp set --targets ""
-            esxcli system snmp set --v3targets monitor.example.com@161/poller/priv --authentication SHA1 --privacy AES128
+            esxcli system snmp set --v3targets monitor.example.com@162/snmpv3user/priv/trap --authentication SHA1 --privacy AES128
             esxcli system snmp set --enable true
             ```
+
+            A v3 target is written as `hostname@port/userid/secLevel/message-type`. The security level is `none`, `auth`, or `priv`, and the message type is `trap` or `inform`; a target that omits the message type is rejected. Port 162 is the default notification port.
 
             The check passes for hosts that keep SNMP enabled with an SNMPv3-only configuration.
         # No Terraform remediation: SNMP service state and startup policy are runtime host configuration with no Terraform resource.

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -5407,6 +5407,7 @@ queries:
             Get-Cluster -Name "CLUSTER_NAME" |
               Set-VsanClusterConfiguration -EncryptionEnabled $true -KmsCluster $kms
             ```
+        # No Terraform remediation: the vsphere_compute_cluster resource exposes vsan_dit_encryption_enabled for data-in-transit only and has no data-at-rest encryption argument; at-rest encryption is bound to a vCenter key provider that the resource cannot reference.
     refs:
       - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-F3B2714F-3406-48E7-AC2D-3677355C94D3.html
         title: Using Data-at-Rest Encryption in vSAN


### PR DESCRIPTION
Deep audit of every `remediation:` block in the four virtualization policies:
`mondoo-vmware-vsphere`, `mondoo-vmware-vsphere-esxi`, `mondoo-nutanix-security`,
and `mondoo-proxmox-security`. 365 `- id:` entries reviewed. Every finding below
was resolved against the vendor's own grammar, schema, or manual before it was
filed; candidates that verified as correct were dropped and are listed at the end.

---

## 1. ESXi: the SNMPv3 target string is malformed and cannot be applied

`mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-snmp-service-is-disabled`

The `- id: cli` block offered this as the SNMPv3-only configuration that makes the
check pass:

```bash
esxcli system snmp set --v3targets monitor.example.com@161/poller/priv --authentication SHA1 --privacy AES128
```

A v3 target has **five** slash/at-separated components. The example supplies four:
the trailing message type is missing, and the port is the agent port rather than
the notification port.

Broadcom, *Configure SNMP v3 Targets* (vSphere 8.0):

> ```
> esxcli system snmp set --v3targets hostname@port/userid/secLevel/message-type
> ```
> **Command format breakdown** (slash-separated components in order):
> 1. `hostname` … 2. `port` (default: 162) … 3. `userid` … 4. `secLevel` (auth, priv, or none) … 5. `message-type` — trap or inform
>
> **Example:** `esxcli system snmp set --v3targets 192.168.1.100@162/monitoruser/auth/trap`
>
> **Default port:** "If you do not specify a port, the default port, 162, is used."

<https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-monitoring-and-performance/snmp-and-vsphere/configure-snmp-for-esx-esxi/configure-esxi-for-snmp-v3/configure-snmpv3-targets.html>

**Fix.** Corrected the example to `monitor.example.com@162/snmpv3user/priv/trap` and
documented the component order inline, so a reader adapting it to their own
collector keeps all five parts.

---

## 2. ESXi: both lockdown-mode checks claim there is no Terraform resource; there is

`…-ensure-normal-lockdown-mode-is-enabled` and `…-ensure-strict-lockdown-mode-is-enabled`

Both remediation lists ended with:

```yaml
# No Terraform remediation: host lockdown mode is runtime host configuration with no Terraform resource.
```

That is false. `terraform providers schema -json` against the version this repo's
own validator pins (`"vsphere": ("hashicorp/vsphere", "~> 2.0")` in
`content/validation/remediation/code/terraform.py`), resolved as v2.12.0:

```
$ terraform providers schema -json | jq '.provider_schemas
    ["registry.terraform.io/hashicorp/vsphere"]
    .resource_schemas.vsphere_host.block.attributes.lockdown'
{
 "type": "string",
 "description": "Set the host's lockdown status. Default is disabled. Valid options are 'disabled', 'normal', 'strict'",
 "description_kind": "plain",
 "optional": true
}
```

The argument exists, takes exactly the three states these two checks distinguish,
and defaults to `disabled` — so a `vsphere_host` that never sets it fails both
checks, which is precisely what a Terraform remediation is for.

**Fix.** Replaced both comments with real `- id: terraform` entries setting
`lockdown = "normal"` and `lockdown = "strict"` respectively. Both new snippets
pass the repo's Terraform validator (`terraform.py vsphere`: 43 PASS, 0 FAIL, up
from 41).

Note: this PR does **not** add the corresponding `-terraform-hcl` variants. Parked
fixtures for them already exist under
`content/validation/scans/fixtures/iac-variants/mondoo-vmware-vsphere-esxi/…-lockdown-mode-…-terraform-hcl/`
carrying `KNOWN_BUG.md` markers that read "is not present in this bundle yet; it is
added by a separate pull request". That work belongs to whoever owns those markers;
this PR fixes only the false claim in the remediation block.

---

## 3. ESXi: the MOB check has no PowerCLI remediation, though VMware documents one

`…-ensure-managed-object-browser-mob-is-disabled`

Every other advanced-setting check in this policy ships a `powershell` entry
(`Security.AccountUnlockTime`, `Security.AccountLockFailures`, `UserVars.DcuiTimeOut`,
`UserVars.ESXiShellTimeOut`, `Mem.ShareForceSalting`, `Syslog.global.logDir`,
`Syslog.global.logHost`, `Net.DVFilterBindIpAddress`). The MOB check had only the
vSphere Client path.

The existing "Note 2" is about `vim-cmd`, not PowerCLI. The DISA STIG for VMware
vSphere 8.0 ESXi gives the PowerCLI fix for this exact setting:

> `Get-VMHost | Get-AdvancedSetting -Name Config.HostAgent.plugins.solo.enableMob | Set-AdvancedSetting -Value false`

<https://cyber.trackr.live/stig/VMware_vSphere_8.0_ESXi/2/1>

**Fix.** Added the `- id: powershell` entry, and kept the lockdown-mode caveat that
the existing prose already carried.

---

## 4. ESXi: the host-firewall check has no CLI remediation, though its own audit uses esxcli

`…-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r`

The check asserts `_['allowedHosts']['allIp'] == false` and
`_['allowedHosts']['ipNetwork'] != null` per ruleset. Its `audit:` block already
reads exactly that state with `esxcli network firewall ruleset list` /
`allowedip list`, but the only remediation offered was a vSphere Client
click-through — the one place in this file where an esxcli-readable setting had no
esxcli fix.

Verified command surface:

> 1. **Disable "Allow All"**: `esxcli network firewall ruleset set --allowed-all false --ruleset-id=<service>`
> 2. **Add Allowed IP Addresses**: `esxcli network firewall ruleset allowedip add --ip-address=<IP/CIDR> --ruleset-id=<service>`
> **Verification**: `esxcli network firewall ruleset allowedip list`

<https://williamlam.com/2011/07/how-to-create-custom-firewall-rules-in.html>, <https://www.vladan.fr/esxi-firewall/>

**Fix.** Added an `- id: cli` entry. The order matters and is stated explicitly:
add the allowed networks **first**, then clear `--allowed-all`, so the ruleset is
never simultaneously closed to everything and empty of exceptions. A warning covers
the case of restricting `sshServer` from the SSH session you are using.

---

## 5. ESXi: the dvfilter click-through contradicts itself mid-list

`…-ensure-dvfilter-api-is-not-configured-if-not-used`

The check asserts `vsphere.host.dvFilterBindIpAddress == empty`. The steps were:

```
4. Set `Net.DVFilterBindIpAddress` has an empty value.
5. If an appliance is being used, make sure the value of this parameter is set to the proper IP address.
6. Enter the proper IP address.
7. Select `OK`.
```

Step 4 is ungrammatical, and steps 5–6 sit inside the same numbered sequence while
instructing the reader to do the opposite of step 4. Followed literally, the list
ends with a non-empty value, which fails the check it is supposed to fix.

**Fix.** Step 4 now reads "Clear the value so `Net.DVFilterBindIpAddress` is empty",
the list ends at `OK`, and the dvfilter-appliance exception is moved out of the
numbered steps into a following sentence where it belongs.

---

## 6. vSphere: vSAN data-at-rest encryption omits the mandated no-Terraform comment

`mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-at-rest-encryption-is-enabled`

`content/CLAUDE.md` requires that where a remediation method is omitted, a YAML
comment inside the `remediation:` list explains why. This check's list ended after
`powershell` with neither a `terraform` entry nor an explanation — while its direct
sibling, the data-in-transit check, has full Terraform variants keyed on
`vsphere_compute_cluster.vsan_dit_encryption_enabled`, which invites the reader to
assume the omission is an oversight.

It is not. The pinned provider carries a data-in-transit argument and no
data-at-rest one:

```
$ jq '.provider_schemas["registry.terraform.io/hashicorp/vsphere"]
     .resource_schemas.vsphere_compute_cluster.block.attributes
     | keys | map(select(test("vsan")))' schema.json
["vsan_compression_enabled","vsan_dedup_enabled","vsan_dit_encryption_enabled",
 "vsan_dit_rekey_interval","vsan_enabled","vsan_esa_enabled",
 "vsan_network_diagnostic_mode_enabled","vsan_performance_enabled",
 "vsan_remote_datastore_ids","vsan_unmap_enabled","vsan_verbose_mode_enabled"]
```

**Fix.** Added the `# No Terraform remediation:` comment recording the asymmetry and
its cause, so the next pass does not re-investigate.

---

## 7. Nutanix: three checks had no CLI remediation despite a documented ncli command

All three verified against the AOS 7.5 Command Reference — the same book this repo
pins in `content/validation/upstream/dump/ncli.py`
(`NCLI_BOOK = "Command-Ref-AOS-v7_5"`).

**a. `…-cluster-encryption-in-transit-enabled`** — console-only, and the console
block's single code fence was a read-only `curl` GET, so the check shipped with no
executable fix at all. The `cluster` entity page documents:

> `ncli> cluster { edit-params | edit-info} … [enable-intransit-encryption="{ true | false }" ]`
> `enable-intransit-encryption` — Enable/Disable data in transit encryption

The check reads `encryptionInTransitStatus == "ENABLED"`; this is the toggle behind it.

**b. `…-cluster-external-key-management`** — console-only. The `key-management-server`
entity page documents both halves of the fix:

> `ncli> key-management-server { add } name="name" [address-list="address_list" ] …`
> `address-list` — … Port 5696 is used as default if port number is not specified
>
> `ncli> key-management-server { change-key-management-server-type } key-management-server-type="key_management_server_type"`
> `key-management-server-type` — The desired key management server type, valid entries are 'ekm', 'lkm', 'pckm', 'ekm_cloud' and 'ekm_pc'

The check reads `network.keyManagementServerType == "EXTERNAL"`, and the existing
console prose already stresses that adding a server is not enough — the type must
change too. `ekm` is that change; `lkm` is the local key manager.

**c. `…-storage-container-encrypted`** — console-only, ending with `ncli container ls`
as a *verification* step. The `container` entity page documents the per-container fix:

> `ncli> container { edit | update} [id="id" ] [name="name" ] … [enable-software-encryption="{ true | false }" ]`
> `enable-software-encryption` — Enable or disable software encryption on the Storage Container

The check is per-container (`nutanix.storageContainers.where(isInternal == false).all(isEncrypted == true)`),
so a per-container command is the right granularity.

**Fix.** Added an `- id: cli` entry to each, carrying over the existing caveats
(rolling application, certificates uploaded first, encryption is irreversible).

---

## 8. Nutanix: a `- id: cli` "remediation" that only inspects the allowlist

`mondoo-nutanix-security-storage-container-nfs-allowlist`

The entry read, in full:

> To confirm the container allowlist using the CLI, run on a Controller VM:
> ```bash
> ncli container ls
> ```
> Each user container should show its NFS allowlist limited to specific subnets or inherited from the restricted global allowlist.

That is an audit step filed under `remediation:`. It changes nothing, so it cannot
move the check from failing to passing. The commands to do so exist on the same
entity:

> Operations … Add addresses to Storage Container's NFS subnet whitelist : `add-to-nfs-whitelist`
> … Remove addresses from Storage Container's NFS subnet whitelist : `remove-from-nfs-whitelist`
>
> `ncli> container { add-to-nfs-whitelist } [id="id" ] [name="name" ] [ip-subnet-masks="ip_subnet_masks" ] [subnets="subnets" ]`
> `ncli> container { remove-from-nfs-whitelist } [id="id" ] [name="name" ] [ip-subnet-masks="ip_subnet_masks" ] [subnets="subnets" ]`

**Fix.** Replaced it with a remove-then-add pair mirroring the cluster-level check's
CLI entry, plus a note that clearing the per-container list makes the container
inherit the restricted global allowlist (the alternative the console entry already
describes). `ncli container ls` is retained as the confirmation step, where it belongs.

All 44 ncli commands in the policy now pass
`content/validation/remediation/commands/validate.py nutanix` (was 39 — the five new
commands are all covered by the grammar validator).

---

## 9. Proxmox: two hedges that steer operators away from the documented commands

Both blocks carried a bolded "verify this first, the syntax has drifted" paragraph
asserting the shown command may be wrong. Both assertions are false against
`pvenode(1)`, and the hedges send the reader to substitute a *different* flag for a
correct one.

**a. `mondoo-proxmox-security-cert-is-not-selfsigned`** claimed:

> on current builds the per-domain flag form `pvenode config set -acmedomain0=<fqdn>` is documented. Substitute the verified flag below:

`pvenode(1)` documents **both** forms, and its own worked example uses the one the
snippet already had:

```
pvenode config set [OPTIONS]
  Set node configuration options.
  --acme [account=<name>] [,domains=<domain[;domain;...]>]
      Node specific ACME settings.
  --acmedomain[n] [domain=]<domain> [,alias=<domain>] [,plugin=<name of the plugin configuration>]
      ACME domain and validation plugin
```

> Setup ACME account and order a certificate for the local node.
> ```
> pvenode acme account register default mail@example.invalid
> pvenode config set --acme domains=example.invalid
> pvenode acme cert order
> systemctl restart pveproxy
> ```

<https://pve.proxmox.com/pve-docs/pvenode.1.html>

**Fix.** Dropped the hedge, added the `systemctl restart pveproxy` the vendor example
ends with (without it the new certificate is on disk but not being served), and
replaced the warning with a factual note on when to prefer `--acmedomain[n]`.

**b. `mondoo-proxmox-security-cert-is-not-expiring`** claimed:

> `pvenode acme cert renew` is not present on every PVE 8.x build. Confirm the available verbs with `pvenode acme help`; if `renew` is absent, re-order the certificate instead …

It is documented, with the exact `--force` flag the snippet uses:

```
pvenode acme cert renew [OPTIONS]
  Renew existing certificate from CA.
  --force <boolean> ( default = 0 )
      Force renewal even if expiry is more than 30 days away.
```

**Fix.** Dropped the hedge and replaced it with what `--force` actually does, which is
the fact the reader needs here — the surrounding script only renews inside the 30-day
window, so `--force` is what makes the manual invocation act immediately.

---

## Checked and found correct

Candidates that looked like defects and verified as correct. Each was dropped rather
than filed.

- **`Set-VMHostHba … -MutualChapEnabled $true` without `-MutualChapType`** (ESXi iSCSI
  CHAP). The check asserts `mutualChapAuthenticationType == 'chapRequired'`, and the
  cmdlet has a separate `-MutualChapType (ChapType)` parameter, so this looked like
  "the snippet never sets the field the check reads". It is not: the vSphere API type
  `HostInternetScsiHbaAuthenticationProperties` has no `mutualChapAuthenticationEnabled`
  field — `mutualChapAuthenticationType` is the only mutual-CHAP state there is, which
  is why the check reads `chapAuthEnabled` but no mutual equivalent. `-MutualChapEnabled`
  therefore maps onto that same field. VMware's own example omits `-MutualChapType` for
  the same reason: `Set-VMHostHba -IScsiHba $iscsi -MutualChapEnabled $true -ChapType Required -ChapName Admin -ChapPassword pass -MutualChapName Administrator -MutualChapPassword Pass`.
- **`Set-VsanClusterConfiguration -EncryptionEnabled $true -KmsCluster $kms`** (vSphere
  vSAN data-at-rest). The current PowerCLI reference page truncates its parameter list
  before reaching `EncryptionEnabled` and `KmsCluster`, and the authoritative full help
  page is behind a 401. **Could not verify either way, so left unchanged** rather than
  filed on suspicion.
- **`ncli authconfig edit-directory … connection-type=LDAP directory-url=ldaps://…`**
  (Nutanix LDAPS). `connection-type=LDAP` next to an `ldaps://` URL reads like a
  contradiction. It is not: `usesLdaps` is derived from the URL scheme, not the
  connection type — `providers/nutanix/resources/iam.go` implements it as
  `urlUsesLdaps(url.Data)` — and Nutanix's own documented form pairs `connection-type=LDAP`
  with the scheme carried in `directory-url`.
- **`acli vm.update <vm> cpu_passthrough=false`** (Nutanix). Verified as the real AHV
  parameter, including the powered-off requirement the prose already states.
- **`ncli data-at-rest-encryption` has no enable operation**, so the console block's
  claim that "there is no CLI command to enable it" is accurate. The entity exposes only
  `backup-software-encryption-keys`, `get-recent-certificate-test-results`, `get-status`,
  `password`, `rekey-disks`, `rekey-software-encryption-keys`, `test-configuration`.
- **`ncli volume-group update … enabled-authentications=`** (Nutanix CHAP). The
  volume-group check's CLI entry deliberately only *confirms* CHAP and points at Prism
  or the Volumes API for the change. The AOS Command Reference contradicts itself on this
  parameter — the syntax line gives `enabled-authentications="{ true | false }"` while the
  argument description says "List of supported authentication types" — so the honest
  entry is the one already shipped. Left alone.
- **Proxmox `pveum realm modify <realm> --tfa type=oath`**, **`pveum realm list --output-format json`**,
  **`pvesm set <storage> --encryption-key autogen`**, **`pvesm set <storage> --master-pubkey <file>`**
  — all four verified against `pveum(1)` and `pvesm(1)`; the last two are quoted almost
  verbatim from the manual ("Use autogen to generate one automatically without passphrase";
  "a file containing a PEM-formatted master public key").
- **ESXi SLP `chkconfig slpd off` + `esxcli network firewall ruleset set --ruleset-id CIMSLP --enabled false`**
  matches VMware's own CVE-2021-21974 workaround verbatim, including `esxcli system slp stats get`
  as the "is it in use" pre-check. Left alone.
- **The unverifiable-looking Proxmox `kernel.unprivileged_userns_clone` hedge** is
  genuinely correct — it is a Debian downstream knob absent from some Proxmox kernels —
  and unlike the two ACME hedges it does not misdirect. Left alone.
- **Proxmox `iommu-is-enabled` / `no-pci-acs-override`** correctly handle both the GRUB
  (`/etc/default/grub` + `update-grub`) and systemd-boot (`/etc/kernel/cmdline` +
  `proxmox-boot-tool refresh`) paths, which is the trap on ZFS-root UEFI installs.
- **Proxmox `vm-spectre-mitigations`** preserves the VM's configured CPU type instead of
  overwriting it with `kvm64`, and the resulting `flags=+spec-ctrl;+ssbd` satisfies the
  check's `[,=;]\+?spec-ctrl\b` regex.
- **The `extra_config` value-case mismatch** across all vSphere VM checks (PowerCLI writes
  `TRUE`, Terraform writes `"true"`) is handled by the variants, which all compare
  `.downcase == "true"`.

## Validation

```
cnspec policy lint ./content/mondoo-vmware-vsphere.mql.yaml        → valid policy bundle(s)
cnspec policy lint ./content/mondoo-vmware-vsphere-esxi.mql.yaml   → valid policy bundle(s)
cnspec policy lint ./content/mondoo-nutanix-security.mql.yaml      → valid policy bundle(s)
cnspec policy lint ./content/mondoo-proxmox-security.mql.yaml      → valid policy bundle(s)
make test/content/lint                                            → valid policy bundle(s)
remediation/commands/validate.py nutanix                          → 44 PASS, 0 FAIL (was 39 PASS)
remediation/code/terraform.py vsphere                             → 43 PASS, 0 FAIL (was 41 PASS)
remediation/code/powershell.py vmware                             → 175 PASS, 0 FAIL
remediation/code/bash.py proxmox / bash.py (all content)          → 0 FAIL
remediation/code/ansible.py proxmox                               → 0 FAIL
go test -tags iac_variants … -run TestRemediationSatisfiesCheck/mondoo-vmware  → ok (31.7s)
go test -tags iac_variants … -run TestTerraformVariantCoverage                 → ok (13.9s)
```

The two `standalone function in a WHERE clause` lint warnings from
`make test/content/lint` are pre-existing on `main` (confirmed by stashing this
branch's changes and re-running); they are not in these files.

The policy `version:` fields are deliberately unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
