### PR TITLE
🐛 content: fix twelve remediation defects across four cloud policies

### DIFF
--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -1876,18 +1876,9 @@ queries:
         values.redirect_http_to_https == true
       )
 
-  # No Terraform variants: tlsCipherPolicy reflects the minimum TLS cipher policy resolved by
-  # the DigitalOcean load balancer service. The digitalocean_loadbalancer Terraform resource
-  # has no argument that selects between the DEFAULT and STRONG cipher policies, so the setting
-  # cannot be asserted in HCL, plan, or state.
   - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy
     title: Ensure TLS load balancers enforce the strong TLS cipher policy
     impact: 70
-    filters: asset.platform == "digitalocean-loadbalancer"
-    mql: |
-      digitalocean.loadBalancer {
-        listeners.none(entryProtocol == "https" || entryProtocol == "tls") || tlsCipherPolicy == "STRONG"
-      }
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
@@ -1903,6 +1894,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-4-2-1
       compliance/soc2-2017: soc2-control-cc6-7-2
       compliance/vda-isa-5: vda-isa-5-5-1-2
+    variants:
+      - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-digitalocean
+        tags:
+          mondoo.com/filter-title: DigitalOcean
+          mondoo.com/filter-icon: digitalocean
+      - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check ensures that any load balancer terminating TLS uses the `STRONG` minimum TLS cipher policy rather than the `DEFAULT` policy. The `STRONG` policy negotiates only TLS 1.2 and later with a restricted set of modern, forward-secret cipher suites, whereas the default policy permits a broader, weaker set for backward compatibility.
@@ -1955,13 +1963,60 @@ queries:
               --region "<region>" \
               --forwarding-rules "<current-forwarding-rules>" \
               --droplet-ids "<droplet-ids>" \
-              --tls-cipher-policy strong
+              --tls-cipher-policy STRONG
             ```
-        # No Terraform remediation: the digitalocean_loadbalancer resource has no argument for the
-        # minimum TLS cipher policy, so the STRONG policy cannot be set through Terraform.
+        - id: terraform
+          desc: |
+            To enforce the strong cipher policy in Terraform, set `tls_cipher_policy = "STRONG"` on the `digitalocean_loadbalancer` resource that terminates TLS:
+
+            ```hcl
+            resource "digitalocean_loadbalancer" "example" {
+              name              = "example-lb"
+              region            = "nyc3"
+              tls_cipher_policy = "STRONG"
+
+              forwarding_rule {
+                entry_port       = 443
+                entry_protocol   = "https"
+                target_port      = 80
+                target_protocol  = "http"
+                certificate_name = digitalocean_certificate.example.name
+              }
+            }
+            ```
     refs:
       - url: https://docs.digitalocean.com/products/networking/load-balancers/how-to/ssl-termination/
         title: Load balancer SSL termination
+
+  - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-digitalocean
+    filters: asset.platform == "digitalocean-loadbalancer"
+    mql: |
+      digitalocean.loadBalancer {
+        listeners.none(entryProtocol == "https" || entryProtocol == "tls") || tlsCipherPolicy == "STRONG"
+      }
+  - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_loadbalancer")
+    mql: |
+      terraform.resources("digitalocean_loadbalancer").all(
+        blocks.where(type == "forwarding_rule").none(arguments["entry_protocol"] == "https" || arguments["entry_protocol"] == "tls") ||
+        arguments["tls_cipher_policy"] == "STRONG"
+      )
+  - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_loadbalancer")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "digitalocean_loadbalancer").all(
+        change.after["forwarding_rule"] == empty ||
+        change.after["forwarding_rule"].none(_["entry_protocol"] == "https" || _["entry_protocol"] == "tls") ||
+        change.after.tls_cipher_policy == "STRONG"
+      )
+  - uid: mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "digitalocean_loadbalancer")
+    mql: |
+      terraform.state.resources.where(type == "digitalocean_loadbalancer").all(
+        values["forwarding_rule"] == empty ||
+        values["forwarding_rule"].none(_["entry_protocol"] == "https" || _["entry_protocol"] == "tls") ||
+        values.tls_cipher_policy == "STRONG"
+      )
 
   - uid: mondoo-digitalocean-security-lb-in-vpc
     title: Ensure load balancers are deployed inside a VPC
@@ -2336,7 +2391,12 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "digitalocean_kubernetes_cluster")
     mql: |
       terraform.resources("digitalocean_kubernetes_cluster").all(
-        arguments["version"] == /^1\.(3[0-9]|[4-9][0-9]|[1-9][0-9]{2})\./
+        arguments["version"] == /^1\.(3[0-9]|[4-9][0-9]|[1-9][0-9]{2})\./ ||
+        arguments["version"] == /^data\.digitalocean_kubernetes_versions\./
+      )
+      terraform.datasources.where(nameLabel == "digitalocean_kubernetes_versions").all(
+        arguments["version_prefix"] == empty ||
+        arguments["version_prefix"] == /^1\.(3[0-9]|[4-9][0-9]|[1-9][0-9]{2})\./
       )
   - uid: mondoo-digitalocean-security-doks-supported-version-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "digitalocean_kubernetes_cluster")
@@ -4836,14 +4896,20 @@ queries:
             3. Add the specific source ranges that need access, or remove the allowlist entirely if the load balancer is meant to be public.
         - id: cli
           desc: |
-            To replace an any-address allowlist with specific source ranges using the `doctl` CLI:
+            The `doctl compute load-balancer update` command replaces the full load balancer configuration, so any attribute you do not pass is reset to its default. Read the current configuration first, then re-apply it together with the scoped allowlist:
 
             ```bash
-            doctl compute load-balancer update <load-balancer-id> \
+            doctl compute load-balancer get "<load-balancer-id>" \
+              --format Name,Region,ForwardingRules,DropletIDs --no-header
+            doctl compute load-balancer update "<load-balancer-id>" \
+              --name "<name>" \
+              --region "<region>" \
+              --forwarding-rules "<current-forwarding-rules>" \
+              --droplet-ids "<droplet-ids>" \
               --allow-list cidr:203.0.113.0/24,ip:198.51.100.10
             ```
 
-            Provide the trusted source ranges that need access. Omit the allowlist entirely if the load balancer is intentionally public.
+            Provide the trusted source ranges that need access. Omit `--allow-list` from the update if the load balancer is intentionally public.
         # No Terraform remediation: the load balancer firewall is a nested block on
         # digitalocean_loadbalancer using cidr:/ip: encoded entries; fix it by editing
         # the firewall.allow list in that block to remove any-address entries.

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -1856,7 +1856,7 @@ queries:
             ```
         - id: terraform
           desc: |
-            Attach every `hcloud_load_balancer` to a network with an `hcloud_load_balancer_network` resource. Set `use_private_ip = true` on the load balancer's targets so forwarding uses the private path:
+            Attach every `hcloud_load_balancer` to a network with an `hcloud_load_balancer_network` resource. `use_private_ip` lives on `hcloud_load_balancer_target`, so set it there as well and the load balancer forwards to its targets over the private path:
 
             ```hcl
             resource "hcloud_network" "main" {
@@ -1881,6 +1881,14 @@ queries:
               load_balancer_id = hcloud_load_balancer.example.id
               network_id       = hcloud_network.main.id
               depends_on       = [hcloud_network_subnet.main]
+            }
+
+            resource "hcloud_load_balancer_target" "example" {
+              type             = "server"
+              load_balancer_id = hcloud_load_balancer.example.id
+              server_id        = hcloud_server.example.id
+              use_private_ip   = true
+              depends_on       = [hcloud_load_balancer_network.example]
             }
             ```
     refs:
@@ -2391,7 +2399,7 @@ queries:
             To disable external reachability using the `hcloud` CLI:
 
             ```bash
-            hcloud storage-box update-access-settings <storage-box> --reachable-externally false
+            hcloud storage-box update-access-settings <storage-box> --reachable-externally=false
             ```
 
             Verify that internal clients can still reach the box afterward.

--- a/content/mondoo-openstack-security.mql.yaml
+++ b/content/mondoo-openstack-security.mql.yaml
@@ -159,7 +159,7 @@ queries:
         Run the OpenStack CLI and inspect the result:
 
         ```bash
-        openstack application credential list --long
+        openstack application credential list
         ```
 
         A passing result lists every credential with `Unrestricted` set to `False`; a failing result shows a credential with `Unrestricted` set to `True`.
@@ -298,7 +298,7 @@ queries:
 
             ```bash
             openstack user set <user> \
-              --multi-factor-auth-enabled \
+              --enable-multi-factor-auth \
               --multi-factor-auth-rule password,totp
             ```
         - id: terraform
@@ -307,8 +307,8 @@ queries:
 
             ```hcl
             resource "openstack_identity_user_v3" "operator" {
-              name                     = "operator"
-              default_project_id       = openstack_identity_project_v3.ops.id
+              name                      = "operator"
+              default_project_id        = openstack_identity_project_v3.ops.id
               multi_factor_auth_enabled = true
 
               multi_factor_auth_rule {
@@ -421,7 +421,7 @@ queries:
             Clear the exemption so the user is subject to the configured lockout policy:
 
             ```bash
-            openstack user set <user> --ignore-lockout-failure-attempts False
+            openstack user set <user> --no-ignore-lockout-failure-attempts
             ```
         - id: terraform
           desc: |
@@ -524,7 +524,7 @@ queries:
         Run the OpenStack CLI and inspect the result:
 
         ```bash
-        openstack application credential list --long
+        openstack application credential list
         ```
 
         A passing result shows a populated `Expires At` value for every credential; a failing result shows an empty `Expires At` field.
@@ -3308,11 +3308,11 @@ queries:
 
             ```hcl
             resource "openstack_containerinfra_clustertemplate_v1" "k8s" {
-              name                  = "k8s"
-              image                 = "fedora-coreos"
-              coe                   = "kubernetes"
-              external_network_id   = openstack_networking_network_v2.public.id
-              tls_disabled          = false
+              name                = "k8s"
+              image               = "fedora-coreos"
+              coe                 = "kubernetes"
+              external_network_id = openstack_networking_network_v2.public.id
+              tls_disabled        = false
             }
             ```
     refs:
@@ -3931,7 +3931,7 @@ queries:
         1. List the service catalog endpoints and review each URL:
 
         ```bash
-        openstack endpoint list --long
+        openstack endpoint list
         ```
 
         A passing endpoint's URL begins with `https://`. A failing endpoint's URL begins with `http://`.
@@ -4012,7 +4012,7 @@ queries:
         1. List application credentials for each user and review their roles:
 
         ```bash
-        openstack application credential list --long
+        openstack application credential list
         ```
 
         A passing credential lists only non-admin roles. A failing credential includes `admin` in its roles.

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -533,7 +533,29 @@ queries:
         - id: console
           desc: |
             In the STACKIT Portal, configure a default retention period (in days) and mode for the Object-Locked bucket so new objects inherit WORM protection.
-        # No Terraform remediation: the stackit Terraform provider exposes the bucket's retention only as the read-only `max_retention_days` attribute (on stackit_objectstorage_bucket / stackit_objectstorage_compliance_lock); there is no writable attribute to set a default retention period. Configure it via the console or API.
+        - id: terraform
+          desc: |
+            Declare a `stackit_objectstorage_default_retention` resource for the Object-Locked bucket, setting `days` to the retention window new objects should inherit and `mode` to the retention mode that matches the protection the data requires:
+
+            ```hcl
+            resource "stackit_objectstorage_compliance_lock" "example" {
+              project_id = var.project_id
+            }
+
+            resource "stackit_objectstorage_bucket" "example" {
+              depends_on  = [stackit_objectstorage_compliance_lock.example]
+              project_id  = var.project_id
+              name        = "secure-bucket"
+              object_lock = true
+            }
+
+            resource "stackit_objectstorage_default_retention" "example" {
+              project_id  = var.project_id
+              bucket_name = stackit_objectstorage_bucket.example.name
+              days        = 30
+              mode        = "GOVERNANCE"
+            }
+            ```
     refs:
       - url: https://docs.stackit.cloud/products/storage/object-storage/
         title: STACKIT Documentation - Object Storage
@@ -1073,7 +1095,7 @@ queries:
             In the STACKIT Portal, scale the PostgreSQL Flex instance to two or more replicas for production workloads.
         - id: terraform
           desc: |
-            Set `replicas` to at least 2 (use 3 for a replicated, highly available setup) on the `stackit_postgresflex_instance` resource:
+            Set `replicas` to at least 2 on the `stackit_postgresflex_instance` resource, using 3 for a replicated, highly available setup. The provider deprecates `replicas` and removes it after February 2027, so plan the move to `flavor_id` with a flavor that already carries the replica count you need. The `stackit_postgresflex_flavors` data source lists the available flavors.
 
             ```hcl
             resource "stackit_postgresflex_instance" "example" {

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-doks-supported-version-terraform-hcl/fail/outdated-version-prefix/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-doks-supported-version-terraform-hcl/fail/outdated-version-prefix/main.tf
@@ -1,0 +1,15 @@
+data "digitalocean_kubernetes_versions" "legacy" {
+  version_prefix = "1.29."
+}
+
+resource "digitalocean_kubernetes_cluster" "primary" {
+  name    = "legacy-cluster"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.legacy.latest_version
+
+  node_pool {
+    name       = "worker-pool"
+    size       = "s-2vcpu-2gb"
+    node_count = 3
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-doks-supported-version-terraform-hcl/pass/version-data-source/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-doks-supported-version-terraform-hcl/pass/version-data-source/main.tf
@@ -1,0 +1,15 @@
+data "digitalocean_kubernetes_versions" "supported" {
+  version_prefix = "1.31."
+}
+
+resource "digitalocean_kubernetes_cluster" "primary" {
+  name    = "prod-cluster"
+  region  = "nyc1"
+  version = data.digitalocean_kubernetes_versions.supported.latest_version
+
+  node_pool {
+    name       = "worker-pool"
+    size       = "s-2vcpu-2gb"
+    node_count = 3
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/fail/default-cipher/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/fail/default-cipher/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: missing-check
-
-Check `mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl` is not present in this bundle yet; it is added by a separate pull request. This fixture is kept so it will validate automatically once the check lands. Until then the scan reports no applicable policy.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/fail/weak-cipher/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/fail/weak-cipher/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: missing-check
-
-Check `mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl` is not present in this bundle yet; it is added by a separate pull request. This fixture is kept so it will validate automatically once the check lands. Until then the scan reports no applicable policy.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/pass/no-tls-rules/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/pass/no-tls-rules/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: missing-check
-
-Check `mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl` is not present in this bundle yet; it is added by a separate pull request. This fixture is kept so it will validate automatically once the check lands. Until then the scan reports no applicable policy.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/pass/strong-cipher/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-digitalocean-security/mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl/pass/strong-cipher/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: missing-check
-
-Check `mondoo-digitalocean-security-lb-strong-tls-cipher-policy-terraform-hcl` is not present in this bundle yet; it is added by a separate pull request. This fixture is kept so it will validate automatically once the check lands. Until then the scan reports no applicable policy.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/validation/scans/remediation-budget.json
+++ b/content/validation/scans/remediation-budget.json
@@ -196,10 +196,6 @@
     "reason": "the snippet is not a scannable document of its kind on its own"
   },
   {
-    "uid": "mondoo-digitalocean-security-doks-supported-version-terraform-hcl",
-    "reason": "the documented fix does not make this check pass"
-  },
-  {
     "uid": "mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-terraform-hcl",
     "reason": "the snippet declares no resource this check's filter matches, so applying it as shown leaves the check unevaluated"
   },


### PR DESCRIPTION
A remediation audit of the four cloud policies below. Every `- id:` entry was read
and every CLI example was executed against the vendor's own parser, not eyeballed.

- `content/mondoo-digitalocean-security.mql.yaml`
- `content/mondoo-hetzner-security.mql.yaml`
- `content/mondoo-stackit-security.mql.yaml`
- `content/mondoo-openstack-security.mql.yaml`

Twelve defects, each verified against an authoritative oracle before it was filed.
Four of them are commands that cannot run at all.

---

## 1. DOKS supported-version check fails on its own documented fix

`mondoo-digitalocean-security-doks-supported-version-terraform-hcl` was the one
DigitalOcean entry in `content/validation/scans/remediation-budget.json`, recorded as
*"the documented fix does not make this check pass"*.

The remediation snippet drives the version from a data source, which is the idiomatic
Terraform pattern:

```hcl
data "digitalocean_kubernetes_versions" "example" {
  version_prefix = "1.31."
}
resource "digitalocean_kubernetes_cluster" "example" {
  version = data.digitalocean_kubernetes_versions.example.latest_version
}
```

Scanning that HCL, `arguments["version"]` is the **reference text**, not a version:

```
$ cnquery run terraform . -c 'terraform.resources("digitalocean_kubernetes_cluster") { arguments["version"] }'
terraform.resources.list: [
  0: {
    arguments.version: "data.digitalocean_kubernetes_versions.example.latest_version"
  }
]
```

So the regex could never match. This is not only a closed-loop failure: it is a false
positive against every correct config that resolves its version through the data source.

The check now accepts a `digitalocean_kubernetes_versions` reference and, as a second
datapoint, holds those data sources to the same supported-version window, so the hole
that would otherwise open is closed:

| fixture | verdict |
|---|---|
| `pass/current` (literal `1.31.1-do.0`) | `[ok]` |
| `pass/version-data-source` (`version_prefix = "1.31."`) | `[ok]` |
| `fail/outdated` (literal `1.29.1-do.0`) | `[failed]` |
| `fail/outdated-version-prefix` (`version_prefix = "1.29."`) | `[failed]` |

A data source with no `version_prefix` resolves to the latest release, so it is guarded
with `== empty` rather than failed. The two datapoints are not correlated by name, so a
module carrying an unsupported-prefix data source fails even if the cluster references a
different one. That errs toward failing rather than passing, which is the right direction
for a supported-version check. Two fixtures were added for the new paths and the budget
entry is removed. The budget file only shrinks.

## 2. DigitalOcean load balancer TLS cipher policy: the "no Terraform" justification is false

`mondoo-digitalocean-security-lb-strong-tls-cipher-policy` carried two comments that
both assert the same thing:

```yaml
# No Terraform variants: ... The digitalocean_loadbalancer Terraform resource
# has no argument that selects between the DEFAULT and STRONG cipher policies, so the setting
# cannot be asserted in HCL, plan, or state.
```
```yaml
# No Terraform remediation: the digitalocean_loadbalancer resource has no argument for the
# minimum TLS cipher policy, so the STRONG policy cannot be set through Terraform.
```

The argument exists. From `terraform providers schema -json` for `digitalocean/digitalocean` 2.99.1:

```json
"tls_cipher_policy": {
  "type": "string",
  "description": "The tls cipher policy to be used for the load balancer. Enum: 'DEFAULT' 'STRONG'",
  "optional": true
}
```

Fixtures for the missing variant were already staged in the repo behind four
`KNOWN_BUG.md` markers reading *"not present in this bundle yet; it is added by a separate
pull request … kept so it will validate automatically once the check lands."* This lands
it: the three Terraform variants and an `- id: terraform` entry are added, and the four
markers are deleted in the same change, as the stale-marker rule requires. All four staged
scenarios reach the right verdict unchanged:

```
--- PASS: .../lb-strong-tls-cipher-policy-terraform-hcl/pass/strong-cipher
--- PASS: .../lb-strong-tls-cipher-policy-terraform-hcl/pass/no-tls-rules
--- PASS: .../lb-strong-tls-cipher-policy-terraform-hcl/fail/weak-cipher
--- PASS: .../lb-strong-tls-cipher-policy-terraform-hcl/fail/default-cipher
```

## 3. `--tls-cipher-policy strong` is not the documented enum value

Same check, CLI entry. The value was lowercase while every other reference in the same
check is uppercase: the query asserts `tlsCipherPolicy == "STRONG"` and the audit section
says *"A passing load balancer that terminates TLS returns `STRONG`"*.

`doctl`'s own flag help: `--tls-cipher-policy DEFAULT ... e.g.: DEFAULT or STRONG`.
The value is passed through to the API verbatim; `godo` declares the two legal values as
constants:

```
godo@v1.204.0/load_balancers.go:31:  LoadBalancerTLSCipherPolicyDefault = "DEFAULT"
godo@v1.204.0/load_balancers.go:32:  LoadBalancerTLSCipherPolicyStrong  = "STRONG"
```

## 4. A `load-balancer update` that silently resets the load balancer

`mondoo-digitalocean-security-lb-firewall-allowlist-not-open` documented:

```bash
doctl compute load-balancer update <load-balancer-id> \
  --allow-list cidr:203.0.113.0/24,ip:198.51.100.10
```

`doctl compute load-balancer update --help` describes the command as a full replacement:

> Using all applicable flags, the command should contain a full representation of the load
> balancer including existing attributes, such as the load balancer's name, region,
> forwarding rules, and Droplet IDs. **Any attribute that is not provided is reset to its
> default value.**

Applying the fix as written would tighten the allowlist and wipe the name, region,
forwarding rules and Droplet IDs. The other two load balancer checks in this same policy
already document the read-then-reapply pattern; this one now matches them.

## 5. Hetzner Storage Box: the command does not parse

`mondoo-hetzner-security-storage-box-not-externally-reachable` documented
`--reachable-externally false`. That flag is a boolean, so the value is read as a second
positional argument:

```
$ hcloud storage-box update-access-settings mybox --reachable-externally false
hcloud: expected exactly 1 positional argument(s), but got 2

$ hcloud storage-box update-access-settings mybox --reachable-externally=false
hcloud: the token you have provided is invalid (unauthorized)
```

The second form reaches the API, so `=false` is the working spelling. Note that if the
extra argument had been tolerated, the bare flag would have set reachability to *true*,
the opposite of the fix. The same policy already uses `--http-redirect-http=true`
elsewhere, so this was a one-off slip.

## 6. Hetzner load balancer: `use_private_ip` had nowhere to go

`mondoo-hetzner-security-lb-in-private-network`'s Terraform entry instructed the reader to
*"Set `use_private_ip = true` on the load balancer's targets"*, but the snippet declared
only the network, subnet, load balancer and `hcloud_load_balancer_network`. There was no
target resource to set it on, and `use_private_ip` does not exist on any of the four:

```
hcloud_load_balancer_target  -> [... server_id, type, use_private_ip]
hcloud_load_balancer_network -> [enable_public_interface, id, ip, load_balancer_id, network_id, subnet_id]
```

An `hcloud_load_balancer_target` with `use_private_ip = true` is added so the instruction
can actually be followed.

## 7. STACKIT default retention: the Terraform resource exists

`mondoo-stackit-security-objectstorage-bucket-retention` omitted Terraform with:

```yaml
# No Terraform remediation: the stackit Terraform provider exposes the bucket's retention only as the
# read-only `max_retention_days` attribute (on stackit_objectstorage_bucket / stackit_objectstorage_compliance_lock);
# there is no writable attribute to set a default retention period.
```

Both halves are wrong. `stackit_objectstorage_bucket` has no `max_retention_days`
attribute at all, and `stackit_objectstorage_default_retention` is a writable resource
whose whole purpose is this setting:

```json
"bucket_name": {"type": "string", "required": true},
"days":        {"type": "number", "description": "The number retention period in days.", "required": true},
"mode":        {"type": "string", "description": "The retention mode for default retention on a bucket.", "required": true}
```

The check asserts `defaultRetentionDays > 0`, which is exactly what `days` sets. The added
snippet follows the provider's own documented example, including the
`stackit_objectstorage_compliance_lock` prerequisite and its `mode = "GOVERNANCE"` value.

## 8. STACKIT PostgreSQL Flex: the recommended attribute is being removed

`mondoo-stackit-security-db-postgres-high-availability` tells the reader to set `replicas`.
The provider deprecates it:

```json
"replicas": {
  "deprecated": true,
  "deprecation_message": "replicas is deprecated and will be removed after February 2027.
   Use instead `flavor_id` and choose a flavor with your wanted replica configuration.
   You can list available flavors using the datasource `stackit_postgresflex_flavors`."
}
```

The working example is kept and the forward path is documented. Checked and left alone:
`stackit_mongodbflex_instance.replicas` is `required` and carries no deprecation, so its
sibling snippet is correct as written.

## 9 and 10. Two OpenStack commands that argparse rejects

Neither could ever have run. Parsed against the real `openstackclient` 10.2.1 parsers:

```
$ openstack user set <user> --ignore-lockout-failure-attempts False
openstack user set: error: unrecognized arguments: False

$ openstack user set <user> --multi-factor-auth-enabled --multi-factor-auth-rule password,totp
openstack user set: error: unrecognized arguments: --multi-factor-auth-enabled
```

The lockout one is the worse of the two. Introspecting the parser:

```
['--ignore-lockout-failure-attempts']     nargs=0  type=_StoreTrueAction
['--no-ignore-lockout-failure-attempts']  nargs=0  type=_StoreTrueAction
['--enable-multi-factor-auth']            nargs=0  type=_StoreTrueAction
['--multi-factor-auth-rule']              nargs=None type=_AppendAction  metavar=<rule>
```

The flag is `store_true` with no value, so had the stray `False` been dropped the command
would have *set* the lockout exemption that
`mondoo-openstack-security-user-lockout-not-bypassed` exists to remove. The negated flag is
the one that clears it:

```
--- parse proposed lockout fix:
OK ignore_lockout_failure_attempts = False
```

`--multi-factor-auth-enabled` simply does not exist; the flag is `--enable-multi-factor-auth`.

## 11 and 12. `--long` on two commands that do not have it

```
$ openstack application credential list --long
openstack application credential list: error: unrecognized arguments: --long

$ openstack endpoint list --long
openstack endpoint list: error: unrecognized arguments: --long
```

Both appear in `audit:` steps, in four places across
`app-credentials-restricted`, `app-credentials-have-expiry`, `app-credential-no-admin` and
`endpoints-use-https`. Dropping the flag is the whole fix, because the default column sets
already carry exactly what the surrounding prose tells the reader to look at:

```python
# identity/v3/application_credential.py
column_headers = ('ID','Name','Description','Project ID','Roles','Unrestricted','Access Rules','Expires At')
# identity/v3/endpoint.py
column_headers = ('ID','Region','Service Name','Service Type','Enabled','Interface','URL')
```

`--long` is genuinely valid on `openstack port list`, `openstack vpn ike policy list` and
`openstack vpn ipsec policy list`, which all parsed clean, so this is not a blanket flag
problem.

## Also fixed: two `terraform fmt` violations

`terraform fmt -check` over all 91 HCL snippets in the four policies flagged two, both in
the OpenStack policy (`user-mfa-enabled` and `cluster-template-tls-enabled`). tflint does
not check formatting, so these shipped. All 91 snippets are now clean.

---

## Reported, not fixed: `mondoo-stackit-security` is missing two required sections

Not touched here because filling it in would mean writing ~69 blocks against a CLI I
cannot execute, and unverified remediation is worse than none. Measured, not estimated:

| policy | documented checks | missing `audit:` | `console` | `cli` | `terraform` |
|---|---|---|---|---|---|
| digitalocean | 45 | 0 | 45 | 41 | 18 |
| hetzner | 19 | 0 | 19 | 17 | 15 |
| openstack | 36 | 0 | 36 | 36 | 29 |
| **stackit** | **36** | **33** | 36 | **0** | 25 |

`content/CLAUDE.md` requires all three of `desc:`, `audit:` and `remediation:` on every
check, and `console` + `cli` + `terraform` for this tier of cloud. StackIT has no `cli`
remediation anywhere, and 33 of its 36 documented checks have no `audit:` section at all.
The STACKIT CLI clearly exists and is usable here: the three checks that *do* have an
`audit:` section use `stackit ske cluster describe`, `stackit service-account list` and
`stackit kms key list`. `cnspec policy lint` does not enforce either requirement, which is
why this drifted silently.

---

## Checked and found correct

Coverage was real; most of what was investigated verified clean.

- **Every HCL attribute and nested field name.** A checker resolved all 91 snippets against
  `terraform providers schema -json` for the four pinned providers, walking into
  framework-style `nested_type` attributes as well as classic blocks: **596 names across 108
  resource and data blocks, zero unknown**. This matters because only aws/azurerm/google
  have tflint rulesets, so the existing validator never checks these four providers' names.
  The single reported hit was `openstack_images_image_v2.properties`, a `map(string)` whose
  nested body is legitimate HCL and a limitation of the checker, not a defect.
- **Every `openstack` command in the policy.** All 85 distinct commands are now parsed
  against the real `openstackclient` argparse parsers, resolving through the Neutron,
  Magnum, Manila, Cinder, Barbican, Octavia, Trove, Keystone, Nova and Glance plugin entry
  points: **85 parsed clean, 0 failed** after the four fixes. There is no `openstack`
  validator under `content/validation/remediation/commands/`, which is how the four bad
  commands shipped.
- **`doctl` and `hcloud`.** The repo's own validators pass at 121 and 78 respectively. Flags
  individually re-checked against `--help` include `doctl compute firewall remove-rules`,
  `add-rules`, `add-droplets`, `droplet tag`, `spaces keys create --grants`,
  `compute cdn update`, `compute certificate create`, `databases firewalls append/replace`,
  `databases options versions`, `databases get-ca`, `kubernetes cluster update --sso-*`,
  `genai agent update-visibility --visibility`, and the `hcloud` load balancer, firewall,
  certificate, ssh-key and storage-box groups.
- **`address:::/0` in `doctl` inbound-rule strings.** Looks like a typo, is not. The rule
  string parses and the request reaches the API:
  `doctl compute firewall remove-rules ... --inbound-rules "protocol:tcp,ports:22,address:::/0"`
  returns a 401, meaning it got past parsing.
- **`stackit_sqlserverflex_instance.replicas` really is read-only** (`"computed": true`
  with no `optional`), so its `# No Terraform remediation` comment is accurate. The other
  ten StackIT omission comments were read and match the provider schema.
- **`openstack volume set --migration-policy on-demand`** parses; an early suspicion that
  it should be `--retype-policy` was wrong and dropped.
- **Undeclared resource references** in snippets (`digitalocean_vpc.example`,
  `hcloud_network.main`, and similar) are a repo-wide convention, scan fine as HCL, and are
  not flagged.
- **Guard chains, `!= empty`, unparenthesized `||`/`&&`, and newline-as-AND** appear
  throughout all four policies and were left alone.
- No policy `version:` was bumped.

## Validation

```
cnspec policy lint            all four policies: valid policy bundle(s)
make test/content/lint        valid (2 pre-existing warnings, identical count on main)
commands/validate.py          digitalocean 121 passed 0 failed; hetzner 78 passed 0 failed
code/terraform.py             digitalocean / hetzner / stackit / openstack: 0 failures
TestTerraformVariants         mondoo-digitalocean-security: ok
TestTerraformVariantCoverage  ok
TestRemediationSatisfiesCheck ok
terraform fmt -check          0 violations across 91 snippets
```
